### PR TITLE
fix(react-ag-ui): preserve queued messages after cancellation

### DIFF
--- a/.changeset/calm-queues-wait.md
+++ b/.changeset/calm-queues-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve queued messages when cancelling an active run

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -27,7 +27,7 @@ const gatedAgent = () => {
     },
   );
   return {
-    agent: { runAgent } as unknown as HttpAgent,
+    agent: { runAgent, abortRun: vi.fn() } as unknown as HttpAgent,
     runAgent,
     release: () => release(),
   };
@@ -92,6 +92,46 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
     await waitFor(() =>
       expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
+  });
+
+  it("preserves queued sends when the active run is cancelled", async () => {
+    const { agent, runAgent, release } = gatedAgent();
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({ agent, unstable_enableMessageQueue: true }),
+    );
+    mount(result.current);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
+    );
+
+    act(() => {
+      result.current.thread.cancelRun();
+    });
+    await act(async () => {
+      release();
+    });
+
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
     );
   });
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -133,6 +133,33 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     await waitFor(() =>
       expect(screen.getByTestId("queued").textContent).toBe("second"),
     );
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "third" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(3));
+    expect(runAgent.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "user", content: "second" }),
+        ]),
+      }),
+    );
+    expect(runAgent.mock.calls[2]?.[0]).toEqual(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "user", content: "third" }),
+        ]),
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
   });
 
   it("keeps accepting sends after a queued run fails", async () => {

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -251,7 +251,7 @@ export function useAgUiRuntime(
           return core.reload(parentId, config);
         },
         onCancel: async () => {
-          queueController?.clear();
+          queueController?.notifyCancelled();
           core.cancel();
         },
         onAddToolResult: (options) => core.addToolResult(options),


### PR DESCRIPTION
Closes #5801

## Problem

With `unstable_enableMessageQueue: true`, cancelling an active AG-UI run cleared every message waiting behind it. The queued message was neither sent nor retained, so it disappeared from the composer queue.

## Fix

Use the message queue's cancellation lifecycle to pause and retain pending sends while the cancelled run settles. Edit, reload, and disabling the queue still clear pending items as before.

## Verification

- Added a gated runtime regression that queues a second message, cancels the active run, and verifies the second message remains queued without being sent.
- Confirmed the regression fails on `main` and passes with this change.
- `pnpm --filter @assistant-ui/react-ag-ui test` (348 tests)
- `pnpm --filter @assistant-ui/react-ag-ui build`
- Targeted oxfmt and oxlint checks passed; oxlint reports only the two pre-existing exhaustive-deps warnings in `useAgUiRuntime.ts`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QOe7lpH8PLaQPIQ19p3Md4UMjjt8cYAvexVVhfRm-rHFX9v0T-KXutkBNTM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->