### PR TITLE
fix(core): emit thread switch events after the flush that rebinds the scopes

### DIFF
--- a/.changeset/tidy-switches-listen.md
+++ b/.changeset/tidy-switches-listen.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/store": patch
+"@assistant-ui/core": patch
+---
+
+fix: deliver `threadListItem.switchedTo` to default-scope listeners (#5699). the thread list item client now emits the switch from its own observed selection transition, after the flush that rebinds the derived scopes, instead of relaying the runtime's synchronous notification. scoped listeners now resolve their scope against the host's current client at delivery time, so a listener subscribed before a structural swap follows the scope's present binding; the notification manager re-reads the listener set at flush time per the documented live-set semantics. listeners that need a pinned instance subscribe on an id-scoped client instead.

--- a/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
@@ -1,12 +1,8 @@
-import type { Unsubscribe } from "../../types/unsubscribe";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import { useAssistantEmit } from "@assistant-ui/store/client";
-import type {
-  ThreadListItemEventType,
-  ThreadListItemRuntime,
-} from "../../runtime/api/thread-list-item-runtime";
+import type { ThreadListItemRuntime } from "../../runtime/api/thread-list-item-runtime";
 import { useSubscribable } from "./useSubscribable";
 
 const useThreadListItemClient = ({
@@ -28,29 +24,18 @@ const useThreadListItemClient = ({
   }, [runtimeState, mainThreadIsRunning]);
   const emit = useAssistantEmit();
 
-  // Bind thread list item events to event manager
+  // Emitted after the flush that rebinds the derived scopes; the runtime's own
+  // synchronous notification would be delivered against the pre-switch binding.
+  const { isMain, id: threadId } = runtimeState;
+  const selectionRef = useRef({ isMain, threadId });
   useEffect(() => {
-    const unsubscribers: Unsubscribe[] = [];
-
-    // Subscribe to thread list item events
-    const threadListItemEvents: ThreadListItemEventType[] = [
-      "switchedTo",
-      "switchedAway",
-    ];
-
-    for (const event of threadListItemEvents) {
-      const unsubscribe = runtime.unstable_on(event, () => {
-        emit(`threadListItem.${event}`, {
-          threadId: runtime.getState()!.id,
-        });
-      });
-      unsubscribers.push(unsubscribe);
-    }
-
-    return () => {
-      for (const unsub of unsubscribers) unsub();
-    };
-  }, [runtime, emit]);
+    const previous = selectionRef.current;
+    if (previous.isMain === isMain && previous.threadId === threadId) return;
+    selectionRef.current = { isMain, threadId };
+    emit(isMain ? "threadListItem.switchedTo" : "threadListItem.switchedAway", {
+      threadId,
+    });
+  }, [isMain, threadId, emit]);
 
   return {
     getState: () => state,

--- a/packages/core/src/tests/thread-switch-events.test.tsx
+++ b/packages/core/src/tests/thread-switch-events.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AuiProvider, useAui, useAuiEvent } from "@assistant-ui/store";
+import { RuntimeAdapter } from "../react/RuntimeAdapter";
+import { AssistantRuntimeImpl } from "../runtime/api/assistant-runtime";
+import { ExternalStoreRuntimeCore } from "../runtimes/external-store/external-store-runtime-core";
+import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
+
+type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
+
+const createRuntime = () => {
+  const threads = [
+    {
+      id: "t1",
+      title: "one",
+      messages: [{ id: "m1", role: "user" as const, text: "a" }],
+    },
+    {
+      id: "t2",
+      title: "two",
+      messages: [{ id: "m2", role: "user" as const, text: "b" }],
+    },
+  ];
+  let currentId = "t1";
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages: threads.find((t) => t.id === currentId)!.messages,
+    convertMessage: (m) => ({
+      id: m.id,
+      role: m.role,
+      content: [{ type: "text", text: m.text }],
+    }),
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: currentId,
+        threads: threads.map((t) => ({
+          status: "regular" as const,
+          id: t.id,
+          title: t.title,
+        })),
+        onSwitchToThread: (threadId: string) => {
+          currentId = threadId;
+          sync();
+        },
+        onSwitchToNewThread: () => {},
+      },
+    },
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const sync = () => core.setAdapter(makeAdapter());
+  return runtime;
+};
+
+describe("thread switch events", () => {
+  it("delivers switchedTo to default-scope, star-scope, and aui.on listeners", async () => {
+    const runtime = createRuntime();
+    const defaultScope = vi.fn();
+    const starScope = vi.fn();
+    const auiOn = vi.fn();
+    const switchedAwayStar = vi.fn();
+    let aui!: ReturnType<typeof useAui>;
+    const Consumer = () => {
+      useAuiEvent("threadListItem.switchedTo" as never, defaultScope as never);
+      useAuiEvent(
+        { scope: "*", event: "threadListItem.switchedTo" } as never,
+        starScope as never,
+      );
+      useAuiEvent(
+        { scope: "*", event: "threadListItem.switchedAway" } as never,
+        switchedAwayStar as never,
+      );
+      return null;
+    };
+    const Harness = () => {
+      aui = useAui({ threads: RuntimeAdapter(runtime) } as never);
+      return (
+        <AuiProvider value={aui}>
+          <Consumer />
+        </AuiProvider>
+      );
+    };
+    render(<Harness />);
+    await act(async () => {});
+
+    aui.on("threadListItem.switchedTo" as never, auiOn as never);
+
+    await act(async () => {
+      aui.threads.item({ index: 1 }).switchTo();
+    });
+    await act(async () => {});
+
+    expect(defaultScope).toHaveBeenCalledExactlyOnceWith({ threadId: "t2" });
+    expect(starScope).toHaveBeenCalledExactlyOnceWith({ threadId: "t2" });
+    expect(auiOn).toHaveBeenCalledExactlyOnceWith({ threadId: "t2" });
+    expect(switchedAwayStar).toHaveBeenCalledExactlyOnceWith({
+      threadId: "t1",
+    });
+
+    await act(async () => {
+      aui.threads.item({ index: 0 }).switchTo();
+    });
+    await act(async () => {});
+
+    expect(defaultScope).toHaveBeenCalledTimes(2);
+    expect(defaultScope).toHaveBeenLastCalledWith({ threadId: "t1" });
+    expect(switchedAwayStar).toHaveBeenCalledTimes(2);
+    expect(switchedAwayStar).toHaveBeenLastCalledWith({ threadId: "t2" });
+  });
+
+  it("does not emit for the initially selected thread on mount", async () => {
+    const runtime = createRuntime();
+    const anySwitch = vi.fn();
+    const Consumer = () => {
+      useAuiEvent(
+        { scope: "*", event: "threadListItem.switchedTo" } as never,
+        anySwitch as never,
+      );
+      return null;
+    };
+    const Harness = () => {
+      const aui = useAui({ threads: RuntimeAdapter(runtime) } as never);
+      return (
+        <AuiProvider value={aui}>
+          <Consumer />
+        </AuiProvider>
+      );
+    };
+    render(<Harness />);
+    await act(async () => {});
+
+    expect(anySwitch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -158,6 +158,27 @@ describe("scope-filtered on", () => {
     expect(late).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "b" });
   });
 
+  it("an in-flight scoped emission is dropped when the scope is removed before delivery", async () => {
+    let aui!: AnyClient;
+    const Harness = ({ hasMessage }: { hasMessage: boolean }) => {
+      aui = useAui(
+        (hasMessage
+          ? { thread: ThreadClient(), message: messageDerived() }
+          : { thread: ThreadClient() }) as unknown as useAui.Props,
+      );
+      return <AuiProvider value={aui as never} />;
+    };
+    const view = render(<Harness hasMessage />);
+    const cb = vi.fn();
+    aui.on("message.pinged", cb);
+
+    aui.thread.message({ index: 0 }).ping("x");
+    view.rerender(<Harness hasMessage={false} />);
+    await flushEvents();
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
   it("unsubscribe stops delivery", async () => {
     const { getAui } = setup();
     const aui = getAui();

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -140,22 +140,22 @@ describe("scope-filtered on", () => {
     );
   });
 
-  it("listeners bind to the instance resolved at subscription time", async () => {
+  it("scoped listeners follow the scope's binding at delivery time", async () => {
     const { getAui } = setup();
-    const boundToM0 = vi.fn();
-    getAui().on("message.pinged", boundToM0);
+    const early = vi.fn();
+    getAui().on("message.pinged", early);
 
     act(() => flushTapSync(() => getAui().thread.setSelected(1)));
 
-    const boundToM1 = vi.fn();
-    getAui().on("message.pinged", boundToM1);
+    const late = vi.fn();
+    getAui().on("message.pinged", late);
 
     getAui().thread.message({ index: 0 }).ping("a");
     getAui().thread.message({ index: 1 }).ping("b");
     await flushEvents();
 
-    expect(boundToM0).toHaveBeenCalledExactlyOnceWith({ id: "m0", value: "a" });
-    expect(boundToM1).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "b" });
+    expect(early).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "b" });
+    expect(late).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "b" });
   });
 
   it("unsubscribe stops delivery", async () => {
@@ -281,6 +281,22 @@ describe("microtask delivery (live-set semantics)", () => {
 
     expect(first).toHaveBeenCalledExactlyOnceWith({ value: "x" });
     expect(late).toHaveBeenCalledExactlyOnceWith({ value: "x" });
+  });
+
+  it("a listener that unsubscribes and resubscribes between emit and flush is invoked", async () => {
+    const { getAui } = setup();
+    const aui = getAui();
+    const removed = vi.fn();
+    const unsub = aui.on("thread.pinged", removed);
+
+    aui.thread.ping("x");
+    unsub();
+    const resubscribed = vi.fn();
+    aui.on("thread.pinged", resubscribed);
+    await flushEvents();
+
+    expect(removed).not.toHaveBeenCalled();
+    expect(resubscribed).toHaveBeenCalledExactlyOnceWith({ value: "x" });
   });
 
   it("listeners removed between emit and flush are skipped", async () => {

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -159,8 +159,11 @@ const useClientFields = ({
             return;
           }
 
+          // Resolved against the host's current client: a structural swap
+          // replaces the client identity, and a listener subscribed on an
+          // earlier generation still follows the scope's present binding
           const scopeClient = getClientId(
-            this[scope as ClientNames],
+            (clientRef.current ?? this)[scope as ClientNames],
           ) as unknown as ClientMethods;
           const index = getClientIndex(scopeClient);
           if (scopeClient === clientStack[index]) {
@@ -301,9 +304,14 @@ const useHostedAssistantClient = ({
     );
 
     // flushTapSync makes structural rebinds triggered by a notification land
-    // before the notification returns
+    // before the notification returns; the client ref is refreshed in the same
+    // window so event delivery resolves scopes against the post-flush client
     useEffect(() => {
-      const notify = () => flushTapSync(notifications.notifySubscribers);
+      const notify = () =>
+        flushTapSync(() => {
+          clientRef.current = store.getValue().client;
+          notifications.notifySubscribers();
+        });
       const unsubscribeStore = store.subscribe(notify);
       const unsubscribeParent = parent.subscribe(notify);
       return () => {

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -162,8 +162,14 @@ const useClientFields = ({
           // Resolved against the host's current client: a structural swap
           // replaces the client identity, and a listener subscribed on an
           // earlier generation still follows the scope's present binding
+          const boundScope = (clientRef.current ?? this)[
+            scope as ClientNames
+          ] as AssistantClientAccessor<ClientNames> | undefined;
+          // A scope removed by a structural change since subscription cannot
+          // match; resolving its identity would throw
+          if (!boundScope || boundScope.source === null) return;
           const scopeClient = getClientId(
-            (clientRef.current ?? this)[scope as ClientNames],
+            boundScope,
           ) as unknown as ClientMethods;
           const index = getClientIndex(scopeClient);
           if (scopeClient === clientStack[index]) {

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -52,11 +52,14 @@ export const createNotificationManager = (): NotificationManager => {
     },
 
     emit(event, payload, clientStack) {
-      const eventListeners = listeners.get(event);
-      if (!eventListeners && wildcardListeners.size === 0) return;
+      if (!listeners.has(event) && wildcardListeners.size === 0) return;
 
       queueMicrotask(() => {
         const errors = [];
+        // Resolved at flush time: a consumer that unsubscribed and resubscribed
+        // since the emit lands in a fresh set, and the live-set contract says
+        // the in-flight emission still reaches it
+        const eventListeners = listeners.get(event);
         if (eventListeners) {
           for (const cb of eventListeners) {
             try {

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -172,11 +172,7 @@ export const ThreadPrimitiveViewport = defineComponent({
       scheduleScrollToBottom("auto");
     });
 
-    // A non-star subscription matches the emitting client against the
-    // listener's scope binding at delivery time; on a switch the event is
-    // emitted by the newly main item client before the derived threadListItem
-    // binding re-resolves to it, so only a star scope observes the emission.
-    useAuiEvent({ scope: "*", event: "threadListItem.switchedTo" }, () => {
+    useAuiEvent("threadListItem.switchedTo", () => {
       if (!props.scrollToBottomOnThreadSwitch) return;
       scheduleScrollToBottom("instant");
     });


### PR DESCRIPTION
## what

closes #5699. a default-scope `useAuiEvent("threadListItem.switchedTo", cb)` never fired on a thread switch while a `{ scope: "*" }` subscription heard the same emission, leaving five shipped React and React Native listeners dead (composer refocus, top-anchor clear, switch scroll, input history reset, RN thread messages) and forcing the Vue viewport onto a wildcard workaround.

two independent causes, each fixed at its own seam, plus the notification manager contract restoration from #5710:

1. **the emission ran before the store settled.** `threadListItem.switchedTo` was relayed from the runtime's synchronous notification, which fires inside the swap, before the tap flush rebinds the derived scopes. the item client now emits from its own observed selection transition (`isMain` / id flip) in an effect, which runs after the flush by construction, for every host: React, Vue, and standalone roots alike. mount-as-main does not emit, matching the old relay whose subscription also attached after a creation swap.
2. **a structural swap orphaned existing listeners.** `useCommittedClient` replaces the client object identity on a structural change, so a listener's captured `this` kept resolving the pre-swap binding forever, and no emission timing can fix that side. scoped delivery now resolves the scope against the host's current client (`clientRef.current`) at delivery time, as the single semantic for both `aui.on` and `useAuiEvent`. the hosted path refreshes the ref inside the existing `flushTapSync` notification closure, the same channel `createAssistantClient` already uses, so no render-phase writes are involved. the "listeners bind to the instance resolved at subscription time" contract test is deliberately flipped: pinning an instance is what id-scoped clients are for.
3. **the flush-time listener set re-read** (kept from #5710, thanks @samdickson22 for isolating it): `emit` no longer snapshots the listener set, so a consumer that unsubscribes and resubscribes between emit and flush still receives the in-flight emission, per the documented live-set semantics.

this supersedes #5710. the binding-mode parameter and the render-phase `clientRef` assignment it introduced are not needed once the emission itself happens after the flush, and a single delivery semantic avoids `aui.on` and `useAuiEvent` diverging on the same selector.

the pre-existing derived-only provider gap surfaced during that review (scoped listeners under by-index providers resolve the parent's scopes) is unaffected by this change in either direction and is now tracked as #5768.

## verification

- new contract test `packages/core/src/tests/thread-switch-events.test.tsx`: the issue's external-store repro as a permanent test, asserting default-scope, star-scope, and `aui.on` subscriptions each hear exactly one `switchedTo` per switch with the right payload, round-trip switches included, and that mount emits nothing.
- store tests: a resubscribe-between-emit-and-flush case for the live-set re-read, and the delivery-time flip of the binding contract test.
- isolated red-first matrix: each of the three source changes reverted alone (file swap, everything else in place) turns exactly its own test red.
- the Vue viewport wildcard workaround from #5698 is reverted to the documented default form and its suite passes, so the fix is proven at a consumer.
- suites: store 143, core 1012, react 404 plus typecheck, vue 66; oxlint and oxfmt clean; api-reference regeneration produces no drift.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.gb2q_TymPXmOfjt3DHR6ALqj_jBWMoiX8EgZVByojub6wzAYhdS61RsJZp8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->