### PR TITLE
fix(react): clean up sandbox frames after bridge setup failures

### DIFF
--- a/.changeset/clean-sandbox-frames.md
+++ b/.changeset/clean-sandbox-frames.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: dispose sandbox frames when bridge setup fails

--- a/packages/react/src/sandbox-host/SandboxHost.test.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.test.tsx
@@ -228,4 +228,28 @@ describe("SandboxHost", () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]![0].message).toBe("boom");
   });
+
+  it("disposes the rendered frame when bridge creation fails", async () => {
+    const rendered = fakeRendered();
+    renderHtmlMock.mockResolvedValue(rendered);
+    const error = new Error("bridge failed");
+    const onError = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <SandboxHost
+          content={{ html: "" }}
+          contentKey="k"
+          createBridge={() => {
+            throw error;
+          }}
+          onError={onError}
+        />,
+      );
+    });
+    await flush();
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(rendered.dispose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react/src/sandbox-host/SandboxHost.test.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.test.tsx
@@ -251,5 +251,10 @@ describe("SandboxHost", () => {
 
     expect(onError).toHaveBeenCalledWith(error);
     expect(rendered.dispose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+    expect(rendered.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/sandbox-host/SandboxHost.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.tsx
@@ -147,6 +147,8 @@ export function SandboxHost({
         window.addEventListener("message", onMessage);
       })
       .catch((err) => {
+        frame?.dispose();
+        frame = null;
         liveRef.current.onError?.(
           err instanceof Error ? err : new Error(String(err)),
         );


### PR DESCRIPTION
## Summary

- dispose a rendered sandbox frame when bridge construction fails
- clear the stored frame reference after failure so later unmount cleanup does not dispose it twice
- cover the post-render bridge failure path with a regression test

## Problem

If `SafeContentFrame.renderHtml()` succeeds but `createBridge()` throws, the existing promise rejection path reports the error without disposing the active frame. The iframe can therefore remain mounted and retain its resources until the host eventually unmounts.

The regression test reproduces the old behavior with `rendered.dispose()` called zero times. The failure path now disposes the frame immediately before forwarding the original error to `onError`.

## Test plan

- `pnpm --filter @assistant-ui/react test` (405 tests)
- `pnpm --filter @assistant-ui/react build`
- `pnpm lint`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.djeWKnHkxKksQtPHLDJJZOtoeoNivmzVfigMBHiOwFwiMobcZxcy70YwE_M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->