### PR TITLE
fix(cloud-ai-sdk): settle disabled in-flight thread refreshes

### DIFF
--- a/.changeset/settle-disabled-cloud-refresh.md
+++ b/.changeset/settle-disabled-cloud-refresh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: settle thread loading when automatic fetching becomes disabled

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -137,6 +137,34 @@ describe("useThreads", () => {
     });
   });
 
+  it("settles loading when automatic fetching becomes disabled", async () => {
+    const deferred =
+      createDeferred<ReturnType<typeof createThreadListResponse>>();
+    const list = vi.fn().mockReturnValue(deferred.promise);
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useThreads({ cloud, enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(list).toHaveBeenCalledOnce();
+
+    rerender({ enabled: false });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(list).toHaveBeenCalledOnce();
+  });
+
   it("keeps the latest refresh when requests resolve out of order", async () => {
     const first = createDeferred<ReturnType<typeof createThreadListResponse>>();
     const second =

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -73,7 +73,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
 
   if (enabled !== previousEnabled) {
     setPreviousEnabled(enabled);
-    if (enabled) setIsLoading(true);
+    setIsLoading(enabled);
   }
 
   const mountedRef = useRef(true);


### PR DESCRIPTION
## Summary

- clear the thread loading state when automatic fetching changes from enabled to disabled
- preserve the existing pending request behavior while preventing a permanent loading indicator when that request hangs
- add a regression test for disabling during an unresolved initial refresh

## Problem

`useThreads()` set `isLoading` when `enabled` changed to `true`, but did nothing for the reverse transition. If an automatic refresh was still pending and never settled, switching to `enabled: false` left consumers at `isLoading: true` indefinitely even though automatic fetching was disabled.

## Sequencing

This is a focused follow-up to #5706 and is based on its branch because that PR changes the same loading and Cloud-scope state. It should land after #5706 and then be retargeted to `main`.

## Verification

- reproduced `isLoading: true` after the `true` to `false` transition before the fix
- `pnpm exec vitest run src/threads/useThreads.test.ts` (11 tests)
- `pnpm exec oxlint packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.21C6lXyS0X3vnJmRae6odHDzWbG4sr9BaOt5HBXrCtlCXaQ03BpSPLDpdvk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->