### PR TITLE
fix(react-ag-ui): preserve image filenames

### DIFF
--- a/.changeset/bright-images-remember.md
+++ b/.changeset/bright-images-remember.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve image filenames through AG-UI snapshots

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.content.test.ts
@@ -41,6 +41,35 @@ describe("toAgUiMessages content metadata", () => {
     ]);
   });
 
+  it("preserves a direct image part's filename through a snapshot round trip", () => {
+    const sent = toAgUiMessages([
+      userMessage([
+        {
+          type: "image",
+          image: "https://example.com/cat.png",
+          filename: "cat.png",
+        },
+      ]),
+    ]);
+
+    expect((sent[0] as { content: unknown }).content).toEqual([
+      {
+        type: "image",
+        source: { type: "url", value: "https://example.com/cat.png" },
+        metadata: { filename: "cat.png" },
+      },
+    ]);
+
+    const rebuilt = fromAgUiMessages(sent as never);
+    const attachment = (rebuilt[0] as unknown as { attachments: unknown[] })
+      .attachments[0];
+
+    expect(attachment).toMatchObject({
+      name: "cat.png",
+      content: [{ type: "image", filename: "cat.png" }],
+    });
+  });
+
   it("merges a file part's metadata with its filename", () => {
     expect(
       contentOf(

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -257,7 +257,7 @@ function toInputContent(
   if (type === "image") {
     const image = getString(part, "image");
     if (image === undefined) return null;
-    const metadata = buildInputMetadata(part);
+    const metadata = buildInputMetadata(part, getString(part, "filename"));
     return {
       type: "image",
       source: buildInputSource(image, fallbackMimeType),


### PR DESCRIPTION
## What

Preserve `filename` when converting direct image message parts into AG-UI multimodal content.

## Why

`ImageMessagePart` supports `filename`, but the image conversion branch omitted it from AG-UI metadata. After a snapshot or history round trip, an attachment such as `cat.png` was rebuilt with the generic name `image`. File parts already preserved this metadata.

## How

Pass the direct image filename through the existing input-metadata helper and add a regression test covering both the AG-UI wire payload and the rebuilt attachment.

## Tests

- `pnpm --filter @assistant-ui/react-ag-ui test`
- `pnpm lint`
- `pnpm turbo build --filter=@assistant-ui/react-ag-ui`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.50nvLUJIxuk_1uyHMYnO5f9EPaj36BLA9-0XZjO2mIETXhiKEAcS2j5xeYs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->