### PR TITLE
fix(react-mcp): serialize oauth state persistence

### DIFF
--- a/.changeset/serialize-mcp-oauth-state.md
+++ b/.changeset/serialize-mcp-oauth-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: serialize OAuth state persistence

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -137,4 +137,32 @@ describe("createOAuthProvider persistence", () => {
       codeVerifier: "pkce-verifier",
     });
   });
+
+  it("continues persisting after a failed auth state write", async () => {
+    const { storage } = createStorage();
+    const failure = new Error("storage unavailable");
+    let saveCount = 0;
+    let persisted: MCPPersistedAuthState | null = null;
+    storage.saveAuthState = async (_serverId, next) => {
+      saveCount += 1;
+      if (saveCount === 1) throw failure;
+      persisted = next;
+    };
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    const verifierSave = provider.saveCodeVerifier("pkce-verifier");
+
+    await expect(tokenSave).rejects.toBe(failure);
+    await expect(verifierSave).resolves.toBeUndefined();
+    expect(saveCount).toBe(2);
+    expect(persisted).toEqual({
+      tokens: { access_token: "access-token", token_type: "bearer" },
+      codeVerifier: "pkce-verifier",
+    });
+  });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -86,7 +86,7 @@ describe("createOAuthProvider discovery state", () => {
 });
 
 describe("createOAuthProvider persistence", () => {
-  it("loads persisted auth state once for concurrent reads", async () => {
+  it("shares one auth state load across provider instances", async () => {
     let resolveLoad!: (value: MCPPersistedAuthState | null) => void;
     const loadAuthState = vi.fn(
       () =>
@@ -96,17 +96,18 @@ describe("createOAuthProvider persistence", () => {
     );
     const { storage } = createStorage();
     storage.loadAuthState = loadAuthState;
-    const provider = createProvider(storage);
+    const firstProvider = createProvider(storage);
+    const secondProvider = createProvider(storage);
 
-    const tokens = provider.tokens();
-    const clientInformation = provider.clientInformation();
+    const tokens = firstProvider.tokens();
+    const clientInformation = secondProvider.clientInformation();
 
     expect(loadAuthState).toHaveBeenCalledTimes(1);
     resolveLoad(null);
     await Promise.all([tokens, clientInformation]);
   });
 
-  it("serializes auth state writes so newer credentials are not overwritten", async () => {
+  it("serializes auth state writes across provider instances", async () => {
     const { storage } = createStorage();
     const pendingWrites: Array<() => void> = [];
     let persisted: MCPPersistedAuthState | null = null;
@@ -114,16 +115,17 @@ describe("createOAuthProvider persistence", () => {
       await new Promise<void>((resolve) => pendingWrites.push(resolve));
       persisted = next;
     };
-    const provider = createProvider(storage);
-    await provider.tokens();
+    const firstProvider = createProvider(storage);
+    await firstProvider.tokens();
 
-    const tokenSave = provider.saveTokens({
+    const tokenSave = firstProvider.saveTokens({
       access_token: "access-token",
       token_type: "bearer",
     });
     await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
 
-    const verifierSave = provider.saveCodeVerifier("pkce-verifier");
+    const secondProvider = createProvider(storage);
+    const verifierSave = secondProvider.saveCodeVerifier("pkce-verifier");
     await Promise.resolve();
     expect(pendingWrites).toHaveLength(1);
 

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -2,7 +2,10 @@ import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
 import type { MCPStorage } from "../resources/storage/types";
 import type { MCPPersistedAuthState } from "./types";
-import { createOAuthProvider } from "./createOAuthProvider";
+import {
+  clearOAuthProviderAuthState,
+  createOAuthProvider,
+} from "./createOAuthProvider";
 
 const discoveryState: OAuthDiscoveryState = {
   authorizationServerUrl: "https://auth.example.com",
@@ -166,5 +169,32 @@ describe("createOAuthProvider persistence", () => {
       tokens: { access_token: "access-token", token_type: "bearer" },
       codeVerifier: "pkce-verifier",
     });
+  });
+
+  it("clears auth state after pending writes and invalidates the cache", async () => {
+    const { storage, getState } = createStorage();
+    let resolveWrite!: () => void;
+    const saveAuthState = storage.saveAuthState;
+    storage.saveAuthState = async (serverId, next) => {
+      await new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      });
+      await saveAuthState(serverId, next);
+    };
+    const provider = createProvider(storage);
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(resolveWrite).toBeTypeOf("function"));
+    const clear = clearOAuthProviderAuthState(storage, "docs");
+
+    resolveWrite();
+    await Promise.all([tokenSave, clear]);
+    expect(getState()).toBeNull();
+
+    const replacementProvider = createProvider(storage);
+    await expect(replacementProvider.tokens()).resolves.toBeUndefined();
   });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -197,4 +197,27 @@ describe("createOAuthProvider persistence", () => {
     const replacementProvider = createProvider(storage);
     await expect(replacementProvider.tokens()).resolves.toBeUndefined();
   });
+
+  it("prevents a save awaiting hydration from writing after clear", async () => {
+    const { storage, getState } = createStorage();
+    let resolveLoad!: (value: MCPPersistedAuthState | null) => void;
+    storage.loadAuthState = () =>
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      });
+    const saveAuthState = vi.spyOn(storage, "saveAuthState");
+    const provider = createProvider(storage);
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    const clear = clearOAuthProviderAuthState(storage, "docs");
+
+    resolveLoad(null);
+    await Promise.all([tokenSave, clear]);
+
+    expect(saveAuthState).not.toHaveBeenCalled();
+    expect(getState()).toBeNull();
+  });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -1,5 +1,5 @@
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { MCPStorage } from "../resources/storage/types";
 import type { MCPPersistedAuthState } from "./types";
 import { createOAuthProvider } from "./createOAuthProvider";
@@ -83,4 +83,58 @@ describe("createOAuthProvider discovery state", () => {
       );
     },
   );
+});
+
+describe("createOAuthProvider persistence", () => {
+  it("loads persisted auth state once for concurrent reads", async () => {
+    let resolveLoad!: (value: MCPPersistedAuthState | null) => void;
+    const loadAuthState = vi.fn(
+      () =>
+        new Promise<MCPPersistedAuthState | null>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const { storage } = createStorage();
+    storage.loadAuthState = loadAuthState;
+    const provider = createProvider(storage);
+
+    const tokens = provider.tokens();
+    const clientInformation = provider.clientInformation();
+
+    expect(loadAuthState).toHaveBeenCalledTimes(1);
+    resolveLoad(null);
+    await Promise.all([tokens, clientInformation]);
+  });
+
+  it("serializes auth state writes so newer credentials are not overwritten", async () => {
+    const { storage } = createStorage();
+    const pendingWrites: Array<() => void> = [];
+    let persisted: MCPPersistedAuthState | null = null;
+    storage.saveAuthState = async (_serverId, next) => {
+      await new Promise<void>((resolve) => pendingWrites.push(resolve));
+      persisted = next;
+    };
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+
+    const verifierSave = provider.saveCodeVerifier("pkce-verifier");
+    await Promise.resolve();
+    expect(pendingWrites).toHaveLength(1);
+
+    pendingWrites.shift()!();
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+    pendingWrites.shift()!();
+    await Promise.all([tokenSave, verifierSave]);
+
+    expect(persisted).toEqual({
+      tokens: { access_token: "access-token", token_type: "bearer" },
+      codeVerifier: "pkce-verifier",
+    });
+  });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -74,38 +74,55 @@ export function createOAuthProvider(
     discoveryState?: OAuthDiscoveryState | undefined;
   };
   let cached: Cache | null = null;
+  let cachePromise: Promise<Cache> | null = null;
+  let persistenceQueue = Promise.resolve();
 
-  const loadCache = async (): Promise<Cache> => {
-    if (cached) return cached;
-    const persisted = await storage.loadAuthState(serverId);
-    const initial: Cache = {};
-    if (persisted?.tokens) initial.tokens = persisted.tokens;
-    if (config.clientId) {
-      const ci: OAuthClientInformationFull = {
-        client_id: config.clientId,
-        redirect_uris: [redirectUri],
-      };
-      if (config.clientSecret) ci.client_secret = config.clientSecret;
-      initial.clientInformation = ci;
-    } else if (persisted?.clientInformation) {
-      initial.clientInformation = persisted.clientInformation;
-    }
-    if (persisted?.codeVerifier) initial.codeVerifier = persisted.codeVerifier;
-    if (persisted?.discoveryState)
-      initial.discoveryState = persisted.discoveryState;
-    cached = initial;
-    return cached;
+  const loadCache = (): Promise<Cache> => {
+    if (cached) return Promise.resolve(cached);
+    if (cachePromise) return cachePromise;
+
+    cachePromise = storage.loadAuthState(serverId).then(
+      (persisted) => {
+        const initial: Cache = {};
+        if (persisted?.tokens) initial.tokens = persisted.tokens;
+        if (config.clientId) {
+          const ci: OAuthClientInformationFull = {
+            client_id: config.clientId,
+            redirect_uris: [redirectUri],
+          };
+          if (config.clientSecret) ci.client_secret = config.clientSecret;
+          initial.clientInformation = ci;
+        } else if (persisted?.clientInformation) {
+          initial.clientInformation = persisted.clientInformation;
+        }
+        if (persisted?.codeVerifier)
+          initial.codeVerifier = persisted.codeVerifier;
+        if (persisted?.discoveryState)
+          initial.discoveryState = persisted.discoveryState;
+        cached = initial;
+        return initial;
+      },
+      (error) => {
+        cachePromise = null;
+        throw error;
+      },
+    );
+    return cachePromise;
   };
 
-  const persist = async () => {
-    const c = cached;
-    if (!c) return;
-    const next: Parameters<typeof storage.saveAuthState>[1] = {};
-    if (c.tokens) next.tokens = c.tokens;
-    if (c.clientInformation) next.clientInformation = c.clientInformation;
-    if (c.codeVerifier) next.codeVerifier = c.codeVerifier;
-    if (c.discoveryState) next.discoveryState = c.discoveryState;
-    await storage.saveAuthState(serverId, next);
+  const persist = () => {
+    const task = persistenceQueue.then(async () => {
+      const c = cached;
+      if (!c) return;
+      const next: Parameters<typeof storage.saveAuthState>[1] = {};
+      if (c.tokens) next.tokens = c.tokens;
+      if (c.clientInformation) next.clientInformation = c.clientInformation;
+      if (c.codeVerifier) next.codeVerifier = c.codeVerifier;
+      if (c.discoveryState) next.discoveryState = c.discoveryState;
+      await storage.saveAuthState(serverId, next);
+    });
+    persistenceQueue = task.catch(() => {});
+    return task;
   };
 
   const clientMetadata: OAuthClientMetadata = {

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -97,6 +97,28 @@ const getPersistenceState = (
   return state;
 };
 
+export const clearOAuthProviderAuthState = async (
+  storage: MCPStorage,
+  serverId: string,
+) => {
+  const storageStates = persistenceStates.get(storage);
+  const state = storageStates?.get(serverId);
+  if (!state) {
+    await storage.clearAuthState(serverId);
+    return;
+  }
+
+  const task = state.persistenceQueue.then(() =>
+    storage.clearAuthState(serverId),
+  );
+  state.persistenceQueue = task.catch(() => {});
+  try {
+    await task;
+  } finally {
+    if (storageStates.get(serverId) === state) storageStates.delete(serverId);
+  }
+};
+
 /**
  * Builds an OAuthClientProvider for the MCP SDK, backed by MCPStorage.
  * Token refresh and DCR are handled by the SDK; this provider only mediates

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -57,6 +57,46 @@ export type CreateOAuthProviderOptions = {
   onAuthorizationUrl: (url: URL) => void;
 };
 
+type OAuthCache = {
+  tokens?: OAuthTokens | undefined;
+  clientInformation?: OAuthClientInformationFull | undefined;
+  codeVerifier?: string | undefined;
+  discoveryState?: OAuthDiscoveryState | undefined;
+};
+
+type OAuthPersistenceState = {
+  cached: OAuthCache | null;
+  cachePromise: Promise<OAuthCache> | null;
+  persistenceQueue: Promise<void>;
+};
+
+const persistenceStates = new WeakMap<
+  MCPStorage,
+  Map<string, OAuthPersistenceState>
+>();
+
+const getPersistenceState = (
+  storage: MCPStorage,
+  serverId: string,
+): OAuthPersistenceState => {
+  let storageStates = persistenceStates.get(storage);
+  if (!storageStates) {
+    storageStates = new Map();
+    persistenceStates.set(storage, storageStates);
+  }
+
+  let state = storageStates.get(serverId);
+  if (!state) {
+    state = {
+      cached: null,
+      cachePromise: null,
+      persistenceQueue: Promise.resolve(),
+    };
+    storageStates.set(serverId, state);
+  }
+  return state;
+};
+
 /**
  * Builds an OAuthClientProvider for the MCP SDK, backed by MCPStorage.
  * Token refresh and DCR are handled by the SDK; this provider only mediates
@@ -66,53 +106,58 @@ export function createOAuthProvider(
   opts: CreateOAuthProviderOptions,
 ): OAuthClientProvider {
   const { serverId, config, storage, redirectUri, onAuthorizationUrl } = opts;
+  const persistenceState = getPersistenceState(storage, serverId);
 
-  type Cache = {
-    tokens?: OAuthTokens | undefined;
-    clientInformation?: OAuthClientInformationFull | undefined;
-    codeVerifier?: string | undefined;
-    discoveryState?: OAuthDiscoveryState | undefined;
+  const applyConfiguredClientInformation = (cache: OAuthCache) => {
+    if (!config.clientId) return cache;
+
+    const clientInformation: OAuthClientInformationFull = {
+      client_id: config.clientId,
+      redirect_uris: [redirectUri],
+    };
+    if (config.clientSecret)
+      clientInformation.client_secret = config.clientSecret;
+    cache.clientInformation = clientInformation;
+    return cache;
   };
-  let cached: Cache | null = null;
-  let cachePromise: Promise<Cache> | null = null;
-  let persistenceQueue = Promise.resolve();
 
-  const loadCache = (): Promise<Cache> => {
-    if (cached) return Promise.resolve(cached);
-    if (cachePromise) return cachePromise;
+  const loadCache = (): Promise<OAuthCache> => {
+    if (persistenceState.cached) {
+      return Promise.resolve(
+        applyConfiguredClientInformation(persistenceState.cached),
+      );
+    }
+    if (persistenceState.cachePromise) {
+      return persistenceState.cachePromise.then(
+        applyConfiguredClientInformation,
+      );
+    }
 
-    cachePromise = storage.loadAuthState(serverId).then(
+    persistenceState.cachePromise = storage.loadAuthState(serverId).then(
       (persisted) => {
-        const initial: Cache = {};
+        const initial: OAuthCache = {};
         if (persisted?.tokens) initial.tokens = persisted.tokens;
-        if (config.clientId) {
-          const ci: OAuthClientInformationFull = {
-            client_id: config.clientId,
-            redirect_uris: [redirectUri],
-          };
-          if (config.clientSecret) ci.client_secret = config.clientSecret;
-          initial.clientInformation = ci;
-        } else if (persisted?.clientInformation) {
+        if (persisted?.clientInformation) {
           initial.clientInformation = persisted.clientInformation;
         }
         if (persisted?.codeVerifier)
           initial.codeVerifier = persisted.codeVerifier;
         if (persisted?.discoveryState)
           initial.discoveryState = persisted.discoveryState;
-        cached = initial;
+        persistenceState.cached = initial;
         return initial;
       },
       (error) => {
-        cachePromise = null;
+        persistenceState.cachePromise = null;
         throw error;
       },
     );
-    return cachePromise;
+    return persistenceState.cachePromise.then(applyConfiguredClientInformation);
   };
 
   const persist = () => {
-    const task = persistenceQueue.then(async () => {
-      const c = cached;
+    const task = persistenceState.persistenceQueue.then(async () => {
+      const c = persistenceState.cached;
       if (!c) return;
       const next: Parameters<typeof storage.saveAuthState>[1] = {};
       if (c.tokens) next.tokens = c.tokens;
@@ -121,7 +166,7 @@ export function createOAuthProvider(
       if (c.discoveryState) next.discoveryState = c.discoveryState;
       await storage.saveAuthState(serverId, next);
     });
-    persistenceQueue = task.catch(() => {});
+    persistenceState.persistenceQueue = task.catch(() => {});
     return task;
   };
 

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -68,6 +68,7 @@ type OAuthPersistenceState = {
   cached: OAuthCache | null;
   cachePromise: Promise<OAuthCache> | null;
   persistenceQueue: Promise<void>;
+  invalidated: boolean;
 };
 
 const persistenceStates = new WeakMap<
@@ -91,6 +92,7 @@ const getPersistenceState = (
       cached: null,
       cachePromise: null,
       persistenceQueue: Promise.resolve(),
+      invalidated: false,
     };
     storageStates.set(serverId, state);
   }
@@ -108,6 +110,8 @@ export const clearOAuthProviderAuthState = async (
     return;
   }
 
+  state.invalidated = true;
+  await state.cachePromise?.catch(() => {});
   const task = state.persistenceQueue.then(() =>
     storage.clearAuthState(serverId),
   );
@@ -179,6 +183,7 @@ export function createOAuthProvider(
 
   const persist = () => {
     const task = persistenceState.persistenceQueue.then(async () => {
+      if (persistenceState.invalidated) return;
       const c = persistenceState.cached;
       if (!c) return;
       const next: Parameters<typeof storage.saveAuthState>[1] = {};

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -12,6 +12,7 @@ import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
 import type { MCPStorage, MCPStorageElement } from "./storage/types";
 import { assertUniqueServerIds } from "../utils/serverId";
+import { clearOAuthProviderAuthState } from "../auth/createOAuthProvider";
 import type {
   MCPAuthConfig,
   MCPConnector,
@@ -300,7 +301,7 @@ const useMcpManagerResource = (
       try {
         await lookup.get({ key: id }).remove();
       } catch {
-        await storage.clearAuthState(id);
+        await clearOAuthProviderAuthState(storage, id);
         setCustomServers((prev) => prev.filter((s) => s.id !== id));
       }
     },

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -10,7 +10,10 @@ import {
   type ElicitResult,
   type StreamableHTTPClientTransportOptions,
 } from "@modelcontextprotocol/client";
-import { createOAuthProvider } from "../auth/createOAuthProvider";
+import {
+  clearOAuthProviderAuthState,
+  createOAuthProvider,
+} from "../auth/createOAuthProvider";
 import { buildHeaders } from "../auth/buildHeaders";
 import { assertValidServerId } from "../utils/serverId";
 import { validateElicitationContent } from "./validateElicitationContent";
@@ -540,7 +543,7 @@ const useMcpServerResource = (
     remove: async () => {
       await doDisconnect();
       try {
-        await props.storage.clearAuthState(props.id);
+        await clearOAuthProviderAuthState(props.storage, props.id);
         await props.onRemove();
       } catch (err) {
         setLastError({


### PR DESCRIPTION
## Summary

- serialize OAuth auth-state writes across provider instances for the same storage and server
- single-flight the initial storage load so reconnect and callback transports share one credential snapshot
- fence cleared provider generations, settle hydration and queued writes, then invalidate shared state
- add regression coverage for cross-provider ordering, queue recovery, removal, and saves awaiting hydration

## Why

`McpServerResource` can build a new OAuth provider when its transport is replaced or reconstructed for the callback leg. Without coordination across those provider instances, an older token-only save can finish after a newer PKCE verifier save and erase the verifier needed to exchange the authorization code. This is observable with supported IndexedDB or remote storage implementations whose writes do not complete in invocation order.

The persistence state is now scoped by `(storage, serverId)`, preserving invocation order across replacement providers while still returning each save failure to its caller. Removing a server invalidates the old provider generation immediately, waits for in-flight hydration and queued writes, then clears storage and discards the shared state. A delayed save from the removed provider therefore cannot restore deleted credentials.

## Stacking

This is a focused follow-up to #5596 and targets its branch because that PR adds OAuth discovery state in the same module. It should merge after #5596, then be retargeted or rebased onto `main`.

## Verification

- `pnpm --filter @assistant-ui/react-mcp test` (122 tests)
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm exec oxlint packages/react-mcp/src/auth/createOAuthProvider.ts packages/react-mcp/src/auth/createOAuthProvider.test.ts packages/react-mcp/src/resources/McpServerResource.ts packages/react-mcp/src/resources/McpManagerResource.ts`
- `pnpm exec oxfmt --check packages/react-mcp/src/auth/createOAuthProvider.ts packages/react-mcp/src/auth/createOAuthProvider.test.ts packages/react-mcp/src/resources/McpServerResource.ts packages/react-mcp/src/resources/McpManagerResource.ts`