### PR TITLE
fix(generative-ui): name the byte budget the Teams payload warning crosses

### DIFF
--- a/.changeset/teams-payload-budget-warning.md
+++ b/.changeset/teams-payload-budget-warning.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: report the Teams payload warning against the 80,000-byte soft budget it actually crosses instead of Teams' 100 KB message limit

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -1158,7 +1158,13 @@ describe("toAdaptiveCard", () => {
       const value = "x".repeat(PAYLOAD_SOFT_CAP + 1000);
       const { warnings } = toAdaptiveCard({ $type: "Text", value });
       expect(warnings).toContainEqual(
-        expect.objectContaining({ code: "clamped", component: "Root" }),
+        expect.objectContaining({
+          code: "clamped",
+          component: "Root",
+          detail: expect.stringContaining(
+            `over the ${PAYLOAD_SOFT_CAP}-byte soft budget`,
+          ),
+        }),
       );
     });
 

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -718,7 +718,7 @@ export function convertRootToCard(
       context,
       "clamped",
       "Root",
-      `the card is ${size} bytes, exceeding Teams' 100 KB bot message limit.`,
+      `the card is ${size} bytes, over the ${PAYLOAD_SOFT_CAP}-byte soft budget kept below Teams' 100 KB bot message limit.`,
     );
   }
   return card;

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.test.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.test.ts
@@ -23,7 +23,13 @@ describe("toTeamsAttachments payload budget", () => {
       ),
     ).toBe(false);
     expect(warnings).toContainEqual(
-      expect.objectContaining({ code: "clamped", component: "Carousel" }),
+      expect.objectContaining({
+        code: "clamped",
+        component: "Carousel",
+        detail: expect.stringContaining(
+          `over the ${PAYLOAD_SOFT_CAP}-byte soft budget`,
+        ),
+      }),
     );
   });
 });

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
@@ -115,7 +115,7 @@ export function toTeamsAttachments(
         warnings.push({
           code: "clamped",
           component: "Carousel",
-          detail: `the carousel attachments total ${size} bytes, exceeding Teams' 100 KB bot message limit.`,
+          detail: `the carousel attachments total ${size} bytes, over the ${PAYLOAD_SOFT_CAP}-byte soft budget kept below Teams' 100 KB bot message limit.`,
         });
       }
       return { attachments, attachmentLayout: "carousel", warnings };


### PR DESCRIPTION
part of #5784

## summary

- the Teams payload warning fires at `PAYLOAD_SOFT_CAP` (80,000 bytes, `teams/constants.ts:70`) but its text reported Teams' 100 KB bot message limit, so a payload between 80,000 and 102,400 bytes was told it exceeded a limit it had not reached
- both emit sites (`teams/toAdaptiveCard.ts:721`, `teams/toTeamsAttachments.ts:118`) now name the soft budget as the thing that was crossed and keep 100 KB as the reason the budget sits where it does
- the docs limits table already described it correctly ("80,000 serialized bytes, set below Teams' 100 KB bot message limit"), so this aligns the runtime text to the docs rather than the other way round
- neither test asserted the detail string (both matched only `code` and `component`), which is why the wording could drift; both now pin it

## test plan

### already verified

- [x] `pnpm -C packages/react-generative-ui test` -> 546/546 green
- [x] `pnpm lint` -> exit 0, formatting clean

### reviewer should verify

- [ ] a card serializing to ~85,000 bytes warns with a detail naming the 80,000-byte soft budget, and the card itself is still returned intact

## notes

- second of four fixes from #5784
- these two warnings also carry `code: "clamped"` while nothing is clamped; that is the third item in #5784 and lands in its own PR alongside the other no-op clamp sites

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.02rWxjlW-N8Oc2-n0sa8KTlhdn3DbgN8ybIRZ869H5FqhB3WgLzl6s5bqyI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->