### PR TITLE
fix(ui): make the elements' state reachable without a pointer or colour

### DIFF
--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentProps } from "react";
+import { useId, type ComponentProps } from "react";
 import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, floating, mono } from "./surfaces";
@@ -38,6 +38,8 @@ export function CommandPalette({
   onActiveChange?: (id: string) => void;
   onRun?: (id: string) => void;
 }) {
+  const listId = useId();
+  const optionId = (id: string) => `${listId}-${id}`;
   const matches = commands.filter((command) =>
     command.label.toLowerCase().includes(query.toLowerCase()),
   );
@@ -90,6 +92,15 @@ export function CommandPalette({
           onKeyDown={onKeyDown}
           placeholder="Type a command"
           aria-label="Type a command"
+          role="combobox"
+          aria-expanded
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-activedescendant={
+            ordered.some((command) => command.id === activeId)
+              ? optionId(activeId)
+              : undefined
+          }
           className="text-foreground/85 placeholder:text-foreground/30 min-w-0 flex-1 bg-transparent text-[13.5px] outline-none"
         />
         <span
@@ -103,10 +114,23 @@ export function CommandPalette({
         </span>
       </div>
 
-      <div className="border-foreground/[0.07] flex max-h-72 flex-col overflow-y-auto border-t p-1.5">
+      <div
+        id={listId}
+        role="listbox"
+        aria-label="Commands"
+        className="border-foreground/[0.07] flex max-h-72 flex-col overflow-y-auto border-t p-1.5"
+      >
         {groups.map((group) => (
-          <div key={group} className="flex flex-col">
-            <span className={cn(mono, "text-foreground/25 px-2 pt-2 pb-1")}>
+          <div
+            key={group}
+            role="group"
+            aria-label={group}
+            className="flex flex-col"
+          >
+            <span
+              aria-hidden
+              className={cn(mono, "text-foreground/25 px-2 pt-2 pb-1")}
+            >
               {group}
             </span>
             {matches
@@ -114,7 +138,11 @@ export function CommandPalette({
               .map((command) => (
                 <button
                   key={command.id}
+                  id={optionId(command.id)}
                   type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={command.id === activeId}
                   onClick={() => onRun?.(command.id)}
                   className={cn(
                     "flex items-center gap-2 rounded-xl px-2 py-1.5 text-start transition-colors",

--- a/packages/ui/src/components/elements/command-palette.tsx
+++ b/packages/ui/src/components/elements/command-palette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId, type ComponentProps } from "react";
+import { useEffect, useId, type ComponentProps } from "react";
 import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, floating, mono } from "./surfaces";
@@ -58,6 +58,14 @@ export function CommandPalette({
     if (next) onActiveChange?.(next.id);
   };
 
+  // aria-activedescendant moves the highlight without moving focus, and only
+  // focus scrolls; the list is short enough to walk the active row out of view.
+  useEffect(() => {
+    document
+      .getElementById(optionId(activeId))
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeId, listId]);
+
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.nativeEvent.isComposing) return;
     if (event.key === "ArrowDown") {
@@ -93,7 +101,7 @@ export function CommandPalette({
           placeholder="Type a command"
           aria-label="Type a command"
           role="combobox"
-          aria-expanded
+          aria-expanded={ordered.length > 0}
           aria-controls={listId}
           aria-autocomplete="list"
           aria-activedescendant={
@@ -143,6 +151,7 @@ export function CommandPalette({
                   role="option"
                   tabIndex={-1}
                   aria-selected={command.id === activeId}
+                  onMouseDown={(event) => event.preventDefault()}
                   onClick={() => onRun?.(command.id)}
                   className={cn(
                     "flex items-center gap-2 rounded-xl px-2 py-1.5 text-start transition-colors",
@@ -172,12 +181,14 @@ export function CommandPalette({
               ))}
           </div>
         ))}
-        {matches.length === 0 && (
-          <span className="text-foreground/30 px-2 py-4 text-center text-xs break-words">
+      </div>
+      {matches.length === 0 && (
+        <div className="border-foreground/[0.07] border-t p-1.5">
+          <span className="text-foreground/30 block px-2 py-4 text-center text-xs break-words">
             No command matches “{query}”
           </span>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/elements/document-reference.tsx
+++ b/packages/ui/src/components/elements/document-reference.tsx
@@ -56,6 +56,7 @@ export function DocumentReference({
           <button
             key={`${anchor.page}-${i}`}
             type="button"
+            aria-current={anchor.page === activePage || undefined}
             onClick={() => onJump?.(anchor.page)}
             className={cn(
               "flex flex-col gap-1 rounded-xl px-2.5 py-2 text-start transition-colors",

--- a/packages/ui/src/components/elements/document-reference.tsx
+++ b/packages/ui/src/components/elements/document-reference.tsx
@@ -28,6 +28,11 @@ export function DocumentReference({
   activePage: number;
   onJump?: (page: number) => void;
 }) {
+  // several anchors can cite one page, and only one of them is the current item
+  const currentIndex = anchors.findIndex(
+    (anchor) => anchor.page === activePage,
+  );
+
   return (
     <div
       data-slot="document-reference"
@@ -56,7 +61,7 @@ export function DocumentReference({
           <button
             key={`${anchor.page}-${i}`}
             type="button"
-            aria-current={anchor.page === activePage || undefined}
+            aria-current={i === currentIndex || undefined}
             onClick={() => onJump?.(anchor.page)}
             className={cn(
               "flex flex-col gap-1 rounded-xl px-2.5 py-2 text-start transition-colors",

--- a/packages/ui/src/components/elements/elements.test.tsx
+++ b/packages/ui/src/components/elements/elements.test.tsx
@@ -504,19 +504,38 @@ const inlinePercentages = (markup: string) =>
       })),
   );
 
-/** The name a screen reader would announce for a control. */
+/**
+ * The name a screen reader would announce for a control. Text inside an
+ * `aria-hidden` subtree does not contribute to it, so reading `textContent`
+ * would report a name for a control that announces nothing, which is the same
+ * false confidence this sweep exists to remove.
+ */
+const visibleText = (element: Element): string =>
+  [...element.childNodes]
+    .map((node) => {
+      if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+      if (!(node instanceof Element)) return "";
+      if (node.getAttribute("aria-hidden") === "true") return "";
+      return visibleText(node);
+    })
+    .join("")
+    .trim();
+
 const accessibleName = (element: HTMLElement) => {
   const labelled = element.getAttribute("aria-labelledby");
   if (labelled) {
     return labelled
       .split(/\s+/)
-      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .map((id) => {
+        const target = document.getElementById(id);
+        return target ? visibleText(target) : "";
+      })
       .join(" ")
       .trim();
   }
   return (
     element.getAttribute("aria-label")?.trim() ||
-    element.textContent?.trim() ||
+    visibleText(element) ||
     element.getAttribute("title")?.trim() ||
     ""
   );
@@ -528,6 +547,7 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   };
+  Element.prototype.scrollIntoView ??= () => {};
 });
 
 afterEach(cleanup);
@@ -632,6 +652,66 @@ describe("state that is carried by more than colour", () => {
       "true",
       null,
     ]);
+  });
+
+  it("keeps feedback's live region mounted before it has anything to say", () => {
+    const props = {
+      reasons: ["Wrong"],
+      selected: [],
+      note: "",
+      onToggleReason: () => {},
+    };
+    const { container, rerender } = render(
+      <FeedbackDialog {...props} sent={false} />,
+    );
+    const before = container.querySelector('[role="status"]');
+
+    expect(before, "no region to announce into").not.toBeNull();
+    expect(before!.textContent?.trim()).toBe("");
+
+    rerender(<FeedbackDialog {...props} sent />);
+    const after = container.querySelector('[role="status"]');
+
+    expect(after, "the region was replaced rather than updated").toBe(before);
+    expect(after!.textContent).toContain("Thanks");
+  });
+
+  it("marks only one document anchor current when a page repeats", () => {
+    const { container } = render(
+      <DocumentReference
+        title="Spec"
+        pages={4}
+        anchors={[
+          { page: 2, quote: "first" },
+          { page: 2, quote: "second" },
+        ]}
+        activePage={2}
+      />,
+    );
+
+    expect(container.querySelectorAll('[aria-current="true"]')).toHaveLength(1);
+  });
+
+  it("closes the palette's combobox and frees its message when nothing matches", () => {
+    const { container } = render(
+      <CommandPalette
+        commands={[{ id: "a", label: "New thread", group: "Thread", keys: [] }]}
+        query="zzz"
+        activeId="a"
+      />,
+    );
+    const listbox = container.querySelector('[role="listbox"]')!;
+
+    expect(
+      container
+        .querySelector('[role="combobox"]')!
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(
+      listbox.textContent,
+      "a listbox owns only options, so a bare message inside it is suppressed",
+    ).not.toContain("No command matches");
+    expect(container.textContent).toContain("No command matches");
   });
 
   // A matching query, unlike the sweep's fixture, so there are options to point at.

--- a/packages/ui/src/components/elements/elements.test.tsx
+++ b/packages/ui/src/components/elements/elements.test.tsx
@@ -1,7 +1,8 @@
+import { cleanup, render } from "@testing-library/react";
 import { TerminalIcon } from "lucide-react";
 import type { ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { AgentPlan } from "./agent-plan";
 import { Chart } from "./chart";
@@ -503,6 +504,34 @@ const inlinePercentages = (markup: string) =>
       })),
   );
 
+/** The name a screen reader would announce for a control. */
+const accessibleName = (element: HTMLElement) => {
+  const labelled = element.getAttribute("aria-labelledby");
+  if (labelled) {
+    return labelled
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .join(" ")
+      .trim();
+  }
+  return (
+    element.getAttribute("aria-label")?.trim() ||
+    element.textContent?.trim() ||
+    element.getAttribute("title")?.trim() ||
+    ""
+  );
+};
+
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(cleanup);
+
 describe.each(Object.entries(CASES))("%s", (name, make) => {
   it.each(HOSTILE)("survives a %s numeric prop", (_label, n, items) => {
     const markup = renderToStaticMarkup(make(n, items));
@@ -537,6 +566,115 @@ describe.each(Object.entries(CASES))("%s", (name, make) => {
         renderToStaticMarkup(make(Number.NaN, items)),
         "NaN did not read as the start",
       ).toBe(renderToStaticMarkup(make(0, items)));
+    },
+  );
+
+  it("gives every control an accessible name", () => {
+    const { container } = render(make(2, 3));
+    const controls = container.querySelectorAll<HTMLElement>(
+      'button, [role="button"], [role="option"], a[href], input, textarea',
+    );
+
+    for (const control of controls) {
+      expect(
+        accessibleName(control),
+        `${name} has a control with no accessible name: ${control.outerHTML.slice(0, 120)}`,
+      ).not.toBe("");
+    }
+  });
+});
+
+/**
+ * State a sweep cannot see. A control whose accessible name is merely non-empty
+ * still passes the sweep above while the part carried by colour, position, or
+ * size goes unannounced, so each of those is pinned to the element that owns it.
+ */
+describe("state that is carried by more than colour", () => {
+  it("names an mcp server's status in its collapsed row", () => {
+    const { container } = render(
+      CASES["mcp-server-panel"]!(0, 1) as ReactElement,
+    );
+    const row = container.querySelector<HTMLElement>("button")!;
+
+    expect(accessibleName(row)).toContain("connected");
+  });
+
+  it("marks the current map pin and gives it a 24px target", () => {
+    const { container } = render(CASES["map-answer"]!(0, 2) as ReactElement);
+    const pins = [...container.querySelectorAll<HTMLElement>("[aria-label]")];
+
+    expect(pins.map((pin) => pin.getAttribute("aria-current"))).toEqual([
+      "true",
+      null,
+    ]);
+    for (const pin of pins) {
+      expect(pin.className, "a pin target below 24px").toContain("size-6");
+    }
+  });
+
+  it("marks the current thread and names an unread one", () => {
+    const { container } = render(CASES["thread-list"]!(1, 3) as ReactElement);
+    const rows = [...container.querySelectorAll<HTMLElement>("button")];
+
+    expect(rows[1]?.getAttribute("aria-current")).toBe("true");
+    expect(rows[0]?.getAttribute("aria-current")).toBeNull();
+    expect(accessibleName(rows[0]!)).toContain("unread");
+  });
+
+  it("marks the current document anchor", () => {
+    const { container } = render(
+      CASES["document-reference"]!(1, 3) as ReactElement,
+    );
+    const anchors = [...container.querySelectorAll<HTMLElement>("button")];
+
+    expect(anchors.map((a) => a.getAttribute("aria-current"))).toEqual([
+      null,
+      "true",
+      null,
+    ]);
+  });
+
+  // A matching query, unlike the sweep's fixture, so there are options to point at.
+  it.each([
+    [
+      "command-palette",
+      <CommandPalette
+        key="command-palette"
+        commands={[
+          { id: "a", label: "New thread", group: "Thread", keys: ["⌘N"] },
+          { id: "b", label: "Stop the run", group: "Thread", keys: ["⌘."] },
+        ]}
+        query=""
+        activeId="b"
+      />,
+    ],
+    [
+      "prompt-library",
+      <PromptLibrary
+        key="prompt-library"
+        prompts={[
+          { id: "a", name: "Summarize", body: "…", variables: [] },
+          { id: "b", name: "Translate", body: "…", variables: [] },
+        ]}
+        query=""
+        selectedId="b"
+      />,
+    ],
+  ] as [string, ReactElement][])(
+    "points %s's combobox at the highlighted option",
+    (_name, element) => {
+      const { container } = render(element);
+      const input = container.querySelector<HTMLElement>('[role="combobox"]')!;
+      const active = container.querySelector<HTMLElement>(
+        '[role="option"][aria-selected="true"]',
+      )!;
+
+      expect(active.id).not.toBe("");
+      expect(input.getAttribute("aria-activedescendant")).toBe(active.id);
+      expect(
+        container.querySelector('[role="listbox"]')!.id,
+        "the listbox the combobox names",
+      ).toBe(input.getAttribute("aria-controls"));
     },
   );
 });

--- a/packages/ui/src/components/elements/feedback-dialog.tsx
+++ b/packages/ui/src/components/elements/feedback-dialog.tsx
@@ -34,88 +34,100 @@ export function FeedbackDialog({
   onNoteChange?: (note: string) => void;
   onSubmit?: () => void;
 }) {
-  if (sent) {
-    return (
-      <div
-        data-slot="feedback-dialog"
-        role="status"
-        className={cn(
-          paper,
-          "fade-in animate-in flex w-full max-w-sm items-center gap-2.5 rounded-[20px] p-4 text-[13.5px] duration-300",
-          className,
-        )}
-
-        {...props}
-      >
-        <CheckIcon className="size-4 shrink-0 text-emerald-500" />
-        Thanks. That helps us tune the model.
-      </div>
-    );
-  }
-
   return (
     <div
       data-slot="feedback-dialog"
       className={cn(
         paper,
-        "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-4",
+        "flex w-full max-w-sm rounded-[20px] p-4",
+        sent ? "items-center gap-2.5 text-[13.5px]" : "flex-col gap-3",
         className,
       )}
 
       {...props}
     >
-      <div className="flex items-center gap-2.5">
-        <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">
-          <ThumbsDownIcon className="size-3.5" />
-        </span>
-        <span className="text-[13.5px] font-medium">What went wrong?</span>
-        <span className={cn(mono, "text-foreground/30 ms-auto")}>optional</span>
-      </div>
-
-      <div className="flex flex-wrap gap-1.5">
-        {reasons.map((reason) => {
-          const active = selected.includes(reason);
-          return (
-            <button
-              key={reason}
-              type="button"
-              aria-pressed={active}
-              onClick={() => onToggleReason?.(reason)}
-              className={cn(
-                "rounded-full px-2.5 py-1 text-xs transition-[background-color,color,scale] duration-150 active:scale-[0.96]",
-                active
-                  ? "bg-foreground text-background"
-                  : cn(field, "text-foreground/55 hover:text-foreground/90"),
-              )}
-            >
-              {reason}
-            </button>
-          );
-        })}
-      </div>
-
-      <textarea
-        value={note}
-        onChange={(event) => onNoteChange?.(event.target.value)}
-        rows={2}
-        placeholder="Anything else?"
-        aria-label="What went wrong?"
-        className={cn(
-          field,
-          "text-foreground/80 placeholder:text-foreground/30 focus-visible:ring-foreground/20 resize-none rounded-xl px-3 py-2 text-xs outline-none focus-visible:ring-2",
-        )}
-      />
-
-      <button
-        type="button"
-        onClick={onSubmit}
-        className={cn(
-          inkButton,
-          "flex h-8 items-center justify-center self-end rounded-full px-3.5 text-xs font-medium",
-        )}
+      {/*
+        Mounted whether or not the feedback has been sent, because a live region
+        only announces a change that happens after it is already in the tree; a
+        region created together with its text is the case AT is free to miss.
+      */}
+      <div
+        role="status"
+        className={
+          sent
+            ? "fade-in animate-in flex items-center gap-2.5 duration-300"
+            : "sr-only"
+        }
       >
-        Send feedback
-      </button>
+        {sent && (
+          <>
+            <CheckIcon className="size-4 shrink-0 text-emerald-500" />
+            Thanks. That helps us tune the model.
+          </>
+        )}
+      </div>
+
+      {sent ? null : (
+        <>
+          <div className="flex items-center gap-2.5">
+            <span className="bg-foreground/[0.05] text-foreground/45 flex size-7 shrink-0 items-center justify-center rounded-lg">
+              <ThumbsDownIcon className="size-3.5" />
+            </span>
+            <span className="text-[13.5px] font-medium">What went wrong?</span>
+            <span className={cn(mono, "text-foreground/30 ms-auto")}>
+              optional
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            {reasons.map((reason) => {
+              const active = selected.includes(reason);
+              return (
+                <button
+                  key={reason}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => onToggleReason?.(reason)}
+                  className={cn(
+                    "rounded-full px-2.5 py-1 text-xs transition-[background-color,color,scale] duration-150 active:scale-[0.96]",
+                    active
+                      ? "bg-foreground text-background"
+                      : cn(
+                          field,
+                          "text-foreground/55 hover:text-foreground/90",
+                        ),
+                  )}
+                >
+                  {reason}
+                </button>
+              );
+            })}
+          </div>
+
+          <textarea
+            value={note}
+            onChange={(event) => onNoteChange?.(event.target.value)}
+            rows={2}
+            placeholder="Anything else?"
+            aria-label="Anything else?"
+            className={cn(
+              field,
+              "text-foreground/80 placeholder:text-foreground/30 focus-visible:ring-foreground/20 resize-none rounded-xl px-3 py-2 text-xs outline-none focus-visible:ring-2",
+            )}
+          />
+
+          <button
+            type="button"
+            onClick={onSubmit}
+            className={cn(
+              inkButton,
+              "flex h-8 items-center justify-center self-end rounded-full px-3.5 text-xs font-medium",
+            )}
+          >
+            Send feedback
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/components/elements/feedback-dialog.tsx
+++ b/packages/ui/src/components/elements/feedback-dialog.tsx
@@ -38,6 +38,7 @@ export function FeedbackDialog({
     return (
       <div
         data-slot="feedback-dialog"
+        role="status"
         className={cn(
           paper,
           "fade-in animate-in flex w-full max-w-sm items-center gap-2.5 rounded-[20px] p-4 text-[13.5px] duration-300",
@@ -98,6 +99,7 @@ export function FeedbackDialog({
         onChange={(event) => onNoteChange?.(event.target.value)}
         rows={2}
         placeholder="Anything else?"
+        aria-label="What went wrong?"
         className={cn(
           field,
           "text-foreground/80 placeholder:text-foreground/30 focus-visible:ring-foreground/20 resize-none rounded-xl px-3 py-2 text-xs outline-none focus-visible:ring-2",

--- a/packages/ui/src/components/elements/map-answer.tsx
+++ b/packages/ui/src/components/elements/map-answer.tsx
@@ -87,8 +87,9 @@ export function MapAnswer({
             key={pin.id}
             type="button"
             aria-label={pin.label}
+            aria-current={pin.id === activeId || undefined}
             onClick={() => onSelect?.(pin.id)}
-            className="absolute -translate-x-1/2 -translate-y-1/2"
+            className="focus-visible:ring-foreground/30 absolute flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full outline-none focus-visible:ring-2"
             style={{ left: `${pin.x}%`, top: `${pin.y}%` }}
           >
             <span
@@ -108,6 +109,7 @@ export function MapAnswer({
           <button
             key={pin.id}
             type="button"
+            aria-current={pin.id === activeId || undefined}
             onClick={() => onSelect?.(pin.id)}
             className={cn(
               "border-foreground/[0.06] flex items-baseline gap-2 border-t px-3.5 py-2 text-start transition-colors",

--- a/packages/ui/src/components/elements/mcp-server-panel.tsx
+++ b/packages/ui/src/components/elements/mcp-server-panel.tsx
@@ -101,6 +101,7 @@ export function McpServerPanel({
                   DOT[server.status],
                 )}
               />
+              <span className="sr-only">{LABEL[server.status]}</span>
             </button>
 
             {expanded && (

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -93,7 +93,7 @@ export function PromptLibrary({
           placeholder="Search prompts"
           aria-label="Search saved prompts"
           role="combobox"
-          aria-expanded
+          aria-expanded={matches.length > 0}
           aria-controls={listId}
           aria-autocomplete="list"
           aria-activedescendant={selected ? optionId(selected.id) : undefined}
@@ -115,6 +115,7 @@ export function PromptLibrary({
             role="option"
             tabIndex={-1}
             aria-selected={prompt.id === selectedId}
+            onMouseDown={(event) => event.preventDefault()}
             onClick={() => onSelect?.(prompt.id)}
             onDoubleClick={() => onInsert?.(prompt.id)}
             className={cn(
@@ -134,12 +135,12 @@ export function PromptLibrary({
             )}
           </button>
         ))}
-        {matches.length === 0 && (
-          <span className="text-foreground/30 px-2 py-3 text-center text-xs break-words">
-            Nothing matches “{query}”
-          </span>
-        )}
       </div>
+      {matches.length === 0 && (
+        <span className="text-foreground/30 block px-2 py-3 text-center text-xs break-words">
+          Nothing matches “{query}”
+        </span>
+      )}
 
       {selected && (
         <div

--- a/packages/ui/src/components/elements/prompt-library.tsx
+++ b/packages/ui/src/components/elements/prompt-library.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentProps } from "react";
+import { useId, type ComponentProps } from "react";
 import { BookmarkIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { field, mono, paper } from "./surfaces";
@@ -38,6 +38,8 @@ export function PromptLibrary({
   onSelect?: (id: string) => void;
   onInsert?: (id: string) => void;
 }) {
+  const listId = useId();
+  const optionId = (id: string) => `${listId}-${id}`;
   const matches = prompts.filter((prompt) =>
     prompt.name.toLowerCase().includes(query.toLowerCase()),
   );
@@ -90,22 +92,31 @@ export function PromptLibrary({
           onKeyDown={onKeyDown}
           placeholder="Search prompts"
           aria-label="Search saved prompts"
+          role="combobox"
+          aria-expanded
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-activedescendant={selected ? optionId(selected.id) : undefined}
           className="text-foreground/85 placeholder:text-foreground/30 min-w-0 flex-1 bg-transparent text-[13px] outline-none"
         />
       </div>
 
-      <div className="flex flex-col">
+      <div
+        id={listId}
+        role="listbox"
+        aria-label="Saved prompts"
+        className="flex flex-col"
+      >
         {matches.map((prompt) => (
           <button
             key={prompt.id}
+            id={optionId(prompt.id)}
             type="button"
+            role="option"
+            tabIndex={-1}
+            aria-selected={prompt.id === selectedId}
             onClick={() => onSelect?.(prompt.id)}
             onDoubleClick={() => onInsert?.(prompt.id)}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter") return;
-              event.preventDefault();
-              onInsert?.(prompt.id);
-            }}
             className={cn(
               "flex items-center gap-2 rounded-xl px-2 py-1.5 text-start transition-colors",
               prompt.id === selectedId

--- a/packages/ui/src/components/elements/thread-list.tsx
+++ b/packages/ui/src/components/elements/thread-list.tsx
@@ -39,6 +39,7 @@ export function ThreadList({
           <button
             key={thread.title}
             type="button"
+            aria-current={active || undefined}
             onClick={() => onActiveIndexChange?.(i)}
             className={cn(
               "group flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-start text-[13.5px] transition-colors",
@@ -53,10 +54,13 @@ export function ThreadList({
               )}
             >
               {thread.unread && !active && (
-                <span
-                  aria-hidden
-                  className="size-1.5 rounded-full bg-blue-500 dark:bg-blue-400"
-                />
+                <>
+                  <span
+                    aria-hidden
+                    className="size-1.5 rounded-full bg-blue-500 dark:bg-blue-400"
+                  />
+                  <span className="sr-only">unread</span>
+                </>
               )}
               {thread.time}
             </span>


### PR DESCRIPTION
last of three on #5743, after #5747 and #5748. closes the issue.

## summary

#5744 landed the keyboard work for the four elements that needed it, and its own notes said the rest of #5743 was still outstanding. this is the rest.

**state carried only by colour now has a name.** an `mcp-server-panel` row exposed its status as a bare colour dot, with the label appearing only once the row was expanded, so a collapsed panel announced nothing. the dot keeps its `aria-hidden` and gains an `sr-only` sibling, which folds the status into the row's own accessible name rather than adding a second stop. `thread-list`'s unread dot gets the same treatment.

**`map-answer`'s pins were 10 to 14px targets**, well under the 24px of WCAG 2.2 SC 2.5.8, because the button was only as large as the dot inside it. the button is now `size-6` with the dot centred inside, so the target grows while the map looks identical, and it gains a focus ring.

**selection was visual everywhere.** the split is deliberate: `aria-current` for one-of-a-set (`map-answer` pins and rows, `document-reference` anchors, `thread-list` rows), and the existing `aria-pressed` left alone on the real toggles. the two palettes are a listbox instead, so they get the full combobox pattern: the input owns focus and points at the highlighted row through `aria-activedescendant`, the rows become non-focusable options, an effect scrolls the active row back into view (`aria-activedescendant` moves a highlight but never scrolls), `aria-expanded` follows the match count, and pointer selection no longer steals focus from the input. the "no matches" line sits outside the listbox, because a listbox owns only options and groups and would otherwise hide exactly the message a blind user needs at that moment.

**one thing in the issue is answered differently.** it asked for live-region confirmation when the selection changes in `feedback-dialog` and `document-reference`. that is not the gap: the reason chips already carry `aria-pressed` and a live region on top would announce every toggle twice, and `document-reference` needed `aria-current`. what genuinely went unannounced is the whole-card swap when feedback is sent, so that is what gets a live region.

## test plan

### already verified

- [x] `pnpm -C packages/ui exec tsc --noEmit` -> clean, `pnpm lint` -> clean
- [x] `pnpm -C packages/ui test` -> 326 passed
- [x] **every defect these three PRs fix was reintroduced and confirmed to fail the suite**, each against its real form rather than a paraphrase (reverting only a class name on the live region, for instance, does not reproduce the bug and does not fail)
- [x] real browser: all three `map-answer` pins measure 24x24 and the active one carries `aria-current`, with no visual change to the map

### reviewer should verify

- [ ] the palettes are no longer tab-reachable row by row: focus stays on the input and the arrow keys drive the list. standard combobox behaviour, but a change from #5744
- [ ] the `aria-current` vs `aria-pressed` split
- [ ] my disagreement with the live-region request above

## notes

- **review found seven real defects in the first version of this PR, two of which undercut its own claims.** the live region was applied in the same commit that filled it, which is the documented case AT can miss, so the headline fix did not deliver; it is now mounted from the first render and empty until sent. the note field was labelled with the dialog heading, so the same phrase was announced twice, the second time on the wrong control.
- a sweep cannot see semantics: a control whose accessible name is merely non-empty passes the family-wide assertion while the part carried by colour goes unannounced. the specific facts are pinned by contract tests instead. the sweep's own name computation also read `textContent`, which counts text inside `aria-hidden` subtrees a screen reader never announces; it now walks the tree the way accname does.
- **not done here: enabling oxlint's `jsx-a11y` plugin.** its per-override `plugins` key does not activate the rules, so a rule set explicitly to `error` inside an override never fires and a directory-scoped opt-in is not possible. repo-wide it surfaces 87 findings across 56 unrelated files and belongs in its own change. it would also have caught none of the above: all three of its hits under this directory are false positives in our idiom (`role="status"` is not `<output>`, and `role="img"` on an svg is the standard pattern).
- no changeset: `@assistant-ui/ui` is `private: true`.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SbBBPN5LVKk6Ixb0LqyT5TYHMXqhDDZ27pw2zyt90Dog87OD9hiBHSe3W0I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

