### PR TITLE
feat(core,react-ag-ui): let a message part carry provider metadata to AG-UI

### DIFF
--- a/.changeset/ag-ui-part-metadata.md
+++ b/.changeset/ag-ui-part-metadata.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: send a part's `providerMetadata.agui` as the AG-UI content item's `metadata`. An image or file part, whether it sits on the message or inside an attachment, now reaches the agent with whatever the host put in that namespace; a file part's own `filename` still wins over a key of the same name. Text is unchanged, its AG-UI schema has no metadata field.

--- a/.changeset/ag-ui-part-metadata.md
+++ b/.changeset/ag-ui-part-metadata.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-feat: send a part's `providerMetadata.agui` as the AG-UI content item's `metadata`. An image or file part, whether it sits on the message or inside an attachment, now reaches the agent with whatever the host put in that namespace; a file part's own `filename` still wins over a key of the same name. Text is unchanged, its AG-UI schema has no metadata field.
+feat: round-trip a part's `providerMetadata.agui` through AG-UI's content `metadata`. An image or file part, whether it sits on the message or inside an attachment, now reaches the agent with whatever the host put in that namespace, and an inbound item puts it back on the rebuilt part, so a snapshot echo resends it instead of dropping it. A file part's own `filename` still wins over a key of the same name. Text is unchanged, its AG-UI schema has no metadata field.

--- a/.changeset/part-provider-metadata.md
+++ b/.changeset/part-provider-metadata.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: accept `providerMetadata` on image and file message parts, the channel text, reasoning and source parts already carry. A runtime adapter reads its own namespace off it, so a part can carry provider-specific data (an upload id, a document handle) without a field per provider.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1911,6 +1911,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -2035,6 +2036,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -460,6 +460,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -508,6 +509,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -758,6 +758,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -820,6 +821,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -475,6 +475,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -541,6 +542,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -819,6 +819,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -899,6 +900,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type InitializableThreadListItem = Pick<ThreadListItemRuntime, "initialize">;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -667,6 +667,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -742,6 +743,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -320,6 +320,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -444,6 +445,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type ImageSize = (typeof IMAGE_SIZE_TOKENS)[number] | number;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1154,6 +1154,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -1213,6 +1214,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-hook-form.ts
+++ b/api-surface/assistant-ui__react-hook-form.ts
@@ -53,6 +53,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -78,6 +79,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type McpAppMetadata = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1594,6 +1594,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -1678,6 +1679,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -760,6 +760,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -819,6 +820,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -781,6 +781,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -840,6 +841,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1426,6 +1426,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -1511,6 +1512,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -538,6 +538,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -586,6 +587,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -540,6 +540,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -588,6 +589,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 interface JSONSchema7 {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2247,6 +2247,7 @@ type FileMessagePart = {
   readonly data: string;
   readonly mimeType: string;
   readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 
@@ -2375,6 +2376,7 @@ type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -382,3 +382,42 @@ describe("fromThreadMessageLike", () => {
     });
   });
 });
+
+describe("fromThreadMessageLike provider metadata", () => {
+  it("keeps it on image and file parts", () => {
+    const result = fromThreadMessageLike(
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            image: "https://example.com/cat.png",
+            providerMetadata: { agui: { file_id: "f_1" } },
+          },
+          {
+            type: "file",
+            data: "https://example.com/spec.pdf",
+            mimeType: "application/pdf",
+            providerMetadata: { agui: { file_id: "f_2" } },
+          },
+        ],
+      },
+      fallbackId,
+      fallbackStatus,
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "image",
+        image: "https://example.com/cat.png",
+        providerMetadata: { agui: { file_id: "f_1" } },
+      },
+      {
+        type: "file",
+        data: "https://example.com/spec.pdf",
+        mimeType: "application/pdf",
+        providerMetadata: { agui: { file_id: "f_2" } },
+      },
+    ]);
+  });
+});

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -56,6 +56,7 @@ export type ImageMessagePart = {
   readonly type: "image";
   readonly image: string;
   readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
 };
 
 export type FileMessagePart = {
@@ -65,6 +66,7 @@ export type FileMessagePart = {
   readonly mimeType: string;
   /** How `data` goes on the wire: a url or id reference; omitted = inferred (http(s) → url, else base64). "url" is honored by the LangChain-family, A2A, AG-UI, and Google ADK runtimes; "id" by the LangChain family only. */
   readonly sourceType?: "url" | "id";
+  readonly providerMetadata?: PartProviderMetadata;
   readonly parentId?: string;
 };
 

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { UserMessageSchema } from "@ag-ui/client";
-import { toAgUiMessages } from "./conversions";
+import { fromAgUiMessages, toAgUiMessages } from "./conversions";
 
 type Message = Parameters<typeof toAgUiMessages>[0][number];
 
@@ -161,5 +161,31 @@ describe("toAgUiMessages content metadata", () => {
       UserMessageSchema.safeParse(JSON.parse(JSON.stringify(converted)))
         .success,
     ).toBe(true);
+  });
+
+  it("survives a snapshot round trip", () => {
+    const sent = toAgUiMessages([
+      userMessage([
+        {
+          type: "file",
+          data: "https://example.com/spec.pdf",
+          mimeType: "application/pdf",
+          filename: "spec.pdf",
+          providerMetadata: { agui: { file_id: "f_7" } },
+        },
+      ]),
+    ]);
+
+    const rebuilt = fromAgUiMessages(sent as never);
+    const attachment = (rebuilt[0] as unknown as { attachments: unknown[] })
+      .attachments[0] as { content: unknown[] };
+
+    expect(attachment.content[0]).toMatchObject({
+      type: "file",
+      filename: "spec.pdf",
+      providerMetadata: { agui: { file_id: "f_7" } },
+    });
+
+    expect(toAgUiMessages(rebuilt as never)).toEqual(sent);
   });
 });

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { UserMessageSchema } from "@ag-ui/client";
+import { toAgUiMessages } from "./conversions";
+
+type Message = Parameters<typeof toAgUiMessages>[0][number];
+
+const userMessage = (
+  content: unknown,
+  attachments?: Message["attachments"],
+): Message =>
+  ({
+    id: "u1",
+    role: "user",
+    content,
+    ...(attachments && { attachments }),
+  }) as Message;
+
+const contentOf = (message: Message) => {
+  const [converted] = toAgUiMessages([message]);
+  return (converted as { content: unknown }).content;
+};
+
+describe("toAgUiMessages content metadata", () => {
+  it("carries a part's agui provider metadata onto an image item", () => {
+    expect(
+      contentOf(
+        userMessage([
+          {
+            type: "image",
+            image: "https://example.com/cat.png",
+            providerMetadata: { agui: { file_id: "f_1" } },
+          },
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: "image",
+        source: { type: "url", value: "https://example.com/cat.png" },
+        metadata: { file_id: "f_1" },
+      },
+    ]);
+  });
+
+  it("merges a file part's metadata with its filename", () => {
+    expect(
+      contentOf(
+        userMessage([
+          {
+            type: "file",
+            data: "https://example.com/spec.pdf",
+            mimeType: "application/pdf",
+            filename: "spec.pdf",
+            providerMetadata: { agui: { file_id: "f_2" } },
+          },
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: "document",
+        source: {
+          type: "url",
+          value: "https://example.com/spec.pdf",
+          mimeType: "application/pdf",
+        },
+        metadata: { file_id: "f_2", filename: "spec.pdf" },
+      },
+    ]);
+  });
+
+  it("keeps the part's own filename over one in the metadata", () => {
+    expect(
+      contentOf(
+        userMessage([
+          {
+            type: "file",
+            data: "https://example.com/spec.pdf",
+            mimeType: "application/pdf",
+            filename: "spec.pdf",
+            providerMetadata: { agui: { filename: "renamed.pdf" } },
+          },
+        ]),
+      ),
+    ).toMatchObject([{ metadata: { filename: "spec.pdf" } }]);
+  });
+
+  it("carries metadata from an attachment's content part", () => {
+    expect(
+      contentOf(
+        userMessage([], [
+          {
+            name: "spec.pdf",
+            contentType: "application/pdf",
+            content: [
+              {
+                type: "file",
+                data: "https://example.com/spec.pdf",
+                mimeType: "application/pdf",
+                providerMetadata: { agui: { file_id: "f_3" } },
+              },
+            ],
+          },
+        ] as Message["attachments"]),
+      ),
+    ).toMatchObject([{ type: "document", metadata: { file_id: "f_3" } }]);
+  });
+
+  it("ignores metadata namespaced for another provider", () => {
+    expect(
+      contentOf(
+        userMessage([
+          {
+            type: "image",
+            image: "https://example.com/cat.png",
+            providerMetadata: { openai: { file_id: "f_4" } },
+          },
+        ]),
+      ),
+    ).toEqual([
+      {
+        type: "image",
+        source: { type: "url", value: "https://example.com/cat.png" },
+      },
+    ]);
+  });
+
+  it("emits no metadata channel for text, which the schema has no field for", () => {
+    expect(
+      contentOf(
+        userMessage([
+          {
+            type: "text",
+            text: "hello",
+            providerMetadata: { agui: { file_id: "f_5" } },
+          },
+          { type: "image", image: "https://example.com/cat.png" },
+        ]),
+      ),
+    ).toEqual([
+      { type: "text", text: "hello" },
+      {
+        type: "image",
+        source: { type: "url", value: "https://example.com/cat.png" },
+      },
+    ]);
+  });
+
+  it("stays valid against the upstream user message schema", () => {
+    const [converted] = toAgUiMessages([
+      userMessage([
+        {
+          type: "file",
+          data: "https://example.com/spec.pdf",
+          mimeType: "application/pdf",
+          filename: "spec.pdf",
+          providerMetadata: { agui: { file_id: "f_6", nested: { a: 1 } } },
+        },
+      ]),
+    ]);
+
+    expect(
+      UserMessageSchema.safeParse(JSON.parse(JSON.stringify(converted)))
+        .success,
+    ).toBe(true);
+  });
+});

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -102,14 +102,33 @@ const getString = (record: Record<string, unknown>, key: string) => {
 const getToolCallId = (record: Record<string, unknown>) =>
   getString(record, "toolCallId") ?? getString(record, "tool_call_id");
 
-const readAgUiReasoningMeta = (providerMetadata: unknown) => {
-  if (!isObject(providerMetadata)) return {};
+const readAgUiNamespace = (providerMetadata: unknown) => {
+  if (!isObject(providerMetadata)) return undefined;
   const namespaced = providerMetadata[AG_UI_METADATA_NAMESPACE];
-  if (!isObject(namespaced)) return {};
+  return isObject(namespaced) ? namespaced : undefined;
+};
+
+const readAgUiReasoningMeta = (providerMetadata: unknown) => {
+  const namespaced = readAgUiNamespace(providerMetadata);
+  if (!namespaced) return {};
   return {
     encryptedValue: getString(namespaced, "encryptedValue"),
     reasoningId: getString(namespaced, "reasoningId"),
   };
+};
+
+// AG-UI carries per-item extras in `metadata`; anything else on the item is
+// stripped by its schema. The part's own `filename` wins over a key of the
+// same name in the bag.
+const buildInputMetadata = (
+  part: Record<string, unknown>,
+  filename?: string | undefined,
+) => {
+  const metadata = {
+    ...readAgUiNamespace(part.providerMetadata),
+    ...(filename !== undefined && { filename }),
+  };
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
 };
 
 function parseJSONText(value: string): unknown {
@@ -216,7 +235,12 @@ function toInputContent(
   if (type === "image") {
     const image = getString(part, "image");
     if (image === undefined) return null;
-    return { type: "image", source: buildInputSource(image, fallbackMimeType) };
+    const metadata = buildInputMetadata(part);
+    return {
+      type: "image",
+      source: buildInputSource(image, fallbackMimeType),
+      ...(metadata && { metadata }),
+    };
   }
 
   if (type === "file") {
@@ -229,7 +253,7 @@ function toInputContent(
       declaredMimeType,
       getString(part, "sourceType"),
     );
-    const metadata = filename !== undefined ? { filename } : undefined;
+    const metadata = buildInputMetadata(part, filename);
     switch (mediaTypeForMime(source.mimeType)) {
       case "image":
         return { type: "image", source, ...(metadata && { metadata }) };

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -3,6 +3,7 @@
 import type { InputContent, RunAgentParameters } from "@ag-ui/client";
 import type {
   ThreadMessageLike as CoreThreadMessageLike,
+  PartProviderMetadata,
   ToolCallMessagePartMcpMetadata,
   ToolModelContentPart,
 } from "@assistant-ui/core";
@@ -129,6 +130,27 @@ const buildInputMetadata = (
     ...(filename !== undefined && { filename }),
   };
   return Object.keys(metadata).length > 0 ? metadata : undefined;
+};
+
+// The inverse: `filename` lands on the part's own field, everything else the
+// item carried goes back into the namespace it came from, so a snapshot echo
+// resends what the host attached.
+const readInputMetadata = (
+  metadata: unknown,
+): {
+  filename?: string | undefined;
+  providerMetadata?: PartProviderMetadata | undefined;
+} => {
+  if (!isObject(metadata)) return {};
+  const { filename: _filename, ...rest } = metadata;
+  return {
+    filename: getString(metadata, "filename"),
+    ...(Object.keys(rest).length > 0 && {
+      providerMetadata: {
+        [AG_UI_METADATA_NAMESPACE]: rest as PartProviderMetadata[string],
+      },
+    }),
+  };
 };
 
 function parseJSONText(value: string): unknown {
@@ -354,9 +376,7 @@ function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
     const source = inputSourceToString(part.source);
     if (!source) continue;
 
-    const filename = isObject(part.metadata)
-      ? getString(part.metadata, "filename")
-      : undefined;
+    const { filename, providerMetadata } = readInputMetadata(part.metadata);
     const id = attachments.length.toString();
 
     if (type === "image") {
@@ -371,6 +391,7 @@ function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
             type: "image",
             image: source.value,
             ...(filename !== undefined && { filename }),
+            ...(providerMetadata && { providerMetadata }),
           },
         ],
       });
@@ -391,6 +412,7 @@ function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
           mimeType,
           ...(source.isUrl && { sourceType: "url" as const }),
           ...(filename !== undefined && { filename }),
+          ...(providerMetadata && { providerMetadata }),
         },
       ],
     });


### PR DESCRIPTION
Closes #5792.

## What

An image or file message part can now carry `providerMetadata`, and `@assistant-ui/react-ag-ui` sends its own namespace from that bag as the AG-UI content item's `metadata`.

```tsx
// e.g. from an AttachmentAdapter that uploaded the file at pick time
content: [
  {
    type: "file",
    data: uploadedUrl,
    mimeType: file.type,
    filename: file.name,
    providerMetadata: { agui: { file_id: upload.id } },
  },
]
```

reaches the agent as:

```json
{ "type": "document", "source": { "type": "url", "value": "…" },
  "metadata": { "file_id": "…", "filename": "…" } }
```

## Why this shape

`metadata` is the only channel upstream leaves open. In `@ag-ui/core@0.0.57`, `ImageInputContentSchema`, `AudioInputContentSchema`, `VideoInputContentSchema` and `DocumentInputContentSchema` each declare `metadata: z.unknown().optional()`, the only refinement on `InputContentSchema` validates binary payloads and never touches it, and the objects are in zod's default strip mode, so any other key put on an item is dropped on the way out. That is why the reporter's extra fields disappeared.

On our side the channel also already exists: `TextMessagePart`, `ReasoningMessagePart` and `SourceMessagePart` all carry `providerMetadata?: PartProviderMetadata`, and this adapter already round-trips reasoning through `providerMetadata.agui` (`AG_UI_METADATA_NAMESPACE`, stamped inbound in `run-aggregator.ts`, read outbound by `readAgUiReasoningMeta`). So this fills a gap in the part types rather than inventing a second metadata concept, and keeps provider-specific data namespaced: another provider's bag never reaches the AG-UI wire.

The issue proposed a flat `metadata?: Record<string, unknown>` on the parts. That would sit next to the existing `providerMetadata` with no way to say which provider it is for, and next to message-level `metadata.custom` with a different meaning again.

## Scope

- `providerMetadata` on `ImageMessagePart` and `FileMessagePart`, matching the three parts that already have it. Optional and additive.
- Text is unchanged, since upstream's text item has no metadata field. The converter's `audio` part branch is also unchanged: `Unstable_AudioMessagePart` has no metadata channel to read.
- A file part's own `filename` wins over a `filename` key in the bag. Nothing is lost by that: the part's field is the way to set it.
- Attachments come along for free, the converter runs `attachment.content[]` through the same `toInputContent`.
- The channel is two-way, the way the reasoning one is: an inbound item's `metadata` goes back onto the rebuilt part, `filename` to its own field and the rest to the namespace, so a `MESSAGES_SNAPSHOT` echo resends what the host attached instead of dropping it.
- Nothing changes for a part without `providerMetadata`, including the existing filename-only metadata on file parts.
- Persistence is out of scope: the format adapters map parts field by field, so a `providerMetadata` on an image or file part is not part of what a stored thread round-trips today.

## Tests

- `conversions.content.test.ts`: metadata reaches an image item and a document item, survives a send → snapshot → resend round trip, merges with the filename, loses to the part's own filename, comes through an attachment's content part, is ignored when namespaced for another provider, and stays absent from text items. The last case parses the converted message with upstream's `UserMessageSchema` to show a nested bag survives validation.
- `thread-message-like.test.ts`: `fromThreadMessageLike` keeps `providerMetadata` on both part types, which is what makes the field survive the trip from the composer.
- The three cases that assert the new behavior fail against the previous converter.
- `@assistant-ui/core` 1042 passed, `@assistant-ui/react-ag-ui` 356 passed; oxlint, oxfmt and `tsc --noEmit` clean on both packages; api-surface and api-reference regenerated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IbzTTZ9R3uiqGZhLo1zgJBFKXv2nf_xbhIE8ZMm5p7XqmD2rSt_KHqhOVW0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->