### PR TITLE
fix(react-pi): release event stream readers

### DIFF
--- a/.changeset/bright-streams-release.md
+++ b/.changeset/bright-streams-release.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: release event stream readers after completion, cancellation, and errors

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -227,6 +227,42 @@ describe("openPiEventStream", () => {
     ]);
   });
 
+  it("cancels a failed response body before reconnecting", async () => {
+    let calls = 0;
+    const cancelBody = vi.fn();
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(
+          new ReadableStream<Uint8Array>({ start() {}, cancel: cancelBody }),
+          { status: 503 },
+        );
+      }
+      expect(cancelBody).toHaveBeenCalledOnce();
+      return sseResponse([
+        sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+      ]);
+    }) as unknown as typeof fetch;
+
+    const errors: unknown[] = [];
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onError: (error) => errors.push(error),
+        onEvent: () => {
+          close();
+          resolve();
+        },
+      });
+    });
+
+    expect(calls).toBe(2);
+    expect(cancelBody).toHaveBeenCalledOnce();
+    expect(errors).toEqual([new Error("Pi event stream failed: HTTP 503")]);
+  });
+
   it("uses the controlled fetch stream even when native EventSource exists", async () => {
     const EventSource = vi.fn();
     const fetchImpl = vi.fn(async () =>

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -321,6 +321,37 @@ describe("openPiEventStream", () => {
     expect(errors).toHaveLength(1);
   });
 
+  it("releases a completed response body before reconnecting", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(body, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+    ) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve) => {
+      let close!: () => void;
+      close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        onEvent: vi.fn(),
+        reconnectDelay: () => {
+          expect(body.locked).toBe(false);
+          close();
+          resolve();
+          return Promise.resolve();
+        },
+      });
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it.each(["throws", "rejects"] as const)(
     "reconnects when the error callback %s",
     async (failureMode) => {
@@ -440,12 +471,13 @@ describe("openPiEventStream", () => {
   it("stops and does not surface abort as an error after close()", async () => {
     const onError = vi.fn();
     const onEvent = vi.fn();
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ start() {}, cancel });
     const fetchImpl = (async () =>
-      new Response(
-        // A body that never enqueues — only an abort can end the read.
-        new ReadableStream<Uint8Array>({ start() {} }),
-        { status: 200, headers: { "content-type": "text/event-stream" } },
-      )) as unknown as typeof fetch;
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as unknown as typeof fetch;
 
     const close = openPiEventStream({
       url: "/events",
@@ -458,10 +490,12 @@ describe("openPiEventStream", () => {
     // Let the fetch resolve and the reader park on read(), then close.
     await Promise.resolve();
     await Promise.resolve();
+    expect(body.locked).toBe(true);
     close();
-    await Promise.resolve();
+    await vi.waitFor(() => expect(body.locked).toBe(false));
 
     expect(onEvent).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -190,6 +190,7 @@ export const openPiEventStream = (
           headers: { Accept: "text/event-stream", ...headers },
         });
         if (!response.ok || !response.body) {
+          void response.body?.cancel().catch(() => undefined);
           throw new Error(`Pi event stream failed: HTTP ${response.status}`);
         }
         validateEventStreamContentType(response);

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -167,6 +167,7 @@ export const openPiEventStream = (
   } = options;
 
   let closed = false;
+  let cancelActiveReader: (() => void) | undefined;
   const abort = new AbortController();
   const reportCallbackError = (callbackError: unknown) => {
     console.error("[react-pi] onError callback threw an error", callbackError);
@@ -197,20 +198,52 @@ export const openPiEventStream = (
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
 
-        while (!closed) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          const chunk = textDecoder.decode(value, { stream: true });
-          for (const frame of decoder.push(chunk)) {
-            if (frame.event === "ping" || frame.data === "") continue;
-            let parsed: PiAnyClientEvent;
+        let shouldCancel = true;
+        let cancelPromise: Promise<void> | undefined;
+        const cancelReader = () => {
+          cancelPromise ??= reader.cancel().catch(() => undefined);
+          return cancelPromise;
+        };
+        const requestCancel = () => {
+          void cancelReader();
+        };
+        cancelActiveReader = requestCancel;
+
+        try {
+          while (!closed) {
+            let result: ReadableStreamReadResult<Uint8Array>;
             try {
-              parsed = JSON.parse(frame.data) as PiAnyClientEvent;
+              result = await reader.read();
             } catch (error) {
-              reportError(error);
-              continue;
+              shouldCancel = false;
+              throw error;
             }
-            if (!closed) onEvent(parsed);
+
+            const { value, done } = result;
+            if (done) {
+              shouldCancel = false;
+              break;
+            }
+            const chunk = textDecoder.decode(value, { stream: true });
+            for (const frame of decoder.push(chunk)) {
+              if (frame.event === "ping" || frame.data === "") continue;
+              let parsed: PiAnyClientEvent;
+              try {
+                parsed = JSON.parse(frame.data) as PiAnyClientEvent;
+              } catch (error) {
+                reportError(error);
+                continue;
+              }
+              if (!closed) onEvent(parsed);
+            }
+          }
+        } finally {
+          if (cancelActiveReader === requestCancel)
+            cancelActiveReader = undefined;
+          try {
+            if (shouldCancel || cancelPromise) await cancelReader();
+          } finally {
+            reader.releaseLock();
           }
         }
       } catch (error) {
@@ -236,5 +269,6 @@ export const openPiEventStream = (
   return () => {
     closed = true;
     abort.abort();
+    cancelActiveReader?.();
   };
 };


### PR DESCRIPTION
## Summary

- release each SSE response reader before reconnecting
- actively cancel a parked reader when the caller unsubscribes
- cover normal EOF and close cleanup with regression tests

## Why

`openPiEventStream()` acquired a response reader for every SSE connection but never released its lock. I reproduced a completed response remaining locked when reconnection began. On unsubscribe, aborting the request alone also did not clean up an injected/custom `fetch` stream that ignored the request signal.

The event source now cancels abnormal or closed reads, awaits that cleanup before releasing the lock, and releases normal EOF readers without cancelling them. This prevents stream resources from accumulating across reconnections without changing event or retry behavior.

## Validation

- `pnpm --filter @assistant-ui/react-pi... build`
- `pnpm --filter @assistant-ui/react-pi test --run` (12 files, 177 tests)
- `pnpm exec oxfmt --check packages/react-pi/src/client/eventSource.ts packages/react-pi/src/client/eventSource.test.ts`
- `pnpm exec oxlint packages/react-pi/src/client/eventSource.ts packages/react-pi/src/client/eventSource.test.ts`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5vbmb2oV3eYYsQR9abIQdx1-tKJKKgfaK3Al85VjeuzMQoJv-LpkG0MI0nA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->