### PR TITLE
feat(ui): normalize the elements' range props at the boundary

### DIFF
--- a/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
@@ -239,6 +239,13 @@ export default async function ElementPage({
               </div>
             </div>
           ))}
+          <p className="text-foreground/40 mt-3 text-[13px] leading-relaxed">
+            Counts and positions are normalized at the boundary, so a value from
+            outside its range reads as the nearest end rather than reaching the
+            DOM: a negative count shows nothing, one past the end shows
+            everything, and a share stays within 0 to 100 percent. A prop that
+            names a selection is the exception, and means nothing is selected.
+          </p>
         </section>
       )}
 

--- a/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
@@ -239,7 +239,8 @@ export default async function ElementPage({
               </div>
             </div>
           ))}
-          {source?.includes('from "./range"') && (
+          {/* Keyed off the element's own import, so the note cannot outlive it. */}
+          {source && /from ["']\.\/range["']/.test(source) && (
             <p className="text-foreground/40 mt-3 text-[13px] leading-relaxed">
               This element normalizes its counts and shares at the boundary, so
               a value from outside its range reads as the nearest end rather

--- a/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
@@ -239,13 +239,16 @@ export default async function ElementPage({
               </div>
             </div>
           ))}
-          <p className="text-foreground/40 mt-3 text-[13px] leading-relaxed">
-            Counts and positions are normalized at the boundary, so a value from
-            outside its range reads as the nearest end rather than reaching the
-            DOM: a negative count shows nothing, one past the end shows
-            everything, and a share stays within 0 to 100 percent. A prop that
-            names a selection is the exception, and means nothing is selected.
-          </p>
+          {source?.includes('from "./range"') && (
+            <p className="text-foreground/40 mt-3 text-[13px] leading-relaxed">
+              This element normalizes its counts and shares at the boundary, so
+              a value from outside its range reads as the nearest end rather
+              than reaching the DOM: a negative count shows nothing, one past
+              the end shows everything, and a share stays within 0 to 100
+              percent. A prop that names a selection is the exception, and means
+              nothing is selected.
+            </p>
+          )}
         </section>
       )}
 

--- a/apps/docs/components/elements/element-docs.ts
+++ b/apps/docs/components/elements/element-docs.ts
@@ -1022,7 +1022,7 @@ import { ToolTimeline } from "@/components/elements/tool-timeline";
             type: "number",
             required: true,
             description:
-              "Index of the step currently running. Values past the end mark every step done.",
+              "Index of the step currently running. Values past the end mark every step done, and values before the start mark none.",
           },
           {
             name: "className",
@@ -1805,7 +1805,8 @@ const matches = useMentionMatches(value, people);
             name: "activeIndex",
             type: "number",
             required: true,
-            description: "Index of the currently selected thread.",
+            description:
+              "Index of the currently selected thread. An index outside the list selects nothing.",
           },
           {
             name: "onActiveIndexChange",
@@ -2706,7 +2707,7 @@ const matches = useMentionMatches(value, people);
             type: "number",
             required: true,
             description:
-              "Index of the word being spoken. Everything before it dims, everything after stays waiting.",
+              "Index of the word being spoken. Everything before it dims, everything after stays waiting, and an index outside the text speaks none of it.",
           },
           {
             name: "playing",
@@ -4385,7 +4386,8 @@ const matches = useMentionMatches(value, people);
             name: "activePage",
             type: "number",
             required: true,
-            description: "Which anchor is highlighted.",
+            description:
+              "Which anchor is highlighted. A page with no anchor highlights nothing.",
           },
           {
             name: "onJump",
@@ -4902,7 +4904,7 @@ const matches = useMentionMatches(value, people);
             type: "number",
             required: true,
             description:
-              "Which stage is running. Passing stages.length marks the job finished.",
+              "Which stage is running. Passing stages.length marks the job finished, and the bar never runs past its track.",
           },
           {
             name: "stageProgress",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -68,6 +68,7 @@ const createElementRegistryItem = (
   ],
   registryDependencies: [
     "https://r.assistant-ui.com/elements-surfaces.json",
+    "https://r.assistant-ui.com/elements-range.json",
     ...(entry.usesElements ?? []).map(
       (slug) => `https://r.assistant-ui.com/elements-${slug}.json`,
     ),
@@ -94,6 +95,20 @@ const elementsRegistryItems: RegistryItem[] = [
     css: {
       '@import "tw-shimmer"': {},
     },
+  },
+  {
+    name: "elements-range",
+    type: "registry:component",
+    title: "Elements Range",
+    description:
+      "Range normalization for the elements family: clamping a caller's counts, indexes, and shares to what the element can render.",
+    files: [
+      {
+        type: "registry:lib",
+        path: "components/elements/range.ts",
+        sourcePath: "../../packages/ui/src/components/elements/range.ts",
+      },
+    ],
   },
   createElementRegistryItem({
     slug: "loading-state",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -68,7 +68,6 @@ const createElementRegistryItem = (
   ],
   registryDependencies: [
     "https://r.assistant-ui.com/elements-surfaces.json",
-    "https://r.assistant-ui.com/elements-range.json",
     ...(entry.usesElements ?? []).map(
       (slug) => `https://r.assistant-ui.com/elements-${slug}.json`,
     ),
@@ -132,6 +131,7 @@ const elementsRegistryItems: RegistryItem[] = [
     file: "reasoning-panel.tsx",
     dependencies: ["lucide-react"],
     usesCollapsible: true,
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "streaming-text",
@@ -139,6 +139,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Tokens arrive softly: the newest words land in blue and settle into ink.",
     file: "streaming-text.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "typing-indicator",
@@ -154,6 +155,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "A user bubble and a streaming assistant reply, with actions that appear on hover.",
     file: "message-pair.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "message-branches",
@@ -203,6 +205,7 @@ const elementsRegistryItems: RegistryItem[] = [
     file: "tool-timeline.tsx",
     dependencies: ["lucide-react"],
     usesCollapsible: true,
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "terminal-block",
@@ -211,6 +214,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "Command output that streams line by line and ends with an exit status.",
     file: "terminal-block.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "code-diff",
@@ -226,6 +230,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "A search query and its results landing one by one as the agent reads.",
     file: "web-search.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "sources",
@@ -271,6 +276,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "A checklist the agent works through, with progress you can glance.",
     file: "agent-plan.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "subagent-list",
@@ -279,6 +285,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "Parallel workers with their own progress, models, and completions.",
     file: "subagent-list.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "agent-status",
@@ -319,6 +326,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "The unified input: attachments, commands, mentions, models, voice, and context in one surface.",
     file: "composer.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "chat-panel",
@@ -392,6 +400,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "Everything a run touched, as a tree, with the churn spelled out per file.",
     file: "file-tree.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "elicitation-form",
@@ -408,6 +417,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "The passages a retrieval answer stands on, scored, before the answer itself arrives.",
     file: "retrieval-chunks.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "chart",
@@ -415,6 +425,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Area, line, and bars, with points landing one at a time as the series streams in.",
     file: "chart.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "trace-waterfall",
@@ -422,6 +433,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Every span in a run on one time axis, nested, so you can see where it actually went.",
     file: "trace-waterfall.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "canvas-split",
@@ -438,6 +450,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "A live call: the orb tracks your voice, the caption names the turn, the transcript follows.",
     file: "voice-conversation.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "read-aloud",
@@ -446,6 +459,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "An answer played back, the spoken word lit as it goes, speed under your thumb.",
     file: "read-aloud.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "mcp-server-panel",
@@ -540,6 +554,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Work as a graph rather than a list: branches that fan out and rejoin.",
     file: "flow-graph.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "activity-graph",
@@ -563,6 +578,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Where the window actually went: prompt, tools, files, conversation, and what's left.",
     file: "context-breakdown.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "model-picker",
@@ -578,6 +594,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "How hard to think, and how much of that budget the run actually spent.",
     file: "reasoning-effort.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "guardrail-notice",
@@ -639,6 +656,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "The screen the agent is driving, with a cursor trail and what it is doing right now.",
     file: "computer-use.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "code-runner",
@@ -685,6 +703,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Rendered expressions with the working shown, one step at a time.",
     file: "math-block.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "spec-sheet",
@@ -692,6 +711,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "The most common structured answer after a table: one object, labeled.",
     file: "spec-sheet.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "comparison-card",
@@ -707,6 +727,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Events on a time axis, with what already happened and what is still coming.",
     file: "timeline.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "job-progress",
@@ -715,6 +736,7 @@ const elementsRegistryItems: RegistryItem[] = [
       "Work measured in minutes: weighted stages, an ETA, and a way out.",
     file: "job-progress.tsx",
     dependencies: ["lucide-react"],
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "score-breakdown",
@@ -722,6 +744,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "A verdict with its arithmetic shown: criteria, weights, and what pulled it down.",
     file: "score-breakdown.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "cost-meter",
@@ -729,6 +752,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "What the run spent, split by model, against the session total.",
     file: "cost-meter.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "quota-banner",
@@ -736,6 +760,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "How much is left, when it comes back, and the way to get more.",
     file: "quota-banner.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "agent-handoff",
@@ -822,6 +847,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Model, system prompt, temperature, and what the assistant is allowed to do.",
     file: "settings-panel.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "onboarding",
@@ -829,6 +855,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "First run: three moves that teach what this assistant is actually for.",
     file: "onboarding.tsx",
+    usesElements: ["range"],
   }),
   createElementRegistryItem({
     slug: "mobile-composer",

--- a/packages/ui/src/components/elements/agent-plan.tsx
+++ b/packages/ui/src/components/elements/agent-plan.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
+import { pct, progressOf } from "./range";
 
 export function AgentPlan({
   steps,
@@ -15,9 +16,9 @@ export function AgentPlan({
   activeIndex: number;
 }) {
   const total = steps.length;
-  const allDone = activeIndex >= total;
-  const completed = allDone ? total : activeIndex;
-  const progress = total === 0 ? 0 : (completed / total) * 100;
+  const completed = progressOf(activeIndex, total);
+  const allDone = completed >= total;
+  const progress = pct(completed, total);
 
   return (
     <div
@@ -40,8 +41,8 @@ export function AgentPlan({
       </div>
       <ul className="flex flex-col gap-2.5">
         {steps.map((step, i) => {
-          const done = allDone || i < activeIndex;
-          const active = !allDone && i === activeIndex;
+          const done = allDone || i < completed;
+          const active = !allDone && i === completed;
           return (
             <li key={step} className="flex items-center gap-2.5 text-[13.5px]">
               <span className="flex size-4 shrink-0 items-center justify-center">

--- a/packages/ui/src/components/elements/chart.tsx
+++ b/packages/ui/src/components/elements/chart.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { clamp, take } from "./range";
 
 export type ChartVariant = "area" | "line" | "bars";
 
@@ -43,7 +44,7 @@ export function Chart({
   visibleCount: number;
   variant?: ChartVariant;
 }) {
-  const shown = points.slice(0, Math.max(1, visibleCount));
+  const shown = take(points, clamp(visibleCount, 1, points.length));
   const y = scale(points);
   const step = points.length > 1 ? (W - PAD * 2) / (points.length - 1) : 0;
   const x = (i: number) => PAD + i * step;

--- a/packages/ui/src/components/elements/composer.tsx
+++ b/packages/ui/src/components/elements/composer.tsx
@@ -27,6 +27,7 @@ import {
   mono,
   paper,
 } from "./surfaces";
+import { clamp, pct } from "./range";
 
 export interface ComposerAttachment {
   name: string;
@@ -299,7 +300,7 @@ export function ComposerAttachmentChip({
         <span
           aria-hidden
           className="absolute inset-x-0 bottom-0 h-0.5 bg-blue-500/70 transition-[width] duration-300 dark:bg-blue-400/70"
-          style={{ width: `${attachment.progress ?? 0}%` }}
+          style={{ width: `${pct(attachment.progress ?? 0, 100)}%` }}
         />
       )}
     </div>
@@ -531,9 +532,7 @@ export function ComposerContext({
                 "h-full transition-[width] duration-700 motion-reduce:transition-none",
                 segment.className,
               )}
-              style={{
-                width: `${usage.total === 0 ? 0 : (segment.value / usage.total) * 100}%`,
-              }}
+              style={{ width: `${pct(segment.value, usage.total)}%` }}
             />
           ))}
         </div>
@@ -589,7 +588,7 @@ export function ComposerContext({
             strokeLinecap="round"
             className="stroke-current transition-[stroke-dashoffset] duration-700 motion-reduce:transition-none"
             strokeDasharray={circumference}
-            strokeDashoffset={circumference * (1 - Math.min(fraction, 1))}
+            strokeDashoffset={circumference * (1 - clamp(fraction, 0, 1))}
           />
         </svg>
       </button>

--- a/packages/ui/src/components/elements/computer-use.tsx
+++ b/packages/ui/src/components/elements/computer-use.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { MousePointer2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
+import { at, progressOf } from "./range";
 
 export interface ComputerStep {
   id: string;
@@ -26,8 +27,9 @@ export function ComputerUse({
   activeIndex: number;
   children: React.ReactNode;
 }) {
-  const active = steps[Math.min(activeIndex, steps.length - 1)];
-  const trail = steps.slice(Math.max(0, activeIndex - 2), activeIndex + 1);
+  const index = progressOf(activeIndex, Math.max(0, steps.length - 1));
+  const active = at(steps, index);
+  const trail = steps.slice(Math.max(0, index - 2), index + 1);
 
   return (
     <div
@@ -99,7 +101,7 @@ export function ComputerUse({
           <span
             className={cn(mono, "text-foreground/30 shrink-0 tabular-nums")}
           >
-            {Math.min(activeIndex + 1, steps.length)}/{steps.length}
+            {Math.min(index + 1, steps.length)}/{steps.length}
           </span>
         </div>
       )}

--- a/packages/ui/src/components/elements/computer-use.tsx
+++ b/packages/ui/src/components/elements/computer-use.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 import { MousePointer2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
-import { at, progressOf } from "./range";
+import { at, indexIn } from "./range";
 
 export interface ComputerStep {
   id: string;
@@ -27,7 +27,7 @@ export function ComputerUse({
   activeIndex: number;
   children: React.ReactNode;
 }) {
-  const index = progressOf(activeIndex, Math.max(0, steps.length - 1));
+  const index = indexIn(steps, activeIndex);
   const active = at(steps, index);
   const trail = steps.slice(Math.max(0, index - 2), index + 1);
 
@@ -101,7 +101,7 @@ export function ComputerUse({
           <span
             className={cn(mono, "text-foreground/30 shrink-0 tabular-nums")}
           >
-            {Math.min(index + 1, steps.length)}/{steps.length}
+            {index + 1}/{steps.length}
           </span>
         </div>
       )}

--- a/packages/ui/src/components/elements/context-breakdown.tsx
+++ b/packages/ui/src/components/elements/context-breakdown.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { pct } from "./range";
 
 const fmt = (n: number) => n.toLocaleString("en-US");
 
@@ -23,7 +24,7 @@ export function ContextBreakdown({
 }) {
   const used = segments.reduce((sum, segment) => sum + segment.tokens, 0);
   const pressure = limit === 0 ? 0 : used / limit;
-  const share = (tokens: number) => (limit === 0 ? 0 : (tokens / limit) * 100);
+  const share = (tokens: number) => pct(tokens, limit);
 
   return (
     <div

--- a/packages/ui/src/components/elements/cost-meter.tsx
+++ b/packages/ui/src/components/elements/cost-meter.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { pct } from "./range";
 
 export interface CostLine {
   model: string;
@@ -59,7 +60,7 @@ export function CostMeter({
                   ? "bg-blue-500/55 dark:bg-blue-400/55"
                   : "bg-foreground/25",
             )}
-            style={{ width: `${line.share * 100}%` }}
+            style={{ width: `${pct(line.share, 1)}%` }}
           />
         ))}
       </div>

--- a/packages/ui/src/components/elements/elements.test.tsx
+++ b/packages/ui/src/components/elements/elements.test.tsx
@@ -1,0 +1,535 @@
+import { TerminalIcon } from "lucide-react";
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { AgentPlan } from "./agent-plan";
+import { Chart } from "./chart";
+import { CodeDiff } from "./code-diff";
+import { CodeRunner } from "./code-runner";
+import { CommandPalette } from "./command-palette";
+import { ComputerUse } from "./computer-use";
+import { ContextBreakdown } from "./context-breakdown";
+import { CostMeter } from "./cost-meter";
+import { DocumentReference } from "./document-reference";
+import { FeedbackDialog } from "./feedback-dialog";
+import { FileTree } from "./file-tree";
+import { FlowGraph } from "./flow-graph";
+import { JobProgress } from "./job-progress";
+import { MapAnswer } from "./map-answer";
+import { MathBlock } from "./math-block";
+import { McpServerPanel } from "./mcp-server-panel";
+import { MessagePair } from "./message-pair";
+import { Onboarding } from "./onboarding";
+import { PromptLibrary } from "./prompt-library";
+import { QuotaBanner } from "./quota-banner";
+import { ReadAloud } from "./read-aloud";
+import { ReasoningEffort } from "./reasoning-effort";
+import { ReasoningPanel } from "./reasoning-panel";
+import { RetrievalChunks } from "./retrieval-chunks";
+import { ReviewableDiff } from "./reviewable-diff";
+import { ScoreBreakdown } from "./score-breakdown";
+import { SettingsPanel } from "./settings-panel";
+import { SpecSheet } from "./spec-sheet";
+import { StreamingText } from "./streaming-text";
+import { SubagentList } from "./subagent-list";
+import { TerminalBlock } from "./terminal-block";
+import { ThreadList } from "./thread-list";
+import { Timeline } from "./timeline";
+import { ToolTimeline } from "./tool-timeline";
+import { TraceWaterfall } from "./trace-waterfall";
+import { VoiceConversation } from "./voice-conversation";
+import { WebSearch } from "./web-search";
+
+/**
+ * A caller drives these from its own state, so every numeric prop is rendered
+ * at values a caller can actually reach. `n` stands in for whatever the element
+ * treats as a position or a count, and `items` for how many rows it was given.
+ */
+type Case = (n: number, items: number) => ReactElement;
+
+const list = <T,>(items: number, make: (i: number) => T) =>
+  Array.from({ length: items }, (_, i) => make(i));
+
+const CASES: Record<string, Case> = {
+  "agent-plan": (n, items) => (
+    <AgentPlan steps={list(items, (i) => `step ${i}`)} activeIndex={n} />
+  ),
+  chart: (n, items) => (
+    <Chart
+      label="Latency"
+      value="180ms"
+      points={list(items, (i) => i * 3)}
+      visibleCount={n}
+    />
+  ),
+  "code-diff": (n, items) => (
+    <CodeDiff
+      filename="a.ts"
+      additions={2}
+      deletions={1}
+      lines={list(items, () => ({
+        kind: "added" as const,
+        text: "x".repeat(400),
+      }))}
+      cycle={n}
+    />
+  ),
+  "code-runner": (_n, items) => (
+    <CodeRunner
+      language="ts"
+      code={"y".repeat(400)}
+      state="ok"
+      output={list(items, () => "z".repeat(400))}
+    />
+  ),
+  "command-palette": (_n, items) => (
+    <CommandPalette
+      commands={list(items, (i) => ({
+        id: `c${i}`,
+        label: `Command ${i}`,
+        group: "Thread",
+        keys: ["⌘K"],
+      }))}
+      query={"q".repeat(200)}
+      activeId="c0"
+    />
+  ),
+  "computer-use": (n, items) => (
+    <ComputerUse
+      url="example.com"
+      steps={list(items, (i) => ({
+        id: `s${i}`,
+        action: "click",
+        target: "Button",
+        x: 10,
+        y: 10,
+      }))}
+      activeIndex={n}
+    >
+      <div />
+    </ComputerUse>
+  ),
+  "context-breakdown": (n, items) => (
+    <ContextBreakdown
+      segments={list(items, (i) => ({
+        label: `seg ${i}`,
+        tokens: 4000,
+        tint: "bg-blue-500",
+      }))}
+      limit={n}
+    />
+  ),
+  "cost-meter": (n, items) => (
+    <CostMeter
+      runCost="$0.10"
+      sessionCost="$1.00"
+      lines={list(items, (i) => ({
+        model: `m${i}`,
+        inputTokens: 10,
+        outputTokens: 10,
+        cost: "$0.01",
+        share: n,
+      }))}
+    />
+  ),
+  "document-reference": (n, items) => (
+    <DocumentReference
+      title="Spec"
+      pages={items}
+      anchors={list(items, (i) => ({ page: i, quote: "q".repeat(300) }))}
+      activePage={n}
+    />
+  ),
+  "feedback-dialog": (_n, items) => (
+    <FeedbackDialog
+      reasons={list(items, (i) => `reason ${i}`)}
+      selected={[]}
+      note=""
+      sent={false}
+    />
+  ),
+  "file-tree": (n, items) => (
+    <FileTree
+      nodes={list(items, (i) => ({
+        path: `p${i}`,
+        name: `n${i}`,
+        depth: 0,
+        kind: "file" as const,
+      }))}
+      visibleCount={n}
+      totalAdditions={2}
+      totalDeletions={1}
+    />
+  ),
+  "flow-graph": (n, items) => (
+    <FlowGraph
+      nodes={list(items, (i) => ({
+        id: `n${i}`,
+        label: `Node ${i}`,
+        column: i,
+        row: 0,
+        state: "done" as const,
+      }))}
+      edges={[]}
+      visibleCount={n}
+    />
+  ),
+  "job-progress": (n, items) => (
+    <JobProgress
+      title="Indexing"
+      stages={list(items, (i) => ({ name: `stage ${i}`, weight: 1 }))}
+      stageIndex={n}
+      stageProgress={n}
+      eta="2m"
+    />
+  ),
+  "map-answer": (_n, items) => (
+    <MapAnswer
+      pins={list(items, (i) => ({
+        id: `p${i}`,
+        label: `Place ${i}`,
+        detail: "1km",
+        x: 20,
+        y: 20,
+      }))}
+      activeId="p0"
+    />
+  ),
+  "math-block": (n, items) => (
+    <MathBlock
+      steps={list(items, (i) => ({ expression: `${i}` }))}
+      visibleSteps={n}
+    />
+  ),
+  "mcp-server-panel": (_n, items) => (
+    <McpServerPanel
+      servers={list(items, (i) => ({
+        id: `s${i}`,
+        name: `Server ${i}`,
+        transport: "stdio",
+        status: "connected" as const,
+        tools: ["read"],
+      }))}
+    />
+  ),
+  "message-pair": (n, items) => (
+    <MessagePair
+      userMessage="hi"
+      words={list(items, (i) => `w${i}`)}
+      visibleWords={n}
+      streaming
+    />
+  ),
+  onboarding: (n, items) => (
+    <Onboarding
+      steps={list(items, (i) => ({
+        title: `t${i}`,
+        body: "b".repeat(300),
+        example: "e",
+      }))}
+      index={n}
+    />
+  ),
+  "prompt-library": (_n, items) => (
+    <PromptLibrary
+      prompts={list(items, (i) => ({
+        id: `p${i}`,
+        name: `Prompt ${i}`,
+        body: "b".repeat(300),
+        variables: ["x"],
+      }))}
+      query={"q".repeat(200)}
+      selectedId="p0"
+    />
+  ),
+  "quota-banner": (n) => (
+    <QuotaBanner
+      used={n}
+      limit={100}
+      unit="runs"
+      resetsIn="2h"
+      upgradeLabel="Upgrade"
+    />
+  ),
+  "read-aloud": (n, items) => (
+    <ReadAloud
+      words={list(items, (i) => `w${i}`)}
+      spokenIndex={n}
+      playing
+      rate={1}
+      elapsed="0:01"
+      duration="0:10"
+    />
+  ),
+  "reasoning-effort": (n, items) => (
+    <ReasoningEffort
+      levels={list(items, (i) => ({
+        key: `k${i}`,
+        label: `L${i}`,
+        budget: 1000,
+      }))}
+      selectedKey="k0"
+      spent={n}
+    />
+  ),
+  "reasoning-panel": (n, items) => (
+    <ReasoningPanel
+      steps={list(items, (i) => ({ title: `t${i}`, body: "b".repeat(300) }))}
+      visibleSteps={n}
+      streaming
+      open
+      onOpenChange={() => {}}
+      restingLabel="Thought"
+    />
+  ),
+  "retrieval-chunks": (n, items) => (
+    <RetrievalChunks
+      query="q"
+      chunks={list(items, (i) => ({
+        id: `c${i}`,
+        source: `s${i}`,
+        locator: "p1",
+        score: n,
+        text: "t",
+      }))}
+      visibleCount={n}
+      searching={false}
+    />
+  ),
+  "reviewable-diff": (_n, items) => (
+    <ReviewableDiff
+      filename="a.ts"
+      hunks={list(items, (i) => ({
+        id: `h${i}`,
+        range: "@@ -1 +1 @@",
+        decision: "pending" as const,
+        lines: [{ kind: "added" as const, text: "x".repeat(400) }],
+      }))}
+    />
+  ),
+  "score-breakdown": (n, items) => (
+    <ScoreBreakdown
+      verdict="Good"
+      total={n}
+      outOf={n}
+      criteria={list(items, (i) => ({
+        label: `c${i}`,
+        score: n,
+        weight: 1,
+        note: "n".repeat(300),
+      }))}
+      visibleCount={n}
+    />
+  ),
+  "settings-panel": (n) => (
+    <SettingsPanel
+      model="a"
+      models={["a", "b"]}
+      systemPrompt=""
+      temperature={n}
+      toggles={[{ key: "k", label: "L", detail: "d", on: true }]}
+    />
+  ),
+  "spec-sheet": (n, items) => (
+    <SpecSheet
+      title="Spec"
+      rows={list(items, (i) => ({ label: `l${i}`, value: `v${i}` }))}
+      visibleCount={n}
+    />
+  ),
+  "streaming-text": (n, items) => (
+    <StreamingText
+      segments={list(items, (i) => ({ text: `w${i}` }))}
+      count={n}
+      streaming
+    />
+  ),
+  "subagent-list": (n, items) => (
+    <SubagentList
+      agents={list(items, (i) => ({ name: `a${i}`, model: "m" }))}
+      completedCount={n}
+      progress={list(items, () => n)}
+      showSummary={false}
+      summaryAgent={{ name: "a", model: "m" }}
+    />
+  ),
+  "terminal-block": (n, items) => (
+    <TerminalBlock
+      command="ls"
+      lines={list(items, (i) => `line ${i}`)}
+      visibleCount={n}
+      done
+    />
+  ),
+  "thread-list": (n, items) => (
+    <ThreadList
+      threads={list(items, (i) => ({
+        title: `t${i}`,
+        time: "1m",
+        unread: true,
+      }))}
+      activeIndex={n}
+    />
+  ),
+  timeline: (n, items) => (
+    <Timeline
+      events={list(items, (i) => ({
+        id: `e${i}`,
+        when: "past" as const,
+        time: "1m",
+        title: "t".repeat(300),
+      }))}
+      visibleCount={n}
+    />
+  ),
+  "tool-timeline": (n, items) => (
+    <ToolTimeline
+      steps={list(items, (i) => ({
+        verb: `v${i}`,
+        chip: `c${i}`,
+        icon: TerminalIcon,
+      }))}
+      visibleSteps={n}
+      streaming
+      open
+      onOpenChange={() => {}}
+      restingLabel="Ran"
+      activeLabel="Running"
+      stats={[]}
+    />
+  ),
+  "trace-waterfall": (n, items) => (
+    <TraceWaterfall
+      spans={list(items, (i) => ({
+        id: `s${i}`,
+        name: `n${i}`,
+        depth: 0,
+        startMs: n,
+        durationMs: n,
+        status: "completed" as const,
+      }))}
+      totalMs={n}
+      visibleCount={n}
+    />
+  ),
+  "voice-conversation": (n, items) => (
+    <VoiceConversation
+      mode="listening"
+      amplitude={n}
+      transcript={list(items, (i) => ({
+        id: `t${i}`,
+        role: "user" as const,
+        text: "x".repeat(300),
+      }))}
+    />
+  ),
+  "web-search": (n, items) => (
+    <WebSearch
+      query="q"
+      results={list(items, (i) => ({ title: `t${i}`, domain: `d${i}.com` }))}
+      visibleResults={n}
+      searching={false}
+      cycle={n}
+    />
+  ),
+};
+
+/**
+ * Elements whose hostile number is how far through a collection they are, and
+ * nothing they print. For these an out-of-range number still names a position:
+ * below the start is the start, past the end is the end. `Array#slice` gives
+ * neither, so this is what separates a routed count from a raw one.
+ *
+ * A prop that identifies a selection rather than a position is excluded on
+ * purpose. `thread-list`'s activeIndex, `document-reference`'s activePage, and
+ * `read-aloud`'s spokenIndex all mean "nothing is selected yet" out of range,
+ * and clamping them would silently select the first row instead.
+ */
+const COUNT_SHAPED = new Set([
+  "agent-plan",
+  "chart",
+  "code-diff",
+  "computer-use",
+  "cost-meter",
+  "file-tree",
+  "flow-graph",
+  "job-progress",
+  "math-block",
+  "message-pair",
+  "onboarding",
+  "reasoning-panel",
+  "settings-panel",
+  "spec-sheet",
+  "streaming-text",
+  "terminal-block",
+  "timeline",
+  "tool-timeline",
+  "voice-conversation",
+  "web-search",
+]);
+
+const HOSTILE: [label: string, n: number, items: number][] = [
+  ["negative", -3, 4],
+  ["zero", 0, 4],
+  ["oversized", 1e9, 4],
+  ["fractional", 1.5, 4],
+  ["NaN", Number.NaN, 4],
+  ["empty collection", 2, 0],
+];
+
+/**
+ * Every percentage an element writes into an inline style, read out of the
+ * server-rendered markup rather than the DOM: jsdom validates the CSSOM the way
+ * a browser does, so it silently drops `width: -75%` and the assertion below
+ * would never see the value that caused the bug.
+ */
+const inlinePercentages = (markup: string) =>
+  [...markup.matchAll(/style="([^"]*)"/g)].flatMap(([, declarations]) =>
+    (declarations ?? "")
+      .split(";")
+      .map((declaration) => declaration.split(":"))
+      .filter(([, value]) => value?.trim().endsWith("%"))
+      .map(([property, value]) => ({
+        property: (property ?? "").trim(),
+        value: (value ?? "").trim(),
+      })),
+  );
+
+describe.each(Object.entries(CASES))("%s", (name, make) => {
+  it.each(HOSTILE)("survives a %s numeric prop", (_label, n, items) => {
+    const markup = renderToStaticMarkup(make(n, items));
+
+    for (const { property, value } of inlinePercentages(markup)) {
+      const share = Number.parseFloat(value);
+      expect(
+        share,
+        `${name} rendered ${property}: ${value}, which a browser drops as invalid`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        share,
+        `${name} rendered ${property}: ${value}, past the end of its track`,
+      ).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it.runIf(COUNT_SHAPED.has(name))(
+    "reads an out-of-range count as its nearest end",
+    () => {
+      const items = 4;
+
+      expect(
+        renderToStaticMarkup(make(-3, items)),
+        "a negative count dropped rows from the end instead of showing none",
+      ).toBe(renderToStaticMarkup(make(0, items)));
+      expect(
+        renderToStaticMarkup(make(1e9, items)),
+        "a count past the end did not show every row",
+      ).toBe(renderToStaticMarkup(make(items, items)));
+      expect(
+        renderToStaticMarkup(make(Number.NaN, items)),
+        "NaN did not read as the start",
+      ).toBe(renderToStaticMarkup(make(0, items)));
+    },
+  );
+});

--- a/packages/ui/src/components/elements/elements.test.tsx
+++ b/packages/ui/src/components/elements/elements.test.tsx
@@ -445,11 +445,15 @@ const CASES: Record<string, Case> = {
  * purpose. `thread-list`'s activeIndex, `document-reference`'s activePage, and
  * `read-aloud`'s spokenIndex all mean "nothing is selected yet" out of range,
  * and clamping them would silently select the first row instead.
+ *
+ * `code-diff` is absent for a different reason: its only numeric prop that it
+ * does not print is `cycle`, which feeds a React key, so its markup is byte
+ * identical at every value and the assertion would hold without exercising
+ * anything.
  */
 const COUNT_SHAPED = new Set([
   "agent-plan",
   "chart",
-  "code-diff",
   "computer-use",
   "cost-meter",
   "file-tree",

--- a/packages/ui/src/components/elements/elements.test.tsx
+++ b/packages/ui/src/components/elements/elements.test.tsx
@@ -290,7 +290,7 @@ const CASES: Record<string, Case> = {
         id: `c${i}`,
         source: `s${i}`,
         locator: "p1",
-        score: n,
+        score: 0.5,
         text: "t",
       }))}
       visibleCount={n}
@@ -311,11 +311,11 @@ const CASES: Record<string, Case> = {
   "score-breakdown": (n, items) => (
     <ScoreBreakdown
       verdict="Good"
-      total={n}
-      outOf={n}
+      total={7}
+      outOf={10}
       criteria={list(items, (i) => ({
         label: `c${i}`,
-        score: n,
+        score: 7,
         weight: 1,
         note: "n".repeat(300),
       }))}
@@ -405,11 +405,11 @@ const CASES: Record<string, Case> = {
         id: `s${i}`,
         name: `n${i}`,
         depth: 0,
-        startMs: n,
-        durationMs: n,
+        startMs: 10,
+        durationMs: 20,
         status: "completed" as const,
       }))}
-      totalMs={n}
+      totalMs={100}
       visibleCount={n}
     />
   ),
@@ -463,12 +463,15 @@ const COUNT_SHAPED = new Set([
   "message-pair",
   "onboarding",
   "reasoning-panel",
+  "retrieval-chunks",
+  "score-breakdown",
   "settings-panel",
   "spec-sheet",
   "streaming-text",
   "terminal-block",
   "timeline",
   "tool-timeline",
+  "trace-waterfall",
   "voice-conversation",
   "web-search",
 ]);

--- a/packages/ui/src/components/elements/file-tree.tsx
+++ b/packages/ui/src/components/elements/file-tree.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { ChevronDownIcon, FileIcon, FolderIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export interface FileTreeNode {
   path: string;
@@ -56,7 +57,7 @@ export function FileTree({
       </div>
 
       <div className="flex flex-col">
-        {nodes.slice(0, visibleCount).map((node) => (
+        {take(nodes, visibleCount).map((node) => (
           <div
             key={node.path}
             className="fade-in slide-in-from-left-1 animate-in fill-mode-both hover:bg-foreground/[0.03] flex items-center gap-2 rounded-lg px-1 py-1 text-[13px] transition-colors duration-300"

--- a/packages/ui/src/components/elements/flow-graph.tsx
+++ b/packages/ui/src/components/elements/flow-graph.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export type FlowNodeState = "done" | "active" | "pending";
 
@@ -38,10 +39,10 @@ export function FlowGraph({
   edges: readonly FlowEdge[];
   visibleCount: number;
 }) {
-  const shown = nodes.slice(0, visibleCount);
+  const shown = take(nodes, visibleCount);
   const shownIds = new Set(shown.map((node) => node.id));
-  const columns = Math.max(...nodes.map((node) => node.column)) + 1;
-  const rows = Math.max(...nodes.map((node) => node.row)) + 1;
+  const columns = Math.max(0, ...nodes.map((node) => node.column)) + 1;
+  const rows = Math.max(0, ...nodes.map((node) => node.row)) + 1;
   const width = (columns - 1) * COL_W + NODE_W;
   const height = (rows - 1) * ROW_H + NODE_H;
 

--- a/packages/ui/src/components/elements/job-progress.tsx
+++ b/packages/ui/src/components/elements/job-progress.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
+import { clamp, pct, progressOf, take } from "./range";
 
 export interface JobStage {
   name: string;
@@ -36,16 +37,19 @@ export function JobProgress({
   eta: string;
   onCancel?: () => void;
 }) {
-  const totalWeight = stages.reduce((sum, stage) => sum + stage.weight, 0) || 1;
-  const completed = stages
-    .slice(0, stageIndex)
-    .reduce((sum, stage) => sum + stage.weight, 0);
-  const current = stages[stageIndex];
-  const overall =
-    ((completed + (current ? current.weight * stageProgress : 0)) /
-      totalWeight) *
-    100;
-  const finished = stageIndex >= stages.length;
+  const stage = progressOf(stageIndex, stages.length);
+  const progress = clamp(stageProgress, 0, 1);
+  const totalWeight = stages.reduce((sum, item) => sum + item.weight, 0) || 1;
+  const completed = take(stages, stage).reduce(
+    (sum, item) => sum + item.weight,
+    0,
+  );
+  const current = stages[stage];
+  const overall = pct(
+    completed + (current ? current.weight * progress : 0),
+    totalWeight,
+  );
+  const finished = stage >= stages.length;
 
   return (
     <div
@@ -88,24 +92,24 @@ export function JobProgress({
             "block h-full rounded-full transition-[width] duration-500 ease-out motion-reduce:transition-none",
             finished ? "bg-emerald-500" : "bg-blue-500 dark:bg-blue-400",
           )}
-          style={{ width: `${Math.min(100, overall)}%` }}
+          style={{ width: `${overall}%` }}
         />
       </span>
 
       <div className="flex flex-wrap gap-x-3 gap-y-1">
-        {stages.map((stage, i) => (
+        {stages.map((item, i) => (
           <span
-            key={stage.name}
+            key={item.name}
             className={cn(
               mono,
-              i < stageIndex
+              i < stage
                 ? "text-foreground/35"
-                : i === stageIndex
+                : i === stage
                   ? "text-foreground/90"
                   : "text-foreground/20",
             )}
           >
-            {stage.name}
+            {item.name}
           </span>
         ))}
       </div>

--- a/packages/ui/src/components/elements/math-block.tsx
+++ b/packages/ui/src/components/elements/math-block.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export interface MathStep {
   expression: React.ReactNode;
@@ -36,7 +37,7 @@ export function MathBlock({
     >
       {label && <span className={cn(mono, "text-foreground/30")}>{label}</span>}
 
-      {steps.slice(0, visibleSteps).map((step, i) => (
+      {take(steps, visibleSteps).map((step, i) => (
         <div
           key={i}
           className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex flex-col gap-1 duration-300"

--- a/packages/ui/src/components/elements/message-pair.tsx
+++ b/packages/ui/src/components/elements/message-pair.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { CopyIcon, RefreshCwIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, paper } from "./surfaces";
+import { take } from "./range";
 
 export interface MessagePairProps extends Omit<
   ComponentProps<"div">,
@@ -25,6 +26,8 @@ export function MessagePair({
   className,
   ...props
 }: MessagePairProps) {
+  const shown = take(words, visibleWords);
+
   return (
     <div
       data-slot="message-pair"
@@ -44,8 +47,8 @@ export function MessagePair({
       </p>
       <div className="group/message flex flex-col items-start">
         <p className="min-h-[4.25rem] text-sm leading-relaxed">
-          {words.slice(0, visibleWords).map((word, index) => {
-            const fresh = streaming && visibleWords - 1 - index < 2;
+          {shown.map((word, index) => {
+            const fresh = streaming && shown.length - 1 - index < 2;
 
             return (
               <span
@@ -63,7 +66,7 @@ export function MessagePair({
               </span>
             );
           })}
-          {streaming && visibleWords > 0 && (
+          {streaming && shown.length > 0 && (
             <span
               aria-hidden
               className="-mb-0.5 ml-0.5 inline-block h-4 w-0.5 animate-pulse rounded-full bg-blue-500 motion-reduce:animate-none dark:bg-blue-400"

--- a/packages/ui/src/components/elements/onboarding.tsx
+++ b/packages/ui/src/components/elements/onboarding.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
-import { progressOf } from "./range";
+import { indexIn } from "./range";
 
 export interface OnboardingStep {
   title: string;
@@ -27,7 +27,7 @@ export function Onboarding({
   onNext?: () => void;
   onSkip?: () => void;
 }) {
-  const current = progressOf(index, Math.max(0, steps.length - 1));
+  const current = indexIn(steps, index);
   const step = steps[current];
   if (!step) return null;
   const last = current >= steps.length - 1;

--- a/packages/ui/src/components/elements/onboarding.tsx
+++ b/packages/ui/src/components/elements/onboarding.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, inkButton, mono, paper } from "./surfaces";
+import { progressOf } from "./range";
 
 export interface OnboardingStep {
   title: string;
@@ -26,9 +27,10 @@ export function Onboarding({
   onNext?: () => void;
   onSkip?: () => void;
 }) {
-  const step = steps[Math.min(index, steps.length - 1)];
+  const current = progressOf(index, Math.max(0, steps.length - 1));
+  const step = steps[current];
   if (!step) return null;
-  const last = index >= steps.length - 1;
+  const last = current >= steps.length - 1;
 
   return (
     <div
@@ -42,11 +44,11 @@ export function Onboarding({
       {...props}
     >
       <div
-        key={index}
+        key={current}
         className="fade-in animate-in flex flex-col gap-2 duration-300"
       >
         <span className={cn(mono, "text-foreground/30 tabular-nums")}>
-          {index + 1} of {steps.length}
+          {current + 1} of {steps.length}
         </span>
         <span className="text-[15px] font-medium tracking-tight">
           {step.title}
@@ -72,7 +74,7 @@ export function Onboarding({
               aria-hidden
               className={cn(
                 "h-1 rounded-full transition-all duration-300 motion-reduce:transition-none",
-                i === index ? "bg-foreground/60 w-4" : "bg-foreground/15 w-1",
+                i === current ? "bg-foreground/60 w-4" : "bg-foreground/15 w-1",
               )}
             />
           ))}

--- a/packages/ui/src/components/elements/quota-banner.tsx
+++ b/packages/ui/src/components/elements/quota-banner.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { inkButton, mono, paper } from "./surfaces";
+import { pct } from "./range";
 
 export function QuotaBanner({
   used,
@@ -65,7 +66,7 @@ export function QuotaBanner({
             "block h-full rounded-full transition-[width] duration-500 motion-reduce:transition-none",
             tight ? "bg-amber-500" : "bg-foreground/40",
           )}
-          style={{ width: `${Math.min(100, ratio * 100)}%` }}
+          style={{ width: `${pct(used, limit)}%` }}
         />
       </span>
 

--- a/packages/ui/src/components/elements/range.test.ts
+++ b/packages/ui/src/components/elements/range.test.ts
@@ -16,8 +16,13 @@ describe("clamp", () => {
     expect(clamp(Number.NEGATIVE_INFINITY, 0, 10)).toBe(0);
   });
 
-  it("maps NaN to the lower bound", () => {
+  it("maps NaN to the lower bound, ahead of the inverted-bounds rule", () => {
     expect(clamp(Number.NaN, 2, 10)).toBe(2);
+    expect(clamp(Number.NaN, 1, 0)).toBe(1);
+  });
+
+  it("lets max win when an empty collection inverts the bounds", () => {
+    expect(clamp(3, 1, 0)).toBe(0);
   });
 });
 

--- a/packages/ui/src/components/elements/range.test.ts
+++ b/packages/ui/src/components/elements/range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { at, clamp, pct, progressOf, take } from "./range";
+import { at, clamp, indexIn, pct, progressOf, take } from "./range";
 
 describe("clamp", () => {
   it("passes an in-range value through", () => {
@@ -69,6 +69,22 @@ describe("at", () => {
   });
 });
 
+describe("indexIn", () => {
+  const items = ["a", "b", "c"];
+
+  it("names the nearest position for an index out of range", () => {
+    expect(indexIn(items, 1)).toBe(1);
+    expect(indexIn(items, -5)).toBe(0);
+    expect(indexIn(items, 99)).toBe(2);
+    expect(indexIn(items, 1.5)).toBe(1);
+    expect(indexIn(items, Number.NaN)).toBe(0);
+  });
+
+  it("is 0 for an empty list rather than -1", () => {
+    expect(indexIn([], 3)).toBe(0);
+  });
+});
+
 describe("pct", () => {
   it("computes a share", () => {
     expect(pct(1, 4)).toBe(25);
@@ -92,5 +108,10 @@ describe("progressOf", () => {
     expect(progressOf(-2, 5)).toBe(0);
     expect(progressOf(9, 5)).toBe(5);
     expect(progressOf(Number.NaN, 5)).toBe(0);
+  });
+
+  it("is 0 for a non-positive total, matching pct", () => {
+    expect(progressOf(3, 0)).toBe(0);
+    expect(progressOf(3, -2)).toBe(0);
   });
 });

--- a/packages/ui/src/components/elements/range.test.ts
+++ b/packages/ui/src/components/elements/range.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { at, clamp, pct, progressOf, take } from "./range";
+
+describe("clamp", () => {
+  it("passes an in-range value through", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("constrains both ends", () => {
+    expect(clamp(-4, 0, 10)).toBe(0);
+    expect(clamp(40, 0, 10)).toBe(10);
+  });
+
+  it("maps the infinities to the bounds", () => {
+    expect(clamp(Number.POSITIVE_INFINITY, 0, 10)).toBe(10);
+    expect(clamp(Number.NEGATIVE_INFINITY, 0, 10)).toBe(0);
+  });
+
+  it("maps NaN to the lower bound", () => {
+    expect(clamp(Number.NaN, 2, 10)).toBe(2);
+  });
+});
+
+describe("take", () => {
+  const items = ["a", "b", "c"];
+
+  it("takes the first n", () => {
+    expect(take(items, 2)).toEqual(["a", "b"]);
+  });
+
+  it("takes nothing for a negative count, rather than counting from the end", () => {
+    expect(take(items, -2)).toEqual([]);
+    expect(items.slice(0, -2)).toEqual(["a"]);
+  });
+
+  it("takes everything for a count past the end", () => {
+    expect(take(items, 99)).toEqual(items);
+    expect(take(items, Number.POSITIVE_INFINITY)).toEqual(items);
+  });
+
+  it("truncates a fractional count", () => {
+    expect(take(items, 1.9)).toEqual(["a"]);
+  });
+
+  it("takes nothing for NaN or from an empty list", () => {
+    expect(take(items, Number.NaN)).toEqual([]);
+    expect(take([], 3)).toEqual([]);
+  });
+});
+
+describe("at", () => {
+  const items = ["a", "b", "c"];
+
+  it("reads an in-range index", () => {
+    expect(at(items, 1)).toBe("b");
+  });
+
+  it("clamps an out-of-range index to an end", () => {
+    expect(at(items, -5)).toBe("a");
+    expect(at(items, 99)).toBe("c");
+  });
+
+  it("floors a fractional index rather than reading a hole", () => {
+    expect(at(items, 1.5)).toBe("b");
+  });
+
+  it("is undefined for an empty list", () => {
+    expect(at([], 0)).toBeUndefined();
+  });
+});
+
+describe("pct", () => {
+  it("computes a share", () => {
+    expect(pct(1, 4)).toBe(25);
+  });
+
+  it("stays inside 0 to 100", () => {
+    expect(pct(-3, 4)).toBe(0);
+    expect(pct(9, 4)).toBe(100);
+  });
+
+  it("is 0 for a non-positive total, rather than NaN or Infinity", () => {
+    expect(pct(3, 0)).toBe(0);
+    expect(pct(3, -1)).toBe(0);
+    expect(pct(Number.NaN, 4)).toBe(0);
+  });
+});
+
+describe("progressOf", () => {
+  it("counts completed items inside 0 to total", () => {
+    expect(progressOf(2, 5)).toBe(2);
+    expect(progressOf(-2, 5)).toBe(0);
+    expect(progressOf(9, 5)).toBe(5);
+    expect(progressOf(Number.NaN, 5)).toBe(0);
+  });
+});

--- a/packages/ui/src/components/elements/range.ts
+++ b/packages/ui/src/components/elements/range.ts
@@ -1,0 +1,37 @@
+/**
+ * Range normalization for the numeric props the elements take.
+ *
+ * Elements are driven by a caller's state, so a prop can arrive negative, past
+ * the end of its collection, or NaN. Left raw, those reach the DOM: a negative
+ * percentage is an invalid CSS width that the browser drops, leaving a bar at
+ * its natural full width, and a negative slice length counts from the end of
+ * the array instead of returning nothing.
+ */
+
+/** Constrains a value to `min…max`, mapping NaN to `min`. */
+export function clamp(value: number, min: number, max: number) {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+/** The first `count` items, for a `count` that may be out of range. */
+export function take<T>(items: readonly T[], count: number) {
+  return items.slice(0, Math.floor(clamp(count, 0, items.length)));
+}
+
+/** The item at `index`, for an `index` that may be out of range. */
+export function at<T>(items: readonly T[], index: number) {
+  if (items.length === 0) return undefined;
+  return items[Math.floor(clamp(index, 0, items.length - 1))];
+}
+
+/** `value` as a share of `total`, as a percentage in `0…100`. */
+export function pct(value: number, total: number) {
+  if (!(total > 0)) return 0;
+  return clamp((value / total) * 100, 0, 100);
+}
+
+/** A count of completed items out of `total`, in `0…total`. */
+export function progressOf(index: number, total: number) {
+  return Math.floor(clamp(index, 0, total));
+}

--- a/packages/ui/src/components/elements/range.ts
+++ b/packages/ui/src/components/elements/range.ts
@@ -9,9 +9,10 @@
  */
 
 /**
- * Constrains a value to `min…max`, mapping NaN to `min`. An empty collection
- * inverts the bounds at some call sites, and `max` wins there: `clamp(v, 1, 0)`
- * is `0`, which is what lets a floor of one item still yield none.
+ * Constrains a value to `min…max`. NaN is decided first and maps to `min`.
+ * For any other value, an empty collection can invert the bounds and `max`
+ * wins there: `clamp(3, 1, 0)` is `0`, which is what lets a floor of one item
+ * still yield none.
  */
 export function clamp(value: number, min: number, max: number) {
   if (Number.isNaN(value)) return min;

--- a/packages/ui/src/components/elements/range.ts
+++ b/packages/ui/src/components/elements/range.ts
@@ -8,7 +8,11 @@
  * the array instead of returning nothing.
  */
 
-/** Constrains a value to `min…max`, mapping NaN to `min`. */
+/**
+ * Constrains a value to `min…max`, mapping NaN to `min`. An empty collection
+ * inverts the bounds at some call sites, and `max` wins there: `clamp(v, 1, 0)`
+ * is `0`, which is what lets a floor of one item still yield none.
+ */
 export function clamp(value: number, min: number, max: number) {
   if (Number.isNaN(value)) return min;
   return Math.min(max, Math.max(min, value));
@@ -19,10 +23,15 @@ export function take<T>(items: readonly T[], count: number) {
   return items.slice(0, Math.floor(clamp(count, 0, items.length)));
 }
 
+/** The position `index` names in `items`, for an `index` out of range. */
+export function indexIn<T>(items: readonly T[], index: number) {
+  return Math.floor(clamp(index, 0, Math.max(0, items.length - 1)));
+}
+
 /** The item at `index`, for an `index` that may be out of range. */
 export function at<T>(items: readonly T[], index: number) {
   if (items.length === 0) return undefined;
-  return items[Math.floor(clamp(index, 0, items.length - 1))];
+  return items[indexIn(items, index)];
 }
 
 /** `value` as a share of `total`, as a percentage in `0…100`. */
@@ -33,5 +42,6 @@ export function pct(value: number, total: number) {
 
 /** A count of completed items out of `total`, in `0…total`. */
 export function progressOf(index: number, total: number) {
+  if (!(total > 0)) return 0;
   return Math.floor(clamp(index, 0, total));
 }

--- a/packages/ui/src/components/elements/read-aloud.tsx
+++ b/packages/ui/src/components/elements/read-aloud.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { PauseIcon, PlayIcon, Volume2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, ghostButton, mono, paper } from "./surfaces";
+import { pct } from "./range";
 
 export function ReadAloud({
   words,
@@ -37,8 +38,7 @@ export function ReadAloud({
   onToggle?: () => void;
   onRateChange?: () => void;
 }) {
-  const progress =
-    words.length === 0 ? 0 : Math.min(100, (spokenIndex / words.length) * 100);
+  const progress = pct(spokenIndex, words.length);
 
   return (
     <div

--- a/packages/ui/src/components/elements/reasoning-effort.tsx
+++ b/packages/ui/src/components/elements/reasoning-effort.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
+import { pct } from "./range";
 
 const fmt = (n: number) => n.toLocaleString("en-US");
 
@@ -30,7 +31,7 @@ export function ReasoningEffort({
 }) {
   const selected = levels.find((level) => level.key === selectedKey);
   const budget = selected?.budget ?? 0;
-  const used = budget === 0 ? 0 : Math.min(100, (spent / budget) * 100);
+  const used = pct(spent, budget);
 
   return (
     <div

--- a/packages/ui/src/components/elements/reasoning-panel.tsx
+++ b/packages/ui/src/components/elements/reasoning-panel.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { collapsePanel, mono, SwapLabel } from "./surfaces";
+import { take } from "./range";
 
 export interface ReasoningStep {
   title: string;
@@ -35,6 +36,8 @@ export function ReasoningPanel({
   elapsed,
   className,
 }: ReasoningPanelProps) {
+  const shown = take(steps, visibleSteps);
+
   return (
     <Collapsible
       data-slot="reasoning-panel"
@@ -66,8 +69,8 @@ export function ReasoningPanel({
       </CollapsibleTrigger>
       <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
         <ol className="flex flex-col gap-4 pt-3 pb-1">
-          {steps.slice(0, visibleSteps).map((step, i) => {
-            const active = streaming && i === visibleSteps - 1;
+          {shown.map((step, i) => {
+            const active = streaming && i === shown.length - 1;
             return (
               <li
                 key={step.title}

--- a/packages/ui/src/components/elements/retrieval-chunks.tsx
+++ b/packages/ui/src/components/elements/retrieval-chunks.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { DatabaseIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
+import { pct, take } from "./range";
 
 export interface RetrievalChunk {
   id: string;
@@ -65,7 +66,7 @@ export function RetrievalChunks({
       </div>
 
       <div className="flex min-h-[7rem] flex-col gap-1.5">
-        {chunks.slice(0, visibleCount).map((chunk) => (
+        {take(chunks, visibleCount).map((chunk) => (
           <div
             key={chunk.id}
             className={cn(
@@ -98,7 +99,7 @@ export function RetrievalChunks({
             <span className="bg-foreground/[0.06] h-[2px] w-full overflow-hidden rounded-full">
               <span
                 className="block h-full rounded-full bg-blue-500/70 transition-[width] duration-500 dark:bg-blue-400/70"
-                style={{ width: `${chunk.score * 100}%` }}
+                style={{ width: `${pct(chunk.score, 1)}%` }}
               />
             </span>
           </div>

--- a/packages/ui/src/components/elements/score-breakdown.tsx
+++ b/packages/ui/src/components/elements/score-breakdown.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { pct, take } from "./range";
 
 export interface ScoreCriterion {
   label: string;
@@ -64,7 +65,7 @@ export function ScoreBreakdown({
       </div>
 
       <div className="flex flex-col gap-2">
-        {criteria.slice(0, visibleCount).map((criterion) => (
+        {take(criteria, visibleCount).map((criterion) => (
           <div
             key={criterion.label}
             className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex flex-col gap-1 duration-300"
@@ -86,7 +87,7 @@ export function ScoreBreakdown({
               <span
                 className="block h-full rounded-full bg-blue-500 transition-[width] duration-500 motion-reduce:transition-none dark:bg-blue-400"
                 style={{
-                  width: `${Math.min(100, outOf === 0 ? 0 : (criterion.score / outOf) * 100)}%`,
+                  width: `${pct(criterion.score, outOf)}%`,
                 }}
               />
             </span>

--- a/packages/ui/src/components/elements/settings-panel.tsx
+++ b/packages/ui/src/components/elements/settings-panel.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
+import { clamp } from "./range";
 
 export interface SettingToggle {
   key: string;
@@ -97,7 +98,7 @@ export function SettingsPanel({
         <span className="flex items-baseline justify-between">
           <span className={cn(mono, "text-foreground/30")}>temperature</span>
           <span className={cn(mono, "text-foreground/55 tabular-nums")}>
-            {Math.min(2, Math.max(0, temperature)).toFixed(1)}
+            {clamp(temperature, 0, 2).toFixed(1)}
           </span>
         </span>
         <input
@@ -105,7 +106,7 @@ export function SettingsPanel({
           min={0}
           max={2}
           step={0.1}
-          value={Math.min(2, Math.max(0, temperature))}
+          value={clamp(temperature, 0, 2)}
           aria-label="Temperature"
           onChange={(event) =>
             onTemperatureChange?.(Number(event.target.value))

--- a/packages/ui/src/components/elements/spec-sheet.tsx
+++ b/packages/ui/src/components/elements/spec-sheet.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export interface SpecRow {
   label: string;
@@ -45,7 +46,7 @@ export function SpecSheet({
       </div>
 
       <div className="flex flex-col">
-        {rows.slice(0, visibleCount).map((row) => (
+        {take(rows, visibleCount).map((row) => (
           <div
             key={row.label}
             className="border-foreground/[0.06] fade-in animate-in fill-mode-both flex items-baseline gap-3 border-t py-1.5 duration-300 first:border-t-0 first:pt-0"

--- a/packages/ui/src/components/elements/streaming-text.tsx
+++ b/packages/ui/src/components/elements/streaming-text.tsx
@@ -2,6 +2,7 @@
 
 import { type ComponentProps, useMemo } from "react";
 import { cn } from "@/lib/utils";
+import { take } from "./range";
 
 export interface Segment {
   text: string;
@@ -31,6 +32,7 @@ export function StreamingText({
       ),
     [segments],
   );
+  const shown = take(words, count);
 
   return (
     <p
@@ -42,8 +44,8 @@ export function StreamingText({
 
       {...props}
     >
-      {words.slice(0, count).map(({ word, mono: isMono }, i) => {
-        const fresh = streaming && count - 1 - i < 2;
+      {shown.map(({ word, mono: isMono }, i) => {
+        const fresh = streaming && shown.length - 1 - i < 2;
         return (
           <span
             key={i}
@@ -62,7 +64,7 @@ export function StreamingText({
           </span>
         );
       })}
-      {streaming && count > 0 && (
+      {streaming && shown.length > 0 && (
         <span
           aria-hidden
           className="-mb-0.5 ml-0.5 inline-block h-4 w-0.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"

--- a/packages/ui/src/components/elements/subagent-list.tsx
+++ b/packages/ui/src/components/elements/subagent-list.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { pct } from "./range";
 
 export interface SubagentItem {
   name: string;
@@ -74,7 +75,7 @@ export function SubagentList({
                   "block h-full rounded-full transition-[width] duration-700",
                   done ? "bg-emerald-500/70" : "bg-foreground/60",
                 )}
-                style={{ width: `${width}%` }}
+                style={{ width: `${pct(width, 100)}%` }}
               />
             </span>
           </div>

--- a/packages/ui/src/components/elements/terminal-block.tsx
+++ b/packages/ui/src/components/elements/terminal-block.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { CheckIcon, Loader2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export function TerminalBlock({
   command,
@@ -81,7 +82,7 @@ export function TerminalBlock({
             : "text-foreground/50",
         )}
       >
-        {lines.slice(0, visibleCount).map((line, i) => {
+        {take(lines, visibleCount).map((line, i) => {
           const isLast = i === lines.length - 1;
           return (
             <div

--- a/packages/ui/src/components/elements/timeline.tsx
+++ b/packages/ui/src/components/elements/timeline.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { take } from "./range";
 
 export type TimelineWhen = "past" | "now" | "future";
 
@@ -34,7 +35,7 @@ export function Timeline({
 
       {...props}
     >
-      {events.slice(0, visibleCount).map((event, i, shown) => (
+      {take(events, visibleCount).map((event, i, shown) => (
         <div
           key={event.id}
           className="fade-in slide-in-from-left-1 animate-in fill-mode-both grid grid-cols-[3.5rem_1rem_1fr] gap-x-2 duration-300"

--- a/packages/ui/src/components/elements/tool-timeline.tsx
+++ b/packages/ui/src/components/elements/tool-timeline.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { collapsePanel, SwapLabel } from "./surfaces";
+import { take } from "./range";
 
 export interface TimelineStep {
   verb: string;
@@ -71,9 +72,9 @@ export function ToolTimeline({
       </CollapsibleTrigger>
       <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
         <div className="flex flex-col gap-2.5 ps-4 pt-2.5">
-          {steps.slice(0, visibleSteps).map((step, index) => {
+          {take(steps, visibleSteps).map((step, index, shown) => {
             const Icon = step.icon;
-            const active = streaming && index === visibleSteps - 1;
+            const active = streaming && index === shown.length - 1;
 
             return (
               <div

--- a/packages/ui/src/components/elements/trace-waterfall.tsx
+++ b/packages/ui/src/components/elements/trace-waterfall.tsx
@@ -3,6 +3,7 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 import { mono, paper } from "./surfaces";
+import { pct, take } from "./range";
 
 export type SpanStatus = "running" | "completed" | "failed";
 
@@ -56,9 +57,9 @@ export function TraceWaterfall({
       </div>
 
       <div className="flex flex-col gap-1">
-        {spans.slice(0, visibleCount).map((item) => {
-          const left = (item.startMs / span) * 100;
-          const width = Math.max(1.5, (item.durationMs / span) * 100);
+        {take(spans, visibleCount).map((item) => {
+          const left = pct(item.startMs, span);
+          const width = Math.max(1.5, pct(item.durationMs, span));
           return (
             <div
               key={item.id}

--- a/packages/ui/src/components/elements/voice-conversation.tsx
+++ b/packages/ui/src/components/elements/voice-conversation.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { MicIcon, MicOffIcon, PhoneOffIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ghostButton, mono, paper } from "./surfaces";
+import { clamp } from "./range";
 
 export type VoiceMode = "connecting" | "listening" | "thinking" | "speaking";
 
@@ -56,7 +57,7 @@ export function VoiceConversation({
   onInterrupt?: () => void;
   onEnd?: () => void;
 }) {
-  const level = Math.max(0, Math.min(1, amplitude));
+  const level = clamp(amplitude, 0, 1);
   const active = mode === "listening" || mode === "speaking";
   const canInterrupt = mode === "speaking" && onInterrupt !== undefined;
 

--- a/packages/ui/src/components/elements/web-search.tsx
+++ b/packages/ui/src/components/elements/web-search.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono } from "./surfaces";
+import { take } from "./range";
 
 export interface WebSearchResult {
   title: string;
@@ -62,7 +63,7 @@ export function WebSearch({
         )}
       </div>
       <div className="flex min-h-[5.75rem] flex-col">
-        {results.slice(0, visibleResults).map((result) => (
+        {take(results, visibleResults).map((result) => (
           <div
             key={`${cycle}-${result.domain}`}
             className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both hover:bg-foreground/[0.03] -mx-2.5 flex items-center gap-2.5 rounded-xl px-2.5 py-1.5 transition-colors duration-300"


### PR DESCRIPTION
first of three on #5743. that issue asked for one sweep across the whole elements family rather than per-element fixes, so it splits by the three categories it names: this one is the out-of-range props, #5748 is overflow, #5749 is keyboard and screen reader access.

## summary

the elements are driven by a caller's state, so a count, an index, or a share can arrive negative, past the end of its collection, or NaN. left raw those reach the DOM. `width: -75%` is an invalid css value that the browser drops, which leaves a progress bar at its natural full width rather than empty, so `agent-plan` renders a **full** bar for a negative `activeIndex`. `slice(0, -3)` counts from the end of the array instead of returning nothing, so `reasoning-panel` drops its last steps instead of showing none.

this adds `range.ts` next to `surfaces.ts` and routes all of it through one funnel: `clamp`, `take`, `at`, `pct`, and `progressOf`. 17 raw `.slice(0, prop)` call sites and 13 raw percentage widths now go through it, and the per-element `Math.min(100, Math.max(0, …))` spellings collapse into the same helper. the point of the funnel is that it makes the guard cheap: the arithmetic gets one unit test, and nothing has to be re-argued per element.

two defects fell out of the sweep that the issue did not list: `flow-graph` computed `Math.max(...[])` for an empty node list, giving `-Infinity` for its column count, and `chart`'s `Math.max(1, visibleCount)` floor was itself defeated by NaN, so the "always show one point" fallback showed none.

a prop that names a selection rather than a position is deliberately left alone. `thread-list`'s `activeIndex`, `document-reference`'s `activePage`, and `read-aloud`'s `spokenIndex` all mean "nothing is selected" out of range, and clamping them would silently select the first row instead. that split is written down in `COUNT_SHAPED` in the test and in the contract note on the props table.

`range.ts` becomes its own registry item and, like `elements-surfaces`, an unconditional `registryDependency` of every element, so the existing "sibling imports are declared" test passes without being touched.

## test plan

### already verified

- [x] `pnpm -C packages/ui exec tsc --noEmit`, `pnpm -C apps/docs exec tsc --noEmit` -> clean
- [x] `pnpm lint` -> oxlint and oxfmt clean (only the pre-existing `surfaces.tsx` exhaustive-deps warning)
- [x] `pnpm -C packages/ui test` -> 276 passed, `pnpm -C apps/registry test` -> 33 passed, `pnpm -C apps/docs test` -> 132 passed
- [x] `pnpm -C apps/docs build` -> `/elements/[slug]` prerendered
- [x] reverted the clamp in `agent-plan` and the `take` in `reasoning-panel` and `timeline`, and confirmed the suite fails on each

### reviewer should verify

- [ ] the `COUNT_SHAPED` split: a position clamps to its nearest end, a selection degrades to "nothing selected". the three exclusions are the whole argument, and disagreeing with any of them is a real review comment.
- [ ] `pct(value, total)` returning 0 for a non-positive total, rather than propagating NaN into markup.

## notes

- the percentage assertion reads the server-rendered markup rather than the DOM on purpose. jsdom validates the CSSOM the way a browser does, so it silently drops `width: -75%`, and the first version of this test passed against a deliberately reverted `agent-plan`. that false green is the reason the assertion moved to `renderToStaticMarkup`.
- no changeset: `@assistant-ui/ui`, `@assistant-ui/docs`, and `@assistant-ui/shadcn-registry` are all `private: true`.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.H0Ok4D_2zc_XsYeCSzHYq7_Sz8Mcils6w6LZ1C6TQ0KcSWzNiaYIe9x9Dkw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
