### PR TITLE
fix(ui): contain hostile content in the elements that keep whitespace

### DIFF
--- a/packages/ui/src/components/elements/code-diff.tsx
+++ b/packages/ui/src/components/elements/code-diff.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
-import { mono, paper } from "./surfaces";
+import { codeRow, codeScroll, mono, paper } from "./surfaces";
 
 export type DiffKind = "context" | "added" | "removed";
 
@@ -55,11 +55,12 @@ export function CodeDiff({
           <span className="text-red-600 dark:text-red-400">−{deletions}</span>
         </span>
       </div>
-      <div>
+      <div className={codeScroll}>
         {lines.map((line, i) => (
           <div
             key={`${cycle}-${i}-${line.text}`}
             className={cn(
+              codeRow,
               "fade-in animate-in fill-mode-both flex px-4 py-0.5 leading-relaxed whitespace-pre duration-300",
               line.kind === "context" && "text-foreground/45",
               line.kind === "added" &&

--- a/packages/ui/src/components/elements/code-diff.tsx
+++ b/packages/ui/src/components/elements/code-diff.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
-import { codeRow, codeScroll, mono, paper } from "./surfaces";
+import { codeScroll, codeSurface, mono, paper } from "./surfaces";
 
 export type DiffKind = "context" | "added" | "removed";
 
@@ -56,26 +56,27 @@ export function CodeDiff({
         </span>
       </div>
       <div className={codeScroll}>
-        {lines.map((line, i) => (
-          <div
-            key={`${cycle}-${i}-${line.text}`}
-            className={cn(
-              codeRow,
-              "fade-in animate-in fill-mode-both flex px-4 py-0.5 leading-relaxed whitespace-pre duration-300",
-              line.kind === "context" && "text-foreground/45",
-              line.kind === "added" &&
-                "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300",
-              line.kind === "removed" &&
-                "bg-red-500/10 text-red-700 dark:text-red-300",
-            )}
-            style={{ animationDelay: `${i * 60}ms` }}
-          >
-            <span className="w-4 shrink-0 select-none">
-              {GUTTER[line.kind]}
-            </span>
-            <span>{line.text}</span>
-          </div>
-        ))}
+        <div className={codeSurface}>
+          {lines.map((line, i) => (
+            <div
+              key={`${cycle}-${i}-${line.text}`}
+              className={cn(
+                "fade-in animate-in fill-mode-both flex px-4 py-0.5 leading-relaxed whitespace-pre duration-300",
+                line.kind === "context" && "text-foreground/45",
+                line.kind === "added" &&
+                  "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300",
+                line.kind === "removed" &&
+                  "bg-red-500/10 text-red-700 dark:text-red-300",
+              )}
+              style={{ animationDelay: `${i * 60}ms` }}
+            >
+              <span className="w-4 shrink-0 select-none">
+                {GUTTER[line.kind]}
+              </span>
+              <span>{line.text}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/components/elements/code-runner.tsx
+++ b/packages/ui/src/components/elements/code-runner.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps } from "react";
 import { Loader2Icon, PlayIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ghostButton, mono, paper } from "./surfaces";
+import { codeRow, codeScroll, ghostButton, mono, paper } from "./surfaces";
 
 export type RunState = "idle" | "running" | "ok" | "error";
 
@@ -74,20 +74,23 @@ export function CodeRunner({
       {state !== "idle" && (
         <div className="border-foreground/[0.07] fade-in animate-in flex flex-col border-t px-3.5 py-2.5 duration-300">
           <span className={cn(mono, "text-foreground/30 pb-1")}>output</span>
-          {output.map((line, i) => (
-            <span
-              key={`${i}-${line}`}
-              className={cn(
-                "fade-in animate-in fill-mode-both font-mono text-xs leading-relaxed whitespace-pre",
-                state === "error"
-                  ? "text-red-600 dark:text-red-400"
-                  : "text-foreground/70",
-              )}
-              style={{ animationDelay: `${i * 80}ms` }}
-            >
-              {line}
-            </span>
-          ))}
+          <div className={cn(codeScroll, "flex flex-col")}>
+            {output.map((line, i) => (
+              <span
+                key={`${i}-${line}`}
+                className={cn(
+                  codeRow,
+                  "fade-in animate-in fill-mode-both font-mono text-xs leading-relaxed whitespace-pre",
+                  state === "error"
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-foreground/70",
+                )}
+                style={{ animationDelay: `${i * 80}ms` }}
+              >
+                {line}
+              </span>
+            ))}
+          </div>
           {state === "running" && (
             <span
               aria-hidden

--- a/packages/ui/src/components/elements/code-runner.tsx
+++ b/packages/ui/src/components/elements/code-runner.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps } from "react";
 import { Loader2Icon, PlayIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { codeRow, codeScroll, ghostButton, mono, paper } from "./surfaces";
+import { codeScroll, codeSurface, ghostButton, mono, paper } from "./surfaces";
 
 export type RunState = "idle" | "running" | "ok" | "error";
 
@@ -74,22 +74,23 @@ export function CodeRunner({
       {state !== "idle" && (
         <div className="border-foreground/[0.07] fade-in animate-in flex flex-col border-t px-3.5 py-2.5 duration-300">
           <span className={cn(mono, "text-foreground/30 pb-1")}>output</span>
-          <div className={cn(codeScroll, "flex flex-col")}>
-            {output.map((line, i) => (
-              <span
-                key={`${i}-${line}`}
-                className={cn(
-                  codeRow,
-                  "fade-in animate-in fill-mode-both font-mono text-xs leading-relaxed whitespace-pre",
-                  state === "error"
-                    ? "text-red-600 dark:text-red-400"
-                    : "text-foreground/70",
-                )}
-                style={{ animationDelay: `${i * 80}ms` }}
-              >
-                {line}
-              </span>
-            ))}
+          <div className={codeScroll}>
+            <div className={cn(codeSurface, "flex flex-col")}>
+              {output.map((line, i) => (
+                <span
+                  key={`${i}-${line}`}
+                  className={cn(
+                    "fade-in animate-in fill-mode-both font-mono text-xs leading-relaxed whitespace-pre",
+                    state === "error"
+                      ? "text-red-600 dark:text-red-400"
+                      : "text-foreground/70",
+                  )}
+                  style={{ animationDelay: `${i * 80}ms` }}
+                >
+                  {line}
+                </span>
+              ))}
+            </div>
           </div>
           {state === "running" && (
             <span

--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -145,7 +145,7 @@ export function CommandPalette({
           </div>
         ))}
         {matches.length === 0 && (
-          <span className="text-foreground/30 px-2 py-4 text-center text-xs">
+          <span className="text-foreground/30 px-2 py-4 text-center text-xs break-words">
             No command matches “{query}”
           </span>
         )}

--- a/packages/ui/src/components/elements/day-separator.tsx
+++ b/packages/ui/src/components/elements/day-separator.tsx
@@ -51,7 +51,7 @@ export function DaySeparator({
             >
               <span
                 className={cn(
-                  "max-w-[80%] text-[13.5px] leading-relaxed",
+                  "max-w-[80%] text-[13.5px] leading-relaxed break-words",
                   message.role === "user"
                     ? "bg-foreground/[0.05] rounded-2xl px-3.5 py-2"
                     : "text-foreground/75",

--- a/packages/ui/src/components/elements/document-reference.tsx
+++ b/packages/ui/src/components/elements/document-reference.tsx
@@ -67,7 +67,7 @@ export function DocumentReference({
             <span className={cn(mono, "text-foreground/30")}>
               p. {anchor.page}
             </span>
-            <span className="text-foreground/65 border-foreground/15 border-s-2 ps-2 text-xs leading-relaxed">
+            <span className="text-foreground/65 border-foreground/15 border-s-2 ps-2 text-xs leading-relaxed break-words">
               {anchor.quote}
             </span>
           </button>

--- a/packages/ui/src/components/elements/onboarding.tsx
+++ b/packages/ui/src/components/elements/onboarding.tsx
@@ -53,7 +53,7 @@ export function Onboarding({
         <span className="text-[15px] font-medium tracking-tight">
           {step.title}
         </span>
-        <p className="text-foreground/55 text-[13px] leading-relaxed">
+        <p className="text-foreground/55 text-[13px] leading-relaxed break-words">
           {step.body}
         </p>
         <span

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -124,7 +124,7 @@ export function PromptLibrary({
           </button>
         ))}
         {matches.length === 0 && (
-          <span className="text-foreground/30 px-2 py-3 text-center text-xs">
+          <span className="text-foreground/30 px-2 py-3 text-center text-xs break-words">
             Nothing matches “{query}”
           </span>
         )}
@@ -137,7 +137,7 @@ export function PromptLibrary({
             "fade-in animate-in flex flex-col gap-2 rounded-xl p-2.5 duration-200",
           )}
         >
-          <p className="text-foreground/65 text-xs leading-relaxed">
+          <p className="text-foreground/65 text-xs leading-relaxed break-words">
             {selected.body}
           </p>
           {selected.variables.length > 0 && (

--- a/packages/ui/src/components/elements/reasoning-panel.tsx
+++ b/packages/ui/src/components/elements/reasoning-panel.tsx
@@ -89,7 +89,7 @@ export function ReasoningPanel({
                   <p className="text-foreground/90 text-[13.5px] font-medium">
                     {step.title}
                   </p>
-                  <p className="text-foreground/50 mt-0.5 text-[13px] leading-relaxed">
+                  <p className="text-foreground/50 mt-0.5 text-[13px] leading-relaxed break-words">
                     {step.body}
                   </p>
                 </span>

--- a/packages/ui/src/components/elements/reasoning-panel.tsx
+++ b/packages/ui/src/components/elements/reasoning-panel.tsx
@@ -85,7 +85,7 @@ export function ReasoningPanel({
                       : "bg-foreground/20",
                   )}
                 />
-                <span className="flex flex-col">
+                <span className="flex min-w-0 flex-1 flex-col">
                   <p className="text-foreground/90 text-[13.5px] font-medium">
                     {step.title}
                   </p>

--- a/packages/ui/src/components/elements/reviewable-diff.tsx
+++ b/packages/ui/src/components/elements/reviewable-diff.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps } from "react";
 import { CheckIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { inkButton, mono, paper } from "./surfaces";
+import { codeRow, codeScroll, inkButton, mono, paper } from "./surfaces";
 import type { DiffLine } from "./code-diff";
 
 export type HunkDecision = "pending" | "kept" | "discarded";
@@ -106,11 +106,12 @@ export function ReviewableDiff({
                 )}
               </span>
             </div>
-            <div className="pb-1.5 font-mono text-xs">
+            <div className={cn(codeScroll, "pb-1.5 font-mono text-xs")}>
               {hunk.lines.map((line, i) => (
                 <div
                   key={`${hunk.id}-${i}`}
                   className={cn(
+                    codeRow,
                     "flex px-4 py-0.5 leading-relaxed whitespace-pre",
                     line.kind === "context" && "text-foreground/40",
                     line.kind === "added" &&

--- a/packages/ui/src/components/elements/reviewable-diff.tsx
+++ b/packages/ui/src/components/elements/reviewable-diff.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps } from "react";
 import { CheckIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { codeRow, codeScroll, inkButton, mono, paper } from "./surfaces";
+import { codeScroll, codeSurface, inkButton, mono, paper } from "./surfaces";
 import type { DiffLine } from "./code-diff";
 
 export type HunkDecision = "pending" | "kept" | "discarded";
@@ -107,25 +107,26 @@ export function ReviewableDiff({
               </span>
             </div>
             <div className={cn(codeScroll, "pb-1.5 font-mono text-xs")}>
-              {hunk.lines.map((line, i) => (
-                <div
-                  key={`${hunk.id}-${i}`}
-                  className={cn(
-                    codeRow,
-                    "flex px-4 py-0.5 leading-relaxed whitespace-pre",
-                    line.kind === "context" && "text-foreground/40",
-                    line.kind === "added" &&
-                      "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-                    line.kind === "removed" &&
-                      "bg-red-500/10 text-red-700 dark:text-red-300",
-                  )}
-                >
-                  <span className="w-4 shrink-0 select-none">
-                    {GUTTER[line.kind]}
-                  </span>
-                  <span>{line.text}</span>
-                </div>
-              ))}
+              <div className={codeSurface}>
+                {hunk.lines.map((line, i) => (
+                  <div
+                    key={`${hunk.id}-${i}`}
+                    className={cn(
+                      "flex px-4 py-0.5 leading-relaxed whitespace-pre",
+                      line.kind === "context" && "text-foreground/40",
+                      line.kind === "added" &&
+                        "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+                      line.kind === "removed" &&
+                        "bg-red-500/10 text-red-700 dark:text-red-300",
+                    )}
+                  >
+                    <span className="w-4 shrink-0 select-none">
+                      {GUTTER[line.kind]}
+                    </span>
+                    <span>{line.text}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         ))}

--- a/packages/ui/src/components/elements/score-breakdown.tsx
+++ b/packages/ui/src/components/elements/score-breakdown.tsx
@@ -92,7 +92,7 @@ export function ScoreBreakdown({
               />
             </span>
             {criterion.note && (
-              <span className="text-foreground/40 text-xs leading-relaxed">
+              <span className="text-foreground/40 text-xs leading-relaxed break-words">
                 {criterion.note}
               </span>
             )}

--- a/packages/ui/src/components/elements/speaker-identity.tsx
+++ b/packages/ui/src/components/elements/speaker-identity.tsx
@@ -63,7 +63,7 @@ export function SpeakerIdentity({
                 </span>
               )}
             </span>
-            <span className="text-foreground/65 text-[13.5px] leading-relaxed">
+            <span className="text-foreground/65 text-[13.5px] leading-relaxed break-words">
               {turn.text}
             </span>
           </div>

--- a/packages/ui/src/components/elements/surfaces.tsx
+++ b/packages/ui/src/components/elements/surfaces.tsx
@@ -44,6 +44,16 @@ export const live = "text-blue-500 dark:text-blue-400";
 
 export const mono = "font-mono text-[11px] tracking-tight";
 
+/**
+ * Scroll region for content that keeps its own whitespace. `whitespace-pre` in
+ * a bounded box clips a long line with no way to reach it, so the rows scroll
+ * instead; each row is `codeRow` so its background spans the scrolled width
+ * rather than stopping at the visible edge.
+ */
+export const codeScroll = "overflow-x-auto";
+
+export const codeRow = "w-max min-w-full";
+
 export function SwapLabel({
   active,
   children,

--- a/packages/ui/src/components/elements/surfaces.tsx
+++ b/packages/ui/src/components/elements/surfaces.tsx
@@ -47,12 +47,16 @@ export const mono = "font-mono text-[11px] tracking-tight";
 /**
  * Scroll region for content that keeps its own whitespace. `whitespace-pre` in
  * a bounded box clips a long line with no way to reach it, so the rows scroll
- * instead; each row is `codeRow` so its background spans the scrolled width
- * rather than stopping at the visible edge.
+ * instead.
+ *
+ * `codeSurface` wraps all the rows as one block, and the rows are its children.
+ * It cannot go on each row: `min-width: 100%` resolves against the scroll
+ * container's visible width rather than its scroll width, so a per-row width
+ * leaves every row except the longest ending its background at the fold.
  */
 export const codeScroll = "overflow-x-auto";
 
-export const codeRow = "w-max min-w-full";
+export const codeSurface = "w-max min-w-full";
 
 export function SwapLabel({
   active,

--- a/packages/ui/src/components/elements/timeline.tsx
+++ b/packages/ui/src/components/elements/timeline.tsx
@@ -38,7 +38,7 @@ export function Timeline({
       {take(events, visibleCount).map((event, i, shown) => (
         <div
           key={event.id}
-          className="fade-in slide-in-from-left-1 animate-in fill-mode-both grid grid-cols-[3.5rem_1rem_1fr] gap-x-2 duration-300"
+          className="fade-in slide-in-from-left-1 animate-in fill-mode-both grid grid-cols-[3.5rem_1rem_minmax(0,1fr)] gap-x-2 duration-300"
         >
           <span
             className={cn(
@@ -83,7 +83,7 @@ export function Timeline({
           >
             <span
               className={cn(
-                "text-[13px]",
+                "text-[13px] break-words",
                 event.when === "future"
                   ? "text-foreground/40"
                   : "text-foreground/90",
@@ -93,7 +93,7 @@ export function Timeline({
               {event.title}
             </span>
             {event.detail && (
-              <span className="text-foreground/45 text-xs leading-relaxed">
+              <span className="text-foreground/45 text-xs leading-relaxed break-words">
                 {event.detail}
               </span>
             )}

--- a/packages/ui/src/components/elements/todo-list.tsx
+++ b/packages/ui/src/components/elements/todo-list.tsx
@@ -61,7 +61,7 @@ export function TodoList({
             </span>
             <span
               className={cn(
-                "leading-5",
+                "leading-5 break-words",
                 item.status === "done" &&
                   "text-foreground/35 line-through decoration-[1.5px]",
                 item.status === "active" && "text-foreground/90",

--- a/packages/ui/src/components/elements/todo-list.tsx
+++ b/packages/ui/src/components/elements/todo-list.tsx
@@ -61,7 +61,7 @@ export function TodoList({
             </span>
             <span
               className={cn(
-                "leading-5 break-words",
+                "min-w-0 flex-1 leading-5 break-words",
                 item.status === "done" &&
                   "text-foreground/35 line-through decoration-[1.5px]",
                 item.status === "active" && "text-foreground/90",

--- a/packages/ui/src/components/elements/voice-conversation.tsx
+++ b/packages/ui/src/components/elements/voice-conversation.tsx
@@ -147,7 +147,7 @@ export function VoiceConversation({
             </span>
             <span
               className={cn(
-                "min-w-0 flex-1",
+                "min-w-0 flex-1 break-words",
                 turn.role === "user"
                   ? "text-foreground/50"
                   : "text-foreground/80",


### PR DESCRIPTION
second of three on #5743, on top of #5747 (merged). that issue asked for one sweep rather than per-element fixes; this layer is the overflow category.

## summary

three elements render monospace rows with `whitespace-pre` inside a card that is `overflow-hidden`, so a long line is not merely cut off, it is unreachable: `code-diff`, `reviewable-diff`, and `code-runner`'s output. the rows now scroll horizontally instead.

that needs two classes, and the **placement is the whole trick**: `codeScroll` is the scroll region, and `codeSurface` (`w-max min-w-full`) goes on **one wrapper** inside it with the rows as its children. it cannot go on each row, because `min-width: 100%` resolves against the scroll container's visible width rather than its scroll width, so a per-row version leaves every row except the longest ending its tint at the fold. the first version of this PR got that wrong; see the note below.

`timeline` is a different failure with the same symptom. its content column was a bare `1fr`, whose automatic minimum is min-content, so a long unbroken title pushed the track wider than the card. `min-w-0` on the child cannot fix this, because the track does its own sizing; the template needs `minmax(0, 1fr)`.

for prose the fix is to let it break, but `break-words` alone is not enough for a row-flex child: it does not change min-content contribution, which is the same reason `timeline` needed the track change. measured across all nine prose sites rather than assumed, and two genuinely overflow: `todo-list` grew its card to 2234px against 384px, and `reasoning-panel` rendered a 2126px line inside a 384px row that the collapsible then clipped away. those two get `min-w-0 flex-1`, matching `voice-conversation`. the other seven hold as they are. the three sites left without `break-words` are short `mono shrink-0` metadata badges, where breaking would change a deliberate layout choice rather than contain anything.

## test plan

### already verified

- [x] `pnpm -C packages/ui exec tsc --noEmit` -> clean, `pnpm lint` -> clean
- [x] `pnpm -C packages/ui test` -> 280 passed
- [x] real browser, 400 character unbroken line, measuring a **short** row rather than the injected one: a `bg-red-500/10` row spans the full 2928px scroll width in both `code-diff` and `reviewable-diff`
- [x] real browser: `code-runner` output scrolls; `timeline` wraps and holds 384px; `todo-list` and `reasoning-panel` contain their text after the `min-w-0` fix
- [x] whole gallery swept for horizontal overflow: 101 cards, zero, beyond the one pre-existing intentional `-mx-2.5` hover bleed in `web-search`

### reviewer should verify

- [ ] scroll a long line in `/elements/code-diff` and `/elements/reviewable-diff` and confirm the added and removed backgrounds extend the whole way rather than ending at the fold
- [ ] `reviewable-diff` keeps one scroller per hunk, so two hunks can sit at different offsets. that is deliberate (each hunk is a bordered unit with its own controls) and is the one UX call in here worth disagreeing with

## notes

- **the first version of this PR was wrong and my own browser check did not catch it.** it put `w-max min-w-full` on each row, and the verification injected the hostile string into a row and then measured that same row, which is the one case that passes either way. review caught it; measuring a different, short row shows 448px against a 2928px scroll width. the numbers above are from the corrected structure.
- **this layer still has no automated test, on purpose.** jsdom has no layout, so it cannot see overflow at all. a source-shape check would look like coverage without being any, which is the false negative recorded in #5744. a durable guard here means playwright and is its own change.
- no changeset: `@assistant-ui/ui` is `private: true`.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8pvbnHucRaqZqjMIWtKiVpwPmtIVzfug52nXbJ7erVSOsRQdNpPuZZeJr2o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

