### PR TITLE
fix(core): derive the suggestions scope from the thread's suggestions

### DIFF
--- a/.changeset/warm-suggestions-derive.md
+++ b/.changeset/warm-suggestions-derive.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: derive the suggestions scope from the thread so runtime-provided suggestions render through `ThreadPrimitive.Suggestions` (#5529)

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -4212,10 +4212,16 @@ declare const Suggestions: Resource<ClientOutput<"suggestions">, [
 
 type SuggestionsClientSchema = {
   methods: SuggestionsMethods;
+  meta: SuggestionsMeta;
 };
 
 type SuggestionsComponentConfig = {
   Suggestion: ComponentType;
+};
+
+type SuggestionsMeta = {
+  source: "thread";
+  query: Record<string, never>;
 };
 
 type SuggestionsMethods = {
@@ -4747,6 +4753,7 @@ type ThreadMeta = {
 type ThreadMethods = {
   getState(): ThreadState$1;
   composer(): ComposerMethods;
+  suggestions(): SuggestionsMethods;
   append(message: CreateAppendMessage): void;
   deleteMessage(messageId: string): void | Promise<void>;
   startRun(config: CreateStartRunConfig): void;

--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -138,7 +138,7 @@ The primitives available for rendering suggestions are `ThreadPrimitive.Suggesti
 
 ## Runtime driven suggestions
 
-The static `Suggestions(...)` API covers welcome screens. For follow up prompts that depend on the conversation, a tool result, or your backend, push suggestions through the runtime itself. They land on `thread.suggestions` rather than the static `suggestions` scope, so they render through a different component.
+The static `Suggestions(...)` API covers welcome screens. For follow up prompts that depend on the conversation, a tool result, or your backend, push suggestions through the runtime itself. They land on `thread.suggestions`, and when no static `Suggestions(...)` configuration is set, the `suggestions` scope derives from them, so `ThreadPrimitive.Suggestions` renders them as well.
 
 ### Local runtime: `SuggestionAdapter`
 
@@ -263,7 +263,7 @@ The local runtime clears its suggestions when a new run starts. External store r
 
 ### Rendering runtime suggestions
 
-Static suggestions go through `ThreadPrimitive.Suggestions`; runtime suggestions go through `thread.suggestions`. The shadcn registry ships `ThreadFollowupSuggestions` for the common single line pill layout. For a custom layout, read the array yourself:
+Runtime suggestions land on `thread.suggestions`, and `ThreadPrimitive.Suggestions` picks them up unless a static `Suggestions(...)` configuration overrides the scope. The shadcn registry ships `ThreadFollowupSuggestions` for the common single line pill layout. For a custom layout, read the array yourself:
 
 ```tsx
 import { useAuiState, ThreadPrimitive, AuiIf } from "@assistant-ui/react";

--- a/apps/docs/content/docs/primitives/suggestion.mdx
+++ b/apps/docs/content/docs/primitives/suggestion.mdx
@@ -130,10 +130,12 @@ When `send={false}`, the `clearComposer` prop controls whether the suggestion re
 
 ### Static configuration vs. runtime suggestions
 
-There are two separate data flows for suggestions:
+There are two data flows for suggestions:
 
 - **Static configuration** flows through the `suggestions` scope. Pass an array to `Suggestions(...)` in your runtime provider; render it with `ThreadPrimitive.Suggestions`. Best for welcome screen prompts.
 - **Runtime / dynamic suggestions** flow through `thread.suggestions`. Populate it via `SuggestionAdapter` (local runtime) or the `suggestions` field on `useExternalStoreRuntime`; render it with the shadcn `ThreadFollowupSuggestions` component or your own component reading `useAuiState((s) => s.thread.suggestions)`. Best for follow up prompts after a turn.
+
+When no static configuration is provided, the `suggestions` scope derives from `thread.suggestions`, so runtime suggestions also render through `ThreadPrimitive.Suggestions`. A static `Suggestions(...)` configuration takes precedence over the derived values.
 
 See [Suggested Prompts](/docs/guides/suggestions) for end to end examples.
 

--- a/packages/core/src/react/runtimes/useExternalStoreRuntime.suggestions.test.tsx
+++ b/packages/core/src/react/runtimes/useExternalStoreRuntime.suggestions.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { StrictMode } from "react";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AuiConfig,
+  useAui,
+  useAuiState,
+  type AssistantClient,
+} from "@assistant-ui/store";
+import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
+import { Suggestions } from "../../store/clients/suggestions";
+import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
+
+let aui!: AssistantClient;
+let scopeSuggestions!: readonly { prompt: string }[];
+
+const Consumer = () => {
+  aui = useAui();
+  scopeSuggestions = useAuiState((s) => s.suggestions.suggestions);
+  return null;
+};
+
+const App = ({
+  suggestions,
+  config,
+  strict,
+}: {
+  suggestions?: ThreadSuggestion[];
+  config?: AuiConfig;
+  strict?: boolean;
+}) => {
+  const runtime = useExternalStoreRuntime({
+    messages: [],
+    onNew: async () => {},
+    ...(suggestions && { suggestions }),
+  });
+  const tree = (
+    <AssistantRuntimeProvider runtime={runtime} config={config}>
+      <Consumer />
+    </AssistantRuntimeProvider>
+  );
+  return strict ? <StrictMode>{tree}</StrictMode> : tree;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useExternalStoreRuntime suggestions scope", () => {
+  it("exposes runtime suggestions on the suggestions scope", () => {
+    render(
+      <App suggestions={[{ prompt: "Tell me a joke" }, { prompt: "Help" }]} />,
+    );
+
+    expect(scopeSuggestions).toEqual([
+      { title: "Tell me a joke", label: "", prompt: "Tell me a joke" },
+      { title: "Help", label: "", prompt: "Help" },
+    ]);
+    expect(aui.suggestions.suggestion({ index: 1 }).getState()).toEqual({
+      title: "Help",
+      label: "",
+      prompt: "Help",
+    });
+    expect(aui.thread.getState().suggestions).toEqual([
+      { prompt: "Tell me a joke" },
+      { prompt: "Help" },
+    ]);
+  });
+
+  it("exposes runtime suggestions under StrictMode", () => {
+    render(<App strict suggestions={[{ prompt: "Tell me a joke" }]} />);
+
+    expect(scopeSuggestions).toEqual([
+      { title: "Tell me a joke", label: "", prompt: "Tell me a joke" },
+    ]);
+  });
+
+  it("reports an empty scope without runtime suggestions", () => {
+    render(<App />);
+
+    expect(scopeSuggestions).toEqual([]);
+  });
+
+  it("follows runtime suggestion updates", async () => {
+    const view = render(<App suggestions={[{ prompt: "First" }]} />);
+    expect(scopeSuggestions).toEqual([
+      { title: "First", label: "", prompt: "First" },
+    ]);
+
+    view.rerender(<App suggestions={[{ prompt: "Second" }]} />);
+    await waitFor(() => {
+      expect(scopeSuggestions).toEqual([
+        { title: "Second", label: "", prompt: "Second" },
+      ]);
+    });
+  });
+
+  it("prefers config-provided suggestions over runtime suggestions", () => {
+    render(
+      <App
+        suggestions={[{ prompt: "Runtime" }]}
+        config={AuiConfig({ suggestions: Suggestions(["Static"]) })}
+      />,
+    );
+
+    expect(scopeSuggestions).toEqual([
+      { title: "Static", label: "", prompt: "Static" },
+    ]);
+    expect(aui.thread.getState().suggestions).toEqual([{ prompt: "Runtime" }]);
+  });
+});

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -1156,7 +1156,7 @@ attachTransformScopes(useExternalThread, (scopes, parent) => {
     scopes.suggestions = Derived({
       source: "thread",
       query: {},
-      get: (aui) => aui.threads.thread("main").suggestions(),
+      get: (aui) => aui.thread.suggestions(),
     });
   }
 });

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -27,6 +27,7 @@ import type {
   RespondToToolApprovalOptions,
   ResumeToolCallOptions,
   SpeechState,
+  ThreadSuggestion,
 } from "../../runtime/interfaces/thread-runtime-core";
 import type {
   ExternalThreadQueueAdapter,
@@ -45,13 +46,14 @@ import { getThreadMessageText } from "../../utils/text";
 import { resolveToolApprovalResponse } from "../../runtime/utils/resolveToolApprovalResponse";
 import { toMessagePartStatus } from "../../utils/normalizePartStatus";
 import { ModelContext } from "./model-context-client";
-import { Suggestions } from "./suggestions";
+import { ThreadSuggestions } from "./suggestions";
 import { Tools } from "../../react/client/Tools";
 import { DataRenderers } from "../../react/client/DataRenderers";
 import { SingleThreadList } from "./single-thread-list";
 
 const EMPTY_QUEUE_ITEMS: readonly QueueItemState[] = [];
 const EMPTY_BRANCH_IDS: readonly string[] = [];
+const EMPTY_SUGGESTIONS: readonly ThreadSuggestion[] = [];
 
 export type ExternalThreadMessage = ThreadMessage & {
   id: string;
@@ -975,6 +977,9 @@ const useExternalThread = ({
       attachmentAdapter,
     }),
   );
+  const suggestionsClient = useClientResource(
+    ThreadSuggestions(EMPTY_SUGGESTIONS),
+  );
 
   const hasQueue = !!queue;
   const hasBranches = !!branches;
@@ -1012,7 +1017,7 @@ const useExternalThread = ({
       },
       messages: messageStates,
       state: threadState ?? {},
-      suggestions: [],
+      suggestions: EMPTY_SUGGESTIONS,
       extras,
       speech,
       voice: undefined,
@@ -1039,6 +1044,7 @@ const useExternalThread = ({
   return {
     getState: () => state,
     composer: () => composerClient.methods,
+    suggestions: () => suggestionsClient.methods,
     append: (message) => {
       const appendMessage: AppendMessage =
         typeof message === "string"
@@ -1147,6 +1153,10 @@ attachTransformScopes(useExternalThread, (scopes, parent) => {
     scopes.dataRenderers = DataRenderers();
   }
   if (!scopes.suggestions && parent.suggestions.source === null) {
-    scopes.suggestions = Suggestions();
+    scopes.suggestions = Derived({
+      source: "thread",
+      query: {},
+      get: (aui) => aui.threads.thread("main").suggestions(),
+    });
   }
 });

--- a/packages/core/src/store/clients/runtime-adapter.ts
+++ b/packages/core/src/store/clients/runtime-adapter.ts
@@ -1,7 +1,6 @@
 import type { AssistantClient, ScopesConfig } from "@assistant-ui/store";
 import { Derived } from "@assistant-ui/store/client";
 import { ModelContext } from "./model-context-client";
-import { Suggestions } from "./suggestions";
 
 export const baseRuntimeAdapterTransformScopes = (
   scopes: ScopesConfig,
@@ -27,6 +26,10 @@ export const baseRuntimeAdapterTransformScopes = (
     scopes.modelContext = ModelContext();
   }
   if (!scopes.suggestions && parent.suggestions.source === null) {
-    scopes.suggestions = Suggestions();
+    scopes.suggestions = Derived({
+      source: "thread",
+      query: {},
+      get: (aui) => aui.threads.thread("main").suggestions(),
+    });
   }
 };

--- a/packages/core/src/store/clients/runtime-adapter.ts
+++ b/packages/core/src/store/clients/runtime-adapter.ts
@@ -29,7 +29,7 @@ export const baseRuntimeAdapterTransformScopes = (
     scopes.suggestions = Derived({
       source: "thread",
       query: {},
-      get: (aui) => aui.threads.thread("main").suggestions(),
+      get: (aui) => aui.thread.suggestions(),
     });
   }
 };

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { resource, withKey } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import { useClientLookup } from "@assistant-ui/store/client";
 import type { SuggestionsState } from "../scopes/suggestions";
 import type { SuggestionState } from "../scopes/suggestion";
+import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
 
 export type SuggestionConfig =
   | string
@@ -19,7 +20,24 @@ const useSuggestionClient = (
 
 const SuggestionClient = resource(useSuggestionClient);
 
-const useSuggestionsResource = (
+const useSuggestionsClient = (
+  state: SuggestionsState,
+): ClientOutput<"suggestions"> => {
+  const suggestionClients = useClientLookup(
+    state.suggestions.map((suggestion, index) =>
+      withKey(index, SuggestionClient(suggestion), [suggestion]),
+    ),
+  );
+
+  return {
+    getState: () => state,
+    suggestion: ({ index }: { index: number }) => {
+      return suggestionClients.get({ index });
+    },
+  };
+};
+
+const useStaticSuggestions = (
   suggestions?: SuggestionConfig[],
 ): ClientOutput<"suggestions"> => {
   const [state] = useState<SuggestionsState>(() => {
@@ -43,18 +61,26 @@ const useSuggestionsResource = (
     };
   });
 
-  const suggestionClients = useClientLookup(
-    state.suggestions.map((suggestion, index) =>
-      withKey(index, SuggestionClient(suggestion), [suggestion]),
-    ),
-  );
-
-  return {
-    getState: () => state,
-    suggestion: ({ index }: { index: number }) => {
-      return suggestionClients.get({ index });
-    },
-  };
+  return useSuggestionsClient(state);
 };
 
-export const Suggestions = resource(useSuggestionsResource);
+export const Suggestions = resource(useStaticSuggestions);
+
+const useThreadSuggestions = (
+  suggestions: readonly ThreadSuggestion[],
+): ClientOutput<"suggestions"> => {
+  const state = useMemo<SuggestionsState>(
+    () => ({
+      suggestions: suggestions.map((s) => ({
+        title: s.prompt,
+        label: "",
+        prompt: s.prompt,
+      })),
+    }),
+    [suggestions],
+  );
+
+  return useSuggestionsClient(state);
+};
+
+export const ThreadSuggestions = resource(useThreadSuggestions);

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -12,6 +12,7 @@ import {
 } from "@assistant-ui/store/client";
 import { ComposerClient } from "./composer-runtime-client";
 import { MessageClient } from "./message-runtime-client";
+import { ThreadSuggestions } from "../clients/suggestions";
 import { useSubscribable } from "./useSubscribable";
 import type { ThreadState } from "../scopes/thread";
 
@@ -78,6 +79,9 @@ const useThreadClient = ({
       threadIdRef,
     }),
   );
+  const suggestions = useClientResource(
+    ThreadSuggestions(runtimeState.suggestions),
+  );
   const messages = useClientLookup(
     runtimeState.messages.map((m) =>
       withKey(m.id, MessageClientById({ runtime, id: m.id, threadIdRef }), [
@@ -109,6 +113,7 @@ const useThreadClient = ({
   return {
     getState: () => state,
     composer: () => composer.methods,
+    suggestions: () => suggestions.methods,
     append: runtime.append,
     deleteMessage: runtime.deleteMessage,
     startRun: runtime.startRun,

--- a/packages/core/src/store/scopes/suggestions.ts
+++ b/packages/core/src/store/scopes/suggestions.ts
@@ -15,6 +15,12 @@ export type SuggestionsMethods = {
   suggestion(query: { index: number }): SuggestionMethods;
 };
 
+export type SuggestionsMeta = {
+  source: "thread";
+  query: Record<string, never>;
+};
+
 export type SuggestionsClientSchema = {
   methods: SuggestionsMethods;
+  meta: SuggestionsMeta;
 };

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -17,6 +17,7 @@ import type {
 import type { ModelContext } from "../../model-context/types";
 import type { MessageMethods, MessageState } from "./message";
 import type { ComposerMethods, ComposerState } from "./composer";
+import type { SuggestionsMethods } from "./suggestions";
 
 export type ThreadState = {
   /**
@@ -71,6 +72,10 @@ export type ThreadMethods = {
    * The thread composer runtime.
    */
   composer(): ComposerMethods;
+  /**
+   * The suggestions shown for this thread.
+   */
+  suggestions(): SuggestionsMethods;
   /**
    * Append a new message to the thread.
    *

--- a/packages/core/src/tests/external-thread-suggestions.test.tsx
+++ b/packages/core/src/tests/external-thread-suggestions.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import type { FC, ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import { ExternalThread } from "../store/clients/external-thread";
+import { SingleThreadList } from "../store/clients/single-thread-list";
+
+let childAui!: ReturnType<typeof useAui>;
+
+const CaptureChild: FC = () => {
+  childAui = useAui();
+  return null;
+};
+
+const Child: FC = () => {
+  const aui = useAui({ thread: ExternalThread({ messages: [] }) });
+  return (
+    <AuiProvider value={aui}>
+      <CaptureChild />
+    </AuiProvider>
+  );
+};
+
+const Parent: FC<{ children: ReactNode }> = ({ children }) => {
+  const aui = useAui({
+    threads: SingleThreadList({ thread: ExternalThread({ messages: [] }) }),
+  });
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExternalThread suggestions scope", () => {
+  it("derives the scope from its own thread when standalone", () => {
+    render(<Child />);
+
+    expect(childAui.suggestions.getState()).toEqual({ suggestions: [] });
+    expect(childAui.suggestions.getState()).toBe(
+      childAui.thread.suggestions().getState(),
+    );
+  });
+
+  it("derives the scope from its own thread when nested under a threads parent", () => {
+    render(
+      <Parent>
+        <Child />
+      </Parent>,
+    );
+
+    expect(childAui.suggestions.getState()).toEqual({ suggestions: [] });
+    expect(childAui.suggestions.getState()).toBe(
+      childAui.thread.suggestions().getState(),
+    );
+  });
+});

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -8,7 +8,7 @@ import {
   useClientResource,
 } from "@assistant-ui/store";
 
-import { ModelContext, Suggestions } from "@assistant-ui/core/store";
+import { ModelContext } from "@assistant-ui/core/store";
 import { Tools, DataRenderers } from "@assistant-ui/core/react";
 
 const RESOLVED_PROMISE = Promise.resolve();
@@ -236,6 +236,10 @@ attachTransformScopes(useInMemoryThreadList, (scopes, parent) => {
     scopes.dataRenderers = DataRenderers();
   }
   if (!scopes.suggestions && parent.suggestions.source === null) {
-    scopes.suggestions = Suggestions();
+    scopes.suggestions = Derived({
+      source: "thread",
+      query: {},
+      get: (aui) => aui.threads.thread("main").suggestions(),
+    });
   }
 });

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -239,7 +239,7 @@ attachTransformScopes(useInMemoryThreadList, (scopes, parent) => {
     scopes.suggestions = Derived({
       source: "thread",
       query: {},
-      get: (aui) => aui.threads.thread("main").suggestions(),
+      get: (aui) => aui.thread.suggestions(),
     });
   }
 });

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -53,3 +53,16 @@ describe("InMemoryThreadList delete", () => {
     });
   });
 });
+
+describe("InMemoryThreadList suggestions", () => {
+  it("derives the suggestions scope from the main thread", async () => {
+    const { aui } = renderThreads();
+
+    await waitFor(() => {
+      expect(aui().suggestions.getState()).toEqual({ suggestions: [] });
+    });
+    expect(aui().suggestions.getState()).toBe(
+      aui().thread.suggestions().getState(),
+    );
+  });
+});


### PR DESCRIPTION
## what

`useChatRuntime({ suggestions })` (and every other runtime provider) accepts suggestions, forwards them into thread state, and then `ThreadPrimitive.Suggestions` renders nothing. the primitive reads the `suggestions` scope, and for runtime providers that scope was filled with a permanently empty static `Suggestions()` client, so the two surfaces never met. this is the second leg reported in #5529 (the comment observation; it reproduces on the 0.14 line too and has never worked, verified back to #4003 where the option passthrough shipped).

## how

mirrors the existing composer pattern: the thread client now exposes a `suggestions()` sub-client, and the default scope fill becomes `Derived({ source: "thread", get: (aui) => aui.threads.thread("main").suggestions() })` at all three transform sites (runtime adapter, external thread, in-memory thread list).

- `ThreadMethods` gains `suggestions(): SuggestionsMethods` (additive; same precedent as `importExternalState` in #5237)
- `SuggestionsClientSchema` gains `meta: { source: "thread" }` so `Derived` is legal for the scope
- the runtime thread client normalizes `ThreadSuggestion` (`{ prompt }`) into the scope shape (`{ title: prompt, label: "", prompt }`), following the same convention the static client uses for string configs
- the static `Suggestions(...)` config path is untouched and still wins: the transform only fills the scope when the user did not provide one, so an explicitly configured scope overrides the derived values
- the external thread client exposes the sub-client over its (currently always empty) thread suggestions, so behavior there is unchanged until the store-first path grows dynamic suggestions

in the shipped UI kit both consumers stay disjoint: welcome chips (`ThreadPrimitive.Suggestions`, new-chat view) and the follow-up row (`thread.suggestions`, non-empty thread) render the same data at different lifecycle stages, gated by mutually exclusive conditions.

## verification

- new contract test `useExternalStoreRuntime.suggestions.test.tsx`: scope exposure, per-index lookup, live updates, StrictMode, and config-over-runtime precedence
- an end-to-end repro of the issue snippet (`useChatRuntime` + provider + `s.suggestions.suggestions`) passes in plain and StrictMode; kept out of the tree per the repro-test convention
- core 1008 tests, react 401 tests (incl. typecheck), react-ai-sdk 213 tests all pass; `pnpm lint` clean; api-reference regen produces no drift
- docs updated in the same PR: `primitives/suggestion.mdx` and `guides/suggestions.mdx` now describe the derived default and the static override


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RG4_NvsbSVJm7P-XousHt1kzeqzKDNTLMkpCsGqmf4p3a_lrBdlOii3ZQHo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->