### PR TITLE
fix(generative-ui): report the depth warning at the nesting level it enforces

### DIFF
--- a/.changeset/converter-depth-warning-levels.md
+++ b/.changeset/converter-depth-warning-levels.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: report the depth warning against the 32 levels of element nesting the Slack and Teams converters actually allow, instead of the 64 traversal units that ceiling is spent in

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -99,7 +99,7 @@ The converter clamps to Slack's published budgets rather than letting the API re
 | Table | 200 data rows, 20 columns, 20,000 characters across all tables in one payload | Rows truncated; a table whose header alone busts the budget is dropped |
 | Markdown | 12,000 characters across the payload | Every markdown block from that point on becomes a `section` |
 
-Traversal itself is bounded too: 200 children per level, 5,000 nodes per call, and a depth ceiling, each reported as a `Root` warning. These bounds exist because the tree arrives from a model.
+Traversal itself is bounded too: 200 children per level, 5,000 nodes per call, and 32 levels of element nesting, each reported as a `Root` warning. These bounds exist because the tree arrives from a model.
 
 ## Actions
 

--- a/apps/docs/content/docs/tools/generative-ui-teams.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-teams.mdx
@@ -149,7 +149,7 @@ With a `Carousel` at the root you get one attachment per card child and `attachm
 | Primary actions | 6 | Later actions move to secondary mode; none are dropped |
 | Payload size | 80,000 serialized bytes, set below Teams' 100 KB bot message limit | Warned, never truncated, so you decide whether to split |
 
-Traversal is bounded as well: 200 children per level, 5,000 nodes per call, and a depth ceiling of 64, each reported as a `Root` warning. These bounds exist because the tree arrives from a model.
+Traversal is bounded as well: 200 children per level, 5,000 nodes per call, and 32 levels of element nesting, each reported as a `Root` warning. These bounds exist because the tree arrives from a model.
 
 ## Reference
 

--- a/packages/react-generative-ui/src/slack/constants.ts
+++ b/packages/react-generative-ui/src/slack/constants.ts
@@ -11,14 +11,15 @@ import type {
   SlackTextObject,
 } from "./types";
 
-/**
- * The maximum traversal depth of the bounded pre-pass, counted in visited
- * values rather than tree levels. An element and its `children` array are two
- * values, so a level of element nesting spends two.
- */
+/** The maximum traversal depth, counted in visited values, not tree levels. */
 export const MAX_TRAVERSAL_DEPTH = 64;
 
-/** The element-nesting ceiling {@link MAX_TRAVERSAL_DEPTH} works out to. */
+/**
+ * The element-nesting ceiling a caller observes. `boundNode` visits an element
+ * and its `children` array separately, so one level of nesting spends two of
+ * {@link MAX_TRAVERSAL_DEPTH}; it runs before the conversion walk and is never
+ * the looser of the two. A root array costs one more level than a root object.
+ */
 export const MAX_ELEMENT_DEPTH = MAX_TRAVERSAL_DEPTH / 2;
 
 /**

--- a/packages/react-generative-ui/src/slack/constants.ts
+++ b/packages/react-generative-ui/src/slack/constants.ts
@@ -11,8 +11,15 @@ import type {
   SlackTextObject,
 } from "./types";
 
-/** The maximum normalized traversal depth. */
+/**
+ * The maximum traversal depth of the bounded pre-pass, counted in visited
+ * values rather than tree levels. An element and its `children` array are two
+ * values, so a level of element nesting spends two.
+ */
 export const MAX_TRAVERSAL_DEPTH = 64;
+
+/** The element-nesting ceiling {@link MAX_TRAVERSAL_DEPTH} works out to. */
+export const MAX_ELEMENT_DEPTH = MAX_TRAVERSAL_DEPTH / 2;
 
 /**
  * The maximum number of entries kept at any single level (root, or a

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1923,8 +1923,24 @@ describe("toSlackBlocks", () => {
       expect(warnings).toContainEqual({
         code: "clamped",
         component: "Root",
-        detail: "nodes deeper than 64 levels were dropped.",
+        detail: "nodes deeper than 32 levels were dropped.",
       });
+    });
+
+    it("reports the depth detail at the level it actually starts dropping", () => {
+      const chain = (levels: number) => {
+        let node: unknown = { $type: "Caption", value: "x" };
+        for (let i = 0; i < levels; i++) {
+          node = { $type: "Card", children: [node] };
+        }
+        return node;
+      };
+      const dropped = (levels: number) =>
+        toSlackBlocks(chain(levels)).warnings.some((warning) =>
+          warning.detail.includes("deeper than"),
+        );
+      expect(dropped(32)).toBe(false);
+      expect(dropped(33)).toBe(true);
     });
   });
 });

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1935,12 +1935,14 @@ describe("toSlackBlocks", () => {
         }
         return node;
       };
-      const dropped = (levels: number) =>
-        toSlackBlocks(chain(levels)).warnings.some((warning) =>
+      const dropped = (node: unknown) =>
+        toSlackBlocks(node).warnings.some((warning) =>
           warning.detail.includes("deeper than"),
         );
-      expect(dropped(32)).toBe(false);
-      expect(dropped(33)).toBe(true);
+      expect(dropped(chain(32))).toBe(false);
+      expect(dropped(chain(33))).toBe(true);
+      expect(dropped([chain(31)])).toBe(false);
+      expect(dropped([chain(32)])).toBe(true);
     });
   });
 });

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -26,6 +26,7 @@ import {
   INPUT_LABEL_CAP,
   INTERACTIVE_TEXT_CAP,
   MARKDOWN_TEXT_BUDGET,
+  MAX_ELEMENT_DEPTH,
   MAX_TRAVERSAL_DEPTH,
   MESSAGE_BLOCK_CAP,
   MODAL_BLOCK_CAP,
@@ -1283,7 +1284,7 @@ export function toSlackBlocks(
           : reason === "cycle"
             ? "a self-referencing node was dropped."
             : reason === "depth"
-              ? `nodes deeper than ${MAX_TRAVERSAL_DEPTH} levels were dropped.`
+              ? `nodes deeper than ${MAX_ELEMENT_DEPTH} levels were dropped.`
               : `children were clamped to ${CHILDREN_CAP} entries.`;
       warn(context, "clamped", "Root", detail);
     });

--- a/packages/react-generative-ui/src/teams/constants.ts
+++ b/packages/react-generative-ui/src/teams/constants.ts
@@ -17,8 +17,15 @@ export const ADAPTIVE_CARD_SCHEMA =
 export const ATTACHMENT_CONTENT_TYPE =
   "application/vnd.microsoft.card.adaptive";
 
-/** The maximum normalized traversal depth. */
+/**
+ * The maximum traversal depth of the bounded pre-pass, counted in visited
+ * values rather than tree levels. An element and its `children` array are two
+ * values, so a level of element nesting spends two.
+ */
 export const MAX_TRAVERSAL_DEPTH = 64;
+
+/** The element-nesting ceiling {@link MAX_TRAVERSAL_DEPTH} works out to. */
+export const MAX_ELEMENT_DEPTH = MAX_TRAVERSAL_DEPTH / 2;
 
 /**
  * The maximum number of entries kept at any single level (root, or a
@@ -46,7 +53,7 @@ export function clampReasonDetail(reason: ClampReason): string {
   }
   if (reason === "cycle") return "a self-referencing node was dropped.";
   if (reason === "depth") {
-    return `nodes deeper than ${MAX_TRAVERSAL_DEPTH} levels were dropped.`;
+    return `nodes deeper than ${MAX_ELEMENT_DEPTH} levels were dropped.`;
   }
   return `children were clamped to ${CHILDREN_CAP} entries.`;
 }

--- a/packages/react-generative-ui/src/teams/constants.ts
+++ b/packages/react-generative-ui/src/teams/constants.ts
@@ -17,14 +17,15 @@ export const ADAPTIVE_CARD_SCHEMA =
 export const ATTACHMENT_CONTENT_TYPE =
   "application/vnd.microsoft.card.adaptive";
 
-/**
- * The maximum traversal depth of the bounded pre-pass, counted in visited
- * values rather than tree levels. An element and its `children` array are two
- * values, so a level of element nesting spends two.
- */
+/** The maximum traversal depth, counted in visited values, not tree levels. */
 export const MAX_TRAVERSAL_DEPTH = 64;
 
-/** The element-nesting ceiling {@link MAX_TRAVERSAL_DEPTH} works out to. */
+/**
+ * The element-nesting ceiling a caller observes. `boundNode` visits an element
+ * and its `children` array separately, so one level of nesting spends two of
+ * {@link MAX_TRAVERSAL_DEPTH}; it runs before the conversion walk and is never
+ * the looser of the two. A root array costs one more level than a root object.
+ */
 export const MAX_ELEMENT_DEPTH = MAX_TRAVERSAL_DEPTH / 2;
 
 /**

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -1315,12 +1315,14 @@ describe("toAdaptiveCard", () => {
         }
         return node;
       };
-      const dropped = (levels: number) =>
-        toAdaptiveCard(chain(levels)).warnings.some((warning) =>
+      const dropped = (node: unknown) =>
+        toAdaptiveCard(node).warnings.some((warning) =>
           warning.detail.includes("deeper than"),
         );
-      expect(dropped(32)).toBe(false);
-      expect(dropped(33)).toBe(true);
+      expect(dropped(chain(32))).toBe(false);
+      expect(dropped(chain(33))).toBe(true);
+      expect(dropped([chain(31)])).toBe(false);
+      expect(dropped([chain(32)])).toBe(true);
     });
   });
 });

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -1303,8 +1303,24 @@ describe("toAdaptiveCard", () => {
       expect(warnings).toContainEqual({
         code: "clamped",
         component: "Root",
-        detail: "nodes deeper than 64 levels were dropped.",
+        detail: "nodes deeper than 32 levels were dropped.",
       });
+    });
+
+    it("reports the depth detail at the level it actually starts dropping", () => {
+      const chain = (levels: number) => {
+        let node: unknown = { $type: "Caption", value: "x" };
+        for (let i = 0; i < levels; i++) {
+          node = { $type: "Card", children: [node] };
+        }
+        return node;
+      };
+      const dropped = (levels: number) =>
+        toAdaptiveCard(chain(levels)).warnings.some((warning) =>
+          warning.detail.includes("deeper than"),
+        );
+      expect(dropped(32)).toBe(false);
+      expect(dropped(33)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
closes #5784

## summary

- `MAX_TRAVERSAL_DEPTH = 64` is spent two units per level of element nesting, because the bounded pre-pass charges one for the element and one for its `children` array (`slack/toSlackBlocks.ts:1205,1225`, `teams/boundSpec.ts:45,65`), so the effective ceiling is 32 levels while the warning claimed 64
- measured against the built dist, both converters first drop at **33** levels of nesting, not 65:

  ```
  levels=32 slack="none"                                     teams="none"
  levels=33 slack="nodes deeper than 32 levels were dropped." teams="nodes deeper than 32 levels were dropped."
  ```

- both details now use a derived `MAX_ELEMENT_DEPTH`, and the constant's JSDoc says what unit it counts in, since "the maximum normalized traversal depth" is what made 64 read as tree levels in the first place
- the two existing tests nest 70 levels, far past the boundary, so nothing pinned where it actually is; each converter gains a test asserting no drop at 32 and a drop at 33
- the docs said "a depth ceiling of 64" on the Teams page and left it unnamed on the Slack page; both now say 32 levels of element nesting

the ceiling itself is unchanged. making 64 units mean 64 levels would double how deep a model-supplied tree may nest, and that bound exists precisely because the tree arrives from a model.

## test plan

### already verified

- [x] `pnpm -C packages/react-generative-ui test` -> 548/548 green
- [x] `pnpm lint` -> exit 0
- [x] `pnpm api-surface` and `pnpm -C apps/docs generate:api-reference` -> no drift, the constants are internal
- [x] the 32/33 boundary measured against the built dist for both converters, output above

### reviewer should verify

- [ ] a 33-level `Card` chain warns `nodes deeper than 32 levels were dropped.` and a 32-level chain converts with no depth warning

## notes

- last of the four fixes from #5784, so this closes it. the earlier three are #5785, #5787, and #5788
- two related defects surfaced while reviewing #5788 and are tracked separately: #5790 (Teams paths that discard content with no warning at all) and #5793 (the Slack `degradeCard` site, which warns once for two different outcomes and truncates silently)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KgBKyI6O57RxHx8bFkbcjUQ08j2b2XZIvR2PADrm5J1TPTiq7Nvs82A9CBY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->