### PR TITLE
docs(mcp): update transport/DCR status for the 2026-07-28 spec revision

### DIFF
--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -46,7 +46,7 @@ MCP_SERVER_URL=https://your-mcp-server.example/mcp
 MCP_TOKEN=...
 ```
 
-Then inside your AI SDK route handler, create the client with the transport that matches your server. **HTTP** is the production transport; **SSE** is the legacy streaming transport; **stdio** spawns a local process and is dev-only.
+Then inside your AI SDK route handler, create the client with the transport that matches your server. **HTTP** is the production transport; **SSE** is deprecated as of the MCP `2026-07-28` revision and keeps working for at least twelve months under the spec's deprecation policy; **stdio** spawns a local process and is dev-only.
 
 ```ts title="app/api/chat/route.ts"
 import { createMCPClient } from "@ai-sdk/mcp";
@@ -448,7 +448,7 @@ Start the app and trigger a tool call (e.g., ask the assistant to do something t
 - **Server-side only.** The MCP client uses Node APIs (sockets, optionally child processes). Never instantiate it in client code.
 - **Per-request lifecycle.** A fresh client per request keeps connection state simple. For high-throughput servers, pool clients yourself with care: the AI SDK's `tools()` call assumes the connection is alive when `streamText` runs.
 - **Sampling.** If your MCP server uses `sampling/createMessage` (lets the server ask the LLM mid-call), assistant-cloud users can instrument it via [`instrumentMcpSampling`](/docs/cloud) for observability. This is independent of the wiring above.
-- **Transport choice.** HTTP for any networked server. SSE only if the server doesn't speak HTTP. stdio is for local development against an MCP server in your monorepo.
+- **Transport choice.** HTTP for any networked server. SSE only if the server doesn't speak HTTP; it is deprecated as of the MCP `2026-07-28` revision, which guarantees a migration window of at least twelve months, so new servers should expose HTTP. stdio is for local development against an MCP server in your monorepo.
 
 ## Related
 

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -24,6 +24,8 @@ AuiConfig({ mcp: McpManagerResource({ connectors }) })
 
 The manager is a single resource. Mount it with `AuiProvider` like any other scope. OAuth (PKCE + RFC 7591 dynamic client registration), bearer, and "no auth" are first-class. Token refresh runs inside the MCP SDK on 401; this package mediates persistence and the redirect step.
 
+The MCP `2026-07-28` revision deprecates dynamic client registration in favor of client ID metadata documents (CIMD). DCR remains supported for backward compatibility, so the flow described here keeps working against authorization servers that accept it.
+
 ## Setup
 
 <Steps>


### PR DESCRIPTION
## What

Updates our two MCP guide pages to reflect the MCP `2026-07-28` spec revision, which formally deprecates the HTTP+SSE transport and dynamic client registration.

## Why

Both pages described the current state of the protocol accurately when written, but the 2026-07-28 revision changed the status of two things we name explicitly:

- `mcp.mdx` called SSE "the legacy streaming transport". It is now formally deprecated, and the revision introduced a deprecation policy with a twelve-month minimum window — which is the part a reader planning a migration needs.
- `user-managed-mcp.mdx` advertises "PKCE + RFC 7591 dynamic client registration" with no indication that DCR is now deprecated in favor of client ID metadata documents (CIMD).

## How

Two prose edits, no behavior change:

- `apps/docs/content/docs/tools/mcp.mdx` — the transport sentence (~line 49) and the "Transport choice" note (~line 451) now state that SSE is deprecated as of `2026-07-28` and keeps working for at least twelve months. The existing guidance (HTTP for production, SSE only if the server doesn't speak HTTP, stdio for local dev) is unchanged.
- `apps/docs/content/docs/tools/user-managed-mcp.mdx` — adds one paragraph noting the DCR-to-CIMD deprecation and that DCR remains supported for backward compatibility, so the documented OAuth flow keeps working.

Both pages are hand-written guides, not generator-owned (no `AUTO-GENERATED` marker). `apps/docs` is `private: true`, so no changeset is needed.

## Verification

- `pnpm -C apps/docs test` — 22 files, 132 tests passing.
- `pnpm -C apps/docs generate:api-reference -- --strict` — exits 0 with zero drift.
- `pnpm lint` — clean, including format.

## Not included

The 2026-07-28 revision also adds `server/discover` and the `ttlMs` / `cacheScope` caching hints on `tools/list`. Our docs MCP endpoint (`apps/docs/app/api/mcp/route.ts`) serves those through `@modelcontextprotocol/server` v2's `WebStandardStreamableHTTPServerTransport` rather than a hand-rolled dispatcher, so protocol-level support arrives with an SDK bump, not with an edit here. That belongs in its own PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TJkmGIFwoh8pAQcx-3QF2bVAYsXtgN3sBAOVkIkeFLK9mAyCaCL1YjWB9uE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->