### PR TITLE
fix(cli): clarify info package json errors

### DIFF
--- a/.changeset/clear-cli-info-json-errors.md
+++ b/.changeset/clear-cli-info-json-errors.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): clarify malformed package.json errors from the info command

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
 import { satisfies } from "semver";
-import { logger } from "../lib/utils/logger";
+import { logPackageJsonParseError } from "../lib/utils/package-json";
 import { findWorkspaceRoot, resolveRealPath } from "../lib/utils/workspace";
 
 export { findWorkspaceRoot };
@@ -432,11 +432,7 @@ export const info = new Command()
     try {
       projectPkg = JSON.parse(packageJsonContent);
     } catch {
-      logger.error("Could not parse package.json.");
-      console.error(`Package path: ${packageJsonPath}`);
-      console.error(
-        "Fix the JSON syntax in that file, then run: assistant-ui info",
-      );
+      logPackageJsonParseError(packageJsonPath, "info");
       process.exit(1);
     }
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
 import { satisfies } from "semver";
+import { logger } from "../lib/utils/logger";
 import { findWorkspaceRoot, resolveRealPath } from "../lib/utils/workspace";
 
 export { findWorkspaceRoot };
@@ -426,7 +427,19 @@ export const info = new Command()
       process.exit(1);
     }
 
-    const projectPkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+    let projectPkg: Record<string, unknown>;
+    try {
+      projectPkg = JSON.parse(packageJsonContent);
+    } catch {
+      logger.error("Could not parse package.json.");
+      console.error(`Package path: ${packageJsonPath}`);
+      console.error(
+        "Fix the JSON syntax in that file, then run: assistant-ui info",
+      );
+      process.exit(1);
+    }
+
     const data = await collectInfo(cwd, projectPkg);
 
     // Colored output for terminal

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -3,16 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { sync as spawnSync } from "cross-spawn";
 import { logger } from "../lib/utils/logger";
+import { logPackageJsonParseError } from "../lib/utils/package-json";
 import { getInstallCommand } from "../lib/utils/package-manager";
-
-const logPackageJsonParseError = (packageJsonPath: string) => {
-  logger.error("Could not parse package.json.");
-  console.error(`Package path: ${packageJsonPath}`);
-  console.error(
-    "Fix the JSON syntax in that file, then run: assistant-ui update",
-  );
-  console.error("No changes were written.");
-};
 
 export const update = new Command()
   .name("update")
@@ -37,7 +29,8 @@ export const update = new Command()
     try {
       pkg = JSON.parse(packageJsonContent);
     } catch {
-      logPackageJsonParseError(packageJsonPath);
+      logPackageJsonParseError(packageJsonPath, "update");
+      console.error("No changes were written.");
       process.exit(1);
     }
     const sections = ["dependencies", "devDependencies"];

--- a/packages/cli/src/lib/utils/package-json.ts
+++ b/packages/cli/src/lib/utils/package-json.ts
@@ -1,0 +1,12 @@
+import { logger } from "./logger";
+
+export function logPackageJsonParseError(
+  packageJsonPath: string,
+  commandName: string,
+) {
+  logger.error("Could not parse package.json.");
+  console.error(`Package path: ${packageJsonPath}`);
+  console.error(
+    `Fix the JSON syntax in that file, then run: assistant-ui ${commandName}`,
+  );
+}

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -139,6 +139,43 @@ describe("findWorkspaceRoot", () => {
 });
 
 describe("info command", () => {
+  it("prints recovery details for invalid package.json", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-invalid-"));
+    const packageJsonPath = path.join(root, "package.json");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      fs.writeFileSync(packageJsonPath, "{ invalid json", "utf8");
+
+      await expect(
+        info.parseAsync(["node", "info", "--cwd", root], {
+          from: "node",
+        }),
+      ).rejects.toThrow("process.exit");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      const stderr = consoleError.mock.calls.flat().join("\n");
+      expect(stderr).toContain("Could not parse package.json.");
+      expect(stderr).toContain(
+        `Package path: ${path.join(fs.realpathSync(root), "package.json")}`,
+      );
+      expect(stderr).toContain(
+        "Fix the JSON syntax in that file, then run: assistant-ui info",
+      );
+      expect(stderr).not.toContain("SyntaxError");
+    } finally {
+      exitSpy.mockRestore();
+      consoleError.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("finds hoisted packages from a symlinked workspace project", async () => {
     const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-link-"));
     const root = path.join(fixture, "workspace");


### PR DESCRIPTION
## Problem

Running `assistant-ui info` in a project with malformed `package.json` currently exposes the raw `JSON.parse` `SyntaxError`. That output does not identify the manifest clearly or tell the user how to recover, unlike the existing `assistant-ui update` behavior.

## Fix

- catch project manifest parse failures in the `info` command
- report the resolved `package.json` path and tell the user to fix its JSON before rerunning `assistant-ui info`
- exit with status 1 without printing the raw parser stack
- keep filesystem read failures outside the parse handler so they retain their original error

## Verification

- `pnpm --dir packages/cli test` (256 tests)
- `pnpm --filter assistant-ui build`
- targeted `oxlint` and `oxfmt` checks
- manually ran the built CLI against `{ invalid json` and confirmed the contextual message with exit code 1

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BeMW0w73pPsih5xynAgOmdOKWo0GX5ZXHngIlr8YL4ku-7ldaTrB0zacxdo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->