### PR TITLE
fix(store): publish hosted scope rebinds before layout effects

### DIFF
--- a/.changeset/quiet-hosts-rebind.md
+++ b/.changeset/quiet-hosts-rebind.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: publish hosted scope rebinds before descendant layout effects

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { Suspense, startTransition, useLayoutEffect, useState } from "react";
 import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { flushTapSync, resource } from "@assistant-ui/tap";
 import { AuiProvider } from "../AuiProvider";
+import { AuiConfig } from "../AuiConfig";
 import { useAui } from "../useAui";
 import { useAuiEvent } from "../useAuiEvent";
 import { useAuiState } from "../useAuiState";
@@ -366,6 +367,121 @@ describe("microtask delivery (live-set semantics)", () => {
 });
 
 describe("Derived scopes", () => {
+  it("delivers a layout-effect event after a derived rebind", () => {
+    const cb = vi.fn();
+    const queued: VoidFunction[] = [];
+    const queueMicrotaskSpy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((callback) => queued.push(callback));
+
+    const Consumer = ({ index }: { index: number }) => {
+      const client = useAui();
+      const message = client.message as AnyClient;
+      useAuiEvent("message.pinged" as never, cb as never);
+      useLayoutEffect(() => {
+        if (index === 1 && message.getState().id === "m1") {
+          message.ping("layout");
+          for (const callback of queued.splice(0)) callback();
+        }
+      }, [index, message]);
+      return null;
+    };
+    const Harness = ({ index }: { index: number }) => {
+      return (
+        <AuiProvider
+          config={AuiConfig({
+            thread: ThreadClient(),
+            message: Derived({
+              source: "thread",
+              query: { index },
+              get: (root: AnyClient) => root.thread.message({ index }),
+            } as never),
+          } as never)}
+        >
+          <Consumer index={index} />
+        </AuiProvider>
+      );
+    };
+
+    try {
+      const view = render(<Harness index={0} />);
+      view.rerender(<Harness index={1} />);
+
+      expect(cb).toHaveBeenCalledExactlyOnceWith({
+        id: "m1",
+        value: "layout",
+      });
+    } finally {
+      queueMicrotaskSpy.mockRestore();
+    }
+  });
+
+  it("does not publish a speculative binding during an interrupted render", async () => {
+    let resolveGate!: () => void;
+    let gateOpen = false;
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve;
+    });
+    let setIndex!: (index: number) => void;
+    let committed!: AnyClient;
+    let attempted = false;
+    const cb = vi.fn();
+
+    const Consumer = ({ index }: { index: number }) => {
+      const client = useAui();
+      useAuiEvent("message.pinged" as never, cb as never);
+      useLayoutEffect(() => {
+        if (index === 0) committed = client;
+      }, [client, index]);
+      if (index === 1) {
+        attempted = true;
+        if (!gateOpen) throw gate;
+      }
+      return null;
+    };
+    const App = () => {
+      const [index, updateIndex] = useState(0);
+      setIndex = updateIndex;
+      return (
+        <Suspense fallback={null}>
+          <AuiProvider
+            config={AuiConfig({
+              thread: ThreadClient(),
+              message: Derived({
+                source: "thread",
+                query: { index },
+                get: (root: AnyClient) => root.thread.message({ index }),
+              } as never),
+            } as never)}
+          >
+            <Consumer index={index} />
+          </AuiProvider>
+        </Suspense>
+      );
+    };
+
+    render(<App />);
+    expect(committed.message.getState().id).toBe("m0");
+
+    act(() => {
+      startTransition(() => setIndex(1));
+    });
+    expect(attempted).toBe(true);
+
+    committed.thread.message({ index: 0 }).ping("committed");
+    await flushEvents();
+    expect(cb).toHaveBeenCalledExactlyOnceWith({
+      id: "m0",
+      value: "committed",
+    });
+
+    gateOpen = true;
+    await act(async () => {
+      resolveGate();
+      await gate;
+    });
+  });
+
   it("useAuiEvent tracks the derived selection across structural swaps", async () => {
     let aui!: AnyClient;
     const cb = vi.fn();

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -13,6 +13,7 @@ import {
 import {
   useMemo,
   useEffect,
+  useInsertionEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -295,8 +296,8 @@ const useHostedAssistantClient = ({
   parent: AssistantClient;
   entries: ScopeEntry[];
 }): ScopedAuiClient => {
+  const clientRef = useRef<ClientRef>({ parent, current: null }).current;
   const { value: client, effects } = useTapHost(function AssistantClientHost() {
-    const clientRef = useRef<ClientRef>({ parent, current: null }).current;
     const notifications = useNotificationManager();
 
     const store = useTapRoot(function AuiRoot() {
@@ -327,17 +328,13 @@ const useHostedAssistantClient = ({
       // oxlint-disable-next-line react-hooks/exhaustive-deps -- parent is a prop of the outer hook; the host re-renders with a fresh closure when it changes
     }, [store, parent, notifications]);
 
-    useEffect(() => {
-      clientRef.parent = parent;
-      clientRef.current = client;
-    });
-
-    if (clientRef.current === null) {
-      clientRef.current = client;
-    }
-
     return client;
   });
+
+  useInsertionEffect(() => {
+    clientRef.parent = parent;
+    clientRef.current = client;
+  }, [client, parent, clientRef]);
 
   return { client, effects };
 };

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -331,6 +331,9 @@ const useHostedAssistantClient = ({
     return client;
   });
 
+  // The only hook that runs before descendant layout effects: a parent's
+  // useLayoutEffect fires after its children's, and useEffect leaves the
+  // pre-passive window this publication exists to close.
   useInsertionEffect(() => {
     clientRef.parent = parent;
     clientRef.current = client;


### PR DESCRIPTION
## Summary

Hosted scoped listeners could miss an event emitted from a descendant layout effect immediately after a derived scope rebind. The listener still resolved the previous hosted client because the ref was published from a passive effect.

This change:

- Publishes the hosted parent and client from `useInsertionEffect`, after React commits and before descendant layout effects.
- Keeps the notification-driven `flushTapSync` refresh path unchanged.
- Adds regression coverage for the layout-effect delivery window and for interrupted renders retaining the committed binding.
- Includes a patch changeset for `@assistant-ui/store`.

Closes #5781

## Verification

- `pnpm --filter @assistant-ui/store test` (19 files, 146 tests)
- `pnpm --filter @assistant-ui/store build`
- `pnpm --filter @assistant-ui/store test:react-compiler` (1 test, after a fresh build)
- Targeted `oxlint` and `oxfmt --check`
- `git diff --check`
- The focused regression passes with the fix and fails against `origin/live-main` with zero callback calls.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ooqOYShiQAhzf_eigfRVH2C5RUEkMN_Ea0Eztpitfo7XECIf0VlPcSRC_Ns?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->