### PR TITLE
fix(cloud): deduplicate concurrent child message appends

### DIFF
--- a/.changeset/deduplicate-cloud-child-appends.md
+++ b/.changeset/deduplicate-cloud-child-appends.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: deduplicate concurrent child message appends while parent persistence is pending

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -52,7 +52,7 @@ export class CloudMessagePersistence {
     const cloud = this.getCloud();
     const mapping = this.getThreadMapping(threadId);
     const existing = mapping.get(messageId);
-    if (existing !== undefined) {
+    if (existing instanceof Promise) {
       await existing;
       return;
     }

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -51,32 +51,36 @@ export class CloudMessagePersistence {
   ): Promise<void> {
     const cloud = this.getCloud();
     const mapping = this.getThreadMapping(threadId);
-    // Resolve parent's remote ID if it exists (may be a promise if concurrent)
-    const resolvedParentId = parentId
-      ? ((await mapping.get(parentId)) ?? parentId)
-      : null;
+    const existing = mapping.get(messageId);
+    if (existing !== undefined) {
+      await existing;
+      return;
+    }
 
-    const task = cloud.threads.messages
-      .create(threadId, {
+    const task = (async () => {
+      const resolvedParentId = parentId
+        ? ((await mapping.get(parentId)) ?? parentId)
+        : null;
+      const { message_id } = await cloud.threads.messages.create(threadId, {
         parent_id: resolvedParentId,
         format,
         content,
-      })
-      .then(({ message_id }) => {
-        mapping.set(messageId, message_id);
-        return message_id;
-      })
-      .catch((err) => {
-        // Only delete if we're still the active task (avoids clobbering a retry)
-        if (mapping.get(messageId) === task) {
-          mapping.delete(messageId);
-        }
-        throw err;
       });
+      return message_id;
+    })();
 
-    // Store the promise immediately so concurrent appends can await it
     mapping.set(messageId, task);
-    return task.then(() => {});
+    try {
+      const remoteId = await task;
+      if (mapping.get(messageId) === task) {
+        mapping.set(messageId, remoteId);
+      }
+    } catch (err) {
+      if (mapping.get(messageId) === task) {
+        mapping.delete(messageId);
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -108,6 +108,41 @@ describe("CloudMessagePersistence", () => {
     });
   });
 
+  it("deduplicates concurrent child appends while the parent is pending", async () => {
+    let resolveParent!: (value: { message_id: string }) => void;
+    vi.mocked(cloud.threads.messages.create)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveParent = resolve;
+          }),
+      )
+      .mockResolvedValue({ message_id: "remote-child" });
+
+    const parent = persistence.append("thread-1", "parent", null, "aui/v0", {
+      text: "parent",
+    });
+    const firstChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+    const secondChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+
+    resolveParent({ message_id: "remote-parent" });
+    await Promise.all([parent, firstChild, secondChild]);
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+  });
+
   it("loaded messages are marked as persisted and not re-created", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: [

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -143,6 +143,24 @@ describe("CloudMessagePersistence", () => {
     expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
   });
 
+  it("re-appends messages whose mapping has already resolved", async () => {
+    vi.mocked(cloud.threads.messages.create)
+      .mockResolvedValueOnce({ message_id: "remote-1" })
+      .mockResolvedValueOnce({ message_id: "remote-2" });
+
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "first",
+    });
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "second",
+    });
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+    expect(await persistence.getRemoteId("thread-1", "local-1")).toBe(
+      "remote-2",
+    );
+  });
+
   it("loaded messages are marked as persisted and not re-created", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: [


### PR DESCRIPTION
## Summary

- reserve a local message ID before waiting for its parent's remote ID
- reuse the same in-flight append promise across overlapping persistence passes
- add a regression test for two concurrent child appends behind a pending parent

## Why

Cloud history persistence can run overlapping passes. Previously, a child append awaited its parent before registering itself as in flight. Two passes could therefore both get past the dedupe check and create the same child message twice.

The focused reproduction holds the parent request open, starts the same child append twice, and then releases the parent. Before this change it made three create requests: one parent and two duplicate children. It now makes exactly two.

This is stacked on #5606 because that PR introduces the thread-scoped mapping changed here. It should merge after #5606; once #5606 lands, this PR can be retargeted to `main`.

## Testing

- `pnpm --filter assistant-cloud test`
- `pnpm --filter assistant-cloud build`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JBg9YW9ekRwCTgcrTQKc_6ccquE33Y3OWS3AFSSZvV4AvRVFmV99gv9FBGc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->