### PR TITLE
feat(react-lexical): reparse drafts after formatter changes

### DIFF
--- a/.changeset/reparse-lexical-directives.md
+++ b/.changeset/reparse-lexical-directives.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-lexical": patch
 ---
 
-fix: reparse composer drafts when directive formatters change
+fix: reparse unedited composer drafts when directive formatters change

--- a/.changeset/reparse-lexical-directives.md
+++ b/.changeset/reparse-lexical-directives.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: reparse composer drafts when directive formatters change

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -46,15 +46,18 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 const createAui = (text: string) => {
+  let currentText = text;
   const runtime = {
-    getState: () => ({ text }),
+    getState: () => ({ text: currentText }),
     subscribe: () => () => {},
   };
 
   return {
     composer: {
       __internal_getRuntime: () => runtime,
-      setText: vi.fn(),
+      setText: vi.fn((nextText: string) => {
+        currentText = nextText;
+      }),
     },
   };
 };
@@ -272,6 +275,65 @@ describe("SyncPlugin", () => {
       }),
     ).toEqual(beforeUnregister);
     expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
+  });
+
+  it("does not reparse text edited before a trigger formatter registers", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-edited-trigger-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+          <LexicalComposer initialConfig={initialConfig}>
+            <SyncPlugin />
+            <EditorProbe capture={capture} />
+            <TriggerFormatterRegistration
+              formatter={registered ? formatter : undefined}
+            />
+          </LexicalComposer>
+        </ComposerPrimitive.Unstable_TriggerPopoverRoot>,
+      );
+
+    mocks.aui = createAui("draft");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const paragraph = $getParagraph();
+        const textNode = $createTextNode("[[alice]]");
+        paragraph.clear();
+        paragraph.append(textNode);
+        textNode.selectEnd();
+        $setCompositionKey(textNode.getKey());
+      });
+    });
+    const beforeRegistration = editor.getEditorState().read(() => {
+      const textNode = $getParagraph().getFirstChild();
+      if (!$isTextNode(textNode)) throw new Error("Expected text");
+      return { key: textNode.getKey(), isComposing: editor.isComposing() };
+    });
+    expect(beforeRegistration.isComposing).toBe(true);
+    expect(mocks.aui.composer.setText).toHaveBeenLastCalledWith("[[alice]]");
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const textNode = $getParagraph().getFirstChild();
+        if (!$isTextNode(textNode)) throw new Error("Expected text");
+        return { key: textNode.getKey(), isComposing: editor.isComposing() };
+      }),
+    ).toEqual(beforeRegistration);
   });
 
   it("preserves metadata when formatter syntax changes", async () => {

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -14,6 +14,7 @@ import {
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  $setCompositionKey,
   type LexicalEditor,
 } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -327,6 +328,7 @@ describe("SyncPlugin", () => {
         lexicalRoot.clear();
         lexicalRoot.append(paragraph);
         textNode.select(4, 4);
+        $setCompositionKey(textNode.getKey());
       });
     });
     const before = editor.getEditorState().read(() => {
@@ -335,8 +337,13 @@ describe("SyncPlugin", () => {
       if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
         throw new Error("Expected a text selection");
       }
-      return { key: textNode.getKey(), offset: selection.anchor.offset };
+      return {
+        key: textNode.getKey(),
+        offset: selection.anchor.offset,
+        isComposing: editor.isComposing(),
+      };
     });
+    expect(before.isComposing).toBe(true);
 
     await act(async () => {
       render(plainTextFormatter);
@@ -348,7 +355,11 @@ describe("SyncPlugin", () => {
         if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
           throw new Error("Expected a text selection");
         }
-        return { key: textNode.getKey(), offset: selection.anchor.offset };
+        return {
+          key: textNode.getKey(),
+          offset: selection.anchor.offset,
+          isComposing: editor.isComposing(),
+        };
       }),
     ).toEqual(before);
 

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -216,7 +216,7 @@ describe("SyncPlugin", () => {
             {
               id: "team",
               type: "group",
-              label: "Team",
+              label: "Old Team",
               description: "Engineering",
               metadata: { workspace: "acme" },
             },

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -6,6 +6,9 @@ import { createRoot, type Root } from "react-dom/client";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
   $getRoot,
   $getSelection,
   $isRangeSelection,
@@ -156,24 +159,27 @@ describe("SyncPlugin", () => {
         </LexicalComposer>,
       );
 
-    mocks.aui = createAui("[[alice]]");
+    mocks.aui = createAui("first\n[[alice]]");
     await act(async () => {
       render();
     });
-    expect(
-      editor
-        .getEditorState()
-        .read(() => $getRoot().getFirstChild()?.getFirstChild()?.getType()),
-    ).toBe("text");
     await act(async () => {
       editor.update(() => {
-        const textNode = $getRoot().getFirstChild()?.getFirstChild();
-        if (!$isTextNode(textNode)) throw new Error("Expected a text node");
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode("[[alice]]");
+        paragraph.append(
+          $createTextNode("first"),
+          $createLineBreakNode(),
+          textNode,
+        );
+        const lexicalRoot = $getRoot();
+        lexicalRoot.clear();
+        lexicalRoot.append(paragraph);
         textNode.select(4, 4);
       });
     });
     const before = editor.getEditorState().read(() => {
-      const textNode = $getRoot().getFirstChild()?.getFirstChild();
+      const textNode = $getRoot().getFirstChild()?.getLastChild();
       const selection = $getSelection();
       if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
         throw new Error("Expected a text selection");
@@ -186,7 +192,7 @@ describe("SyncPlugin", () => {
     });
     expect(
       editor.getEditorState().read(() => {
-        const textNode = $getRoot().getFirstChild()?.getFirstChild();
+        const textNode = $getRoot().getFirstChild()?.getLastChild();
         const selection = $getSelection();
         if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
           throw new Error("Expected a text selection");
@@ -201,7 +207,7 @@ describe("SyncPlugin", () => {
     expect(
       editor
         .getEditorState()
-        .read(() => $getRoot().getFirstChild()?.getFirstChild()?.getType()),
+        .read(() => $getRoot().getChildAtIndex(1)?.getFirstChild()?.getType()),
     ).toBe("directive");
     expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
   });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -461,6 +461,77 @@ describe("SyncPlugin", () => {
     ).toEqual(before);
   });
 
+  it("normalizes line breaks and selects the end on a required reparse", async () => {
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <TriggerSyncEditor
+          formatter={registered ? formatter : undefined}
+          capture={capture}
+        />,
+      );
+
+    mocks.aui = createAui("[[alice]]\nrest");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const firstText = $createTextNode("[[alice]]");
+          paragraph.append(
+            firstText,
+            $createLineBreakNode(),
+            $createTextNode("rest"),
+          );
+          const lexicalRoot = $getRoot();
+          lexicalRoot.clear();
+          lexicalRoot.append(paragraph);
+          firstText.select(2, 2);
+        },
+        { tag: "aui-sync" },
+      );
+    });
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const lexicalRoot = $getRoot();
+        const directive = $getParagraph().getFirstChild();
+        const trailingText = $getParagraph(1).getFirstChild();
+        const selection = $getSelection();
+        if (
+          !$isDirectiveNode(directive) ||
+          !$isTextNode(trailingText) ||
+          !$isRangeSelection(selection)
+        ) {
+          throw new Error("Expected normalized content and a text selection");
+        }
+        return {
+          paragraphCount: lexicalRoot.getChildren().length,
+          directiveText: directive.getDirectiveText(),
+          trailingText: trailingText.getTextContent(),
+          selectionAtEnd:
+            selection.anchor.key === trailingText.getKey() &&
+            selection.focus.key === trailingText.getKey() &&
+            selection.anchor.offset === trailingText.getTextContentSize() &&
+            selection.focus.offset === trailingText.getTextContentSize(),
+        };
+      }),
+    ).toEqual({
+      paragraphCount: 2,
+      directiveText: "[[alice]]",
+      trailingText: "rest",
+      selectionAtEnd: true,
+    });
+  });
+
   it("preserves duplicate metadata when formatter syntax changes", async () => {
     const initialConfig = {
       namespace: "sync-plugin-formatter-metadata-test",

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -439,5 +439,23 @@ describe("SyncPlugin", () => {
       },
     ]);
     expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
+
+    mocks.aui = createAui("@team");
+    await act(async () => {
+      render(formatter);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const node = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+        return node.getDirectiveItem();
+      }),
+    ).toEqual({
+      id: "team",
+      type: "group",
+      label: "Team",
+      description: undefined,
+      metadata: undefined,
+    });
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -533,7 +533,7 @@ describe("SyncPlugin", () => {
     expect(reparseTags?.has(SKIP_DOM_SELECTION_TAG)).toBe(true);
   });
 
-  it("updates parser labels without discarding hydrated labels unnecessarily", async () => {
+  it("preserves labels per occurrence and ignores equivalent formatter wrappers", async () => {
     const initialConfig = {
       namespace: "sync-plugin-formatter-label-test",
       nodes: [DirectiveNode],
@@ -544,13 +544,36 @@ describe("SyncPlugin", () => {
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
     };
-    const createFormatter = (label: string): Unstable_DirectiveFormatter => ({
-      serialize: (item) => `[[${item.id}]]`,
-      parse: (text) => {
-        if (text !== "[[alice]]") return [{ kind: "text", text }];
-        return [{ kind: "mention", type: "person", id: "alice", label }];
-      },
-    });
+    const serialize: Unstable_DirectiveFormatter["serialize"] = (item) =>
+      `[[${item.id}]]`;
+    const createParse =
+      (
+        aliceLabel: string,
+        includeBob: boolean,
+      ): Unstable_DirectiveFormatter["parse"] =>
+      (text) => {
+        if (text === "[[alice]]") {
+          return [
+            {
+              kind: "mention",
+              type: "person",
+              id: "alice",
+              label: aliceLabel,
+            },
+          ];
+        }
+        if (includeBob && text === "[[bob]]") {
+          return [
+            {
+              kind: "mention",
+              type: "person",
+              id: "bob",
+              label: "Bob",
+            },
+          ];
+        }
+        return [{ kind: "text", text }];
+      };
     const render = (formatter: Unstable_DirectiveFormatter) =>
       root.render(
         <LexicalComposer initialConfig={initialConfig}>
@@ -558,10 +581,20 @@ describe("SyncPlugin", () => {
           <EditorProbe capture={capture} />
         </LexicalComposer>,
       );
+    const readDirectiveItems = () =>
+      editor.getEditorState().read(() =>
+        [0, 1].map((index) => {
+          const directive = $getParagraph(index).getFirstChild();
+          if (!$isDirectiveNode(directive)) {
+            throw new Error("Expected a directive");
+          }
+          return directive.getDirectiveItem();
+        }),
+      );
 
-    mocks.aui = createAui("[[alice]]");
+    mocks.aui = createAui("[[alice]]\n[[bob]]");
     await act(async () => {
-      render(createFormatter("Alice"));
+      render({ serialize, parse: createParse("Alice", false) });
     });
     await act(async () => {
       editor.update(
@@ -585,37 +618,38 @@ describe("SyncPlugin", () => {
         { tag: "aui-sync" },
       );
     });
-    const hydrated = editor.getEditorState().read(() => {
-      const directive = $getParagraph().getFirstChild();
-      if (!$isDirectiveNode(directive)) throw new Error("Expected a directive");
-      return { key: directive.getKey(), item: directive.getDirectiveItem() };
+
+    const expandedParse = vi.fn(createParse("Alice", true));
+    await act(async () => {
+      render({ serialize, parse: expandedParse });
     });
+    expect(readDirectiveItems()).toEqual([
+      {
+        id: "alice",
+        type: "person",
+        label: "Alice Smith",
+        description: "Project owner",
+        metadata: { workspace: "acme" },
+      },
+      {
+        id: "bob",
+        type: "person",
+        label: "Bob",
+        description: undefined,
+        metadata: undefined,
+      },
+    ]);
+
+    expandedParse.mockClear();
+    await act(async () => {
+      render({ serialize, parse: expandedParse });
+    });
+    expect(expandedParse).not.toHaveBeenCalled();
 
     await act(async () => {
-      render(createFormatter("Alice"));
+      render({ serialize, parse: createParse("Alice Cooper", true) });
     });
-    expect(
-      editor.getEditorState().read(() => {
-        const directive = $getParagraph().getFirstChild();
-        if (!$isDirectiveNode(directive)) {
-          throw new Error("Expected a directive");
-        }
-        return { key: directive.getKey(), item: directive.getDirectiveItem() };
-      }),
-    ).toEqual(hydrated);
-
-    await act(async () => {
-      render(createFormatter("Alice Cooper"));
-    });
-    expect(
-      editor.getEditorState().read(() => {
-        const directive = $getParagraph().getFirstChild();
-        if (!$isDirectiveNode(directive)) {
-          throw new Error("Expected a directive");
-        }
-        return directive.getDirectiveItem();
-      }),
-    ).toEqual({
+    expect(readDirectiveItems()[0]).toEqual({
       id: "alice",
       type: "person",
       label: "Alice Cooper",

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -533,6 +533,97 @@ describe("SyncPlugin", () => {
     expect(reparseTags?.has(SKIP_DOM_SELECTION_TAG)).toBe(true);
   });
 
+  it("updates parser labels without discarding hydrated labels unnecessarily", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-formatter-label-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const createFormatter = (label: string): Unstable_DirectiveFormatter => ({
+      serialize: (item) => `[[${item.id}]]`,
+      parse: (text) => {
+        if (text !== "[[alice]]") return [{ kind: "text", text }];
+        return [{ kind: "mention", type: "person", id: "alice", label }];
+      },
+    });
+    const render = (formatter: Unstable_DirectiveFormatter) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={formatter} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(createFormatter("Alice"));
+    });
+    await act(async () => {
+      editor.update(
+        () => {
+          const directive = $getParagraph().getFirstChild();
+          if (!$isDirectiveNode(directive)) {
+            throw new Error("Expected a directive");
+          }
+          directive.replace(
+            $createDirectiveNode(
+              {
+                ...directive.getDirectiveItem(),
+                label: "Alice Smith",
+                description: "Project owner",
+                metadata: { workspace: "acme" },
+              },
+              directive.getDirectiveText(),
+            ),
+          );
+        },
+        { tag: "aui-sync" },
+      );
+    });
+    const hydrated = editor.getEditorState().read(() => {
+      const directive = $getParagraph().getFirstChild();
+      if (!$isDirectiveNode(directive)) throw new Error("Expected a directive");
+      return { key: directive.getKey(), item: directive.getDirectiveItem() };
+    });
+
+    await act(async () => {
+      render(createFormatter("Alice"));
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const directive = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(directive)) {
+          throw new Error("Expected a directive");
+        }
+        return { key: directive.getKey(), item: directive.getDirectiveItem() };
+      }),
+    ).toEqual(hydrated);
+
+    await act(async () => {
+      render(createFormatter("Alice Cooper"));
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const directive = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(directive)) {
+          throw new Error("Expected a directive");
+        }
+        return directive.getDirectiveItem();
+      }),
+    ).toEqual({
+      id: "alice",
+      type: "person",
+      label: "Alice Cooper",
+      description: "Project owner",
+      metadata: { workspace: "acme" },
+    });
+  });
+
   it("preserves duplicate metadata when formatter syntax changes", async () => {
     const initialConfig = {
       namespace: "sync-plugin-formatter-metadata-test",

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -15,6 +15,8 @@ import {
   $isRangeSelection,
   $isTextNode,
   $setCompositionKey,
+  $setSelection,
+  SKIP_DOM_SELECTION_TAG,
   type LexicalEditor,
 } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -461,7 +463,7 @@ describe("SyncPlugin", () => {
     ).toEqual(before);
   });
 
-  it("normalizes line breaks and selects the end on a required reparse", async () => {
+  it("normalizes line breaks without selecting an unfocused editor", async () => {
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
     };
@@ -491,45 +493,44 @@ describe("SyncPlugin", () => {
           const lexicalRoot = $getRoot();
           lexicalRoot.clear();
           lexicalRoot.append(paragraph);
-          firstText.select(2, 2);
+          $setSelection(null);
         },
         { tag: "aui-sync" },
       );
     });
 
+    let reparseTags: ReadonlySet<string> | undefined;
+    const unregister = editor.registerUpdateListener(({ tags }) => {
+      reparseTags = tags;
+    });
+
     await act(async () => {
       render(true);
     });
+    unregister();
     expect(
       editor.getEditorState().read(() => {
         const lexicalRoot = $getRoot();
         const directive = $getParagraph().getFirstChild();
         const trailingText = $getParagraph(1).getFirstChild();
         const selection = $getSelection();
-        if (
-          !$isDirectiveNode(directive) ||
-          !$isTextNode(trailingText) ||
-          !$isRangeSelection(selection)
-        ) {
-          throw new Error("Expected normalized content and a text selection");
+        if (!$isDirectiveNode(directive) || !$isTextNode(trailingText)) {
+          throw new Error("Expected normalized content");
         }
         return {
           paragraphCount: lexicalRoot.getChildren().length,
           directiveText: directive.getDirectiveText(),
           trailingText: trailingText.getTextContent(),
-          selectionAtEnd:
-            selection.anchor.key === trailingText.getKey() &&
-            selection.focus.key === trailingText.getKey() &&
-            selection.anchor.offset === trailingText.getTextContentSize() &&
-            selection.focus.offset === trailingText.getTextContentSize(),
+          selection,
         };
       }),
     ).toEqual({
       paragraphCount: 2,
       directiveText: "[[alice]]",
       trailingText: "rest",
-      selectionAtEnd: true,
+      selection: null,
     });
+    expect(reparseTags?.has(SKIP_DOM_SELECTION_TAG)).toBe(true);
   });
 
   it("preserves duplicate metadata when formatter syntax changes", async () => {

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -11,12 +11,18 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   $isTextNode,
   type LexicalEditor,
 } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
+import {
+  ComposerPrimitive,
+  unstable_useTriggerPopoverRootContext,
+  type Unstable_RegisteredTrigger,
+} from "@assistant-ui/react";
 import {
   $createDirectiveNode,
   $isDirectiveNode,
@@ -25,7 +31,7 @@ import {
 import { SyncPlugin } from "./SyncPlugin";
 
 const mocks = vi.hoisted(() => ({
-  aui: undefined as unknown,
+  aui: undefined as unknown as ReturnType<typeof createAui>,
 }));
 
 vi.mock("@assistant-ui/store", async (importOriginal) => {
@@ -55,6 +61,12 @@ const createAui = (text: string) => {
 const readEditorText = (editor: LexicalEditor) =>
   editor.getEditorState().read(() => $getRoot().getTextContent());
 
+function $getParagraph(index = 0) {
+  const paragraph = $getRoot().getChildAtIndex(index);
+  if (!$isElementNode(paragraph)) throw new Error("Expected a paragraph");
+  return paragraph;
+}
+
 function EditorProbe({
   capture,
 }: {
@@ -68,6 +80,42 @@ function EditorProbe({
 
   return null;
 }
+
+function TriggerFormatterRegistration({
+  formatter,
+}: {
+  formatter: Unstable_DirectiveFormatter | undefined;
+}) {
+  const triggerRoot = unstable_useTriggerPopoverRootContext();
+
+  useEffect(() => {
+    if (!formatter) return undefined;
+    return triggerRoot.register({
+      char: "@",
+      behavior: { kind: "directive", formatter },
+      resource: {} as Unstable_RegisteredTrigger["resource"],
+    });
+  }, [formatter, triggerRoot]);
+
+  return null;
+}
+
+const createBracketFormatter = (): Unstable_DirectiveFormatter => ({
+  serialize: (item) => `[[${item.id}]]`,
+  parse: (text) => {
+    const match = /^\[\[(.+)\]\]$/.exec(text);
+    if (!match) return [{ kind: "text", text }];
+    const id = match[1]!;
+    return [
+      {
+        kind: "mention",
+        type: id === "team" ? "group" : "person",
+        id,
+        label: id === "team" ? "Team" : "Alice",
+      },
+    ];
+  },
+});
 
 describe("SyncPlugin", () => {
   let container: HTMLDivElement;
@@ -98,10 +146,10 @@ describe("SyncPlugin", () => {
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
     };
-    const render = () =>
+    const render = (formatter?: Unstable_DirectiveFormatter) =>
       root.render(
         <LexicalComposer initialConfig={initialConfig}>
-          <SyncPlugin />
+          <SyncPlugin formatter={formatter} />
           <EditorProbe capture={capture} />
         </LexicalComposer>,
       );
@@ -134,7 +182,98 @@ describe("SyncPlugin", () => {
     expect(readEditorText(editor)).toBe("");
   });
 
-  it("reparses the current draft when the formatter changes", async () => {
+  it("reparses a restored draft when a trigger formatter registers", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-trigger-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+          <LexicalComposer initialConfig={initialConfig}>
+            <SyncPlugin />
+            <EditorProbe capture={capture} />
+            <TriggerFormatterRegistration
+              formatter={registered ? formatter : undefined}
+            />
+          </LexicalComposer>
+        </ComposerPrimitive.Unstable_TriggerPopoverRoot>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isTextNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isDirectiveNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+
+    await act(async () => {
+      editor.update(() => {
+        const directive = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(directive)) {
+          throw new Error("Expected a directive");
+        }
+        directive.replace(
+          $createDirectiveNode(
+            {
+              ...directive.getDirectiveItem(),
+              description: "Project owner",
+              metadata: { workspace: "acme" },
+            },
+            directive.getDirectiveText(),
+          ),
+        );
+      });
+    });
+    const beforeUnregister = editor.getEditorState().read(() => {
+      const directive = $getParagraph().getFirstChild();
+      if (!$isDirectiveNode(directive)) {
+        throw new Error("Expected a directive");
+      }
+      return {
+        key: directive.getKey(),
+        item: directive.getDirectiveItem(),
+      };
+    });
+
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const directive = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(directive)) {
+          throw new Error("Expected a directive");
+        }
+        return {
+          key: directive.getKey(),
+          item: directive.getDirectiveItem(),
+        };
+      }),
+    ).toEqual(beforeUnregister);
+    expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
+  });
+
+  it("preserves metadata when formatter syntax changes", async () => {
     const initialConfig = {
       namespace: "sync-plugin-formatter-test",
       nodes: [DirectiveNode],
@@ -147,19 +286,17 @@ describe("SyncPlugin", () => {
     };
     const formatter: Unstable_DirectiveFormatter = {
       serialize: (item) => `[[${item.id}]]`,
-      parse: (text) => {
-        const id = text === "[[team]]" ? "team" : "alice";
-        return text === "[[team]]" || text === "[[alice]]"
+      parse: (text) =>
+        text === "@team"
           ? [
               {
                 kind: "mention" as const,
-                type: id === "team" ? "group" : "person",
-                id,
-                label: id === "team" ? "Team" : "Alice",
+                type: "group",
+                id: "team",
+                label: "Team",
               },
             ]
-          : [{ kind: "text" as const, text }];
-      },
+          : [{ kind: "text" as const, text }],
     };
     const plainTextFormatter: Unstable_DirectiveFormatter = {
       serialize: (item) => item.label,
@@ -173,16 +310,16 @@ describe("SyncPlugin", () => {
         </LexicalComposer>,
       );
 
-    mocks.aui = createAui("[[team]]\n[[alice]]");
+    mocks.aui = createAui("@team\n@team");
     await act(async () => {
       render();
     });
     await act(async () => {
       editor.update(() => {
         const paragraph = $createParagraphNode();
-        const textNode = $createTextNode("[[alice]]");
+        const textNode = $createTextNode("@team");
         paragraph.append(
-          $createTextNode("[[team]]"),
+          $createTextNode("@team"),
           $createLineBreakNode(),
           textNode,
         );
@@ -193,7 +330,7 @@ describe("SyncPlugin", () => {
       });
     });
     const before = editor.getEditorState().read(() => {
-      const textNode = $getRoot().getFirstChild()?.getLastChild();
+      const textNode = $getParagraph().getLastChild();
       const selection = $getSelection();
       if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
         throw new Error("Expected a text selection");
@@ -206,7 +343,7 @@ describe("SyncPlugin", () => {
     });
     expect(
       editor.getEditorState().read(() => {
-        const textNode = $getRoot().getFirstChild()?.getLastChild();
+        const textNode = $getParagraph().getLastChild();
         const selection = $getSelection();
         if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
           throw new Error("Expected a text selection");
@@ -217,18 +354,34 @@ describe("SyncPlugin", () => {
 
     await act(async () => {
       editor.update(() => {
-        const team = $getRoot().getFirstChild()?.getFirstChild();
-        if (!$isTextNode(team)) throw new Error("Expected team text");
-        team.replace(
+        const paragraph = $getParagraph();
+        const firstTeam = paragraph.getFirstChild();
+        const secondTeam = paragraph.getLastChild();
+        if (!$isTextNode(firstTeam) || !$isTextNode(secondTeam)) {
+          throw new Error("Expected team text");
+        }
+        firstTeam.replace(
           $createDirectiveNode(
             {
               id: "team",
               type: "group",
-              label: "Old Team",
-              description: "Engineering",
-              metadata: { workspace: "acme" },
+              label: "First Team",
+              description: "First occurrence",
+              metadata: { order: 1 },
             },
-            "[[team]]",
+            "@team",
+          ),
+        );
+        secondTeam.replace(
+          $createDirectiveNode(
+            {
+              id: "team",
+              type: "group",
+              label: "Second Team",
+              description: "Second occurrence",
+              metadata: { order: 2 },
+            },
+            "@team",
           ),
         );
       });
@@ -237,21 +390,43 @@ describe("SyncPlugin", () => {
     expect(
       editor
         .getEditorState()
-        .read(() => $getRoot().getChildAtIndex(1)?.getFirstChild()?.getType()),
+        .read(() => $getParagraph(1).getFirstChild()?.getType()),
     ).toBe("directive");
     expect(
       editor.getEditorState().read(() => {
-        const node = $getRoot().getFirstChild()?.getFirstChild();
-        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
-        return node.getDirectiveItem();
+        return [0, 1].map((index) => {
+          const node = $getParagraph(index).getFirstChild();
+          if (!$isDirectiveNode(node)) {
+            throw new Error("Expected a directive");
+          }
+          return {
+            item: node.getDirectiveItem(),
+            text: node.getDirectiveText(),
+          };
+        });
       }),
-    ).toEqual({
-      id: "team",
-      type: "group",
-      label: "Team",
-      description: "Engineering",
-      metadata: { workspace: "acme" },
-    });
+    ).toEqual([
+      {
+        item: {
+          id: "team",
+          type: "group",
+          label: "Team",
+          description: "First occurrence",
+          metadata: { order: 1 },
+        },
+        text: "[[team]]",
+      },
+      {
+        item: {
+          id: "team",
+          type: "group",
+          label: "Team",
+          description: "Second occurrence",
+          metadata: { order: 2 },
+        },
+        text: "[[team]]",
+      },
+    ]);
     expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -7,6 +7,8 @@ import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getRoot, type LexicalEditor } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
+import { DirectiveNode } from "../nodes/DirectiveNode";
 import { SyncPlugin } from "./SyncPlugin";
 
 const mocks = vi.hoisted(() => ({
@@ -103,5 +105,59 @@ describe("SyncPlugin", () => {
     });
 
     expect(readEditorText(editor)).toBe("");
+  });
+
+  it("reparses the current draft when the formatter changes", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-formatter-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => `[[${item.id}]]`,
+      parse: (text) =>
+        text === "[[alice]]"
+          ? [
+              {
+                kind: "mention" as const,
+                type: "person",
+                id: "alice",
+                label: "Alice",
+              },
+            ]
+          : [{ kind: "text" as const, text }],
+    };
+    const render = (currentFormatter?: Unstable_DirectiveFormatter) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={currentFormatter} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render();
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $getRoot().getFirstChild()?.getFirstChild()?.getType()),
+    ).toBe("text");
+
+    await act(async () => {
+      render(formatter);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $getRoot().getFirstChild()?.getFirstChild()?.getType()),
+    ).toBe("directive");
+    expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -112,6 +112,14 @@ describe("SyncPlugin", () => {
     });
     expect(editor.getEditorState().read(() => $getSelection())).toBeNull();
 
+    await act(async () => {
+      render({
+        serialize: (item) => `[[${item.id}]]`,
+        parse: (text) => [{ kind: "text", text }],
+      });
+    });
+    expect(editor.getEditorState().read(() => $getSelection())).toBeNull();
+
     mocks.aui = createAui("draft from thread A");
     await act(async () => {
       render();

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -17,7 +17,11 @@ import {
 } from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
-import { DirectiveNode } from "../nodes/DirectiveNode";
+import {
+  $createDirectiveNode,
+  $isDirectiveNode,
+  DirectiveNode,
+} from "../nodes/DirectiveNode";
 import { SyncPlugin } from "./SyncPlugin";
 
 const mocks = vi.hoisted(() => ({
@@ -135,17 +139,19 @@ describe("SyncPlugin", () => {
     };
     const formatter: Unstable_DirectiveFormatter = {
       serialize: (item) => `[[${item.id}]]`,
-      parse: (text) =>
-        text === "[[alice]]"
+      parse: (text) => {
+        const id = text === "[[team]]" ? "team" : "alice";
+        return text === "[[team]]" || text === "[[alice]]"
           ? [
               {
                 kind: "mention" as const,
-                type: "person",
-                id: "alice",
-                label: "Alice",
+                type: id === "team" ? "group" : "person",
+                id,
+                label: id === "team" ? "Team" : "Alice",
               },
             ]
-          : [{ kind: "text" as const, text }],
+          : [{ kind: "text" as const, text }];
+      },
     };
     const plainTextFormatter: Unstable_DirectiveFormatter = {
       serialize: (item) => item.label,
@@ -159,7 +165,7 @@ describe("SyncPlugin", () => {
         </LexicalComposer>,
       );
 
-    mocks.aui = createAui("first\n[[alice]]");
+    mocks.aui = createAui("[[team]]\n[[alice]]");
     await act(async () => {
       render();
     });
@@ -168,7 +174,7 @@ describe("SyncPlugin", () => {
         const paragraph = $createParagraphNode();
         const textNode = $createTextNode("[[alice]]");
         paragraph.append(
-          $createTextNode("first"),
+          $createTextNode("[[team]]"),
           $createLineBreakNode(),
           textNode,
         );
@@ -202,6 +208,22 @@ describe("SyncPlugin", () => {
     ).toEqual(before);
 
     await act(async () => {
+      editor.update(() => {
+        const team = $getRoot().getFirstChild()?.getFirstChild();
+        if (!$isTextNode(team)) throw new Error("Expected team text");
+        team.replace(
+          $createDirectiveNode(
+            {
+              id: "team",
+              type: "group",
+              label: "Team",
+              description: "Engineering",
+              metadata: { workspace: "acme" },
+            },
+            "[[team]]",
+          ),
+        );
+      });
       render(formatter);
     });
     expect(
@@ -209,6 +231,19 @@ describe("SyncPlugin", () => {
         .getEditorState()
         .read(() => $getRoot().getChildAtIndex(1)?.getFirstChild()?.getType()),
     ).toBe("directive");
+    expect(
+      editor.getEditorState().read(() => {
+        const node = $getRoot().getFirstChild()?.getFirstChild();
+        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+        return node.getDirectiveItem();
+      }),
+    ).toEqual({
+      id: "team",
+      type: "group",
+      label: "Team",
+      description: "Engineering",
+      metadata: { workspace: "acme" },
+    });
     expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -104,6 +104,32 @@ function TriggerFormatterRegistration({
   return null;
 }
 
+const triggerEditorConfig = {
+  namespace: "sync-plugin-trigger-test",
+  nodes: [DirectiveNode],
+  onError: (error: Error) => {
+    throw error;
+  },
+};
+
+function TriggerSyncEditor({
+  formatter,
+  capture,
+}: {
+  formatter: Unstable_DirectiveFormatter | undefined;
+  capture: (editor: LexicalEditor) => void;
+}) {
+  return (
+    <ComposerPrimitive.Unstable_TriggerPopoverRoot>
+      <LexicalComposer initialConfig={triggerEditorConfig}>
+        <SyncPlugin />
+        <EditorProbe capture={capture} />
+        <TriggerFormatterRegistration formatter={formatter} />
+      </LexicalComposer>
+    </ComposerPrimitive.Unstable_TriggerPopoverRoot>
+  );
+}
+
 const createBracketFormatter = (): Unstable_DirectiveFormatter => ({
   serialize: (item) => `[[${item.id}]]`,
   parse: (text) => {
@@ -187,28 +213,16 @@ describe("SyncPlugin", () => {
   });
 
   it("reparses a restored draft when a trigger formatter registers", async () => {
-    const initialConfig = {
-      namespace: "sync-plugin-trigger-test",
-      nodes: [DirectiveNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-    };
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
     };
     const formatter = createBracketFormatter();
     const render = (registered: boolean) =>
       root.render(
-        <ComposerPrimitive.Unstable_TriggerPopoverRoot>
-          <LexicalComposer initialConfig={initialConfig}>
-            <SyncPlugin />
-            <EditorProbe capture={capture} />
-            <TriggerFormatterRegistration
-              formatter={registered ? formatter : undefined}
-            />
-          </LexicalComposer>
-        </ComposerPrimitive.Unstable_TriggerPopoverRoot>,
+        <TriggerSyncEditor
+          formatter={registered ? formatter : undefined}
+          capture={capture}
+        />,
       );
 
     mocks.aui = createAui("[[alice]]");
@@ -278,28 +292,16 @@ describe("SyncPlugin", () => {
   });
 
   it("does not reparse text edited before a trigger formatter registers", async () => {
-    const initialConfig = {
-      namespace: "sync-plugin-edited-trigger-test",
-      nodes: [DirectiveNode],
-      onError: (error: Error) => {
-        throw error;
-      },
-    };
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
     };
     const formatter = createBracketFormatter();
     const render = (registered: boolean) =>
       root.render(
-        <ComposerPrimitive.Unstable_TriggerPopoverRoot>
-          <LexicalComposer initialConfig={initialConfig}>
-            <SyncPlugin />
-            <EditorProbe capture={capture} />
-            <TriggerFormatterRegistration
-              formatter={registered ? formatter : undefined}
-            />
-          </LexicalComposer>
-        </ComposerPrimitive.Unstable_TriggerPopoverRoot>,
+        <TriggerSyncEditor
+          formatter={registered ? formatter : undefined}
+          capture={capture}
+        />,
       );
 
     mocks.aui = createAui("draft");
@@ -336,9 +338,57 @@ describe("SyncPlugin", () => {
     ).toEqual(beforeRegistration);
   });
 
-  it("preserves metadata when formatter syntax changes", async () => {
+  it("does not reparse after the selection moves", async () => {
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <TriggerSyncEditor
+          formatter={registered ? formatter : undefined}
+          capture={capture}
+        />,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const textNode = $getParagraph().getFirstChild();
+        if (!$isTextNode(textNode)) throw new Error("Expected text");
+        textNode.select(2, 2);
+      });
+    });
+    const beforeRegistration = editor.getEditorState().read(() => {
+      const textNode = $getParagraph().getFirstChild();
+      const selection = $getSelection();
+      if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
+        throw new Error("Expected a text selection");
+      }
+      return { key: textNode.getKey(), offset: selection.anchor.offset };
+    });
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const textNode = $getParagraph().getFirstChild();
+        const selection = $getSelection();
+        if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
+          throw new Error("Expected a text selection");
+        }
+        return { key: textNode.getKey(), offset: selection.anchor.offset };
+      }),
+    ).toEqual(beforeRegistration);
+  });
+
+  it("preserves state when a formatter keeps the parsed structure", async () => {
     const initialConfig = {
-      namespace: "sync-plugin-formatter-test",
+      namespace: "sync-plugin-formatter-state-test",
       nodes: [DirectiveNode],
       onError: (error: Error) => {
         throw error;
@@ -346,20 +396,6 @@ describe("SyncPlugin", () => {
     };
     const capture = (capturedEditor: LexicalEditor) => {
       editor = capturedEditor;
-    };
-    const formatter: Unstable_DirectiveFormatter = {
-      serialize: (item) => `[[${item.id}]]`,
-      parse: (text) =>
-        text === "@team"
-          ? [
-              {
-                kind: "mention" as const,
-                type: "group",
-                id: "team",
-                label: "Team",
-              },
-            ]
-          : [{ kind: "text" as const, text }],
     };
     const plainTextFormatter: Unstable_DirectiveFormatter = {
       serialize: (item) => item.label,
@@ -378,20 +414,22 @@ describe("SyncPlugin", () => {
       render();
     });
     await act(async () => {
-      editor.update(() => {
-        const paragraph = $createParagraphNode();
-        const textNode = $createTextNode("@team");
-        paragraph.append(
-          $createTextNode("@team"),
-          $createLineBreakNode(),
-          textNode,
-        );
-        const lexicalRoot = $getRoot();
-        lexicalRoot.clear();
-        lexicalRoot.append(paragraph);
-        textNode.select(4, 4);
-        $setCompositionKey(textNode.getKey());
-      });
+      editor.update(
+        () => {
+          const paragraph = $createParagraphNode();
+          const textNode = $createTextNode("@team");
+          paragraph.append(
+            $createTextNode("@team"),
+            $createLineBreakNode(),
+            textNode,
+          );
+          const lexicalRoot = $getRoot();
+          lexicalRoot.clear();
+          lexicalRoot.append(paragraph);
+          textNode.select(4, 4);
+        },
+        { tag: "aui-sync" },
+      );
     });
     const before = editor.getEditorState().read(() => {
       const textNode = $getParagraph().getLastChild();
@@ -402,10 +440,8 @@ describe("SyncPlugin", () => {
       return {
         key: textNode.getKey(),
         offset: selection.anchor.offset,
-        isComposing: editor.isComposing(),
       };
     });
-    expect(before.isComposing).toBe(true);
 
     await act(async () => {
       render(plainTextFormatter);
@@ -420,45 +456,81 @@ describe("SyncPlugin", () => {
         return {
           key: textNode.getKey(),
           offset: selection.anchor.offset,
-          isComposing: editor.isComposing(),
         };
       }),
     ).toEqual(before);
+  });
+
+  it("preserves duplicate metadata when formatter syntax changes", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-formatter-metadata-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const parseTeam: Unstable_DirectiveFormatter["parse"] = (text) =>
+      text === "@team"
+        ? [
+            {
+              kind: "mention",
+              type: "group",
+              id: "team",
+              label: "Team",
+            },
+          ]
+        : [{ kind: "text", text }];
+    const oldFormatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => `@${item.id}`,
+      parse: parseTeam,
+    };
+    const newFormatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => `[[${item.id}]]`,
+      parse: parseTeam,
+    };
+    const render = (formatter: Unstable_DirectiveFormatter) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={formatter} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("@team\n@team");
+    await act(async () => {
+      render(oldFormatter);
+    });
 
     await act(async () => {
-      editor.update(() => {
-        const paragraph = $getParagraph();
-        const firstTeam = paragraph.getFirstChild();
-        const secondTeam = paragraph.getLastChild();
-        if (!$isTextNode(firstTeam) || !$isTextNode(secondTeam)) {
-          throw new Error("Expected team text");
-        }
-        firstTeam.replace(
-          $createDirectiveNode(
-            {
-              id: "team",
-              type: "group",
-              label: "First Team",
-              description: "First occurrence",
-              metadata: { order: 1 },
-            },
-            "@team",
-          ),
-        );
-        secondTeam.replace(
-          $createDirectiveNode(
-            {
-              id: "team",
-              type: "group",
-              label: "Second Team",
-              description: "Second occurrence",
-              metadata: { order: 2 },
-            },
-            "@team",
-          ),
-        );
-      });
-      render(formatter);
+      editor.update(
+        () => {
+          for (const [index, description] of [
+            "First occurrence",
+            "Second occurrence",
+          ].entries()) {
+            const team = $getParagraph(index).getFirstChild();
+            if (!$isDirectiveNode(team))
+              throw new Error("Expected a directive");
+            team.replace(
+              $createDirectiveNode(
+                {
+                  id: "team",
+                  type: "group",
+                  label: team.getDirectiveItem().label,
+                  description,
+                  metadata: { order: index + 1 },
+                },
+                "@team",
+              ),
+            );
+          }
+        },
+        { tag: "aui-sync" },
+      );
+      render(newFormatter);
     });
     expect(
       editor
@@ -504,7 +576,7 @@ describe("SyncPlugin", () => {
 
     mocks.aui = createAui("@team");
     await act(async () => {
-      render(formatter);
+      render(newFormatter);
     });
     expect(
       editor.getEditorState().read(() => {
@@ -519,5 +591,103 @@ describe("SyncPlugin", () => {
       description: undefined,
       metadata: undefined,
     });
+  });
+
+  it("does not move metadata to a different matching occurrence", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-formatter-position-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const team = {
+      kind: "mention" as const,
+      type: "group",
+      id: "team",
+      label: "Team",
+    };
+    const oldFormatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => `[[${item.id}]]`,
+      parse: (text) => {
+        if (text === "@team [[team]]") {
+          return [{ kind: "text", text: "@team " }, team];
+        }
+        return text === "[[team]]" ? [team] : [{ kind: "text", text }];
+      },
+    };
+    const newFormatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => `@${item.id}`,
+      parse: (text) => {
+        if (text === "@team [[team]]") {
+          return [team, { kind: "text", text: " [[team]]" }];
+        }
+        return text === "@team" ? [team] : [{ kind: "text", text }];
+      },
+    };
+    const render = (formatter: Unstable_DirectiveFormatter) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={formatter} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("@team [[team]]");
+    await act(async () => {
+      render(oldFormatter);
+    });
+    await act(async () => {
+      editor.update(
+        () => {
+          const directive = $getParagraph().getLastChild();
+          if (!$isDirectiveNode(directive)) {
+            throw new Error("Expected a directive");
+          }
+          directive.replace(
+            $createDirectiveNode(
+              {
+                ...directive.getDirectiveItem(),
+                description: "Original occurrence",
+                metadata: { source: "brackets" },
+              },
+              directive.getDirectiveText(),
+            ),
+          );
+        },
+        { tag: "aui-sync" },
+      );
+    });
+    const before = editor.getEditorState().read(() => {
+      const directive = $getParagraph().getLastChild();
+      if (!$isDirectiveNode(directive)) {
+        throw new Error("Expected a directive");
+      }
+      return { key: directive.getKey(), item: directive.getDirectiveItem() };
+    });
+
+    await act(async () => {
+      render(newFormatter);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const paragraph = $getParagraph();
+        const text = paragraph.getFirstChild();
+        const directive = paragraph.getLastChild();
+        if (!$isTextNode(text) || !$isDirectiveNode(directive)) {
+          throw new Error("Expected text followed by a directive");
+        }
+        return {
+          text: text.getTextContent(),
+          directive: {
+            key: directive.getKey(),
+            item: directive.getDirectiveItem(),
+          },
+        };
+      }),
+    ).toEqual({ text: "@team ", directive: before });
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -5,7 +5,13 @@ import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $getRoot, type LexicalEditor } from "lexical";
+import {
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  type LexicalEditor,
+} from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
 import { DirectiveNode } from "../nodes/DirectiveNode";
@@ -93,6 +99,12 @@ describe("SyncPlugin", () => {
         </LexicalComposer>,
       );
 
+    mocks.aui = createAui("");
+    await act(async () => {
+      render();
+    });
+    expect(editor.getEditorState().read(() => $getSelection())).toBeNull();
+
     mocks.aui = createAui("draft from thread A");
     await act(async () => {
       render();
@@ -132,6 +144,10 @@ describe("SyncPlugin", () => {
             ]
           : [{ kind: "text" as const, text }],
     };
+    const plainTextFormatter: Unstable_DirectiveFormatter = {
+      serialize: (item) => item.label,
+      parse: (text) => [{ kind: "text", text }],
+    };
     const render = (currentFormatter?: Unstable_DirectiveFormatter) =>
       root.render(
         <LexicalComposer initialConfig={initialConfig}>
@@ -149,6 +165,35 @@ describe("SyncPlugin", () => {
         .getEditorState()
         .read(() => $getRoot().getFirstChild()?.getFirstChild()?.getType()),
     ).toBe("text");
+    await act(async () => {
+      editor.update(() => {
+        const textNode = $getRoot().getFirstChild()?.getFirstChild();
+        if (!$isTextNode(textNode)) throw new Error("Expected a text node");
+        textNode.select(4, 4);
+      });
+    });
+    const before = editor.getEditorState().read(() => {
+      const textNode = $getRoot().getFirstChild()?.getFirstChild();
+      const selection = $getSelection();
+      if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
+        throw new Error("Expected a text selection");
+      }
+      return { key: textNode.getKey(), offset: selection.anchor.offset };
+    });
+
+    await act(async () => {
+      render(plainTextFormatter);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const textNode = $getRoot().getFirstChild()?.getFirstChild();
+        const selection = $getSelection();
+        if (!$isTextNode(textNode) || !$isRangeSelection(selection)) {
+          throw new Error("Expected a text selection");
+        }
+        return { key: textNode.getKey(), offset: selection.anchor.offset };
+      }),
+    ).toEqual(before);
 
     await act(async () => {
       render(formatter);

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -200,6 +200,7 @@ function syncRuntimeToLexical(
   editor: LexicalEditor,
   runtimeText: string,
   parse: CompositeParser,
+  preserveDirectiveMetadata: boolean,
   onComplete: () => void,
 ) {
   editor.update(
@@ -209,18 +210,20 @@ function syncRuntimeToLexical(
         string,
         Pick<Unstable_TriggerItem, "description" | "metadata">[]
       >();
-      for (const paragraph of root.getChildren()) {
-        if (!$isElementNode(paragraph)) continue;
-        for (const child of paragraph.getChildren()) {
-          if (!$isDirectiveNode(child)) continue;
-          const item = child.getDirectiveItem();
-          const key = getDirectiveKey(item);
-          const items = preservedDirectiveItems.get(key) ?? [];
-          items.push({
-            description: item.description,
-            metadata: item.metadata,
-          });
-          preservedDirectiveItems.set(key, items);
+      if (preserveDirectiveMetadata) {
+        for (const paragraph of root.getChildren()) {
+          if (!$isElementNode(paragraph)) continue;
+          for (const child of paragraph.getChildren()) {
+            if (!$isDirectiveNode(child)) continue;
+            const item = child.getDirectiveItem();
+            const key = getDirectiveKey(item);
+            const items = preservedDirectiveItems.get(key) ?? [];
+            items.push({
+              description: item.description,
+              metadata: item.metadata,
+            });
+            preservedDirectiveItems.set(key, items);
+          }
         }
       }
       root.clear();
@@ -352,14 +355,20 @@ export function SyncPlugin({
     const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
     const parserRequiresResync =
       parserChanged &&
-      parserPreservesExistingDirectives(editor, initialText, parser) &&
-      !editorMatchesParsedText(editor, initialText, parser);
+      !editorMatchesParsedText(editor, initialText, parser) &&
+      parserPreservesExistingDirectives(editor, initialText, parser);
     if (runtimeTextChanged || parserRequiresResync) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
-      syncRuntimeToLexical(editor, initialText, parser, () => {
-        isSyncingFromRuntimeRef.current = false;
-      });
+      syncRuntimeToLexical(
+        editor,
+        initialText,
+        parser,
+        parserRequiresResync && !runtimeTextChanged,
+        () => {
+          isSyncingFromRuntimeRef.current = false;
+        },
+      );
     }
 
     return composerRuntime.subscribe(() => {
@@ -371,7 +380,7 @@ export function SyncPlugin({
 
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = runtimeText;
-      syncRuntimeToLexical(editor, runtimeText, parser, () => {
+      syncRuntimeToLexical(editor, runtimeText, parser, false, () => {
         isSyncingFromRuntimeRef.current = false;
       });
     });

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -158,12 +158,11 @@ export function SyncPlugin({
   );
 
   const parser = useMemo(() => composeParsers(formatters), [formatters]);
-  const parserRef = useRef<CompositeParser>(parser);
-  parserRef.current = parser;
 
   const isSyncingFromLexicalRef = useRef(false);
   const isSyncingFromRuntimeRef = useRef(false);
   const lastSyncedTextRef = useRef("");
+  const lastAppliedParserRef = useRef<CompositeParser | null>(null);
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
@@ -205,10 +204,14 @@ export function SyncPlugin({
     if (!composerRuntime) return;
 
     const initialText = composerRuntime.getState().text;
-    if (initialText !== lastSyncedTextRef.current) {
+    if (
+      initialText !== lastSyncedTextRef.current ||
+      parser !== lastAppliedParserRef.current
+    ) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
-      syncRuntimeToLexical(editor, initialText, parserRef.current, () => {
+      lastAppliedParserRef.current = parser;
+      syncRuntimeToLexical(editor, initialText, parser, () => {
         isSyncingFromRuntimeRef.current = false;
       });
     }
@@ -222,11 +225,12 @@ export function SyncPlugin({
 
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = runtimeText;
-      syncRuntimeToLexical(editor, runtimeText, parserRef.current, () => {
+      lastAppliedParserRef.current = parser;
+      syncRuntimeToLexical(editor, runtimeText, parser, () => {
         isSyncingFromRuntimeRef.current = false;
       });
     });
-  }, [editor, aui]);
+  }, [editor, aui, parser]);
 
   return null;
 }

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -307,6 +307,7 @@ function syncRuntimeToLexical(
               label: segment.label,
             };
             const key = getDirectiveKey(item);
+            // The parser guard keeps same-identity occurrences ordered and count-equal, so positional metadata stays with its original occurrence.
             const preservedItem = preservedDirectiveItems.get(key)?.shift();
             paragraph.append(
               $createDirectiveNodeWithFormatter(

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -117,8 +117,43 @@ function getParsedLines(
   });
 }
 
-function getDirectiveKey(item: Unstable_TriggerItem, directiveText: string) {
-  return JSON.stringify([item.id, item.type, directiveText]);
+function getDirectiveKey(item: Pick<Unstable_TriggerItem, "id" | "type">) {
+  return JSON.stringify([item.id, item.type]);
+}
+
+function parserPreservesExistingDirectives(
+  editor: LexicalEditor,
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  const parsedDirectiveKeys = getParsedLines(runtimeText, parse)
+    .flat()
+    .flatMap((segment) =>
+      segment[0] === "mention"
+        ? [getDirectiveKey({ id: segment[1], type: segment[2] })]
+        : [],
+    );
+  if (parsedDirectiveKeys.length === 0) return false;
+
+  return editor.getEditorState().read(() => {
+    let parsedIndex = 0;
+    for (const paragraph of $getRoot().getChildren()) {
+      if (!$isElementNode(paragraph)) continue;
+      for (const child of paragraph.getChildren()) {
+        if (!$isDirectiveNode(child)) continue;
+        const key = getDirectiveKey(child.getDirectiveItem());
+        while (
+          parsedIndex < parsedDirectiveKeys.length &&
+          parsedDirectiveKeys[parsedIndex] !== key
+        ) {
+          parsedIndex += 1;
+        }
+        if (parsedIndex === parsedDirectiveKeys.length) return false;
+        parsedIndex += 1;
+      }
+    }
+    return true;
+  });
 }
 
 function editorMatchesParsedText(
@@ -179,7 +214,7 @@ function syncRuntimeToLexical(
         for (const child of paragraph.getChildren()) {
           if (!$isDirectiveNode(child)) continue;
           const item = child.getDirectiveItem();
-          const key = getDirectiveKey(item, child.getDirectiveText());
+          const key = getDirectiveKey(item);
           const items = preservedDirectiveItems.get(key) ?? [];
           items.push({
             description: item.description,
@@ -212,7 +247,7 @@ function syncRuntimeToLexical(
               type: segment.type,
               label: segment.label,
             };
-            const key = getDirectiveKey(item, formatter.serialize(segment));
+            const key = getDirectiveKey(item);
             const preservedItem = preservedDirectiveItems.get(key)?.shift();
             paragraph.append(
               $createDirectiveNodeWithFormatter(
@@ -316,7 +351,9 @@ export function SyncPlugin({
     lastAppliedParserRef.current = parser;
     const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
     const parserRequiresResync =
-      parserChanged && !editorMatchesParsedText(editor, initialText, parser);
+      parserChanged &&
+      parserPreservesExistingDirectives(editor, initialText, parser) &&
+      !editorMatchesParsedText(editor, initialText, parser);
     if (runtimeTextChanged || parserRequiresResync) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -13,6 +13,7 @@ import {
   $createTextNode,
   $createParagraphNode,
   $isElementNode,
+  $isLineBreakNode,
   $isTextNode,
   type LexicalEditor,
 } from "lexical";
@@ -96,8 +97,7 @@ function getParsedLines(
   runtimeText: string,
   parse: CompositeParser,
 ): SegmentKey[][] {
-  const lines = runtimeText.length === 0 ? [""] : runtimeText.split("\n");
-  return lines.map((line) => {
+  return runtimeText.split("\n").map((line) => {
     const result: SegmentKey[] = [];
     for (const { segment, formatter } of parse(line)) {
       if (segment.kind === "text") {
@@ -124,13 +124,15 @@ function editorMatchesParsedText(
   const parsedLines = getParsedLines(runtimeText, parse);
   return editor.getEditorState().read(() => {
     const paragraphs = $getRoot().getChildren();
-    if (paragraphs.length !== parsedLines.length) return false;
     const lexicalLines: SegmentKey[][] = [];
     for (const paragraph of paragraphs) {
       if (!$isElementNode(paragraph)) return false;
-      const segments: SegmentKey[] = [];
+      let segments: SegmentKey[] = [];
       for (const child of paragraph.getChildren()) {
-        if ($isTextNode(child)) {
+        if ($isLineBreakNode(child)) {
+          lexicalLines.push(segments);
+          segments = [];
+        } else if ($isTextNode(child)) {
           appendTextSegment(segments, child.getTextContent());
         } else if ($isDirectiveNode(child)) {
           const item = child.getDirectiveItem();
@@ -147,6 +149,7 @@ function editorMatchesParsedText(
       }
       lexicalLines.push(segments);
     }
+    if (lexicalLines.length !== parsedLines.length) return false;
     return JSON.stringify(lexicalLines) === JSON.stringify(parsedLines);
   });
 }

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -48,7 +48,7 @@ type SegmentKey =
   | readonly ["text", string]
   | readonly ["mention", string, string, string];
 
-type DirectiveLabelKey = readonly [string, string, string];
+type DirectiveLabelKey = readonly [string, string];
 
 /** Ordered, identity-deduped: prop formatter, trigger formatters, default tail. */
 export function collectFormatters(
@@ -131,10 +131,23 @@ function getParsedDirectiveLabels(
     .flatMap((line) =>
       parse(line).flatMap(({ segment }) =>
         segment.kind === "mention"
-          ? [[segment.id, segment.type, segment.label] as const]
+          ? [[getDirectiveKey(segment), segment.label] as const]
           : [],
       ),
     );
+}
+
+function getParsedDirectiveLabelQueues(
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  const result = new Map<string, string[]>();
+  for (const [key, label] of getParsedDirectiveLabels(runtimeText, parse)) {
+    const labels = result.get(key) ?? [];
+    labels.push(label);
+    result.set(key, labels);
+  }
+  return result;
 }
 
 function getDirectiveKey(item: Pick<Unstable_TriggerItem, "id" | "type">) {
@@ -271,17 +284,25 @@ function syncRuntimeToLexical(
   editor: LexicalEditor,
   runtimeText: string,
   parse: CompositeParser,
-  isParserOnlyReparse: boolean,
+  previousParser: CompositeParser | undefined,
   onComplete: () => void,
 ) {
+  const isParserOnlyReparse = previousParser !== undefined;
   editor.update(
     () => {
       const root = $getRoot();
       const preservedDirectiveItems = new Map<
         string,
-        Pick<Unstable_TriggerItem, "description" | "metadata">[]
+        (Pick<Unstable_TriggerItem, "description" | "metadata"> & {
+          readonly label?: string;
+        })[]
       >();
       if (isParserOnlyReparse) {
+        const previousLabels = getParsedDirectiveLabelQueues(
+          runtimeText,
+          previousParser,
+        );
+        const nextLabels = getParsedDirectiveLabelQueues(runtimeText, parse);
         for (const paragraph of root.getChildren()) {
           if (!$isElementNode(paragraph)) continue;
           for (const child of paragraph.getChildren()) {
@@ -289,9 +310,14 @@ function syncRuntimeToLexical(
             const item = child.getDirectiveItem();
             const key = getDirectiveKey(item);
             const items = preservedDirectiveItems.get(key) ?? [];
+            const previousLabel = previousLabels.get(key)?.shift();
+            const nextLabel = nextLabels.get(key)?.shift();
             items.push({
               description: item.description,
               metadata: item.metadata,
+              ...(previousLabel !== undefined && previousLabel === nextLabel
+                ? { label: item.label }
+                : {}),
             });
             preservedDirectiveItems.set(key, items);
           }
@@ -373,9 +399,20 @@ export function SyncPlugin({
 
   const triggers = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
+  const propFormatterParse = propFormatter?.parse;
+  const propFormatterSerialize = propFormatter?.serialize;
   const formatters = useMemo(
-    () => collectFormatters(triggers, propFormatter),
-    [triggers, propFormatter],
+    () =>
+      collectFormatters(
+        triggers,
+        propFormatterParse && propFormatterSerialize
+          ? {
+              parse: propFormatterParse,
+              serialize: propFormatterSerialize,
+            }
+          : undefined,
+      ),
+    [triggers, propFormatterParse, propFormatterSerialize],
   );
 
   const parser = useMemo(() => composeParsers(formatters), [formatters]);
@@ -455,7 +492,9 @@ export function SyncPlugin({
         editor,
         initialText,
         parser,
-        parserRequiresResync && !runtimeTextChanged,
+        parserRequiresResync && !runtimeTextChanged
+          ? previousParser
+          : undefined,
         () => {
           isSyncingFromRuntimeRef.current = false;
           editorDirtySinceSyncRef.current = false;
@@ -472,7 +511,7 @@ export function SyncPlugin({
 
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = runtimeText;
-      syncRuntimeToLexical(editor, runtimeText, parser, false, () => {
+      syncRuntimeToLexical(editor, runtimeText, parser, undefined, () => {
         isSyncingFromRuntimeRef.current = false;
         editorDirtySinceSyncRef.current = false;
       });

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -12,9 +12,12 @@ import {
   $getRoot,
   $createTextNode,
   $createParagraphNode,
+  $getSelection,
   $isElementNode,
   $isLineBreakNode,
+  $isRangeSelection,
   $isTextNode,
+  type EditorState,
   type LexicalEditor,
 } from "lexical";
 import { useAui } from "@assistant-ui/store";
@@ -121,6 +124,19 @@ function getDirectiveKey(item: Pick<Unstable_TriggerItem, "id" | "type">) {
   return JSON.stringify([item.id, item.type]);
 }
 
+function getOnlyParsedDirectiveKey(text: string, parse: CompositeParser) {
+  let directiveKey: string | undefined;
+  for (const { segment } of parse(text)) {
+    if (segment.kind === "text") {
+      if (segment.text.length > 0) return undefined;
+    } else {
+      if (directiveKey !== undefined) return undefined;
+      directiveKey = getDirectiveKey(segment);
+    }
+  }
+  return directiveKey;
+}
+
 function parserPreservesExistingDirectives(
   editor: LexicalEditor,
   runtimeText: string,
@@ -135,13 +151,28 @@ function parserPreservesExistingDirectives(
     );
   if (parsedDirectiveKeys.length === 0) return false;
 
+  const parsedDirectiveCounts = new Map<string, number>();
+  for (const key of parsedDirectiveKeys) {
+    parsedDirectiveCounts.set(key, (parsedDirectiveCounts.get(key) ?? 0) + 1);
+  }
+
   return editor.getEditorState().read(() => {
+    const existingDirectiveCounts = new Map<string, number>();
     let parsedIndex = 0;
     for (const paragraph of $getRoot().getChildren()) {
       if (!$isElementNode(paragraph)) continue;
       for (const child of paragraph.getChildren()) {
         if (!$isDirectiveNode(child)) continue;
         const key = getDirectiveKey(child.getDirectiveItem());
+        if (
+          getOnlyParsedDirectiveKey(child.getDirectiveText(), parse) !== key
+        ) {
+          return false;
+        }
+        existingDirectiveCounts.set(
+          key,
+          (existingDirectiveCounts.get(key) ?? 0) + 1,
+        );
         while (
           parsedIndex < parsedDirectiveKeys.length &&
           parsedDirectiveKeys[parsedIndex] !== key
@@ -152,7 +183,32 @@ function parserPreservesExistingDirectives(
         parsedIndex += 1;
       }
     }
+    for (const [key, count] of existingDirectiveCounts) {
+      if (parsedDirectiveCounts.get(key) !== count) return false;
+    }
     return true;
+  });
+}
+
+function getSelectionKey(editorState: EditorState) {
+  return editorState.read(() => {
+    const selection = $getSelection();
+    if (selection === null) return null;
+    if ($isRangeSelection(selection)) {
+      return JSON.stringify([
+        "range",
+        selection.anchor.key,
+        selection.anchor.offset,
+        selection.anchor.type,
+        selection.focus.key,
+        selection.focus.offset,
+        selection.focus.type,
+      ]);
+    }
+    return JSON.stringify([
+      "nodes",
+      ...selection.getNodes().map((node) => node.getKey()),
+    ]);
   });
 }
 
@@ -312,39 +368,45 @@ export function SyncPlugin({
   const lastAppliedParserRef = useRef(parser);
 
   useEffect(() => {
-    return editor.registerUpdateListener(({ editorState, tags }) => {
-      if (isSyncingFromRuntimeRef.current) return;
-      if (tags.has(SYNC_TAG)) return;
+    return editor.registerUpdateListener(
+      ({ editorState, prevEditorState, tags }) => {
+        if (isSyncingFromRuntimeRef.current) return;
+        if (tags.has(SYNC_TAG)) return;
 
-      editorState.read(() => {
-        isSyncingFromLexicalRef.current = true;
-
-        try {
-          const rootNode = $getRoot();
-          let fullText = "";
-
-          for (const paragraph of rootNode.getChildren()) {
-            if (fullText.length > 0) {
-              fullText += "\n";
-            }
-            if (!$isElementNode(paragraph)) continue;
-            for (const child of paragraph.getChildren()) {
-              fullText += child.getTextContent();
-            }
-          }
-
-          const composer = aui.composer;
-
-          if (fullText !== lastSyncedTextRef.current) {
-            editorDirtySinceSyncRef.current = true;
-            lastSyncedTextRef.current = fullText;
-            composer.setText(fullText);
-          }
-        } finally {
-          isSyncingFromLexicalRef.current = false;
+        if (getSelectionKey(editorState) !== getSelectionKey(prevEditorState)) {
+          editorDirtySinceSyncRef.current = true;
         }
-      });
-    });
+
+        editorState.read(() => {
+          isSyncingFromLexicalRef.current = true;
+
+          try {
+            const rootNode = $getRoot();
+            let fullText = "";
+
+            for (const paragraph of rootNode.getChildren()) {
+              if (fullText.length > 0) {
+                fullText += "\n";
+              }
+              if (!$isElementNode(paragraph)) continue;
+              for (const child of paragraph.getChildren()) {
+                fullText += child.getTextContent();
+              }
+            }
+
+            const composer = aui.composer;
+
+            if (fullText !== lastSyncedTextRef.current) {
+              editorDirtySinceSyncRef.current = true;
+              lastSyncedTextRef.current = fullText;
+              composer.setText(fullText);
+            }
+          } finally {
+            isSyncingFromLexicalRef.current = false;
+          }
+        });
+      },
+    );
   }, [editor, aui]);
 
   useEffect(() => {
@@ -358,6 +420,7 @@ export function SyncPlugin({
     const parserRequiresResync =
       parserChanged &&
       !editorDirtySinceSyncRef.current &&
+      !editor.isComposing() &&
       !editorMatchesParsedText(editor, initialText, parser) &&
       parserPreservesExistingDirectives(editor, initialText, parser);
     if (runtimeTextChanged || parserRequiresResync) {

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -17,6 +17,7 @@ import {
   $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
+  SKIP_DOM_SELECTION_TAG,
   type EditorState,
   type LexicalEditor,
 } from "lexical";
@@ -255,7 +256,7 @@ function syncRuntimeToLexical(
   editor: LexicalEditor,
   runtimeText: string,
   parse: CompositeParser,
-  preserveDirectiveMetadata: boolean,
+  isParserOnlyReparse: boolean,
   onComplete: () => void,
 ) {
   editor.update(
@@ -265,7 +266,7 @@ function syncRuntimeToLexical(
         string,
         Pick<Unstable_TriggerItem, "description" | "metadata">[]
       >();
-      if (preserveDirectiveMetadata) {
+      if (isParserOnlyReparse) {
         for (const paragraph of root.getChildren()) {
           if (!$isElementNode(paragraph)) continue;
           for (const child of paragraph.getChildren()) {
@@ -285,7 +286,7 @@ function syncRuntimeToLexical(
 
       if (runtimeText.length === 0) {
         root.append($createParagraphNode());
-        root.selectEnd();
+        if (!isParserOnlyReparse) root.selectEnd();
         return;
       }
 
@@ -320,9 +321,12 @@ function syncRuntimeToLexical(
         root.append(paragraph);
       }
 
-      root.selectEnd();
+      if (!isParserOnlyReparse) root.selectEnd();
     },
-    { onUpdate: onComplete, tag: SYNC_TAG },
+    {
+      onUpdate: onComplete,
+      tag: isParserOnlyReparse ? [SYNC_TAG, SKIP_DOM_SELECTION_TAG] : SYNC_TAG,
+    },
   );
 }
 

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -221,7 +221,6 @@ function editorMatchesParsedText(
   return editor.getEditorState().read(() => {
     const root = $getRoot();
     const paragraphs = root.getChildren();
-    if (runtimeText.length === 0 && paragraphs.length === 0) return true;
     const lexicalLines: SegmentKey[][] = [];
     for (const paragraph of paragraphs) {
       if (!$isElementNode(paragraph)) return false;

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -307,6 +307,7 @@ export function SyncPlugin({
 
   const isSyncingFromLexicalRef = useRef(false);
   const isSyncingFromRuntimeRef = useRef(false);
+  const editorDirtySinceSyncRef = useRef(false);
   const lastSyncedTextRef = useRef("");
   const lastAppliedParserRef = useRef(parser);
 
@@ -335,6 +336,7 @@ export function SyncPlugin({
           const composer = aui.composer;
 
           if (fullText !== lastSyncedTextRef.current) {
+            editorDirtySinceSyncRef.current = true;
             lastSyncedTextRef.current = fullText;
             composer.setText(fullText);
           }
@@ -355,6 +357,7 @@ export function SyncPlugin({
     const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
     const parserRequiresResync =
       parserChanged &&
+      !editorDirtySinceSyncRef.current &&
       !editorMatchesParsedText(editor, initialText, parser) &&
       parserPreservesExistingDirectives(editor, initialText, parser);
     if (runtimeTextChanged || parserRequiresResync) {
@@ -367,6 +370,7 @@ export function SyncPlugin({
         parserRequiresResync && !runtimeTextChanged,
         () => {
           isSyncingFromRuntimeRef.current = false;
+          editorDirtySinceSyncRef.current = false;
         },
       );
     }
@@ -382,6 +386,7 @@ export function SyncPlugin({
       lastSyncedTextRef.current = runtimeText;
       syncRuntimeToLexical(editor, runtimeText, parser, false, () => {
         isSyncingFromRuntimeRef.current = false;
+        editorDirtySinceSyncRef.current = false;
       });
     });
   }, [editor, aui, parser]);

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -13,6 +13,7 @@ import {
   $createTextNode,
   $createParagraphNode,
   $isElementNode,
+  $isTextNode,
   type LexicalEditor,
 } from "lexical";
 import { useAui } from "@assistant-ui/store";
@@ -25,7 +26,10 @@ import {
   unstable_useTriggerPopoverRootContextOptional,
   type Unstable_RegisteredTrigger,
 } from "@assistant-ui/react";
-import { $createDirectiveNodeWithFormatter } from "../nodes/DirectiveNode";
+import {
+  $createDirectiveNodeWithFormatter,
+  $isDirectiveNode,
+} from "../nodes/DirectiveNode";
 
 type ParsedSegment = {
   readonly segment: Unstable_DirectiveSegment;
@@ -33,6 +37,10 @@ type ParsedSegment = {
 };
 
 type CompositeParser = (text: string) => readonly ParsedSegment[];
+
+type SegmentKey =
+  | readonly ["text", string]
+  | readonly ["mention", string, string, string, string];
 
 /** Ordered, identity-deduped: prop formatter, trigger formatters, default tail. */
 export function collectFormatters(
@@ -72,6 +80,75 @@ export function composeParsers(
     }
     return fallback!;
   };
+}
+
+function appendTextSegment(segments: SegmentKey[], text: string) {
+  if (text.length === 0) return;
+  const previous = segments.at(-1);
+  if (previous?.[0] === "text") {
+    segments[segments.length - 1] = ["text", previous[1] + text];
+  } else {
+    segments.push(["text", text]);
+  }
+}
+
+function getParsedLines(
+  runtimeText: string,
+  parse: CompositeParser,
+): SegmentKey[][] {
+  const lines = runtimeText.length === 0 ? [""] : runtimeText.split("\n");
+  return lines.map((line) => {
+    const result: SegmentKey[] = [];
+    for (const { segment, formatter } of parse(line)) {
+      if (segment.kind === "text") {
+        appendTextSegment(result, segment.text);
+      } else {
+        result.push([
+          "mention",
+          segment.id,
+          segment.type,
+          segment.label,
+          formatter.serialize(segment),
+        ]);
+      }
+    }
+    return result;
+  });
+}
+
+function editorMatchesParsedText(
+  editor: LexicalEditor,
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  const parsedLines = getParsedLines(runtimeText, parse);
+  return editor.getEditorState().read(() => {
+    const paragraphs = $getRoot().getChildren();
+    if (paragraphs.length !== parsedLines.length) return false;
+    const lexicalLines: SegmentKey[][] = [];
+    for (const paragraph of paragraphs) {
+      if (!$isElementNode(paragraph)) return false;
+      const segments: SegmentKey[] = [];
+      for (const child of paragraph.getChildren()) {
+        if ($isTextNode(child)) {
+          appendTextSegment(segments, child.getTextContent());
+        } else if ($isDirectiveNode(child)) {
+          const item = child.getDirectiveItem();
+          segments.push([
+            "mention",
+            item.id,
+            item.type,
+            item.label,
+            child.getDirectiveText(),
+          ]);
+        } else {
+          return false;
+        }
+      }
+      lexicalLines.push(segments);
+    }
+    return JSON.stringify(lexicalLines) === JSON.stringify(parsedLines);
+  });
 }
 
 function syncRuntimeToLexical(
@@ -162,7 +239,7 @@ export function SyncPlugin({
   const isSyncingFromLexicalRef = useRef(false);
   const isSyncingFromRuntimeRef = useRef(false);
   const lastSyncedTextRef = useRef("");
-  const lastAppliedParserRef = useRef<CompositeParser | null>(null);
+  const lastAppliedParserRef = useRef(parser);
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
@@ -204,13 +281,14 @@ export function SyncPlugin({
     if (!composerRuntime) return;
 
     const initialText = composerRuntime.getState().text;
+    const parserChanged = parser !== lastAppliedParserRef.current;
+    lastAppliedParserRef.current = parser;
     if (
       initialText !== lastSyncedTextRef.current ||
-      parser !== lastAppliedParserRef.current
+      (parserChanged && !editorMatchesParsedText(editor, initialText, parser))
     ) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
-      lastAppliedParserRef.current = parser;
       syncRuntimeToLexical(editor, initialText, parser, () => {
         isSyncingFromRuntimeRef.current = false;
       });
@@ -225,7 +303,6 @@ export function SyncPlugin({
 
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = runtimeText;
-      lastAppliedParserRef.current = parser;
       syncRuntimeToLexical(editor, runtimeText, parser, () => {
         isSyncingFromRuntimeRef.current = false;
       });

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -21,6 +21,7 @@ import { useAui } from "@assistant-ui/store";
 import type {
   Unstable_DirectiveFormatter,
   Unstable_DirectiveSegment,
+  Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
 import {
@@ -116,6 +117,10 @@ function getParsedLines(
   });
 }
 
+function getDirectiveKey(item: Unstable_TriggerItem, directiveText: string) {
+  return JSON.stringify([item.id, item.type, item.label, directiveText]);
+}
+
 function editorMatchesParsedText(
   editor: LexicalEditor,
   runtimeText: string,
@@ -159,10 +164,25 @@ function syncRuntimeToLexical(
   runtimeText: string,
   parse: CompositeParser,
   onComplete: () => void,
+  preserveDirectiveItems = false,
 ) {
   editor.update(
     () => {
       const root = $getRoot();
+      const preservedDirectiveItems = new Map<string, Unstable_TriggerItem[]>();
+      if (preserveDirectiveItems) {
+        for (const paragraph of root.getChildren()) {
+          if (!$isElementNode(paragraph)) continue;
+          for (const child of paragraph.getChildren()) {
+            if (!$isDirectiveNode(child)) continue;
+            const item = child.getDirectiveItem();
+            const key = getDirectiveKey(item, child.getDirectiveText());
+            const items = preservedDirectiveItems.get(key) ?? [];
+            items.push(item);
+            preservedDirectiveItems.set(key, items);
+          }
+        }
+      }
       root.clear();
 
       if (runtimeText.length === 0) {
@@ -182,13 +202,15 @@ function syncRuntimeToLexical(
               paragraph.append($createTextNode(segment.text));
             }
           } else {
+            const item = {
+              id: segment.id,
+              type: segment.type,
+              label: segment.label,
+            };
+            const key = getDirectiveKey(item, formatter.serialize(segment));
             paragraph.append(
               $createDirectiveNodeWithFormatter(
-                {
-                  id: segment.id,
-                  type: segment.type,
-                  label: segment.label,
-                },
+                preservedDirectiveItems.get(key)?.shift() ?? item,
                 formatter,
               ),
             );
@@ -286,15 +308,21 @@ export function SyncPlugin({
     const initialText = composerRuntime.getState().text;
     const parserChanged = parser !== lastAppliedParserRef.current;
     lastAppliedParserRef.current = parser;
-    if (
-      initialText !== lastSyncedTextRef.current ||
-      (parserChanged && !editorMatchesParsedText(editor, initialText, parser))
-    ) {
+    const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
+    const parserRequiresResync =
+      parserChanged && !editorMatchesParsedText(editor, initialText, parser);
+    if (runtimeTextChanged || parserRequiresResync) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
-      syncRuntimeToLexical(editor, initialText, parser, () => {
-        isSyncingFromRuntimeRef.current = false;
-      });
+      syncRuntimeToLexical(
+        editor,
+        initialText,
+        parser,
+        () => {
+          isSyncingFromRuntimeRef.current = false;
+        },
+        parserRequiresResync && !runtimeTextChanged,
+      );
     }
 
     return composerRuntime.subscribe(() => {

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -128,7 +128,9 @@ function editorMatchesParsedText(
 ) {
   const parsedLines = getParsedLines(runtimeText, parse);
   return editor.getEditorState().read(() => {
-    const paragraphs = $getRoot().getChildren();
+    const root = $getRoot();
+    const paragraphs = root.getChildren();
+    if (runtimeText.length === 0 && paragraphs.length === 0) return true;
     const lexicalLines: SegmentKey[][] = [];
     for (const paragraph of paragraphs) {
       if (!$isElementNode(paragraph)) return false;

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -46,7 +46,9 @@ type CompositeParser = (text: string) => readonly ParsedSegment[];
 
 type SegmentKey =
   | readonly ["text", string]
-  | readonly ["mention", string, string, string, string];
+  | readonly ["mention", string, string, string];
+
+type DirectiveLabelKey = readonly [string, string, string];
 
 /** Ordered, identity-deduped: prop formatter, trigger formatters, default tail. */
 export function collectFormatters(
@@ -112,13 +114,27 @@ function getParsedLines(
           "mention",
           segment.id,
           segment.type,
-          segment.label,
           formatter.serialize(segment),
         ]);
       }
     }
     return result;
   });
+}
+
+function getParsedDirectiveLabels(
+  runtimeText: string,
+  parse: CompositeParser,
+): DirectiveLabelKey[] {
+  return runtimeText
+    .split("\n")
+    .flatMap((line) =>
+      parse(line).flatMap(({ segment }) =>
+        segment.kind === "mention"
+          ? [[segment.id, segment.type, segment.label] as const]
+          : [],
+      ),
+    );
 }
 
 function getDirectiveKey(item: Pick<Unstable_TriggerItem, "id" | "type">) {
@@ -238,7 +254,6 @@ function editorMatchesParsedText(
             "mention",
             item.id,
             item.type,
-            item.label,
             child.getDirectiveText(),
           ]);
         } else {
@@ -418,14 +433,20 @@ export function SyncPlugin({
     if (!composerRuntime) return;
 
     const initialText = composerRuntime.getState().text;
-    const parserChanged = parser !== lastAppliedParserRef.current;
+    const previousParser = lastAppliedParserRef.current;
+    const parserChanged = parser !== previousParser;
     lastAppliedParserRef.current = parser;
     const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
+    const parserLabelsChanged =
+      parserChanged &&
+      JSON.stringify(getParsedDirectiveLabels(initialText, previousParser)) !==
+        JSON.stringify(getParsedDirectiveLabels(initialText, parser));
     const parserRequiresResync =
       parserChanged &&
       !editorDirtySinceSyncRef.current &&
       !editor.isComposing() &&
-      !editorMatchesParsedText(editor, initialText, parser) &&
+      (!editorMatchesParsedText(editor, initialText, parser) ||
+        parserLabelsChanged) &&
       parserPreservesExistingDirectives(editor, initialText, parser);
     if (runtimeTextChanged || parserRequiresResync) {
       isSyncingFromRuntimeRef.current = true;

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -118,7 +118,7 @@ function getParsedLines(
 }
 
 function getDirectiveKey(item: Unstable_TriggerItem, directiveText: string) {
-  return JSON.stringify([item.id, item.type, item.label, directiveText]);
+  return JSON.stringify([item.id, item.type, directiveText]);
 }
 
 function editorMatchesParsedText(
@@ -169,7 +169,10 @@ function syncRuntimeToLexical(
   editor.update(
     () => {
       const root = $getRoot();
-      const preservedDirectiveItems = new Map<string, Unstable_TriggerItem[]>();
+      const preservedDirectiveItems = new Map<
+        string,
+        Pick<Unstable_TriggerItem, "description" | "metadata">[]
+      >();
       if (preserveDirectiveItems) {
         for (const paragraph of root.getChildren()) {
           if (!$isElementNode(paragraph)) continue;
@@ -178,7 +181,10 @@ function syncRuntimeToLexical(
             const item = child.getDirectiveItem();
             const key = getDirectiveKey(item, child.getDirectiveText());
             const items = preservedDirectiveItems.get(key) ?? [];
-            items.push(item);
+            items.push({
+              description: item.description,
+              metadata: item.metadata,
+            });
             preservedDirectiveItems.set(key, items);
           }
         }
@@ -208,9 +214,10 @@ function syncRuntimeToLexical(
               label: segment.label,
             };
             const key = getDirectiveKey(item, formatter.serialize(segment));
+            const preservedItem = preservedDirectiveItems.get(key)?.shift();
             paragraph.append(
               $createDirectiveNodeWithFormatter(
-                preservedDirectiveItems.get(key)?.shift() ?? item,
+                preservedItem ? { ...item, ...preservedItem } : item,
                 formatter,
               ),
             );

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -164,7 +164,6 @@ function syncRuntimeToLexical(
   runtimeText: string,
   parse: CompositeParser,
   onComplete: () => void,
-  preserveDirectiveItems = false,
 ) {
   editor.update(
     () => {
@@ -173,20 +172,18 @@ function syncRuntimeToLexical(
         string,
         Pick<Unstable_TriggerItem, "description" | "metadata">[]
       >();
-      if (preserveDirectiveItems) {
-        for (const paragraph of root.getChildren()) {
-          if (!$isElementNode(paragraph)) continue;
-          for (const child of paragraph.getChildren()) {
-            if (!$isDirectiveNode(child)) continue;
-            const item = child.getDirectiveItem();
-            const key = getDirectiveKey(item, child.getDirectiveText());
-            const items = preservedDirectiveItems.get(key) ?? [];
-            items.push({
-              description: item.description,
-              metadata: item.metadata,
-            });
-            preservedDirectiveItems.set(key, items);
-          }
+      for (const paragraph of root.getChildren()) {
+        if (!$isElementNode(paragraph)) continue;
+        for (const child of paragraph.getChildren()) {
+          if (!$isDirectiveNode(child)) continue;
+          const item = child.getDirectiveItem();
+          const key = getDirectiveKey(item, child.getDirectiveText());
+          const items = preservedDirectiveItems.get(key) ?? [];
+          items.push({
+            description: item.description,
+            metadata: item.metadata,
+          });
+          preservedDirectiveItems.set(key, items);
         }
       }
       root.clear();
@@ -321,15 +318,9 @@ export function SyncPlugin({
     if (runtimeTextChanged || parserRequiresResync) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
-      syncRuntimeToLexical(
-        editor,
-        initialText,
-        parser,
-        () => {
-          isSyncingFromRuntimeRef.current = false;
-        },
-        parserRequiresResync && !runtimeTextChanged,
-      );
+      syncRuntimeToLexical(editor, initialText, parser, () => {
+        isSyncingFromRuntimeRef.current = false;
+      });
     }
 
     return composerRuntime.subscribe(() => {


### PR DESCRIPTION
## Summary

- detect composed directive parser changes and compare their parsed structure with the current Lexical tree
- reparse untouched restored drafts when a newly registered formatter changes their structure without demoting chips on removal or reparsing active edits
- skip no-op parser changes so active caret and composition state remain untouched
- preserve description and metadata only for the same directive occurrences during syntax changes and duplicate matches
- add regression coverage for empty-mount selection, multiline no-op registration, directive conversion, and metadata retention

## Why

`SyncPlugin` previously resynchronized only when the runtime text changed. If an unedited restored draft such as `[[alice]]` loaded before its formatter registered, Lexical created a plain text node. Registering the formatter later changed the parser but left the unchanged, unedited draft stale, so dynamic tool and mention registrations were not reflected until the text was edited.

The plugin now tracks which parser produced the editor state. When that parser changes, it compares normalized text/directive segments and rebuilds only if the resulting structure differs and the editor has not been edited or had its selection moved since the last runtime sync. Empty initial drafts retain the prior mount behavior, no-op formatter registrations preserve the existing nodes and caret, and parser-only rebuilds do not move DOM focus into an untouched composer. Hydrated node labels are preserved per occurrence when the old and new parsers agree, while genuine parser label changes still apply. Equivalent formatter wrappers reuse the composed parser when their parse and serialize functions are unchanged. When a parser-only rebuild is necessary, matching existing directive items retain richer metadata that was hydrated without changing the draft text. The existing sync tag prevents a genuine internal reparse from calling `composer.setText()`. Required parser-only rebuilds normalize inline line breaks to paragraph boundaries. For a custom formatter whose serialize and parse operations are not round-trip identical, the editor can show the new directive syntax while submission retains the prior runtime text until the next edit.

## Verification

- `pnpm --filter @assistant-ui/react-lexical test` \(45 tests\)
- `pnpm --filter @assistant-ui/react-lexical build`
- `pnpm exec oxlint packages/react-lexical/src/plugins/SyncPlugin.tsx packages/react-lexical/src/plugins/SyncPlugin.test.tsx`
- `pnpm exec oxfmt --check packages/react-lexical/src/plugins/SyncPlugin.tsx packages/react-lexical/src/plugins/SyncPlugin.test.tsx`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tdb4JpF9aEEisK6kudORaaX7nZY6jw_0Ou-UGS2bTR8QfeLElVFkGnh1_94?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->