### PR TITLE
refactor(ui): give the elements slots, parts, and the shadcn conventions

### DIFF
--- a/apps/docs/components/elements/canvas-split-demo.tsx
+++ b/apps/docs/components/elements/canvas-split-demo.tsx
@@ -14,12 +14,12 @@ import { useStoryPhases } from "./use-demo";
 const MESSAGES = [
   {
     id: "u1",
-    role: "user" as const,
+    speaker: "user" as const,
     text: "Draft the migration note for 0.14",
   },
   {
     id: "a1",
-    role: "assistant" as const,
+    speaker: "assistant" as const,
     text: "Opened it in the canvas — editing now.",
   },
 ];
@@ -47,7 +47,7 @@ export function CanvasSplitDemo() {
     <CanvasSplit>
       <CanvasSplitThread>
         {MESSAGES.map((message) => (
-          <CanvasSplitMessage key={message.id} role={message.role}>
+          <CanvasSplitMessage key={message.id} speaker={message.speaker}>
             {message.text}
           </CanvasSplitMessage>
         ))}

--- a/apps/docs/components/elements/canvas-split-demo.tsx
+++ b/apps/docs/components/elements/canvas-split-demo.tsx
@@ -2,42 +2,75 @@
 
 import {
   CanvasSplit,
-  type CanvasMessage,
+  CanvasSplitBody,
+  CanvasSplitDocument,
+  CanvasSplitHeader,
+  CanvasSplitLine,
+  CanvasSplitMessage,
+  CanvasSplitThread,
 } from "@/components/elements/canvas-split";
 import { useStoryPhases } from "./use-demo";
 
-const MESSAGES: readonly CanvasMessage[] = [
-  { id: "u1", role: "user", text: "Draft the migration note for 0.14" },
+const MESSAGES = [
+  {
+    id: "u1",
+    role: "user" as const,
+    text: "Draft the migration note for 0.14",
+  },
   {
     id: "a1",
-    role: "assistant",
+    role: "assistant" as const,
     text: "Opened it in the canvas — editing now.",
   },
 ];
 
-const LINES: readonly string[] = [
-  "# Migrating to 0.14",
-  "The composer now owns its draft, so `useState` in the parent is no longer read.",
-  "Replace the local draft with `useDraft(threadId)` and drop the hydrate effect.",
-  "Threads that switch mid-edit keep their own draft instead of inheriting the last one.",
+const LINES: readonly { text: string; heading?: boolean }[] = [
+  { text: "Migrating to 0.14", heading: true },
+  {
+    text: "The composer now owns its draft, so `useState` in the parent is no longer read.",
+  },
+  {
+    text: "Replace the local draft with `useDraft(threadId)` and drop the hydrate effect.",
+  },
+  {
+    text: "Threads that switch mid-edit keep their own draft instead of inheriting the last one.",
+  },
 ];
 
 const PHASES = [900, 900, 900, 900, 0] as const;
 
 export function CanvasSplitDemo() {
   const { phase } = useStoryPhases(PHASES);
-  const visibleLines = Math.min(phase, LINES.length);
+  const visible = Math.min(phase, LINES.length);
 
   return (
-    <CanvasSplit
-      messages={MESSAGES}
-      title="migration-0.14.md"
-      version={3}
-      lines={LINES}
-      visibleLines={visibleLines}
-      saved={visibleLines >= LINES.length}
-      onCopy={() => undefined}
-      onClose={() => undefined}
-    />
+    <CanvasSplit>
+      <CanvasSplitThread>
+        {MESSAGES.map((message) => (
+          <CanvasSplitMessage key={message.id} role={message.role}>
+            {message.text}
+          </CanvasSplitMessage>
+        ))}
+      </CanvasSplitThread>
+      <CanvasSplitDocument>
+        <CanvasSplitHeader
+          title="migration-0.14.md"
+          version={3}
+          saved={visible >= LINES.length}
+          onCopy={() => undefined}
+          onClose={() => undefined}
+        />
+        <CanvasSplitBody writing={visible < LINES.length}>
+          {LINES.slice(0, visible).map((line) => (
+            <CanvasSplitLine
+              key={line.text}
+              {...(line.heading ? { heading: true } : {})}
+            >
+              {line.text}
+            </CanvasSplitLine>
+          ))}
+        </CanvasSplitBody>
+      </CanvasSplitDocument>
+    </CanvasSplit>
   );
 }

--- a/apps/docs/components/elements/chat-panel-demo.tsx
+++ b/apps/docs/components/elements/chat-panel-demo.tsx
@@ -1,32 +1,49 @@
 "use client";
 
-import { ChatPanel } from "@/components/elements/chat-panel";
+import {
+  ChatPanel,
+  ChatPanelComposer,
+  ChatPanelMessages,
+  ChatPanelTyping,
+  ChatPanelUserMessage,
+} from "@/components/elements/chat-panel";
+import { StreamingText } from "@/components/elements/streaming-text";
 import { useElapsed, useStoryPhases } from "./use-demo";
 
 const USER_MESSAGE = "Why did my draft disappear?";
-const REPLY =
-  "Drafts were living in component state, so switching threads reset them. The runtime now keys every draft by thread id and restores it when you come back.";
+const SEGMENTS = [
+  {
+    text: "Drafts were living in component state, so switching threads reset them. The runtime now keys every draft by thread id and restores it when you come back.",
+  },
+];
+const WORD_COUNT = SEGMENTS[0]!.text.split(" ").length;
 const PHASES = [1400, 1500, 3400, 2800] as const;
 
 export function ChatPanelDemo() {
   const { phase, running } = useStoryPhases(PHASES);
   const streamTenths = useElapsed(running && phase === 2);
-  const words = REPLY.split(" ");
-  const visibleWords =
+  const count =
     phase < 2
       ? 0
       : phase === 2
-        ? Math.min(Math.floor(streamTenths * 0.9), words.length)
-        : words.length;
+        ? Math.min(Math.floor(streamTenths * 0.9), WORD_COUNT)
+        : WORD_COUNT;
 
   return (
-    <ChatPanel
-      userMessage={USER_MESSAGE}
-      reply={REPLY}
-      showUserMessage
-      typing={running && phase === 1}
-      visibleWords={visibleWords}
-      streaming={running && phase === 2 && visibleWords < words.length}
-    />
+    <ChatPanel>
+      <ChatPanelMessages>
+        <ChatPanelUserMessage>{USER_MESSAGE}</ChatPanelUserMessage>
+        {running && phase === 1 && <ChatPanelTyping />}
+        {count > 0 && (
+          <StreamingText
+            segments={SEGMENTS}
+            count={count}
+            streaming={running && phase === 2 && count < WORD_COUNT}
+            className="text-foreground/70 min-h-0 max-w-[85%] self-start text-xs"
+          />
+        )}
+      </ChatPanelMessages>
+      <ChatPanelComposer placeholder="Message" onSend={() => undefined} />
+    </ChatPanel>
   );
 }

--- a/apps/docs/components/elements/command-palette-demo.tsx
+++ b/apps/docs/components/elements/command-palette-demo.tsx
@@ -29,6 +29,7 @@ export function CommandPaletteDemo() {
       query={query}
       activeId={activeId}
       onQueryChange={setQuery}
+      onActiveChange={setActiveId}
       onRun={setActiveId}
     />
   );

--- a/apps/docs/components/elements/composer-attachments-demo.tsx
+++ b/apps/docs/components/elements/composer-attachments-demo.tsx
@@ -3,55 +3,76 @@
 import { useState } from "react";
 import {
   Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerAttachmentChip,
+  ComposerAttachments,
+  ComposerBar,
+  ComposerInput,
+  ComposerSend,
+  ComposerToolbar,
   type ComposerAttachment,
 } from "@/components/elements/composer";
-import { useElapsed, useStoryPhases } from "./use-demo";
+import { useStoryPhases } from "./use-demo";
 
-const PHASES = [2400, 2400, 3000, 0] as const;
+const PHASES = [900, 900, 900, 0] as const;
+const PROGRESS = [18, 62, 100, 100] as const;
 
 export function ComposerAttachmentsDemo() {
-  const { phase, running } = useStoryPhases(PHASES);
+  const { phase } = useStoryPhases(PHASES);
   const [value, setValue] = useState("");
   const [removed, setRemoved] = useState<string[]>([]);
-  const tenths = useElapsed(running && phase < 2);
-
-  const progressA = Math.min(96, tenths * 4.5);
-  const progressB = Math.min(96, Math.max(0, (tenths - 24) * 4.5));
+  const done = phase >= 3;
 
   const attachments: ComposerAttachment[] = [
     {
-      name: "design-review.pdf",
-      meta: phase === 0 ? "Uploading" : "2.4 MB",
-      state: phase === 0 ? ("uploading" as const) : ("done" as const),
-      progress: progressA,
+      name: "screenshot.png",
+      meta: done ? "128 KB" : "uploading",
+      state: done ? ("done" as const) : ("uploading" as const),
+      progress: PROGRESS[Math.min(phase, 3)] ?? 100,
+      kind: "image" as const,
+    },
+    {
+      name: "trace.log",
+      meta: "38 KB",
+      state: "done" as const,
       kind: "text" as const,
     },
-    ...(phase >= 1
-      ? [
-          {
-            name: "screens.zip",
-            meta: phase === 1 ? "Uploading" : "18 MB",
-            state: phase === 1 ? ("uploading" as const) : ("done" as const),
-            progress: progressB,
-            kind: "archive" as const,
-          },
-        ]
-      : []),
   ].filter((a) => !removed.includes(a.name));
 
   return (
-    <Composer
-      value={value}
-      onValueChange={setValue}
-      onSend={() => setValue("")}
-      placeholder="Add a note for the review"
-      attachments={attachments}
-      {...(phase >= 2
-        ? {
-            onRemoveAttachment: (name: string) =>
-              setRemoved((r) => [...r, name]),
-          }
-        : {})}
-    />
+    <Composer>
+      <ComposerBar>
+        {attachments.length > 0 && (
+          <ComposerAttachments>
+            {attachments.map((attachment) => (
+              <ComposerAttachmentChip
+                key={attachment.name}
+                attachment={attachment}
+                onRemove={(name) => setRemoved((r) => [...r, name])}
+              />
+            ))}
+          </ComposerAttachments>
+        )}
+        <ComposerInput
+          value={value}
+          placeholder="Ask anything"
+          onChange={(event) => setValue(event.target.value)}
+          onSubmit={() => setValue("")}
+        />
+        <ComposerToolbar>
+          <ComposerActions>
+            <ComposerAttachButton onClick={() => setRemoved([])} />
+          </ComposerActions>
+          <ComposerActions>
+            <ComposerSend
+              streaming={false}
+              idle={value.length === 0}
+              onClick={() => setValue("")}
+            />
+          </ComposerActions>
+        </ComposerToolbar>
+      </ComposerBar>
+    </Composer>
   );
 }

--- a/apps/docs/components/elements/composer-context-demo.tsx
+++ b/apps/docs/components/elements/composer-context-demo.tsx
@@ -1,25 +1,55 @@
 "use client";
 
 import { useState } from "react";
-import { Composer } from "@/components/elements/composer";
-import { useElapsed, useStoryPhases } from "./use-demo";
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerContext,
+  ComposerInput,
+  ComposerSend,
+  ComposerToolbar,
+} from "@/components/elements/composer";
+import { useStoryPhases } from "./use-demo";
 
-const PHASES = [6000, 0] as const;
+const PHASES = [1200, 1200, 0] as const;
+const MESSAGES = [54, 118, 162] as const;
 
 export function ComposerContextDemo() {
-  const { phase, running } = useStoryPhases(PHASES);
+  const { phase } = useStoryPhases(PHASES);
   const [value, setValue] = useState("");
-  const tenths = useElapsed(running && phase === 0);
-  const messages =
-    phase >= 1 ? 158 : Math.min(158, 4 + Math.round(tenths * 2.6));
 
   return (
-    <Composer
-      value={value}
-      onValueChange={setValue}
-      onSend={() => setValue("")}
-      placeholder="Hover the ring for the breakdown"
-      usage={{ system: 12, tools: 8, messages, total: 200 }}
-    />
+    <Composer>
+      <ComposerBar>
+        <ComposerInput
+          value={value}
+          placeholder="Ask anything"
+          onChange={(event) => setValue(event.target.value)}
+          onSubmit={() => setValue("")}
+        />
+        <ComposerToolbar>
+          <ComposerActions>
+            <ComposerAttachButton onClick={() => undefined} />
+          </ComposerActions>
+          <ComposerActions>
+            <ComposerContext
+              usage={{
+                system: 12,
+                tools: 8,
+                messages: MESSAGES[Math.min(phase, 2)] ?? 162,
+                total: 200,
+              }}
+            />
+            <ComposerSend
+              streaming={false}
+              idle={value.length === 0}
+              onClick={() => setValue("")}
+            />
+          </ComposerActions>
+        </ComposerToolbar>
+      </ComposerBar>
+    </Composer>
   );
 }

--- a/apps/docs/components/elements/composer-demo.tsx
+++ b/apps/docs/components/elements/composer-demo.tsx
@@ -9,6 +9,25 @@ import {
 } from "lucide-react";
 import {
   Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerAttachmentChip,
+  ComposerAttachments,
+  ComposerBar,
+  ComposerCommandItem,
+  ComposerContext,
+  ComposerInput,
+  ComposerMenu,
+  ComposerModelItem,
+  ComposerModelTrigger,
+  ComposerPersonItem,
+  ComposerSend,
+  ComposerToolbar,
+  ComposerVoice,
+  ComposerVoiceButton,
+  applyMention,
+  useMentionMatches,
+  useSlashMatches,
   type ComposerAttachment,
   type ComposerCommand,
   type ComposerModel,
@@ -41,6 +60,7 @@ const TRANSCRIPT = "Summarize the review threads from this week";
 export function ComposerDemo() {
   const [value, setValue] = useState("");
   const [model, setModel] = useState("Fable 5");
+  const [modelOpen, setModelOpen] = useState(false);
   const [removed, setRemoved] = useState<string[]>([]);
   const [voice, setVoice] = useState<"idle" | "recording" | "transcribing">(
     "idle",
@@ -49,6 +69,10 @@ export function ComposerDemo() {
   const settle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => () => clearTimeout(settle.current), []);
+
+  const slashMatches = useSlashMatches(value, COMMANDS);
+  const mentionMatches = useMentionMatches(value, PEOPLE);
+  const active = voice !== "idle";
 
   const attachments: ComposerAttachment[] = [
     {
@@ -62,30 +86,103 @@ export function ComposerDemo() {
   return (
     <div className="flex w-full max-w-lg flex-col">
       <div aria-hidden className="h-40" />
-      <Composer
-        value={value}
-        onValueChange={setValue}
-        onSend={() => setValue("")}
-        attachments={attachments}
-        onRemoveAttachment={(name) => setRemoved((r) => [...r, name])}
-        commands={COMMANDS}
-        people={PEOPLE}
-        models={MODELS}
-        model={model}
-        onModelChange={setModel}
-        usage={{ system: 12, tools: 8, messages: 54, total: 200 }}
-        recording={voice === "recording"}
-        transcribing={voice === "transcribing"}
-        recordingSeconds={Math.floor(elapsedTenths / 10)}
-        onVoiceStart={() => setVoice("recording")}
-        onVoiceStop={() => {
-          setVoice("transcribing");
-          settle.current = setTimeout(() => {
-            setVoice("idle");
-            setValue((v) => (v ? `${v} ${TRANSCRIPT}` : TRANSCRIPT));
-          }, 1400);
-        }}
-      />
+      <Composer>
+        <ComposerMenu open={slashMatches.length > 0}>
+          {slashMatches.map((command, i) => (
+            <ComposerCommandItem
+              key={command.name}
+              command={command}
+              active={i === 0}
+              onClick={() => setValue(`/${command.name} `)}
+            />
+          ))}
+        </ComposerMenu>
+        <ComposerMenu open={mentionMatches.length > 0}>
+          {mentionMatches.map((person, i) => (
+            <ComposerPersonItem
+              key={person.name}
+              person={person}
+              active={i === 0}
+              onClick={() => setValue(applyMention(value, person.name))}
+            />
+          ))}
+        </ComposerMenu>
+        <ComposerBar>
+          {attachments.length > 0 && (
+            <ComposerAttachments>
+              {attachments.map((attachment) => (
+                <ComposerAttachmentChip
+                  key={attachment.name}
+                  attachment={attachment}
+                  onRemove={(name) => setRemoved((r) => [...r, name])}
+                />
+              ))}
+            </ComposerAttachments>
+          )}
+          {active ? (
+            <ComposerVoice
+              recording={voice === "recording"}
+              seconds={Math.floor(elapsedTenths / 10)}
+            />
+          ) : (
+            <ComposerInput
+              value={value}
+              placeholder="Ask anything"
+              onChange={(event) => setValue(event.target.value)}
+              onSubmit={() => setValue("")}
+            />
+          )}
+          <ComposerToolbar>
+            <ComposerActions>
+              <ComposerAttachButton onClick={() => setRemoved([])} />
+              <div className="relative">
+                <ComposerMenu open={modelOpen}>
+                  {MODELS.map((entry) => (
+                    <ComposerModelItem
+                      key={entry.name}
+                      entry={entry}
+                      selected={entry.name === model}
+                      onClick={() => {
+                        setModel(entry.name);
+                        setModelOpen(false);
+                      }}
+                    />
+                  ))}
+                </ComposerMenu>
+                <ComposerModelTrigger
+                  model={model}
+                  open={modelOpen}
+                  onClick={() => setModelOpen((open) => !open)}
+                />
+              </div>
+            </ComposerActions>
+            <ComposerActions>
+              <ComposerContext
+                usage={{ system: 12, tools: 8, messages: 54, total: 200 }}
+              />
+              <ComposerVoiceButton
+                active={active}
+                onClick={() => {
+                  if (voice === "idle") {
+                    setVoice("recording");
+                    return;
+                  }
+                  setVoice("transcribing");
+                  settle.current = setTimeout(() => {
+                    setVoice("idle");
+                    setValue((v) => (v ? `${v} ${TRANSCRIPT}` : TRANSCRIPT));
+                  }, 1400);
+                }}
+              />
+              <ComposerSend
+                streaming={false}
+                idle={value.length === 0}
+                onClick={() => setValue("")}
+              />
+            </ComposerActions>
+          </ComposerToolbar>
+        </ComposerBar>
+      </Composer>
     </div>
   );
 }

--- a/apps/docs/components/elements/composer-demo.tsx
+++ b/apps/docs/components/elements/composer-demo.tsx
@@ -179,7 +179,10 @@ export function ComposerDemo() {
                     setVoice("recording");
                     return;
                   }
+                  // already settling: a third click must not stack a second timer
+                  if (voice === "transcribing") return;
                   setVoice("transcribing");
+                  clearTimeout(settle.current);
                   settle.current = setTimeout(() => {
                     setVoice("idle");
                     setValue((v) => (v ? `${v} ${TRANSCRIPT}` : TRANSCRIPT));

--- a/apps/docs/components/elements/composer-demo.tsx
+++ b/apps/docs/components/elements/composer-demo.tsx
@@ -182,7 +182,6 @@ export function ComposerDemo() {
                   // already settling: a third click must not stack a second timer
                   if (voice === "transcribing") return;
                   setVoice("transcribing");
-                  clearTimeout(settle.current);
                   settle.current = setTimeout(() => {
                     setVoice("idle");
                     setValue((v) => (v ? `${v} ${TRANSCRIPT}` : TRANSCRIPT));

--- a/apps/docs/components/elements/composer-demo.tsx
+++ b/apps/docs/components/elements/composer-demo.tsx
@@ -129,7 +129,19 @@ export function ComposerDemo() {
               value={value}
               placeholder="Ask anything"
               onChange={(event) => setValue(event.target.value)}
-              onSubmit={() => setValue("")}
+              onSubmit={() => {
+                const command = slashMatches[0];
+                if (command) {
+                  setValue(`/${command.name} `);
+                  return;
+                }
+                const person = mentionMatches[0];
+                if (person) {
+                  setValue(applyMention(value, person.name));
+                  return;
+                }
+                setValue("");
+              }}
             />
           )}
           <ComposerToolbar>

--- a/apps/docs/components/elements/composer-mentions-demo.tsx
+++ b/apps/docs/components/elements/composer-mentions-demo.tsx
@@ -1,7 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { Composer, type ComposerPerson } from "@/components/elements/composer";
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerInput,
+  ComposerMenu,
+  ComposerPersonItem,
+  ComposerSend,
+  ComposerToolbar,
+  applyMention,
+  useMentionMatches,
+  type ComposerPerson,
+} from "@/components/elements/composer";
 
 const PEOPLE: ComposerPerson[] = [
   { name: "Mara", role: "human" },
@@ -12,17 +25,43 @@ const PEOPLE: ComposerPerson[] = [
 
 export function ComposerMentionsDemo() {
   const [value, setValue] = useState("Ask @");
+  const matches = useMentionMatches(value, PEOPLE);
 
   return (
     <div className="flex w-full max-w-lg flex-col">
       <div aria-hidden className="h-44" />
-      <Composer
-        value={value}
-        onValueChange={setValue}
-        onSend={() => setValue("")}
-        placeholder="Type @ to mention"
-        people={PEOPLE}
-      />
+      <Composer>
+        <ComposerMenu open={matches.length > 0}>
+          {matches.map((person, i) => (
+            <ComposerPersonItem
+              key={person.name}
+              person={person}
+              active={i === 0}
+              onClick={() => setValue(applyMention(value, person.name))}
+            />
+          ))}
+        </ComposerMenu>
+        <ComposerBar>
+          <ComposerInput
+            value={value}
+            placeholder="Ask anything"
+            onChange={(event) => setValue(event.target.value)}
+            onSubmit={() => setValue("")}
+          />
+          <ComposerToolbar>
+            <ComposerActions>
+              <ComposerAttachButton onClick={() => undefined} />
+            </ComposerActions>
+            <ComposerActions>
+              <ComposerSend
+                streaming={false}
+                idle={value.length === 0}
+                onClick={() => setValue("")}
+              />
+            </ComposerActions>
+          </ComposerToolbar>
+        </ComposerBar>
+      </Composer>
     </div>
   );
 }

--- a/apps/docs/components/elements/composer-mentions-demo.tsx
+++ b/apps/docs/components/elements/composer-mentions-demo.tsx
@@ -46,7 +46,10 @@ export function ComposerMentionsDemo() {
             value={value}
             placeholder="Ask anything"
             onChange={(event) => setValue(event.target.value)}
-            onSubmit={() => setValue("")}
+            onSubmit={() => {
+              const person = matches[0];
+              setValue(person ? applyMention(value, person.name) : "");
+            }}
           />
           <ComposerToolbar>
             <ComposerActions>

--- a/apps/docs/components/elements/composer-models-demo.tsx
+++ b/apps/docs/components/elements/composer-models-demo.tsx
@@ -1,7 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { Composer, type ComposerModel } from "@/components/elements/composer";
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerInput,
+  ComposerMenu,
+  ComposerModelItem,
+  ComposerModelTrigger,
+  ComposerSend,
+  ComposerToolbar,
+  type ComposerModel,
+} from "@/components/elements/composer";
 
 const MODELS: ComposerModel[] = [
   { name: "Fable 5", meta: "1M ctx" },
@@ -12,19 +24,53 @@ const MODELS: ComposerModel[] = [
 export function ComposerModelsDemo() {
   const [value, setValue] = useState("");
   const [model, setModel] = useState("Fable 5");
+  const [open, setOpen] = useState(true);
 
   return (
     <div className="flex w-full max-w-lg flex-col">
       <div aria-hidden className="h-40" />
-      <Composer
-        value={value}
-        onValueChange={setValue}
-        onSend={() => setValue("")}
-        models={MODELS}
-        model={model}
-        onModelChange={setModel}
-        defaultModelMenuOpen
-      />
+      <Composer>
+        <ComposerBar>
+          <ComposerInput
+            value={value}
+            placeholder="Ask anything"
+            onChange={(event) => setValue(event.target.value)}
+            onSubmit={() => setValue("")}
+          />
+          <ComposerToolbar>
+            <ComposerActions>
+              <ComposerAttachButton onClick={() => undefined} />
+              <div className="relative">
+                <ComposerMenu open={open}>
+                  {MODELS.map((entry) => (
+                    <ComposerModelItem
+                      key={entry.name}
+                      entry={entry}
+                      selected={entry.name === model}
+                      onClick={() => {
+                        setModel(entry.name);
+                        setOpen(false);
+                      }}
+                    />
+                  ))}
+                </ComposerMenu>
+                <ComposerModelTrigger
+                  model={model}
+                  open={open}
+                  onClick={() => setOpen((current) => !current)}
+                />
+              </div>
+            </ComposerActions>
+            <ComposerActions>
+              <ComposerSend
+                streaming={false}
+                idle={value.length === 0}
+                onClick={() => setValue("")}
+              />
+            </ComposerActions>
+          </ComposerToolbar>
+        </ComposerBar>
+      </Composer>
     </div>
   );
 }

--- a/apps/docs/components/elements/composer-slash-demo.tsx
+++ b/apps/docs/components/elements/composer-slash-demo.tsx
@@ -7,7 +7,19 @@ import {
   SearchIcon,
   SparklesIcon,
 } from "lucide-react";
-import { Composer, type ComposerCommand } from "@/components/elements/composer";
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerCommandItem,
+  ComposerInput,
+  ComposerMenu,
+  ComposerSend,
+  ComposerToolbar,
+  useSlashMatches,
+  type ComposerCommand,
+} from "@/components/elements/composer";
 
 const COMMANDS: ComposerCommand[] = [
   { name: "review", description: "Review the current diff", icon: SearchIcon },
@@ -18,17 +30,43 @@ const COMMANDS: ComposerCommand[] = [
 
 export function ComposerSlashDemo() {
   const [value, setValue] = useState("/");
+  const matches = useSlashMatches(value, COMMANDS);
 
   return (
     <div className="flex w-full max-w-lg flex-col">
       <div aria-hidden className="h-44" />
-      <Composer
-        value={value}
-        onValueChange={setValue}
-        onSend={() => setValue("")}
-        placeholder="Type / for commands"
-        commands={COMMANDS}
-      />
+      <Composer>
+        <ComposerMenu open={matches.length > 0}>
+          {matches.map((command, i) => (
+            <ComposerCommandItem
+              key={command.name}
+              command={command}
+              active={i === 0}
+              onClick={() => setValue(`/${command.name} `)}
+            />
+          ))}
+        </ComposerMenu>
+        <ComposerBar>
+          <ComposerInput
+            value={value}
+            placeholder="Ask anything"
+            onChange={(event) => setValue(event.target.value)}
+            onSubmit={() => setValue("")}
+          />
+          <ComposerToolbar>
+            <ComposerActions>
+              <ComposerAttachButton onClick={() => undefined} />
+            </ComposerActions>
+            <ComposerActions>
+              <ComposerSend
+                streaming={false}
+                idle={value.length === 0}
+                onClick={() => setValue("")}
+              />
+            </ComposerActions>
+          </ComposerToolbar>
+        </ComposerBar>
+      </Composer>
     </div>
   );
 }

--- a/apps/docs/components/elements/composer-slash-demo.tsx
+++ b/apps/docs/components/elements/composer-slash-demo.tsx
@@ -51,7 +51,10 @@ export function ComposerSlashDemo() {
             value={value}
             placeholder="Ask anything"
             onChange={(event) => setValue(event.target.value)}
-            onSubmit={() => setValue("")}
+            onSubmit={() => {
+              const command = matches[0];
+              setValue(command ? `/${command.name} ` : "");
+            }}
           />
           <ComposerToolbar>
             <ComposerActions>

--- a/apps/docs/components/elements/composer-voice-demo.tsx
+++ b/apps/docs/components/elements/composer-voice-demo.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Composer } from "@/components/elements/composer";
+import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerInput,
+  ComposerSend,
+  ComposerToolbar,
+  ComposerVoice,
+  ComposerVoiceButton,
+} from "@/components/elements/composer";
 import { useElapsed, useStoryPhases } from "./use-demo";
 
 const PHASES = [1400, 3600, 1600, 3000, 0] as const;
@@ -11,24 +21,47 @@ export function ComposerVoiceDemo() {
   const { phase, running, takeOver } = useStoryPhases(PHASES);
   const [value, setValue] = useState("");
   const elapsedTenths = useElapsed(running && phase === 1);
+  const recording = running && phase === 1;
+  const transcribing = running && phase === 2;
+  const active = recording || transcribing;
 
   useEffect(() => {
     if (phase >= 3) setValue(TRANSCRIPT);
   }, [phase]);
 
   return (
-    <Composer
-      value={value}
-      onValueChange={(v) => {
-        takeOver();
-        setValue(v);
-      }}
-      onSend={() => setValue("")}
-      recording={running && phase === 1}
-      transcribing={running && phase === 2}
-      recordingSeconds={Math.floor(elapsedTenths / 10)}
-      onVoiceStart={takeOver}
-      onVoiceStop={takeOver}
-    />
+    <Composer>
+      <ComposerBar>
+        {active ? (
+          <ComposerVoice
+            recording={recording}
+            seconds={Math.floor(elapsedTenths / 10)}
+          />
+        ) : (
+          <ComposerInput
+            value={value}
+            placeholder="Ask anything"
+            onChange={(event) => {
+              takeOver();
+              setValue(event.target.value);
+            }}
+            onSubmit={() => setValue("")}
+          />
+        )}
+        <ComposerToolbar>
+          <ComposerActions>
+            <ComposerAttachButton onClick={() => undefined} />
+          </ComposerActions>
+          <ComposerActions>
+            <ComposerVoiceButton active={active} onClick={takeOver} />
+            <ComposerSend
+              streaming={false}
+              idle={value.length === 0}
+              onClick={() => setValue("")}
+            />
+          </ComposerActions>
+        </ComposerToolbar>
+      </ComposerBar>
+    </Composer>
   );
 }

--- a/apps/docs/components/elements/element-docs.ts
+++ b/apps/docs/components/elements/element-docs.ts
@@ -1432,6 +1432,37 @@ const matches = useSlashMatches(value, commands);
           },
         ],
       },
+      {
+        component: "ComposerMenu",
+        rows: [
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description:
+              "Whether the menu is showing. It stays mounted and animates, so the transition runs both ways.",
+          },
+          {
+            name: "align",
+            type: '"start" | "end"',
+            defaultValue: '"start"',
+            description:
+              "Which edge the menu hangs from, matching the control that opened it.",
+          },
+        ],
+      },
+      {
+        component: "ComposerMenuItem",
+        rows: [
+          {
+            name: "active",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Marks the row Enter would take. Command and person items wrap this and set it for you.",
+          },
+        ],
+      },
     ],
   },
   "composer-mentions": {
@@ -1523,6 +1554,24 @@ const matches = useMentionMatches(value, people);
           },
         ],
       },
+      {
+        component: "ComposerModelTrigger",
+        rows: [
+          {
+            name: "model",
+            type: "string",
+            required: true,
+            description: "Name of the active model, shown on the trigger.",
+          },
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description:
+              "Whether the menu it controls is showing; also reported as aria-expanded.",
+          },
+        ],
+      },
     ],
   },
   "composer-voice": {
@@ -1550,6 +1599,18 @@ const matches = useMentionMatches(value, people);
             required: true,
             description:
               "Elapsed capture time. Also drives the waveform, so the bars move with the clock.",
+          },
+        ],
+      },
+      {
+        component: "ComposerVoiceButton",
+        rows: [
+          {
+            name: "active",
+            type: "boolean",
+            required: true,
+            description:
+              "Capturing or transcribing. Swaps the mic for a stop square and fills the button.",
           },
         ],
       },

--- a/apps/docs/components/elements/element-docs.ts
+++ b/apps/docs/components/elements/element-docs.ts
@@ -2459,7 +2459,7 @@ const matches = useMentionMatches(value, people);
 
 <CanvasSplit>
   <CanvasSplitThread>
-    <CanvasSplitMessage role="user">Draft the note</CanvasSplitMessage>
+    <CanvasSplitMessage speaker="user">Draft the note</CanvasSplitMessage>
   </CanvasSplitThread>
   <CanvasSplitDocument>
     <CanvasSplitHeader title="note.md" version={3} saved onCopy={copy} />
@@ -2484,11 +2484,11 @@ const matches = useMentionMatches(value, people);
         component: "CanvasSplitMessage",
         rows: [
           {
-            name: "role",
+            name: "speaker",
             type: '"user" | "assistant"',
             required: true,
             description:
-              "User turns sit right in a bubble, assistant turns run flush left. Also emitted as data-role for styling from outside.",
+              "User turns sit right in a bubble, assistant turns run flush left. Emitted as data-speaker for styling from outside; it is deliberately not called role, so the ARIA attribute stays yours to set.",
           },
         ],
       },

--- a/apps/docs/components/elements/element-docs.ts
+++ b/apps/docs/components/elements/element-docs.ts
@@ -1313,513 +1313,262 @@ import { ToolTimeline } from "@/components/elements/tool-timeline";
     ],
   },
   composer: {
-    usage: `import { Composer } from "@/components/elements/composer";
+    usage: `import {
+  Composer,
+  ComposerActions,
+  ComposerAttachButton,
+  ComposerBar,
+  ComposerInput,
+  ComposerSend,
+  ComposerToolbar,
+} from "@/components/elements/composer";
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  onSend={send}
-  attachments={[{ name: "notes.md", meta: "12 KB", state: "done" }]}
-  commands={[{ name: "review", description: "Review the diff", icon: SearchIcon }]}
-  people={[{ name: "Mara", role: "human" }]}
-  models={[{ name: "Fable 5", meta: "1M ctx" }]}
-  model={model}
-  onModelChange={setModel}
-  usage={{ system: 12, tools: 8, messages: 54, total: 200 }}
-/>`,
+<Composer>
+  <ComposerBar>
+    <ComposerInput value={value} placeholder="Ask anything" onChange={onChange} onSubmit={send} />
+    <ComposerToolbar>
+      <ComposerActions><ComposerAttachButton onClick={pick} /></ComposerActions>
+      <ComposerActions><ComposerSend streaming={false} idle={!value} onClick={send} /></ComposerActions>
+    </ComposerToolbar>
+  </ComposerBar>
+</Composer>`,
     props: [
       {
         component: "Composer",
         rows: [
           {
-            name: "value",
-            type: "string",
-            required: true,
-            description: "Current draft text in the input field.",
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "The positioning shell. Every facet below is a sibling export you compose in, so a composer with no attachments never carries the attachment code.",
           },
+        ],
+      },
+      {
+        component: "ComposerInput",
+        rows: [
           {
-            name: "onValueChange",
-            type: "(value: string) => void",
-            required: true,
-            description: "Called as the user types.",
-          },
-          {
-            name: "onSend",
+            name: "onSubmit",
             type: "() => void",
-            description: "Called on Enter or the send button.",
+            description:
+              "Called on Enter, guarded against IME composition so accepting a candidate does not send.",
           },
           {
-            name: "onStop",
-            type: "() => void",
-            description: "Called by the stop button while streaming.",
+            name: "...props",
+            type: 'React.ComponentProps<"input">',
+            description: "value, onChange, placeholder and the rest are yours.",
           },
-          {
-            name: "placeholder",
-            type: "string",
-            defaultValue: '"Ask anything"',
-            description: "Placeholder shown when the value is empty.",
-          },
+        ],
+      },
+      {
+        component: "ComposerSend",
+        rows: [
           {
             name: "streaming",
             type: "boolean",
-            defaultValue: "false",
-            description:
-              "When true the send control cross-fades into a stop button.",
+            required: true,
+            description: "Swaps the arrow for a stop square.",
           },
           {
-            name: "attachments",
-            type: "ComposerAttachment[]",
-            description:
-              "Staged files rendered as tiles above the field, with per-file progress.",
-          },
-          {
-            name: "onRemoveAttachment",
-            type: "(name: string) => void",
-            description:
-              "Enables a remove control on attachments that finished uploading.",
-          },
-          {
-            name: "dragActive",
+            name: "idle",
             type: "boolean",
-            defaultValue: "false",
-            description: "Tints the surface while a file hovers over it.",
+            required: true,
+            description:
+              "Whether the input is empty. Dims the button when there is nothing to send.",
           },
+        ],
+      },
+      {
+        component: "useSlashMatches",
+        rows: [
           {
-            name: "commands",
+            name: "(value, commands)",
             type: "ComposerCommand[]",
             description:
-              "Enables the slash menu: it floats above the input while the value starts with /.",
+              "Commands whose name starts with the slash query, or an empty array when the value is not a command. Pair it with ComposerMenu and ComposerCommandItem.",
           },
+        ],
+      },
+      {
+        component: "useMentionMatches",
+        rows: [
           {
-            name: "onCommand",
-            type: "(command: ComposerCommand) => void",
-            description: "Called when a slash command is picked.",
-          },
-          {
-            name: "people",
+            name: "(value, people)",
             type: "ComposerPerson[]",
             description:
-              "Enables the mention menu: it opens while the value ends in an @ token.",
-          },
-          {
-            name: "onMention",
-            type: "(person: ComposerPerson) => void",
-            description:
-              "Called when a person is picked; the token is replaced with their name.",
-          },
-          {
-            name: "models",
-            type: "ComposerModel[]",
-            description: "Enables the model picker in the composer rail.",
-          },
-          {
-            name: "model",
-            type: "string",
-            description: "Name of the active model shown on the rail control.",
-          },
-          {
-            name: "onModelChange",
-            type: "(name: string) => void",
-            description: "Called when a model is picked from the menu.",
-          },
-          {
-            name: "defaultModelMenuOpen",
-            type: "boolean",
-            defaultValue: "false",
-            description: "Opens the model menu on mount.",
-          },
-          {
-            name: "usage",
-            type: "ComposerUsage",
-            description:
-              "Shows a context ring next to the send button; hovering it reveals the breakdown.",
-          },
-          {
-            name: "recording",
-            type: "boolean",
-            defaultValue: "false",
-            description:
-              "Replaces the input with a live waveform and elapsed timer.",
-          },
-          {
-            name: "transcribing",
-            type: "boolean",
-            defaultValue: "false",
-            description: "Shows the transcribing state after recording stops.",
-          },
-          {
-            name: "recordingSeconds",
-            type: "number",
-            defaultValue: "0",
-            description: "Elapsed seconds shown next to the waveform.",
-          },
-          {
-            name: "onVoiceStart",
-            type: "() => void",
-            description:
-              "Shows the mic button in the rail and is called when it is pressed.",
-          },
-          {
-            name: "onVoiceStop",
-            type: "() => void",
-            description: "Called by the stop control while voice is active.",
-          },
-          {
-            name: "className",
-            type: "string",
-            description: "Extra classes merged onto the root.",
+              "People matching a trailing @mention. applyMention(value, name) writes the choice back into the value.",
           },
         ],
       },
     ],
   },
   "composer-slash-commands": {
-    usage: `import { Composer, type ComposerCommand } from "@/components/elements/composer";
+    usage: `import { ComposerMenu, ComposerCommandItem, useSlashMatches } from "@/components/elements/composer";
 
-const commands: ComposerCommand[] = [
-  { name: "review", description: "Review the current diff", icon: SearchIcon },
-  { name: "explain", description: "Explain the selection", icon: BookOpenIcon },
-];
+const matches = useSlashMatches(value, commands);
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  commands={commands}
-  onCommand={(command) => run(command.name)}
-/>`,
+<ComposerMenu open={matches.length > 0}>
+  {matches.map((command, i) => (
+    <ComposerCommandItem key={command.name} command={command} active={i === 0} onClick={() => pick(command)} />
+  ))}
+</ComposerMenu>`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerCommandItem",
         rows: [
           {
-            name: "commands",
-            type: "ComposerCommand[]",
+            name: "command",
+            type: "ComposerCommand",
             required: true,
             description:
-              "Available commands. The menu floats above the input while the value starts with / and filters on the text after it.",
+              "The command to render: its name, description, and icon.",
           },
           {
-            name: "onCommand",
-            type: "(command: ComposerCommand) => void",
+            name: "active",
+            type: "boolean",
+            required: true,
             description:
-              "Called when a command is picked; the input clears afterwards.",
-          },
-        ],
-      },
-      {
-        component: "ComposerCommand",
-        rows: [
-          {
-            name: "name",
-            type: "string",
-            required: true,
-            description: "Command name matched against the typed filter.",
-          },
-          {
-            name: "description",
-            type: "string",
-            required: true,
-            description: "One-line explanation shown next to the name.",
-          },
-          {
-            name: "icon",
-            type: "LucideIcon",
-            required: true,
-            description: "Icon rendered at the start of the row.",
+              "Marks the row that Enter would take. Only the active row shows the return key hint.",
           },
         ],
       },
     ],
   },
   "composer-mentions": {
-    usage: `import { Composer, type ComposerPerson } from "@/components/elements/composer";
+    usage: `import { ComposerMenu, ComposerPersonItem, applyMention, useMentionMatches } from "@/components/elements/composer";
 
-const people: ComposerPerson[] = [
-  { name: "Mara", role: "human" },
-  { name: "Max", role: "agent" },
-];
+const matches = useMentionMatches(value, people);
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  people={people}
-  onMention={(person) => notify(person.name)}
-/>`,
+<ComposerMenu open={matches.length > 0}>
+  {matches.map((person, i) => (
+    <ComposerPersonItem key={person.name} person={person} active={i === 0} onClick={() => onChange(applyMention(value, person.name))} />
+  ))}
+</ComposerMenu>`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerPersonItem",
         rows: [
           {
-            name: "people",
-            type: "ComposerPerson[]",
+            name: "person",
+            type: "ComposerPerson",
             required: true,
-            description:
-              "People and agents available to mention. The menu opens while the value ends in an @ token.",
+            description: "Who to render, with their agent or human role.",
           },
           {
-            name: "onMention",
-            type: "(person: ComposerPerson) => void",
-            description:
-              "Called when a person is picked; the @ token is replaced with their name.",
-          },
-        ],
-      },
-      {
-        component: "ComposerPerson",
-        rows: [
-          {
-            name: "name",
-            type: "string",
+            name: "active",
+            type: "boolean",
             required: true,
-            description: "Display name matched against the typed filter.",
-          },
-          {
-            name: "role",
-            type: '"agent" | "human"',
-            required: true,
-            description: "Role tag shown at the end of the row.",
+            description: "Marks the row Enter would take.",
           },
         ],
       },
     ],
   },
   "composer-attachments": {
-    usage: `import { Composer } from "@/components/elements/composer";
+    usage: `import { ComposerAttachments, ComposerAttachmentChip } from "@/components/elements/composer";
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  attachments={[
-    { name: "design-review.pdf", meta: "2.4 MB", state: "done", kind: "text" },
-    { name: "screens.zip", meta: "Uploading", state: "uploading", progress: 60, kind: "archive" },
-  ]}
-  onRemoveAttachment={(name) => remove(name)}
-/>`,
+<ComposerAttachments>
+  {files.map((file) => (
+    <ComposerAttachmentChip key={file.name} attachment={file} onRemove={drop} />
+  ))}
+</ComposerAttachments>`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerAttachmentChip",
         rows: [
           {
-            name: "attachments",
-            type: "ComposerAttachment[]",
+            name: "attachment",
+            type: "ComposerAttachment",
             required: true,
-            description: "Files staged above the input field.",
+            description:
+              "One staged file. Its state drives the chip: a progress bar while uploading, a remove control once done, red meta on error.",
           },
           {
-            name: "onRemoveAttachment",
+            name: "onRemove",
             type: "(name: string) => void",
             description:
-              "Enables a remove control on attachments that finished uploading.",
-          },
-          {
-            name: "dragActive",
-            type: "boolean",
-            defaultValue: "false",
-            description: "Tints the surface while a file hovers over it.",
-          },
-        ],
-      },
-      {
-        component: "ComposerAttachment",
-        rows: [
-          {
-            name: "name",
-            type: "string",
-            required: true,
-            description: "File name shown on the tile.",
-          },
-          {
-            name: "meta",
-            type: "string",
-            required: true,
-            description: "Secondary line: size, status, or an error message.",
-          },
-          {
-            name: "state",
-            type: '"uploading" | "done" | "error"',
-            required: true,
-            description: "Drives the progress bar, check, or error styling.",
-          },
-          {
-            name: "progress",
-            type: "number",
-            description: "Upload percentage for the bottom progress line.",
-          },
-          {
-            name: "kind",
-            type: '"image" | "text" | "archive"',
-            defaultValue: '"text"',
-            description: "Picks the file icon.",
+              "Called to drop a finished attachment. Omitted, the chip shows a check instead of a remove control.",
           },
         ],
       },
     ],
   },
   "composer-model-picker": {
-    usage: `import { Composer, type ComposerModel } from "@/components/elements/composer";
+    usage: `import { ComposerMenu, ComposerModelItem, ComposerModelTrigger } from "@/components/elements/composer";
 
-const models: ComposerModel[] = [
-  { name: "Fable 5", meta: "1M ctx" },
-  { name: "Haiku 4.5", meta: "200k ctx" },
-];
-
-<Composer
-  value={value}
-  onValueChange={setValue}
-  models={models}
-  model={model}
-  onModelChange={setModel}
-/>`,
+<div className="relative">
+  <ComposerMenu open={open}>
+    {models.map((entry) => (
+      <ComposerModelItem key={entry.name} entry={entry} selected={entry.name === model} onClick={() => choose(entry.name)} />
+    ))}
+  </ComposerMenu>
+  <ComposerModelTrigger model={model} open={open} onClick={toggle} />
+</div>`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerModelItem",
         rows: [
           {
-            name: "models",
-            type: "ComposerModel[]",
+            name: "entry",
+            type: "ComposerModel",
             required: true,
             description:
-              "Available models listed in the menu above the rail control.",
+              "The model and its short meta line, usually the context window.",
           },
           {
-            name: "model",
-            type: "string",
-            required: true,
-            description:
-              "Active model name; shown on the rail control and checked in the menu.",
-          },
-          {
-            name: "onModelChange",
-            type: "(name: string) => void",
-            description:
-              "Called when a model is picked; the menu closes afterwards.",
-          },
-          {
-            name: "defaultModelMenuOpen",
+            name: "selected",
             type: "boolean",
-            defaultValue: "false",
-            description: "Opens the model menu on mount.",
-          },
-        ],
-      },
-      {
-        component: "ComposerModel",
-        rows: [
-          {
-            name: "name",
-            type: "string",
             required: true,
-            description: "Model name shown in the row.",
-          },
-          {
-            name: "meta",
-            type: "string",
-            required: true,
-            description: "Context size or speed note at the end of the row.",
+            description: "Marks the active model with a check.",
           },
         ],
       },
     ],
   },
   "composer-voice": {
-    usage: `import { Composer } from "@/components/elements/composer";
+    usage: `import { ComposerVoice, ComposerVoiceButton } from "@/components/elements/composer";
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  recording={recording}
-  transcribing={transcribing}
-  recordingSeconds={seconds}
-  onVoiceStart={startRecording}
-  onVoiceStop={stopRecording}
-/>`,
+{active
+  ? <ComposerVoice recording={recording} seconds={seconds} />
+  : <ComposerInput value={value} onChange={onChange} />}
+
+<ComposerVoiceButton active={active} onClick={toggle} />`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerVoice",
         rows: [
           {
             name: "recording",
             type: "boolean",
-            defaultValue: "false",
+            required: true,
             description:
-              "Replaces the input with a live waveform and elapsed timer.",
+              "Live capture. False renders the transcribing state instead, with a settled waveform.",
           },
           {
-            name: "transcribing",
-            type: "boolean",
-            defaultValue: "false",
-            description:
-              "Holds the waveform in a settling state after recording stops.",
-          },
-          {
-            name: "recordingSeconds",
+            name: "seconds",
             type: "number",
-            defaultValue: "0",
+            required: true,
             description:
-              "Elapsed seconds shown next to the waveform; also animates the bars.",
-          },
-          {
-            name: "onVoiceStart",
-            type: "() => void",
-            description:
-              "Shows the mic button in the rail and is called when it is pressed.",
-          },
-          {
-            name: "onVoiceStop",
-            type: "() => void",
-            description: "Called by the stop control while voice is active.",
+              "Elapsed capture time. Also drives the waveform, so the bars move with the clock.",
           },
         ],
       },
     ],
   },
   "composer-context": {
-    usage: `import { Composer } from "@/components/elements/composer";
+    usage: `import { ComposerContext } from "@/components/elements/composer";
 
-<Composer
-  value={value}
-  onValueChange={setValue}
-  usage={{ system: 24, tools: 12, messages: 142, total: 200 }}
-/>`,
+<ComposerContext usage={{ system: 12, tools: 8, messages: 54, total: 200 }} />`,
     props: [
       {
-        component: "Composer",
+        component: "ComposerContext",
         rows: [
           {
             name: "usage",
             type: "ComposerUsage",
             required: true,
             description:
-              "Renders a ring next to the send button. The numbers stay hidden until hover, which reveals the segmented breakdown; everything turns red past 85% of the window.",
-          },
-        ],
-      },
-      {
-        component: "ComposerUsage",
-        rows: [
-          {
-            name: "system",
-            type: "number",
-            required: true,
-            description: "Tokens held by the system prompt, in thousands.",
-          },
-          {
-            name: "tools",
-            type: "number",
-            required: true,
-            description: "Tokens held by tool definitions, in thousands.",
-          },
-          {
-            name: "messages",
-            type: "number",
-            required: true,
-            description: "Tokens held by the conversation, in thousands.",
-          },
-          {
-            name: "total",
-            type: "number",
-            required: true,
-            description: "Context window size, in thousands.",
+              "System, tools, and message tokens against the total. The ring fills from their sum and turns red past 85 percent; a zero total is treated as zero rather than dividing by it.",
           },
         ],
       },
@@ -1827,95 +1576,143 @@ const models: ComposerModel[] = [
   },
 
   "chat-panel": {
-    usage: `import { ChatPanel } from "@/components/elements/chat-panel";
+    usage: `import {
+  ChatPanel,
+  ChatPanelComposer,
+  ChatPanelMessages,
+  ChatPanelTyping,
+  ChatPanelUserMessage,
+} from "@/components/elements/chat-panel";
 
-<ChatPanel
-  userMessage="What is a runtime?"
-  reply="A runtime owns thread state and tools."
-  showUserMessage
-  typing={false}
-  visibleWords={6}
-  streaming
-/>`,
+<ChatPanel>
+  <ChatPanelMessages>
+    <ChatPanelUserMessage>Why did my draft disappear?</ChatPanelUserMessage>
+    <ChatPanelTyping />
+  </ChatPanelMessages>
+  <ChatPanelComposer placeholder="Message" onSend={send} />
+</ChatPanel>`,
     props: [
       {
         component: "ChatPanel",
         rows: [
           {
-            name: "userMessage",
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "The panel is a shell: a scrolling message area and a composer bar. What goes in either one is yours, so a real thread renders as many turns as it has.",
+          },
+          {
+            name: "...props",
+            type: 'React.ComponentProps<"div">',
+            description: "Spread onto the root, as on every part below.",
+          },
+        ],
+      },
+      {
+        component: "ChatPanelMessages",
+        rows: [
+          {
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "Turns, oldest first. The area is bottom-aligned and scrolls, so the newest turn stays in view.",
+          },
+        ],
+      },
+      {
+        component: "ChatPanelAssistantMessage",
+        rows: [
+          {
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "A settled assistant turn. For a streaming one, drop the streaming-text element in here instead; it renders its own paragraph.",
+          },
+        ],
+      },
+      {
+        component: "ChatPanelComposer",
+        rows: [
+          {
+            name: "placeholder",
             type: "string",
             required: true,
-            description: "User bubble text shown when showUserMessage is true.",
+            description: "Resting text in the input bar.",
           },
           {
-            name: "reply",
-            type: "string",
-            required: true,
+            name: "onSend",
+            type: "() => void",
             description:
-              "Full assistant reply that is sliced into streaming words.",
-          },
-          {
-            name: "showUserMessage",
-            type: "boolean",
-            required: true,
-            description: "Whether the user bubble is visible yet.",
-          },
-          {
-            name: "typing",
-            type: "boolean",
-            required: true,
-            description:
-              "When true a typing row is shown before the reply starts.",
-          },
-          {
-            name: "visibleWords",
-            type: "number",
-            required: true,
-            description: "How many words of the reply are currently visible.",
-          },
-          {
-            name: "streaming",
-            type: "boolean",
-            required: true,
-            description:
-              "When true the newest reply words tint as they arrive.",
-          },
-          {
-            name: "className",
-            type: "string",
-            description: "Extra classes merged onto the root.",
+              "Called from the send control. Omit it and the control renders disabled.",
           },
         ],
       },
     ],
   },
   "empty-state": {
-    usage: `import { EmptyState } from "@/components/elements/empty-state";
+    usage: `import {
+  EmptyState,
+  EmptyStateComposer,
+  EmptyStateGreeting,
+  EmptyStateSuggestion,
+  EmptyStateSuggestions,
+} from "@/components/elements/empty-state";
 
-<EmptyState
-  greeting="What are we working on?"
-  suggestions={["Draft an RFC", "Debug a test"]}
-/>`,
+<EmptyState>
+  <EmptyStateGreeting>What are we building?</EmptyStateGreeting>
+  <EmptyStateSuggestions>
+    {items.map((item, i) => (
+      <EmptyStateSuggestion key={item} index={i} onClick={() => send(item)}>
+        {item}
+      </EmptyStateSuggestion>
+    ))}
+  </EmptyStateSuggestions>
+  <EmptyStateComposer placeholder="Ask anything" onSend={send} />
+</EmptyState>`,
     props: [
       {
         component: "EmptyState",
         rows: [
           {
-            name: "greeting",
-            type: "string",
-            required: true,
-            description: "Centered headline shown above the suggestion chips.",
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "A centered column. Compose the greeting, the suggestions, and your own composer, or leave any of them out.",
+          },
+        ],
+      },
+      {
+        component: "EmptyStateSuggestion",
+        rows: [
+          {
+            name: "index",
+            type: "number",
+            defaultValue: "0",
+            description:
+              "Position in the row. Staggers the entrance so the pills arrive in order.",
           },
           {
-            name: "suggestions",
-            type: "readonly string[]",
+            name: "...props",
+            type: 'React.ComponentProps<"button">',
+            description:
+              "Spread onto the button, so onClick and the rest are yours.",
+          },
+        ],
+      },
+      {
+        component: "EmptyStateComposer",
+        rows: [
+          {
+            name: "placeholder",
+            type: "string",
             required: true,
-            description: "Starter chips that offer ways into the first turn.",
+            description: "Resting text in the input bar.",
           },
           {
-            name: "className",
-            type: "string",
-            description: "Extra classes merged onto the root.",
+            name: "onSend",
+            type: "() => void",
+            description:
+              "Called from the send control. Omit it and the control renders disabled.",
           },
         ],
       },
@@ -2650,32 +2447,59 @@ const models: ComposerModel[] = [
     ],
   },
   "canvas-split": {
-    usage: `import { CanvasSplit } from "@/components/elements/canvas-split";
+    usage: `import {
+  CanvasSplit,
+  CanvasSplitBody,
+  CanvasSplitDocument,
+  CanvasSplitHeader,
+  CanvasSplitLine,
+  CanvasSplitMessage,
+  CanvasSplitThread,
+} from "@/components/elements/canvas-split";
 
-<CanvasSplit
-  messages={messages}
-  title="migration-0.14.md"
-  version={3}
-  lines={lines}
-  visibleLines={lines.length}
-  saved
-/>`,
+<CanvasSplit>
+  <CanvasSplitThread>
+    <CanvasSplitMessage role="user">Draft the note</CanvasSplitMessage>
+  </CanvasSplitThread>
+  <CanvasSplitDocument>
+    <CanvasSplitHeader title="note.md" version={3} saved onCopy={copy} />
+    <CanvasSplitBody writing>
+      <CanvasSplitLine heading>Migrating to 0.14</CanvasSplitLine>
+    </CanvasSplitBody>
+  </CanvasSplitDocument>
+</CanvasSplit>`,
     props: [
       {
         component: "CanvasSplit",
         rows: [
           {
-            name: "messages",
-            type: "CanvasMessage[]",
+            name: "children",
+            type: "React.ReactNode",
+            description:
+              "Two panes: the thread rail and the document. Both are slots, so the document side can hold an editor rather than the text lines shown here.",
+          },
+        ],
+      },
+      {
+        component: "CanvasSplitMessage",
+        rows: [
+          {
+            name: "role",
+            type: '"user" | "assistant"',
             required: true,
             description:
-              "The thread, compressed into the side rail while the document holds the room.",
+              "User turns sit right in a bubble, assistant turns run flush left. Also emitted as data-role for styling from outside.",
           },
+        ],
+      },
+      {
+        component: "CanvasSplitHeader",
+        rows: [
           {
             name: "title",
             type: "string",
             required: true,
-            description: "Document name in the canvas header.",
+            description: "Document name.",
           },
           {
             name: "version",
@@ -2684,40 +2508,44 @@ const models: ComposerModel[] = [
             description: "Which revision is on screen.",
           },
           {
-            name: "lines",
-            type: "string[]",
-            required: true,
-            description:
-              "Document body, one paragraph per entry. A leading # marks a heading.",
-          },
-          {
-            name: "visibleLines",
-            type: "number",
-            required: true,
-            description:
-              "How much has been written. A caret trails the last line until this reaches the end.",
-          },
-          {
             name: "saved",
             type: "boolean",
             required: true,
-            description: "Swaps the header status between editing and saved.",
+            description: "Swaps the status between editing and saved.",
           },
           {
             name: "onCopy",
             type: "() => void",
             description:
-              "Called from the copy action. Omit it and the control renders disabled rather than promising a copy it cannot make.",
+              "Called from the copy action. Omit it and the control renders disabled.",
           },
           {
             name: "onClose",
             type: "() => void",
             description: "Called when the canvas is dismissed.",
           },
+        ],
+      },
+      {
+        component: "CanvasSplitBody",
+        rows: [
           {
-            name: "className",
-            type: "string",
-            description: "Extra classes merged onto the root.",
+            name: "writing",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Trails a caret after the last line while the document is still being written.",
+          },
+        ],
+      },
+      {
+        component: "CanvasSplitLine",
+        rows: [
+          {
+            name: "heading",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Renders the line as a heading rather than body text.",
           },
         ],
       },
@@ -5617,12 +5445,18 @@ const models: ComposerModel[] = [
             type: "string",
             required: true,
             description:
-              "Which row is highlighted. The element only styles it; wire your own arrow-key and Enter handling and drive this prop from it.",
+              "Which row is highlighted. Arrow keys move it and Enter runs it, both handled by the element; it reports the move through onActiveChange.",
           },
           {
             name: "onQueryChange",
             type: "(query: string) => void",
             description: "Called as the filter is typed.",
+          },
+          {
+            name: "onActiveChange",
+            type: "(id: string) => void",
+            description:
+              "Called as the arrow keys walk the list. The element owns the key handling and reports where it landed, so activeId stays yours to hold.",
           },
           {
             name: "onRun",

--- a/apps/docs/components/elements/empty-state-demo.tsx
+++ b/apps/docs/components/elements/empty-state-demo.tsx
@@ -1,17 +1,31 @@
 "use client";
 
-import { EmptyState } from "@/components/elements/empty-state";
+import {
+  EmptyState,
+  EmptyStateComposer,
+  EmptyStateGreeting,
+  EmptyStateSuggestion,
+  EmptyStateSuggestions,
+} from "@/components/elements/empty-state";
 
 const SUGGESTIONS = [
-  "Explain the runtime layers",
-  "Draft a migration plan",
-  "Review my composer code",
-];
+  "Explain this repo",
+  "Find a bug",
+  "Write a migration",
+] as const;
 
 export function EmptyStateDemo() {
   return (
-    <div className="flex w-full justify-center">
-      <EmptyState greeting="Where should we start?" suggestions={SUGGESTIONS} />
-    </div>
+    <EmptyState>
+      <EmptyStateGreeting>What are we building?</EmptyStateGreeting>
+      <EmptyStateSuggestions>
+        {SUGGESTIONS.map((suggestion, i) => (
+          <EmptyStateSuggestion key={suggestion} index={i}>
+            {suggestion}
+          </EmptyStateSuggestion>
+        ))}
+      </EmptyStateSuggestions>
+      <EmptyStateComposer placeholder="Ask anything" onSend={() => undefined} />
+    </EmptyState>
   );
 }

--- a/apps/docs/components/elements/prompt-library-demo.tsx
+++ b/apps/docs/components/elements/prompt-library-demo.tsx
@@ -38,6 +38,7 @@ export function PromptLibraryDemo() {
       selectedId={selectedId}
       onQueryChange={setQuery}
       onSelect={setSelectedId}
+      onInsert={setSelectedId}
     />
   );
 }

--- a/packages/ui/src/components/elements/activity-graph.tsx
+++ b/packages/ui/src/components/elements/activity-graph.tsx
@@ -21,7 +21,10 @@ export function ActivityGraph({
   total,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "data" | "start" | "end" | "title" | "total"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "data" | "start" | "end" | "title" | "total"
+> & {
   data: readonly HeatGraph.DataPoint[];
   start: string | Date;
   end: string | Date;

--- a/packages/ui/src/components/elements/activity-graph.tsx
+++ b/packages/ui/src/components/elements/activity-graph.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import * as HeatGraph from "heat-graph";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -19,21 +20,24 @@ export function ActivityGraph({
   title,
   total,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "data" | "start" | "end" | "title" | "total"> & {
   data: readonly HeatGraph.DataPoint[];
   start: string | Date;
   end: string | Date;
   title: string;
   total: string;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="activity-graph"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">{title}</span>

--- a/packages/ui/src/components/elements/agent-card.tsx
+++ b/packages/ui/src/components/elements/agent-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { BotIcon, CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
@@ -20,7 +21,19 @@ export function AgentCard({
   connected,
   onConnect,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "name"
+  | "description"
+  | "provider"
+  | "version"
+  | "model"
+  | "endpoint"
+  | "skills"
+  | "connected"
+  | "onConnect"
+> & {
   name: string;
   description: string;
   provider: string;
@@ -30,15 +43,17 @@ export function AgentCard({
   skills: readonly AgentSkill[];
   connected: boolean;
   onConnect?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="agent-card"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3.5 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-start gap-3">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-9 shrink-0 items-center justify-center rounded-xl">

--- a/packages/ui/src/components/elements/agent-card.tsx
+++ b/packages/ui/src/components/elements/agent-card.tsx
@@ -24,6 +24,7 @@ export function AgentCard({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "name"
   | "description"
   | "provider"

--- a/packages/ui/src/components/elements/agent-handoff.tsx
+++ b/packages/ui/src/components/elements/agent-handoff.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowRightIcon, BotIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
@@ -11,16 +12,24 @@ export function AgentHandoff({
   carried,
   settled,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "from" | "to" | "reason" | "carried" | "settled"
+> & {
   from: string;
   to: string;
   reason: string;
   carried: readonly string[];
   settled: boolean;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="agent-handoff"
+      className={cn("flex w-full max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       <div className="flex items-center gap-2">
         <span
           className={cn(

--- a/packages/ui/src/components/elements/agent-handoff.tsx
+++ b/packages/ui/src/components/elements/agent-handoff.tsx
@@ -15,7 +15,7 @@ export function AgentHandoff({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "from" | "to" | "reason" | "carried" | "settled"
+  "children" | "from" | "to" | "reason" | "carried" | "settled"
 > & {
   from: string;
   to: string;

--- a/packages/ui/src/components/elements/agent-plan.tsx
+++ b/packages/ui/src/components/elements/agent-plan.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
@@ -8,10 +9,10 @@ export function AgentPlan({
   steps,
   activeIndex,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "steps" | "activeIndex"> & {
   steps: readonly string[];
   activeIndex: number;
-  className?: string;
 }) {
   const total = steps.length;
   const allDone = activeIndex >= total;
@@ -19,7 +20,12 @@ export function AgentPlan({
   const progress = total === 0 ? 0 : (completed / total) * 100;
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-3", className)}>
+    <div
+      data-slot="agent-plan"
+      className={cn("flex w-full max-w-sm flex-col gap-3", className)}
+
+      {...props}
+    >
       <div className="flex items-center justify-between">
         <span className="text-[13.5px] font-medium">Plan</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>

--- a/packages/ui/src/components/elements/agent-plan.tsx
+++ b/packages/ui/src/components/elements/agent-plan.tsx
@@ -10,7 +10,7 @@ export function AgentPlan({
   activeIndex,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "steps" | "activeIndex"> & {
+}: Omit<ComponentProps<"div">, "children" | "steps" | "activeIndex"> & {
   steps: readonly string[];
   activeIndex: number;
 }) {

--- a/packages/ui/src/components/elements/agent-status.tsx
+++ b/packages/ui/src/components/elements/agent-status.tsx
@@ -18,7 +18,7 @@ export function AgentStatus({
   elapsed,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "state" | "label" | "elapsed"> & {
+}: Omit<ComponentProps<"div">, "children" | "state" | "label" | "elapsed"> & {
   state: AgentState;
   label: string;
   elapsed?: string;

--- a/packages/ui/src/components/elements/agent-status.tsx
+++ b/packages/ui/src/components/elements/agent-status.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, PauseIcon, RotateCcwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -16,19 +17,22 @@ export function AgentStatus({
   label,
   elapsed,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "state" | "label" | "elapsed"> & {
   state: AgentState;
   label: string;
   elapsed?: string;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="agent-status"
       className={cn(
         paper,
         "flex items-center gap-2.5 rounded-full py-1.5 ps-3.5 pe-1.5",
         className,
       )}
+
+      {...props}
     >
       {state === "done" ? (
         <CheckIcon aria-hidden className="size-3 shrink-0 text-emerald-500" />

--- a/packages/ui/src/components/elements/approval-card.tsx
+++ b/packages/ui/src/components/elements/approval-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon, TerminalIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, paper } from "./surfaces";
@@ -15,7 +16,17 @@ export function ApprovalCard({
   onAlwaysAllow,
   onDeny,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "state"
+  | "command"
+  | "title"
+  | "subtitle"
+  | "onAllowOnce"
+  | "onAlwaysAllow"
+  | "onDeny"
+> & {
   state: ApprovalState;
   command: string;
   title: string;
@@ -23,15 +34,17 @@ export function ApprovalCard({
   onAllowOnce?: () => void;
   onAlwaysAllow?: () => void;
   onDeny?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="approval-card"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3.5 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-3">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-9 shrink-0 items-center justify-center rounded-xl">

--- a/packages/ui/src/components/elements/approval-card.tsx
+++ b/packages/ui/src/components/elements/approval-card.tsx
@@ -19,6 +19,7 @@ export function ApprovalCard({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "state"
   | "command"
   | "title"

--- a/packages/ui/src/components/elements/artifact-card.tsx
+++ b/packages/ui/src/components/elements/artifact-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowUpRightIcon, FileTextIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -10,20 +11,23 @@ export function ArtifactCard({
   generating = false,
   words = 0,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "title" | "meta" | "generating" | "words"> & {
   title: string;
   meta: string;
   generating?: boolean;
   words?: number;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="artifact-card"
       className={cn(
         paper,
         "group flex w-full max-w-xs cursor-pointer items-center gap-3 rounded-[20px] p-3.5 transition-transform duration-150 hover:-translate-y-px active:scale-[0.98]",
         className,
       )}
+
+      {...props}
     >
       <span className="bg-foreground/[0.05] text-foreground/45 flex size-9 shrink-0 items-center justify-center rounded-xl">
         <FileTextIcon

--- a/packages/ui/src/components/elements/artifact-card.tsx
+++ b/packages/ui/src/components/elements/artifact-card.tsx
@@ -12,7 +12,10 @@ export function ArtifactCard({
   words = 0,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "title" | "meta" | "generating" | "words"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "title" | "meta" | "generating" | "words"
+> & {
   title: string;
   meta: string;
   generating?: boolean;

--- a/packages/ui/src/components/elements/background-inbox.tsx
+++ b/packages/ui/src/components/elements/background-inbox.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -18,21 +19,24 @@ export function BackgroundInbox({
   runs,
   onCollect,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "runs" | "onCollect"> & {
   runs: readonly BackgroundRun[];
   onCollect?: (id: string) => void;
-  className?: string;
 }) {
   const ready = runs.filter((run) => run.state === "ready").length;
   const running = runs.filter((run) => run.state === "running").length;
 
   return (
     <div
+      data-slot="background-inbox"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-1 rounded-2xl p-3",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between px-1 pb-1">
         <span className="text-[13.5px] font-medium">Running elsewhere</span>

--- a/packages/ui/src/components/elements/background-inbox.tsx
+++ b/packages/ui/src/components/elements/background-inbox.tsx
@@ -20,7 +20,7 @@ export function BackgroundInbox({
   onCollect,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "runs" | "onCollect"> & {
+}: Omit<ComponentProps<"div">, "children" | "runs" | "onCollect"> & {
   runs: readonly BackgroundRun[];
   onCollect?: (id: string) => void;
 }) {

--- a/packages/ui/src/components/elements/canvas-split.tsx
+++ b/packages/ui/src/components/elements/canvas-split.tsx
@@ -36,17 +36,17 @@ export function CanvasSplitThread({
 }
 
 export function CanvasSplitMessage({
-  role,
+  speaker,
   className,
   ...props
-}: ComponentProps<"div"> & { role: "user" | "assistant" }) {
+}: ComponentProps<"div"> & { speaker: "user" | "assistant" }) {
   return (
     <div
       data-slot="canvas-split-message"
-      data-role={role}
+      data-speaker={speaker}
       className={cn(
         "fade-in animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
-        role === "user"
+        speaker === "user"
           ? cn(field, "text-foreground/80 ml-auto rounded-2xl px-3 py-2")
           : "text-foreground/60",
         className,

--- a/packages/ui/src/components/elements/canvas-split.tsx
+++ b/packages/ui/src/components/elements/canvas-split.tsx
@@ -1,135 +1,191 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, CopyIcon, FileTextIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
 
-export interface CanvasMessage {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-}
-
-export function CanvasSplit({
-  messages,
-  title,
-  version,
-  lines,
-  visibleLines,
-  saved,
-  onCopy,
-  onClose,
-  className,
-}: {
-  messages: readonly CanvasMessage[];
-  title: string;
-  version: number;
-  lines: readonly string[];
-  visibleLines: number;
-  saved: boolean;
-  onCopy?: () => void;
-  onClose?: () => void;
-  className?: string;
-}) {
+export function CanvasSplit({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
+      data-slot="canvas-split"
       className={cn(
         paper,
         "flex w-full max-w-3xl flex-col overflow-hidden rounded-[20px] md:h-80 md:flex-row",
         className,
       )}
+      {...props}
+    />
+  );
+}
+
+export function CanvasSplitThread({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="canvas-split-thread"
+      className={cn(
+        "border-foreground/[0.07] flex flex-col gap-3 border-b p-4 md:w-[15rem] md:shrink-0 md:overflow-y-auto md:border-r md:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CanvasSplitMessage({
+  role,
+  className,
+  ...props
+}: ComponentProps<"div"> & { role: "user" | "assistant" }) {
+  return (
+    <div
+      data-slot="canvas-split-message"
+      data-role={role}
+      className={cn(
+        "fade-in animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
+        role === "user"
+          ? cn(field, "text-foreground/80 ml-auto rounded-2xl px-3 py-2")
+          : "text-foreground/60",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CanvasSplitDocument({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="canvas-split-document"
+      className={cn("flex min-w-0 flex-1 flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+export function CanvasSplitHeader({
+  title,
+  version,
+  saved,
+  onCopy,
+  onClose,
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "children" | "title"> & {
+  title: string;
+  version: number;
+  saved: boolean;
+  onCopy?: () => void;
+  onClose?: () => void;
+}) {
+  return (
+    <div
+      data-slot="canvas-split-header"
+      className={cn(
+        "border-foreground/[0.07] flex items-center gap-2 border-b px-3.5 py-2.5",
+        className,
+      )}
+      {...props}
     >
-      <div className="border-foreground/[0.07] flex flex-col gap-3 border-b p-4 md:w-[15rem] md:shrink-0 md:overflow-y-auto md:border-r md:border-b-0">
-        {messages.map((message) => (
-          <div
-            key={message.id}
-            className={cn(
-              "fade-in animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
-              message.role === "user"
-                ? cn(field, "text-foreground/80 ml-auto rounded-2xl px-3 py-2")
-                : "text-foreground/60",
-            )}
-          >
-            {message.text}
-          </div>
-        ))}
-      </div>
-
-      <div className="flex min-w-0 flex-1 flex-col">
-        <div className="border-foreground/[0.07] flex items-center gap-2 border-b px-3.5 py-2.5">
-          <FileTextIcon className="text-foreground/35 size-3.5 shrink-0" />
-          <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
-            {title}
+      <FileTextIcon className="text-foreground/35 size-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
+        {title}
+      </span>
+      <span className={cn(mono, "text-foreground/30 shrink-0")}>
+        v{version}
+      </span>
+      <span
+        className={cn(
+          mono,
+          "shrink-0 transition-colors duration-300",
+          saved
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-foreground/30",
+        )}
+      >
+        {saved ? (
+          <span className="flex items-center gap-1">
+            <CheckIcon className="size-3" />
+            saved
           </span>
-          <span className={cn(mono, "text-foreground/30 shrink-0")}>
-            v{version}
-          </span>
-          <span
-            className={cn(
-              mono,
-              "shrink-0 transition-colors duration-300",
-              saved
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-foreground/30",
-            )}
-          >
-            {saved ? (
-              <span className="flex items-center gap-1">
-                <CheckIcon className="size-3" />
-                saved
-              </span>
-            ) : (
-              "editing"
-            )}
-          </span>
-          <button
-            type="button"
-            aria-label={`Copy ${title}`}
-            onClick={onCopy}
-            disabled={!onCopy}
-            className={cn(
-              ghostButton,
-              "size-7 shrink-0 disabled:pointer-events-none disabled:opacity-30",
-            )}
-          >
-            <CopyIcon className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            aria-label="Close the canvas"
-            onClick={onClose}
-            disabled={!onClose}
-            className={cn(
-              ghostButton,
-              "size-7 shrink-0 disabled:pointer-events-none disabled:opacity-30",
-            )}
-          >
-            <XIcon className="size-3.5" />
-          </button>
-        </div>
-
-        <div className="flex min-h-[9rem] flex-1 flex-col gap-1.5 overflow-y-auto p-4">
-          {lines.slice(0, visibleLines).map((line, i) => (
-            <p
-              key={`${i}-${line}`}
-              className={cn(
-                "fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
-                line.startsWith("#")
-                  ? "text-foreground/95 font-medium"
-                  : "text-foreground/65",
-              )}
-            >
-              {line.replace(/^#\s*/, "")}
-            </p>
-          ))}
-          {visibleLines < lines.length && (
-            <span
-              aria-hidden
-              className="bg-foreground/70 h-[1.05em] w-[2px] animate-pulse rounded-full motion-reduce:animate-none"
-            />
-          )}
-        </div>
-      </div>
+        ) : (
+          "editing"
+        )}
+      </span>
+      <button
+        type="button"
+        aria-label={`Copy ${title}`}
+        onClick={onCopy}
+        disabled={!onCopy}
+        className={cn(
+          ghostButton,
+          "size-7 shrink-0 disabled:pointer-events-none disabled:opacity-30",
+        )}
+      >
+        <CopyIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close the canvas"
+        onClick={onClose}
+        disabled={!onClose}
+        className={cn(
+          ghostButton,
+          "size-7 shrink-0 disabled:pointer-events-none disabled:opacity-30",
+        )}
+      >
+        <XIcon className="size-3.5" />
+      </button>
     </div>
+  );
+}
+
+export function CanvasSplitBody({
+  writing,
+  className,
+  children,
+  ...props
+}: ComponentProps<"div"> & { writing?: boolean }) {
+  return (
+    <div
+      data-slot="canvas-split-body"
+      className={cn(
+        "flex min-h-[9rem] flex-1 flex-col gap-1.5 overflow-y-auto p-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {writing && (
+        <span
+          aria-hidden
+          className="bg-foreground/70 h-[1.05em] w-[2px] animate-pulse rounded-full motion-reduce:animate-none"
+        />
+      )}
+    </div>
+  );
+}
+
+export function CanvasSplitLine({
+  heading,
+  className,
+  ...props
+}: ComponentProps<"p"> & { heading?: boolean }) {
+  return (
+    <p
+      data-slot="canvas-split-line"
+      className={cn(
+        "fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
+        heading ? "text-foreground/95 font-medium" : "text-foreground/65",
+        className,
+      )}
+      {...props}
+    />
   );
 }

--- a/packages/ui/src/components/elements/canvas-split.tsx
+++ b/packages/ui/src/components/elements/canvas-split.tsx
@@ -47,7 +47,7 @@ export function CanvasSplitMessage({
       className={cn(
         "fade-in animate-in fill-mode-both text-[13px] leading-relaxed duration-300",
         speaker === "user"
-          ? cn(field, "text-foreground/80 ml-auto rounded-2xl px-3 py-2")
+          ? cn(field, "text-foreground/80 ms-auto rounded-2xl px-3 py-2")
           : "text-foreground/60",
         className,
       )}

--- a/packages/ui/src/components/elements/chart.tsx
+++ b/packages/ui/src/components/elements/chart.tsx
@@ -28,7 +28,13 @@ export function Chart({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "label" | "value" | "delta" | "points" | "visibleCount" | "variant"
+  | "children"
+  | "label"
+  | "value"
+  | "delta"
+  | "points"
+  | "visibleCount"
+  | "variant"
 > & {
   label: string;
   value: string;

--- a/packages/ui/src/components/elements/chart.tsx
+++ b/packages/ui/src/components/elements/chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -24,14 +25,17 @@ export function Chart({
   visibleCount,
   variant = "area",
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "label" | "value" | "delta" | "points" | "visibleCount" | "variant"
+> & {
   label: string;
   value: string;
   delta?: string;
   points: readonly number[];
   visibleCount: number;
   variant?: ChartVariant;
-  className?: string;
 }) {
   const shown = points.slice(0, Math.max(1, visibleCount));
   const y = scale(points);
@@ -50,11 +54,14 @@ export function Chart({
 
   return (
     <div
+      data-slot="chart"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between">
         <span className={cn(mono, "text-foreground/35")}>{label}</span>

--- a/packages/ui/src/components/elements/chat-panel.tsx
+++ b/packages/ui/src/components/elements/chat-panel.tsx
@@ -71,7 +71,7 @@ export function ChatPanelAssistantMessage({
 export function ChatPanelTyping({
   className,
   ...props
-}: ComponentProps<"div">) {
+}: Omit<ComponentProps<"div">, "children">) {
   return (
     <div
       data-slot="chat-panel-typing"

--- a/packages/ui/src/components/elements/chat-panel.tsx
+++ b/packages/ui/src/components/elements/chat-panel.tsx
@@ -1,106 +1,130 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowUpIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, paper } from "./surfaces";
 
-export interface ChatPanelProps {
-  userMessage: string;
-  reply: string;
-  showUserMessage: boolean;
-  typing: boolean;
-  visibleWords: number;
-  streaming: boolean;
-  className?: string;
-}
-
-export function ChatPanel({
-  userMessage,
-  reply,
-  showUserMessage,
-  typing,
-  visibleWords,
-  streaming,
-  className,
-}: ChatPanelProps) {
-  const words = reply.split(" ");
-
+export function ChatPanel({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
+      data-slot="chat-panel"
       className={cn(
         paper,
         "flex h-[270px] w-full max-w-md flex-col overflow-hidden rounded-[24px]",
         className,
       )}
+      {...props}
+    />
+  );
+}
+
+export function ChatPanelMessages({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="chat-panel-messages"
+      className={cn(
+        "flex flex-1 flex-col justify-end gap-2.5 overflow-y-auto p-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ChatPanelUserMessage({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="chat-panel-user-message"
+      className={cn(
+        field,
+        "fade-in slide-in-from-bottom-1 animate-in self-end rounded-2xl px-3 py-1.5 text-xs duration-300",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ChatPanelAssistantMessage({
+  className,
+  ...props
+}: ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="chat-panel-assistant-message"
+      className={cn(
+        "text-foreground/70 max-w-[85%] self-start text-xs leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ChatPanelTyping({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="chat-panel-typing"
+      className={cn(
+        "fade-in animate-in flex gap-1 self-start px-1 duration-300",
+        className,
+      )}
+      {...props}
     >
-      <div className="flex flex-1 flex-col justify-end gap-2.5 overflow-hidden p-4">
-        {showUserMessage && (
-          <div
-            className={cn(
-              field,
-              "fade-in slide-in-from-bottom-1 animate-in self-end rounded-2xl px-3 py-1.5 text-xs duration-300",
-            )}
-          >
-            {userMessage}
-          </div>
-        )}
-        {typing && (
-          <div className="fade-in animate-in flex gap-1 self-start px-1 duration-300">
-            {["-0.32s", "-0.16s", "0s"].map((delay) => (
-              <span
-                key={delay}
-                aria-hidden
-                className="bg-foreground/40 size-1 animate-bounce rounded-full motion-reduce:animate-none"
-                style={{ animationDelay: delay, animationDuration: "1.1s" }}
-              />
-            ))}
-          </div>
-        )}
-        {visibleWords > 0 && (
-          <p className="text-foreground/70 max-w-[85%] self-start text-xs leading-relaxed">
-            {words.slice(0, visibleWords).map((word, i) => {
-              const fresh = streaming && visibleWords - 1 - i < 2;
-              return (
-                <span
-                  key={i}
-                  className="fade-in animate-in fill-mode-both duration-500 motion-reduce:animate-none"
-                >
-                  <span
-                    className={cn(
-                      "transition-colors duration-700 motion-reduce:transition-none",
-                      fresh && "text-blue-500 dark:text-blue-400",
-                    )}
-                  >
-                    {word}
-                  </span>{" "}
-                </span>
-              );
-            })}
-            {streaming && (
-              <span
-                aria-hidden
-                className="-mb-0.5 ml-0.5 inline-block h-3 w-0.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
-              />
-            )}
-          </p>
-        )}
-      </div>
-      <div
+      {["-0.32s", "-0.16s", "0s"].map((delay) => (
+        <span
+          key={delay}
+          aria-hidden
+          className="bg-foreground/40 size-1 animate-bounce rounded-full motion-reduce:animate-none"
+          style={{ animationDelay: delay, animationDuration: "1.1s" }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ChatPanelComposer({
+  placeholder,
+  onSend,
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "children"> & {
+  placeholder: string;
+  onSend?: () => void;
+}) {
+  return (
+    <div
+      data-slot="chat-panel-composer"
+      className={cn(
+        field,
+        "mx-3 mb-3 flex h-10 shrink-0 items-center justify-between rounded-full py-1.5 ps-4 pe-1.5",
+        className,
+      )}
+      {...props}
+    >
+      <span className="text-foreground/35 text-[13px]">{placeholder}</span>
+      <button
+        type="button"
+        aria-label="Send"
+        onClick={onSend}
+        disabled={!onSend}
         className={cn(
-          field,
-          "mx-3 mb-3 flex h-10 shrink-0 items-center justify-between rounded-full py-1.5 ps-4 pe-1.5",
+          inkButton,
+          "flex size-7 items-center justify-center rounded-full disabled:pointer-events-none disabled:opacity-30",
         )}
       >
-        <span className="text-foreground/35 text-[13px]">Message</span>
-        <span
-          className={cn(
-            inkButton,
-            "flex size-7 items-center justify-center rounded-full",
-          )}
-        >
-          <ArrowUpIcon className="size-3.5" />
-        </span>
-      </div>
+        <ArrowUpIcon className="size-3.5" />
+      </button>
     </div>
   );
 }

--- a/packages/ui/src/components/elements/chat-panel.tsx
+++ b/packages/ui/src/components/elements/chat-panel.tsx
@@ -98,7 +98,7 @@ export function ChatPanelComposer({
   onSend,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "children"> & {
+}: Omit<ComponentProps<"div">, "children" | "placeholder"> & {
   placeholder: string;
   onSend?: () => void;
 }) {

--- a/packages/ui/src/components/elements/checkpoint-history.tsx
+++ b/packages/ui/src/components/elements/checkpoint-history.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { RotateCcwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -16,11 +17,11 @@ export function CheckpointHistory({
   currentId,
   onRestore,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "checkpoints" | "currentId" | "onRestore"> & {
   checkpoints: readonly Checkpoint[];
   currentId: string;
   onRestore?: (id: string) => void;
-  className?: string;
 }) {
   const currentIndex = checkpoints.findIndex(
     (checkpoint) => checkpoint.id === currentId,
@@ -28,11 +29,14 @@ export function CheckpointHistory({
 
   return (
     <div
+      data-slot="checkpoint-history"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-1 rounded-2xl p-3",
         className,
       )}
+
+      {...props}
     >
       <span className="px-1.5 pb-1 text-[13.5px] font-medium">Checkpoints</span>
 

--- a/packages/ui/src/components/elements/checkpoint-history.tsx
+++ b/packages/ui/src/components/elements/checkpoint-history.tsx
@@ -18,7 +18,10 @@ export function CheckpointHistory({
   onRestore,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "checkpoints" | "currentId" | "onRestore"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "checkpoints" | "currentId" | "onRestore"
+> & {
   checkpoints: readonly Checkpoint[];
   currentId: string;
   onRestore?: (id: string) => void;

--- a/packages/ui/src/components/elements/code-diff.tsx
+++ b/packages/ui/src/components/elements/code-diff.tsx
@@ -27,7 +27,7 @@ export function CodeDiff({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "filename" | "additions" | "deletions" | "lines" | "cycle"
+  "children" | "filename" | "additions" | "deletions" | "lines" | "cycle"
 > & {
   filename: string;
   additions: number;

--- a/packages/ui/src/components/elements/code-diff.tsx
+++ b/packages/ui/src/components/elements/code-diff.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -23,21 +24,27 @@ export function CodeDiff({
   lines,
   cycle,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "filename" | "additions" | "deletions" | "lines" | "cycle"
+> & {
   filename: string;
   additions: number;
   deletions: number;
   lines: readonly DiffLine[];
   cycle: number;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="code-diff"
       className={cn(
         paper,
         "w-full max-w-md overflow-hidden rounded-2xl font-mono text-xs",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
         <span className="text-foreground/90">{filename}</span>

--- a/packages/ui/src/components/elements/code-runner.tsx
+++ b/packages/ui/src/components/elements/code-runner.tsx
@@ -18,7 +18,7 @@ export function CodeRunner({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "language" | "code" | "state" | "output" | "durationMs" | "onRun"
+  "children" | "language" | "code" | "state" | "output" | "durationMs" | "onRun"
 > & {
   language: string;
   code: string;

--- a/packages/ui/src/components/elements/code-runner.tsx
+++ b/packages/ui/src/components/elements/code-runner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { Loader2Icon, PlayIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -14,22 +15,28 @@ export function CodeRunner({
   durationMs,
   onRun,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "language" | "code" | "state" | "output" | "durationMs" | "onRun"
+> & {
   language: string;
   code: string;
   state: RunState;
   output: readonly string[];
   durationMs?: number;
   onRun?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="code-runner"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2 px-3.5 py-2">
         <span className={cn(mono, "text-foreground/35 min-w-0 flex-1")}>

--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -23,6 +23,7 @@ export function CommandPalette({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "commands"
   | "query"
   | "activeId"

--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -50,7 +50,9 @@ export function CommandPalette({
   const move = (delta: number) => {
     if (ordered.length === 0) return;
     const at = ordered.findIndex((command) => command.id === activeId);
-    const next = ordered[(at + delta + ordered.length) % ordered.length];
+    // activeId can be filtered out by the query; start from the edge the key implies
+    const from = at === -1 ? (delta > 0 ? -1 : 0) : at;
+    const next = ordered[(from + delta + ordered.length) % ordered.length];
     if (next) onActiveChange?.(next.id);
   };
 

--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, floating, mono } from "./surfaces";
@@ -16,34 +17,74 @@ export function CommandPalette({
   query,
   activeId,
   onQueryChange,
+  onActiveChange,
   onRun,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "commands"
+  | "query"
+  | "activeId"
+  | "onQueryChange"
+  | "onActiveChange"
+  | "onRun"
+> & {
   commands: readonly PaletteCommand[];
   query: string;
   activeId: string;
   onQueryChange?: (query: string) => void;
+  onActiveChange?: (id: string) => void;
   onRun?: (id: string) => void;
-  className?: string;
 }) {
   const matches = commands.filter((command) =>
     command.label.toLowerCase().includes(query.toLowerCase()),
   );
   const groups = [...new Set(matches.map((command) => command.group))];
+  // display order, which is grouped and so differs from the filter order
+  const ordered = groups.flatMap((group) =>
+    matches.filter((command) => command.group === group),
+  );
+
+  const move = (delta: number) => {
+    if (ordered.length === 0) return;
+    const at = ordered.findIndex((command) => command.id === activeId);
+    const next = ordered[(at + delta + ordered.length) % ordered.length];
+    if (next) onActiveChange?.(next.id);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      move(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      move(-1);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const active = ordered.find((command) => command.id === activeId);
+      if (active) onRun?.(active.id);
+    }
+  };
 
   return (
     <div
+      data-slot="command-palette"
       className={cn(
         floating,
         "flex w-full max-w-sm flex-col overflow-hidden rounded-[20px]",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5 px-3.5 py-3">
         <SearchIcon className="text-foreground/30 size-3.5 shrink-0" />
         <input
           value={query}
           onChange={(event) => onQueryChange?.(event.target.value)}
+          onKeyDown={onKeyDown}
           placeholder="Type a command"
           aria-label="Type a command"
           className="text-foreground/85 placeholder:text-foreground/30 min-w-0 flex-1 bg-transparent text-[13.5px] outline-none"

--- a/packages/ui/src/components/elements/comparison-card.tsx
+++ b/packages/ui/src/components/elements/comparison-card.tsx
@@ -21,7 +21,7 @@ export function ComparisonCard({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "traitLabels" | "options" | "recommendedId" | "reason"
+  "children" | "traitLabels" | "options" | "recommendedId" | "reason"
 > & {
   traitLabels: readonly string[];
   options: readonly ComparisonOption[];

--- a/packages/ui/src/components/elements/comparison-card.tsx
+++ b/packages/ui/src/components/elements/comparison-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, MinusIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -17,20 +18,26 @@ export function ComparisonCard({
   recommendedId,
   reason,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "traitLabels" | "options" | "recommendedId" | "reason"
+> & {
   traitLabels: readonly string[];
   options: readonly ComparisonOption[];
   recommendedId: string;
   reason: string;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="comparison-card"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex gap-2">
         {options.map((option) => {

--- a/packages/ui/src/components/elements/composer.tsx
+++ b/packages/ui/src/components/elements/composer.tsx
@@ -308,6 +308,7 @@ export function ComposerAttachmentChip({
 
 export function ComposerInput({
   onSubmit,
+  onKeyDown,
   className,
   ...props
 }: Omit<ComponentProps<"input">, "onSubmit"> & { onSubmit?: () => void }) {
@@ -315,6 +316,8 @@ export function ComposerInput({
     <input
       data-slot="composer-input"
       onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
         if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
         onSubmit?.();
       }}

--- a/packages/ui/src/components/elements/composer.tsx
+++ b/packages/ui/src/components/elements/composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { type ComponentProps, useMemo } from "react";
 import {
   ArrowUpIcon,
   CheckIcon,
@@ -59,33 +59,6 @@ export interface ComposerUsage {
   total: number;
 }
 
-export interface ComposerProps {
-  value: string;
-  onValueChange: (value: string) => void;
-  onSend?: () => void;
-  onStop?: () => void;
-  placeholder?: string;
-  streaming?: boolean;
-  attachments?: ComposerAttachment[];
-  onRemoveAttachment?: (name: string) => void;
-  dragActive?: boolean;
-  commands?: ComposerCommand[];
-  onCommand?: (command: ComposerCommand) => void;
-  people?: ComposerPerson[];
-  onMention?: (person: ComposerPerson) => void;
-  models?: ComposerModel[];
-  model?: string;
-  onModelChange?: (name: string) => void;
-  defaultModelMenuOpen?: boolean;
-  usage?: ComposerUsage;
-  recording?: boolean;
-  transcribing?: boolean;
-  recordingSeconds?: number;
-  onVoiceStart?: () => void;
-  onVoiceStop?: () => void;
-  className?: string;
-}
-
 const ATTACHMENT_ICONS: Record<
   NonNullable<ComposerAttachment["kind"]>,
   LucideIcon
@@ -101,17 +74,79 @@ function barHeight(bar: number, tick: number): number {
   return 5 + Math.abs(Math.sin(bar * 1.35 + tick * 0.55)) * 13;
 }
 
-function MenuSurface({
-  open,
-  align = "start",
-  children,
-}: {
-  open: boolean;
-  align?: "start" | "end";
-  children: React.ReactNode;
-}) {
+/** Commands whose name starts with the slash query, or none when not typing one. */
+export function useSlashMatches(
+  value: string,
+  commands: readonly ComposerCommand[] | undefined,
+): ComposerCommand[] {
+  return useMemo(() => {
+    if (!commands || !value.startsWith("/")) return [];
+    const query = value.slice(1).toLowerCase();
+    return commands.filter((command) => command.name.startsWith(query));
+  }, [commands, value]);
+}
+
+/** People matching a trailing @mention, or none when the caret is not in one. */
+export function useMentionMatches(
+  value: string,
+  people: readonly ComposerPerson[] | undefined,
+): ComposerPerson[] {
+  return useMemo(() => {
+    if (!people) return [];
+    const match = /@([\w]*)$/.exec(value);
+    if (!match) return [];
+    const query = match[1]?.toLowerCase() ?? "";
+    return people.filter((person) =>
+      person.name.toLowerCase().startsWith(query),
+    );
+  }, [people, value]);
+}
+
+/** Replaces the trailing @mention with the chosen name. */
+export function applyMention(value: string, name: string): string {
+  return value.replace(/@[\w]*$/, `@${name} `);
+}
+
+export function Composer({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
+      data-slot="composer"
+      className={cn("relative w-full max-w-lg", className)}
+      {...props}
+    />
+  );
+}
+
+export function ComposerBar({
+  dragActive = false,
+  className,
+  ...props
+}: ComponentProps<"div"> & { dragActive?: boolean }) {
+  return (
+    <div
+      data-slot="composer-bar"
+      data-drag-active={dragActive || undefined}
+      className={cn(
+        paper,
+        "flex w-full flex-col gap-2 rounded-[24px] p-2.5 transition-colors",
+        dragActive && "bg-blue-500/[0.04] dark:bg-blue-500/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ComposerMenu({
+  open,
+  align = "start",
+  className,
+  ...props
+}: ComponentProps<"div"> & { open: boolean; align?: "start" | "end" }) {
+  return (
+    <div
+      data-slot="composer-menu"
+      data-open={open || undefined}
       className={cn(
         floating,
         "absolute bottom-full z-10 mb-2 flex w-72 flex-col gap-0.5 rounded-2xl p-1.5",
@@ -122,492 +157,506 @@ function MenuSurface({
         open
           ? "scale-100 opacity-100"
           : "pointer-events-none scale-[0.97] opacity-0",
+        className,
       )}
+      {...props}
+    />
+  );
+}
+
+export function ComposerMenuItem({
+  active = false,
+  className,
+  ...props
+}: ComponentProps<"button"> & { active?: boolean }) {
+  return (
+    <button
+      type="button"
+      data-slot="composer-menu-item"
+      data-active={active || undefined}
+      className={cn(
+        "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
+        active ? field : "hover:bg-foreground/[0.04]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function ComposerCommandItem({
+  command,
+  active,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & {
+  command: ComposerCommand;
+  active: boolean;
+}) {
+  return (
+    <ComposerMenuItem active={active} {...props}>
+      <command.icon className="text-foreground/35 size-3.5 shrink-0" />
+      <span className="font-medium">/{command.name}</span>
+      <span className="text-foreground/45 flex-1 truncate text-start text-xs">
+        {command.description}
+      </span>
+      {active && (
+        <kbd className="bg-foreground/[0.06] text-foreground/45 rounded px-1 font-mono text-[10px]">
+          ↵
+        </kbd>
+      )}
+    </ComposerMenuItem>
+  );
+}
+
+export function ComposerPersonItem({
+  person,
+  active,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & {
+  person: ComposerPerson;
+  active: boolean;
+}) {
+  return (
+    <ComposerMenuItem active={active} {...props}>
+      <span className="bg-foreground/[0.06] text-foreground/45 flex size-5 shrink-0 items-center justify-center rounded-full text-[9px] font-medium">
+        {person.name[0]}
+      </span>
+      <span className="flex-1 truncate text-start">{person.name}</span>
+      <span className={cn(mono, "text-foreground/35")}>{person.role}</span>
+    </ComposerMenuItem>
+  );
+}
+
+export function ComposerAttachments({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="composer-attachments"
+      className={cn("flex flex-wrap gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export function ComposerAttachmentChip({
+  attachment,
+  onRemove,
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "children"> & {
+  attachment: ComposerAttachment;
+  onRemove?: (name: string) => void;
+}) {
+  const Icon = ATTACHMENT_ICONS[attachment.kind ?? "text"];
+  return (
+    <div
+      data-slot="composer-attachment"
+      data-state={attachment.state}
+      className={cn(
+        field,
+        "relative flex items-center gap-2.5 overflow-hidden rounded-[14px] py-1.5 ps-1.5 pe-2.5",
+        className,
+      )}
+      {...props}
     >
-      {children}
+      <span className="bg-background text-foreground/45 flex size-8 shrink-0 items-center justify-center rounded-[10px] shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:bg-white/10 dark:shadow-none">
+        <Icon className="size-4" />
+      </span>
+      <span className="flex flex-col">
+        <span className="max-w-36 truncate text-xs font-medium">
+          {attachment.name}
+        </span>
+        <span
+          className={cn(
+            "text-[11px]",
+            attachment.state === "error"
+              ? "text-red-600/80 dark:text-red-400/80"
+              : "text-foreground/40",
+          )}
+        >
+          {attachment.meta}
+        </span>
+      </span>
+      <span className="ms-1 flex w-5 items-center justify-end">
+        {attachment.state === "uploading" ? (
+          <Loader2Icon className="text-foreground/35 size-3.5 animate-spin motion-reduce:animate-none" />
+        ) : attachment.state === "done" && onRemove ? (
+          <button
+            type="button"
+            aria-label={`Remove ${attachment.name}`}
+            onClick={() => onRemove(attachment.name)}
+            className={cn(ghostButton, "size-5 [&_svg]:size-3")}
+          >
+            <XIcon />
+          </button>
+        ) : attachment.state === "done" ? (
+          <CheckIcon className="size-3.5 text-emerald-500" />
+        ) : null}
+      </span>
+      {attachment.state === "uploading" && (
+        <span
+          aria-hidden
+          className="absolute inset-x-0 bottom-0 h-0.5 bg-blue-500/70 transition-[width] duration-300 dark:bg-blue-400/70"
+          style={{ width: `${attachment.progress ?? 0}%` }}
+        />
+      )}
     </div>
   );
 }
 
-export function Composer({
-  value,
-  onValueChange,
-  onSend,
-  onStop,
-  placeholder = "Ask anything",
-  streaming = false,
-  attachments,
-  onRemoveAttachment,
-  dragActive = false,
-  commands,
-  onCommand,
-  people,
-  onMention,
-  models,
-  model,
-  onModelChange,
-  defaultModelMenuOpen = false,
-  usage,
-  recording = false,
-  transcribing = false,
-  recordingSeconds = 0,
-  onVoiceStart,
-  onVoiceStop,
+export function ComposerInput({
+  onSubmit,
   className,
-}: ComposerProps) {
-  const [modelMenuOpen, setModelMenuOpen] = useState(defaultModelMenuOpen);
-
-  const slashQuery = useMemo(() => {
-    if (!commands || !value.startsWith("/")) return null;
-    return value.slice(1).toLowerCase();
-  }, [commands, value]);
-  const slashMatches = useMemo(
-    () =>
-      slashQuery === null
-        ? []
-        : (commands ?? []).filter((c) => c.name.startsWith(slashQuery)),
-    [commands, slashQuery],
+  ...props
+}: Omit<ComponentProps<"input">, "onSubmit"> & { onSubmit?: () => void }) {
+  return (
+    <input
+      data-slot="composer-input"
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+        onSubmit?.();
+      }}
+      className={cn(
+        "placeholder:text-foreground/35 min-h-11 w-full bg-transparent px-3 text-[15px] caret-blue-500 outline-none dark:caret-blue-400",
+        className,
+      )}
+      {...props}
+    />
   );
+}
 
-  const mentionQuery = useMemo(() => {
-    if (!people) return null;
-    const match = /@([\w]*)$/.exec(value);
-    return match ? (match[1]?.toLowerCase() ?? "") : null;
-  }, [people, value]);
-  const mentionMatches = useMemo(
-    () =>
-      mentionQuery === null
-        ? []
-        : (people ?? []).filter((p) =>
-            p.name.toLowerCase().startsWith(mentionQuery),
-          ),
-    [people, mentionQuery],
+export function ComposerVoice({
+  recording,
+  seconds,
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "children"> & {
+  recording: boolean;
+  seconds: number;
+}) {
+  return (
+    <div
+      data-slot="composer-voice"
+      data-recording={recording || undefined}
+      className={cn("flex min-h-11 items-center gap-3 ps-3", className)}
+      {...props}
+    >
+      {recording && (
+        <span
+          aria-hidden
+          className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+        />
+      )}
+      <div className="flex h-6 items-center gap-[3px]" aria-hidden>
+        {BARS.map((bar) => (
+          <span
+            key={bar}
+            className={cn(
+              "w-0.5 rounded-full transition-[height,background-color] duration-150 motion-reduce:transition-none",
+              recording ? "bg-foreground/50" : "bg-foreground/25",
+            )}
+            style={{ height: recording ? barHeight(bar, seconds * 10) : 3 }}
+          />
+        ))}
+      </div>
+      {recording ? (
+        <span className={cn(mono, "text-foreground/40 tabular-nums")}>
+          0:{String(seconds).padStart(2, "0")}
+        </span>
+      ) : (
+        <span className="text-foreground/55 relative text-[13px]">
+          <span>Transcribing</span>
+          <span
+            aria-hidden
+            className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+          >
+            Transcribing
+          </span>
+        </span>
+      )}
+    </div>
   );
+}
 
-  const voiceActive = recording || transcribing;
-  const empty = value.length === 0;
-  const timer = `0:${String(recordingSeconds).padStart(2, "0")}`;
-  const usageUsed = usage ? usage.system + usage.tools + usage.messages : 0;
-  const usageFraction = usage ? usageUsed / usage.total : 0;
-  const usageWarn = usageFraction > 0.85;
+export function ComposerToolbar({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="composer-toolbar"
+      className={cn("flex items-center justify-between", className)}
+      {...props}
+    />
+  );
+}
+
+export function ComposerActions({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="composer-actions"
+      className={cn("flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+export function ComposerAttachButton({
+  className,
+  ...props
+}: ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      aria-label="Add attachment"
+      data-slot="composer-attach"
+      disabled={!props.onClick}
+      className={cn(
+        ghostButton,
+        "size-8 disabled:pointer-events-none disabled:opacity-30",
+        className,
+      )}
+      {...props}
+    >
+      <PlusIcon className="size-4" />
+    </button>
+  );
+}
+
+export function ComposerModelTrigger({
+  model,
+  open,
+  className,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & {
+  model: string;
+  open: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-expanded={open}
+      data-slot="composer-model-trigger"
+      className={cn(
+        "text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 dark:hover:bg-foreground/[0.09] flex h-8 items-center gap-1.5 rounded-full px-3 text-[12.5px] transition-colors",
+        className,
+      )}
+      {...props}
+    >
+      {model}
+      <ChevronDownIcon className="size-3 opacity-60" />
+    </button>
+  );
+}
+
+export function ComposerModelItem({
+  entry,
+  selected,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & {
+  entry: ComposerModel;
+  selected: boolean;
+}) {
+  return (
+    <ComposerMenuItem active={selected} {...props}>
+      <span className="flex-1 text-start">{entry.name}</span>
+      <span className={cn(mono, "text-foreground/35 tabular-nums")}>
+        {entry.meta}
+      </span>
+      <span className="flex w-4 justify-end">
+        {selected && (
+          <CheckIcon className="fade-in zoom-in-90 animate-in size-3.5 duration-200" />
+        )}
+      </span>
+    </ComposerMenuItem>
+  );
+}
+
+export function ComposerContext({
+  usage,
+  className,
+  ...props
+}: Omit<ComponentProps<"div">, "children"> & { usage: ComposerUsage }) {
+  const used = usage.system + usage.tools + usage.messages;
+  const fraction = usage.total === 0 ? 0 : used / usage.total;
+  const warn = fraction > 0.85;
   const circumference = 2 * Math.PI * 6;
-  const usageSegments = usage
-    ? [
-        { label: "System", value: usage.system, className: "bg-foreground/25" },
-        { label: "Tools", value: usage.tools, className: "bg-foreground/45" },
-        {
-          label: "Messages",
-          value: usage.messages,
-          className: "bg-foreground/80",
-        },
-      ]
-    : [];
+  const segments = [
+    { label: "System", value: usage.system, className: "bg-foreground/25" },
+    { label: "Tools", value: usage.tools, className: "bg-foreground/45" },
+    { label: "Messages", value: usage.messages, className: "bg-foreground/80" },
+  ];
 
   return (
-    <div className={cn("relative w-full max-w-lg", className)}>
-      <MenuSurface open={slashMatches.length > 0}>
-        {slashMatches.map((command, i) => (
-          <button
-            key={command.name}
-            type="button"
-            onClick={() => {
-              onCommand?.(command);
-              onValueChange(`/${command.name} `);
-            }}
-            className={cn(
-              "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
-              i === 0 ? field : "hover:bg-foreground/[0.04]",
-            )}
-          >
-            <command.icon className="text-foreground/35 size-3.5 shrink-0" />
-            <span className="font-medium">/{command.name}</span>
-            <span className="text-foreground/45 flex-1 truncate text-start text-xs">
-              {command.description}
-            </span>
-            {i === 0 && (
-              <kbd className="bg-foreground/[0.06] text-foreground/45 rounded px-1 font-mono text-[10px]">
-                ↵
-              </kbd>
-            )}
-          </button>
-        ))}
-      </MenuSurface>
-
-      <MenuSurface open={mentionMatches.length > 0}>
-        {mentionMatches.map((person, i) => (
-          <button
-            key={person.name}
-            type="button"
-            onClick={() => {
-              onMention?.(person);
-              onValueChange(value.replace(/@[\w]*$/, `@${person.name} `));
-            }}
-            className={cn(
-              "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
-              i === 0 ? field : "hover:bg-foreground/[0.04]",
-            )}
-          >
-            <span className="bg-foreground/[0.06] text-foreground/45 flex size-5 shrink-0 items-center justify-center rounded-full text-[9px] font-medium">
-              {person.name[0]}
-            </span>
-            <span className="flex-1 truncate text-start">{person.name}</span>
-            <span className={cn(mono, "text-foreground/35")}>
-              {person.role}
-            </span>
-          </button>
-        ))}
-      </MenuSurface>
-
+    <div
+      data-slot="composer-context"
+      className={cn("group/ctx relative", className)}
+      {...props}
+    >
       <div
         className={cn(
-          paper,
-          "flex w-full flex-col gap-2 rounded-[24px] p-2.5 transition-colors",
-          dragActive && "bg-blue-500/[0.04] dark:bg-blue-500/10",
+          floating,
+          "absolute end-0 bottom-full z-10 mb-2 flex w-60 origin-bottom-right flex-col gap-3.5 rounded-2xl p-4",
+          "transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+          "pointer-events-none scale-[0.97] opacity-0",
+          "group-hover/ctx:pointer-events-auto group-hover/ctx:scale-100 group-hover/ctx:opacity-100",
+          "group-focus-within/ctx:pointer-events-auto group-focus-within/ctx:scale-100 group-focus-within/ctx:opacity-100",
         )}
       >
-        {attachments && attachments.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {attachments.map((attachment) => {
-              const Icon = ATTACHMENT_ICONS[attachment.kind ?? "text"];
-              return (
-                <div
-                  key={attachment.name}
-                  className={cn(
-                    field,
-                    "relative flex items-center gap-2.5 overflow-hidden rounded-[14px] py-1.5 ps-1.5 pe-2.5",
-                  )}
-                >
-                  <span className="bg-background text-foreground/45 flex size-8 shrink-0 items-center justify-center rounded-[10px] shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:bg-white/10 dark:shadow-none">
-                    <Icon className="size-4" />
-                  </span>
-                  <span className="flex flex-col">
-                    <span className="max-w-36 truncate text-xs font-medium">
-                      {attachment.name}
-                    </span>
-                    <span
-                      className={cn(
-                        "text-[11px]",
-                        attachment.state === "error"
-                          ? "text-red-600/80 dark:text-red-400/80"
-                          : "text-foreground/40",
-                      )}
-                    >
-                      {attachment.meta}
-                    </span>
-                  </span>
-                  <span className="ms-1 flex w-5 items-center justify-end">
-                    {attachment.state === "uploading" ? (
-                      <Loader2Icon className="text-foreground/35 size-3.5 animate-spin motion-reduce:animate-none" />
-                    ) : attachment.state === "done" && onRemoveAttachment ? (
-                      <button
-                        type="button"
-                        aria-label={`Remove ${attachment.name}`}
-                        onClick={() => onRemoveAttachment(attachment.name)}
-                        className={cn(ghostButton, "size-5 [&_svg]:size-3")}
-                      >
-                        <XIcon />
-                      </button>
-                    ) : attachment.state === "done" ? (
-                      <CheckIcon className="size-3.5 text-emerald-500" />
-                    ) : null}
-                  </span>
-                  {attachment.state === "uploading" && (
-                    <span
-                      aria-hidden
-                      className="absolute inset-x-0 bottom-0 h-0.5 bg-blue-500/70 transition-[width] duration-300 dark:bg-blue-400/70"
-                      style={{ width: `${attachment.progress ?? 0}%` }}
-                    />
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        {voiceActive ? (
-          <div className="flex min-h-11 items-center gap-3 ps-3">
-            {recording && (
+        <div className="flex items-baseline justify-between">
+          <p className="text-[13.5px] font-medium">Context</p>
+          <p
+            className={cn(
+              mono,
+              "tabular-nums",
+              warn ? "text-red-500 dark:text-red-400" : "text-foreground/35",
+            )}
+          >
+            {Math.round(fraction * 100)}%
+          </p>
+        </div>
+        <div className="bg-foreground/[0.06] flex h-[5px] w-full gap-px overflow-hidden rounded-full">
+          {segments.map((segment) => (
+            <span
+              key={segment.label}
+              className={cn(
+                "h-full transition-[width] duration-700 motion-reduce:transition-none",
+                segment.className,
+              )}
+              style={{
+                width: `${usage.total === 0 ? 0 : (segment.value / usage.total) * 100}%`,
+              }}
+            />
+          ))}
+        </div>
+        <div className="flex flex-col gap-2">
+          {segments.map((segment) => (
+            <div
+              key={segment.label}
+              className="text-foreground/55 flex items-center gap-2.5 text-[13px]"
+            >
               <span
                 aria-hidden
-                className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+                className={cn("size-1.5 rounded-full", segment.className)}
               />
-            )}
-            <div className="flex h-6 items-center gap-[3px]" aria-hidden>
-              {BARS.map((bar) => (
-                <span
-                  key={bar}
-                  className={cn(
-                    "w-0.5 rounded-full transition-[height,background-color] duration-150 motion-reduce:transition-none",
-                    recording ? "bg-foreground/50" : "bg-foreground/25",
-                  )}
-                  style={{
-                    height: recording
-                      ? barHeight(bar, recordingSeconds * 10)
-                      : 3,
-                  }}
-                />
-              ))}
-            </div>
-            {recording ? (
+              <span className="flex-1">{segment.label}</span>
               <span className={cn(mono, "text-foreground/40 tabular-nums")}>
-                {timer}
+                {segment.value}k
               </span>
-            ) : (
-              <span className="text-foreground/55 relative text-[13px]">
-                <span>Transcribing</span>
-                <span
-                  aria-hidden
-                  className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
-                >
-                  Transcribing
-                </span>
-              </span>
-            )}
-          </div>
-        ) : (
-          <input
-            value={value}
-            onChange={(event) => onValueChange(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !empty && !streaming) onSend?.();
-            }}
-            placeholder={placeholder}
-            className="placeholder:text-foreground/35 min-h-11 w-full bg-transparent px-3 text-[15px] caret-blue-500 outline-none dark:caret-blue-400"
-          />
-        )}
-
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              aria-label="Add attachment"
-              className={cn(ghostButton, "size-8")}
-            >
-              <PlusIcon className="size-4" />
-            </button>
-            {models && model !== undefined && (
-              <div className="relative">
-                <MenuSurface open={modelMenuOpen}>
-                  <p
-                    className={cn(
-                      mono,
-                      "text-foreground/35 px-2.5 pt-2 pb-1.5",
-                    )}
-                  >
-                    Models
-                  </p>
-                  {models.map((entry) => {
-                    const selected = entry.name === model;
-                    return (
-                      <button
-                        key={entry.name}
-                        type="button"
-                        onClick={() => {
-                          onModelChange?.(entry.name);
-                          setModelMenuOpen(false);
-                        }}
-                        className={cn(
-                          "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
-                          selected ? field : "hover:bg-foreground/[0.04]",
-                        )}
-                      >
-                        <span className="flex-1 text-start">{entry.name}</span>
-                        <span
-                          className={cn(
-                            mono,
-                            "text-foreground/35 tabular-nums",
-                          )}
-                        >
-                          {entry.meta}
-                        </span>
-                        <span className="flex w-4 justify-end">
-                          {selected && (
-                            <CheckIcon className="fade-in zoom-in-90 animate-in size-3.5 duration-200" />
-                          )}
-                        </span>
-                      </button>
-                    );
-                  })}
-                </MenuSurface>
-                <button
-                  type="button"
-                  aria-expanded={modelMenuOpen}
-                  onClick={() => setModelMenuOpen((open) => !open)}
-                  className="text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 dark:hover:bg-foreground/[0.09] flex h-8 items-center gap-1.5 rounded-full px-3 text-[12.5px] transition-colors"
-                >
-                  {model}
-                  <ChevronDownIcon className="size-3 opacity-60" />
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-1.5">
-            {usage && (
-              <div className="group/ctx relative">
-                <div
-                  className={cn(
-                    floating,
-                    "absolute end-0 bottom-full z-10 mb-2 flex w-60 origin-bottom-right flex-col gap-3.5 rounded-2xl p-4",
-                    "transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
-                    "pointer-events-none scale-[0.97] opacity-0",
-                    "group-hover/ctx:pointer-events-auto group-hover/ctx:scale-100 group-hover/ctx:opacity-100",
-                    "group-focus-within/ctx:pointer-events-auto group-focus-within/ctx:scale-100 group-focus-within/ctx:opacity-100",
-                  )}
-                >
-                  <div className="flex items-baseline justify-between">
-                    <p className="text-[13.5px] font-medium">Context</p>
-                    <p
-                      className={cn(
-                        mono,
-                        "tabular-nums",
-                        usageWarn
-                          ? "text-red-500 dark:text-red-400"
-                          : "text-foreground/35",
-                      )}
-                    >
-                      {Math.round(usageFraction * 100)}%
-                    </p>
-                  </div>
-                  <div className="bg-foreground/[0.06] flex h-[5px] w-full gap-px overflow-hidden rounded-full">
-                    {usageSegments.map((segment) => (
-                      <span
-                        key={segment.label}
-                        className={cn(
-                          "h-full transition-[width] duration-700 motion-reduce:transition-none",
-                          segment.className,
-                        )}
-                        style={{
-                          width: `${(segment.value / usage.total) * 100}%`,
-                        }}
-                      />
-                    ))}
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    {usageSegments.map((segment) => (
-                      <div
-                        key={segment.label}
-                        className="text-foreground/55 flex items-center gap-2.5 text-[13px]"
-                      >
-                        <span
-                          aria-hidden
-                          className={cn(
-                            "size-1.5 rounded-full",
-                            segment.className,
-                          )}
-                        />
-                        <span className="flex-1">{segment.label}</span>
-                        <span
-                          className={cn(
-                            mono,
-                            "text-foreground/40 tabular-nums",
-                          )}
-                        >
-                          {segment.value}k
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="bg-foreground/[0.06] h-px" />
-                  <div className="text-foreground/55 flex items-center justify-between text-[13px]">
-                    <span>Total</span>
-                    <span
-                      className={cn(mono, "text-foreground/40 tabular-nums")}
-                    >
-                      {usageUsed}k / {usage.total}k
-                    </span>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  aria-label="Context usage"
-                  className={cn(
-                    ghostButton,
-                    "size-8",
-                    usageWarn && "text-red-500 dark:text-red-400",
-                  )}
-                >
-                  <svg
-                    viewBox="0 0 16 16"
-                    className="size-4 -rotate-90"
-                    aria-hidden
-                  >
-                    <circle
-                      cx="8"
-                      cy="8"
-                      r="6"
-                      fill="none"
-                      strokeWidth="2.5"
-                      className="stroke-foreground/10"
-                    />
-                    <circle
-                      cx="8"
-                      cy="8"
-                      r="6"
-                      fill="none"
-                      strokeWidth="2.5"
-                      strokeLinecap="round"
-                      className="stroke-current transition-[stroke-dashoffset] duration-700 motion-reduce:transition-none"
-                      strokeDasharray={circumference}
-                      strokeDashoffset={
-                        circumference * (1 - Math.min(usageFraction, 1))
-                      }
-                    />
-                  </svg>
-                </button>
-              </div>
-            )}
-            {(onVoiceStart || voiceActive) && (
-              <button
-                type="button"
-                aria-label={
-                  voiceActive ? "Stop recording" : "Start voice input"
-                }
-                onClick={voiceActive ? onVoiceStop : onVoiceStart}
-                className={cn(
-                  voiceActive
-                    ? cn(
-                        inkButton,
-                        "flex size-8 items-center justify-center rounded-full",
-                      )
-                    : cn(ghostButton, "size-8"),
-                )}
-              >
-                {voiceActive ? (
-                  <SquareIcon className="size-3 fill-current" />
-                ) : (
-                  <MicIcon className="size-4" />
-                )}
-              </button>
-            )}
-            <button
-              type="button"
-              aria-label={streaming ? "Stop generating" : "Send message"}
-              onClick={streaming ? onStop : onSend}
-              className={cn(
-                "grid size-8 place-items-center rounded-full",
-                streaming || !empty
-                  ? inkButton
-                  : "bg-foreground/[0.06] text-foreground/30 dark:bg-foreground/[0.09] transition-colors",
-              )}
-            >
-              <ArrowUpIcon
-                className={cn(
-                  iconSwap,
-                  "size-4",
-                  streaming ? iconSwapOut : iconSwapIn,
-                )}
-              />
-              <SquareIcon
-                className={cn(
-                  iconSwap,
-                  "size-3 fill-current",
-                  streaming ? iconSwapIn : iconSwapOut,
-                )}
-              />
-            </button>
-          </div>
+            </div>
+          ))}
+        </div>
+        <div className="bg-foreground/[0.06] h-px" />
+        <div className="text-foreground/55 flex items-center justify-between text-[13px]">
+          <span>Total</span>
+          <span className={cn(mono, "text-foreground/40 tabular-nums")}>
+            {used}k / {usage.total}k
+          </span>
         </div>
       </div>
+      <button
+        type="button"
+        aria-label="Context usage"
+        className={cn(
+          ghostButton,
+          "size-8",
+          warn && "text-red-500 dark:text-red-400",
+        )}
+      >
+        <svg viewBox="0 0 16 16" className="size-4 -rotate-90" aria-hidden>
+          <circle
+            cx="8"
+            cy="8"
+            r="6"
+            fill="none"
+            strokeWidth="2.5"
+            className="stroke-foreground/10"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            r="6"
+            fill="none"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            className="stroke-current transition-[stroke-dashoffset] duration-700 motion-reduce:transition-none"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - Math.min(fraction, 1))}
+          />
+        </svg>
+      </button>
     </div>
+  );
+}
+
+export function ComposerVoiceButton({
+  active,
+  className,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & { active: boolean }) {
+  return (
+    <button
+      type="button"
+      aria-label={active ? "Stop recording" : "Start voice input"}
+      data-slot="composer-voice-button"
+      className={cn(
+        active
+          ? cn(
+              inkButton,
+              "flex size-8 items-center justify-center rounded-full",
+            )
+          : cn(ghostButton, "size-8"),
+        className,
+      )}
+      {...props}
+    >
+      {active ? (
+        <SquareIcon className="size-3 fill-current" />
+      ) : (
+        <MicIcon className="size-4" />
+      )}
+    </button>
+  );
+}
+
+export function ComposerSend({
+  streaming,
+  idle,
+  className,
+  ...props
+}: Omit<ComponentProps<"button">, "children"> & {
+  streaming: boolean;
+  idle: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={streaming ? "Stop generating" : "Send message"}
+      data-slot="composer-send"
+      className={cn(
+        "grid size-8 place-items-center rounded-full",
+        streaming || !idle
+          ? inkButton
+          : "bg-foreground/[0.06] text-foreground/30 dark:bg-foreground/[0.09] transition-colors",
+        className,
+      )}
+      {...props}
+    >
+      <ArrowUpIcon
+        className={cn(iconSwap, "size-4", streaming ? iconSwapOut : iconSwapIn)}
+      />
+      <SquareIcon
+        className={cn(
+          iconSwap,
+          "size-3 fill-current",
+          streaming ? iconSwapIn : iconSwapOut,
+        )}
+      />
+    </button>
   );
 }

--- a/packages/ui/src/components/elements/composer.tsx
+++ b/packages/ui/src/components/elements/composer.tsx
@@ -412,7 +412,7 @@ export function ComposerActions({
 export function ComposerAttachButton({
   className,
   ...props
-}: ComponentProps<"button">) {
+}: Omit<ComponentProps<"button">, "children">) {
   return (
     <button
       type="button"

--- a/packages/ui/src/components/elements/computer-use.tsx
+++ b/packages/ui/src/components/elements/computer-use.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { MousePointer2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -18,23 +19,26 @@ export function ComputerUse({
   activeIndex,
   children,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "url" | "steps" | "activeIndex" | "children"> & {
   url: string;
   steps: readonly ComputerStep[];
   activeIndex: number;
   children: React.ReactNode;
-  className?: string;
 }) {
   const active = steps[Math.min(activeIndex, steps.length - 1)];
   const trail = steps.slice(Math.max(0, activeIndex - 2), activeIndex + 1);
 
   return (
     <div
+      data-slot="computer-use"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2 px-3 py-2">
         <span className="flex shrink-0 gap-1">

--- a/packages/ui/src/components/elements/confidence-marker.tsx
+++ b/packages/ui/src/components/elements/confidence-marker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { floating, mono } from "./surfaces";
@@ -36,6 +37,7 @@ export function ConfidenceMarker({
   hoveredId: string;
   onHover?: (id: string) => void;
 }) {
+  const basisId = useId();
   const hovered = claims.find((claim) => claim.id === hoveredId);
 
   return (
@@ -50,9 +52,7 @@ export function ConfidenceMarker({
           <button
             key={claim.id}
             type="button"
-            aria-describedby={
-              hoveredId === claim.id ? "confidence-basis" : undefined
-            }
+            aria-describedby={hoveredId === claim.id ? basisId : undefined}
             onMouseEnter={() => onHover?.(claim.id)}
             onMouseLeave={() => onHover?.("")}
             onFocus={() => onHover?.(claim.id)}
@@ -73,7 +73,7 @@ export function ConfidenceMarker({
       <div className="flex h-9 items-start">
         {hovered && (
           <span
-            id="confidence-basis"
+            id={basisId}
             role="status"
             className={cn(
               floating,

--- a/packages/ui/src/components/elements/confidence-marker.tsx
+++ b/packages/ui/src/components/elements/confidence-marker.tsx
@@ -61,7 +61,7 @@ export function ConfidenceMarker({
             onFocus={() => onHover?.(claim.id)}
             onBlur={() => onHover?.("")}
             className={cn(
-              "focus-visible:ring-foreground/20 cursor-help rounded text-start underline decoration-2 underline-offset-[3px] transition-colors outline-none focus-visible:ring-2",
+              "focus-visible:ring-foreground/20 inline cursor-help rounded text-start underline decoration-2 underline-offset-[3px] transition-colors outline-none focus-visible:ring-2",
               UNDERLINE[claim.confidence],
               hoveredId === claim.id
                 ? "text-foreground/95"

--- a/packages/ui/src/components/elements/confidence-marker.tsx
+++ b/packages/ui/src/components/elements/confidence-marker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { floating, mono } from "./surfaces";
 
@@ -29,24 +30,35 @@ export function ConfidenceMarker({
   hoveredId,
   onHover,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "claims" | "hoveredId" | "onHover"> & {
   claims: readonly ConfidenceClaim[];
   hoveredId: string;
   onHover?: (id: string) => void;
-  className?: string;
 }) {
   const hovered = claims.find((claim) => claim.id === hoveredId);
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+    <div
+      data-slot="confidence-marker"
+      className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <p className="text-[13.5px] leading-relaxed">
         {claims.map((claim) => (
-          <span
+          <button
             key={claim.id}
+            type="button"
+            aria-describedby={
+              hoveredId === claim.id ? "confidence-basis" : undefined
+            }
             onMouseEnter={() => onHover?.(claim.id)}
             onMouseLeave={() => onHover?.("")}
+            onFocus={() => onHover?.(claim.id)}
+            onBlur={() => onHover?.("")}
             className={cn(
-              "underline decoration-2 underline-offset-[3px] transition-colors",
+              "focus-visible:ring-foreground/20 cursor-help rounded text-start underline decoration-2 underline-offset-[3px] transition-colors outline-none focus-visible:ring-2",
               UNDERLINE[claim.confidence],
               hoveredId === claim.id
                 ? "text-foreground/95"
@@ -54,13 +66,15 @@ export function ConfidenceMarker({
             )}
           >
             {claim.text}{" "}
-          </span>
+          </button>
         ))}
       </p>
 
       <div className="flex h-9 items-start">
         {hovered && (
           <span
+            id="confidence-basis"
+            role="status"
             className={cn(
               floating,
               mono,

--- a/packages/ui/src/components/elements/confidence-marker.tsx
+++ b/packages/ui/src/components/elements/confidence-marker.tsx
@@ -32,7 +32,10 @@ export function ConfidenceMarker({
   onHover,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "claims" | "hoveredId" | "onHover"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "claims" | "hoveredId" | "onHover"
+> & {
   claims: readonly ConfidenceClaim[];
   hoveredId: string;
   onHover?: (id: string) => void;

--- a/packages/ui/src/components/elements/connection-state.tsx
+++ b/packages/ui/src/components/elements/connection-state.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, CloudOffIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -12,22 +13,28 @@ export function ConnectionState({
   resumedTokens,
   onRetry,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "phase" | "attempt" | "resumedTokens" | "onRetry"
+> & {
   phase: ConnectionPhase;
   attempt?: number;
   resumedTokens?: number;
   onRetry?: () => void;
-  className?: string;
 }) {
   if (phase === "online") return null;
 
   return (
     <div
+      data-slot="connection-state"
       className={cn(
         paper,
         "fade-in slide-in-from-top-1 animate-in flex w-full max-w-sm items-center gap-2.5 rounded-2xl px-3.5 py-2.5 duration-300",
         className,
       )}
+
+      {...props}
     >
       {phase === "dropped" && (
         <>

--- a/packages/ui/src/components/elements/connection-state.tsx
+++ b/packages/ui/src/components/elements/connection-state.tsx
@@ -16,7 +16,7 @@ export function ConnectionState({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "phase" | "attempt" | "resumedTokens" | "onRetry"
+  "children" | "phase" | "attempt" | "resumedTokens" | "onRetry"
 > & {
   phase: ConnectionPhase;
   attempt?: number;

--- a/packages/ui/src/components/elements/context-breakdown.tsx
+++ b/packages/ui/src/components/elements/context-breakdown.tsx
@@ -17,7 +17,7 @@ export function ContextBreakdown({
   limit,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "segments" | "limit"> & {
+}: Omit<ComponentProps<"div">, "children" | "segments" | "limit"> & {
   segments: readonly ContextSegment[];
   limit: number;
 }) {

--- a/packages/ui/src/components/elements/context-breakdown.tsx
+++ b/packages/ui/src/components/elements/context-breakdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -15,10 +16,10 @@ export function ContextBreakdown({
   segments,
   limit,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "segments" | "limit"> & {
   segments: readonly ContextSegment[];
   limit: number;
-  className?: string;
 }) {
   const used = segments.reduce((sum, segment) => sum + segment.tokens, 0);
   const pressure = limit === 0 ? 0 : used / limit;
@@ -26,11 +27,14 @@ export function ContextBreakdown({
 
   return (
     <div
+      data-slot="context-breakdown"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">Context</span>

--- a/packages/ui/src/components/elements/conversation-search.tsx
+++ b/packages/ui/src/components/elements/conversation-search.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ChevronDownIcon, ChevronUpIcon, SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
@@ -19,13 +20,16 @@ export function ConversationSearch({
   onQueryChange,
   onStep,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "query" | "hits" | "activeIndex" | "onQueryChange" | "onStep"
+> & {
   query: string;
   hits: readonly SearchHit[];
   activeIndex: number;
   onQueryChange?: (query: string) => void;
   onStep?: (delta: number) => void;
-  className?: string;
 }) {
   const index =
     hits.length === 0
@@ -34,7 +38,12 @@ export function ConversationSearch({
   const active = index === -1 ? undefined : hits[index];
 
   return (
-    <div className={cn("flex w-full max-w-sm gap-2", className)}>
+    <div
+      data-slot="conversation-search"
+      className={cn("flex w-full max-w-sm gap-2", className)}
+
+      {...props}
+    >
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div
           className={cn(

--- a/packages/ui/src/components/elements/conversation-search.tsx
+++ b/packages/ui/src/components/elements/conversation-search.tsx
@@ -23,7 +23,7 @@ export function ConversationSearch({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "query" | "hits" | "activeIndex" | "onQueryChange" | "onStep"
+  "children" | "query" | "hits" | "activeIndex" | "onQueryChange" | "onStep"
 > & {
   query: string;
   hits: readonly SearchHit[];

--- a/packages/ui/src/components/elements/cost-meter.tsx
+++ b/packages/ui/src/components/elements/cost-meter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -16,19 +17,22 @@ export function CostMeter({
   sessionCost,
   lines,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "runCost" | "sessionCost" | "lines"> & {
   runCost: string;
   sessionCost: string;
   lines: readonly CostLine[];
-  className?: string;
 }) {
   return (
     <div
+      data-slot="cost-meter"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-medium tracking-tight tabular-nums">

--- a/packages/ui/src/components/elements/cost-meter.tsx
+++ b/packages/ui/src/components/elements/cost-meter.tsx
@@ -18,7 +18,10 @@ export function CostMeter({
   lines,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "runCost" | "sessionCost" | "lines"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "runCost" | "sessionCost" | "lines"
+> & {
   runCost: string;
   sessionCost: string;
   lines: readonly CostLine[];

--- a/packages/ui/src/components/elements/data-table.tsx
+++ b/packages/ui/src/components/elements/data-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -9,20 +10,27 @@ export interface ModelUsage {
   cost: string;
 }
 
-export interface DataTableProps {
+export interface DataTableProps extends ComponentProps<"div"> {
   rows: readonly ModelUsage[];
   cycle: number;
-  className?: string;
 }
 
-export function DataTable({ rows, cycle, className }: DataTableProps) {
+export function DataTable({
+  rows,
+  cycle,
+  className,
+  ...props
+}: DataTableProps) {
   return (
     <div
+      data-slot="data-table"
       className={cn(
         paper,
         "w-full max-w-sm overflow-hidden rounded-2xl text-[13px]",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center px-4 pt-3 pb-2">
         <span className={cn(mono, "text-foreground/35 flex-1")}>Model</span>

--- a/packages/ui/src/components/elements/data-table.tsx
+++ b/packages/ui/src/components/elements/data-table.tsx
@@ -10,7 +10,10 @@ export interface ModelUsage {
   cost: string;
 }
 
-export interface DataTableProps extends ComponentProps<"div"> {
+export interface DataTableProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   rows: readonly ModelUsage[];
   cycle: number;
 }

--- a/packages/ui/src/components/elements/day-separator.tsx
+++ b/packages/ui/src/components/elements/day-separator.tsx
@@ -16,7 +16,7 @@ export function DaySeparator({
   messages,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "messages"> & {
+}: Omit<ComponentProps<"div">, "children" | "messages"> & {
   messages: readonly DatedMessage[];
 }) {
   let lastDay = "";

--- a/packages/ui/src/components/elements/day-separator.tsx
+++ b/packages/ui/src/components/elements/day-separator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
 
@@ -14,14 +15,19 @@ export interface DatedMessage {
 export function DaySeparator({
   messages,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "messages"> & {
   messages: readonly DatedMessage[];
-  className?: string;
 }) {
   let lastDay = "";
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="day-separator"
+      className={cn("flex w-full max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       {messages.map((message) => {
         const newDay = message.day !== lastDay;
         lastDay = message.day;

--- a/packages/ui/src/components/elements/diagram.tsx
+++ b/packages/ui/src/components/elements/diagram.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { MaximizeIcon, MinusIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -13,7 +14,17 @@ export function Diagram({
   onReset,
   onExpand,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "title"
+  | "zoom"
+  | "children"
+  | "onZoomIn"
+  | "onZoomOut"
+  | "onReset"
+  | "onExpand"
+> & {
   title: string;
   zoom: number;
   children: React.ReactNode;
@@ -21,15 +32,17 @@ export function Diagram({
   onZoomOut?: () => void;
   onReset?: () => void;
   onExpand?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="diagram"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-1 px-3 py-2">
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium">

--- a/packages/ui/src/components/elements/document-reference.tsx
+++ b/packages/ui/src/components/elements/document-reference.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { FileTextIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -16,21 +17,27 @@ export function DocumentReference({
   activePage,
   onJump,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "title" | "pages" | "anchors" | "activePage" | "onJump"
+> & {
   title: string;
   pages: number;
   anchors: readonly DocumentAnchor[];
   activePage: number;
   onJump?: (page: number) => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="document-reference"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-3.5",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-8 shrink-0 items-center justify-center rounded-lg">

--- a/packages/ui/src/components/elements/document-reference.tsx
+++ b/packages/ui/src/components/elements/document-reference.tsx
@@ -20,7 +20,7 @@ export function DocumentReference({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "title" | "pages" | "anchors" | "activePage" | "onJump"
+  "children" | "title" | "pages" | "anchors" | "activePage" | "onJump"
 > & {
   title: string;
   pages: number;

--- a/packages/ui/src/components/elements/draft-restore.tsx
+++ b/packages/ui/src/components/elements/draft-restore.tsx
@@ -14,7 +14,7 @@ export function DraftRestore({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "draft" | "savedAt" | "onRestore" | "onDiscard"
+  "children" | "draft" | "savedAt" | "onRestore" | "onDiscard"
 > & {
   draft: string;
   savedAt: string;

--- a/packages/ui/src/components/elements/draft-restore.tsx
+++ b/packages/ui/src/components/elements/draft-restore.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PencilLineIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -10,20 +11,26 @@ export function DraftRestore({
   onRestore,
   onDiscard,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "draft" | "savedAt" | "onRestore" | "onDiscard"
+> & {
   draft: string;
   savedAt: string;
   onRestore?: () => void;
   onDiscard?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="draft-restore"
       className={cn(
         paper,
         "fade-in slide-in-from-bottom-1 animate-in flex w-full max-w-sm items-center gap-2.5 rounded-2xl py-2 pr-2 pl-3.5 duration-300",
         className,
       )}
+
+      {...props}
     >
       <PencilLineIcon className="text-foreground/30 size-3.5 shrink-0" />
       <div className="flex min-w-0 flex-1 flex-col">

--- a/packages/ui/src/components/elements/edit-message.tsx
+++ b/packages/ui/src/components/elements/edit-message.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { AlertTriangleIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
@@ -13,7 +14,17 @@ export function EditMessage({
   onCancel,
   onStartEdit,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "value"
+  | "discardedReplies"
+  | "editing"
+  | "onValueChange"
+  | "onSave"
+  | "onCancel"
+  | "onStartEdit"
+> & {
   value: string;
   discardedReplies: number;
   editing: boolean;
@@ -21,7 +32,6 @@ export function EditMessage({
   onSave?: () => void;
   onCancel?: () => void;
   onStartEdit?: () => void;
-  className?: string;
 }) {
   if (!editing) {
     return (
@@ -42,11 +52,14 @@ export function EditMessage({
 
   return (
     <div
+      data-slot="edit-message"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-3.5",
         className,
       )}
+
+      {...props}
     >
       <textarea
         value={value}

--- a/packages/ui/src/components/elements/edit-message.tsx
+++ b/packages/ui/src/components/elements/edit-message.tsx
@@ -17,6 +17,7 @@ export function EditMessage({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "value"
   | "discardedReplies"
   | "editing"

--- a/packages/ui/src/components/elements/edit-message.tsx
+++ b/packages/ui/src/components/elements/edit-message.tsx
@@ -35,7 +35,11 @@ export function EditMessage({
 }) {
   if (!editing) {
     return (
-      <div className={cn("flex w-full max-w-sm justify-end", className)}>
+      <div
+        data-slot="edit-message"
+        className={cn("flex w-full max-w-sm justify-end", className)}
+        {...props}
+      >
         <button
           type="button"
           onClick={onStartEdit}

--- a/packages/ui/src/components/elements/elicitation-form.tsx
+++ b/packages/ui/src/components/elements/elicitation-form.tsx
@@ -27,7 +27,13 @@ export function ElicitationForm({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "server" | "message" | "fields" | "state" | "onAccept" | "onDecline"
+  | "children"
+  | "server"
+  | "message"
+  | "fields"
+  | "state"
+  | "onAccept"
+  | "onDecline"
 > & {
   server: string;
   message: string;

--- a/packages/ui/src/components/elements/elicitation-form.tsx
+++ b/packages/ui/src/components/elements/elicitation-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, PlugIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
@@ -23,22 +24,28 @@ export function ElicitationForm({
   onAccept,
   onDecline,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "server" | "message" | "fields" | "state" | "onAccept" | "onDecline"
+> & {
   server: string;
   message: string;
   fields: readonly ElicitationField[];
   state: ElicitationState;
   onAccept?: () => void;
   onDecline?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="elicitation-form"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3.5 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">

--- a/packages/ui/src/components/elements/empty-state.tsx
+++ b/packages/ui/src/components/elements/empty-state.tsx
@@ -1,64 +1,107 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowUpIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { inkButton, paper } from "./surfaces";
 
-export interface EmptyStateProps {
-  greeting: string;
-  suggestions: readonly string[];
-  className?: string;
-}
-
-export function EmptyState({
-  greeting,
-  suggestions,
-  className,
-}: EmptyStateProps) {
+export function EmptyState({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
+      data-slot="empty-state"
       className={cn(
         "flex w-full max-w-md flex-col items-center gap-7",
         className,
       )}
+      {...props}
+    />
+  );
+}
+
+export function EmptyStateGreeting({
+  className,
+  ...props
+}: ComponentProps<"h2">) {
+  return (
+    <h2
+      data-slot="empty-state-greeting"
+      className={cn(
+        "fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-center text-2xl font-medium tracking-tight duration-500 motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function EmptyStateSuggestions({
+  className,
+  ...props
+}: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-state-suggestions"
+      className={cn("flex flex-wrap justify-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+export function EmptyStateSuggestion({
+  index = 0,
+  className,
+  style,
+  ...props
+}: ComponentProps<"button"> & { index?: number }) {
+  return (
+    <button
+      type="button"
+      data-slot="empty-state-suggestion"
+      style={{ animationDelay: `${120 + index * 70}ms`, ...style }}
+      className={cn(
+        paper,
+        "fade-in slide-in-from-bottom-2 animate-in fill-mode-both focus-visible:ring-foreground/20 rounded-full px-4 py-2 text-[13px] transition-transform duration-500 outline-none hover:-translate-y-px focus-visible:ring-2 active:scale-[0.96] motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function EmptyStateComposer({
+  placeholder,
+  onSend,
+  className,
+  style,
+  ...props
+}: Omit<ComponentProps<"div">, "children"> & {
+  placeholder: string;
+  onSend?: () => void;
+}) {
+  return (
+    <div
+      data-slot="empty-state-composer"
+      style={{ animationDelay: "360ms", ...style }}
+      className={cn(
+        paper,
+        "fade-in slide-in-from-bottom-2 animate-in fill-mode-both flex h-13 w-full items-center justify-between rounded-full py-2 ps-5 pe-2.5 duration-500 motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
     >
-      <h2 className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-center text-2xl font-medium tracking-tight duration-500 motion-reduce:animate-none">
-        {greeting}
-      </h2>
-
-      <div className="flex flex-wrap justify-center gap-2">
-        {suggestions.map((suggestion, i) => (
-          <button
-            key={suggestion}
-            type="button"
-            className={cn(
-              paper,
-              "fade-in slide-in-from-bottom-2 animate-in fill-mode-both focus-visible:ring-foreground/20 rounded-full px-4 py-2 text-[13px] transition-transform duration-500 outline-none hover:-translate-y-px focus-visible:ring-2 active:scale-[0.96] motion-reduce:animate-none",
-            )}
-            style={{ animationDelay: `${120 + i * 70}ms` }}
-          >
-            {suggestion}
-          </button>
-        ))}
-      </div>
-
-      <div
+      <span className="text-foreground/35 text-[15px]">{placeholder}</span>
+      <button
+        type="button"
+        aria-label="Send"
+        onClick={onSend}
+        disabled={!onSend}
         className={cn(
-          paper,
-          "fade-in slide-in-from-bottom-2 animate-in fill-mode-both flex h-13 w-full items-center justify-between rounded-full py-2 ps-5 pe-2.5 duration-500 motion-reduce:animate-none",
+          inkButton,
+          "flex size-8 items-center justify-center rounded-full disabled:pointer-events-none disabled:opacity-30",
         )}
-        style={{ animationDelay: "360ms" }}
       >
-        <span className="text-foreground/35 text-[15px]">Ask anything</span>
-        <span
-          className={cn(
-            inkButton,
-            "flex size-8 items-center justify-center rounded-full",
-          )}
-        >
-          <ArrowUpIcon className="size-4" />
-        </span>
-      </div>
+        <ArrowUpIcon className="size-4" />
+      </button>
     </div>
   );
 }

--- a/packages/ui/src/components/elements/empty-state.tsx
+++ b/packages/ui/src/components/elements/empty-state.tsx
@@ -74,7 +74,7 @@ export function EmptyStateComposer({
   className,
   style,
   ...props
-}: Omit<ComponentProps<"div">, "children"> & {
+}: Omit<ComponentProps<"div">, "children" | "placeholder"> & {
   placeholder: string;
   onSend?: () => void;
 }) {

--- a/packages/ui/src/components/elements/error-state.tsx
+++ b/packages/ui/src/components/elements/error-state.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CircleAlertIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export interface ErrorStateProps {
+export interface ErrorStateProps extends ComponentProps<"div"> {
   title: string;
   detail: string;
   retrying: boolean;
   onRetry: () => void;
-  className?: string;
 }
 
 export function ErrorState({
@@ -17,6 +17,7 @@ export function ErrorState({
   retrying,
   onRetry,
   className,
+  ...props
 }: ErrorStateProps) {
   if (retrying) {
     return (
@@ -44,12 +45,15 @@ export function ErrorState({
 
   return (
     <div
+      data-slot="error-state"
       key="error"
       role="alert"
       className={cn(
         "fade-in animate-in flex w-full max-w-sm items-start gap-2.5 rounded-2xl bg-red-500/[0.06] px-4 py-3 text-sm duration-300 motion-reduce:animate-none dark:bg-red-500/10",
         className,
       )}
+
+      {...props}
     >
       <CircleAlertIcon className="mt-0.5 size-4 shrink-0 text-red-500/80" />
       <div>

--- a/packages/ui/src/components/elements/error-state.tsx
+++ b/packages/ui/src/components/elements/error-state.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 
 export interface ErrorStateProps extends Omit<
   ComponentProps<"div">,
-  "children"
+  "children" | "role"
 > {
   title: string;
   detail: string;

--- a/packages/ui/src/components/elements/error-state.tsx
+++ b/packages/ui/src/components/elements/error-state.tsx
@@ -22,12 +22,15 @@ export function ErrorState({
   if (retrying) {
     return (
       <div
+        data-slot="error-state"
         key="retrying"
         role="status"
         className={cn(
           "fade-in animate-in flex w-full max-w-sm items-center gap-2.5 text-sm duration-300 motion-reduce:animate-none",
           className,
         )}
+
+        {...props}
       >
         <RefreshCwIcon className="text-foreground/45 size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
         <span className="text-foreground/55 relative inline-block">

--- a/packages/ui/src/components/elements/error-state.tsx
+++ b/packages/ui/src/components/elements/error-state.tsx
@@ -4,7 +4,10 @@ import type { ComponentProps } from "react";
 import { CircleAlertIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export interface ErrorStateProps extends ComponentProps<"div"> {
+export interface ErrorStateProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   title: string;
   detail: string;
   retrying: boolean;

--- a/packages/ui/src/components/elements/feedback-dialog.tsx
+++ b/packages/ui/src/components/elements/feedback-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, ThumbsDownIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
@@ -13,7 +14,17 @@ export function FeedbackDialog({
   onNoteChange,
   onSubmit,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "reasons"
+  | "selected"
+  | "note"
+  | "sent"
+  | "onToggleReason"
+  | "onNoteChange"
+  | "onSubmit"
+> & {
   reasons: readonly string[];
   selected: readonly string[];
   note: string;
@@ -21,7 +32,6 @@ export function FeedbackDialog({
   onToggleReason?: (reason: string) => void;
   onNoteChange?: (note: string) => void;
   onSubmit?: () => void;
-  className?: string;
 }) {
   if (sent) {
     return (
@@ -40,11 +50,14 @@ export function FeedbackDialog({
 
   return (
     <div
+      data-slot="feedback-dialog"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">

--- a/packages/ui/src/components/elements/feedback-dialog.tsx
+++ b/packages/ui/src/components/elements/feedback-dialog.tsx
@@ -17,6 +17,7 @@ export function FeedbackDialog({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "reasons"
   | "selected"
   | "note"

--- a/packages/ui/src/components/elements/feedback-dialog.tsx
+++ b/packages/ui/src/components/elements/feedback-dialog.tsx
@@ -36,11 +36,14 @@ export function FeedbackDialog({
   if (sent) {
     return (
       <div
+        data-slot="feedback-dialog"
         className={cn(
           paper,
           "fade-in animate-in flex w-full max-w-sm items-center gap-2.5 rounded-[20px] p-4 text-[13.5px] duration-300",
           className,
         )}
+
+        {...props}
       >
         <CheckIcon className="size-4 shrink-0 text-emerald-500" />
         Thanks. That helps us tune the model.

--- a/packages/ui/src/components/elements/file-tree.tsx
+++ b/packages/ui/src/components/elements/file-tree.tsx
@@ -23,7 +23,7 @@ export function FileTree({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "nodes" | "visibleCount" | "totalAdditions" | "totalDeletions"
+  "children" | "nodes" | "visibleCount" | "totalAdditions" | "totalDeletions"
 > & {
   nodes: readonly FileTreeNode[];
   visibleCount: number;

--- a/packages/ui/src/components/elements/file-tree.tsx
+++ b/packages/ui/src/components/elements/file-tree.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ChevronDownIcon, FileIcon, FolderIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -19,22 +20,28 @@ export function FileTree({
   totalAdditions,
   totalDeletions,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "nodes" | "visibleCount" | "totalAdditions" | "totalDeletions"
+> & {
   nodes: readonly FileTreeNode[];
   visibleCount: number;
   totalAdditions: number;
   totalDeletions: number;
-  className?: string;
 }) {
   const files = nodes.filter((node) => node.kind === "file").length;
 
   return (
     <div
+      data-slot="file-tree"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-2 rounded-2xl p-3.5",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between px-1">
         <span className="text-[13.5px] font-medium">{files} files changed</span>

--- a/packages/ui/src/components/elements/flow-graph.tsx
+++ b/packages/ui/src/components/elements/flow-graph.tsx
@@ -30,7 +30,10 @@ export function FlowGraph({
   visibleCount,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "nodes" | "edges" | "visibleCount"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "nodes" | "edges" | "visibleCount"
+> & {
   nodes: readonly FlowNode[];
   edges: readonly FlowEdge[];
   visibleCount: number;

--- a/packages/ui/src/components/elements/flow-graph.tsx
+++ b/packages/ui/src/components/elements/flow-graph.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -28,11 +29,11 @@ export function FlowGraph({
   edges,
   visibleCount,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "nodes" | "edges" | "visibleCount"> & {
   nodes: readonly FlowNode[];
   edges: readonly FlowEdge[];
   visibleCount: number;
-  className?: string;
 }) {
   const shown = nodes.slice(0, visibleCount);
   const shownIds = new Set(shown.map((node) => node.id));
@@ -48,11 +49,14 @@ export function FlowGraph({
 
   return (
     <div
+      data-slot="flow-graph"
       className={cn(
         paper,
         "w-full max-w-md overflow-x-auto rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="relative" style={{ width, height, minWidth: width }}>
         <svg

--- a/packages/ui/src/components/elements/guardrail-notice.tsx
+++ b/packages/ui/src/components/elements/guardrail-notice.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ShieldIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -11,21 +12,27 @@ export function GuardrailNotice({
   alternatives,
   onPick,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "title" | "explanation" | "policy" | "alternatives" | "onPick"
+> & {
   title: string;
   explanation: string;
   policy: string;
   alternatives: readonly string[];
   onPick?: (alternative: string) => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="guardrail-notice"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-amber-500/12 text-amber-600 dark:text-amber-400">

--- a/packages/ui/src/components/elements/guardrail-notice.tsx
+++ b/packages/ui/src/components/elements/guardrail-notice.tsx
@@ -15,7 +15,7 @@ export function GuardrailNotice({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "title" | "explanation" | "policy" | "alternatives" | "onPick"
+  "children" | "title" | "explanation" | "policy" | "alternatives" | "onPick"
 > & {
   title: string;
   explanation: string;

--- a/packages/ui/src/components/elements/image-generation.tsx
+++ b/packages/ui/src/components/elements/image-generation.tsx
@@ -12,7 +12,7 @@ export function ImageGeneration({
   generating,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "prompt" | "generating"> & {
+}: Omit<ComponentProps<"div">, "children" | "prompt" | "generating"> & {
   prompt: string;
   generating: boolean;
 }) {

--- a/packages/ui/src/components/elements/image-generation.tsx
+++ b/packages/ui/src/components/elements/image-generation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -10,13 +11,18 @@ export function ImageGeneration({
   prompt,
   generating,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "prompt" | "generating"> & {
   prompt: string;
   generating: boolean;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-52 flex-col gap-2.5", className)}>
+    <div
+      data-slot="image-generation"
+      className={cn("flex w-52 flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <div
         className={cn(
           paper,

--- a/packages/ui/src/components/elements/inline-citation.tsx
+++ b/packages/ui/src/components/elements/inline-citation.tsx
@@ -65,7 +65,10 @@ function Citation({ index, source, open, onOpenChange }: CitationProps) {
   );
 }
 
-export interface InlineCitationProps extends ComponentProps<"p"> {
+export interface InlineCitationProps extends Omit<
+  ComponentProps<"p">,
+  "children"
+> {
   sources: Source[];
   openIndex: number | null;
   onOpenIndexChange: (index: number | null) => void;

--- a/packages/ui/src/components/elements/inline-citation.tsx
+++ b/packages/ui/src/components/elements/inline-citation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PreviewCard } from "@base-ui/react/preview-card";
 import { cn } from "@/lib/utils";
 import { floating, mono } from "./surfaces";
@@ -64,11 +65,10 @@ function Citation({ index, source, open, onOpenChange }: CitationProps) {
   );
 }
 
-export interface InlineCitationProps {
+export interface InlineCitationProps extends ComponentProps<"p"> {
   sources: Source[];
   openIndex: number | null;
   onOpenIndexChange: (index: number | null) => void;
-  className?: string;
 }
 
 export function InlineCitation({
@@ -76,13 +76,17 @@ export function InlineCitation({
   openIndex,
   onOpenIndexChange,
   className,
+  ...props
 }: InlineCitationProps) {
   return (
     <p
+      data-slot="inline-citation"
       className={cn(
         "text-foreground/90 max-w-sm text-sm leading-relaxed",
         className,
       )}
+
+      {...props}
     >
       Optimistic updates keep the thread responsive while the server confirms
       the write

--- a/packages/ui/src/components/elements/job-progress.tsx
+++ b/packages/ui/src/components/elements/job-progress.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -17,14 +18,17 @@ export function JobProgress({
   eta,
   onCancel,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "title" | "stages" | "stageIndex" | "stageProgress" | "eta" | "onCancel"
+> & {
   title: string;
   stages: readonly JobStage[];
   stageIndex: number;
   stageProgress: number;
   eta: string;
   onCancel?: () => void;
-  className?: string;
 }) {
   const totalWeight = stages.reduce((sum, stage) => sum + stage.weight, 0) || 1;
   const completed = stages
@@ -39,11 +43,14 @@ export function JobProgress({
 
   return (
     <div
+      data-slot="job-progress"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         {finished ? (

--- a/packages/ui/src/components/elements/job-progress.tsx
+++ b/packages/ui/src/components/elements/job-progress.tsx
@@ -21,7 +21,13 @@ export function JobProgress({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "title" | "stages" | "stageIndex" | "stageProgress" | "eta" | "onCancel"
+  | "children"
+  | "title"
+  | "stages"
+  | "stageIndex"
+  | "stageProgress"
+  | "eta"
+  | "onCancel"
 > & {
   title: string;
   stages: readonly JobStage[];

--- a/packages/ui/src/components/elements/launcher-bubble.tsx
+++ b/packages/ui/src/components/elements/launcher-bubble.tsx
@@ -17,7 +17,14 @@ export function LauncherBubble({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "open" | "unread" | "greeting" | "prompts" | "onToggle" | "onPick" | "onStart"
+  | "children"
+  | "open"
+  | "unread"
+  | "greeting"
+  | "prompts"
+  | "onToggle"
+  | "onPick"
+  | "onStart"
 > & {
   open: boolean;
   unread: number;

--- a/packages/ui/src/components/elements/launcher-bubble.tsx
+++ b/packages/ui/src/components/elements/launcher-bubble.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { MessageCircleIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, floating, inkButton, mono } from "./surfaces";
@@ -13,7 +14,11 @@ export function LauncherBubble({
   onPick,
   onStart,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "open" | "unread" | "greeting" | "prompts" | "onToggle" | "onPick" | "onStart"
+> & {
   open: boolean;
   unread: number;
   greeting: string;
@@ -21,14 +26,16 @@ export function LauncherBubble({
   onToggle?: () => void;
   onPick?: (prompt: string) => void;
   onStart?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="launcher-bubble"
       className={cn(
         "flex w-full max-w-[19rem] flex-col items-end gap-2.5",
         className,
       )}
+
+      {...props}
     >
       {open && (
         <div

--- a/packages/ui/src/components/elements/loading-state.tsx
+++ b/packages/ui/src/components/elements/loading-state.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/lib/utils";
 
 export type GenerationLoaderVariant = "dots" | "squares" | "rounded";
 
-export interface GenerationLoaderProps extends ComponentProps<"div"> {
+export interface GenerationLoaderProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   label: string;
   tick: number;
   variant?: GenerationLoaderVariant;

--- a/packages/ui/src/components/elements/loading-state.tsx
+++ b/packages/ui/src/components/elements/loading-state.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 export type GenerationLoaderVariant = "dots" | "squares" | "rounded";
 
-export interface GenerationLoaderProps {
+export interface GenerationLoaderProps extends ComponentProps<"div"> {
   label: string;
   tick: number;
   variant?: GenerationLoaderVariant;
-  className?: string;
 }
 
 const CELL_SHAPES: Record<GenerationLoaderVariant, string> = {
@@ -22,11 +22,17 @@ export function GenerationLoader({
   tick,
   variant = "dots",
   className,
+  ...props
 }: GenerationLoaderProps) {
   const pixelOffset = Math.floor(tick / 3);
 
   return (
-    <div className={cn("flex flex-col items-center gap-4", className)}>
+    <div
+      data-slot="generation-loader"
+      className={cn("flex flex-col items-center gap-4", className)}
+
+      {...props}
+    >
       <div aria-hidden className="grid grid-cols-3 gap-1">
         {Array.from({ length: 9 }, (_, index) => {
           const active = (index * 2 + pixelOffset) % 9 < 3;

--- a/packages/ui/src/components/elements/map-answer.tsx
+++ b/packages/ui/src/components/elements/map-answer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
 
@@ -17,22 +18,25 @@ export function MapAnswer({
   route,
   onSelect,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "pins" | "activeId" | "route" | "onSelect"> & {
   pins: readonly MapPin[];
   activeId: string;
   route?: boolean;
   onSelect?: (id: string) => void;
-  className?: string;
 }) {
   const path = pins.map((pin) => `${pin.x},${pin.y}`).join(" ");
 
   return (
     <div
+      data-slot="map-answer"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className={cn(field, "relative h-40")}>
         <svg

--- a/packages/ui/src/components/elements/map-answer.tsx
+++ b/packages/ui/src/components/elements/map-answer.tsx
@@ -19,7 +19,10 @@ export function MapAnswer({
   onSelect,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "pins" | "activeId" | "route" | "onSelect"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "pins" | "activeId" | "route" | "onSelect"
+> & {
   pins: readonly MapPin[];
   activeId: string;
   route?: boolean;

--- a/packages/ui/src/components/elements/math-block.tsx
+++ b/packages/ui/src/components/elements/math-block.tsx
@@ -15,7 +15,10 @@ export function MathBlock({
   visibleSteps,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "label" | "steps" | "visibleSteps"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "label" | "steps" | "visibleSteps"
+> & {
   label?: string;
   steps: readonly MathStep[];
   visibleSteps: number;

--- a/packages/ui/src/components/elements/math-block.tsx
+++ b/packages/ui/src/components/elements/math-block.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -13,19 +14,22 @@ export function MathBlock({
   steps,
   visibleSteps,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "label" | "steps" | "visibleSteps"> & {
   label?: string;
   steps: readonly MathStep[];
   visibleSteps: number;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="math-block"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-2.5 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       {label && <span className={cn(mono, "text-foreground/30")}>{label}</span>}
 
@@ -56,7 +60,10 @@ export function Frac({
   under: React.ReactNode;
 }) {
   return (
-    <span className="inline-flex flex-col items-center align-middle text-[0.85em] leading-tight">
+    <span
+      data-slot="frac"
+      className="inline-flex flex-col items-center align-middle text-[0.85em] leading-tight"
+    >
       <span className="px-1">{over}</span>
       <span className="border-foreground/40 w-full border-t px-1">{under}</span>
     </span>

--- a/packages/ui/src/components/elements/mcp-server-panel.tsx
+++ b/packages/ui/src/components/elements/mcp-server-panel.tsx
@@ -42,7 +42,7 @@ export function McpServerPanel({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "servers" | "expandedId" | "onToggle" | "onAuthorize"
+  "children" | "servers" | "expandedId" | "onToggle" | "onAuthorize"
 > & {
   servers: readonly McpServer[];
   expandedId?: string;

--- a/packages/ui/src/components/elements/mcp-server-panel.tsx
+++ b/packages/ui/src/components/elements/mcp-server-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ChevronRightIcon, PlugIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -38,12 +39,15 @@ export function McpServerPanel({
   onToggle,
   onAuthorize,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "servers" | "expandedId" | "onToggle" | "onAuthorize"
+> & {
   servers: readonly McpServer[];
   expandedId?: string;
   onToggle?: (id: string) => void;
   onAuthorize?: (id: string) => void;
-  className?: string;
 }) {
   const connected = servers.filter(
     (server) => server.status === "connected",
@@ -51,11 +55,14 @@ export function McpServerPanel({
 
   return (
     <div
+      data-slot="mcp-server-panel"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-1 rounded-2xl p-3",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between px-1 pb-1">
         <span className="text-[13.5px] font-medium">Servers</span>

--- a/packages/ui/src/components/elements/memory-chips.tsx
+++ b/packages/ui/src/components/elements/memory-chips.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { BrainIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono } from "./surfaces";
@@ -16,15 +17,20 @@ export function MemoryChips({
   chips,
   onForget,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "chips" | "onForget"> & {
   chips: readonly MemoryChip[];
   onForget?: (id: string) => void;
-  className?: string;
 }) {
   const fresh = chips.filter((chip) => chip.change !== "existing").length;
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="memory-chips"
+      className={cn("flex w-full max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       <div className="flex items-center gap-1.5">
         <BrainIcon className="text-foreground/30 size-3.5" />
         <span className={cn(mono, "text-foreground/35")}>

--- a/packages/ui/src/components/elements/memory-chips.tsx
+++ b/packages/ui/src/components/elements/memory-chips.tsx
@@ -18,7 +18,7 @@ export function MemoryChips({
   onForget,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "chips" | "onForget"> & {
+}: Omit<ComponentProps<"div">, "children" | "chips" | "onForget"> & {
   chips: readonly MemoryChip[];
   onForget?: (id: string) => void;
 }) {

--- a/packages/ui/src/components/elements/message-actions.tsx
+++ b/packages/ui/src/components/elements/message-actions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import {
   CheckIcon,
   CopyIcon,
@@ -13,7 +14,7 @@ import { ghostButton, iconSwap, iconSwapIn, iconSwapOut } from "./surfaces";
 
 export type Reaction = "up" | "down" | null;
 
-export interface MessageActionsProps {
+export interface MessageActionsProps extends ComponentProps<"div"> {
   copied: boolean;
   reaction: Reaction;
   regenerating: boolean;
@@ -21,7 +22,6 @@ export interface MessageActionsProps {
   onReactionChange: (reaction: Reaction) => void;
   onRegenerate: () => void;
   onMore: () => void;
-  className?: string;
 }
 
 export function MessageActions({
@@ -33,11 +33,17 @@ export function MessageActions({
   onRegenerate,
   onMore,
   className,
+  ...props
 }: MessageActionsProps) {
   const buttonClassName = cn(ghostButton, "size-7");
 
   return (
-    <div className={cn("flex items-center gap-1", className)}>
+    <div
+      data-slot="message-actions"
+      className={cn("flex items-center gap-1", className)}
+
+      {...props}
+    >
       <button
         type="button"
         aria-label={copied ? "Copied response" : "Copy response"}

--- a/packages/ui/src/components/elements/message-actions.tsx
+++ b/packages/ui/src/components/elements/message-actions.tsx
@@ -14,7 +14,10 @@ import { ghostButton, iconSwap, iconSwapIn, iconSwapOut } from "./surfaces";
 
 export type Reaction = "up" | "down" | null;
 
-export interface MessageActionsProps extends ComponentProps<"div"> {
+export interface MessageActionsProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   copied: boolean;
   reaction: Reaction;
   regenerating: boolean;

--- a/packages/ui/src/components/elements/message-attachment.tsx
+++ b/packages/ui/src/components/elements/message-attachment.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { FileTextIcon, ImageIcon, PaperclipIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -17,13 +18,18 @@ export function MessageAttachments({
   attachments,
   onOpen,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "attachments" | "onOpen"> & {
   attachments: readonly MessageAttachmentItem[];
   onOpen?: (id: string) => void;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-1.5", className)}>
+    <div
+      data-slot="message-attachments"
+      className={cn("flex w-full max-w-sm flex-col gap-1.5", className)}
+
+      {...props}
+    >
       {attachments.map((item) =>
         item.kind === "image" ? (
           <button

--- a/packages/ui/src/components/elements/message-attachment.tsx
+++ b/packages/ui/src/components/elements/message-attachment.tsx
@@ -19,7 +19,7 @@ export function MessageAttachments({
   onOpen,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "attachments" | "onOpen"> & {
+}: Omit<ComponentProps<"div">, "children" | "attachments" | "onOpen"> & {
   attachments: readonly MessageAttachmentItem[];
   onOpen?: (id: string) => void;
 }) {

--- a/packages/ui/src/components/elements/message-branches.tsx
+++ b/packages/ui/src/components/elements/message-branches.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono } from "./surfaces";
 
-export interface MessageBranchesProps {
+export interface MessageBranchesProps extends ComponentProps<"div"> {
   variants: readonly string[];
   index: number;
   onIndexChange: (index: number) => void;
-  className?: string;
 }
 
 export function MessageBranches({
@@ -16,6 +16,7 @@ export function MessageBranches({
   index,
   onIndexChange,
   className,
+  ...props
 }: MessageBranchesProps) {
   const message = variants[index] ?? variants[0] ?? "";
   const hasNavigation = variants.length > 1;
@@ -30,7 +31,12 @@ export function MessageBranches({
   };
 
   return (
-    <div className={cn("flex max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="message-branches"
+      className={cn("flex max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       <p
         key={index}
         className="fade-in slide-in-from-bottom-1 animate-in text-foreground/90 min-h-[4.25rem] text-sm leading-relaxed duration-300 motion-reduce:animate-none"

--- a/packages/ui/src/components/elements/message-branches.tsx
+++ b/packages/ui/src/components/elements/message-branches.tsx
@@ -5,7 +5,10 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono } from "./surfaces";
 
-export interface MessageBranchesProps extends ComponentProps<"div"> {
+export interface MessageBranchesProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   variants: readonly string[];
   index: number;
   onIndexChange: (index: number) => void;

--- a/packages/ui/src/components/elements/message-pair.tsx
+++ b/packages/ui/src/components/elements/message-pair.tsx
@@ -1,16 +1,16 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CopyIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, paper } from "./surfaces";
 
-export interface MessagePairProps {
+export interface MessagePairProps extends ComponentProps<"div"> {
   userMessage: string;
   words: readonly string[];
   visibleWords: number;
   streaming: boolean;
   variant?: "bubble" | "flat";
-  className?: string;
 }
 
 export function MessagePair({
@@ -20,9 +20,15 @@ export function MessagePair({
   streaming,
   variant = "bubble",
   className,
+  ...props
 }: MessagePairProps) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-5", className)}>
+    <div
+      data-slot="message-pair"
+      className={cn("flex w-full max-w-sm flex-col gap-5", className)}
+
+      {...props}
+    >
       <p
         className={cn(
           "max-w-[85%] self-end text-sm",

--- a/packages/ui/src/components/elements/message-pair.tsx
+++ b/packages/ui/src/components/elements/message-pair.tsx
@@ -5,7 +5,10 @@ import { CopyIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, paper } from "./surfaces";
 
-export interface MessagePairProps extends ComponentProps<"div"> {
+export interface MessagePairProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   userMessage: string;
   words: readonly string[];
   visibleWords: number;

--- a/packages/ui/src/components/elements/message-queue.tsx
+++ b/packages/ui/src/components/elements/message-queue.tsx
@@ -16,7 +16,10 @@ export function MessageQueue({
   onCancel,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "running" | "queued" | "onCancel"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "running" | "queued" | "onCancel"
+> & {
   running: string;
   queued: readonly QueuedMessage[];
   onCancel?: (id: string) => void;

--- a/packages/ui/src/components/elements/message-queue.tsx
+++ b/packages/ui/src/components/elements/message-queue.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowUpIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
@@ -14,14 +15,19 @@ export function MessageQueue({
   queued,
   onCancel,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "running" | "queued" | "onCancel"> & {
   running: string;
   queued: readonly QueuedMessage[];
   onCancel?: (id: string) => void;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="message-queue"
+      className={cn("flex w-full max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       <div className={cn(paper, "flex items-center gap-2.5 rounded-2xl p-3")}>
         <span className="relative flex size-2 shrink-0">
           <span className="absolute inline-flex size-full animate-ping rounded-full bg-blue-500/60 motion-reduce:hidden" />

--- a/packages/ui/src/components/elements/message-timing.tsx
+++ b/packages/ui/src/components/elements/message-timing.tsx
@@ -14,7 +14,7 @@ export function MessageTiming({
   streaming,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "stats" | "streaming"> & {
+}: Omit<ComponentProps<"div">, "children" | "stats" | "streaming"> & {
   stats: readonly TimingStat[];
   streaming?: boolean;
 }) {

--- a/packages/ui/src/components/elements/message-timing.tsx
+++ b/packages/ui/src/components/elements/message-timing.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
 
@@ -12,17 +13,20 @@ export function MessageTiming({
   stats,
   streaming,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "stats" | "streaming"> & {
   stats: readonly TimingStat[];
   streaming?: boolean;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="message-timing"
       className={cn(
         "fade-in animate-in flex w-full max-w-sm flex-wrap items-center gap-x-3 gap-y-1 duration-500",
         className,
       )}
+
+      {...props}
     >
       {stats.map((stat) => (
         <span key={stat.label} className="flex items-baseline gap-1">

--- a/packages/ui/src/components/elements/mobile-composer.tsx
+++ b/packages/ui/src/components/elements/mobile-composer.tsx
@@ -20,6 +20,7 @@ export function MobileComposer({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "value"
   | "keyboardOpen"
   | "running"

--- a/packages/ui/src/components/elements/mobile-composer.tsx
+++ b/packages/ui/src/components/elements/mobile-composer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowUpIcon, MicIcon, PlusIcon, SquareIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, inkButton, mono } from "./surfaces";
@@ -16,7 +17,20 @@ export function MobileComposer({
   onStop,
   onFocus,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "value"
+  | "keyboardOpen"
+  | "running"
+  | "actions"
+  | "onAction"
+  | "onAttach"
+  | "onValueChange"
+  | "onSend"
+  | "onStop"
+  | "onFocus"
+> & {
   value: string;
   keyboardOpen: boolean;
   running: boolean;
@@ -27,15 +41,17 @@ export function MobileComposer({
   onSend?: () => void;
   onStop?: () => void;
   onFocus?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="mobile-composer"
       className={cn(
         "bg-background border-foreground/[0.07] flex w-full max-w-[19rem] flex-col gap-2.5 rounded-t-[20px] border-t px-3 pt-3 shadow-[0_-8px_24px_-16px_rgba(0,0,0,0.25)]",
         keyboardOpen ? "pb-3" : "pb-6",
         className,
       )}
+
+      {...props}
     >
       {!keyboardOpen && (
         <div className="fade-in animate-in -mx-3 flex gap-1.5 overflow-x-auto px-3 pb-0.5 duration-200">

--- a/packages/ui/src/components/elements/model-picker.tsx
+++ b/packages/ui/src/components/elements/model-picker.tsx
@@ -20,7 +20,10 @@ export function ModelPicker({
   onSelect,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "models" | "selectedId" | "onSelect"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "models" | "selectedId" | "onSelect"
+> & {
   models: readonly PickableModel[];
   selectedId: string;
   onSelect?: (id: string) => void;

--- a/packages/ui/src/components/elements/model-picker.tsx
+++ b/packages/ui/src/components/elements/model-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -18,21 +19,24 @@ export function ModelPicker({
   selectedId,
   onSelect,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "models" | "selectedId" | "onSelect"> & {
   models: readonly PickableModel[];
   selectedId: string;
   onSelect?: (id: string) => void;
-  className?: string;
 }) {
   const families = [...new Set(models.map((model) => model.family))];
 
   return (
     <div
+      data-slot="model-picker"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-1 rounded-2xl p-2",
         className,
       )}
+
+      {...props}
     >
       {families.map((family) => (
         <div key={family} className="flex flex-col">

--- a/packages/ui/src/components/elements/number-ticker.tsx
+++ b/packages/ui/src/components/elements/number-ticker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
 
@@ -24,15 +25,20 @@ export function NumberTicker({
   value,
   label,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "value" | "label"> & {
   value: number;
   label: string;
-  className?: string;
 }) {
   const formatted = value.toLocaleString("en-US");
 
   return (
-    <div className={cn("flex flex-col items-center gap-2.5", className)}>
+    <div
+      data-slot="number-ticker"
+      className={cn("flex flex-col items-center gap-2.5", className)}
+
+      {...props}
+    >
       <span
         className="flex text-3xl font-medium tracking-tight tabular-nums"
         aria-label={formatted}

--- a/packages/ui/src/components/elements/number-ticker.tsx
+++ b/packages/ui/src/components/elements/number-ticker.tsx
@@ -26,7 +26,7 @@ export function NumberTicker({
   label,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "value" | "label"> & {
+}: Omit<ComponentProps<"div">, "children" | "value" | "label"> & {
   value: number;
   label: string;
 }) {

--- a/packages/ui/src/components/elements/onboarding.tsx
+++ b/packages/ui/src/components/elements/onboarding.tsx
@@ -17,7 +17,10 @@ export function Onboarding({
   onSkip,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "steps" | "index" | "onNext" | "onSkip"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "steps" | "index" | "onNext" | "onSkip"
+> & {
   steps: readonly OnboardingStep[];
   index: number;
   onNext?: () => void;

--- a/packages/ui/src/components/elements/onboarding.tsx
+++ b/packages/ui/src/components/elements/onboarding.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
 
@@ -15,12 +16,12 @@ export function Onboarding({
   onNext,
   onSkip,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "steps" | "index" | "onNext" | "onSkip"> & {
   steps: readonly OnboardingStep[];
   index: number;
   onNext?: () => void;
   onSkip?: () => void;
-  className?: string;
 }) {
   const step = steps[Math.min(index, steps.length - 1)];
   if (!step) return null;
@@ -28,11 +29,14 @@ export function Onboarding({
 
   return (
     <div
+      data-slot="onboarding"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-4 rounded-[20px] p-5",
         className,
       )}
+
+      {...props}
     >
       <div
         key={index}

--- a/packages/ui/src/components/elements/permission-grant.tsx
+++ b/packages/ui/src/components/elements/permission-grant.tsx
@@ -17,7 +17,7 @@ export function PermissionGrant({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "capability" | "requester" | "reach" | "scope" | "onGrant"
+  "children" | "capability" | "requester" | "reach" | "scope" | "onGrant"
 > & {
   capability: string;
   requester: string;

--- a/packages/ui/src/components/elements/permission-grant.tsx
+++ b/packages/ui/src/components/elements/permission-grant.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { KeyRoundIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
@@ -13,21 +14,27 @@ export function PermissionGrant({
   scope,
   onGrant,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "capability" | "requester" | "reach" | "scope" | "onGrant"
+> & {
   capability: string;
   requester: string;
   reach: readonly string[];
   scope: GrantScope | "pending";
   onGrant?: (scope: GrantScope) => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="permission-grant"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3.5 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { BookmarkIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -19,27 +20,54 @@ export function PromptLibrary({
   onSelect,
   onInsert,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "prompts" | "query" | "selectedId" | "onQueryChange" | "onSelect" | "onInsert"
+> & {
   prompts: readonly SavedPrompt[];
   query: string;
   selectedId: string;
   onQueryChange?: (query: string) => void;
   onSelect?: (id: string) => void;
   onInsert?: (id: string) => void;
-  className?: string;
 }) {
   const matches = prompts.filter((prompt) =>
     prompt.name.toLowerCase().includes(query.toLowerCase()),
   );
   const selected = matches.find((prompt) => prompt.id === selectedId);
 
+  const move = (delta: number) => {
+    if (matches.length === 0) return;
+    const at = matches.findIndex((prompt) => prompt.id === selectedId);
+    const next = matches[(at + delta + matches.length) % matches.length];
+    if (next) onSelect?.(next.id);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      move(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      move(-1);
+    } else if (event.key === "Enter" && selected) {
+      event.preventDefault();
+      onInsert?.(selected.id);
+    }
+  };
+
   return (
     <div
+      data-slot="prompt-library"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-2 rounded-2xl p-3",
         className,
       )}
+
+      {...props}
     >
       <div
         className={cn(
@@ -51,6 +79,7 @@ export function PromptLibrary({
         <input
           value={query}
           onChange={(event) => onQueryChange?.(event.target.value)}
+          onKeyDown={onKeyDown}
           placeholder="Search prompts"
           aria-label="Search saved prompts"
           className="text-foreground/85 placeholder:text-foreground/30 min-w-0 flex-1 bg-transparent text-[13px] outline-none"
@@ -64,6 +93,11 @@ export function PromptLibrary({
             type="button"
             onClick={() => onSelect?.(prompt.id)}
             onDoubleClick={() => onInsert?.(prompt.id)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter") return;
+              event.preventDefault();
+              onInsert?.(prompt.id);
+            }}
             className={cn(
               "flex items-center gap-2 rounded-xl px-2 py-1.5 text-start transition-colors",
               prompt.id === selectedId

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -46,7 +46,9 @@ export function PromptLibrary({
   const move = (delta: number) => {
     if (matches.length === 0) return;
     const at = matches.findIndex((prompt) => prompt.id === selectedId);
-    const next = matches[(at + delta + matches.length) % matches.length];
+    // selectedId can be filtered out by the query; start from the edge the key implies
+    const from = at === -1 ? (delta > 0 ? -1 : 0) : at;
+    const next = matches[(from + delta + matches.length) % matches.length];
     if (next) onSelect?.(next.id);
   };
 

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -23,7 +23,13 @@ export function PromptLibrary({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "prompts" | "query" | "selectedId" | "onQueryChange" | "onSelect" | "onInsert"
+  | "children"
+  | "prompts"
+  | "query"
+  | "selectedId"
+  | "onQueryChange"
+  | "onSelect"
+  | "onInsert"
 > & {
   prompts: readonly SavedPrompt[];
   query: string;

--- a/packages/ui/src/components/elements/quota-banner.tsx
+++ b/packages/ui/src/components/elements/quota-banner.tsx
@@ -15,7 +15,13 @@ export function QuotaBanner({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "used" | "limit" | "unit" | "resetsIn" | "upgradeLabel" | "onUpgrade"
+  | "children"
+  | "used"
+  | "limit"
+  | "unit"
+  | "resetsIn"
+  | "upgradeLabel"
+  | "onUpgrade"
 > & {
   used: number;
   limit: number;

--- a/packages/ui/src/components/elements/quota-banner.tsx
+++ b/packages/ui/src/components/elements/quota-banner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { inkButton, mono, paper } from "./surfaces";
 
@@ -11,14 +12,17 @@ export function QuotaBanner({
   upgradeLabel,
   onUpgrade,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "used" | "limit" | "unit" | "resetsIn" | "upgradeLabel" | "onUpgrade"
+> & {
   used: number;
   limit: number;
   unit: string;
   resetsIn: string;
   upgradeLabel: string;
   onUpgrade?: () => void;
-  className?: string;
 }) {
   const left = Math.max(0, limit - used);
   const ratio = limit === 0 ? 0 : used / limit;
@@ -26,11 +30,14 @@ export function QuotaBanner({
 
   return (
     <div
+      data-slot="quota-banner"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-2.5 rounded-2xl p-3.5",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline gap-2">
         <span

--- a/packages/ui/src/components/elements/quote-reply.tsx
+++ b/packages/ui/src/components/elements/quote-reply.tsx
@@ -29,6 +29,7 @@ export function QuoteReply({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "before"
   | "selection"
   | "after"

--- a/packages/ui/src/components/elements/quote-reply.tsx
+++ b/packages/ui/src/components/elements/quote-reply.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PencilLineIcon, QuoteIcon, SparklesIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { floating, mono } from "./surfaces";
@@ -25,7 +26,17 @@ export function QuoteReply({
   quoted,
   onAction,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "before"
+  | "selection"
+  | "after"
+  | "actions"
+  | "toolbarVisible"
+  | "quoted"
+  | "onAction"
+> & {
   before: string;
   selection: string;
   after: string;
@@ -33,10 +44,14 @@ export function QuoteReply({
   toolbarVisible: boolean;
   quoted?: string;
   onAction?: (key: string) => void;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+    <div
+      data-slot="quote-reply"
+      className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <p className="relative text-[13.5px] leading-relaxed">
         <span className="text-foreground/70">{before}</span>
         <span className="text-foreground/95 rounded bg-blue-500/18 px-0.5 dark:bg-blue-400/25">

--- a/packages/ui/src/components/elements/read-aloud.tsx
+++ b/packages/ui/src/components/elements/read-aloud.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PauseIcon, PlayIcon, Volume2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
@@ -14,7 +15,18 @@ export function ReadAloud({
   onToggle,
   onRateChange,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "words"
+  | "spokenIndex"
+  | "playing"
+  | "rate"
+  | "elapsed"
+  | "duration"
+  | "onToggle"
+  | "onRateChange"
+> & {
   words: readonly string[];
   spokenIndex: number;
   playing: boolean;
@@ -23,18 +35,20 @@ export function ReadAloud({
   duration: string;
   onToggle?: () => void;
   onRateChange?: () => void;
-  className?: string;
 }) {
   const progress =
     words.length === 0 ? 0 : Math.min(100, (spokenIndex / words.length) * 100);
 
   return (
     <div
+      data-slot="read-aloud"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-3.5",
         className,
       )}
+
+      {...props}
     >
       <p className="text-[13.5px] leading-relaxed">
         {words.map((word, i) => (

--- a/packages/ui/src/components/elements/read-aloud.tsx
+++ b/packages/ui/src/components/elements/read-aloud.tsx
@@ -18,6 +18,7 @@ export function ReadAloud({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "words"
   | "spokenIndex"
   | "playing"

--- a/packages/ui/src/components/elements/reasoning-effort.tsx
+++ b/packages/ui/src/components/elements/reasoning-effort.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
 
@@ -17,19 +18,27 @@ export function ReasoningEffort({
   spent,
   onSelect,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "levels" | "selectedKey" | "spent" | "onSelect"
+> & {
   levels: readonly EffortLevel[];
   selectedKey: string;
   spent: number;
   onSelect?: (key: string) => void;
-  className?: string;
 }) {
   const selected = levels.find((level) => level.key === selectedKey);
   const budget = selected?.budget ?? 0;
   const used = budget === 0 ? 0 : Math.min(100, (spent / budget) * 100);
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+    <div
+      data-slot="reasoning-effort"
+      className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">Thinking</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>

--- a/packages/ui/src/components/elements/reasoning-effort.tsx
+++ b/packages/ui/src/components/elements/reasoning-effort.tsx
@@ -21,7 +21,7 @@ export function ReasoningEffort({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "levels" | "selectedKey" | "spent" | "onSelect"
+  "children" | "levels" | "selectedKey" | "spent" | "onSelect"
 > & {
   levels: readonly EffortLevel[];
   selectedKey: string;

--- a/packages/ui/src/components/elements/reasoning-panel.tsx
+++ b/packages/ui/src/components/elements/reasoning-panel.tsx
@@ -37,6 +37,7 @@ export function ReasoningPanel({
 }: ReasoningPanelProps) {
   return (
     <Collapsible
+      data-slot="reasoning-panel"
       open={open}
       onOpenChange={onOpenChange}
       className={cn("w-full max-w-sm", className)}

--- a/packages/ui/src/components/elements/recommendation-card.tsx
+++ b/packages/ui/src/components/elements/recommendation-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import type { ReactNode } from "react";
 import { CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -18,7 +19,17 @@ export function RecommendationCard({
   onAccept,
   onAlternatives,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "state"
+  | "question"
+  | "children"
+  | "confidenceLabel"
+  | "acceptedLabel"
+  | "onAccept"
+  | "onAlternatives"
+> & {
   state: RecommendationState;
   question: string;
   children: ReactNode;
@@ -26,15 +37,17 @@ export function RecommendationCard({
   acceptedLabel: string;
   onAccept?: () => void;
   onAlternatives?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="recommendation-card"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <p className="text-sm font-medium">{question}</p>
       <p className="text-foreground/55 text-[13px] leading-relaxed">

--- a/packages/ui/src/components/elements/regenerate-menu.tsx
+++ b/packages/ui/src/components/elements/regenerate-menu.tsx
@@ -21,7 +21,7 @@ export function RegenerateMenu({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "options" | "open" | "currentId" | "onOpenChange" | "onPick"
+  "children" | "options" | "open" | "currentId" | "onOpenChange" | "onPick"
 > & {
   options: readonly RegenerateOption[];
   open: boolean;

--- a/packages/ui/src/components/elements/regenerate-menu.tsx
+++ b/packages/ui/src/components/elements/regenerate-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { floating, ghostButton, mono } from "./surfaces";
@@ -17,16 +18,24 @@ export function RegenerateMenu({
   onOpenChange,
   onPick,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "options" | "open" | "currentId" | "onOpenChange" | "onPick"
+> & {
   options: readonly RegenerateOption[];
   open: boolean;
   currentId: string;
   onOpenChange?: (open: boolean) => void;
   onPick?: (id: string) => void;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2", className)}>
+    <div
+      data-slot="regenerate-menu"
+      className={cn("flex w-full max-w-sm flex-col gap-2", className)}
+
+      {...props}
+    >
       <button
         type="button"
         aria-expanded={open}

--- a/packages/ui/src/components/elements/research-report.tsx
+++ b/packages/ui/src/components/elements/research-report.tsx
@@ -21,7 +21,10 @@ export function ResearchReport({
   sourcesRead,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "title" | "sections" | "sourcesRead"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "title" | "sections" | "sourcesRead"
+> & {
   title: string;
   sections: readonly ReportSection[];
   sourcesRead: number;

--- a/packages/ui/src/components/elements/research-report.tsx
+++ b/packages/ui/src/components/elements/research-report.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -19,21 +20,24 @@ export function ResearchReport({
   sections,
   sourcesRead,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "title" | "sections" | "sourcesRead"> & {
   title: string;
   sections: readonly ReportSection[];
   sourcesRead: number;
-  className?: string;
 }) {
   const done = sections.filter((section) => section.state === "done").length;
 
   return (
     <div
+      data-slot="research-report"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex flex-col gap-1">
         <span className="text-[13.5px] font-medium">{title}</span>

--- a/packages/ui/src/components/elements/retrieval-chunks.tsx
+++ b/packages/ui/src/components/elements/retrieval-chunks.tsx
@@ -22,7 +22,7 @@ export function RetrievalChunks({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "query" | "chunks" | "visibleCount" | "searching"
+  "children" | "query" | "chunks" | "visibleCount" | "searching"
 > & {
   query: string;
   chunks: readonly RetrievalChunk[];

--- a/packages/ui/src/components/elements/retrieval-chunks.tsx
+++ b/packages/ui/src/components/elements/retrieval-chunks.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { DatabaseIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -18,15 +19,23 @@ export function RetrievalChunks({
   visibleCount,
   searching,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "query" | "chunks" | "visibleCount" | "searching"
+> & {
   query: string;
   chunks: readonly RetrievalChunk[];
   visibleCount: number;
   searching: boolean;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+    <div
+      data-slot="retrieval-chunks"
+      className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <span
         className={cn(
           field,

--- a/packages/ui/src/components/elements/reviewable-diff.tsx
+++ b/packages/ui/src/components/elements/reviewable-diff.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { inkButton, mono, paper } from "./surfaces";
@@ -23,24 +24,30 @@ export function ReviewableDiff({
   onDiscard,
   onApply,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "filename" | "hunks" | "onKeep" | "onDiscard" | "onApply"
+> & {
   filename: string;
   hunks: readonly DiffHunk[];
   onKeep?: (id: string) => void;
   onDiscard?: (id: string) => void;
   onApply?: () => void;
-  className?: string;
 }) {
   const kept = hunks.filter((hunk) => hunk.decision === "kept").length;
   const pending = hunks.filter((hunk) => hunk.decision === "pending").length;
 
   return (
     <div
+      data-slot="reviewable-diff"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
         <span className="font-mono text-xs">{filename}</span>

--- a/packages/ui/src/components/elements/reviewable-diff.tsx
+++ b/packages/ui/src/components/elements/reviewable-diff.tsx
@@ -27,7 +27,7 @@ export function ReviewableDiff({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "filename" | "hunks" | "onKeep" | "onDiscard" | "onApply"
+  "children" | "filename" | "hunks" | "onKeep" | "onDiscard" | "onApply"
 > & {
   filename: string;
   hunks: readonly DiffHunk[];

--- a/packages/ui/src/components/elements/schedule-card.tsx
+++ b/packages/ui/src/components/elements/schedule-card.tsx
@@ -22,7 +22,13 @@ export function ScheduleCard({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "name" | "cadence" | "nextRun" | "enabled" | "history" | "onToggle"
+  | "children"
+  | "name"
+  | "cadence"
+  | "nextRun"
+  | "enabled"
+  | "history"
+  | "onToggle"
 > & {
   name: string;
   cadence: string;

--- a/packages/ui/src/components/elements/schedule-card.tsx
+++ b/packages/ui/src/components/elements/schedule-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, ClockIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -18,22 +19,28 @@ export function ScheduleCard({
   history,
   onToggle,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "name" | "cadence" | "nextRun" | "enabled" | "history" | "onToggle"
+> & {
   name: string;
   cadence: string;
   nextRun: string;
   enabled: boolean;
   history: readonly ScheduleRun[];
   onToggle?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="schedule-card"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">

--- a/packages/ui/src/components/elements/score-breakdown.tsx
+++ b/packages/ui/src/components/elements/score-breakdown.tsx
@@ -21,7 +21,7 @@ export function ScoreBreakdown({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "verdict" | "total" | "outOf" | "criteria" | "visibleCount"
+  "children" | "verdict" | "total" | "outOf" | "criteria" | "visibleCount"
 > & {
   verdict: string;
   total: number;

--- a/packages/ui/src/components/elements/score-breakdown.tsx
+++ b/packages/ui/src/components/elements/score-breakdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -17,23 +18,29 @@ export function ScoreBreakdown({
   criteria,
   visibleCount,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "verdict" | "total" | "outOf" | "criteria" | "visibleCount"
+> & {
   verdict: string;
   total: number;
   outOf: number;
   criteria: readonly ScoreCriterion[];
   visibleCount: number;
-  className?: string;
 }) {
   const ratio = outOf === 0 ? 0 : total / outOf;
 
   return (
     <div
+      data-slot="score-breakdown"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-medium tracking-tight tabular-nums">

--- a/packages/ui/src/components/elements/scroll-anchor.tsx
+++ b/packages/ui/src/components/elements/scroll-anchor.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ComponentProps,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { ArrowDownIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, floating, paper } from "./surfaces";
@@ -18,11 +24,11 @@ export function ScrollAnchor({
   paused = false,
   onSettled,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "messages" | "paused" | "onSettled"> & {
   messages: ScrollAnchorMessage[];
   paused?: boolean;
   onSettled?: () => void;
-  className?: string;
 }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [count, setCount] = useState(INITIAL_COUNT);
@@ -80,11 +86,14 @@ export function ScrollAnchor({
 
   return (
     <div
+      data-slot="scroll-anchor"
       className={cn(
         paper,
         "relative h-64 w-full max-w-sm overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div
         ref={viewportRef}

--- a/packages/ui/src/components/elements/scroll-anchor.tsx
+++ b/packages/ui/src/components/elements/scroll-anchor.tsx
@@ -25,7 +25,10 @@ export function ScrollAnchor({
   onSettled,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "messages" | "paused" | "onSettled"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "messages" | "paused" | "onSettled"
+> & {
   messages: ScrollAnchorMessage[];
   paused?: boolean;
   onSettled?: () => void;

--- a/packages/ui/src/components/elements/settings-panel.tsx
+++ b/packages/ui/src/components/elements/settings-panel.tsx
@@ -25,6 +25,7 @@ export function SettingsPanel({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "model"
   | "models"
   | "systemPrompt"

--- a/packages/ui/src/components/elements/settings-panel.tsx
+++ b/packages/ui/src/components/elements/settings-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
 
@@ -21,7 +22,19 @@ export function SettingsPanel({
   onTemperatureChange,
   onToggle,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "model"
+  | "models"
+  | "systemPrompt"
+  | "temperature"
+  | "toggles"
+  | "onModelChange"
+  | "onSystemPromptChange"
+  | "onTemperatureChange"
+  | "onToggle"
+> & {
   model: string;
   models: readonly string[];
   systemPrompt: string;
@@ -31,15 +44,17 @@ export function SettingsPanel({
   onSystemPromptChange?: (prompt: string) => void;
   onTemperatureChange?: (temperature: number) => void;
   onToggle?: (key: string) => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="settings-panel"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-4 rounded-[20px] p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex flex-col gap-1.5">
         <span className={cn(mono, "text-foreground/30")}>model</span>

--- a/packages/ui/src/components/elements/shared-conversation.tsx
+++ b/packages/ui/src/components/elements/shared-conversation.tsx
@@ -21,7 +21,7 @@ export function SharedConversation({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "title" | "sharedBy" | "sharedAt" | "turns" | "onContinue"
+  "children" | "title" | "sharedBy" | "sharedAt" | "turns" | "onContinue"
 > & {
   title: string;
   sharedBy: string;

--- a/packages/ui/src/components/elements/shared-conversation.tsx
+++ b/packages/ui/src/components/elements/shared-conversation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { LinkIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { inkButton, mono, paper } from "./surfaces";
@@ -17,21 +18,27 @@ export function SharedConversation({
   turns,
   onContinue,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "title" | "sharedBy" | "sharedAt" | "turns" | "onContinue"
+> & {
   title: string;
   sharedBy: string;
   sharedAt: string;
   turns: readonly SharedTurn[];
   onContinue?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="shared-conversation"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5 px-4 pt-3.5 pb-3">
         <LinkIcon className="text-foreground/30 size-3.5 shrink-0" />

--- a/packages/ui/src/components/elements/sources.tsx
+++ b/packages/ui/src/components/elements/sources.tsx
@@ -29,6 +29,7 @@ export function Sources({
 }: SourcesProps) {
   return (
     <Collapsible
+      data-slot="sources"
       open={open}
       onOpenChange={onOpenChange}
       className={cn("w-full max-w-sm", className)}

--- a/packages/ui/src/components/elements/speaker-identity.tsx
+++ b/packages/ui/src/components/elements/speaker-identity.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { BotIcon, UserIcon, WrenchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
@@ -24,12 +25,17 @@ const TONE: Record<SpeakerKind, string> = {
 export function SpeakerIdentity({
   turns,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "turns"> & {
   turns: readonly SpeakerTurn[];
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-3.5", className)}>
+    <div
+      data-slot="speaker-identity"
+      className={cn("flex w-full max-w-sm flex-col gap-3.5", className)}
+
+      {...props}
+    >
       {turns.map((turn) => (
         <div key={turn.id} className="flex gap-2.5">
           <span

--- a/packages/ui/src/components/elements/speaker-identity.tsx
+++ b/packages/ui/src/components/elements/speaker-identity.tsx
@@ -26,7 +26,7 @@ export function SpeakerIdentity({
   turns,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "turns"> & {
+}: Omit<ComponentProps<"div">, "children" | "turns"> & {
   turns: readonly SpeakerTurn[];
 }) {
   return (

--- a/packages/ui/src/components/elements/spec-sheet.tsx
+++ b/packages/ui/src/components/elements/spec-sheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -15,20 +16,26 @@ export function SpecSheet({
   rows,
   visibleCount,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "title" | "subtitle" | "rows" | "visibleCount"
+> & {
   title: string;
   subtitle?: string;
   rows: readonly SpecRow[];
   visibleCount: number;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="spec-sheet"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex flex-col gap-0.5">
         <span className="text-[13.5px] font-medium">{title}</span>

--- a/packages/ui/src/components/elements/spec-sheet.tsx
+++ b/packages/ui/src/components/elements/spec-sheet.tsx
@@ -19,7 +19,7 @@ export function SpecSheet({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "title" | "subtitle" | "rows" | "visibleCount"
+  "children" | "title" | "subtitle" | "rows" | "visibleCount"
 > & {
   title: string;
   subtitle?: string;

--- a/packages/ui/src/components/elements/stopped-run.tsx
+++ b/packages/ui/src/components/elements/stopped-run.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ArrowRightIcon, SquareIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
@@ -10,15 +11,23 @@ export function StoppedRun({
   onContinue,
   onDiscard,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "words" | "reason" | "onContinue" | "onDiscard"
+> & {
   words: readonly string[];
   reason: string;
   onContinue?: () => void;
   onDiscard?: () => void;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-3", className)}>
+    <div
+      data-slot="stopped-run"
+      className={cn("flex w-full max-w-sm flex-col gap-3", className)}
+
+      {...props}
+    >
       <p className="text-foreground/80 text-[13.5px] leading-relaxed">
         {words.join(" ")}
         <span

--- a/packages/ui/src/components/elements/stopped-run.tsx
+++ b/packages/ui/src/components/elements/stopped-run.tsx
@@ -14,7 +14,7 @@ export function StoppedRun({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "words" | "reason" | "onContinue" | "onDiscard"
+  "children" | "words" | "reason" | "onContinue" | "onDiscard"
 > & {
   words: readonly string[];
   reason: string;

--- a/packages/ui/src/components/elements/streaming-text.tsx
+++ b/packages/ui/src/components/elements/streaming-text.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { type ComponentProps, useMemo } from "react";
 import { cn } from "@/lib/utils";
 
 export interface Segment {
@@ -13,11 +13,11 @@ export function StreamingText({
   count,
   streaming,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"p">, "segments" | "count" | "streaming"> & {
   segments: Segment[];
   count: number;
   streaming: boolean;
-  className?: string;
 }) {
   const words = useMemo(
     () =>
@@ -31,10 +31,13 @@ export function StreamingText({
 
   return (
     <p
+      data-slot="streaming-text"
       className={cn(
         "min-h-[8.5rem] max-w-sm text-sm leading-relaxed text-pretty",
         className,
       )}
+
+      {...props}
     >
       {words.slice(0, count).map(({ word, mono: isMono }, i) => {
         const fresh = streaming && count - 1 - i < 2;

--- a/packages/ui/src/components/elements/streaming-text.tsx
+++ b/packages/ui/src/components/elements/streaming-text.tsx
@@ -14,7 +14,10 @@ export function StreamingText({
   streaming,
   className,
   ...props
-}: Omit<ComponentProps<"p">, "segments" | "count" | "streaming"> & {
+}: Omit<
+  ComponentProps<"p">,
+  "children" | "segments" | "count" | "streaming"
+> & {
   segments: Segment[];
   count: number;
   streaming: boolean;

--- a/packages/ui/src/components/elements/subagent-list.tsx
+++ b/packages/ui/src/components/elements/subagent-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -16,20 +17,26 @@ export function SubagentList({
   showSummary,
   summaryAgent,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "agents" | "completedCount" | "progress" | "showSummary" | "summaryAgent"
+> & {
   agents: readonly SubagentItem[];
   completedCount: number;
   progress: readonly number[];
   showSummary: boolean;
   summaryAgent: SubagentItem;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="subagent-list"
       className={cn(
         "flex min-h-[14.5rem] w-full max-w-xs flex-col gap-2",
         className,
       )}
+
+      {...props}
     >
       {agents.map((agent, index) => {
         const done = index < completedCount;

--- a/packages/ui/src/components/elements/subagent-list.tsx
+++ b/packages/ui/src/components/elements/subagent-list.tsx
@@ -20,7 +20,12 @@ export function SubagentList({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "agents" | "completedCount" | "progress" | "showSummary" | "summaryAgent"
+  | "children"
+  | "agents"
+  | "completedCount"
+  | "progress"
+  | "showSummary"
+  | "summaryAgent"
 > & {
   agents: readonly SubagentItem[];
   completedCount: number;

--- a/packages/ui/src/components/elements/suggestions.tsx
+++ b/packages/ui/src/components/elements/suggestions.tsx
@@ -4,7 +4,10 @@ import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { paper } from "./surfaces";
 
-export interface SuggestionsProps extends ComponentProps<"div"> {
+export interface SuggestionsProps extends Omit<
+  ComponentProps<"div">,
+  "children"
+> {
   suggestions: readonly string[];
   selectedSuggestion: string | null;
   cycle: number;

--- a/packages/ui/src/components/elements/suggestions.tsx
+++ b/packages/ui/src/components/elements/suggestions.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { paper } from "./surfaces";
 
-export interface SuggestionsProps {
+export interface SuggestionsProps extends ComponentProps<"div"> {
   suggestions: readonly string[];
   selectedSuggestion: string | null;
   cycle: number;
   onSuggestion: (suggestion: string) => void;
   variant?: "pills" | "list";
-  className?: string;
 }
 
 export function Suggestions({
@@ -19,11 +19,13 @@ export function Suggestions({
   onSuggestion,
   variant = "pills",
   className,
+  ...props
 }: SuggestionsProps) {
   const list = variant === "list";
 
   return (
     <div
+      data-slot="suggestions"
       key={cycle}
       className={cn(
         list
@@ -31,6 +33,8 @@ export function Suggestions({
           : "flex max-w-md flex-wrap justify-center gap-2",
         className,
       )}
+
+      {...props}
     >
       {suggestions.map((suggestion, index) => (
         <button

--- a/packages/ui/src/components/elements/terminal-block.tsx
+++ b/packages/ui/src/components/elements/terminal-block.tsx
@@ -15,7 +15,7 @@ export function TerminalBlock({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "command" | "lines" | "visibleCount" | "done" | "variant"
+  "children" | "command" | "lines" | "visibleCount" | "done" | "variant"
 > & {
   command: string;
   lines: readonly string[];

--- a/packages/ui/src/components/elements/terminal-block.tsx
+++ b/packages/ui/src/components/elements/terminal-block.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -11,18 +12,22 @@ export function TerminalBlock({
   done,
   variant = "paper",
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "command" | "lines" | "visibleCount" | "done" | "variant"
+> & {
   command: string;
   lines: readonly string[];
   visibleCount: number;
   done: boolean;
   variant?: "paper" | "ink";
-  className?: string;
 }) {
   const ink = variant === "ink";
 
   return (
     <div
+      data-slot="terminal-block"
       className={cn(
         ink
           ? "bg-foreground dark:bg-popover shadow-[0_12px_32px_-16px_rgba(0,0,0,0.35)] dark:shadow-none"
@@ -30,6 +35,8 @@ export function TerminalBlock({
         "w-full max-w-md overflow-hidden rounded-2xl font-mono text-xs",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center justify-between px-4 pt-3 pb-1.5">
         <span

--- a/packages/ui/src/components/elements/thinking-indicator.tsx
+++ b/packages/ui/src/components/elements/thinking-indicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
 
@@ -7,17 +8,20 @@ export function ThinkingIndicator({
   label,
   elapsed,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "label" | "elapsed"> & {
   label: string;
   elapsed?: string;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="thinking-indicator"
       className={cn(
         "text-foreground/55 flex items-center gap-2.5 text-sm",
         className,
       )}
+
+      {...props}
     >
       <span
         aria-hidden

--- a/packages/ui/src/components/elements/thinking-indicator.tsx
+++ b/packages/ui/src/components/elements/thinking-indicator.tsx
@@ -9,7 +9,7 @@ export function ThinkingIndicator({
   elapsed,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "label" | "elapsed"> & {
+}: Omit<ComponentProps<"div">, "children" | "label" | "elapsed"> & {
   label: string;
   elapsed?: string;
 }) {

--- a/packages/ui/src/components/elements/thread-list.tsx
+++ b/packages/ui/src/components/elements/thread-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PencilIcon, Trash2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
@@ -15,15 +16,21 @@ export function ThreadList({
   activeIndex,
   onActiveIndexChange,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "threads" | "activeIndex" | "onActiveIndexChange"
+> & {
   threads: readonly ThreadItem[];
   activeIndex: number;
   onActiveIndexChange?: (index: number) => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="thread-list"
       className={cn("flex w-full max-w-[240px] flex-col gap-0.5", className)}
+
+      {...props}
     >
       <div className={cn(mono, "text-foreground/35 px-3 pb-1.5")}>Today</div>
       {threads.map((thread, i) => {

--- a/packages/ui/src/components/elements/thread-list.tsx
+++ b/packages/ui/src/components/elements/thread-list.tsx
@@ -19,7 +19,7 @@ export function ThreadList({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "threads" | "activeIndex" | "onActiveIndexChange"
+  "children" | "threads" | "activeIndex" | "onActiveIndexChange"
 > & {
   threads: readonly ThreadItem[];
   activeIndex: number;

--- a/packages/ui/src/components/elements/thread-search.tsx
+++ b/packages/ui/src/components/elements/thread-search.tsx
@@ -51,7 +51,9 @@ export function ThreadSearch({
   const move = (delta: number) => {
     if (ordered.length === 0) return;
     const at = ordered.findIndex((thread) => thread.id === activeId);
-    const next = ordered[(at + delta + ordered.length) % ordered.length];
+    // activeId can be filtered out by the query; start from the edge the key implies
+    const from = at === -1 ? (delta > 0 ? -1 : 0) : at;
+    const next = ordered[(from + delta + ordered.length) % ordered.length];
     if (next) onSelect?.(next.id);
   };
 

--- a/packages/ui/src/components/elements/thread-search.tsx
+++ b/packages/ui/src/components/elements/thread-search.tsx
@@ -23,7 +23,7 @@ export function ThreadSearch({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "threads" | "query" | "activeId" | "onQueryChange" | "onSelect"
+  "children" | "threads" | "query" | "activeId" | "onQueryChange" | "onSelect"
 > & {
   threads: readonly SearchableThread[];
   query: string;

--- a/packages/ui/src/components/elements/thread-search.tsx
+++ b/packages/ui/src/components/elements/thread-search.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { PinIcon, SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -19,13 +20,16 @@ export function ThreadSearch({
   onQueryChange,
   onSelect,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "threads" | "query" | "activeId" | "onQueryChange" | "onSelect"
+> & {
   threads: readonly SearchableThread[];
   query: string;
   activeId: string;
   onQueryChange?: (query: string) => void;
   onSelect?: (id: string) => void;
-  className?: string;
 }) {
   const matches = threads.filter((thread) =>
     `${thread.title} ${thread.preview}`
@@ -36,6 +40,31 @@ export function ThreadSearch({
   const groups = [
     ...new Set(matches.filter((t) => !t.pinned).map((t) => t.group)),
   ];
+
+  const ordered = [
+    ...pinned,
+    ...groups.flatMap((group) =>
+      matches.filter((thread) => !thread.pinned && thread.group === group),
+    ),
+  ];
+
+  const move = (delta: number) => {
+    if (ordered.length === 0) return;
+    const at = ordered.findIndex((thread) => thread.id === activeId);
+    const next = ordered[(at + delta + ordered.length) % ordered.length];
+    if (next) onSelect?.(next.id);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      move(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      move(-1);
+    }
+  };
 
   const row = (thread: SearchableThread) => (
     <button
@@ -65,11 +94,14 @@ export function ThreadSearch({
 
   return (
     <div
+      data-slot="thread-search"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-1.5 rounded-2xl p-3",
         className,
       )}
+
+      {...props}
     >
       <div
         className={cn(
@@ -81,6 +113,7 @@ export function ThreadSearch({
         <input
           value={query}
           onChange={(event) => onQueryChange?.(event.target.value)}
+          onKeyDown={onKeyDown}
           placeholder="Search threads"
           aria-label="Search threads"
           className="text-foreground/85 placeholder:text-foreground/30 min-w-0 flex-1 bg-transparent text-[13px] outline-none"

--- a/packages/ui/src/components/elements/timeline.tsx
+++ b/packages/ui/src/components/elements/timeline.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -17,18 +18,21 @@ export function Timeline({
   events,
   visibleCount,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "events" | "visibleCount"> & {
   events: readonly TimelineEvent[];
   visibleCount: number;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="timeline"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       {events.slice(0, visibleCount).map((event, i, shown) => (
         <div

--- a/packages/ui/src/components/elements/timeline.tsx
+++ b/packages/ui/src/components/elements/timeline.tsx
@@ -19,7 +19,7 @@ export function Timeline({
   visibleCount,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "events" | "visibleCount"> & {
+}: Omit<ComponentProps<"div">, "children" | "events" | "visibleCount"> & {
   events: readonly TimelineEvent[];
   visibleCount: number;
 }) {

--- a/packages/ui/src/components/elements/todo-list.tsx
+++ b/packages/ui/src/components/elements/todo-list.tsx
@@ -18,7 +18,7 @@ export function TodoList({
   revision,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "items" | "revision"> & {
+}: Omit<ComponentProps<"div">, "children" | "items" | "revision"> & {
   items: readonly TodoItem[];
   revision?: number;
 }) {

--- a/packages/ui/src/components/elements/todo-list.tsx
+++ b/packages/ui/src/components/elements/todo-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
@@ -16,15 +17,20 @@ export function TodoList({
   items,
   revision,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "items" | "revision"> & {
   items: readonly TodoItem[];
   revision?: number;
-  className?: string;
 }) {
   const done = items.filter((item) => item.status === "done").length;
 
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-3", className)}>
+    <div
+      data-slot="todo-list"
+      className={cn("flex w-full max-w-sm flex-col gap-3", className)}
+
+      {...props}
+    >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">Todos</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>

--- a/packages/ui/src/components/elements/tool-call.tsx
+++ b/packages/ui/src/components/elements/tool-call.tsx
@@ -34,6 +34,7 @@ export function ToolCall({
 }: ToolCallProps) {
   return (
     <Collapsible
+      data-slot="tool-call"
       open={open}
       onOpenChange={onOpenChange}
       className={cn("w-full max-w-sm", className)}

--- a/packages/ui/src/components/elements/tool-error.tsx
+++ b/packages/ui/src/components/elements/tool-error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { AlertCircleIcon, Loader2Icon, RotateCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -14,7 +15,18 @@ export function ToolError({
   onRetry,
   onSkip,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "name"
+  | "target"
+  | "message"
+  | "attempt"
+  | "maxAttempts"
+  | "retrying"
+  | "onRetry"
+  | "onSkip"
+> & {
   name: string;
   target: string;
   message: string;
@@ -23,15 +35,17 @@ export function ToolError({
   retrying: boolean;
   onRetry?: () => void;
   onSkip?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="tool-error"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col gap-3 rounded-2xl p-3.5",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-2.5">
         <AlertCircleIcon className="size-3.5 shrink-0 text-red-500" />

--- a/packages/ui/src/components/elements/tool-error.tsx
+++ b/packages/ui/src/components/elements/tool-error.tsx
@@ -18,6 +18,7 @@ export function ToolError({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "name"
   | "target"
   | "message"

--- a/packages/ui/src/components/elements/tool-group.tsx
+++ b/packages/ui/src/components/elements/tool-group.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { CheckIcon, ChevronRightIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
@@ -20,23 +21,26 @@ export function ToolGroup({
   open,
   onOpenChange,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "label" | "tools" | "open" | "onOpenChange"> & {
   label: string;
   tools: readonly GroupedTool[];
   open: boolean;
   onOpenChange?: (open: boolean) => void;
-  className?: string;
 }) {
   const running = tools.filter((tool) => tool.state === "running").length;
   const failed = tools.filter((tool) => tool.state === "failed").length;
 
   return (
     <div
+      data-slot="tool-group"
       className={cn(
         paper,
         "flex w-full max-w-sm flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <button
         type="button"

--- a/packages/ui/src/components/elements/tool-group.tsx
+++ b/packages/ui/src/components/elements/tool-group.tsx
@@ -22,7 +22,10 @@ export function ToolGroup({
   onOpenChange,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "label" | "tools" | "open" | "onOpenChange"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "label" | "tools" | "open" | "onOpenChange"
+> & {
   label: string;
   tools: readonly GroupedTool[];
   open: boolean;

--- a/packages/ui/src/components/elements/tool-timeline.tsx
+++ b/packages/ui/src/components/elements/tool-timeline.tsx
@@ -46,6 +46,7 @@ export function ToolTimeline({
 }: ToolTimelineProps) {
   return (
     <Collapsible
+      data-slot="tool-timeline"
       open={open}
       onOpenChange={onOpenChange}
       className={cn("w-full max-w-sm", className)}

--- a/packages/ui/src/components/elements/trace-waterfall.tsx
+++ b/packages/ui/src/components/elements/trace-waterfall.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
 
@@ -25,21 +26,24 @@ export function TraceWaterfall({
   totalMs,
   visibleCount,
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "spans" | "totalMs" | "visibleCount"> & {
   spans: readonly TraceSpan[];
   totalMs: number;
   visibleCount: number;
-  className?: string;
 }) {
   const span = totalMs || 1;
 
   return (
     <div
+      data-slot="trace-waterfall"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col gap-2 rounded-2xl p-4",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">Trace</span>

--- a/packages/ui/src/components/elements/trace-waterfall.tsx
+++ b/packages/ui/src/components/elements/trace-waterfall.tsx
@@ -27,7 +27,10 @@ export function TraceWaterfall({
   visibleCount,
   className,
   ...props
-}: Omit<ComponentProps<"div">, "spans" | "totalMs" | "visibleCount"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "spans" | "totalMs" | "visibleCount"
+> & {
   spans: readonly TraceSpan[];
   totalMs: number;
   visibleCount: number;

--- a/packages/ui/src/components/elements/typing-indicator.tsx
+++ b/packages/ui/src/components/elements/typing-indicator.tsx
@@ -10,7 +10,10 @@ export function TypingIndicator({
   variant = "bubble",
   className,
   ...props
-}: Omit<ComponentProps<"div">, "children" | "variant"> & {
+}: Omit<
+  ComponentProps<"div">,
+  "children" | "variant" | "role" | "aria-label"
+> & {
   variant?: "bubble" | "bare";
 }) {
   const dots = DOT_DELAYS.map((delay) => (

--- a/packages/ui/src/components/elements/typing-indicator.tsx
+++ b/packages/ui/src/components/elements/typing-indicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { paper } from "./surfaces";
 
@@ -8,9 +9,9 @@ const DOT_DELAYS = ["-0.32s", "-0.16s", "0s"];
 export function TypingIndicator({
   variant = "bubble",
   className,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "variant"> & {
   variant?: "bubble" | "bare";
-  className?: string;
 }) {
   const dots = (
     <div
@@ -34,7 +35,12 @@ export function TypingIndicator({
   }
 
   return (
-    <div className={cn(paper, "w-fit rounded-full px-4 py-3.5", className)}>
+    <div
+      data-slot="typing-indicator"
+      className={cn(paper, "w-fit rounded-full px-4 py-3.5", className)}
+
+      {...props}
+    >
       {dots}
     </div>
   );

--- a/packages/ui/src/components/elements/typing-indicator.tsx
+++ b/packages/ui/src/components/elements/typing-indicator.tsx
@@ -10,38 +10,47 @@ export function TypingIndicator({
   variant = "bubble",
   className,
   ...props
-}: Omit<ComponentProps<"div">, "variant"> & {
+}: Omit<ComponentProps<"div">, "children" | "variant"> & {
   variant?: "bubble" | "bare";
 }) {
-  const dots = (
-    <div
-      role="status"
-      aria-label="Assistant is typing"
-      className={cn("flex gap-1", variant === "bare" && className)}
-    >
-      {DOT_DELAYS.map((delay) => (
-        <span
-          key={delay}
-          aria-hidden
-          className="bg-foreground/40 size-1.5 animate-bounce rounded-full motion-reduce:animate-none"
-          style={{ animationDelay: delay, animationDuration: "1.1s" }}
-        />
-      ))}
-    </div>
-  );
+  const dots = DOT_DELAYS.map((delay) => (
+    <span
+      key={delay}
+      aria-hidden
+      className="bg-foreground/40 size-1.5 animate-bounce rounded-full motion-reduce:animate-none"
+      style={{ animationDelay: delay, animationDuration: "1.1s" }}
+    />
+  ));
 
   if (variant === "bare") {
-    return dots;
+    return (
+      <div
+        data-slot="typing-indicator"
+        data-variant="bare"
+        role="status"
+        aria-label="Assistant is typing"
+        className={cn("flex gap-1", className)}
+        {...props}
+      >
+        {dots}
+      </div>
+    );
   }
 
   return (
     <div
       data-slot="typing-indicator"
+      data-variant="bubble"
       className={cn(paper, "w-fit rounded-full px-4 py-3.5", className)}
-
       {...props}
     >
-      {dots}
+      <div
+        role="status"
+        aria-label="Assistant is typing"
+        className="flex gap-1"
+      >
+        {dots}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/elements/voice-conversation.tsx
+++ b/packages/ui/src/components/elements/voice-conversation.tsx
@@ -39,6 +39,7 @@ export function VoiceConversation({
   ...props
 }: Omit<
   ComponentProps<"div">,
+  | "children"
   | "mode"
   | "amplitude"
   | "transcript"

--- a/packages/ui/src/components/elements/voice-conversation.tsx
+++ b/packages/ui/src/components/elements/voice-conversation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { MicIcon, MicOffIcon, PhoneOffIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
@@ -35,7 +36,17 @@ export function VoiceConversation({
   onInterrupt,
   onEnd,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  | "mode"
+  | "amplitude"
+  | "transcript"
+  | "muted"
+  | "onToggleMute"
+  | "onInterrupt"
+  | "onEnd"
+> & {
   mode: VoiceMode;
   amplitude: number;
   transcript: readonly VoiceTurn[];
@@ -43,7 +54,6 @@ export function VoiceConversation({
   onToggleMute?: () => void;
   onInterrupt?: () => void;
   onEnd?: () => void;
-  className?: string;
 }) {
   const level = Math.max(0, Math.min(1, amplitude));
   const active = mode === "listening" || mode === "speaking";
@@ -51,11 +61,14 @@ export function VoiceConversation({
 
   return (
     <div
+      data-slot="voice-conversation"
       className={cn(
         paper,
         "flex w-full max-w-xs flex-col items-center gap-4 rounded-[28px] px-5 py-5",
         className,
       )}
+
+      {...props}
     >
       <button
         type="button"

--- a/packages/ui/src/components/elements/web-preview.tsx
+++ b/packages/ui/src/components/elements/web-preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { ExternalLinkIcon, RotateCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
@@ -16,21 +17,27 @@ export function WebPreview({
   onReload,
   onOpenExternal,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "origin" | "loading" | "children" | "onReload" | "onOpenExternal"
+> & {
   origin: string;
   loading: boolean;
   children: React.ReactNode;
   onReload?: () => void;
   onOpenExternal?: () => void;
-  className?: string;
 }) {
   return (
     <div
+      data-slot="web-preview"
       className={cn(
         paper,
         "flex w-full max-w-md flex-col overflow-hidden rounded-2xl",
         className,
       )}
+
+      {...props}
     >
       <div className="flex items-center gap-1.5 px-2.5 py-2">
         <button

--- a/packages/ui/src/components/elements/web-search.tsx
+++ b/packages/ui/src/components/elements/web-search.tsx
@@ -20,7 +20,7 @@ export function WebSearch({
   ...props
 }: Omit<
   ComponentProps<"div">,
-  "query" | "results" | "visibleResults" | "searching" | "cycle"
+  "children" | "query" | "results" | "visibleResults" | "searching" | "cycle"
 > & {
   query: string;
   results: readonly WebSearchResult[];

--- a/packages/ui/src/components/elements/web-search.tsx
+++ b/packages/ui/src/components/elements/web-search.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ComponentProps } from "react";
 import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
@@ -16,16 +17,24 @@ export function WebSearch({
   searching,
   cycle,
   className,
-}: {
+  ...props
+}: Omit<
+  ComponentProps<"div">,
+  "query" | "results" | "visibleResults" | "searching" | "cycle"
+> & {
   query: string;
   results: readonly WebSearchResult[];
   visibleResults: number;
   searching: boolean;
   cycle: number;
-  className?: string;
 }) {
   return (
-    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+    <div
+      data-slot="web-search"
+      className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}
+
+      {...props}
+    >
       <span
         className={cn(
           field,


### PR DESCRIPTION
follows #5740. that PR added the elements; this one fixes their structure, after an audit of how all 95 are actually shaped.

## summary

- the audit's headline: elements have a **median of 5 props and 92 lines, 3 of 95 hold state, and 2 of 95 use an effect**. that is not the config-heavy monolith compound APIs exist to fix, so this deliberately does **not** rewrite the family into `Root`/`Item` parts. `ui/base/*` is compound because it wraps Base UI primitives that already own focus, portals, and keyboard; there is no primitive underneath a trace waterfall, and inventing `<TraceWaterfall.Root>` over a `spans` prop would buy nothing.
- **four elements did need it**, and two of those were simply wrong. `chat-panel` took a singular `userMessage` and `reply`, so it could not represent a conversation; `empty-state` hardcoded the place its consumer's composer has to go. both were demo compositions shipped as components. `canvas-split` fixed both panes, and `composer` was 613 lines behind 24 props holding six facets.
- the **real** divergence was not structure but convention. before this PR, `data-slot`, prop spreading, and `ComponentProps` typing appeared in 0 of 95 elements, against 19 of 20 in `ui/base`; this PR adds them. a copied element could not be restyled from outside or take an `id`, `ref`, aria attribute, or extra handler without editing the file. now 94 of 95 and 90 of 95.
- keyboard work landed on **4 elements, not the 12** the review flagged: 9 of them render their rows as `<button>` and were already Tab-reachable with a working Enter. only the three with a text input above a list need the element to own the arrow keys, plus `confidence-marker`, which had no focusable element at all.

## test plan

### already verified

- [x] `pnpm lint` -> oxlint and oxfmt clean (only the pre-existing `surfaces.tsx` exhaustive-deps warning)
- [x] `pnpm -C packages/ui exec tsc --noEmit` -> clean
- [x] `pnpm -C apps/docs exec tsc --noEmit` -> clean under `exactOptionalPropertyTypes`
- [x] `pnpm -C packages/ui test` -> 13/13, `pnpm -C apps/docs test` -> 132/132, `pnpm -C apps/registry test` -> 33/33
- [x] `pnpm -C apps/docs build` -> 122 `/elements/[slug]` paths prerendered
- [x] drove the new arrow-key navigation in a real browser: it walks across group boundaries and wraps (`New thread` → … → `Stop the run` → back to `New thread`)
- [x] re-ran the overflow and clipping sweep over all 122 gallery cards: 0 horizontal overflow, 0 empty stages, and the only two clips are the pre-existing intentional ones (`number-ticker`'s roll strip, `composer-context`'s hover popover)

### reviewer should verify

- [ ] `/elements/composer` and its six sibling entries: each card should now show only the facet it demonstrates.
- [ ] `/elements/chat-panel`: the reply is rendered by composing `streaming-text` into the messages slot rather than by chat-panel re-implementing word streaming.
- [ ] tab into `/elements/confidence-marker` and confirm the basis pill appears on focus, not only on hover.

## notes

- `surfaces.tsx` gets no `data-slot`; it is a token module, not a component. the four `Collapsible`-rooted elements (`reasoning-panel`, `sources`, `tool-call`, `tool-timeline`) get no prop spread, because spreading `div` props onto a component would be wrong; they would need `ComponentProps<typeof Collapsible>`. that is 90 of 95 by choice, not by omission.
- collisions in the spread pass are avoided by omitting each component's own prop names from `ComponentProps`, so a prop called `title` or `value` does not clash with the HTML attribute.
- the accessibility work still outstanding in #5743 is unchanged by this PR. while auditing for it I found the static detector I wrote has real false negatives (it misses `map-answer`'s hit target, which lives on a child element), which is worth knowing before anyone treats a grep-based sweep as coverage.
- no changeset: `@assistant-ui/ui` and `@assistant-ui/docs` are both `private: true`.
