### PR TITLE
fix(core): cancel pending ExternalThread attachment adds

### DIFF
--- a/.changeset/calm-attachments-stay-cleared.md
+++ b/.changeset/calm-attachments-stay-cleared.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: prevent pending ExternalThread attachment additions from restoring cleared drafts

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -412,6 +412,11 @@ type ComposerClientResourceProps = {
   attachmentAdapter?: AttachmentAdapter | undefined;
 };
 
+type AttachmentAddOperation = {
+  cancelled: boolean;
+  attachmentIds: Set<string>;
+};
+
 const useQueueItemClient = ({
   item,
   onMove,
@@ -433,11 +438,11 @@ const QueueItemClient = resource(useQueueItemClient);
 
 const drainAdapterAdd = async (
   result: ReturnType<AttachmentAdapter["add"]>,
-  upsert: (attachment: Attachment) => void,
+  upsert: (attachment: Attachment) => boolean,
 ) => {
   if (Symbol.asyncIterator in result) {
     for await (const attachment of result) {
-      upsert(attachment);
+      if (!upsert(attachment)) break;
     }
   } else {
     upsert(await result);
@@ -486,6 +491,22 @@ const useComposerClientResource = ({
   const [quote, setQuote, quoteRef] = useLiveState<
     { readonly text: string; readonly messageId: string } | undefined
   >(undefined);
+  const attachmentAddOperationsRef = useRef(new Set<AttachmentAddOperation>());
+
+  const cancelAttachmentAdd = useCallback((attachmentId: string) => {
+    for (const operation of [...attachmentAddOperationsRef.current]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      attachmentAddOperationsRef.current.delete(operation);
+    }
+  }, []);
+
+  const cancelAllAttachmentAdds = useCallback(() => {
+    for (const operation of attachmentAddOperationsRef.current) {
+      operation.cancelled = true;
+    }
+    attachmentAddOperationsRef.current.clear();
+  }, []);
 
   const updateFromMessage = () => {
     if (!message) return;
@@ -505,6 +526,7 @@ const useComposerClientResource = ({
         AttachmentResource({
           attachment,
           onRemove: async () => {
+            cancelAttachmentAdd(attachment.id);
             await attachmentAdapter?.remove(attachment);
             setAttachments((prev) =>
               prev.filter((a) => a.id !== attachment.id),
@@ -609,10 +631,27 @@ const useComposerClientResource = ({
           );
       }
       if (!isCreateAttachment(fileOrAttachment) && attachmentAdapter) {
-        await drainAdapterAdd(
-          attachmentAdapter.add({ file: fileOrAttachment }),
-          upsertAttachment,
-        );
+        const operation: AttachmentAddOperation = {
+          cancelled: false,
+          attachmentIds: new Set(),
+        };
+        const operations = attachmentAddOperationsRef.current;
+        operations.add(operation);
+        try {
+          await drainAdapterAdd(
+            attachmentAdapter.add({ file: fileOrAttachment }),
+            (attachment) => {
+              if (operation.cancelled) return false;
+              operation.attachmentIds.add(attachment.id);
+              upsertAttachment(attachment);
+              return true;
+            },
+          );
+        } catch (error) {
+          if (!operation.cancelled) throw error;
+        } finally {
+          operations.delete(operation);
+        }
       } else if (!isCreateAttachment(fileOrAttachment)) {
         const newAttachment: Attachment = {
           id: Math.random().toString(36).substring(7),
@@ -637,6 +676,7 @@ const useComposerClientResource = ({
       }
     },
     clearAttachments: async () => {
+      cancelAllAttachmentAdds();
       const removed = attachmentsRef.current;
       setAttachments([]);
       await removePendingAttachments(removed);
@@ -648,6 +688,7 @@ const useComposerClientResource = ({
       return attachmentClients.get(selector);
     },
     reset: async () => {
+      cancelAllAttachmentAdds();
       const removed = attachmentsRef.current;
       setText("");
       setRole("user");

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -730,6 +730,7 @@ const useComposerClientResource = ({
       if (!isEditingRef.current) throw new Error("Composer is not available");
       if (isEmpty || isSendDisabled) return;
 
+      attachmentAddOperations.cancelAll();
       setText("");
       setAttachments([]);
       setQuote(undefined);

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -417,6 +417,48 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
+class AttachmentAddOperations {
+  private readonly operations = new Set<AttachmentAddOperation>();
+
+  start() {
+    const operation: AttachmentAddOperation = {
+      cancelled: false,
+      attachmentIds: new Set(),
+    };
+    this.operations.add(operation);
+    return operation;
+  }
+
+  accept(operation: AttachmentAddOperation, attachmentId: string) {
+    if (operation.cancelled) return false;
+    operation.attachmentIds.add(attachmentId);
+    return true;
+  }
+
+  finish(operation: AttachmentAddOperation) {
+    this.operations.delete(operation);
+  }
+
+  isCancelled(operation: AttachmentAddOperation) {
+    return operation.cancelled;
+  }
+
+  cancel(attachmentId: string) {
+    for (const operation of [...this.operations]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      this.operations.delete(operation);
+    }
+  }
+
+  cancelAll() {
+    for (const operation of this.operations) {
+      operation.cancelled = true;
+    }
+    this.operations.clear();
+  }
+}
+
 const useQueueItemClient = ({
   item,
   onMove,
@@ -491,22 +533,10 @@ const useComposerClientResource = ({
   const [quote, setQuote, quoteRef] = useLiveState<
     { readonly text: string; readonly messageId: string } | undefined
   >(undefined);
-  const attachmentAddOperationsRef = useRef(new Set<AttachmentAddOperation>());
-
-  const cancelAttachmentAdd = useCallback((attachmentId: string) => {
-    for (const operation of [...attachmentAddOperationsRef.current]) {
-      if (!operation.attachmentIds.has(attachmentId)) continue;
-      operation.cancelled = true;
-      attachmentAddOperationsRef.current.delete(operation);
-    }
-  }, []);
-
-  const cancelAllAttachmentAdds = useCallback(() => {
-    for (const operation of attachmentAddOperationsRef.current) {
-      operation.cancelled = true;
-    }
-    attachmentAddOperationsRef.current.clear();
-  }, []);
+  const attachmentAddOperations = useMemo(
+    () => new AttachmentAddOperations(),
+    [],
+  );
 
   const updateFromMessage = () => {
     if (!message) return;
@@ -526,7 +556,7 @@ const useComposerClientResource = ({
         AttachmentResource({
           attachment,
           onRemove: async () => {
-            cancelAttachmentAdd(attachment.id);
+            attachmentAddOperations.cancel(attachment.id);
             await attachmentAdapter?.remove(attachment);
             setAttachments((prev) =>
               prev.filter((a) => a.id !== attachment.id),
@@ -631,26 +661,21 @@ const useComposerClientResource = ({
           );
       }
       if (!isCreateAttachment(fileOrAttachment) && attachmentAdapter) {
-        const operation: AttachmentAddOperation = {
-          cancelled: false,
-          attachmentIds: new Set(),
-        };
-        const operations = attachmentAddOperationsRef.current;
-        operations.add(operation);
+        const operation = attachmentAddOperations.start();
         try {
           await drainAdapterAdd(
             attachmentAdapter.add({ file: fileOrAttachment }),
             (attachment) => {
-              if (operation.cancelled) return false;
-              operation.attachmentIds.add(attachment.id);
+              if (!attachmentAddOperations.accept(operation, attachment.id))
+                return false;
               upsertAttachment(attachment);
               return true;
             },
           );
+          attachmentAddOperations.finish(operation);
         } catch (error) {
-          if (!operation.cancelled) throw error;
-        } finally {
-          operations.delete(operation);
+          attachmentAddOperations.finish(operation);
+          if (!attachmentAddOperations.isCancelled(operation)) throw error;
         }
       } else if (!isCreateAttachment(fileOrAttachment)) {
         const newAttachment: Attachment = {
@@ -676,7 +701,7 @@ const useComposerClientResource = ({
       }
     },
     clearAttachments: async () => {
-      cancelAllAttachmentAdds();
+      attachmentAddOperations.cancelAll();
       const removed = attachmentsRef.current;
       setAttachments([]);
       await removePendingAttachments(removed);
@@ -688,7 +713,7 @@ const useComposerClientResource = ({
       return attachmentClients.get(selector);
     },
     reset: async () => {
-      cancelAllAttachmentAdds();
+      attachmentAddOperations.cancelAll();
       const removed = attachmentsRef.current;
       setText("");
       setRole("user");

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -311,6 +311,56 @@ describe("ExternalThread attachments", () => {
     },
   );
 
+  it("stops attachment generator updates after removal", async () => {
+    let resumeAdd!: () => void;
+    const drainedAfterRemoval = vi.fn();
+    const file = new File(["data"], "notes.txt", { type: "text/plain" });
+    const pendingAttachment: PendingAttachment = {
+      id: "att-1",
+      type: "file",
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: { type: "requires-action", reason: "composer-send" },
+    };
+    const add = vi.fn(async function* () {
+      yield pendingAttachment;
+      await new Promise<void>((resolve) => {
+        resumeAdd = resolve;
+      });
+      yield {
+        ...pendingAttachment,
+        status: { type: "running", reason: "uploading", progress: 1 },
+      } satisfies PendingAttachment;
+      drainedAfterRemoval();
+    });
+    const aui = renderThreadWithProps({
+      attachmentAdapter: {
+        accept: "*",
+        add,
+        send: async () => ({}) as never,
+        remove: async () => {},
+      },
+    });
+    const composer = () => aui().thread.composer();
+
+    let addPromise!: Promise<void>;
+    act(() => {
+      addPromise = composer().addAttachment(file);
+    });
+    await waitFor(() =>
+      expect(composer().getState().attachments).toHaveLength(1),
+    );
+    await act(() => composer().attachment({ id: "att-1" }).remove());
+    await act(async () => {
+      resumeAdd();
+      await addPromise;
+    });
+
+    expect(composer().getState().attachments).toHaveLength(0);
+    expect(drainedAfterRemoval).not.toHaveBeenCalled();
+  });
+
   it("routes edit-composer attachments through the adapter", async () => {
     const add = vi.fn(async ({ file }: { file: File }) => ({
       id: "att-edit",

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -361,6 +361,66 @@ describe("ExternalThread attachments", () => {
     expect(drainedAfterRemoval).not.toHaveBeenCalled();
   });
 
+  it("does not restore attachment generator updates after send", async () => {
+    let resumeAdd!: () => void;
+    const drainedAfterSend = vi.fn();
+    const onNew = vi.fn();
+    const file = new File(["data"], "notes.txt", { type: "text/plain" });
+    const pendingAttachment: PendingAttachment = {
+      id: "att-1",
+      type: "file",
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: { type: "requires-action", reason: "composer-send" },
+    };
+    const add = vi.fn(async function* () {
+      yield pendingAttachment;
+      await new Promise<void>((resolve) => {
+        resumeAdd = resolve;
+      });
+      yield {
+        ...pendingAttachment,
+        status: { type: "running", reason: "uploading", progress: 1 },
+      } satisfies PendingAttachment;
+      drainedAfterSend();
+    });
+    const aui = renderThreadWithProps({
+      attachmentAdapter: {
+        accept: "*",
+        add,
+        send: async (attachment) => ({
+          ...attachment,
+          status: { type: "complete" },
+          content: [],
+        }),
+        remove: async () => {},
+      },
+      onNew,
+    });
+    const composer = () => aui().thread.composer();
+
+    let addPromise!: Promise<void>;
+    act(() => {
+      addPromise = composer().addAttachment(file);
+    });
+    await waitFor(() =>
+      expect(composer().getState().attachments).toHaveLength(1),
+    );
+    act(() => {
+      composer().setText("hello");
+      composer().send();
+    });
+    await waitFor(() => expect(onNew).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resumeAdd();
+      await addPromise;
+    });
+
+    expect(composer().getState().attachments).toHaveLength(0);
+    expect(drainedAfterSend).not.toHaveBeenCalled();
+  });
+
   it("routes edit-composer attachments through the adapter", async () => {
     const add = vi.fn(async ({ file }: { file: File }) => ({
       id: "att-edit",

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -9,6 +9,7 @@ import type {
   ExternalThreadProps,
 } from "../store/clients/external-thread";
 import { ExternalThread } from "../store/clients/external-thread";
+import type { PendingAttachment } from "../types/attachment";
 
 const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
   const captured: { aui?: ReturnType<typeof useAui> } = {};
@@ -259,6 +260,53 @@ describe("ExternalThread attachments", () => {
       expect(remove).toHaveBeenCalledWith(
         expect.objectContaining({ id: "att-1" }),
       );
+      expect(aui().thread.composer().getState().attachments).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    [
+      "clearAttachments",
+      (c: { clearAttachments(): Promise<void> }) => c.clearAttachments(),
+    ],
+    ["reset", (c: { reset(): Promise<void> }) => c.reset()],
+  ] as const)(
+    "does not restore an attachment that resolves after %s",
+    async (_name, invoke) => {
+      let resolveAdd!: (attachment: PendingAttachment) => void;
+      const add = vi.fn(
+        () =>
+          new Promise<PendingAttachment>((resolve) => {
+            resolveAdd = resolve;
+          }),
+      );
+      const aui = renderThreadWithProps({
+        attachmentAdapter: {
+          accept: "*",
+          add,
+          send: async () => ({}) as never,
+          remove: async () => {},
+        },
+      });
+      const file = new File(["data"], "notes.txt", { type: "text/plain" });
+
+      let addPromise!: Promise<void>;
+      act(() => {
+        addPromise = aui().thread.composer().addAttachment(file);
+      });
+      await act(() => invoke(aui().thread.composer()));
+      await act(async () => {
+        resolveAdd({
+          id: "att-1",
+          type: "file",
+          name: file.name,
+          contentType: file.type,
+          file,
+          status: { type: "requires-action", reason: "composer-send" },
+        });
+        await addPromise;
+      });
+
       expect(aui().thread.composer().getState().attachments).toHaveLength(0);
     },
   );


### PR DESCRIPTION
## Summary

- cancel in-flight ExternalThread attachment additions when the draft is cleared, reset, or sent
- stop late async-generator updates after an attachment is removed
- add regression coverage for late promise and generator updates

## Why

While testing an asynchronous attachment adapter, I found that clearing or resetting the composer before `attachmentAdapter.add()` resolved did not invalidate the operation. Its late result was inserted into the already-cleared draft, so a removed file reappeared.

The same race existed during send: once the optimistic send cleared the draft, a later generator update could put the sent attachment into the next draft.

This is the store-runtime counterpart of the attachment lifecycle race fixed in #5233.

## Implementation

Each attachment add now has a tracked operation associated with the attachment IDs it yields. Clear, reset, and send cancel all pending operations, while individual removal cancels the operation that owns that attachment. Cancelled promise results and later async-generator updates are ignored.

If attachment sending fails, the existing send snapshot is still restored for retry; the cancelled add generator can no longer mutate that restored snapshot or a newer draft.

## Testing

- reproduced the clear/reset promise race against unchanged main
- covered generator updates after individual removal and send
- `pnpm exec vitest run src/tests/external-thread-attachments.test.tsx` (13 tests)
- `pnpm check:resource-memo`
- `pnpm lint`
- `pnpm build` (88/88 tasks)
