### PR TITLE
fix(core): disable unsupported external thread cancellation

### DIFF
--- a/.changeset/honest-cancel-capability.md
+++ b/.changeset/honest-cancel-capability.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: hide external thread cancellation when no handler is configured

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -403,6 +403,7 @@ const AttachmentResource = resource(useAttachmentResource);
 type ComposerClientResourceProps = {
   type: "thread" | "edit";
   canCancel: boolean;
+  isRunning?: boolean;
   isSendDisabled?: boolean;
   onCancel?: () => void;
   onBeginEdit?: () => void;
@@ -509,6 +510,7 @@ const useLiveState = <T>(initial: T) => {
 const useComposerClientResource = ({
   type,
   canCancel,
+  isRunning = false,
   isSendDisabled = false,
   onCancel,
   onBeginEdit,
@@ -755,7 +757,7 @@ const useComposerClientResource = ({
         };
         // edit sends carry a sourceId contract; only thread sends queue
         if (queue && type === "thread") {
-          if (opts?.steer ?? canCancel) queue.steer(composedMessage);
+          if (opts?.steer ?? isRunning) queue.steer(composedMessage);
           else queue.enqueue(composedMessage);
         } else {
           onSend?.(composedMessage);
@@ -1031,6 +1033,7 @@ const useExternalThread = ({
   };
 
   const headId = messages.at(-1)?.id ?? null;
+  const hasCancel = !!onCancel;
   const composerQueue = useMemo(
     (): ExternalThreadQueueAdapter | undefined =>
       queue && {
@@ -1046,7 +1049,8 @@ const useExternalThread = ({
   const composerClient = useClientResource(
     ComposerClientResource({
       type: "thread",
-      canCancel: isRunning,
+      canCancel: isRunning && hasCancel,
+      isRunning,
       isSendDisabled,
       onCancel: handleCancelRun,
       onSend: handleSendNew,
@@ -1081,7 +1085,7 @@ const useExternalThread = ({
         delete: false,
         reload: hasReload,
         refetchThread: false,
-        cancel: isRunning,
+        cancel: hasCancel,
         speech: hasSpeech,
         attachments: hasAttachments,
         feedback: hasFeedback,
@@ -1110,6 +1114,7 @@ const useExternalThread = ({
     hasBranches,
     hasEdit,
     hasReload,
+    hasCancel,
     hasAttachments,
     hasFeedback,
     hasSpeech,

--- a/packages/core/src/tests/external-thread-parity.test.tsx
+++ b/packages/core/src/tests/external-thread-parity.test.tsx
@@ -305,6 +305,8 @@ describe("ExternalThread composer", () => {
     expect(notifyCancelled.mock.invocationCallOrder[0]!).toBeLessThan(
       onCancel.mock.invocationCallOrder[0]!,
     );
+    expect(aui().thread.getState().capabilities.cancel).toBe(true);
+    expect(aui().thread.composer().getState().canCancel).toBe(true);
   });
 
   it("leaves the queue alone when the host cannot cancel", async () => {
@@ -327,6 +329,8 @@ describe("ExternalThread composer", () => {
     aui().thread.cancelRun();
 
     expect(notifyCancelled).not.toHaveBeenCalled();
+    expect(aui().thread.getState().capabilities.cancel).toBe(false);
+    expect(aui().thread.composer().getState().canCancel).toBe(false);
   });
 
   it("routes edit-composer sends to onEdit with sourceId, bypassing the queue", async () => {


### PR DESCRIPTION
## What

Report ExternalThread cancellation only when `onCancel` is configured, and disable composer cancellation otherwise.

## Why

`isRunning: true` previously advertised cancellation even when no cancellation handler existed. The Stop action was enabled, but `cancelRun()` immediately returned, so clicking it could not stop anything.

## How

Separate the active-run signal from host cancellation support inside the composer resource. `thread.capabilities.cancel` describes whether the host provides `onCancel`, while `composer.canCancel` remains actionable state and additionally requires an active run. The active-run signal still controls the default queue steering lane, so existing mid-run message routing is preserved.

## Reproduction

Render an ExternalThread with `isRunning: true` and no `onCancel`. Before this change, both the thread and composer reported cancellation as available even though invoking it did nothing. After this change, cancellation support and the composer action are both false.

## Tests

- `pnpm --filter @assistant-ui/core test`
- `pnpm lint`
- `pnpm turbo build --filter=@assistant-ui/core`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VpegP5XnHrtgHW0zxEAY6R3W9cuBSCj5RwaeR5hMu4VJPzZorUurieEGc0Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->