### PR TITLE
fix(react): keep in-memory thread selection valid after mutations

### DIFF
--- a/.changeset/valid-in-memory-thread-selection.md
+++ b/.changeset/valid-in-memory-thread-selection.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep in-memory thread selections valid after archive and delete operations

--- a/.changeset/valid-in-memory-thread-selection.md
+++ b/.changeset/valid-in-memory-thread-selection.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: keep in-memory thread selections valid after archive and delete operations
+fix: keep in-memory thread selections valid after archive and delete operations by selecting a fresh thread when the active thread is removed from the regular list

--- a/.changeset/valid-in-memory-thread-selection.md
+++ b/.changeset/valid-in-memory-thread-selection.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: keep in-memory thread selections valid after archive and delete operations by selecting a live thread or creating one when needed
+fix: keep in-memory thread selections valid after archive and delete operations, and notify consumers when those mutations relocate the selection

--- a/.changeset/valid-in-memory-thread-selection.md
+++ b/.changeset/valid-in-memory-thread-selection.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: keep in-memory thread selections valid after archive and delete operations by selecting a fresh thread when the active thread is removed from the regular list
+fix: keep in-memory thread selections valid after archive and delete operations by selecting a live thread or creating one when needed

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -32,20 +32,13 @@ type ThreadListData = {
   threads: readonly ThreadData[];
 };
 
-const ensureRegularMainThread = (
+const replaceChangedMainThread = (
   threads: readonly ThreadData[],
   mainThreadId: string,
+  changedThreadId: string,
   fallbackId: string,
 ): ThreadListData => {
-  const fallback = threads.find((thread) => thread.status === "regular");
-  if (
-    threads.some(
-      (thread) => thread.id === mainThreadId && thread.status === "regular",
-    )
-  ) {
-    return { mainThreadId, threads };
-  }
-  if (fallback) return { mainThreadId: fallback.id, threads };
+  if (mainThreadId !== changedThreadId) return { mainThreadId, threads };
 
   return {
     mainThreadId: fallbackId,
@@ -140,11 +133,12 @@ const useInMemoryThreadList = (
   const handleArchive = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
     setThreadList((prev) =>
-      ensureRegularMainThread(
+      replaceChangedMainThread(
         prev.threads.map((t) =>
           t.id === threadId ? { ...t, status: "archived" as const } : t,
         ),
         prev.mainThreadId,
+        threadId,
         fallbackId,
       ),
     );
@@ -174,9 +168,10 @@ const useInMemoryThreadList = (
   const handleDelete = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
     setThreadList((prev) =>
-      ensureRegularMainThread(
+      replaceChangedMainThread(
         prev.threads.filter((t) => t.id !== threadId),
         prev.mainThreadId,
+        threadId,
         fallbackId,
       ),
     );

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -126,30 +126,22 @@ const useInMemoryThreadList = (
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
       pendingSwitchId: null,
     }));
-  const notifySwitchToThread = useEffectEvent((threadId: string) => {
-    onSwitchToThread?.(threadId);
-  });
-  const pendingSwitchIdRef = useRef(pendingSwitchId);
-  pendingSwitchIdRef.current = pendingSwitchId;
-
-  useEffect(() => {
-    if (
-      pendingSwitchId === null ||
-      pendingSwitchIdRef.current !== pendingSwitchId
-    ) {
-      return;
-    }
-    pendingSwitchIdRef.current = null;
+  const flushPendingSwitch = useEffectEvent((threadId: string) => {
+    if (pendingSwitchId !== threadId) return;
     setThreadList((prev) =>
-      prev.pendingSwitchId === pendingSwitchId
+      prev.pendingSwitchId === threadId
         ? { ...prev, pendingSwitchId: null }
         : prev,
     );
-    notifySwitchToThread(pendingSwitchId);
+    onSwitchToThread?.(threadId);
+  });
+
+  useEffect(() => {
+    if (pendingSwitchId === null) return;
+    flushPendingSwitch(pendingSwitchId);
   }, [pendingSwitchId]);
 
   const handleSwitchToThread = (threadId: string) => {
-    pendingSwitchIdRef.current = null;
     setThreadList((prev) => ({
       ...prev,
       mainThreadId: threadId,
@@ -221,7 +213,6 @@ const useInMemoryThreadList = (
 
   const handleSwitchToNewThread = () => {
     const newId = `thread-${generateId()}`;
-    pendingSwitchIdRef.current = null;
     setThreadList((prev) => ({
       mainThreadId: newId,
       pendingSwitchId: null,

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -40,6 +40,9 @@ const replaceChangedMainThread = (
 ): ThreadListData => {
   if (mainThreadId !== changedThreadId) return { mainThreadId, threads };
 
+  const fallback = threads.find((thread) => thread.status === "regular");
+  if (fallback) return { mainThreadId: fallback.id, threads };
+
   return {
     mainThreadId: fallbackId,
     threads: [

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -17,8 +17,8 @@ const RESOLVED_PROMISE = Promise.resolve();
 export type InMemoryThreadListProps = {
   thread: (threadId: string) => ResourceElement<ClientOutput<"thread">>;
   /**
-   * Called whenever the selected thread changes, including automatic
-   * relocations after archiving or deleting the selected thread. Replacement
+   * Called after an explicit `switchToThread()` action or an automatic
+   * relocation after archiving or deleting the selected thread. Replacement
    * threads created during relocation report their generated ID here.
    */
   onSwitchToThread?: (threadId: string) => void;

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -27,6 +27,35 @@ type ThreadData = {
   custom?: Record<string, unknown> | undefined;
 };
 
+type ThreadListData = {
+  mainThreadId: string;
+  threads: readonly ThreadData[];
+};
+
+const ensureRegularMainThread = (
+  threads: readonly ThreadData[],
+  mainThreadId: string,
+  fallbackId: string,
+): ThreadListData => {
+  const fallback = threads.find((thread) => thread.status === "regular");
+  if (
+    threads.some(
+      (thread) => thread.id === mainThreadId && thread.status === "regular",
+    )
+  ) {
+    return { mainThreadId, threads };
+  }
+  if (fallback) return { mainThreadId: fallback.id, threads };
+
+  return {
+    mainThreadId: fallbackId,
+    threads: [
+      ...threads,
+      { id: fallbackId, title: "New Thread", status: "regular" },
+    ],
+  };
+};
+
 // ThreadListItem Client
 const useThreadListItemClient = (props: {
   data: ThreadData;
@@ -87,63 +116,81 @@ const useInMemoryThreadList = (
     onSwitchToNewThread,
   } = props;
 
-  const [mainThreadId, setMainThreadId] = useState("main");
-  const [threads, setThreads] = useState<readonly ThreadData[]>(() => [
-    { id: "main", title: "Main Thread", status: "regular" },
-  ]);
+  const [{ mainThreadId, threads }, setThreadList] = useState<ThreadListData>(
+    () => ({
+      mainThreadId: "main",
+      threads: [{ id: "main", title: "Main Thread", status: "regular" }],
+    }),
+  );
 
   const handleSwitchToThread = (threadId: string) => {
-    setMainThreadId(threadId);
+    setThreadList((prev) => ({ ...prev, mainThreadId: threadId }));
     onSwitchToThread?.(threadId);
   };
 
   const handleRename = (threadId: string, title: string) => {
-    setThreads((prev) =>
-      prev.map((t) => (t.id === threadId ? { ...t, title } : t)),
-    );
+    setThreadList((prev) => ({
+      ...prev,
+      threads: prev.threads.map((t) =>
+        t.id === threadId ? { ...t, title } : t,
+      ),
+    }));
   };
 
   const handleArchive = (threadId: string) => {
-    setThreads((prev) =>
-      prev.map((t) =>
-        t.id === threadId ? { ...t, status: "archived" as const } : t,
+    const fallbackId = `thread-${generateId()}`;
+    setThreadList((prev) =>
+      ensureRegularMainThread(
+        prev.threads.map((t) =>
+          t.id === threadId ? { ...t, status: "archived" as const } : t,
+        ),
+        prev.mainThreadId,
+        fallbackId,
       ),
     );
   };
 
   const handleUnarchive = (threadId: string) => {
-    setThreads((prev) =>
-      prev.map((t) =>
+    setThreadList((prev) => ({
+      ...prev,
+      threads: prev.threads.map((t) =>
         t.id === threadId ? { ...t, status: "regular" as const } : t,
       ),
-    );
+    }));
   };
 
   const handleUpdateCustom = (
     threadId: string,
     custom: Record<string, unknown> | undefined,
   ) => {
-    setThreads((prev) =>
-      prev.map((t) => (t.id === threadId ? { ...t, custom } : t)),
-    );
+    setThreadList((prev) => ({
+      ...prev,
+      threads: prev.threads.map((t) =>
+        t.id === threadId ? { ...t, custom } : t,
+      ),
+    }));
   };
 
   const handleDelete = (threadId: string) => {
-    setThreads((prev) => prev.filter((t) => t.id !== threadId));
-    setMainThreadId((prev) =>
-      prev === threadId
-        ? threads.find((t) => t.id !== threadId)?.id || "main"
-        : prev,
+    const fallbackId = `thread-${generateId()}`;
+    setThreadList((prev) =>
+      ensureRegularMainThread(
+        prev.threads.filter((t) => t.id !== threadId),
+        prev.mainThreadId,
+        fallbackId,
+      ),
     );
   };
 
   const handleSwitchToNewThread = () => {
     const newId = `thread-${generateId()}`;
-    setThreads((prev) => [
-      ...prev,
-      { id: newId, title: "New Thread", status: "regular" },
-    ]);
-    setMainThreadId(newId);
+    setThreadList((prev) => ({
+      mainThreadId: newId,
+      threads: [
+        ...prev.threads,
+        { id: newId, title: "New Thread", status: "regular" },
+      ],
+    }));
     onSwitchToNewThread?.();
   };
 

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -126,7 +126,6 @@ const useInMemoryThreadList = (
       pendingSwitchId: null,
     }));
   const flushPendingSwitch = useEffectEvent((threadId: string) => {
-    if (pendingSwitchId !== threadId) return;
     setThreadList((prev) =>
       prev.pendingSwitchId === threadId
         ? { ...prev, pendingSwitchId: null }

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -202,6 +202,8 @@ const useInMemoryThreadList = (
   const handleDelete = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
     setThreadList((prev) => {
+      if (!prev.threads.some((thread) => thread.id === threadId)) return prev;
+
       const nextThreads = prev.threads.filter((t) => t.id !== threadId);
       return replaceChangedMainThread(
         nextThreads,

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -30,21 +30,28 @@ type ThreadData = {
 type ThreadListData = {
   mainThreadId: string;
   threads: readonly ThreadData[];
+  pendingSwitchId: string | null;
 };
 
 const replaceChangedMainThread = (
   threads: readonly ThreadData[],
   mainThreadId: string,
+  pendingSwitchId: string | null,
   changedThreadId: string,
   fallbackId: string,
 ): ThreadListData => {
-  if (mainThreadId !== changedThreadId) return { mainThreadId, threads };
+  if (mainThreadId !== changedThreadId) {
+    return { mainThreadId, threads, pendingSwitchId };
+  }
 
   const fallback = threads.find((thread) => thread.status === "regular");
-  if (fallback) return { mainThreadId: fallback.id, threads };
+  if (fallback) {
+    return { mainThreadId: fallback.id, threads, pendingSwitchId: fallback.id };
+  }
 
   return {
     mainThreadId: fallbackId,
+    pendingSwitchId: fallbackId,
     threads: [
       ...threads,
       { id: fallbackId, title: "New Thread", status: "regular" },
@@ -112,15 +119,32 @@ const useInMemoryThreadList = (
     onSwitchToNewThread,
   } = props;
 
-  const [{ mainThreadId, threads }, setThreadList] = useState<ThreadListData>(
-    () => ({
+  const [{ mainThreadId, threads, pendingSwitchId }, setThreadList] =
+    useState<ThreadListData>(() => ({
       mainThreadId: "main",
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
-    }),
-  );
+      pendingSwitchId: null,
+    }));
+  const notifySwitchToThread = useEffectEvent((threadId: string) => {
+    onSwitchToThread?.(threadId);
+  });
+
+  useEffect(() => {
+    if (pendingSwitchId === null) return;
+    setThreadList((prev) =>
+      prev.pendingSwitchId === pendingSwitchId
+        ? { ...prev, pendingSwitchId: null }
+        : prev,
+    );
+    notifySwitchToThread(pendingSwitchId);
+  }, [pendingSwitchId]);
 
   const handleSwitchToThread = (threadId: string) => {
-    setThreadList((prev) => ({ ...prev, mainThreadId: threadId }));
+    setThreadList((prev) => ({
+      ...prev,
+      mainThreadId: threadId,
+      pendingSwitchId: null,
+    }));
     onSwitchToThread?.(threadId);
   };
 
@@ -141,6 +165,7 @@ const useInMemoryThreadList = (
           t.id === threadId ? { ...t, status: "archived" as const } : t,
         ),
         prev.mainThreadId,
+        prev.pendingSwitchId,
         threadId,
         fallbackId,
       ),
@@ -174,6 +199,7 @@ const useInMemoryThreadList = (
       replaceChangedMainThread(
         prev.threads.filter((t) => t.id !== threadId),
         prev.mainThreadId,
+        prev.pendingSwitchId,
         threadId,
         fallbackId,
       ),
@@ -184,6 +210,7 @@ const useInMemoryThreadList = (
     const newId = `thread-${generateId()}`;
     setThreadList((prev) => ({
       mainThreadId: newId,
+      pendingSwitchId: null,
       threads: [
         ...prev.threads,
         { id: newId, title: "New Thread", status: "regular" },

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -44,6 +44,7 @@ const replaceChangedMainThread = (
     return { mainThreadId, threads, pendingSwitchId };
   }
 
+  // Local mutations reuse a live sibling instead of creating an empty thread.
   const fallback = threads.find((thread) => thread.status === "regular");
   if (fallback) {
     return { mainThreadId: fallback.id, threads, pendingSwitchId: fallback.id };
@@ -128,9 +129,17 @@ const useInMemoryThreadList = (
   const notifySwitchToThread = useEffectEvent((threadId: string) => {
     onSwitchToThread?.(threadId);
   });
+  const pendingSwitchIdRef = useRef(pendingSwitchId);
+  pendingSwitchIdRef.current = pendingSwitchId;
 
   useEffect(() => {
-    if (pendingSwitchId === null) return;
+    if (
+      pendingSwitchId === null ||
+      pendingSwitchIdRef.current !== pendingSwitchId
+    ) {
+      return;
+    }
+    pendingSwitchIdRef.current = null;
     setThreadList((prev) =>
       prev.pendingSwitchId === pendingSwitchId
         ? { ...prev, pendingSwitchId: null }
@@ -140,6 +149,7 @@ const useInMemoryThreadList = (
   }, [pendingSwitchId]);
 
   const handleSwitchToThread = (threadId: string) => {
+    pendingSwitchIdRef.current = null;
     setThreadList((prev) => ({
       ...prev,
       mainThreadId: threadId,
@@ -211,6 +221,7 @@ const useInMemoryThreadList = (
 
   const handleSwitchToNewThread = () => {
     const newId = `thread-${generateId()}`;
+    pendingSwitchIdRef.current = null;
     setThreadList((prev) => ({
       mainThreadId: newId,
       pendingSwitchId: null,

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -30,28 +30,44 @@ type ThreadData = {
 type ThreadListData = {
   mainThreadId: string;
   threads: readonly ThreadData[];
-  pendingSwitchId: string | null;
+  pendingSwitch: { threadId: string; version: number } | null;
+};
+
+const useSwitchVersion = () => {
+  const versionRef = useRef(0);
+  return useMemo(
+    () => ({
+      current: () => versionRef.current,
+      advance: () => ++versionRef.current,
+    }),
+    [],
+  );
 };
 
 const replaceChangedMainThread = (
   threads: readonly ThreadData[],
   mainThreadId: string,
-  pendingSwitchId: string | null,
+  pendingSwitch: ThreadListData["pendingSwitch"],
   changedThreadId: string,
   fallback: ThreadData | undefined,
   fallbackId: string,
+  switchVersion: number,
 ): ThreadListData => {
   if (mainThreadId !== changedThreadId) {
-    return { mainThreadId, threads, pendingSwitchId };
+    return { mainThreadId, threads, pendingSwitch };
   }
 
   if (fallback) {
-    return { mainThreadId: fallback.id, threads, pendingSwitchId: fallback.id };
+    return {
+      mainThreadId: fallback.id,
+      threads,
+      pendingSwitch: { threadId: fallback.id, version: switchVersion },
+    };
   }
 
   return {
     mainThreadId: fallbackId,
-    pendingSwitchId: fallbackId,
+    pendingSwitch: { threadId: fallbackId, version: switchVersion },
     threads: [
       ...threads,
       { id: fallbackId, title: "New Thread", status: "regular" },
@@ -119,32 +135,42 @@ const useInMemoryThreadList = (
     onSwitchToNewThread,
   } = props;
 
-  const [{ mainThreadId, threads, pendingSwitchId }, setThreadList] =
+  const switchVersion = useSwitchVersion();
+  const [{ mainThreadId, threads, pendingSwitch }, setThreadList] =
     useState<ThreadListData>(() => ({
       mainThreadId: "main",
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
-      pendingSwitchId: null,
+      pendingSwitch: null,
     }));
-  const flushPendingSwitch = useEffectEvent((threadId: string) => {
-    setThreadList((prev) =>
-      prev.pendingSwitchId === threadId
-        ? { ...prev, pendingSwitchId: null }
-        : prev,
-    );
-    onSwitchToThread?.(threadId);
-  });
+  const flushPendingSwitch = useEffectEvent(
+    (pending: NonNullable<ThreadListData["pendingSwitch"]>) => {
+      if (switchVersion.current() !== pending.version) return;
+
+      setThreadList((prev) =>
+        prev.pendingSwitch === pending
+          ? { ...prev, pendingSwitch: null }
+          : prev,
+      );
+      onSwitchToThread?.(pending.threadId);
+    },
+  );
 
   useEffect(() => {
-    if (pendingSwitchId === null) return;
-    flushPendingSwitch(pendingSwitchId);
-  }, [pendingSwitchId]);
+    if (pendingSwitch === null) return;
+    flushPendingSwitch(pendingSwitch);
+  }, [pendingSwitch]);
 
   const handleSwitchToThread = (threadId: string) => {
-    setThreadList((prev) => ({
-      ...prev,
-      mainThreadId: threadId,
-      pendingSwitchId: null,
-    }));
+    switchVersion.advance();
+    setThreadList((prev) =>
+      prev.mainThreadId === threadId && prev.pendingSwitch === null
+        ? prev
+        : {
+            ...prev,
+            mainThreadId: threadId,
+            pendingSwitch: null,
+          },
+    );
     onSwitchToThread?.(threadId);
   };
 
@@ -159,6 +185,7 @@ const useInMemoryThreadList = (
 
   const handleArchive = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
+    const currentSwitchVersion = switchVersion.current();
     setThreadList((prev) => {
       const thread = prev.threads.find((item) => item.id === threadId);
       if (thread?.status !== "regular") return prev;
@@ -169,10 +196,11 @@ const useInMemoryThreadList = (
       return replaceChangedMainThread(
         nextThreads,
         prev.mainThreadId,
-        prev.pendingSwitchId,
+        prev.pendingSwitch,
         threadId,
         nextThreads.find((item) => item.status === "regular"),
         fallbackId,
+        currentSwitchVersion,
       );
     });
   };
@@ -200,6 +228,7 @@ const useInMemoryThreadList = (
 
   const handleDelete = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
+    const currentSwitchVersion = switchVersion.current();
     setThreadList((prev) => {
       if (!prev.threads.some((thread) => thread.id === threadId)) return prev;
 
@@ -207,19 +236,21 @@ const useInMemoryThreadList = (
       return replaceChangedMainThread(
         nextThreads,
         prev.mainThreadId,
-        prev.pendingSwitchId,
+        prev.pendingSwitch,
         threadId,
         nextThreads[0],
         fallbackId,
+        currentSwitchVersion,
       );
     });
   };
 
   const handleSwitchToNewThread = () => {
     const newId = `thread-${generateId()}`;
+    switchVersion.advance();
     setThreadList((prev) => ({
       mainThreadId: newId,
-      pendingSwitchId: null,
+      pendingSwitch: null,
       threads: [
         ...prev.threads,
         { id: newId, title: "New Thread", status: "regular" },

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -125,27 +125,19 @@ const useInMemoryThreadList = (
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
       pendingSwitchId: null,
     }));
-  const pendingSwitchIdRef = useRef(pendingSwitchId);
-  const onSwitchToThreadRef = useRef(onSwitchToThread);
-
-  useEffect(() => {
-    pendingSwitchIdRef.current = pendingSwitchId;
-    onSwitchToThreadRef.current = onSwitchToThread;
-  }, [pendingSwitchId, onSwitchToThread]);
-
-  useEffect(() => {
-    if (
-      pendingSwitchId === null ||
-      pendingSwitchIdRef.current !== pendingSwitchId
-    ) {
-      return;
-    }
+  const flushPendingSwitch = useEffectEvent((threadId: string) => {
+    if (pendingSwitchId !== threadId) return;
     setThreadList((prev) =>
-      prev.pendingSwitchId === pendingSwitchId
+      prev.pendingSwitchId === threadId
         ? { ...prev, pendingSwitchId: null }
         : prev,
     );
-    onSwitchToThreadRef.current?.(pendingSwitchId);
+    onSwitchToThread?.(threadId);
+  });
+
+  useEffect(() => {
+    if (pendingSwitchId === null) return;
+    flushPendingSwitch(pendingSwitchId);
   }, [pendingSwitchId]);
 
   const handleSwitchToThread = (threadId: string) => {

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -125,20 +125,15 @@ const useInMemoryThreadList = (
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
       pendingSwitchId: null,
     }));
-  const flushPendingSwitch = useEffectEvent((threadId: string) => {
-    if (pendingSwitchId !== threadId) return;
+  useEffect(() => {
+    if (pendingSwitchId === null) return;
     setThreadList((prev) =>
-      prev.pendingSwitchId === threadId
+      prev.pendingSwitchId === pendingSwitchId
         ? { ...prev, pendingSwitchId: null }
         : prev,
     );
-    onSwitchToThread?.(threadId);
-  });
-
-  useEffect(() => {
-    if (pendingSwitchId === null) return;
-    flushPendingSwitch(pendingSwitchId);
-  }, [pendingSwitchId]);
+    onSwitchToThread?.(pendingSwitchId);
+  }, [pendingSwitchId, onSwitchToThread]);
 
   const handleSwitchToThread = (threadId: string) => {
     setThreadList((prev) => ({

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { resource, withKey, type ResourceElement } from "@assistant-ui/tap";
 import {
   type ClientOutput,
@@ -125,15 +125,28 @@ const useInMemoryThreadList = (
       threads: [{ id: "main", title: "Main Thread", status: "regular" }],
       pendingSwitchId: null,
     }));
+  const pendingSwitchIdRef = useRef(pendingSwitchId);
+  const onSwitchToThreadRef = useRef(onSwitchToThread);
+
   useEffect(() => {
-    if (pendingSwitchId === null) return;
+    pendingSwitchIdRef.current = pendingSwitchId;
+    onSwitchToThreadRef.current = onSwitchToThread;
+  }, [pendingSwitchId, onSwitchToThread]);
+
+  useEffect(() => {
+    if (
+      pendingSwitchId === null ||
+      pendingSwitchIdRef.current !== pendingSwitchId
+    ) {
+      return;
+    }
     setThreadList((prev) =>
       prev.pendingSwitchId === pendingSwitchId
         ? { ...prev, pendingSwitchId: null }
         : prev,
     );
-    onSwitchToThread?.(pendingSwitchId);
-  }, [pendingSwitchId, onSwitchToThread]);
+    onSwitchToThreadRef.current?.(pendingSwitchId);
+  }, [pendingSwitchId]);
 
   const handleSwitchToThread = (threadId: string) => {
     setThreadList((prev) => ({

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -16,7 +16,13 @@ const RESOLVED_PROMISE = Promise.resolve();
 
 export type InMemoryThreadListProps = {
   thread: (threadId: string) => ResourceElement<ClientOutput<"thread">>;
+  /**
+   * Called whenever the selected thread changes, including automatic
+   * relocations after archiving or deleting the selected thread. Replacement
+   * threads created during relocation report their generated ID here.
+   */
   onSwitchToThread?: (threadId: string) => void;
+  /** Called only for an explicit `switchToNewThread()` action. */
   onSwitchToNewThread?: () => void;
 };
 
@@ -238,6 +244,7 @@ const useInMemoryThreadList = (
         prev.mainThreadId,
         prev.pendingSwitch,
         threadId,
+        // Deletion may select an archived sibling to retain that conversation.
         nextThreads[0],
         fallbackId,
         currentSwitchVersion,

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -159,8 +159,11 @@ const useInMemoryThreadList = (
 
   const handleArchive = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
-    setThreadList((prev) =>
-      replaceChangedMainThread(
+    setThreadList((prev) => {
+      const thread = prev.threads.find((item) => item.id === threadId);
+      if (thread?.status !== "regular") return prev;
+
+      return replaceChangedMainThread(
         prev.threads.map((t) =>
           t.id === threadId ? { ...t, status: "archived" as const } : t,
         ),
@@ -168,8 +171,8 @@ const useInMemoryThreadList = (
         prev.pendingSwitchId,
         threadId,
         fallbackId,
-      ),
-    );
+      );
+    });
   };
 
   const handleUnarchive = (threadId: string) => {

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -38,14 +38,13 @@ const replaceChangedMainThread = (
   mainThreadId: string,
   pendingSwitchId: string | null,
   changedThreadId: string,
+  fallback: ThreadData | undefined,
   fallbackId: string,
 ): ThreadListData => {
   if (mainThreadId !== changedThreadId) {
     return { mainThreadId, threads, pendingSwitchId };
   }
 
-  // Local mutations reuse a live sibling instead of creating an empty thread.
-  const fallback = threads.find((thread) => thread.status === "regular");
   if (fallback) {
     return { mainThreadId: fallback.id, threads, pendingSwitchId: fallback.id };
   }
@@ -165,13 +164,15 @@ const useInMemoryThreadList = (
       const thread = prev.threads.find((item) => item.id === threadId);
       if (thread?.status !== "regular") return prev;
 
+      const nextThreads = prev.threads.map((t) =>
+        t.id === threadId ? { ...t, status: "archived" as const } : t,
+      );
       return replaceChangedMainThread(
-        prev.threads.map((t) =>
-          t.id === threadId ? { ...t, status: "archived" as const } : t,
-        ),
+        nextThreads,
         prev.mainThreadId,
         prev.pendingSwitchId,
         threadId,
+        nextThreads.find((item) => item.status === "regular"),
         fallbackId,
       );
     });
@@ -200,15 +201,17 @@ const useInMemoryThreadList = (
 
   const handleDelete = (threadId: string) => {
     const fallbackId = `thread-${generateId()}`;
-    setThreadList((prev) =>
-      replaceChangedMainThread(
-        prev.threads.filter((t) => t.id !== threadId),
+    setThreadList((prev) => {
+      const nextThreads = prev.threads.filter((t) => t.id !== threadId);
+      return replaceChangedMainThread(
+        nextThreads,
         prev.mainThreadId,
         prev.pendingSwitchId,
         threadId,
+        nextThreads[0],
         fallbackId,
-      ),
-    );
+      );
+    });
   };
 
   const handleSwitchToNewThread = () => {

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -125,6 +125,33 @@ describe("InMemoryThreadList", () => {
     expect(onSwitchToThread).not.toHaveBeenCalled();
   });
 
+  it("preserves an archived selection when another thread is archived", async () => {
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
+
+    aui().threads.item({ id: "main" }).archive();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+    const regularId = aui().threads.getState().mainThreadId;
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+    onSwitchToThread.mockClear();
+
+    act(() => aui().threads.item({ id: regularId }).archive());
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.mainThreadId).toBe("main");
+      expect(state.threadIds).toEqual([]);
+      expect(state.archivedThreadIds).toEqual(["main", regularId]);
+      expect(onSwitchToThread).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps the selection valid across batched deletions", async () => {
     const { aui } = renderThreads();
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
+import { flushSync } from "react-dom";
 import { describe, it, expect, vi } from "vitest";
 import { useAui, AuiProvider } from "@assistant-ui/store";
 import { InMemoryThreadList } from "../client/InMemoryThreadList";
@@ -262,7 +263,7 @@ describe("InMemoryThreadList", () => {
     await waitFor(() =>
       expect(aui().threads.getState().threadIds).toHaveLength(3),
     );
-    const [, relocationId, latestId] = aui().threads.getState().threadIds;
+    const [, , latestId] = aui().threads.getState().threadIds;
 
     aui().threads.switchToThread("main");
     await waitFor(() =>
@@ -277,9 +278,33 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       expect(aui().threads.getState().mainThreadId).toBe(latestId);
-      expect(onSwitchToThread).toHaveBeenCalledOnce();
-      expect(onSwitchToThread).toHaveBeenCalledWith(latestId);
-      expect(onSwitchToThread).not.toHaveBeenCalledWith(relocationId);
+      expect(onSwitchToThread.mock.calls).toEqual([[latestId]]);
+    });
+  });
+
+  it("does not report a relocation superseded before its effect flushes", async () => {
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
+
+    aui().threads.switchToNewThread();
+    aui().threads.switchToNewThread();
+    await waitFor(() =>
+      expect(aui().threads.getState().threadIds).toHaveLength(3),
+    );
+    const [, , latestId] = aui().threads.getState().threadIds;
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+    onSwitchToThread.mockClear();
+
+    flushSync(() => aui().threads.item({ id: "main" }).archive());
+    aui().threads.switchToThread(latestId!);
+
+    await waitFor(() => {
+      expect(aui().threads.getState().mainThreadId).toBe(latestId);
+      expect(onSwitchToThread.mock.calls).toEqual([[latestId]]);
     });
   });
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -30,7 +30,7 @@ const renderThreads = () => {
 };
 
 describe("InMemoryThreadList", () => {
-  it("creates a new selection when the selected thread is archived", async () => {
+  it("selects an existing regular thread when the selected thread is archived", async () => {
     const { aui } = renderThreads();
 
     aui().threads.switchToNewThread();
@@ -44,9 +44,7 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       const state = aui().threads.getState();
-      expect(state.mainThreadId).not.toBe("main");
-      expect(state.mainThreadId).not.toBe(siblingId);
-      expect(state.threadIds).toContain(state.mainThreadId);
+      expect(state.mainThreadId).toBe(siblingId);
       expect(state.threadIds).toContain(siblingId);
       expect(state.archivedThreadIds).toEqual(["main"]);
     });
@@ -98,14 +96,12 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       const state = aui().threads.getState();
-      expect(state.threadIds).toContain(lastGeneratedId);
-      expect(state.threadIds).toContain(state.mainThreadId);
-      expect(state.threadIds).not.toContain("main");
-      expect(state.threadIds).not.toContain(firstGeneratedId);
+      expect(state.threadIds).toEqual([lastGeneratedId]);
+      expect(state.mainThreadId).toBe(lastGeneratedId);
     });
   });
 
-  it("creates a live replacement when the switch target is deleted in the same tick", async () => {
+  it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
     const { aui } = renderThreads();
 
     aui().threads.switchToNewThread();
@@ -123,8 +119,7 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       const state = aui().threads.getState();
-      expect(state.mainThreadId).not.toBe("main");
-      expect(state.threadIds).toContain(state.mainThreadId);
+      expect(state.mainThreadId).toBe("main");
       expect(state.threadIds).not.toContain(newId);
     });
   });

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -253,6 +253,36 @@ describe("InMemoryThreadList", () => {
     });
   });
 
+  it("does not report a relocation superseded by a newer switch", async () => {
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
+
+    aui().threads.switchToNewThread();
+    aui().threads.switchToNewThread();
+    await waitFor(() =>
+      expect(aui().threads.getState().threadIds).toHaveLength(3),
+    );
+    const [, relocationId, latestId] = aui().threads.getState().threadIds;
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+    onSwitchToThread.mockClear();
+
+    act(() => {
+      aui().threads.item({ id: "main" }).archive();
+      aui().threads.switchToThread(latestId!);
+    });
+
+    await waitFor(() => {
+      expect(aui().threads.getState().mainThreadId).toBe(latestId);
+      expect(onSwitchToThread).toHaveBeenCalledOnce();
+      expect(onSwitchToThread).toHaveBeenCalledWith(latestId);
+      expect(onSwitchToThread).not.toHaveBeenCalledWith(relocationId);
+    });
+  });
+
   it("creates unique IDs for threads created in the same millisecond", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -83,6 +83,27 @@ describe("InMemoryThreadList", () => {
     });
   });
 
+  it("preserves an archived selection when it is archived again", async () => {
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
+
+    aui().threads.item({ id: "main" }).archive();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+    onSwitchToThread.mockClear();
+
+    act(() => aui().threads.item({ id: "main" }).archive());
+
+    expect(aui().threads.getState().mainThreadId).toBe("main");
+    expect(onSwitchToThread).not.toHaveBeenCalled();
+  });
+
   it("keeps the selection valid across batched deletions", async () => {
     const { aui } = renderThreads();
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -176,6 +176,27 @@ describe("InMemoryThreadList", () => {
     });
   });
 
+  it("reports a replacement when the last thread is deleted", async () => {
+    const onSwitchToThread = vi.fn();
+    const onSwitchToNewThread = vi.fn();
+    const { aui } = renderThreads({
+      onSwitchToThread,
+      onSwitchToNewThread,
+    });
+
+    act(() => aui().threads.item({ id: "main" }).delete());
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.threadIds).toHaveLength(1);
+      expect(state.threadIds).not.toContain("main");
+      expect(state.mainThreadId).toBe(state.threadIds[0]);
+      expect(onSwitchToThread).toHaveBeenCalledOnce();
+      expect(onSwitchToThread).toHaveBeenCalledWith(state.mainThreadId);
+      expect(onSwitchToNewThread).not.toHaveBeenCalled();
+    });
+  });
+
   it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
     const onSwitchToThread = vi.fn();
     const { aui } = renderThreads({ onSwitchToThread });

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -60,6 +60,27 @@ describe("InMemoryThreadList", () => {
     });
   });
 
+  it("reports a replacement when the last regular thread is archived", async () => {
+    const onSwitchToThread = vi.fn();
+    const onSwitchToNewThread = vi.fn();
+    const { aui } = renderThreads({
+      onSwitchToThread,
+      onSwitchToNewThread,
+    });
+
+    act(() => aui().threads.item({ id: "main" }).archive());
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.threadIds).toHaveLength(1);
+      expect(state.mainThreadId).toBe(state.threadIds[0]);
+      expect(state.archivedThreadIds).toEqual(["main"]);
+      expect(onSwitchToThread).toHaveBeenCalledOnce();
+      expect(onSwitchToThread).toHaveBeenCalledWith(state.mainThreadId);
+      expect(onSwitchToNewThread).not.toHaveBeenCalled();
+    });
+  });
+
   it("preserves an archived selection after an unrelated deletion", async () => {
     const { aui } = renderThreads();
 
@@ -129,6 +150,29 @@ describe("InMemoryThreadList", () => {
       const state = aui().threads.getState();
       expect(state.threadIds).toEqual([lastGeneratedId]);
       expect(state.mainThreadId).toBe(lastGeneratedId);
+    });
+  });
+
+  it("preserves the archived sibling fallback when the selected thread is deleted", async () => {
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
+
+    aui().threads.item({ id: "main" }).archive();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+    const regularId = aui().threads.getState().mainThreadId;
+    onSwitchToThread.mockClear();
+
+    act(() => aui().threads.item({ id: regularId }).delete());
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.mainThreadId).toBe("main");
+      expect(state.threadIds).toEqual([]);
+      expect(state.archivedThreadIds).toEqual(["main"]);
+      expect(onSwitchToThread).toHaveBeenCalledOnce();
+      expect(onSwitchToThread).toHaveBeenCalledWith("main");
     });
   });
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -7,7 +7,12 @@ import { useAui, AuiProvider } from "@assistant-ui/store";
 import { InMemoryThreadList } from "../client/InMemoryThreadList";
 import { ExternalThread } from "../index";
 
-const renderThreads = () => {
+const renderThreads = (
+  callbacks: {
+    onSwitchToThread?: (threadId: string) => void;
+    onSwitchToNewThread?: () => void;
+  } = {},
+) => {
   const captured: { aui?: ReturnType<typeof useAui> } = {};
   const Capture: FC = () => {
     captured.aui = useAui();
@@ -17,6 +22,7 @@ const renderThreads = () => {
     const aui = useAui({
       threads: InMemoryThreadList({
         thread: () => ExternalThread({ messages: [] }),
+        ...callbacks,
       }),
     });
     return (
@@ -31,7 +37,8 @@ const renderThreads = () => {
 
 describe("InMemoryThreadList", () => {
   it("selects an existing regular thread when the selected thread is archived", async () => {
-    const { aui } = renderThreads();
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
 
     aui().threads.switchToNewThread();
     await waitFor(() =>
@@ -39,14 +46,17 @@ describe("InMemoryThreadList", () => {
     );
     const siblingId = aui().threads.getState().mainThreadId;
     aui().threads.switchToThread("main");
+    onSwitchToThread.mockClear();
 
-    aui().threads.item({ id: "main" }).archive();
+    act(() => aui().threads.item({ id: "main" }).archive());
 
     await waitFor(() => {
       const state = aui().threads.getState();
       expect(state.mainThreadId).toBe(siblingId);
       expect(state.threadIds).toContain(siblingId);
       expect(state.archivedThreadIds).toEqual(["main"]);
+      expect(onSwitchToThread).toHaveBeenCalledOnce();
+      expect(onSwitchToThread).toHaveBeenCalledWith(siblingId);
     });
   });
 
@@ -102,7 +112,8 @@ describe("InMemoryThreadList", () => {
   });
 
   it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
-    const { aui } = renderThreads();
+    const onSwitchToThread = vi.fn();
+    const { aui } = renderThreads({ onSwitchToThread });
 
     aui().threads.switchToNewThread();
     await waitFor(() =>
@@ -113,14 +124,19 @@ describe("InMemoryThreadList", () => {
     await waitFor(() =>
       expect(aui().threads.getState().mainThreadId).toBe("main"),
     );
+    onSwitchToThread.mockClear();
 
-    aui().threads.switchToThread(newId);
-    aui().threads.item({ id: newId }).delete();
+    act(() => {
+      aui().threads.switchToThread(newId);
+      aui().threads.item({ id: newId }).delete();
+    });
 
     await waitFor(() => {
       const state = aui().threads.getState();
       expect(state.mainThreadId).toBe("main");
       expect(state.threadIds).not.toContain(newId);
+      expect(onSwitchToThread).toHaveBeenCalledTimes(2);
+      expect(onSwitchToThread).toHaveBeenLastCalledWith("main");
     });
   });
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { useAui, AuiProvider } from "@assistant-ui/store";
@@ -30,6 +30,47 @@ const renderThreads = () => {
 };
 
 describe("InMemoryThreadList", () => {
+  it("moves away from a selected thread when it is archived", async () => {
+    const { aui } = renderThreads();
+
+    aui().threads.item({ id: "main" }).archive();
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.mainThreadId).not.toBe("main");
+      expect(state.threadIds).toContain(state.mainThreadId);
+      expect(state.archivedThreadIds).toEqual(["main"]);
+    });
+  });
+
+  it("keeps the selection valid across batched deletions", async () => {
+    const { aui } = renderThreads();
+
+    aui().threads.switchToNewThread();
+    aui().threads.switchToNewThread();
+    await waitFor(() =>
+      expect(aui().threads.getState().threadIds).toHaveLength(3),
+    );
+    const [, firstGeneratedId, lastGeneratedId] =
+      aui().threads.getState().threadIds;
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+
+    act(() => {
+      aui().threads.item({ id: "main" }).delete();
+      aui().threads.item({ id: firstGeneratedId! }).delete();
+    });
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.threadIds).toEqual([lastGeneratedId]);
+      expect(state.mainThreadId).toBe(lastGeneratedId);
+    });
+  });
+
   it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
     const { aui } = renderThreads();
 

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -30,16 +30,48 @@ const renderThreads = () => {
 };
 
 describe("InMemoryThreadList", () => {
-  it("moves away from a selected thread when it is archived", async () => {
+  it("creates a new selection when the selected thread is archived", async () => {
     const { aui } = renderThreads();
+
+    aui().threads.switchToNewThread();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+    const siblingId = aui().threads.getState().mainThreadId;
+    aui().threads.switchToThread("main");
 
     aui().threads.item({ id: "main" }).archive();
 
     await waitFor(() => {
       const state = aui().threads.getState();
       expect(state.mainThreadId).not.toBe("main");
+      expect(state.mainThreadId).not.toBe(siblingId);
       expect(state.threadIds).toContain(state.mainThreadId);
+      expect(state.threadIds).toContain(siblingId);
       expect(state.archivedThreadIds).toEqual(["main"]);
+    });
+  });
+
+  it("preserves an archived selection after an unrelated deletion", async () => {
+    const { aui } = renderThreads();
+
+    aui().threads.item({ id: "main" }).archive();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+    const regularId = aui().threads.getState().mainThreadId;
+
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+    aui().threads.item({ id: regularId }).delete();
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.mainThreadId).toBe("main");
+      expect(state.archivedThreadIds).toEqual(["main"]);
+      expect(state.threadIds).not.toContain(regularId);
     });
   });
 
@@ -66,12 +98,14 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       const state = aui().threads.getState();
-      expect(state.threadIds).toEqual([lastGeneratedId]);
-      expect(state.mainThreadId).toBe(lastGeneratedId);
+      expect(state.threadIds).toContain(lastGeneratedId);
+      expect(state.threadIds).toContain(state.mainThreadId);
+      expect(state.threadIds).not.toContain("main");
+      expect(state.threadIds).not.toContain(firstGeneratedId);
     });
   });
 
-  it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
+  it("creates a live replacement when the switch target is deleted in the same tick", async () => {
     const { aui } = renderThreads();
 
     aui().threads.switchToNewThread();
@@ -89,7 +123,8 @@ describe("InMemoryThreadList", () => {
 
     await waitFor(() => {
       const state = aui().threads.getState();
-      expect(state.mainThreadId).toBe("main");
+      expect(state.mainThreadId).not.toBe("main");
+      expect(state.threadIds).toContain(state.mainThreadId);
       expect(state.threadIds).not.toContain(newId);
     });
   });


### PR DESCRIPTION
## Summary

- keep the selected in-memory thread ID valid after archive and delete operations
- preserve an intentionally selected archived thread when an unrelated thread changes
- notify `onSwitchToThread` when archive or delete automatically relocates the selection
- apply thread-list and selection mutations atomically so batched operations cannot leave an invalid or stale selection

## Problem

Archiving the selected thread moved it into `archivedThreadIds` but left it mounted as `mainThreadId`. Deleting multiple threads before React rerendered also calculated each fallback from the same stale `threads` closure, so the final selection could reference a thread that another deletion had already removed. Automatic relocation also needs to notify controlled consumers so their mirrored thread ID does not remain stale.

## Fallback behavior

Deletion preserves the existing in-memory behavior by selecting the first remaining sibling, including an archived sibling. Archiving the selected thread instead selects the first regular sibling, because the archived thread remains stored but should no longer stay selected as the active thread; it creates a regular replacement only when no regular sibling exists. Relocating the selected thread also unmounts its active in-memory thread client, so an in-progress local run can stop; this matches the remote runtime's archive behavior.

This intentionally differs from the remote runtime's always-create-new fallback. Reusing an existing thread ID preserves the caller-owned conversation associated with that ID and avoids replacing it with an empty thread; only the selected thread client is mounted by this implementation. When a replacement must be created, `onSwitchToThread(newId)` is the canonical selection notification; `onSwitchToNewThread` remains reserved for an explicit `switchToNewThread()` action because it cannot carry the generated ID. Pending relocation notifications carry the selection-operation version that created them, so a newer explicit switch suppresses an older effect before it can report a stale target. `useEffectEvent` keeps the consumer callback current; the package build rewrites that import to `@assistant-ui/tap/react-shim`, which supplies the React 18 fallback.

## Verification

- reproduced the archive and batched-deletion failures with focused regression tests before the fix
- covered existing-sibling and newly-created archive and delete fallbacks, callback notification, repeated and unrelated archives, unrelated archived selections, historical archived-sibling deletion fallback, batched deletions, and superseded relocation cancellation before and after commit
- `pnpm exec vitest run src/tests/in-memory-thread-list.test.tsx` (13 tests)
- `pnpm --filter @assistant-ui/react test` (414 tests)
- `pnpm exec oxlint src/client/InMemoryThreadList.ts src/tests/in-memory-thread-list.test.tsx`
- `pnpm check:resource-memo`
- `pnpm --filter @assistant-ui/react... build`
