### PR TITLE
feat(react-a2a): validate message roles in send responses

### DIFF
--- a/.changeset/validate-a2a-message-roles.md
+++ b/.changeset/validate-a2a-message-roles.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: reject synchronous message responses with invalid A2A roles

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -460,6 +460,16 @@ describe("A2AClient", () => {
           },
         },
       ],
+      [
+        "a message with an unknown role",
+        {
+          message: {
+            messageId: "m2",
+            role: "banana",
+            parts: [{ text: "Hi" }],
+          },
+        },
+      ],
     ])("rejects %s returned with a successful status", async (_name, body) => {
       fetchMock.mockResolvedValue(mockFetchResponse(body));
 

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -171,6 +171,17 @@ const TASK_STATES: ReadonlySet<string> = new Set(
 const isTaskState = (value: unknown): value is A2ATaskState =>
   typeof value === "string" && TASK_STATES.has(value);
 
+const ROLES: ReadonlySet<string> = new Set(
+  Object.keys({
+    unspecified: true,
+    user: true,
+    agent: true,
+  } satisfies Record<A2ARole, true>),
+);
+
+const isRole = (value: unknown): value is A2ARole =>
+  typeof value === "string" && ROLES.has(value);
+
 const isTask = (value: unknown): value is A2ATask =>
   isRecord(value) &&
   typeof value.id === "string" &&
@@ -182,8 +193,7 @@ const isMessage = (value: unknown): value is A2AMessage =>
   isRecord(value) &&
   typeof value.messageId === "string" &&
   value.messageId.length > 0 &&
-  typeof value.role === "string" &&
-  value.role.length > 0 &&
+  isRole(value.role) &&
   Array.isArray(value.parts) &&
   value.parts.every(isRecord);
 


### PR DESCRIPTION
## Summary

- validate normalized synchronous A2A message roles against the protocol role enum
- reject malformed successful responses at the client boundary
- add a regression for an unknown role returned by `message:send`

## Problem

The synchronous send-response validator previously accepted every non-empty role string. A successful response with `role: "banana"` therefore resolved as an `A2AMessage`; the runtime ignored its content because it was not an agent message, then marked the assistant response complete and displayed a blank result.

The validator now accepts only the normalized A2A roles `unspecified`, `user`, and `agent`. Unknown values fail with the existing contextual `Invalid A2A message:send response` error instead of reaching runtime conversion.

## Test plan

- `pnpm --filter @assistant-ui/react-a2a test` (205 tests)
- `pnpm --filter @assistant-ui/react-a2a build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UZW71K1q1aiWtSSxkV35aZSYpHGgRwuDe0mwMl36RV23qzsDDthUALPDmbk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->