### PR TITLE
fix(core): snapshot ExternalThread composer state before uploads

### DIFF
--- a/.changeset/quiet-composers-snapshot.md
+++ b/.changeset/quiet-composers-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve ExternalThread composer state while attachments are prepared for send

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -725,6 +725,8 @@ const useComposerClientResource = ({
     send: (opts?: ComposerSendOptions) => {
       const currentQuote = quoteRef.current;
       const currentText = textRef.current;
+      const currentRole = roleRef.current;
+      const currentRunConfig = runConfigRef.current;
       const currentAttachments = attachmentsRef.current;
       const isEmpty = !currentText.trim() && !currentAttachments.length;
       if (!isEditingRef.current) throw new Error("Composer is not available");
@@ -737,7 +739,7 @@ const useComposerClientResource = ({
 
       const dispatch = (sendAttachments: readonly Attachment[]) => {
         const composedMessage: AppendMessage = {
-          role: roleRef.current,
+          role: currentRole,
           content: currentText
             ? [{ type: "text" as const, text: currentText }]
             : [],
@@ -745,7 +747,7 @@ const useComposerClientResource = ({
           createdAt: new Date(),
           parentId: null,
           sourceId: null,
-          runConfig: runConfigRef.current,
+          runConfig: currentRunConfig,
           startRun: opts?.startRun,
           metadata: {
             custom: { ...(currentQuote ? { quote: currentQuote } : {}) },

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -9,7 +9,10 @@ import type {
   ExternalThreadProps,
 } from "../store/clients/external-thread";
 import { ExternalThread } from "../store/clients/external-thread";
-import type { PendingAttachment } from "../types/attachment";
+import type {
+  CompleteAttachment,
+  PendingAttachment,
+} from "../types/attachment";
 
 const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
   const captured: { aui?: ReturnType<typeof useAui> } = {};
@@ -214,6 +217,59 @@ describe("ExternalThread attachments", () => {
       "Failed to send attachments",
       expect.any(Error),
     );
+  });
+
+  it("preserves composer state while attachments are prepared for send", async () => {
+    let resolveSend!: (attachment: CompleteAttachment) => void;
+    const onNew = vi.fn();
+    const file = new File(["data"], "notes.txt", { type: "text/plain" });
+    const adapter = {
+      accept: "*",
+      add: async () => ({
+        id: "att-1",
+        type: "file" as const,
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: {
+          type: "requires-action" as const,
+          reason: "composer-send" as const,
+        },
+      }),
+      send: () =>
+        new Promise<CompleteAttachment>((resolve) => {
+          resolveSend = resolve;
+        }),
+      remove: async () => {},
+    };
+    const aui = renderThreadWithProps({ attachmentAdapter: adapter, onNew });
+    const composer = () => aui().thread.composer();
+
+    await act(() => composer().addAttachment(file));
+    act(() => {
+      composer().setText("first message");
+      composer().setRole("assistant");
+      composer().setRunConfig({ model: "model-a" });
+      composer().send();
+      composer().setRole("system");
+      composer().setRunConfig({ model: "model-b" });
+    });
+    await act(async () => {
+      resolveSend({
+        id: "att-1",
+        type: "file",
+        name: file.name,
+        contentType: file.type,
+        status: { type: "complete" },
+        content: [],
+      });
+    });
+
+    await waitFor(() => expect(onNew).toHaveBeenCalledTimes(1));
+    expect(onNew.mock.calls[0]![0]).toMatchObject({
+      role: "assistant",
+      runConfig: { model: "model-a" },
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- snapshot the ExternalThread composer role and run configuration when send starts
- use that snapshot after asynchronous attachment preparation finishes
- add regression coverage for draft configuration changes during upload

## Why

ExternalThread already captured text, attachments, and quote state before awaiting `attachmentAdapter.send()`, but it read `role` and `runConfig` only after the upload finished. If someone changed the model, role, or other run configuration for their next draft while the first message was uploading, those new settings were applied to the message already in flight.

## Implementation

Capture `role` and `runConfig` alongside the other composer fields at send initiation, then build the delayed message from that single consistent snapshot.

## Testing

- reproduced the failure against unchanged main: an in-flight message started with `model-a` was dispatched with the later `model-b`
- `pnpm exec vitest run src/tests/external-thread-attachments.test.tsx` (10 tests)
- `pnpm lint`
- `pnpm build` (88/88 tasks)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.cOr-Xt8HQHOV58ciHFAHlkuENwN-C7lJFk0Xk6ruaEwD1SBEgh7GKnEE6bw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->