### PR TITLE
fix(core): avoid duplicate user messages after cancel

### DIFF
--- a/.changeset/tame-cancellations-stay-single.md
+++ b/.changeset/tame-cancellations-stay-single.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep trailing user messages out of the composer when an external store cannot persist deletions

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -630,6 +630,7 @@ export class ExternalStoreThreadRuntimeCore
     let messages = this.repository.getMessages();
     const previousMessage = messages[messages.length - 1];
     if (
+      this._store.setMessages &&
       previousMessage?.role === "user" &&
       previousMessage.id === messages.at(-1)?.id // ensure the previous message is a leaf node
     ) {

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -278,6 +278,7 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(core.composer.text).toBe("");
+      expect(core.export().messages.map((m) => m.message.id)).toContain("u1");
     });
   });
 

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -264,6 +264,21 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
       expect(lastCall.map((m) => m.id)).not.toContain("server-msg");
     });
+
+    it("keeps a trailing user message out of the composer without setMessages", async () => {
+      const userMessage = createUserMessage("u1", "Do not duplicate me");
+      const adapter = createBaseAdapter({
+        messages: [userMessage],
+        isRunning: true,
+        onCancel: vi.fn(),
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.composer.text).toBe("");
+    });
   });
 
   describe("optimistic assistant message", () => {

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -954,7 +954,7 @@ describe("useEveAgentRuntime concurrent sends", () => {
     expect(getText(result.current)).toEqual(["earlier", "earlier answer"]);
   });
 
-  it("leaves the composer to the message cancelRun restored there", async () => {
+  it("returns the queued send when cancel keeps the trailing message", async () => {
     let resolveFirstSend!: () => void;
     const send = vi
       .fn()
@@ -966,7 +966,7 @@ describe("useEveAgentRuntime concurrent sends", () => {
       )
       .mockResolvedValue(undefined);
     // Before the turn streams, the dispatched message is the thread's trailing
-    // user leaf, which core hands back to the composer on cancel.
+    // user leaf. Eve owns that message and cannot remove it on cancel.
     const agent = createAgent({
       data: {
         messages: [
@@ -993,13 +993,15 @@ describe("useEveAgentRuntime concurrent sends", () => {
     act(() => {
       result.current.thread.cancelRun();
     });
-    expect(result.current.thread.composer.getState().text).toBe("first");
+    expect(result.current.thread.composer.getState().text).toBe("");
 
     await act(async () => {
       resolveFirstSend();
     });
 
-    expect(result.current.thread.composer.getState().text).toBe("first");
+    await waitFor(() => {
+      expect(result.current.thread.composer.getState().text).toBe("queued");
+    });
     expect(send).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Fixes #5791.

`ExternalStoreThreadRuntimeCore.cancelRun()` moved a trailing user message back into the composer after deleting it from the local repository. For adapters without `setMessages`, that deletion could not be persisted, so the next external snapshot restored the thread message while the composer kept a copy.

This change uses `setMessages` as the guard for the existing delete-and-restore behavior. Adapters that own their message list keep the current behavior. Adapters that cannot persist the deletion leave the canceled message in the thread and the composer unchanged.

Validation:

- `pnpm --filter @assistant-ui/core exec vitest run src/tests/external-store-thread-runtime-core-adapter.test.ts` (33 tests passed)
- `pnpm --filter @assistant-ui/eve exec vitest run src/useEveAgentRuntime.test.tsx` (38 tests passed)
- `pnpm exec oxfmt --check packages/eve/src/useEveAgentRuntime.test.tsx packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts`
- `pnpm --filter @assistant-ui/core build`

`pnpm --filter @assistant-ui/core exec tsc --noEmit` still reports existing errors in unrelated test files on `main`; the package build and the focused test files are clean.

The behavioral change is limited to adapters without `setMessages`: cancel no longer copies a trailing user message into the composer when the adapter cannot persist its removal. Adapters with `setMessages` are unchanged.
