### PR TITLE
fix(core): pause an external store's queue when the user cancels

### DIFF
--- a/.changeset/external-store-cancel-pauses-queue.md
+++ b/.changeset/external-store-cancel-pauses-queue.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: pause an external store's message queue when the user cancels. cancelling left the queue running, so the aborted run's settle dispatched the next pending message at the moment the user pressed Stop; the pending items now survive and the next send drains them, matching what the local runtime does under `unstable_queueClearOnCancel: false` and the behaviour that flag becomes once it is removed.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1891,6 +1891,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -442,6 +442,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -740,6 +740,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -457,6 +457,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -801,6 +801,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1136,6 +1136,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -742,6 +742,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -763,6 +763,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -520,6 +520,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -522,6 +522,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 type FeedbackAdapter = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2227,6 +2227,7 @@ type ExternalThreadQueueAdapter = {
   edit: (queueItemId: string, message: AppendMessage) => void;
   remove: (queueItemId: string) => void;
   __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
 };
 
 declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -421,7 +421,7 @@ useEffect(() => {
 }, [isRunning, queue]);
 ```
 
-Cancelling pauses the queue for you: the runtime tells the queue before your `onCancel` runs, so the cancelled run's settle keeps the pending items instead of dispatching the next one, and the next send resumes draining. Call `queue.clear()` in `onCancel` instead if you want a cancel to drop them. Edit and reload stay host-owned: call `queue.clear()` in your `onEdit` and `onReload` handlers so stale items do not drain onto the new branch.
+With a `createMessageQueue` adapter, cancelling pauses the queue for you: the runtime tells the queue before your `onCancel` runs, so the cancelled run's settle keeps the pending items instead of dispatching the next one, and the next send resumes draining. Call `queue.clear()` in `onCancel` instead if you want a cancel to drop them. A hand-rolled adapter has no such channel, so it owns its cancel policy the same way it owns the rest. Edit and reload stay host-owned: call `queue.clear()` in your `onEdit` and `onReload` handlers so stale items do not drain onto the new branch.
 
 ```tsx
 const runtime = useExternalStoreRuntime({

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -421,13 +421,13 @@ useEffect(() => {
 }, [isRunning, queue]);
 ```
 
-Queue policy on cancel, edit, and reload is host-owned. Call `queue.notifyCancelled()` in your `onCancel` handler before aborting so the cancelled run's settle pauses draining instead of dispatching the next item (the next send or run start resumes it), or call `queue.clear()` to drop the pending items. Call `queue.clear()` in your `onEdit` and `onReload` handlers so stale items do not drain onto the new branch.
+Cancelling pauses the queue for you: the runtime tells the queue before your `onCancel` runs, so the cancelled run's settle keeps the pending items instead of dispatching the next one, and the next send resumes draining. Call `queue.clear()` in `onCancel` instead if you want a cancel to drop them. Edit and reload stay host-owned: call `queue.clear()` in your `onEdit` and `onReload` handlers so stale items do not drain onto the new branch.
 
 ```tsx
 const runtime = useExternalStoreRuntime({
   // ...
   onCancel: async () => {
-    queue.notifyCancelled(); // or queue.clear() to drop pending items
+    // the runtime already paused the queue; clear() here to drop the items
     await cancelRun();
   },
   onEdit: async (message) => {

--- a/packages/core/src/runtime/queue/external-thread-queue-adapter.ts
+++ b/packages/core/src/runtime/queue/external-thread-queue-adapter.ts
@@ -37,4 +37,11 @@ export type ExternalThreadQueueAdapter = {
   __internal_setDispatchTransform?:
     | ((transform: (message: AppendMessage) => AppendMessage) => void)
     | undefined;
+  /**
+   * Called by the owning runtime when the user cancels the run, before the run
+   * is aborted. Pauses the queue so the cancelled run's settle keeps the
+   * pending items instead of dispatching the next one; the next send re-arms
+   * draining. A hand-rolled adapter that omits it drains on cancel.
+   */
+  __internal_notifyCancelled?: (() => void) | undefined;
 };

--- a/packages/core/src/runtime/queue/message-queue.ts
+++ b/packages/core/src/runtime/queue/message-queue.ts
@@ -84,6 +84,7 @@ export const createMessageQueue = (
   let suppressIdle = 0;
   // settles from cancelled runs that must drop `running` without advancing
   let cancelSettles = 0;
+  let interrupting = false;
 
   const notify = () => {
     for (const callback of subscribers) callback();
@@ -127,7 +128,15 @@ export const createMessageQueue = (
     // already cancel-notified
     suppressIdle += Math.max(cancelSettles, 1);
     cancelSettles = 0;
-    driver.cancel!();
+    // a driver whose cancel routes through the runtime notifies this queue
+    // back; the interrupt already accounted for that settle and is dispatching
+    // in its place
+    interrupting = true;
+    try {
+      driver.cancel!();
+    } finally {
+      interrupting = false;
+    }
     running = true;
     driver.run(dispatchTransform(message), { steer: true });
   };
@@ -243,6 +252,7 @@ export const createMessageQueue = (
   };
 
   const notifyCancelled = () => {
+    if (interrupting) return;
     if (running && cancelSettles === 0) {
       paused = true;
       cancelSettles = 1;

--- a/packages/core/src/runtime/queue/message-queue.ts
+++ b/packages/core/src/runtime/queue/message-queue.ts
@@ -242,6 +242,13 @@ export const createMessageQueue = (
     });
   };
 
+  const notifyCancelled = () => {
+    if (running && cancelSettles === 0) {
+      paused = true;
+      cancelSettles = 1;
+    }
+  };
+
   const adapter: ExternalThreadQueueAdapter = {
     items: lanes.queue,
     steerItems: lanes.steer,
@@ -253,6 +260,7 @@ export const createMessageQueue = (
     __internal_setDispatchTransform: (transform) => {
       dispatchTransform = transform;
     },
+    __internal_notifyCancelled: notifyCancelled,
   };
 
   return {
@@ -274,12 +282,7 @@ export const createMessageQueue = (
       running = false;
       advance();
     },
-    notifyCancelled: () => {
-      if (running && cancelSettles === 0) {
-        paused = true;
-        cancelSettles = 1;
-      }
-    },
+    notifyCancelled,
     clear: () => {
       messages.clear();
       setLanes({ queue: EMPTY_QUEUE_ITEMS, steer: EMPTY_QUEUE_ITEMS });

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -619,6 +619,11 @@ export class ExternalStoreThreadRuntimeCore
     // cancel on it.
     void this._toolInvocations?.abort();
 
+    // Before the run is aborted, so the settle it produces keeps the pending
+    // items instead of dispatching the next one at the moment the user
+    // stopped.
+    this._store.queue?.__internal_notifyCancelled?.();
+
     this._store.onCancel();
 
     // Drop an empty optimistic head (placeholder or pre-stream message); a

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -1013,11 +1013,15 @@ const useExternalThread = ({
   );
 
   const handleCancelRun = () => {
+    // Nothing is aborted without a handler, so pausing the queue would hold
+    // the pending items against a run that keeps going.
+    if (!onCancel) return;
+
     // Before the run is aborted, so the settle it produces keeps the pending
     // items instead of dispatching the next one at the moment the user
     // stopped.
     queue?.__internal_notifyCancelled?.();
-    onCancel?.();
+    onCancel();
   };
 
   const handleSendNew = (message: AppendMessage) => {

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -1013,6 +1013,10 @@ const useExternalThread = ({
   );
 
   const handleCancelRun = () => {
+    // Before the run is aborted, so the settle it produces keeps the pending
+    // items instead of dispatching the next one at the moment the user
+    // stopped.
+    queue?.__internal_notifyCancelled?.();
     onCancel?.();
   };
 

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -6,6 +6,8 @@ import {
 import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
 import type { ModelContextProvider } from "../model-context/types";
 import type { AppendMessage, ThreadMessage } from "../types/message";
+import { createMessageQueue } from "../runtime/queue/message-queue";
+import { getThreadMessageText } from "../utils/text";
 
 const createContextProvider = (): ModelContextProvider => ({
   getModelContext: () => ({}),
@@ -263,6 +265,45 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
       expect(lastCall.map((m) => m.id)).not.toContain("server-msg");
+    });
+
+    it("pauses a queue instead of dispatching the next message", async () => {
+      const dispatched: string[] = [];
+      const queue = createMessageQueue({
+        run: (message) => {
+          dispatched.push(getThreadMessageText(message));
+        },
+      });
+      const adapter = createBaseAdapter({
+        isRunning: true,
+        onCancel: vi.fn(),
+        queue: queue.adapter,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+      const appendAtTail = (text: string) =>
+        core.append({
+          role: "user",
+          content: [{ type: "text", text }],
+          attachments: [],
+          createdAt: new Date(),
+          parentId: core.messages.at(-1)?.id ?? null,
+          sourceId: null,
+          runConfig: undefined,
+          metadata: { custom: {} },
+        } as AppendMessage);
+
+      await appendAtTail("first");
+      await appendAtTail("queued");
+
+      core.cancelRun();
+      // the aborted run settles; a queue host reports that the same way it
+      // reports any other run ending
+      queue.notifyIdle();
+
+      expect(dispatched).toEqual(["first"]);
+      expect(queue.adapter.steerItems.map((item) => item.prompt)).toEqual([
+        "queued",
+      ]);
     });
 
     it("keeps a trailing user message out of the composer without setMessages", async () => {

--- a/packages/core/src/tests/external-thread-parity.test.tsx
+++ b/packages/core/src/tests/external-thread-parity.test.tsx
@@ -279,6 +279,34 @@ describe("ExternalThread composer", () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
+  it("pauses the queue on cancel", async () => {
+    const notifyCancelled = vi.fn();
+    const onCancel = vi.fn();
+    const { aui } = renderThread({
+      messages: [],
+      isRunning: true,
+      onCancel,
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue: vi.fn(),
+        steer: vi.fn(),
+        move: vi.fn(),
+        edit: vi.fn(),
+        remove: vi.fn(),
+        __internal_notifyCancelled: notifyCancelled,
+      },
+    });
+
+    aui().thread.cancelRun();
+
+    expect(notifyCancelled).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(notifyCancelled.mock.invocationCallOrder[0]!).toBeLessThan(
+      onCancel.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("routes edit-composer sends to onEdit with sourceId, bypassing the queue", async () => {
     const onEdit = vi.fn();
     const enqueue = vi.fn();

--- a/packages/core/src/tests/external-thread-parity.test.tsx
+++ b/packages/core/src/tests/external-thread-parity.test.tsx
@@ -307,6 +307,28 @@ describe("ExternalThread composer", () => {
     );
   });
 
+  it("leaves the queue alone when the host cannot cancel", async () => {
+    const notifyCancelled = vi.fn();
+    const { aui } = renderThread({
+      messages: [],
+      isRunning: true,
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue: vi.fn(),
+        steer: vi.fn(),
+        move: vi.fn(),
+        edit: vi.fn(),
+        remove: vi.fn(),
+        __internal_notifyCancelled: notifyCancelled,
+      },
+    });
+
+    aui().thread.cancelRun();
+
+    expect(notifyCancelled).not.toHaveBeenCalled();
+  });
+
   it("routes edit-composer sends to onEdit with sourceId, bypassing the queue", async () => {
     const onEdit = vi.fn();
     const enqueue = vi.fn();

--- a/packages/core/src/tests/message-queue.test.ts
+++ b/packages/core/src/tests/message-queue.test.ts
@@ -626,3 +626,29 @@ describe("createMessageQueue", () => {
     expect(adapter.items).toHaveLength(0);
   });
 });
+
+describe("createMessageQueue interrupt with a runtime-routed cancel", () => {
+  it("keeps draining when the driver's cancel notifies back", () => {
+    const runs: string[] = [];
+    const controller = createMessageQueue({
+      run: (message) => {
+        runs.push(
+          message.content[0]!.type === "text" ? message.content[0].text : "",
+        );
+      },
+      cancel: () => controller.notifyCancelled(),
+    });
+
+    controller.adapter.enqueue(msg("first"));
+    controller.adapter.enqueue(msg("second"));
+    controller.adapter.steer(msg("steered"));
+
+    expect(runs).toEqual(["first", "steered"]);
+
+    // the interrupted run and the steer run each settle once
+    controller.notifyIdle();
+    controller.notifyIdle();
+
+    expect(runs).toEqual(["first", "steered", "second"]);
+  });
+});


### PR DESCRIPTION
Closes #5796.

## What

`ExternalStoreThreadRuntimeCore.cancelRun` now pauses the queue before the run is aborted, so the settle that follows keeps the pending items instead of dispatching the next one.

## Why

The queue keeps the `running` flag from the dispatch that started the cancelled run. `cancelRun` never touched the queue, so as soon as that run settled and the host reported it through `notifyIdle`, `advance()` dispatched the next pending message. Pressing Stop started work the user had not asked to start:

```
before cancel   dispatched: [first]           pending: [queued]
after cancel    dispatched: [first]           pending: [queued]
after settle    dispatched: [first, queued]   pending: []
```

That was the only one of the three cancel paths that neither cleared nor kept its queue. The local runtime clears by default (`unstable_queueClearOnCancel ?? true`) and pauses under the opt-out, and that opt-out is deprecated: after its removal, pausing and keeping the items is the only behaviour. This puts the external store on the side the flag is heading to rather than on a third one.

## How

`notifyCancelled` lives on the controller `createMessageQueue` returns, while the runtime only ever sees `ExternalThreadQueueAdapter`, which had no cancel channel. It gains `__internal_notifyCancelled`, provided by `createMessageQueue` and called by the runtime, the same shape as the `__internal_setDispatchTransform` hook already on that type. A hand-rolled adapter that omits it keeps today's behaviour, which the field documents.

Reaches every queue host without an opt-in, which is the point: `react-langgraph` and `react-ag-ui` both call `notifyBusy`/`notifyIdle` around their runs and never `notifyCancelled`, so neither could have paused on its own.

## Scope

- Additive on an internal hook type; no exported symbol changed, and the controller's own `notifyCancelled` is unchanged, now shared with the adapter rather than duplicated.
- Nothing changes for a runtime with no queue installed.
- The tap `ExternalThread` client carries the same fix, since it owns this surface during the migration and its cancel handler had the same gap.
- The external-store docs said this policy was host-owned and told hosts to call `notifyCancelled()` themselves; the page now says the runtime does it, with `queue.clear()` as the way to drop the items instead. Host code that still calls it stays correct, the second call is a no-op.
- `react-langgraph` clears its own queue in `cancelActiveRun`, a deliberate policy this runs before and does not change. `react-ag-ui` builds its own core and is not reached at all; its queued message disappears on cancel, filed as #5801.
- Unrelated to what a cancel does with the *thread's* trailing user message, which #5799 settled.

## Tests

- `pauses a queue instead of dispatching the next message` — appends two messages behind a run, cancels, reports the settle, and expects the second still pending. Fails without the call, dispatching `[first, queued]`.
- `pauses the queue on cancel` in the tap parity suite — asserts the notify happens, and happens before `onCancel`.
- `@assistant-ui/core` 1039 passed, `@assistant-ui/react` 404 passed; oxlint, oxfmt, `tsc --noEmit` clean; api-surface regenerated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.zY0Ql5QAvxJ6wwQEGcmevKrWj9-mLT-TowgT1rqGAsCl9ag7vZ36QSSc30c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->