### PR TITLE
feat(react-google-adk): expose tool confirmations through the core tool-approval seam

### DIFF
--- a/.changeset/adk-tool-approval-parity.md
+++ b/.changeset/adk-tool-approval-parity.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+feat: expose ADK tool confirmations through the core tool-approval seam

--- a/packages/react-google-adk/src/adkToolApproval.test.ts
+++ b/packages/react-google-adk/src/adkToolApproval.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  adkToolApprovalsKey,
+  projectAdkToolApprovals,
+  toAdkConfirmationReply,
+  toAdkToolConfirmationReply,
+} from "./adkToolApproval";
+import type { AdkMessage, AdkToolConfirmation } from "./types";
+
+const confirmation = (
+  overrides: Partial<AdkToolConfirmation> = {},
+): AdkToolConfirmation => ({
+  toolCallId: "tc-1",
+  toolName: "delete_file",
+  args: { path: "/tmp/a" },
+  hint: "Delete /tmp/a?",
+  confirmed: false,
+  ...overrides,
+});
+
+const aiWithToolCall = (toolCallId: string, name: string): AdkMessage => ({
+  id: "ai-1",
+  type: "ai",
+  content: [],
+  tool_calls: [{ id: toolCallId, name, args: {}, argsText: "{}" }],
+});
+
+const toolReply = (
+  toolCallId: string,
+  name: string,
+  content: string,
+): AdkMessage => ({
+  id: `tool-${toolCallId}`,
+  type: "tool",
+  tool_call_id: toolCallId,
+  name,
+  content,
+  status: "success",
+});
+
+describe("projectAdkToolApprovals", () => {
+  it("opens an approval gate for a pending confirmation", () => {
+    const approvals = projectAdkToolApprovals(
+      [aiWithToolCall("tc-1", "adk_request_confirmation")],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({ id: "tc-1" });
+  });
+
+  it("returns no approvals when there are no confirmations", () => {
+    const approvals = projectAdkToolApprovals(
+      [aiWithToolCall("tc-1", "delete_file")],
+      [],
+    );
+    expect(approvals.size).toBe(0);
+  });
+
+  it("settles an approved confirmation from its reply", () => {
+    const approvals = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "adk_request_confirmation"),
+        toolReply(
+          "tc-1",
+          "adk_request_confirmation",
+          JSON.stringify({ confirmed: true }),
+        ),
+      ],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({ id: "tc-1", approved: true });
+  });
+
+  it("settles a denied confirmation from its reply", () => {
+    const approvals = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "adk_request_confirmation"),
+        toolReply(
+          "tc-1",
+          "adk_request_confirmation",
+          JSON.stringify({ confirmed: false }),
+        ),
+      ],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({ id: "tc-1", approved: false });
+  });
+
+  it("settles a confirmation the snapshot already records as confirmed", () => {
+    const approvals = projectAdkToolApprovals(
+      [aiWithToolCall("tc-1", "adk_request_confirmation")],
+      [confirmation({ confirmed: true })],
+    );
+    expect(approvals.get("tc-1")).toEqual({ id: "tc-1", approved: true });
+  });
+
+  it("records a gate closed by some other result as cancelled", () => {
+    const approvals = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "delete_file"),
+        toolReply("tc-1", "delete_file", JSON.stringify({ deleted: true })),
+      ],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({
+      id: "tc-1",
+      resolution: "cancelled",
+    });
+  });
+
+  it("prefers the confirmation reply over a later tool result", () => {
+    const approvals = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "delete_file"),
+        toolReply(
+          "tc-1",
+          "adk_request_confirmation",
+          JSON.stringify({ confirmed: true }),
+        ),
+        toolReply("tc-1", "delete_file", JSON.stringify({ deleted: true })),
+      ],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({ id: "tc-1", approved: true });
+  });
+
+  it("records an unreadable confirmation reply as cancelled rather than a decision", () => {
+    const approvals = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "adk_request_confirmation"),
+        toolReply("tc-1", "adk_request_confirmation", "not json"),
+      ],
+      [confirmation()],
+    );
+    expect(approvals.get("tc-1")).toEqual({
+      id: "tc-1",
+      resolution: "cancelled",
+    });
+  });
+
+  it("skips confirmations without a usable tool call id", () => {
+    const approvals = projectAdkToolApprovals(
+      [],
+      [
+        confirmation({ toolCallId: "" }),
+        confirmation({ toolCallId: undefined as unknown as string }),
+      ],
+    );
+    expect(approvals.size).toBe(0);
+  });
+
+  it("does not throw on malformed messages or confirmations", () => {
+    expect(() =>
+      projectAdkToolApprovals(
+        [undefined as unknown as AdkMessage, { type: "tool" } as AdkMessage],
+        [
+          undefined as unknown as AdkToolConfirmation,
+          confirmation({ confirmed: undefined as unknown as boolean }),
+        ],
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("adkToolApprovalsKey", () => {
+  it("is empty when nothing is gated", () => {
+    expect(adkToolApprovalsKey(new Map())).toBe("");
+  });
+
+  it("changes when a gate settles", () => {
+    const pending = projectAdkToolApprovals(
+      [aiWithToolCall("tc-1", "adk_request_confirmation")],
+      [confirmation()],
+    );
+    const settled = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "adk_request_confirmation"),
+        toolReply(
+          "tc-1",
+          "adk_request_confirmation",
+          JSON.stringify({ confirmed: true }),
+        ),
+      ],
+      [confirmation()],
+    );
+    expect(adkToolApprovalsKey(pending)).not.toBe(adkToolApprovalsKey(settled));
+  });
+});
+
+describe("toAdkToolConfirmationReply", () => {
+  const pending = projectAdkToolApprovals(
+    [aiWithToolCall("tc-1", "adk_request_confirmation")],
+    [confirmation()],
+  );
+
+  it("maps an approval onto a confirming ADK reply", () => {
+    const reply = toAdkToolConfirmationReply(
+      { approvalId: "tc-1", approved: true },
+      pending,
+    );
+    expect(reply).toMatchObject({
+      type: "tool",
+      tool_call_id: "tc-1",
+      name: "adk_request_confirmation",
+      status: "success",
+    });
+    expect(JSON.parse(reply.content)).toEqual({ confirmed: true });
+  });
+
+  it("maps a denial onto a rejecting ADK reply", () => {
+    const reply = toAdkToolConfirmationReply(
+      { approvalId: "tc-1", approved: false },
+      pending,
+    );
+    expect(JSON.parse(reply.content)).toEqual({ confirmed: false });
+  });
+
+  it("carries no reason, since ADK confirmations have no field for one", () => {
+    const reply = toAdkToolConfirmationReply(
+      { approvalId: "tc-1", approved: false, reason: "too risky" },
+      pending,
+    );
+    expect(JSON.parse(reply.content)).toEqual({ confirmed: false });
+  });
+
+  it("throws for an approval id with no pending confirmation", () => {
+    expect(() =>
+      toAdkToolConfirmationReply(
+        { approvalId: "tc-9", approved: true },
+        pending,
+      ),
+    ).toThrow('No pending ADK tool confirmation for approval id "tc-9"');
+  });
+
+  it("throws for an approval that already settled", () => {
+    const settled = projectAdkToolApprovals(
+      [
+        aiWithToolCall("tc-1", "adk_request_confirmation"),
+        toolReply(
+          "tc-1",
+          "adk_request_confirmation",
+          JSON.stringify({ confirmed: true }),
+        ),
+      ],
+      [confirmation()],
+    );
+    expect(() =>
+      toAdkToolConfirmationReply(
+        { approvalId: "tc-1", approved: false },
+        settled,
+      ),
+    ).toThrow("No pending ADK tool confirmation");
+  });
+});
+
+describe("toAdkConfirmationReply", () => {
+  it("includes a payload when one is supplied", () => {
+    const reply = toAdkConfirmationReply("tc-1", true, { scope: "session" });
+    expect(JSON.parse(reply.content)).toEqual({
+      confirmed: true,
+      payload: { scope: "session" },
+    });
+  });
+
+  it("omits the payload key when none is supplied", () => {
+    const reply = toAdkConfirmationReply("tc-1", true);
+    expect(JSON.parse(reply.content)).toEqual({ confirmed: true });
+  });
+});

--- a/packages/react-google-adk/src/adkToolApproval.ts
+++ b/packages/react-google-adk/src/adkToolApproval.ts
@@ -1,0 +1,131 @@
+import type { ToolCallMessagePart } from "@assistant-ui/core";
+import type { RespondToToolApprovalOptions } from "@assistant-ui/core";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import { v4 as uuidv4 } from "uuid";
+import type { AdkMessage, AdkToolConfirmation } from "./types";
+
+export type AdkToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
+
+const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
+
+const EMPTY_APPROVALS: ReadonlyMap<string, AdkToolApproval> = new Map();
+
+const readConfirmed = (content: unknown): boolean | undefined => {
+  if (typeof content !== "string") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const confirmed = (parsed as { confirmed?: unknown }).confirmed;
+  return typeof confirmed === "boolean" ? confirmed : undefined;
+};
+
+/**
+ * Projects ADK tool confirmations onto core's approval gate, keyed by the tool
+ * call id the confirmation is answered with.
+ *
+ * A confirmation answered by an `adk_request_confirmation` reply settles to
+ * that reply's decision. A confirmation whose call already carries some other
+ * result settles as `cancelled`: the gate is closed, but nothing in the
+ * transcript records which way the user decided.
+ */
+export const projectAdkToolApprovals = (
+  messages: readonly AdkMessage[],
+  confirmations: readonly AdkToolConfirmation[],
+): ReadonlyMap<string, AdkToolApproval> => {
+  if (confirmations.length === 0) return EMPTY_APPROVALS;
+
+  const confirmationReplies = new Map<string, AdkMessage & { type: "tool" }>();
+  const otherReplies = new Set<string>();
+  for (const message of messages) {
+    if (message?.type !== "tool") continue;
+    const toolCallId = message.tool_call_id;
+    if (typeof toolCallId !== "string" || toolCallId === "") continue;
+    if (message.name === ADK_REQUEST_CONFIRMATION) {
+      confirmationReplies.set(toolCallId, message);
+    } else {
+      otherReplies.add(toolCallId);
+    }
+  }
+
+  const approvals = new Map<string, AdkToolApproval>();
+  for (const confirmation of confirmations) {
+    const id = confirmation?.toolCallId;
+    if (typeof id !== "string" || id === "") continue;
+
+    const reply = confirmationReplies.get(id);
+    if (reply !== undefined) {
+      const confirmed = readConfirmed(reply.content);
+      approvals.set(
+        id,
+        confirmed === undefined
+          ? { id, resolution: "cancelled" }
+          : { id, approved: confirmed },
+      );
+      continue;
+    }
+
+    if (otherReplies.has(id)) {
+      approvals.set(id, { id, resolution: "cancelled" });
+      continue;
+    }
+
+    approvals.set(
+      id,
+      confirmation.confirmed === true ? { id, approved: true } : { id },
+    );
+  }
+  return approvals;
+};
+
+/**
+ * Identity of a projection's decision state, so a converter closure is rebuilt
+ * only when an approval appears, settles, or disappears.
+ */
+export const adkToolApprovalsKey = (
+  approvals: ReadonlyMap<string, AdkToolApproval>,
+): string =>
+  [...approvals.values()]
+    .map((a) => `${a.id}:${a.approved ?? ""}:${a.resolution ?? ""}`)
+    .join(",");
+
+export const toAdkConfirmationReply = (
+  toolCallId: string,
+  confirmed: boolean,
+  payload?: ReadonlyJSONValue,
+): AdkMessage & { type: "tool" } => ({
+  id: uuidv4(),
+  type: "tool",
+  tool_call_id: toolCallId,
+  name: ADK_REQUEST_CONFIRMATION,
+  content: JSON.stringify({
+    confirmed,
+    ...(payload != null && { payload }),
+  }),
+  status: "success",
+});
+
+/**
+ * Maps a core approval decision onto the ADK confirmation reply. ADK
+ * confirmations are a plain confirm/reject pair, so no option or reason from
+ * core has a field to land in.
+ */
+export const toAdkToolConfirmationReply = (
+  { approvalId, approved }: RespondToToolApprovalOptions,
+  approvals: ReadonlyMap<string, AdkToolApproval>,
+): AdkMessage & { type: "tool" } => {
+  const approval = approvals.get(approvalId);
+  if (
+    approval === undefined ||
+    approval.approved !== undefined ||
+    approval.resolution !== undefined
+  )
+    throw new Error(
+      `No pending ADK tool confirmation for approval id "${approvalId}"`,
+    );
+
+  return toAdkConfirmationReply(approvalId, approved);
+};

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { convertAdkMessage } from "./convertAdkMessages";
+import {
+  convertAdkMessage,
+  createAdkMessageConverter,
+} from "./convertAdkMessages";
+import type { ToolCallMessagePart } from "@assistant-ui/core";
 import type { AdkMessage } from "./types";
 
 describe("convertAdkMessage - human messages", () => {
@@ -371,5 +375,64 @@ describe("convertAdkMessage - tool messages", () => {
     };
     const result = convertAdkMessage(msg, {});
     expect(result).toMatchObject({ isError: true });
+  });
+});
+
+describe("createAdkMessageConverter - tool approvals", () => {
+  const gatedMessage: AdkMessage = {
+    id: "ai-1",
+    type: "ai",
+    content: [],
+    tool_calls: [
+      {
+        id: "tc-1",
+        name: "adk_request_confirmation",
+        args: {},
+        argsText: "{}",
+      },
+      { id: "tc-2", name: "search", args: {}, argsText: "{}" },
+    ],
+  };
+
+  const toolCallParts = (
+    result: ReturnType<typeof convertAdkMessage>,
+  ): ToolCallMessagePart[] => {
+    const message = Array.isArray(result) ? result[0]! : result;
+    const content = "content" in message ? message.content : [];
+    if (typeof content === "string") return [];
+    return content.filter(
+      (part): part is ToolCallMessagePart => part.type === "tool-call",
+    );
+  };
+
+  it("stamps the approval gate onto the tool call it belongs to", () => {
+    const convert = createAdkMessageConverter(
+      new Map([["tc-1", { id: "tc-1" }]]),
+    );
+    const parts = toolCallParts(convert(gatedMessage, {}));
+    expect(parts.map((p) => p.toolCallId)).toEqual(["tc-1", "tc-2"]);
+    expect(parts[0]!.approval).toEqual({ id: "tc-1" });
+    expect(parts[1]!.approval).toBeUndefined();
+  });
+
+  it("carries a settled decision onto the part", () => {
+    const convert = createAdkMessageConverter(
+      new Map([["tc-1", { id: "tc-1", approved: false }]]),
+    );
+    expect(convert(gatedMessage, {})).toMatchObject({
+      content: [
+        {
+          toolCallId: "tc-1",
+          approval: { id: "tc-1", approved: false },
+        },
+        { toolCallId: "tc-2" },
+      ],
+    });
+  });
+
+  it("leaves every part ungated when nothing is pending", () => {
+    for (const part of toolCallParts(convertAdkMessage(gatedMessage, {}))) {
+      expect(part.approval).toBeUndefined();
+    }
   });
 });

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -2,6 +2,7 @@
 
 import type { ToolCallMessagePart } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
+import type { AdkToolApproval } from "./adkToolApproval";
 import type { AdkMessage, AdkMessageContentPart } from "./types";
 
 type ContentPart =
@@ -81,50 +82,61 @@ const contentToParts = (
     .filter((p): p is NonNullable<typeof p> => p !== null);
 };
 
-export const convertAdkMessage: useExternalMessageConverter.Callback<
-  AdkMessage
-> = (message) => {
-  switch (message.type) {
-    case "human":
-      return {
-        role: "user",
-        id: message.id,
-        content: contentToParts(message.content, "user"),
-      };
+const EMPTY_APPROVALS: ReadonlyMap<string, AdkToolApproval> = new Map();
 
-    case "ai": {
-      const toolCallParts: ToolCallMessagePart[] =
-        message.tool_calls?.map((tc) => ({
-          type: "tool-call",
-          toolCallId: tc.id,
-          toolName: tc.name,
-          args: tc.args,
-          argsText: tc.argsText ?? JSON.stringify(tc.args),
-        })) ?? [];
+export const createAdkMessageConverter =
+  (
+    approvals: ReadonlyMap<string, AdkToolApproval>,
+  ): useExternalMessageConverter.Callback<AdkMessage> =>
+  (message) => {
+    switch (message.type) {
+      case "human":
+        return {
+          role: "user",
+          id: message.id,
+          content: contentToParts(message.content, "user"),
+        };
 
-      return {
-        role: "assistant",
-        id: message.id,
-        content: [
-          ...contentToParts(message.content, "assistant"),
-          ...toolCallParts,
-        ],
-        ...(message.status && { status: message.status }),
-        ...(message.author && {
-          metadata: {
-            custom: { author: message.author, branch: message.branch },
-          },
-        }),
-      };
+      case "ai": {
+        const toolCallParts: ToolCallMessagePart[] =
+          message.tool_calls?.map((tc) => {
+            const approval = approvals.get(tc.id);
+            return {
+              type: "tool-call",
+              toolCallId: tc.id,
+              toolName: tc.name,
+              args: tc.args,
+              argsText: tc.argsText ?? JSON.stringify(tc.args),
+              ...(approval && { approval }),
+            };
+          }) ?? [];
+
+        return {
+          role: "assistant",
+          id: message.id,
+          content: [
+            ...contentToParts(message.content, "assistant"),
+            ...toolCallParts,
+          ],
+          ...(message.status && { status: message.status }),
+          ...(message.author && {
+            metadata: {
+              custom: { author: message.author, branch: message.branch },
+            },
+          }),
+        };
+      }
+
+      case "tool":
+        return {
+          role: "tool",
+          toolCallId: message.tool_call_id,
+          toolName: message.name,
+          result: message.content,
+          isError: message.status === "error",
+        };
     }
+  };
 
-    case "tool":
-      return {
-        role: "tool",
-        toolCallId: message.tool_call_id,
-        toolName: message.name,
-        result: message.content,
-        isError: message.status === "error",
-      };
-  }
-};
+export const convertAdkMessage: useExternalMessageConverter.Callback<AdkMessage> =
+  createAdkMessageConverter(EMPTY_APPROVALS);

--- a/packages/react-google-adk/src/hooks.ts
+++ b/packages/react-google-adk/src/hooks.ts
@@ -2,6 +2,7 @@ import { useAui } from "@assistant-ui/store";
 import { v4 as uuidv4 } from "uuid";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { adkExtras } from "./adkExtras";
+import { toAdkConfirmationReply } from "./adkToolApproval";
 import type {
   AdkMessage,
   AdkSendMessageConfig,
@@ -66,22 +67,9 @@ export const useAdkConfirmTool = () => {
     confirmed: boolean,
     payload?: ReadonlyJSONValue,
   ) =>
-    adkExtras.get(aui).send(
-      [
-        {
-          id: uuidv4(),
-          type: "tool",
-          tool_call_id: toolCallId,
-          name: "adk_request_confirmation",
-          content: JSON.stringify({
-            confirmed,
-            ...(payload != null && { payload }),
-          }),
-          status: "success",
-        },
-      ],
-      {},
-    );
+    adkExtras
+      .get(aui)
+      .send([toAdkConfirmationReply(toolCallId, confirmed, payload)], {});
 };
 
 /** Returns a function to submit auth credentials for a pending auth request. */

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getExternalStoreMessages,
   pickExternalStoreSharedOptions,
@@ -33,7 +33,15 @@ import type {
   OnAdkAgentTransferCallback,
 } from "./types";
 import { useAdkMessages } from "./useAdkMessages";
-import { convertAdkMessage } from "./convertAdkMessages";
+import {
+  convertAdkMessage,
+  createAdkMessageConverter,
+} from "./convertAdkMessages";
+import {
+  adkToolApprovalsKey,
+  projectAdkToolApprovals,
+  toAdkToolConfirmationReply,
+} from "./adkToolApproval";
 import { adkExtras } from "./adkExtras";
 import { v4 as uuidv4 } from "uuid";
 
@@ -285,8 +293,23 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     }
   };
 
+  const toolApprovals = projectAdkToolApprovals(messages, toolConfirmations);
+  const toolApprovalsKey = adkToolApprovalsKey(toolApprovals);
+  const toolApprovalsRef = useRef(toolApprovals);
+  toolApprovalsRef.current = toolApprovals;
+
+  // Keyed on the decision state rather than the map, so a converter that would
+  // re-run over the whole thread is rebuilt only when a gate opens or settles.
+  const messageConverter = useMemo(
+    () =>
+      toolApprovalsKey === ""
+        ? convertAdkMessage
+        : createAdkMessageConverter(toolApprovalsRef.current),
+    [toolApprovalsKey],
+  );
+
   const threadMessages = useExternalMessageConverter({
-    callback: convertAdkMessage,
+    callback: messageConverter,
     messages,
     isRunning: effectiveIsRunning,
   });
@@ -553,6 +576,12 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
             status: isError ? "error" : "success",
           },
         ],
+        {},
+      );
+    },
+    onRespondToToolApproval: async (options) => {
+      await handleSendMessage(
+        [toAdkToolConfirmationReply(options, toolApprovalsRef.current)],
         {},
       );
     },

--- a/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
@@ -1,0 +1,219 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  RespondToToolApprovalOptions,
+  ThreadMessage,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import type { AdkMessage, AdkToolConfirmation } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  adapters: [] as unknown[],
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  messages: [] as AdkMessage[],
+  toolConfirmations: [] as AdkToolConfirmation[],
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: () => ({}),
+  useExternalStoreRuntime: (adapter: unknown) => {
+    mocks.adapters.push(adapter);
+    return {};
+  },
+  useRemoteThreadListRuntime: (options: { runtimeHook: () => unknown }) =>
+    options.runtimeHook(),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({
+    threadListItem: {
+      source: null,
+      getState: () => ({ externalId: undefined }),
+      initialize: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("./useAdkMessages", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useAdkMessages")>()),
+  useAdkMessages: () => ({
+    messages: mocks.messages,
+    stateDelta: {},
+    agentInfo: {},
+    longRunningToolIds: [],
+    artifactDelta: {},
+    toolConfirmations: mocks.toolConfirmations,
+    authRequests: [],
+    escalated: false,
+    messageMetadata: new Map(),
+    sendMessage: mocks.sendMessage,
+    cancel: vi.fn(),
+    setMessages: vi.fn(),
+    replaceMessages: vi.fn(),
+    applySnapshot: vi.fn(),
+  }),
+}));
+
+import { useAdkRuntime } from "./useAdkRuntime";
+
+type ApprovalAdapter = {
+  messages: readonly ThreadMessage[];
+  onRespondToToolApproval?: (
+    options: RespondToToolApprovalOptions,
+  ) => Promise<void> | void;
+};
+
+const CONFIRMATION_CALL_ID = "tc-1";
+
+const pendingConfirmationThread = () => {
+  mocks.messages = [
+    { id: "u-1", type: "human", content: "delete the file" },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: [],
+      tool_calls: [
+        {
+          id: CONFIRMATION_CALL_ID,
+          name: "adk_request_confirmation",
+          args: { hint: "Delete /tmp/a?" },
+          argsText: '{"hint":"Delete /tmp/a?"}',
+        },
+      ],
+    },
+  ];
+  mocks.toolConfirmations = [
+    {
+      toolCallId: CONFIRMATION_CALL_ID,
+      toolName: "delete_file",
+      args: { path: "/tmp/a" },
+      hint: "Delete /tmp/a?",
+      confirmed: false,
+    },
+  ];
+};
+
+const mountRuntime = () => {
+  renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+  return mocks.adapters.at(-1) as ApprovalAdapter;
+};
+
+afterEach(() => {
+  mocks.adapters.length = 0;
+  mocks.messages = [];
+  mocks.toolConfirmations = [];
+  vi.clearAllMocks();
+});
+
+describe("useAdkRuntime tool approvals", () => {
+  it("surfaces a pending confirmation as an approval gate awaiting action", async () => {
+    pendingConfirmationThread();
+    const adapter = mountRuntime();
+
+    const assistantMessage = adapter.messages.at(-1)!;
+    expect(assistantMessage.role).toBe("assistant");
+    expect(assistantMessage.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(assistantMessage.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: CONFIRMATION_CALL_ID,
+        approval: { id: CONFIRMATION_CALL_ID },
+      }),
+    );
+  });
+
+  it("leaves an ungated tool call without an approval", () => {
+    mocks.messages = [
+      {
+        id: "ai-1",
+        type: "ai",
+        content: [],
+        tool_calls: [{ id: "tc-9", name: "search", args: {}, argsText: "{}" }],
+      },
+    ];
+    const adapter = mountRuntime();
+
+    const part = adapter.messages.at(-1)!.content[0] as ToolCallMessagePart;
+    expect(part.type).toBe("tool-call");
+    expect(part.approval).toBeUndefined();
+    expect(adapter.messages.at(-1)!.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+
+  it("settles the gate once the confirmation is answered", async () => {
+    pendingConfirmationThread();
+    mocks.messages = [
+      ...mocks.messages,
+      {
+        id: "tool-1",
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL_ID,
+        name: "adk_request_confirmation",
+        content: JSON.stringify({ confirmed: true }),
+        status: "success",
+      },
+    ];
+    const adapter = mountRuntime();
+
+    expect(adapter.messages.at(-1)!.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        approval: { id: CONFIRMATION_CALL_ID, approved: true },
+      }),
+    );
+  });
+
+  it("sends an approval through the ADK confirmation reply", async () => {
+    pendingConfirmationThread();
+    const adapter = mountRuntime();
+
+    await adapter.onRespondToToolApproval!({
+      approvalId: CONFIRMATION_CALL_ID,
+      approved: true,
+    });
+
+    const [sent] = mocks.sendMessage.mock.calls.at(-1)!;
+    expect(sent).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL_ID,
+        name: "adk_request_confirmation",
+        content: JSON.stringify({ confirmed: true }),
+        status: "success",
+      }),
+    ]);
+  });
+
+  it("sends a denial through the ADK confirmation reply", async () => {
+    pendingConfirmationThread();
+    const adapter = mountRuntime();
+
+    await adapter.onRespondToToolApproval!({
+      approvalId: CONFIRMATION_CALL_ID,
+      approved: false,
+    });
+
+    const [sent] = mocks.sendMessage.mock.calls.at(-1)!;
+    expect(sent[0].content).toBe(JSON.stringify({ confirmed: false }));
+  });
+
+  it("refuses an approval id with no pending confirmation", async () => {
+    pendingConfirmationThread();
+    const adapter = mountRuntime();
+
+    await expect(
+      adapter.onRespondToToolApproval!({
+        approvalId: "stale-id",
+        approved: true,
+      }),
+    ).rejects.toThrow("No pending ADK tool confirmation");
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

`react-google-adk` receives ADK tool confirmations (`adk_request_confirmation` function calls and `actions.requestedToolConfirmations`) but never mapped them onto core's tool-approval gate. This maps them onto `ToolCallMessagePart.approval` and wires `onRespondToToolApproval` on the adapter's external-store config, so a confirmation-gated tool call is answered through the standard path.

## Why

Cross-runtime parity: a capability that exists on one runtime should exist on every runtime that supports the concept. `onRespondToToolApproval` is currently wired in exactly four adapters — `react-ai-sdk`, `eve`, `react-opencode`, and `react-pi`. On `react-google-adk` it is absent, so `aui.part.respondToToolApproval` throws "Runtime does not support tool approvals."

The user-visible failure is quieter than that, and worth stating precisely. Because a pending ADK confirmation still puts the tool call in `requires-action`, the default `ToolFallback` kit *does* render Allow/Deny today — but with no `approval` on the part it falls back to `addResult`, so pressing Allow writes the literal string `"Approved by user"` as that tool call's result. ADK never receives a confirmation reply, the gated tool never runs, and the turn ends looking answered. I verified this against `upstream/main` with a deterministic ADK stream: Allow yields `Result: "Approved by user"` and nothing else happens; on this branch the same click yields `{"confirmed":true}`, the gated `delete_file` runs, and the agent replies. Today the only correct answer path is the bespoke `useAdkConfirmTool`, which the default kit does not know about.

`react-opencode`'s conversion (#5325) is the template this follows.

## How

- `projectAdkToolApprovals(messages, confirmations)` (new, pure) maps each pending confirmation to `approval: { id }`, keyed by the tool call id the confirmation is answered with — the same id `useAdkConfirmTool` already takes, which covers both the `adk_request_confirmation` function-call path and the `requestedToolConfirmations` actions path. With the gate open, the kit routes Allow/Deny through `respondToApproval` instead of the `addResult` fallback.
- Settling: a confirmation answered by an `adk_request_confirmation` reply settles to that reply's `confirmed` boolean, so the card clears rather than lingering over a decided call. A gate closed by some other result — or by an unreadable reply — settles as `resolution: "cancelled"`: terminal, but without inventing a decision the transcript does not record.
- `createAdkMessageConverter(approvals)` is the existing converter parameterized by the projection; `convertAdkMessage` is now that factory applied to an empty map, so its behavior and signature are unchanged. The runtime rebuilds the closure only when a gate opens or settles, keyed on the projected decision state, so an ordinary streaming turn does not re-convert the thread.
- `onRespondToToolApproval` maps approve → `{ confirmed: true }` and deny → `{ confirmed: false }` through `toAdkConfirmationReply`, the exact reply builder `useAdkConfirmTool` now shares, sent over the same `handleSendMessage` path. ADK confirmations are a plain confirm/reject pair with no option list and no reason field, so no `optionId` is declared and core's `reason` is not fabricated into the payload. An approval id with no pending confirmation throws rather than sending a reply ADK cannot place.
- The converters defend against missing or malformed confirmation payloads (absent tool call ids, non-string content, unparseable JSON) instead of throwing.

The bespoke surface is untouched and keeps working: `useAdkToolConfirmations`, `useAdkConfirmTool`, `useAdkSubmitAuth`, and `useAdkSubmitInput` are unchanged, and nothing new is added to the package's public exports. `adk_request_credential` is deliberately left alone — auth is not an approval.

## Tests

28 new tests, all colocated:

- `adkToolApproval.test.ts` — the projection (pending gate, approved/denied settle, snapshot-confirmed, cancelled-by-other-result, confirmation reply preferred over a later tool result, unreadable reply, malformed input does not throw) and the response mapping (approve, deny, reason dropped, unknown id, already-settled id).
- `convertAdkMessages.test.ts` — the converter stamps the gate onto the right tool call and leaves siblings ungated; `convertAdkMessage` gates nothing.
- `useAdkRuntimeApproval.test.tsx` — the seam, through a mounted runtime and the real external message converter: a pending confirmation yields `requires-action` / `interrupt` with the approval on the part, an ungated pending call stays on `tool-calls` with no approval, an answered gate reads as settled, and `onRespondToToolApproval` reaches the ADK reply for both approve and deny.

Reverting only the runtime wiring fails 5 of the 6 seam tests (the ungated control still passes); the full package suite is 260 passing.

A demo video of the before/after will be added to this PR.