### PR TITLE
fix(generative-ui): report the content the converters were discarding silently

### DIFF
--- a/.changeset/converter-silent-content-loss.md
+++ b/.changeset/converter-silent-content-loss.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: report the content the Slack and Teams converters were discarding silently. A non-item `ListView` child, a non-card child of a nested `Carousel`, a malformed `Select` or `RadioGroup` option, and a Slack table column that is not an object all warn `dropped` now. A dropped Slack column also keeps its position so the header stays aligned with the data, and a discarded Teams `ListView` child no longer reserves an input id that renames a control which survives

--- a/.changeset/converter-silent-content-loss.md
+++ b/.changeset/converter-silent-content-loss.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-generative-ui": patch
 ---
 
-fix: report the content the Slack and Teams converters were discarding silently. A `ListView` or `Carousel` child that would have rendered, a malformed `Select` or `RadioGroup` option, and a Slack table column without a string label all warn `dropped` now, while a child that renders nothing anyway stays silent. A dropped Slack column also keeps its position so the header stays aligned with the data, and a discarded child no longer spends the shared markdown and data-table budgets or reserves a Teams input id that renames a control which survives
+fix: report the content the Slack and Teams converters were discarding silently. A `ListView` or `Carousel` child that would have rendered, a malformed `Select` or `RadioGroup` option, and a table column without a string label all warn `dropped` now, while a child that renders nothing anyway stays silent. A Slack column without a label also keeps its position now, so the header stays aligned with the data, and a discarded child no longer spends the shared markdown and data-table budgets or reserves a Teams input id that renames a control which survives

--- a/.changeset/converter-silent-content-loss.md
+++ b/.changeset/converter-silent-content-loss.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-generative-ui": patch
 ---
 
-fix: report the content the Slack and Teams converters were discarding silently. A non-item `ListView` child, a non-card child of a nested `Carousel`, a malformed `Select` or `RadioGroup` option, and a Slack table column that is not an object all warn `dropped` now. A dropped Slack column also keeps its position so the header stays aligned with the data, and a discarded Teams `ListView` child no longer reserves an input id that renames a control which survives
+fix: report the content the Slack and Teams converters were discarding silently. A `ListView` or `Carousel` child that would have rendered, a malformed `Select` or `RadioGroup` option, and a Slack table column without a string label all warn `dropped` now, while a child that renders nothing anyway stays silent. A dropped Slack column also keeps its position so the header stays aligned with the data, and a discarded child no longer spends the shared markdown and data-table budgets or reserves a Teams input id that renames a control which survives

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -54,9 +54,9 @@ type SlackConversionWarning = {
 | `Fact` | Merged into one `section`'s `fields`, as `*label*` then value | Consecutive facts merge; every 10 fields start a new section |
 | `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width; a column that is not an object keeps its position with an empty label and warns |
 | `Card` | Native `card` block, or a header plus inline blocks | See [Cards](#cards) |
-| `Carousel` | `carousel` block of `card` elements | Non-card children are dropped; cards that cannot map cleanly degrade to title and body |
+| `Carousel` | `carousel` block of `card` elements | A non-card child that would have rendered is dropped with a warning; cards that cannot map cleanly degrade to title and body |
 | `Alert` | Native `alert` block on a modal; a `context` plus `section` pair on a message | Slack supports `alert` [only in modals](https://docs.slack.dev/reference/block-kit/blocks/alert-block) |
-| `ListView` | One `section` per item, with `divider` blocks between them | Item children collapse into concatenated text; a non-item child is dropped with a warning |
+| `ListView` | One `section` per item, with `divider` blocks between them | Item children collapse into concatenated text; a non-item child that would have rendered is dropped with a warning |
 | `ListViewItem` | `section`, plus an "Open" button accessory when it carries an action | |
 | `Button` | `button` element inside an `actions` block | `primary` and `danger` styles survive; other styles are dropped |
 | `Select` | `static_select` element | An option without a string label and value is dropped with a warning |

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -52,7 +52,7 @@ type SlackConversionWarning = {
 | `Image` | `image` block | Only `src` and `alt` survive; `size` and `round` are dropped silently |
 | `Divider` | `divider` block | Faithful |
 | `Fact` | Merged into one `section`'s `fields`, as `*label*` then value | Consecutive facts merge; every 10 fields start a new section |
-| `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width; a column that is not an object keeps its position with an empty label and warns |
+| `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width; a column without a string label keeps its position with an empty header and warns |
 | `Card` | Native `card` block, or a header plus inline blocks | See [Cards](#cards) |
 | `Carousel` | `carousel` block of `card` elements | A non-card child that would have rendered is dropped with a warning; cards that cannot map cleanly degrade to title and body |
 | `Alert` | Native `alert` block on a modal; a `context` plus `section` pair on a message | Slack supports `alert` [only in modals](https://docs.slack.dev/reference/block-kit/blocks/alert-block) |

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -52,15 +52,15 @@ type SlackConversionWarning = {
 | `Image` | `image` block | Only `src` and `alt` survive; `size` and `round` are dropped silently |
 | `Divider` | `divider` block | Faithful |
 | `Fact` | Merged into one `section`'s `fields`, as `*label*` then value | Consecutive facts merge; every 10 fields start a new section |
-| `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width |
+| `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width; a column that is not an object keeps its position with an empty label and warns |
 | `Card` | Native `card` block, or a header plus inline blocks | See [Cards](#cards) |
 | `Carousel` | `carousel` block of `card` elements | Non-card children are dropped; cards that cannot map cleanly degrade to title and body |
 | `Alert` | Native `alert` block on a modal; a `context` plus `section` pair on a message | Slack supports `alert` [only in modals](https://docs.slack.dev/reference/block-kit/blocks/alert-block) |
-| `ListView` | One `section` per item, with `divider` blocks between them | Item children collapse into concatenated text |
+| `ListView` | One `section` per item, with `divider` blocks between them | Item children collapse into concatenated text; a non-item child is dropped with a warning |
 | `ListViewItem` | `section`, plus an "Open" button accessory when it carries an action | |
 | `Button` | `button` element inside an `actions` block | `primary` and `danger` styles survive; other styles are dropped |
-| `Select` | `static_select` element | |
-| `RadioGroup` | `radio_buttons` element | |
+| `Select` | `static_select` element | An option without a string label and value is dropped with a warning |
+| `RadioGroup` | `radio_buttons` element | An option without a string label and value is dropped with a warning |
 | `Checkbox` | `checkboxes` element with a single option | |
 | `DatePicker` | `datepicker` element | `min` and `max` are dropped; a non-`YYYY-MM-DD` value is dropped with a warning |
 | `Input` | Its own `input` block | Not grouped into an `actions` block |

--- a/apps/docs/content/docs/tools/generative-ui-teams.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-teams.mdx
@@ -57,7 +57,7 @@ type TeamsConversionWarning = {
 | `Caption`, `Badge` | Small subtle `TextBlock` | The two become identical output |
 | `Image` | `Image` | A numeric `size` is dropped with a warning; `round` is dropped silently |
 | `Fact` | `FactSet` | Consecutive facts merge into one set |
-| `Table` | Native `Table` with the first row as headers | Requires schema 1.5, so it will not render on Teams mobile |
+| `Table` | Native `Table` with the first row as headers | Requires schema 1.5, so it will not render on Teams mobile; a column without a string label keeps its position with an empty header and warns |
 | `Card` | `Container`, with the title as a leading heading | Footer buttons become an `ActionSet` beside the container, not inside it |
 | `Alert` | `Container` with a semantic style (`accent`, `good`, `warning`, `attention`) | Title and description become two text blocks |
 | `Carousel` | Multiple attachments through `toTeamsAttachments` | See [Carousels](#carousels); a non-card child that would have rendered is dropped with a warning |

--- a/apps/docs/content/docs/tools/generative-ui-teams.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-teams.mdx
@@ -60,8 +60,8 @@ type TeamsConversionWarning = {
 | `Table` | Native `Table` with the first row as headers | Requires schema 1.5, so it will not render on Teams mobile |
 | `Card` | `Container`, with the title as a leading heading | Footer buttons become an `ActionSet` beside the container, not inside it |
 | `Alert` | `Container` with a semantic style (`accent`, `good`, `warning`, `attention`) | Title and description become two text blocks |
-| `Carousel` | Multiple attachments through `toTeamsAttachments` | See [Carousels](#carousels); a non-card child is dropped with a warning |
-| `ListView` | One `Container` per item, separated after the first | A non-item child is dropped with a warning, and never reserves an input id |
+| `Carousel` | Multiple attachments through `toTeamsAttachments` | See [Carousels](#carousels); a non-card child that would have rendered is dropped with a warning |
+| `ListView` | One `Container` per item, separated after the first | A non-item child that would have rendered is dropped with a warning, and never reserves an input id |
 | `ListViewItem` | `Container`, with a select action when it carries an action | |
 | `Button` | `Action.Submit` inside an `ActionSet` | Consecutive buttons merge into one set; `buttonStyle` is dropped, since Teams [ignores action styling](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference) |
 | `Select` | `Input.ChoiceSet`, compact | An option without a string value is dropped with a warning |

--- a/apps/docs/content/docs/tools/generative-ui-teams.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-teams.mdx
@@ -60,12 +60,12 @@ type TeamsConversionWarning = {
 | `Table` | Native `Table` with the first row as headers | Requires schema 1.5, so it will not render on Teams mobile |
 | `Card` | `Container`, with the title as a leading heading | Footer buttons become an `ActionSet` beside the container, not inside it |
 | `Alert` | `Container` with a semantic style (`accent`, `good`, `warning`, `attention`) | Title and description become two text blocks |
-| `Carousel` | Multiple attachments through `toTeamsAttachments` | See [Carousels](#carousels) |
-| `ListView` | One `Container` per item, separated after the first | |
+| `Carousel` | Multiple attachments through `toTeamsAttachments` | See [Carousels](#carousels); a non-card child is dropped with a warning |
+| `ListView` | One `Container` per item, separated after the first | A non-item child is dropped with a warning, and never reserves an input id |
 | `ListViewItem` | `Container`, with a select action when it carries an action | |
 | `Button` | `Action.Submit` inside an `ActionSet` | Consecutive buttons merge into one set; `buttonStyle` is dropped, since Teams [ignores action styling](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference) |
-| `Select` | `Input.ChoiceSet`, compact | |
-| `RadioGroup` | `Input.ChoiceSet`, expanded | |
+| `Select` | `Input.ChoiceSet`, compact | An option without a string value is dropped with a warning |
+| `RadioGroup` | `Input.ChoiceSet`, expanded | An option without a string value is dropped with a warning |
 | `Checkbox` | `Input.Toggle` | Its value is the string `"true"` or `"false"` |
 | `Input` | `Input.Text` | |
 | `DatePicker` | `Input.Date` | `value`, `min`, and `max` are kept only in `YYYY-MM-DD` form, otherwise dropped silently |

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1133,7 +1133,7 @@ describe("toSlackBlocks", () => {
       expect(warnings).toContainEqual({
         code: "dropped",
         component: "Carousel",
-        detail: "A non-card child was dropped.",
+        detail: "1 non-card child was dropped.",
       });
     });
 
@@ -1657,7 +1657,7 @@ describe("toSlackBlocks", () => {
       expect(warnings).toContainEqual({
         code: "dropped",
         component: "ListView",
-        detail: "A non-item child was dropped.",
+        detail: "1 non-item child was dropped.",
       });
     });
 

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -328,6 +328,21 @@ describe("toSlackBlocks", () => {
   });
 
   describe("Select", () => {
+    it("reports options dropped for want of a string label and value", () => {
+      const { blocks, warnings } = toSlackBlocks({
+        $type: "Select",
+        options: [{ label: "ok", value: "a" }, { label: "bad" }, "nope"],
+      });
+      const select = (blocks[0] as SlackActionsBlock)
+        .elements[0] as SlackStaticSelectElement;
+      expect(select.options).toHaveLength(1);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Select",
+        detail: "2 options were dropped for want of a string label and value.",
+      });
+    });
+
     it("converts options and placeholder", () => {
       const { blocks } = toSlackBlocks({
         $type: "Select",
@@ -1360,6 +1375,25 @@ describe("toSlackBlocks", () => {
   });
 
   describe("Table", () => {
+    it("keeps a non-object column's position in the header and reports it", () => {
+      const { blocks, warnings } = toSlackBlocks({
+        $type: "Table",
+        columns: ["A", { label: "B" }],
+        rows: [["1", "2"]],
+      });
+      const table = blocks[0] as SlackDataTableBlock;
+      expect(table.rows[0]).toEqual([
+        { type: "raw_text", text: "" },
+        { type: "raw_text", text: "B" },
+      ]);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Table",
+        detail:
+          "1 column label was dropped for want of an object with a label.",
+      });
+    });
+
     it("converts columns and rows into a header-first rows array with typed cells", () => {
       const { blocks } = toSlackBlocks({
         $type: "Table",
@@ -1611,6 +1645,22 @@ describe("toSlackBlocks", () => {
   });
 
   describe("ListView and ListViewItem", () => {
+    it("reports a non-item child it filters out", () => {
+      const { blocks, warnings } = toSlackBlocks({
+        $type: "ListView",
+        children: [
+          { $type: "Text", value: "stray" },
+          { $type: "ListViewItem", children: { $type: "Text", value: "Kept" } },
+        ],
+      });
+      expect(blocks).toHaveLength(1);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "ListView",
+        detail: "A non-item child was dropped.",
+      });
+    });
+
     it("renders each item as a section, separated by dividers", () => {
       const { blocks } = toSlackBlocks({
         $type: "ListView",

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -594,6 +594,18 @@ describe("toSlackBlocks", () => {
   });
 
   describe("RadioGroup", () => {
+    it("names RadioGroup when the same option loss happens there", () => {
+      const { warnings } = toSlackBlocks({
+        $type: "RadioGroup",
+        options: [{ label: "ok", value: "a" }, { label: "bad" }],
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "RadioGroup",
+        detail: "1 option was dropped for want of a string label and value.",
+      });
+    });
+
     const options = [
       { label: "Small", value: "s" },
       { label: "Large", value: "l" },

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1647,6 +1647,26 @@ describe("toSlackBlocks", () => {
   });
 
   describe("ListView and ListViewItem", () => {
+    it("forwards a discarded child's own dropped warning and counts it", () => {
+      const { warnings } = toSlackBlocks({
+        $type: "ListView",
+        children: [
+          { $type: "Mystery" },
+          { $type: "ListViewItem", children: { $type: "Text", value: "row" } },
+        ],
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Mystery",
+        detail: "Unknown component type was dropped.",
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "ListView",
+        detail: "1 non-item child was dropped.",
+      });
+    });
+
     it("does not let a discarded child spend the markdown budget", () => {
       const { blocks, warnings } = toSlackBlocks([
         {

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.test.ts
@@ -1375,24 +1375,26 @@ describe("toSlackBlocks", () => {
   });
 
   describe("Table", () => {
-    it("keeps a non-object column's position in the header and reports it", () => {
-      const { blocks, warnings } = toSlackBlocks({
-        $type: "Table",
-        columns: ["A", { label: "B" }],
-        rows: [["1", "2"]],
-      });
-      const table = blocks[0] as SlackDataTableBlock;
-      expect(table.rows[0]).toEqual([
-        { type: "raw_text", text: "" },
-        { type: "raw_text", text: "B" },
-      ]);
-      expect(warnings).toContainEqual({
-        code: "dropped",
-        component: "Table",
-        detail:
-          "1 column label was dropped for want of an object with a label.",
-      });
-    });
+    it.each([["A"], [{}], [{ label: 42 }]])(
+      "keeps an unlabeled column's position in the header and reports it: %j",
+      (column) => {
+        const { blocks, warnings } = toSlackBlocks({
+          $type: "Table",
+          columns: [column, { label: "B" }],
+          rows: [["1", "2"]],
+        });
+        const table = blocks[0] as SlackDataTableBlock;
+        expect(table.rows[0]).toEqual([
+          { type: "raw_text", text: "" },
+          { type: "raw_text", text: "B" },
+        ]);
+        expect(warnings).toContainEqual({
+          code: "dropped",
+          component: "Table",
+          detail: "1 column header was left blank for want of a string label.",
+        });
+      },
+    );
 
     it("converts columns and rows into a header-first rows array with typed cells", () => {
       const { blocks } = toSlackBlocks({
@@ -1645,6 +1647,29 @@ describe("toSlackBlocks", () => {
   });
 
   describe("ListView and ListViewItem", () => {
+    it("does not let a discarded child spend the markdown budget", () => {
+      const { blocks, warnings } = toSlackBlocks([
+        {
+          $type: "ListView",
+          children: [
+            { $type: "Markdown", value: "x".repeat(MARKDOWN_TEXT_BUDGET) },
+            {
+              $type: "ListViewItem",
+              children: { $type: "Text", value: "row" },
+            },
+          ],
+        },
+        { $type: "Markdown", value: "**real**" },
+      ]);
+      expect(blocks[blocks.length - 1]).toEqual({
+        type: "markdown",
+        text: "**real**",
+      });
+      expect(warnings.some((warning) => warning.component === "Markdown")).toBe(
+        false,
+      );
+    });
+
     it("reports a non-item child it filters out", () => {
       const { blocks, warnings } = toSlackBlocks({
         $type: "ListView",

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -202,6 +202,22 @@ const optionFrom = (
   };
 };
 
+const warnDroppedOptions = (
+  kept: number,
+  taken: number,
+  component: string,
+  context: ConversionContext,
+) => {
+  const dropped = taken - kept;
+  if (dropped === 0) return;
+  warn(
+    context,
+    "dropped",
+    component,
+    `${dropped} ${dropped === 1 ? "option was" : "options were"} dropped for want of a string label and value.`,
+  );
+};
+
 const toActionElement = (
   element: NormalizedUIElement,
   context: ConversionContext,
@@ -228,10 +244,16 @@ const toActionElement = (
           `options were clamped to ${SELECT_OPTION_CAP} entries.`,
         );
       }
-      const options = rawOptions
-        .slice(0, SELECT_OPTION_CAP)
+      const takenOptions = rawOptions.slice(0, SELECT_OPTION_CAP);
+      const options = takenOptions
         .map((option) => optionFrom(option, "Select", context))
         .filter((option): option is SlackOption => option !== undefined);
+      warnDroppedOptions(
+        options.length,
+        takenOptions.length,
+        "Select",
+        context,
+      );
       const placeholder = clampText(
         asString(props["placeholder"]),
         PLACEHOLDER_TEXT_CAP,
@@ -297,10 +319,16 @@ const toActionElement = (
           `options were clamped to ${RADIO_OPTION_CAP} entries.`,
         );
       }
-      const options = rawOptions
-        .slice(0, RADIO_OPTION_CAP)
+      const takenOptions = rawOptions.slice(0, RADIO_OPTION_CAP);
+      const options = takenOptions
         .map((option) => optionFrom(option, "RadioGroup", context))
         .filter((option): option is SlackOption => option !== undefined);
+      warnDroppedOptions(
+        options.length,
+        takenOptions.length,
+        "RadioGroup",
+        context,
+      );
       const selectedValue =
         typeof props["value"] === "string"
           ? props["value"]
@@ -704,10 +732,14 @@ const convertListView = (
   context: ConversionContext,
   depth: number,
 ): SlackBlock[] => {
-  const items = normalizedList(element.children).filter(
+  const children = normalizedList(element.children);
+  const items = children.filter(
     (child): child is NormalizedUIElement =>
       isElement(child) && child.type === "ListViewItem",
   );
+  if (items.length !== children.length) {
+    warn(context, "dropped", "ListView", "A non-item child was dropped.");
+  }
   return items.flatMap((item, index) => [
     ...(index > 0 ? [{ type: "divider" as const }] : []),
     convertListItem(item, context, depth + 1),
@@ -791,13 +823,20 @@ const convertTable = (
     );
   }
 
-  const columnHeaderRow: SlackDataTableCell[] = rawColumns
-    .slice(0, DATA_TABLE_COLUMN_CAP)
-    .filter(isRecord)
-    .map((column) => ({
-      type: "raw_text" as const,
-      text: asString(column["label"]),
-    }));
+  const takenColumns = rawColumns.slice(0, DATA_TABLE_COLUMN_CAP);
+  const unlabeled = takenColumns.filter((column) => !isRecord(column)).length;
+  if (unlabeled > 0) {
+    warn(
+      context,
+      "dropped",
+      "Table",
+      `${unlabeled} column ${unlabeled === 1 ? "label was" : "labels were"} dropped for want of an object with a label.`,
+    );
+  }
+  const columnHeaderRow: SlackDataTableCell[] = takenColumns.map((column) => ({
+    type: "raw_text" as const,
+    text: isRecord(column) ? asString(column["label"]) : "",
+  }));
   const dataRows: SlackDataTableCell[][] = rawRows
     .slice(0, DATA_TABLE_ROW_CAP)
     .map((row) =>

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -727,6 +727,25 @@ const convertListItem = (
   };
 };
 
+/**
+ * Converts a child whose output is thrown away, and reports whether anything
+ * was lost with it. A scratch context keeps the throwaway out of the shared
+ * markdown and data-table budgets that surviving blocks still need; only its
+ * `dropped` warnings are forwarded, because those describe the tree the caller
+ * wrote, while a clamp or a fallback would describe content never delivered.
+ */
+const discardedChild = (
+  child: NormalizedUINode,
+  context: ConversionContext,
+  depth: number,
+): boolean => {
+  const scratch: ConversionContext = { ...context, warnings: [] };
+  const produced = convertSequence(child, scratch, depth).length > 0;
+  const lost = scratch.warnings.filter((warning) => warning.code === "dropped");
+  context.warnings.push(...lost);
+  return produced || lost.length > 0;
+};
+
 const convertListView = (
   element: NormalizedUIElement,
   context: ConversionContext,
@@ -739,12 +758,7 @@ const convertListView = (
       items.push(child);
       continue;
     }
-    // Converted only to learn whether it would have rendered. A scratch
-    // context keeps the throwaway out of the shared markdown and data-table
-    // budgets, which a surviving block still needs, and out of the warnings,
-    // which would otherwise describe content the reader never receives.
-    const scratch: ConversionContext = { ...context, warnings: [] };
-    if (convertSequence(child, scratch, depth + 1).length > 0) discarded += 1;
+    if (discardedChild(child, context, depth + 1)) discarded += 1;
   }
   if (discarded > 0) {
     warn(

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -784,9 +784,9 @@ const convertCarousel = (
   for (const child of normalizedList(element.children)) {
     if (isElement(child) && child.type === "Card") {
       cardChildren.push(child);
-    } else {
-      droppedCards += 1;
+      continue;
     }
+    if (discardedChild(child, context, depth + 1)) droppedCards += 1;
   }
   if (droppedCards > 0) {
     warn(

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -739,9 +739,12 @@ const convertListView = (
       items.push(child);
       continue;
     }
-    // Converted only so the child's own warnings fire; the blocks are thrown
-    // away, and a child that produced none lost nothing worth reporting.
-    if (convertSequence(child, context, depth + 1).length > 0) discarded += 1;
+    // Converted only to learn whether it would have rendered. A scratch
+    // context keeps the throwaway out of the shared markdown and data-table
+    // budgets, which a surviving block still needs, and out of the warnings,
+    // which would otherwise describe content the reader never receives.
+    const scratch: ConversionContext = { ...context, warnings: [] };
+    if (convertSequence(child, scratch, depth + 1).length > 0) discarded += 1;
   }
   if (discarded > 0) {
     warn(
@@ -844,13 +847,15 @@ const convertTable = (
   }
 
   const takenColumns = rawColumns.slice(0, DATA_TABLE_COLUMN_CAP);
-  const unlabeled = takenColumns.filter((column) => !isRecord(column)).length;
+  const unlabeled = takenColumns.filter(
+    (column) => !isRecord(column) || typeof column["label"] !== "string",
+  ).length;
   if (unlabeled > 0) {
     warn(
       context,
       "dropped",
       "Table",
-      `${unlabeled} column ${unlabeled === 1 ? "label was" : "labels were"} dropped for want of an object with a label.`,
+      `${unlabeled} column ${unlabeled === 1 ? "header was" : "headers were"} left blank for want of a string label.`,
     );
   }
   const columnHeaderRow: SlackDataTableCell[] = takenColumns.map((column) => ({

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -732,13 +732,24 @@ const convertListView = (
   context: ConversionContext,
   depth: number,
 ): SlackBlock[] => {
-  const children = normalizedList(element.children);
-  const items = children.filter(
-    (child): child is NormalizedUIElement =>
-      isElement(child) && child.type === "ListViewItem",
-  );
-  if (items.length !== children.length) {
-    warn(context, "dropped", "ListView", "A non-item child was dropped.");
+  const items: NormalizedUIElement[] = [];
+  let discarded = 0;
+  for (const child of normalizedList(element.children)) {
+    if (isElement(child) && child.type === "ListViewItem") {
+      items.push(child);
+      continue;
+    }
+    // Converted only so the child's own warnings fire; the blocks are thrown
+    // away, and a child that produced none lost nothing worth reporting.
+    if (convertSequence(child, context, depth + 1).length > 0) discarded += 1;
+  }
+  if (discarded > 0) {
+    warn(
+      context,
+      "dropped",
+      "ListView",
+      `${discarded} non-item ${discarded === 1 ? "child was" : "children were"} dropped.`,
+    );
   }
   return items.flatMap((item, index) => [
     ...(index > 0 ? [{ type: "divider" as const }] : []),
@@ -752,12 +763,21 @@ const convertCarousel = (
   depth: number,
 ): SlackBlock[] => {
   const cardChildren: NormalizedUIElement[] = [];
+  let droppedCards = 0;
   for (const child of normalizedList(element.children)) {
     if (isElement(child) && child.type === "Card") {
       cardChildren.push(child);
     } else {
-      warn(context, "dropped", "Carousel", "A non-card child was dropped.");
+      droppedCards += 1;
     }
+  }
+  if (droppedCards > 0) {
+    warn(
+      context,
+      "dropped",
+      "Carousel",
+      `${droppedCards} non-card ${droppedCards === 1 ? "child was" : "children were"} dropped.`,
+    );
   }
   if (cardChildren.length > CAROUSEL_CARD_CAP) {
     warn(

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -865,6 +865,83 @@ describe("toAdaptiveCard", () => {
         detail: "Unknown component type was dropped.",
       });
     });
+
+    it("reports a renderable non-item child whose output it discards", () => {
+      const { card, warnings } = toAdaptiveCard({
+        $type: "ListView",
+        children: [
+          { $type: "Text", value: "stray" },
+          { $type: "ListViewItem", children: { $type: "Text", value: "Kept" } },
+        ],
+      });
+      expect(card.body).toEqual([
+        {
+          type: "Container",
+          items: [{ type: "TextBlock", text: "Kept", wrap: true }],
+        },
+      ]);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "ListView",
+        detail: "1 non-item child was dropped.",
+      });
+    });
+
+    it("does not let a discarded non-item child reserve an input id", () => {
+      const { card, warnings } = toAdaptiveCard([
+        {
+          $type: "ListView",
+          children: [
+            { $type: "Input", name: "email" },
+            { $type: "ListViewItem", title: "row" },
+          ],
+        },
+        { $type: "Input", name: "email", label: "Real" },
+      ]);
+      const ids = card.body.map((element) => (element as { id?: string }).id);
+      expect(ids).toContain("email");
+      expect(
+        warnings.some((warning) => warning.detail.includes("email_2")),
+      ).toBe(false);
+    });
+  });
+
+  describe("Carousel", () => {
+    it("reports the non-card children a nested carousel filters out", () => {
+      const { warnings } = toAdaptiveCard({
+        $type: "Col",
+        children: {
+          $type: "Carousel",
+          children: [
+            { $type: "Text", value: "lost" },
+            { $type: "Card", title: "kept" },
+          ],
+        },
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Carousel",
+        detail: "A non-card child was dropped.",
+      });
+    });
+  });
+
+  describe("choices", () => {
+    it("reports options dropped for want of a string value", () => {
+      const { card, warnings } = toAdaptiveCard({
+        $type: "Select",
+        name: "s",
+        options: [{ label: "ok", value: "a" }, { label: "bad" }, "nope"],
+      });
+      expect((card.body[0] as { choices: unknown[] }).choices).toEqual([
+        { title: "ok", value: "a" },
+      ]);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Select",
+        detail: "2 options were dropped for want of a string value.",
+      });
+    });
   });
 
   describe("Table", () => {

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -952,6 +952,34 @@ describe("toAdaptiveCard", () => {
         detail: "1 non-card child was dropped.",
       });
     });
+
+    it("stays silent for a nested-carousel child that renders nothing anyway", () => {
+      const { warnings } = toAdaptiveCard({
+        $type: "Col",
+        children: {
+          $type: "Carousel",
+          children: [{ $type: "Spacer" }, { $type: "Card", title: "kept" }],
+        },
+      });
+      expect(warnings.some((warning) => warning.code === "dropped")).toBe(
+        false,
+      );
+    });
+
+    it("forwards a nested-carousel child's own dropped warning", () => {
+      const { warnings } = toAdaptiveCard({
+        $type: "Col",
+        children: {
+          $type: "Carousel",
+          children: [{ $type: "Mystery" }, { $type: "Card", title: "kept" }],
+        },
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Mystery",
+        detail: "Unknown component type was dropped.",
+      });
+    });
   });
 
   describe("choices", () => {
@@ -968,6 +996,19 @@ describe("toAdaptiveCard", () => {
         code: "dropped",
         component: "Select",
         detail: "2 options were dropped for want of a string value.",
+      });
+    });
+
+    it("names RadioGroup when the same loss happens there", () => {
+      const { warnings } = toAdaptiveCard({
+        $type: "RadioGroup",
+        name: "r",
+        options: [{ label: "ok", value: "a" }, { label: "bad" }],
+      });
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "RadioGroup",
+        detail: "1 option was dropped for want of a string value.",
       });
     });
   });

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -887,23 +887,30 @@ describe("toAdaptiveCard", () => {
       });
     });
 
-    it("does not let a discarded non-item child reserve an input id", () => {
-      const { card, warnings } = toAdaptiveCard([
-        {
+    it.each([
+      ["before", 0],
+      ["after", 1],
+    ] as const)(
+      "does not let a discarded non-item child claim or report an input id, surviving control %s",
+      (_position, listViewIndex) => {
+        const listView = {
           $type: "ListView",
           children: [
             { $type: "Input", name: "email" },
             { $type: "ListViewItem", title: "row" },
           ],
-        },
-        { $type: "Input", name: "email", label: "Real" },
-      ]);
-      const ids = card.body.map((element) => (element as { id?: string }).id);
-      expect(ids).toContain("email");
-      expect(
-        warnings.some((warning) => warning.detail.includes("email_2")),
-      ).toBe(false);
-    });
+        };
+        const survivor = { $type: "Input", name: "email", label: "Real" };
+        const { card, warnings } = toAdaptiveCard(
+          listViewIndex === 0 ? [listView, survivor] : [survivor, listView],
+        );
+        const ids = card.body.map((element) => (element as { id?: string }).id);
+        expect(ids).toContain("email");
+        expect(
+          warnings.some((warning) => warning.detail.includes("email_2")),
+        ).toBe(false);
+      },
+    );
   });
 
   describe("Carousel", () => {
@@ -921,7 +928,7 @@ describe("toAdaptiveCard", () => {
       expect(warnings).toContainEqual({
         code: "dropped",
         component: "Carousel",
-        detail: "A non-card child was dropped.",
+        detail: "1 non-card child was dropped.",
       });
     });
   });

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -1014,6 +1014,28 @@ describe("toAdaptiveCard", () => {
   });
 
   describe("Table", () => {
+    it.each([["A"], [{}], [{ label: 42 }]])(
+      "keeps an unlabeled column's position in the header and reports it: %j",
+      (column) => {
+        const { card, warnings } = toAdaptiveCard({
+          $type: "Table",
+          columns: [column, { label: "B" }],
+          rows: [["1", "2"]],
+        });
+        const table = card.body[0] as TeamsTable;
+        expect(
+          table.rows[0]?.cells.map(
+            (cell) => (cell.items[0] as TeamsTextBlock).text,
+          ),
+        ).toEqual(["", "B"]);
+        expect(warnings).toContainEqual({
+          code: "dropped",
+          component: "Table",
+          detail: "1 column header was left blank for want of a string label.",
+        });
+      },
+    );
+
     it("renders firstRowAsHeaders true and a header row when columns are present", () => {
       const { card } = toAdaptiveCard({
         $type: "Table",

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.test.ts
@@ -866,6 +866,27 @@ describe("toAdaptiveCard", () => {
       });
     });
 
+    it("keeps a discarded child's clamp warning out of the result", () => {
+      const { warnings } = toAdaptiveCard({
+        $type: "ListView",
+        children: [
+          {
+            $type: "Table",
+            rows: Array.from({ length: TABLE_ROW_CAP + 5 }, () => ["x"]),
+          },
+          { $type: "ListViewItem", title: "row" },
+        ],
+      });
+      expect(warnings.some((warning) => warning.code === "clamped")).toBe(
+        false,
+      );
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "ListView",
+        detail: "1 non-item child was dropped.",
+      });
+    });
+
     it("reports a renderable non-item child whose output it discards", () => {
       const { card, warnings } = toAdaptiveCard({
         $type: "ListView",

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -39,6 +39,12 @@ import type {
 export interface ConversionContext {
   readonly warnings: TeamsConversionWarning[];
   usedInputIds: Set<string>;
+  /**
+   * Set while converting a subtree whose output is thrown away. An id claimed
+   * there would rename a control that survives, and a rename reported there
+   * names a control the reader never receives.
+   */
+  discardingOutput?: boolean;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -99,6 +105,7 @@ function reservedSafeId(
 ): string {
   const reserved = id === RESERVED_INPUT_ID;
   const base = reserved ? `${RESERVED_INPUT_ID}_` : id;
+  if (context.discardingOutput) return base;
   let candidate = base;
   let n = 2;
   while (context.usedInputIds.has(candidate)) {
@@ -566,11 +573,11 @@ export function convertElement(
           continue;
         }
         // A non-item child still runs through the converter so its own
-        // warnings fire, but its output is discarded, so the ids it claimed
-        // are released rather than renaming a later control that survives.
-        const reservedIds = new Set(context.usedInputIds);
+        // warnings fire, but its output never reaches the card.
+        const wasDiscarding = context.discardingOutput;
+        context.discardingOutput = true;
         const converted = convertSequence(child, context, depth + 1);
-        context.usedInputIds = reservedIds;
+        context.discardingOutput = wasDiscarding;
         if (converted.length > 0) discarded += 1;
       }
       if (discarded > 0) {
@@ -614,8 +621,14 @@ export function convertElement(
         (child): child is NormalizedUIElement =>
           isElement(child) && child.type === "Card",
       );
-      if (cards.length !== carouselChildren.length) {
-        warn(context, "dropped", "Carousel", "A non-card child was dropped.");
+      const droppedCards = carouselChildren.length - cards.length;
+      if (droppedCards > 0) {
+        warn(
+          context,
+          "dropped",
+          "Carousel",
+          `${droppedCards} non-card ${droppedCards === 1 ? "child was" : "children were"} dropped.`,
+        );
       }
       return cards.flatMap((card) => convertElement(card, context, depth + 1));
     }

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -39,12 +39,6 @@ import type {
 export interface ConversionContext {
   readonly warnings: TeamsConversionWarning[];
   usedInputIds: Set<string>;
-  /**
-   * Set while converting a subtree whose output is thrown away. An id claimed
-   * there would rename a control that survives, and a rename reported there
-   * names a control the reader never receives.
-   */
-  discardingOutput?: boolean;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -105,7 +99,6 @@ function reservedSafeId(
 ): string {
   const reserved = id === RESERVED_INPUT_ID;
   const base = reserved ? `${RESERVED_INPUT_ID}_` : id;
-  if (context.discardingOutput) return base;
   let candidate = base;
   let n = 2;
   while (context.usedInputIds.has(candidate)) {
@@ -365,6 +358,29 @@ function convertListViewItem(
   };
 }
 
+/**
+ * Converts a child whose output is thrown away, and reports whether anything
+ * was lost with it. A scratch context keeps the ids it claims out of the card,
+ * where they would rename a control that survives; only its `dropped` warnings
+ * are forwarded, because those describe the tree the caller wrote, while a
+ * clamp or a rename would describe content never delivered.
+ */
+const discardedChild = (
+  child: NormalizedUINode,
+  context: ConversionContext,
+  depth: number,
+): boolean => {
+  const scratch: ConversionContext = {
+    ...context,
+    warnings: [],
+    usedInputIds: new Set(context.usedInputIds),
+  };
+  const produced = convertSequence(child, scratch, depth).length > 0;
+  const lost = scratch.warnings.filter((warning) => warning.code === "dropped");
+  context.warnings.push(...lost);
+  return produced || lost.length > 0;
+};
+
 export function convertElement(
   element: NormalizedUIElement,
   context: ConversionContext,
@@ -572,13 +588,7 @@ export function convertElement(
           containers.push(convertListViewItem(child, context, depth + 1));
           continue;
         }
-        // A non-item child still runs through the converter so its own
-        // warnings fire, but its output never reaches the card.
-        const wasDiscarding = context.discardingOutput;
-        context.discardingOutput = true;
-        const converted = convertSequence(child, context, depth + 1);
-        context.discardingOutput = wasDiscarding;
-        if (converted.length > 0) discarded += 1;
+        if (discardedChild(child, context, depth + 1)) discarded += 1;
       }
       if (discarded > 0) {
         warn(

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -626,12 +626,15 @@ export function convertElement(
         "Carousel",
         "A carousel was rendered as sequential cards because it is not at the root.",
       );
-      const carouselChildren = normalizedList(element.children);
-      const cards = carouselChildren.filter(
-        (child): child is NormalizedUIElement =>
-          isElement(child) && child.type === "Card",
-      );
-      const droppedCards = carouselChildren.length - cards.length;
+      const cards: NormalizedUIElement[] = [];
+      let droppedCards = 0;
+      for (const child of normalizedList(element.children)) {
+        if (isElement(child) && child.type === "Card") {
+          cards.push(child);
+          continue;
+        }
+        if (discardedChild(child, context, depth + 1)) droppedCards += 1;
+      }
       if (droppedCards > 0) {
         warn(
           context,

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -365,7 +365,7 @@ function convertListViewItem(
  * are forwarded, because those describe the tree the caller wrote, while a
  * clamp or a rename would describe content never delivered.
  */
-const discardedChild = (
+export const discardedChild = (
   child: NormalizedUINode,
   context: ConversionContext,
   depth: number,

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -311,6 +311,17 @@ function convertTable(
     );
   }
 
+  const unlabeled = rawColumns.filter(
+    (column) => !isRecord(column) || typeof column["label"] !== "string",
+  ).length;
+  if (unlabeled > 0) {
+    warn(
+      context,
+      "dropped",
+      "Table",
+      `${unlabeled} column ${unlabeled === 1 ? "header was" : "headers were"} left blank for want of a string label.`,
+    );
+  }
   const hasColumns = rawColumns.length > 0;
   const columns: TeamsTableColumnDefinition[] = rawColumns.map(() => ({
     width: 1 as const,

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -191,6 +191,15 @@ const choicesFrom = (
     const choice = toChoice(item);
     if (choice !== undefined) choices.push(choice);
   }
+  const dropped = items.length - choices.length;
+  if (dropped > 0) {
+    warn(
+      context,
+      "dropped",
+      component,
+      `${dropped} ${dropped === 1 ? "option was" : "options were"} dropped for want of a string value.`,
+    );
+  }
   return choices;
 };
 
@@ -550,13 +559,27 @@ export function convertElement(
     }
     case "ListView": {
       const containers: TeamsContainer[] = [];
+      let discarded = 0;
       for (const child of normalizedList(element.children)) {
-        if (!isElement(child)) continue;
-        if (child.type === "ListViewItem") {
+        if (isElement(child) && child.type === "ListViewItem") {
           containers.push(convertListViewItem(child, context, depth + 1));
-        } else {
-          convertElement(child, context, depth + 1);
+          continue;
         }
+        // A non-item child still runs through the converter so its own
+        // warnings fire, but its output is discarded, so the ids it claimed
+        // are released rather than renaming a later control that survives.
+        const reservedIds = new Set(context.usedInputIds);
+        const converted = convertSequence(child, context, depth + 1);
+        context.usedInputIds = reservedIds;
+        if (converted.length > 0) discarded += 1;
+      }
+      if (discarded > 0) {
+        warn(
+          context,
+          "dropped",
+          "ListView",
+          `${discarded} non-item ${discarded === 1 ? "child was" : "children were"} dropped.`,
+        );
       }
       return containers.map((container, index) =>
         index > 0 ? { ...container, separator: true } : container,
@@ -586,10 +609,14 @@ export function convertElement(
         "Carousel",
         "A carousel was rendered as sequential cards because it is not at the root.",
       );
-      const cards = normalizedList(element.children).filter(
+      const carouselChildren = normalizedList(element.children);
+      const cards = carouselChildren.filter(
         (child): child is NormalizedUIElement =>
           isElement(child) && child.type === "Card",
       );
+      if (cards.length !== carouselChildren.length) {
+        warn(context, "dropped", "Carousel", "A non-card child was dropped.");
+      }
       return cards.flatMap((card) => convertElement(card, context, depth + 1));
     }
     case "Chart":

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.test.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.test.ts
@@ -34,3 +34,41 @@ describe("toTeamsAttachments payload budget", () => {
     );
   });
 });
+
+describe("toTeamsAttachments root carousel children", () => {
+  it("reports a renderable non-card child instead of dropping it silently", () => {
+    const { attachments, warnings } = toTeamsAttachments({
+      $type: "Carousel",
+      children: [
+        { $type: "Text", value: "lost" },
+        { $type: "Card", title: "kept" },
+      ],
+    });
+    expect(attachments).toHaveLength(1);
+    expect(warnings).toContainEqual({
+      code: "dropped",
+      component: "Carousel",
+      detail: "1 non-card child was dropped.",
+    });
+  });
+
+  it("forwards a discarded child's own dropped warning", () => {
+    const { warnings } = toTeamsAttachments({
+      $type: "Carousel",
+      children: [{ $type: "Mystery" }, { $type: "Card", title: "kept" }],
+    });
+    expect(warnings).toContainEqual({
+      code: "dropped",
+      component: "Mystery",
+      detail: "Unknown component type was dropped.",
+    });
+  });
+
+  it("stays silent for a child that renders nothing anyway", () => {
+    const { warnings } = toTeamsAttachments({
+      $type: "Carousel",
+      children: [{ $type: "Spacer" }, { $type: "Card", title: "kept" }],
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
@@ -12,8 +12,8 @@ import {
   utf8ByteLength,
 } from "./constants";
 import {
-  convertElement,
   convertRootToCard,
+  discardedChild,
   type ConversionContext,
 } from "./toAdaptiveCard";
 import type {
@@ -47,10 +47,9 @@ const clampArray = <T>(
 
 /**
  * Recognizes a root that is a single `Carousel` element, returning its `Card`
- * children. Every child is routed through {@link convertElement} first (its
- * result is discarded) so an unknown or unsupported child still produces its
- * usual "dropped" warning instead of being filtered out silently; non-card
- * children are then dropped. `undefined` means the root is not exclusively a
+ * children. A non-card child is routed through {@link discardedChild}, which
+ * reports it and forwards whatever it lost, rather than being filtered out
+ * silently. `undefined` means the root is not exclusively a
  * root-level carousel, so the caller falls back to converting the whole tree
  * as one card.
  */
@@ -61,13 +60,20 @@ function rootCarouselCards(
   const element = Array.isArray(root) && root.length === 1 ? root[0] : root;
   if (!isElement(element) || element.type !== "Carousel") return undefined;
   const cards: NormalizedUIElement[] = [];
+  let discarded = 0;
   for (const child of normalizedList(element.children)) {
-    if (!isElement(child)) continue;
-    if (child.type === "Card") {
+    if (isElement(child) && child.type === "Card") {
       cards.push(child);
-    } else {
-      convertElement(child, context, 1);
+      continue;
     }
+    if (discardedChild(child, context, 1)) discarded += 1;
+  }
+  if (discarded > 0) {
+    context.warnings.push({
+      code: "dropped",
+      component: "Carousel",
+      detail: `${discarded} non-card ${discarded === 1 ? "child was" : "children were"} dropped.`,
+    });
   }
   return cards;
 }


### PR DESCRIPTION
closes #5790

## summary

five paths dropped content and emitted no warning, so a consumer reading `warnings` to decide whether the payload is faithful got a false negative. two of them turned out to be worse than a missing warning.

- **a Slack table column that is not an object was filtered out of the header array**, so every remaining label shifted left and stopped lining up with its data. `columns: ["A", { label: "B" }]` with `rows: [["1", "2"]]` emitted the header `["B", ""]` over the data `["1", "2"]`, putting B's label above A's column. it now keeps its position with an empty label, matching the position-preserving convention the cell path already uses, and warns
- **the Teams `ListView` let a discarded child reserve an input id.** the `else` branch ran non-item children through `convertElement` and threw the result away, which is deliberate (an unknown `$type` inside a `ListView` still reports its own warning, pinned by an existing test) but also registered their input ids. an `Input` that is never emitted therefore renamed the real one to `email_2` with a spurious `fallback` warning. the routing stays, the ids it claims are released, and the count of children whose output was thrown away is reported
- a non-item `ListView` child is reported in both converters (`slack/toSlackBlocks.ts:707` filtered, `teams/toAdaptiveCard.ts:551` discarded)
- a non-card child of a nested `Carousel` is reported in Teams, matching what Slack already did at `slack/toSlackBlocks.ts:726`
- a `Select` or `RadioGroup` option the parser rejects is reported in both, with the per-converter reason (Teams needs a string `value`, Slack needs a string `label` and `value`)

the issue named three Teams paths; the sweep found the `ListView` and option cases in Slack too, and the table column while measuring. `convertActions`' filter at `slack/toSlackBlocks.ts:367` was checked and is not affected: it only ever receives `INTERACTIVE_TYPES` members, every one of which `toActionElement` handles, so it cannot drop.

## test plan

### already verified

- [x] `pnpm -C packages/react-generative-ui test` -> 555/555 green (7 new tests, one per path plus the input-id case)
- [x] `pnpm lint` -> exit 0
- [x] `pnpm api-surface` and `pnpm -C apps/docs generate:api-reference` -> no drift, no exported type changed
- [x] all five measured against the built dist before and after; the header case goes from `["B", ""]` to `["", "B"]`, and the input id from `email_2` back to `email`

### reviewer should verify

- [ ] a `ListView` holding a stray `Text` still renders only its items, and now warns `dropped` once
- [ ] an `Input` named `email` inside a `ListView`, followed by a real `Input` named `email`, leaves the real one called `email`

## notes

- the sibling issue #5793 (Slack `degradeCard` warning once for two different outcomes) is a separate change and lands separately

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Oipx7BWqJuTa0ZXyETHxsW5CM4Js6JByixFoytERKMfVQaspS5qdZ0lbYCs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->