### PR TITLE
fix(generative-ui): raise the data_table caps to Slack's current limit

### DIFF
--- a/.changeset/slack-data-table-platform-caps.md
+++ b/.changeset/slack-data-table-platform-caps.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: raise the Slack `data_table` caps to the current platform ceiling (200 data rows, 20,000 characters) so large tables are no longer clamped below what Slack accepts

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -96,14 +96,10 @@ The converter clamps to Slack's published budgets rather than letting the API re
 | Button action payload | 2,000 characters | Dropped entirely, not truncated, so a partial payload never round-trips |
 | Card title | 150 characters, body and subtext 200 | Truncated |
 | Carousel cards | 10 | Truncated; a carousel with no renderable card is dropped |
-| Table | 100 data rows, 20 columns, 10,000 characters across all tables in one payload | Rows truncated; a table whose header alone busts the budget is dropped |
+| Table | 200 data rows, 20 columns, 20,000 characters across all tables in one payload | Rows truncated; a table whose header alone busts the budget is dropped |
 | Markdown | 12,000 characters across the payload | Every markdown block from that point on becomes a `section` |
 
 Traversal itself is bounded too: 200 children per level, 5,000 nodes per call, and a depth ceiling, each reported as a `Root` warning. These bounds exist because the tree arrives from a model.
-
-<Callout type="warn">
-The table budgets above are the converter's. Slack has since raised the platform ceiling for [`data_table`](https://docs.slack.dev/reference/block-kit/blocks/data-table-block) to 200 data rows plus a header and 20,000 characters, so trees larger than the converter's limit are clamped even though Slack would now accept them.
-</Callout>
 
 ## Actions
 

--- a/packages/react-generative-ui/src/slack/constants.ts
+++ b/packages/react-generative-ui/src/slack/constants.ts
@@ -112,7 +112,7 @@ export const ALERT_TEXT_CAP = 200;
  * The maximum number of data rows in a data-table block; the emitted `rows`
  * array additionally carries one header row.
  */
-export const DATA_TABLE_ROW_CAP = 100;
+export const DATA_TABLE_ROW_CAP = 200;
 
 /** The maximum number of columns in a data-table block. */
 export const DATA_TABLE_COLUMN_CAP = 20;
@@ -121,7 +121,7 @@ export const DATA_TABLE_COLUMN_CAP = 20;
  * The cumulative character limit (summed across every cell's text) shared by
  * every data-table block in one payload.
  */
-export const DATA_TABLE_CHAR_BUDGET = 10000;
+export const DATA_TABLE_CHAR_BUDGET = 20000;
 
 /** The caption emitted on every native data-table block. */
 export const TABLE_CAPTION = "Table";

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1511,6 +1511,41 @@ describe("toSlackBlocks", () => {
       const table = blocks[0] as SlackDataTableBlock;
       expect(table.rows).toHaveLength(2);
     });
+
+    it("emits Slack's documented ceiling of 200 data rows unclamped", () => {
+      const { blocks, warnings } = toSlackBlocks({
+        $type: "Table",
+        columns: [{ label: "n" }],
+        rows: Array.from({ length: 200 }, (_, r) => [String(r)]),
+      });
+      const table = blocks[0] as SlackDataTableBlock;
+      expect(table.rows).toHaveLength(201);
+      expect(warnings).toEqual([]);
+    });
+
+    it("emits Slack's documented ceiling of 20,000 characters and clamps at 20,001", () => {
+      const atBudget = toSlackBlocks({
+        $type: "Table",
+        columns: [{ label: "h" }],
+        rows: [["c".repeat(19999)]],
+      });
+      expect((atBudget.blocks[0] as SlackDataTableBlock).rows).toHaveLength(2);
+      expect(atBudget.warnings).toEqual([]);
+
+      const overBudget = toSlackBlocks({
+        $type: "Table",
+        columns: [{ label: "h" }],
+        rows: [["c".repeat(20000)]],
+      });
+      expect((overBudget.blocks[0] as SlackDataTableBlock).rows).toHaveLength(
+        1,
+      );
+      expect(overBudget.warnings).toContainEqual({
+        code: "clamped",
+        component: "Table",
+        detail: "rows were clamped to fit the 20000-character table budget.",
+      });
+    });
   });
 
   describe("Markdown", () => {

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1433,7 +1433,7 @@ describe("toSlackBlocks", () => {
     });
 
     it(`clamps rows to fit the ${DATA_TABLE_CHAR_BUDGET}-character table budget, always keeping the header row`, () => {
-      const bigCell = "z".repeat(2000);
+      const bigCell = "z".repeat(Math.ceil(DATA_TABLE_CHAR_BUDGET / 5));
       const rows = Array.from({ length: 6 }, (_, r) => [`row${r}`, bigCell]);
       const { blocks, warnings } = toSlackBlocks({
         $type: "Table",
@@ -1454,10 +1454,11 @@ describe("toSlackBlocks", () => {
     });
 
     it("shares the character budget across multiple data-table blocks in one payload", () => {
-      const filler = "f".repeat(9994);
+      const secondValue = "second";
+      const filler = "f".repeat(DATA_TABLE_CHAR_BUDGET - secondValue.length);
       const { blocks, warnings } = toSlackBlocks([
         { $type: "Table", columns: [{ label: "A" }], rows: [[filler]] },
-        { $type: "Table", columns: [{ label: "B" }], rows: [["second"]] },
+        { $type: "Table", columns: [{ label: "B" }], rows: [[secondValue]] },
       ]);
       const first = blocks[0] as SlackDataTableBlock;
       const second = blocks[1] as SlackDataTableBlock;
@@ -1922,7 +1923,7 @@ describe("toSlackBlocks data_table integrity", () => {
   it("drops a table whose header row alone exceeds the character budget", () => {
     const { blocks, warnings } = toSlackBlocks({
       $type: "Table",
-      columns: [{ label: "h".repeat(10001) }],
+      columns: [{ label: "h".repeat(DATA_TABLE_CHAR_BUDGET + 1) }],
       rows: [["x"]],
     });
     expect(blocks).toEqual([]);


### PR DESCRIPTION
part of #5784

## summary

- Slack's [data_table reference](https://docs.slack.dev/reference/block-kit/blocks/data-table-block/) documents "a maximum of 201 rows (200 regular rows plus the header)" and a 20,000 character budget both per table and in aggregate per message, but the converter still carried `DATA_TABLE_ROW_CAP = 100` and `DATA_TABLE_CHAR_BUDGET = 10000`, so a 150 row table was clamped with a `clamped` warning even though Slack would have accepted all of it
- raises both to the platform numbers; `DATA_TABLE_COLUMN_CAP = 20` was already correct, and the constant is shared with `fromSlackBlocks` so the inbound cap moves with it
- the two budget tests that hardcoded the old 10,000 now derive their fixture sizes from `DATA_TABLE_CHAR_BUDGET`, so the next platform bump cannot silently rot them
- drops the docs Callout that flagged this exact gap and corrects the limits table row it was warning about

## test plan

### already verified

- [x] `pnpm -C packages/react-generative-ui test` -> 544/544 green
- [x] `pnpm lint` -> clean, only the pre-existing `packages/vue` rules-of-hooks warnings

### reviewer should verify

- [ ] a `Table` with 150 data rows emits 151 rows (header plus 150) and reports no `clamped` warning

## notes

- first of four fixes from #5784; the other three are diagnostics accuracy and land as separate PRs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bSRfM4B2XPRLNqn_QKcGz_zGxXCaj9xUF8ErobECoeyE_U8pJpq5a1WZ31Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->