### PR TITLE
fix(react-a2a): retry failed history appends

### DIFF
--- a/.changeset/retry-a2a-history-appends.md
+++ b/.changeset/retry-a2a-history-appends.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: retry failed history appends without losing assistant parent relationships

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -371,6 +371,71 @@ describe("A2AThreadRuntimeCore", () => {
     });
   });
 
+  describe("history persistence", () => {
+    it("retries a failed user message append", async () => {
+      const history = {
+        load: vi.fn(),
+        append: vi
+          .fn()
+          .mockRejectedValueOnce(new Error("history unavailable"))
+          .mockResolvedValueOnce(undefined),
+      };
+      const core = createCore({}, { history });
+
+      await core.append({
+        ...createUserAppendMessage("Hello"),
+        id: "user-1",
+        startRun: false,
+      });
+
+      await vi.waitFor(() => {
+        expect(history.append).toHaveBeenCalledTimes(2);
+      });
+      expect(history.append).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          parentId: null,
+          message: expect.objectContaining({ id: "user-1" }),
+        }),
+      );
+    });
+
+    it("retains an assistant message parent while retrying", async () => {
+      const history = {
+        load: vi.fn(),
+        append: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error("history unavailable"))
+          .mockResolvedValueOnce(undefined),
+      };
+      const core = createCore(
+        {
+          streamMessage: vi.fn().mockImplementation(async function* () {
+            yield statusUpdateEvent("completed", "Done");
+          }),
+        },
+        { history },
+      );
+
+      await core.append({
+        ...createUserAppendMessage("Hello"),
+        id: "user-1",
+      });
+
+      await vi.waitFor(() => {
+        expect(history.append).toHaveBeenCalledTimes(3);
+      });
+      expect(history.append).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          parentId: "user-1",
+          message: expect.objectContaining({ role: "assistant" }),
+        }),
+      );
+    });
+  });
+
   // --- Edit & Reload ---
 
   describe("edit", () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -812,15 +812,28 @@ export class A2AThreadRuntimeCore {
       message.status?.type !== "incomplete"
     )
       return;
-    this.assistantHistoryParents.delete(messageId);
-    this.appendHistoryItem(parentId, message);
+    this.appendHistoryItem(parentId, message, () => {
+      this.assistantHistoryParents.delete(messageId);
+    });
   }
 
-  private appendHistoryItem(parentId: string | null, message: ThreadMessage) {
+  private appendHistoryItem(
+    parentId: string | null,
+    message: ThreadMessage,
+    onSuccess?: () => void,
+    retry = true,
+  ) {
     if (!this.history || this.recordedHistoryIds.has(message.id)) return;
+    const history = this.history;
     this.recordedHistoryIds.add(message.id);
-    void this.history.append({ parentId, message }).catch(() => {
-      this.recordedHistoryIds.delete(message.id);
-    });
+    void history
+      .append({ parentId, message })
+      .then(onSuccess)
+      .catch(() => {
+        this.recordedHistoryIds.delete(message.id);
+        if (retry && this.history === history) {
+          this.appendHistoryItem(parentId, message, onSuccess, false);
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary

- retry a failed A2A history append once
- keep assistant parent metadata until persistence succeeds
- add regressions for user and assistant history failures

## Why

A2A history writes are fire-and-forget. When an append rejected, the runtime removed the message from its in-flight set but never initiated another append, so a temporary storage or network failure silently lost that history entry. Assistant messages also removed their saved parent before the write succeeded, leaving no branch relationship available for a retry.

This change performs one bounded retry without exposing persistence failures as unhandled rejections. Assistant parent metadata is cleared only after a successful write, and a second failure stops rather than creating an unbounded retry loop.

The regression tests reproduce both paths: a failed user append now retries, and a failed assistant append retries with the original user message as its parent.

## Testing

- `pnpm --filter @assistant-ui/react-a2a test -- A2AThreadRuntimeCore.test.ts`
- `pnpm --filter @assistant-ui/react-a2a build`
- `pnpm lint`
- `pnpm build`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4hwFjUjEKd7HxQiADwW-TMfjp7JLoOsWm_PQ0ccAaNgQ5WP7KW1wHVCj8vw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

