### PR TITLE
fix(react): release replay boundary stream readers

### DIFF
--- a/.changeset/calm-readers-release.md
+++ b/.changeset/calm-readers-release.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: release replay response readers after completion, cancellation, and errors

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -272,8 +272,11 @@ describe("createReplayBoundaryStream", () => {
   it("clears replaying when the stream ends before the boundary", async () => {
     const { waitForRender, releaseNext } = createRenderWait();
     const setReplaying = vi.fn();
+    const body = createBody(["hi"]);
     const streamPromise = createReplayBoundaryStream(
-      createResponse(["hi"], 10),
+      new Response(body, {
+        headers: { [REPLAY_CONTENT_LENGTH_HEADER]: "10" },
+      }),
       {
         setReplaying,
         waitForRender,
@@ -288,6 +291,7 @@ describe("createReplayBoundaryStream", () => {
 
     await expect(text).resolves.toBe("hi");
     expect(setReplaying).toHaveBeenLastCalledWith(false);
+    expect(body.locked).toBe(false);
   });
 
   it("clears replaying when the gated stream is cancelled", async () => {
@@ -313,6 +317,27 @@ describe("createReplayBoundaryStream", () => {
 
     expect(setReplaying).toHaveBeenLastCalledWith(false);
     expect(cancelled).toBe(true);
+    expect(body.locked).toBe(false);
+  });
+
+  it("releases the response body reader after a read failure", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const error = new Error("stream failed");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(error);
+      },
+    });
+    const streamPromise = createReplayBoundaryStream(
+      new Response(body, { headers: { [REPLAY_CONTENT_LENGTH_HEADER]: "10" } }),
+      { setReplaying: vi.fn(), waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+
+    await expect(stream.getReader().read()).rejects.toBe(error);
+    expect(body.locked).toBe(false);
   });
 
   it("does not wait for replay completion after cancellation unblocks a read", async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -90,6 +90,26 @@ export const createReplayBoundaryStream = async (
   const reader = body.getReader();
   let bytesForwarded = 0;
   let replayFinished = false;
+  let readerCleanup: Promise<void> | undefined;
+
+  const releaseReader = () => {
+    if (readerCleanup) return readerCleanup;
+    reader.releaseLock();
+    readerCleanup = Promise.resolve();
+    return readerCleanup;
+  };
+
+  const cancelReader = (reason?: unknown) => {
+    if (readerCleanup) return readerCleanup;
+    readerCleanup = (async () => {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        reader.releaseLock();
+      }
+    })();
+    return readerCleanup;
+  };
 
   const finishReplay = async () => {
     if (replayFinished) return;
@@ -103,44 +123,50 @@ export const createReplayBoundaryStream = async (
 
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
-      const { done, value } = await reader.read();
+      try {
+        const { done, value } = await reader.read();
 
-      if (done) {
+        if (done) {
+          await releaseReader();
+          await finishReplay();
+          controller.close();
+          return;
+        }
+
+        if (replayFinished) {
+          controller.enqueue(value);
+          return;
+        }
+
+        const nextBytesForwarded = bytesForwarded + value.byteLength;
+
+        if (nextBytesForwarded < replayContentLength) {
+          bytesForwarded = nextBytesForwarded;
+          controller.enqueue(value);
+          return;
+        }
+
+        if (nextBytesForwarded === replayContentLength) {
+          controller.enqueue(value);
+          await finishReplay();
+          return;
+        }
+
+        const replayBytesInChunk = replayContentLength - bytesForwarded;
+
+        controller.enqueue(value.subarray(0, replayBytesInChunk));
         await finishReplay();
-        controller.close();
-        return;
+        controller.enqueue(value.subarray(replayBytesInChunk));
+      } catch (error) {
+        await cancelReader(error).catch(() => {});
+        throw error;
       }
-
-      if (replayFinished) {
-        controller.enqueue(value);
-        return;
-      }
-
-      const nextBytesForwarded = bytesForwarded + value.byteLength;
-
-      if (nextBytesForwarded < replayContentLength) {
-        bytesForwarded = nextBytesForwarded;
-        controller.enqueue(value);
-        return;
-      }
-
-      if (nextBytesForwarded === replayContentLength) {
-        controller.enqueue(value);
-        await finishReplay();
-        return;
-      }
-
-      const replayBytesInChunk = replayContentLength - bytesForwarded;
-
-      controller.enqueue(value.subarray(0, replayBytesInChunk));
-      await finishReplay();
-      controller.enqueue(value.subarray(replayBytesInChunk));
     },
     async cancel(reason) {
       const wasFinished = replayFinished;
       replayFinished = true;
       if (!wasFinished) setReplaying(false);
-      await reader.cancel(reason);
+      await cancelReader(reason);
     },
   });
 };


### PR DESCRIPTION
## Summary

- release the replay response reader after normal completion
- cancel and release it when the wrapper is cancelled or reading fails
- cover completion, cancellation, and read-error cleanup with regression tests

## Why

`createReplayBoundaryStream()` acquired a reader from the response body but never released its lock. I reproduced complete consumption leaving `response.body.locked === true`, and cancellation had the same behavior. That retained ownership of the underlying response stream after the replay wrapper was finished.

The cleanup is shared across `pull()` and `cancel()` so concurrent settlement cannot cancel or release the same reader twice. Existing replay boundary behavior remains unchanged.

## Validation

- `pnpm --filter @assistant-ui/react... build`
- `pnpm --filter @assistant-ui/react test --run` (54 files, 445 tests)
- `pnpm exec oxfmt --check packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts`
- `pnpm exec oxlint packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._4nMQBqvd-MEVa-4SQs_Pj9FlINkb7xHfZBJwSx23PwRXjFLiG8L2xEfaLA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->