### PR TITLE
fix(react-native): respect prevented composer key events

### DIFF
--- a/.changeset/quiet-cats-listen.md
+++ b/.changeset/quiet-cats-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: respect prevented composer key events

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -315,6 +315,18 @@ describe("ComposerInput", () => {
 
       expect(onKeyPress).toHaveBeenCalledTimes(2);
     });
+
+    it("does not submit when the consumer prevents the key event", async () => {
+      const input = await mount({
+        onKeyPress: (event) => event.preventDefault(),
+      });
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("native", () => {

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -87,6 +87,7 @@ export const ComposerInput = ({
   const onKeyPress = useCallback(
     (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
       onKeyPressProp?.(e);
+      if (e.isDefaultPrevented()) return;
 
       if (Platform.OS !== "web") return;
       if (submitMode !== "enter") return;


### PR DESCRIPTION
## Summary

- stop the React Native web composer internal Enter handler when a consumer prevents the key event
- add a regression test for custom composer keyboard handling

## Why

Apps can use `onKeyPress` to override Enter submission, for example to implement custom multiline or keyboard behavior. The callback ran before the built-in handler, but `preventDefault()` was ignored, so the composer still sent the message. This also differed from the web composer event-handler contract.

The internal handler now checks the React Native synthetic event after invoking the consumer callback. Native behavior is unchanged because built-in keyboard submission remains web-only.

## Verification

- reproduced the bug with the new focused test before applying the fix
- `pnpm --dir packages/react-native exec vitest run src/primitives/composer/ComposerInput.test.tsx`
- `pnpm --filter @assistant-ui/react-native build`
- `pnpm exec oxlint packages/react-native/src/primitives/composer/ComposerInput.tsx packages/react-native/src/primitives/composer/ComposerInput.test.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4zkXq8ONaxw1E6s69YGxUwgH0jFzqTNH7iCvPV-nMwVuKgaqkTy4rpGMo-U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->