### PR TITLE
fix(core): load archived threads in the cloud thread list adapter

### DIFF
--- a/.changeset/cloud-adapter-archived-threads.md
+++ b/.changeset/cloud-adapter-archived-threads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: load archived threads in the cloud thread list adapter

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -19,7 +19,38 @@ const makeThread = (id: string) => ({
 });
 
 describe("useCloudThreadListAdapter", () => {
-  it("exposes full Cloud pages through the remote thread cursor", async () => {
+  it("loads archived Cloud threads alongside regular threads", async () => {
+    const activeThreads = [makeThread("active-1")];
+    const archivedThreads = [
+      { ...makeThread("archived-1"), is_archived: true },
+    ];
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: activeThreads })
+      .mockResolvedValueOnce({ threads: archivedThreads });
+    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
+
+    const page = await result.current.list();
+
+    expect(list).toHaveBeenNthCalledWith(1, { limit: 20 });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      is_archived: true,
+      limit: 20,
+    });
+    expect(page.threads.map((thread) => thread.remoteId)).toEqual([
+      "active-1",
+      "archived-1",
+    ]);
+    expect(
+      page.threads.find((thread) => thread.remoteId === "active-1")?.status,
+    ).toBe("regular");
+    expect(
+      page.threads.find((thread) => thread.remoteId === "archived-1")?.status,
+    ).toBe("archived");
+  });
+
+  it("continues the active list once the archived list is exhausted", async () => {
     const firstPage = Array.from({ length: 20 }, (_, index) =>
       makeThread(`thread-${index + 1}`),
     );
@@ -27,17 +58,20 @@ describe("useCloudThreadListAdapter", () => {
     const list = vi
       .fn()
       .mockResolvedValueOnce({ threads: firstPage })
+      .mockResolvedValueOnce({ threads: [] })
       .mockResolvedValueOnce({ threads: secondPage });
     const cloud = { threads: { list } } as unknown as AssistantCloud;
     const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
 
     const first = await result.current.list();
     expect(list).toHaveBeenNthCalledWith(1, { limit: 20 });
+    expect(list).toHaveBeenNthCalledWith(2, { is_archived: true, limit: 20 });
     expect(first.threads).toHaveLength(20);
-    expect(first.nextCursor).toBe("thread-20");
+    expect(JSON.parse(first.nextCursor!)).toEqual({ a: "thread-20", re: true });
 
     const second = await result.current.list({ after: first.nextCursor });
-    expect(list).toHaveBeenNthCalledWith(2, {
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(list).toHaveBeenNthCalledWith(3, {
       limit: 20,
       after: "thread-20",
     });
@@ -45,5 +79,66 @@ describe("useCloudThreadListAdapter", () => {
       "thread-21",
     ]);
     expect(second.nextCursor).toBeUndefined();
+  });
+
+  it("paginates both legs without dropping or duplicating items", async () => {
+    const activePage1 = Array.from({ length: 20 }, (_, index) =>
+      makeThread(`a-${index + 1}`),
+    );
+    const archivedPage1 = Array.from({ length: 20 }, (_, index) => ({
+      ...makeThread(`r-${index + 1}`),
+      is_archived: true,
+    }));
+    const activePage2 = [makeThread("a-21")];
+    const archivedPage2 = [{ ...makeThread("r-21"), is_archived: true }];
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: activePage1 })
+      .mockResolvedValueOnce({ threads: archivedPage1 })
+      .mockResolvedValueOnce({ threads: activePage2 })
+      .mockResolvedValueOnce({ threads: archivedPage2 });
+    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
+
+    const page1 = await result.current.list();
+    expect(page1.threads).toHaveLength(40);
+    expect(JSON.parse(page1.nextCursor!)).toEqual({ a: "a-20", r: "r-20" });
+
+    const page2 = await result.current.list({ after: page1.nextCursor });
+    expect(list).toHaveBeenNthCalledWith(3, { limit: 20, after: "a-20" });
+    expect(list).toHaveBeenNthCalledWith(4, {
+      is_archived: true,
+      limit: 20,
+      after: "r-20",
+    });
+    expect(page2.threads.map((thread) => thread.remoteId)).toEqual([
+      "a-21",
+      "r-21",
+    ]);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+
+  it("accepts a legacy bare-id cursor for the active list", async () => {
+    const activeThreads = [makeThread("thread-21")];
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: activeThreads })
+      .mockResolvedValueOnce({ threads: [] });
+    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
+
+    const page = await result.current.list({ after: "thread-20" });
+
+    expect(list).toHaveBeenNthCalledWith(1, {
+      limit: 20,
+      after: "thread-20",
+    });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      is_archived: true,
+      limit: 20,
+    });
+    expect(page.threads.map((thread) => thread.remoteId)).toEqual([
+      "thread-21",
+    ]);
   });
 });

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -44,6 +44,35 @@ const autoCloud = baseUrl
 
 const CLOUD_THREAD_PAGE_SIZE = 20;
 
+type CloudListCursor = {
+  activeCursor: string | undefined;
+  archivedCursor: string | undefined;
+  activeExhausted: boolean;
+  archivedExhausted: boolean;
+};
+
+const parseListCursor = (after: string | undefined): CloudListCursor => {
+  const fallback: CloudListCursor = {
+    activeCursor: after,
+    archivedCursor: undefined,
+    activeExhausted: false,
+    archivedExhausted: false,
+  };
+  if (!after || !after.startsWith("{")) return fallback;
+  try {
+    const parsed = JSON.parse(after);
+    if (!isRecord(parsed)) return fallback;
+    return {
+      activeCursor: typeof parsed.a === "string" ? parsed.a : undefined,
+      archivedCursor: typeof parsed.r === "string" ? parsed.r : undefined,
+      activeExhausted: parsed.ae === true,
+      archivedExhausted: parsed.re === true,
+    };
+  } catch {
+    return fallback;
+  }
+};
+
 const useCloudThreadListAdapters = (
   adapterRef: RefObject<CloudThreadListAdapterOptions>,
 ): RuntimeAdapters => {
@@ -105,10 +134,38 @@ export const useCloudThreadListAdapter = (
 
     return {
       list: async ({ after } = {}) => {
-        const { threads } = await cloud.threads.list({
-          limit: CLOUD_THREAD_PAGE_SIZE,
-          ...(after ? { after } : {}),
-        });
+        const {
+          activeCursor,
+          archivedCursor,
+          activeExhausted,
+          archivedExhausted,
+        } = parseListCursor(after);
+        const [{ threads: activeThreads }, { threads: archivedThreads }] =
+          await Promise.all([
+            activeExhausted
+              ? Promise.resolve({ threads: [] })
+              : cloud.threads.list({
+                  limit: CLOUD_THREAD_PAGE_SIZE,
+                  ...(activeCursor ? { after: activeCursor } : {}),
+                }),
+            archivedExhausted
+              ? Promise.resolve({ threads: [] })
+              : cloud.threads.list({
+                  is_archived: true,
+                  limit: CLOUD_THREAD_PAGE_SIZE,
+                  ...(archivedCursor ? { after: archivedCursor } : {}),
+                }),
+          ]);
+        const activeNext =
+          !activeExhausted && activeThreads.length === CLOUD_THREAD_PAGE_SIZE
+            ? activeThreads.at(-1)?.id
+            : undefined;
+        const archivedNext =
+          !archivedExhausted &&
+          archivedThreads.length === CLOUD_THREAD_PAGE_SIZE
+            ? archivedThreads.at(-1)?.id
+            : undefined;
+        const threads = [...activeThreads, ...archivedThreads];
         return {
           threads: threads.map((t) => ({
             status: t.is_archived ? "archived" : "regular",
@@ -121,8 +178,13 @@ export const useCloudThreadListAdapter = (
             custom: toCustom(t.metadata),
           })),
           nextCursor:
-            threads.length === CLOUD_THREAD_PAGE_SIZE
-              ? threads.at(-1)?.id
+            activeNext || archivedNext
+              ? JSON.stringify({
+                  a: activeNext,
+                  r: archivedNext,
+                  ...(activeNext === undefined ? { ae: true } : {}),
+                  ...(archivedNext === undefined ? { re: true } : {}),
+                })
               : undefined,
         };
       },

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -83,17 +83,17 @@ describe("useLocalRuntime", () => {
     const { rerender } = render(<App cloud={firstCloud} label="first" />);
 
     await waitFor(() => {
-      expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+      expect(firstCloud.threads.list).toHaveBeenCalledTimes(2);
     });
 
     rerender(<App cloud={firstCloud} label="second" />);
-    expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+    expect(firstCloud.threads.list).toHaveBeenCalledTimes(2);
 
     rerender(<App cloud={secondCloud} label="third" />);
     await waitFor(() => {
-      expect(secondCloud.threads.list).toHaveBeenCalledOnce();
+      expect(secondCloud.threads.list).toHaveBeenCalledTimes(2);
     });
-    expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+    expect(firstCloud.threads.list).toHaveBeenCalledTimes(2);
   });
 
   it("uses the current Cloud client for attachment uploads", async () => {
@@ -118,7 +118,7 @@ describe("useLocalRuntime", () => {
     const { rerender } = render(<App cloud={firstCloud} />);
 
     await waitFor(() => {
-      expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+      expect(firstCloud.threads.list).toHaveBeenCalledTimes(2);
     });
 
     rerender(<App cloud={secondCloud} />);


### PR DESCRIPTION
## Problem

The Cloud thread-list endpoint defaults an omitted `is_archived` query parameter to `false`, but `useCloudThreadListAdapter()` currently calls `cloud.threads.list()` without any filter. As a result, the adapter only ever receives active threads and `archivedThreadIds` stays empty, so `<ThreadListPrimitive.Items archived>` cannot display archived Cloud threads after load or reload.

## Root cause

`useCloudThreadListAdapter.list` makes a single unfiltered request in `packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx`. The server applies `eq(threadsTable.is_archived, data.is_archived ?? false)` for both the cursor lookup and the main list query, so archived threads are filtered out before they can reach the existing status classifier (`classifyThreads`).

## Fix

`useCloudThreadListAdapter.list` now issues two concurrent requests — the default active page and an explicit `is_archived: true` page — via `Promise.all`, then merges both responses and preserves the existing metadata conversion and status mapping. Only the explicit `true` filter is used; `AssistantCloudAPI.makeRawRequest` serializes `true` correctly (boolean `false` values are skipped).

## Test

- Updated `useCloudThreadListAdapter.test.tsx` to reflect the two-request contract (active page + archived page) for both the initial load and the paginated load.
- Added a regression test that mounts the adapter with one active and one archived thread and asserts both are returned and classified into `regular` / `archived` statuses.

## Verification (before / after)

- **Before** (parent `e28a62d`): `list` made a single unfiltered `cloud.threads.list()` call, so archived threads were filtered out server-side by the `is_archived ?? false` default and `archivedThreadIds` stayed empty. The `loads archived Cloud threads alongside regular threads` regression test fails.
- **After** (this head): `list` issues the default active page and an explicit `is_archived: true` page; the regression test passes and the status classifier maps the archived thread to `archived`.
- Cloneable reproduction attached to #5716 (vitest case, fails at the parent revision / passes at this head).

Why two filtered requests: the Cloud endpoint applies `eq(threadsTable.is_archived, data.is_archived ?? false)` to **both** the cursor lookup and the main list query, so an omitted `is_archived` excludes archived threads entirely — no filter parameter can be "left off" to get both statuses. The adapter has to ask for each status explicitly.

Fixes #5716

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.i5WEHBFC2RQBWcvsXBgGrNZlR6N2WRfuYp85LdLDG0Urbl_DCXIBGh4erZ4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
