### PR TITLE
fix(react): generate unique in-memory thread ids

### DIFF
--- a/.changeset/calm-threads-create.md
+++ b/.changeset/calm-threads-create.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: generate unique in-memory thread IDs

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -7,6 +7,7 @@ import {
   attachTransformScopes,
   useClientResource,
 } from "@assistant-ui/store";
+import { generateId } from "@assistant-ui/core";
 
 import { ModelContext, Suggestions } from "@assistant-ui/core/store";
 import { Tools, DataRenderers } from "@assistant-ui/core/react";
@@ -137,7 +138,7 @@ const useInMemoryThreadList = (
   };
 
   const handleSwitchToNewThread = () => {
-    const newId = `thread-${Date.now()}`;
+    const newId = `thread-${generateId()}`;
     setThreads((prev) => [
       ...prev,
       { id: newId, title: "New Thread", status: "regular" },

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { useAui, AuiProvider } from "@assistant-ui/store";
 import { InMemoryThreadList } from "../client/InMemoryThreadList";
 import { ExternalThread } from "../index";
@@ -29,7 +29,7 @@ const renderThreads = () => {
   return { aui: () => captured.aui! };
 };
 
-describe("InMemoryThreadList delete", () => {
+describe("InMemoryThreadList", () => {
   it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
     const { aui } = renderThreads();
 
@@ -51,5 +51,25 @@ describe("InMemoryThreadList delete", () => {
       expect(state.mainThreadId).toBe("main");
       expect(state.threadIds).not.toContain(newId);
     });
+  });
+
+  it("creates unique IDs for threads created in the same millisecond", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const { aui } = renderThreads();
+
+    try {
+      aui().threads.switchToNewThread();
+      aui().threads.switchToNewThread();
+
+      await waitFor(() => {
+        const generatedIds = aui()
+          .threads.getState()
+          .threadIds.filter((id) => id !== "main");
+        expect(generatedIds).toHaveLength(2);
+        expect(new Set(generatedIds)).toHaveLength(2);
+      });
+    } finally {
+      now.mockRestore();
+    }
   });
 });

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -55,9 +55,9 @@ describe("InMemoryThreadList", () => {
 
   it("creates unique IDs for threads created in the same millisecond", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
-    const { aui } = renderThreads();
 
     try {
+      const { aui } = renderThreads();
       aui().threads.switchToNewThread();
       aui().threads.switchToNewThread();
 
@@ -66,7 +66,7 @@ describe("InMemoryThreadList", () => {
           .threads.getState()
           .threadIds.filter((id) => id !== "main");
         expect(generatedIds).toHaveLength(2);
-        expect(new Set(generatedIds)).toHaveLength(2);
+        expect(new Set(generatedIds).size).toBe(2);
       });
     } finally {
       now.mockRestore();


### PR DESCRIPTION
## Summary

- generate in-memory thread IDs with the shared portable ID helper
- add a regression test for multiple thread creations in one millisecond

## Why

`InMemoryThreadList` derived IDs only from `Date.now()`. Two synchronous `switchToNewThread()` calls, or two user actions handled in the same millisecond, therefore created the same key. The duplicate reaches `useClientLookup` and throws `Duplicate key ... in useResources`, leaving the thread list broken.

The fix keeps the existing `thread-` prefix while replacing the timestamp with the same ID generator used throughout the runtime.

## Verification

- reproduced the duplicate-key failure with `Date.now()` fixed to one value before applying the fix
- `pnpm --dir packages/react exec vitest run src/tests/in-memory-thread-list.test.tsx`
- `pnpm exec oxlint packages/react/src/client/InMemoryThreadList.ts packages/react/src/tests/in-memory-thread-list.test.tsx`
- `pnpm --filter @assistant-ui/react build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6Ftu6MfWi5lul0d6f551LoHsYMTlqH1bCgAT0oX7NRA-HfmuCC-enZWOqdw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->