### PR TITLE
feat(react-ag-ui): expose confirmation interrupts through the core tool-approval seam

### DIFF
--- a/.changeset/agui-tool-approval-parity.md
+++ b/.changeset/agui-tool-approval-parity.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: expose AG-UI confirmation interrupts through the core tool-approval seam

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -14,6 +14,7 @@ import type {
   ChatModelRunResult,
   ExportedMessageRepository,
   MessageStatus,
+  RespondToToolApprovalOptions,
   ThreadAssistantMessage,
   ThreadHistoryAdapter,
   ThreadMessage,
@@ -45,6 +46,12 @@ import {
   toAgUiTools,
 } from "./adapter/conversions";
 import { createAgUiSubscriber } from "./adapter/subscriber";
+import {
+  collectToolApprovalResume,
+  findToolApprovalInterrupt,
+  withClosedToolApprovals,
+  withToolApprovalDecision,
+} from "./adapter/tool-approval";
 
 // AbstractAgent.runAgent declares two parameters. HttpAgent ignores a third and
 // is cancelled through agent.abortRun(); the run options stay for subclasses
@@ -556,6 +563,56 @@ export class AgUiThreadRuntimeCore {
     await this.startRun(pending.messageId, this.lastRunConfig, resume);
   }
 
+  async respondToToolApproval(
+    options: RespondToToolApprovalOptions,
+  ): Promise<void> {
+    const pending = this.getPendingInterrupts();
+    if (!pending) {
+      throw new Error(
+        "[agui] respondToToolApproval: no pending interrupts on this thread",
+      );
+    }
+
+    const interrupt = findToolApprovalInterrupt(
+      pending.interrupts,
+      options.approvalId,
+    );
+    if (!interrupt) {
+      throw new Error(
+        `[agui] respondToToolApproval: no pending confirmation interrupt for approval id "${options.approvalId}"`,
+      );
+    }
+
+    const recorded = this.updateMessage(pending.messageId, (message) => {
+      if (message.role !== "assistant") return message;
+      const assistant = message as ThreadAssistantMessage;
+      const content = withToolApprovalDecision(assistant.content, options);
+      if (content === assistant.content) return assistant;
+      return { ...assistant, content };
+    });
+    if (!recorded) {
+      throw new Error(
+        `[agui] respondToToolApproval: approval "${options.approvalId}" is already decided`,
+      );
+    }
+    this.notifyUpdate();
+
+    const assistant = this.tryGetMessage(pending.messageId)?.message as
+      | ThreadAssistantMessage
+      | undefined;
+    if (!assistant) return;
+
+    // AG-UI resumes a run with one response per open interrupt, so the run
+    // stays paused until every gate in the batch has been answered.
+    const resume = collectToolApprovalResume(
+      assistant.content,
+      pending.interrupts,
+    );
+    if (!resume) return;
+
+    await this.submitInterruptResponses(resume);
+  }
+
   async steerAway(
     message: CreateAppendMessage,
     responses?: readonly AgUiResumeEntry[],
@@ -699,6 +756,7 @@ export class AgUiThreadRuntimeCore {
       }
       return {
         ...assistant,
+        content: withClosedToolApprovals(assistant.content),
         status: { type: "complete" as const, reason: "unknown" as const },
         metadata: { ...assistant.metadata, custom: newCustom },
       };

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -15,6 +15,7 @@ import {
   type A2uiSurfaceState,
 } from "@assistant-ui/react-generative-ui/a2ui";
 import { readMcpAppResourceUri } from "../mcp-tool-result";
+import { projectAgUiToolApprovals } from "./tool-approval";
 import type { AgUiEvent, AgUiInterrupt } from "../types";
 import type { Logger } from "../logger";
 
@@ -614,6 +615,7 @@ export class RunAggregator {
 
   private emit(): void {
     const snapshot: ThreadAssistantMessagePart[] = [];
+    const approvals = projectAgUiToolApprovals(this.interrupts);
 
     for (const part of this.partOrder) {
       if (part.kind === "reasoning") {
@@ -648,12 +650,14 @@ export class RunAggregator {
 
       const entry = this.toolCalls.get(part.toolCallId);
       if (!entry) continue;
+      const approval = approvals.get(entry.toolCallId);
       const toolPart: ToolCallMessagePart = {
         type: "tool-call",
         toolCallId: entry.toolCallId,
         toolName: entry.toolCallName,
         args: (entry.parsedArgs ?? {}) as any,
         argsText: entry.argsText,
+        ...(approval ? { approval } : {}),
         ...(entry.result !== undefined ? { result: entry.result } : {}),
         ...(entry.modelContent !== undefined
           ? { modelContent: entry.modelContent }

--- a/packages/react-ag-ui/src/runtime/adapter/tool-approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/tool-approval.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadAssistantMessagePart } from "@assistant-ui/core";
+import type { AgUiToolApproval } from "./tool-approval";
+import {
+  collectToolApprovalResume,
+  findToolApprovalInterrupt,
+  isToolApprovalInterrupt,
+  projectAgUiToolApprovals,
+  withClosedToolApprovals,
+  withToolApprovalDecision,
+} from "./tool-approval";
+import type { AgUiInterrupt } from "../types";
+
+const confirmation = (
+  overrides: Partial<AgUiInterrupt> = {},
+): AgUiInterrupt => ({
+  id: "int-1",
+  reason: "confirmation",
+  toolCallId: "tc-1",
+  message: "Delete /tmp/a?",
+  ...overrides,
+});
+
+const toolCall = (
+  toolCallId: string,
+  approval?: AgUiToolApproval,
+): ThreadAssistantMessagePart => ({
+  type: "tool-call",
+  toolCallId,
+  toolName: "delete_file",
+  args: {},
+  argsText: "{}",
+  ...(approval && { approval }),
+});
+
+const approvalOf = (content: readonly ThreadAssistantMessagePart[], i = 0) => {
+  const part = content[i];
+  return part?.type === "tool-call" ? part.approval : undefined;
+};
+
+describe("isToolApprovalInterrupt", () => {
+  it("accepts a confirmation that names its tool call", () => {
+    expect(isToolApprovalInterrupt(confirmation())).toBe(true);
+  });
+
+  it("rejects a reason that is not a confirmation", () => {
+    expect(
+      isToolApprovalInterrupt(confirmation({ reason: "input_required" })),
+    ).toBe(false);
+  });
+
+  it("rejects a confirmation with no tool call to gate", () => {
+    const { toolCallId: _omitted, ...withoutToolCall } = confirmation();
+    expect(isToolApprovalInterrupt(withoutToolCall)).toBe(false);
+    expect(isToolApprovalInterrupt(confirmation({ toolCallId: "" }))).toBe(
+      false,
+    );
+  });
+
+  it("does not throw on a malformed interrupt", () => {
+    expect(isToolApprovalInterrupt(undefined)).toBe(false);
+    expect(
+      isToolApprovalInterrupt({ reason: "confirmation" } as AgUiInterrupt),
+    ).toBe(false);
+  });
+});
+
+describe("projectAgUiToolApprovals", () => {
+  it("opens a gate keyed by the gated tool call, carrying the interrupt id", () => {
+    expect(projectAgUiToolApprovals([confirmation()]).get("tc-1")).toEqual({
+      id: "int-1",
+    });
+  });
+
+  it("gates only the confirmations, leaving other interrupts alone", () => {
+    const approvals = projectAgUiToolApprovals([
+      confirmation(),
+      confirmation({
+        id: "int-2",
+        reason: "input_required",
+        toolCallId: "tc-2",
+      }),
+    ]);
+    expect([...approvals.keys()]).toEqual(["tc-1"]);
+  });
+
+  it("is empty when there are no interrupts", () => {
+    expect(projectAgUiToolApprovals(undefined).size).toBe(0);
+    expect(projectAgUiToolApprovals([]).size).toBe(0);
+  });
+
+  it("does not throw on malformed interrupts", () => {
+    expect(() =>
+      projectAgUiToolApprovals([
+        undefined as unknown as AgUiInterrupt,
+        { reason: "confirmation" } as AgUiInterrupt,
+      ]),
+    ).not.toThrow();
+  });
+});
+
+describe("findToolApprovalInterrupt", () => {
+  it("finds the confirmation an approval id addresses", () => {
+    expect(findToolApprovalInterrupt([confirmation()], "int-1")?.id).toBe(
+      "int-1",
+    );
+  });
+
+  it("returns nothing for a stale approval id", () => {
+    expect(
+      findToolApprovalInterrupt([confirmation()], "int-9"),
+    ).toBeUndefined();
+  });
+
+  it("returns nothing for an interrupt that is not a tool gate", () => {
+    expect(
+      findToolApprovalInterrupt(
+        [confirmation({ reason: "input_required" })],
+        "int-1",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("withToolApprovalDecision", () => {
+  const content = [toolCall("tc-1", { id: "int-1" })];
+
+  it("records an approval on the gated part", () => {
+    const next = withToolApprovalDecision(content, {
+      approvalId: "int-1",
+      approved: true,
+    });
+    expect(approvalOf(next)).toEqual({ id: "int-1", approved: true });
+  });
+
+  it("records a denial with its reason, which has no wire field", () => {
+    const next = withToolApprovalDecision(content, {
+      approvalId: "int-1",
+      approved: false,
+      reason: "too risky",
+    });
+    expect(approvalOf(next)).toEqual({
+      id: "int-1",
+      approved: false,
+      reason: "too risky",
+    });
+  });
+
+  it("leaves the content untouched for a stale approval id", () => {
+    expect(
+      withToolApprovalDecision(content, {
+        approvalId: "int-9",
+        approved: true,
+      }),
+    ).toBe(content);
+  });
+
+  it("leaves an already decided gate untouched", () => {
+    const decided = [toolCall("tc-1", { id: "int-1", approved: true })];
+    expect(
+      withToolApprovalDecision(decided, {
+        approvalId: "int-1",
+        approved: false,
+      }),
+    ).toBe(decided);
+  });
+});
+
+describe("withClosedToolApprovals", () => {
+  it("closes an undecided gate as cancelled", () => {
+    const next = withClosedToolApprovals([toolCall("tc-1", { id: "int-1" })]);
+    expect(approvalOf(next)).toEqual({ id: "int-1", resolution: "cancelled" });
+  });
+
+  it("keeps a decided gate as it was", () => {
+    const decided = [toolCall("tc-1", { id: "int-1", approved: false })];
+    expect(withClosedToolApprovals(decided)).toBe(decided);
+  });
+
+  it("leaves ungated tool calls alone", () => {
+    const ungated = [toolCall("tc-1")];
+    expect(withClosedToolApprovals(ungated)).toBe(ungated);
+  });
+});
+
+describe("collectToolApprovalResume", () => {
+  it("resumes the run for an approval", () => {
+    expect(
+      collectToolApprovalResume(
+        [toolCall("tc-1", { id: "int-1", approved: true })],
+        [confirmation()],
+      ),
+    ).toEqual([{ interruptId: "int-1", status: "resolved" }]);
+  });
+
+  it("cancels the interrupt for a denial, the only refusal AG-UI can express", () => {
+    expect(
+      collectToolApprovalResume(
+        [toolCall("tc-1", { id: "int-1", approved: false, reason: "no" })],
+        [confirmation()],
+      ),
+    ).toEqual([{ interruptId: "int-1", status: "cancelled" }]);
+  });
+
+  it("waits while another gate in the batch is undecided", () => {
+    expect(
+      collectToolApprovalResume(
+        [
+          toolCall("tc-1", { id: "int-1", approved: true }),
+          toolCall("tc-2", { id: "int-2" }),
+        ],
+        [confirmation(), confirmation({ id: "int-2", toolCallId: "tc-2" })],
+      ),
+    ).toBeNull();
+  });
+
+  it("answers a fully decided batch in interrupt order", () => {
+    expect(
+      collectToolApprovalResume(
+        [
+          toolCall("tc-1", { id: "int-1", approved: true }),
+          toolCall("tc-2", { id: "int-2", approved: false }),
+        ],
+        [confirmation(), confirmation({ id: "int-2", toolCallId: "tc-2" })],
+      ),
+    ).toEqual([
+      { interruptId: "int-1", status: "resolved" },
+      { interruptId: "int-2", status: "cancelled" },
+    ]);
+  });
+
+  it("waits when the batch holds an interrupt the seam cannot answer", () => {
+    expect(
+      collectToolApprovalResume(
+        [toolCall("tc-1", { id: "int-1", approved: true })],
+        [
+          confirmation(),
+          confirmation({
+            id: "int-2",
+            reason: "input_required",
+            toolCallId: "tc-2",
+          }),
+        ],
+      ),
+    ).toBeNull();
+  });
+
+  it("does not throw on malformed content or interrupts", () => {
+    expect(() =>
+      collectToolApprovalResume(
+        [{ type: "text", text: "hi" }, toolCall("tc-1")],
+        [undefined as unknown as AgUiInterrupt],
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
@@ -1,0 +1,139 @@
+import type {
+  RespondToToolApprovalOptions,
+  ThreadAssistantMessagePart,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import type { AgUiInterrupt, AgUiResumeEntry } from "../types";
+
+export type AgUiToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
+
+const CONFIRMATION_REASON = "confirmation";
+
+const EMPTY_APPROVALS: ReadonlyMap<string, AgUiToolApproval> = new Map();
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value !== "";
+
+/**
+ * An interrupt is a tool approval gate when it asks for a confirmation and
+ * names the tool call it gates. Every other reason (`input_required`, a
+ * provider-specific reason, a confirmation with no tool call) stays on the
+ * bespoke interrupt hooks.
+ */
+export const isToolApprovalInterrupt = (
+  interrupt: AgUiInterrupt | undefined | null,
+): interrupt is AgUiInterrupt & { toolCallId: string } =>
+  !!interrupt &&
+  interrupt.reason === CONFIRMATION_REASON &&
+  isNonEmptyString(interrupt.id) &&
+  isNonEmptyString(interrupt.toolCallId);
+
+/**
+ * Projects the open confirmation interrupts onto core's approval gate, keyed
+ * by the tool call each one gates. The gate carries the interrupt's id, which
+ * is what a resume entry is addressed to.
+ */
+export const projectAgUiToolApprovals = (
+  interrupts: readonly AgUiInterrupt[] | undefined,
+): ReadonlyMap<string, AgUiToolApproval> => {
+  if (!interrupts?.length) return EMPTY_APPROVALS;
+
+  const approvals = new Map<string, AgUiToolApproval>();
+  for (const interrupt of interrupts) {
+    if (!isToolApprovalInterrupt(interrupt)) continue;
+    approvals.set(interrupt.toolCallId, { id: interrupt.id });
+  }
+  return approvals.size === 0 ? EMPTY_APPROVALS : approvals;
+};
+
+export const findToolApprovalInterrupt = (
+  interrupts: readonly AgUiInterrupt[],
+  approvalId: string,
+): (AgUiInterrupt & { toolCallId: string }) | undefined =>
+  interrupts.find(
+    (interrupt): interrupt is AgUiInterrupt & { toolCallId: string } =>
+      isToolApprovalInterrupt(interrupt) && interrupt.id === approvalId,
+  );
+
+const isPending = (approval: AgUiToolApproval | undefined): boolean =>
+  !!approval && approval.approved === undefined && !approval.resolution;
+
+/**
+ * Records a decision on the gated tool call. The decision is held on the part
+ * until every interrupt in the batch is answered, because AG-UI resumes a run
+ * with one response per open interrupt rather than one response per gate.
+ * Returns the same array when nothing matched.
+ */
+export const withToolApprovalDecision = (
+  content: readonly ThreadAssistantMessagePart[],
+  { approvalId, approved, reason }: RespondToToolApprovalOptions,
+): readonly ThreadAssistantMessagePart[] => {
+  let changed = false;
+  const next = content.map((part) => {
+    if (part.type !== "tool-call") return part;
+    const approval = part.approval;
+    if (approval?.id !== approvalId || !isPending(approval)) return part;
+    changed = true;
+    return {
+      ...part,
+      approval: {
+        ...approval,
+        approved,
+        ...(reason !== undefined && { reason }),
+      },
+    };
+  });
+  return changed ? next : content;
+};
+
+/**
+ * Closes the gates that are still open, for a batch that settled without a
+ * decision reaching the part: the interrupts were answered through the bespoke
+ * hooks, or discarded by `steerAway`.
+ */
+export const withClosedToolApprovals = (
+  content: readonly ThreadAssistantMessagePart[],
+): readonly ThreadAssistantMessagePart[] => {
+  let changed = false;
+  const next = content.map((part) => {
+    if (part.type !== "tool-call" || !isPending(part.approval)) return part;
+    changed = true;
+    return {
+      ...part,
+      approval: { ...part.approval!, resolution: "cancelled" as const },
+    };
+  });
+  return changed ? next : content;
+};
+
+/**
+ * Maps the decisions recorded on the parts onto AG-UI resume entries, or
+ * `null` while the batch is incomplete. `resolved` and `cancelled` are the only
+ * outcomes AG-UI's resume vocabulary can express, so an approval resumes the
+ * run and a denial cancels the interrupt; a denial reason has no field to land
+ * in and stays on the part.
+ */
+export const collectToolApprovalResume = (
+  content: readonly ThreadAssistantMessagePart[],
+  interrupts: readonly AgUiInterrupt[],
+): AgUiResumeEntry[] | null => {
+  const decisions = new Map<string, boolean>();
+  for (const part of content) {
+    if (part.type !== "tool-call") continue;
+    const approval = part.approval;
+    if (!approval || approval.approved === undefined) continue;
+    decisions.set(approval.id, approval.approved);
+  }
+
+  const resume: AgUiResumeEntry[] = [];
+  for (const interrupt of interrupts) {
+    if (!isToolApprovalInterrupt(interrupt)) return null;
+    const approved = decisions.get(interrupt.id);
+    if (approved === undefined) return null;
+    resume.push({
+      interruptId: interrupt.id,
+      status: approved ? "resolved" : "cancelled",
+    });
+  }
+  return resume;
+};

--- a/packages/react-ag-ui/src/useAgUiRuntime.approval.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.approval.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  waitFor,
+} from "@testing-library/react";
+import type { AssistantRuntime, ToolCallMessagePart } from "@assistant-ui/core";
+import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import type { HttpAgent } from "@ag-ui/client";
+import { useAgUiRuntime } from "./useAgUiRuntime";
+import { useAgUiSteerAway } from "./hooks";
+import type { AgUiInterrupt } from "./runtime/types";
+
+type Subscriber = Record<string, ((payload: any) => void) | undefined>;
+
+const CONFIRMATION: AgUiInterrupt = {
+  id: "int-1",
+  reason: "confirmation",
+  toolCallId: "tc-1",
+  message: "Delete /tmp/a?",
+};
+
+// Gates the first run on an interrupt and lets every later run settle, so a
+// resumed run is observable as a second call rather than a second gate.
+const gatingAgent = (interrupts: readonly AgUiInterrupt[] = [CONFIRMATION]) => {
+  const runAgent = vi.fn(async (input: unknown, subscriber: Subscriber) => {
+    if (runAgent.mock.calls.length > 1) {
+      subscriber.onRunFinalized?.(undefined);
+      return;
+    }
+    for (const interrupt of interrupts) {
+      const toolCallId = interrupt.toolCallId ?? "tc-x";
+      subscriber.onToolCallStartEvent?.({
+        event: {
+          type: "TOOL_CALL_START",
+          toolCallId,
+          toolCallName: "delete_file",
+        },
+      });
+      subscriber.onToolCallArgsEvent?.({
+        event: {
+          type: "TOOL_CALL_ARGS",
+          toolCallId,
+          delta: '{"path":"/tmp/a"}',
+        },
+      });
+      subscriber.onToolCallEndEvent?.({
+        event: { type: "TOOL_CALL_END", toolCallId },
+      });
+    }
+    subscriber.onRunFinishedEvent?.({
+      event: {
+        type: "RUN_FINISHED",
+        runId: "run-1",
+        outcome: { type: "interrupt", interrupts },
+      },
+    });
+    subscriber.onRunFinalized?.(undefined);
+    void input;
+  });
+  return {
+    agent: { runAgent, abortRun: vi.fn() } as unknown as HttpAgent,
+    runAgent,
+  };
+};
+
+const steerAwayRef: { current: ReturnType<typeof useAgUiSteerAway> | null } = {
+  current: null,
+};
+
+const SteerAway = () => {
+  steerAwayRef.current = useAgUiSteerAway();
+  return null;
+};
+
+const mount = (runtime: AssistantRuntime) =>
+  render(
+    <AssistantRuntimeProvider runtime={runtime}>
+      <SteerAway />
+    </AssistantRuntimeProvider>,
+  );
+
+const gatedThread = async (
+  interrupts: readonly AgUiInterrupt[] = [CONFIRMATION],
+) => {
+  const { agent, runAgent } = gatingAgent(interrupts);
+  const { result } = renderHook(() => useAgUiRuntime({ agent }));
+  mount(result.current);
+
+  await act(async () => {
+    await result.current.thread.append({
+      role: "user",
+      content: [{ type: "text", text: "delete it" }],
+    });
+  });
+  await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+  return { runtime: result, runAgent };
+};
+
+const lastAssistant = (runtime: AssistantRuntime) =>
+  runtime.thread.getState().messages.at(-1)!;
+
+const gatedPart = (runtime: AssistantRuntime, toolCallId = "tc-1") =>
+  runtime.thread
+    .getMessageByIndex(runtime.thread.getState().messages.length - 1)
+    .getMessagePartByToolCallId(toolCallId);
+
+const allToolCalls = (runtime: AssistantRuntime): ToolCallMessagePart[] =>
+  runtime.thread
+    .getState()
+    .messages.flatMap((message) => message.content as readonly unknown[])
+    .filter(
+      (part): part is ToolCallMessagePart =>
+        (part as ToolCallMessagePart).type === "tool-call",
+    );
+
+const toolCallParts = (runtime: AssistantRuntime) =>
+  lastAssistant(runtime).content.filter(
+    (part): part is ToolCallMessagePart => part.type === "tool-call",
+  );
+
+const resumeOf = (runAgent: ReturnType<typeof vi.fn>) =>
+  (runAgent.mock.calls.at(-1)?.[0] as { resume?: unknown } | undefined)?.resume;
+
+afterEach(() => cleanup());
+
+describe("useAgUiRuntime tool approvals", () => {
+  it("surfaces a pending confirmation as an approval gate on the gated tool call", async () => {
+    const { runtime } = await gatedThread();
+
+    expect(lastAssistant(runtime.current).status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(toolCallParts(runtime.current)[0]!.approval).toEqual({
+      id: "int-1",
+    });
+    expect(gatedPart(runtime.current).getState().status).toMatchObject({
+      type: "requires-action",
+    });
+  });
+
+  it("leaves a tool call ungated when the interrupt is not a confirmation", async () => {
+    const { runtime } = await gatedThread([
+      { ...CONFIRMATION, reason: "input_required" },
+    ]);
+
+    expect(toolCallParts(runtime.current)[0]!.approval).toBeUndefined();
+  });
+
+  it("resumes the run with a resolved response when the gate is allowed", async () => {
+    const { runtime, runAgent } = await gatedThread();
+
+    await act(async () => {
+      gatedPart(runtime.current).respondToToolApproval({ approved: true });
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    expect(resumeOf(runAgent)).toEqual([
+      { interruptId: "int-1", status: "resolved" },
+    ]);
+  });
+
+  it("cancels the interrupt when the gate is denied", async () => {
+    const { runtime, runAgent } = await gatedThread();
+
+    await act(async () => {
+      gatedPart(runtime.current).respondToToolApproval({ approved: false });
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    expect(resumeOf(runAgent)).toEqual([
+      { interruptId: "int-1", status: "cancelled" },
+    ]);
+  });
+
+  it("never answers the gated tool call with a fabricated result", async () => {
+    const { runtime, runAgent } = await gatedThread();
+
+    await act(async () => {
+      gatedPart(runtime.current).respondToToolApproval({ approved: true });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+
+    expect(
+      allToolCalls(runtime.current).every((part) => part.result === undefined),
+    ).toBe(true);
+  });
+
+  it("refuses a second decision on a settled gate", async () => {
+    const { runtime, runAgent } = await gatedThread();
+    const part = gatedPart(runtime.current);
+
+    await act(async () => {
+      part.respondToToolApproval({ approved: true });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+
+    expect(() => part.respondToToolApproval({ approved: false })).toThrow(
+      "Tool call has no pending approval",
+    );
+  });
+
+  it("holds the run until every gate in the batch is decided", async () => {
+    const second: AgUiInterrupt = {
+      id: "int-2",
+      reason: "confirmation",
+      toolCallId: "tc-2",
+      message: "Delete /tmp/b?",
+    };
+    const { runtime, runAgent } = await gatedThread([CONFIRMATION, second]);
+
+    await act(async () => {
+      gatedPart(runtime.current, "tc-1").respondToToolApproval({
+        approved: true,
+      });
+    });
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(toolCallParts(runtime.current)[0]!.approval).toEqual({
+      id: "int-1",
+      approved: true,
+    });
+
+    await act(async () => {
+      gatedPart(runtime.current, "tc-2").respondToToolApproval({
+        approved: false,
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    expect(resumeOf(runAgent)).toEqual([
+      { interruptId: "int-1", status: "resolved" },
+      { interruptId: "int-2", status: "cancelled" },
+    ]);
+  });
+
+  it("closes an undecided gate when the interrupt is discarded", async () => {
+    const { runtime } = await gatedThread();
+
+    await act(async () => {
+      await steerAwayRef.current!("never mind");
+    });
+
+    const gate = allToolCalls(runtime.current).find(
+      (part) => part.approval?.id === "int-1",
+    );
+    expect(gate?.approval).toEqual({ id: "int-1", resolution: "cancelled" });
+  });
+});

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -255,6 +255,8 @@ export function useAgUiRuntime(
           core.cancel();
         },
         onAddToolResult: (options) => core.addToolResult(options),
+        onRespondToToolApproval: (options) =>
+          core.respondToToolApproval(options),
         onResume: (config) => core.resume(config),
         setMessages: (messages: readonly ThreadMessage[]) =>
           core.applyExternalMessages(messages),


### PR DESCRIPTION
## What

`react-ag-ui` already knows when the agent is asking permission: `RUN_FINISHED` can carry `outcome: { type: "interrupt", interrupts }`, and an `AgUiInterrupt` with `reason: "confirmation"` names the `toolCallId` it gates. Until now that only reached the app through the bespoke extras (`useAgUiInterrupts` / `useAgUiSubmitInterruptResponses`); nothing was mapped onto core's tool-approval seam, so `aui.part.respondToToolApproval` was unusable and the built-in tool-call kit had no way to answer.

This PR projects a pending confirmation onto the gated tool call as `approval: { id: interrupt.id }`, and implements `onRespondToToolApproval` so the decision goes back to the agent as an AG-UI resume entry.

## Why

AGENTS.md asks for cross-runtime parity: a capability exposed on one runtime should be exposed on every runtime that supports the concept, or the divergence should be written down. `react-ai-sdk`, `eve`, `react-opencode` and `react-pi` all wire this seam. AG-UI has an unambiguous per-tool-call confirmation concept and an existing response path, so there was no reason for it to diverge.

## The behavior on `main` today

Observed, not assumed — reproduced in a mounted runtime with an agent that gates a `delete_file` call on a `confirmation` interrupt:

- The assistant message is `requires-action` / `interrupt`, and the unresolved tool-call part inherits that status, so the default kit **does** render the Allow/Deny bar.
- The part has no `approval`, so `part.respondToToolApproval(...)` throws `Tool call has no pending approval` before it ever reaches the runtime, and the kit's `respond()` falls through to its `addResult` branch (`tool-fallback.tsx`).
- Clicking **Allow** therefore writes the literal string `"Approved by user"` as the tool result, with `isError: false`. The agent is never told anything: `runAgent` is not called again, the interrupt stays pending, and the gated tool never runs. The turn looks answered and is not.
- Because the interrupt is still pending, later sends do not start a run either — the thread is stuck until the app answers the interrupt through the bespoke hooks.

Same silently-wrong-answer shape as the ADK gap in #5816.

## How

- `runtime/adapter/tool-approval.ts` (new, pure): `projectAgUiToolApprovals` turns the open confirmations into gates keyed by tool call; `withToolApprovalDecision` / `withClosedToolApprovals` record and close decisions on the part; `collectToolApprovalResume` maps recorded decisions onto `AgUiResumeEntry[]`.
- The run aggregator stamps `approval` onto the tool-call part it belongs to when it emits a snapshot carrying interrupts. `requires-action` then comes free, and the default kit renders Allow/Deny wired to the real seam.
- `AgUiThreadRuntimeCore.respondToToolApproval` records the decision on the part and, once the whole interrupt batch is decided, resumes through the existing `submitInterruptResponses`.
- `useAgUiRuntime` supplies `onRespondToToolApproval` on the external-store adapter.

### Mapping, and what it deliberately does not do

- **Approve → `{ interruptId, status: "resolved" }`. Deny → `{ interruptId, status: "cancelled" }`.** `resolved | cancelled` is the entire vocabulary `AgUiResumeEntry` has; a denial has no other native encoding, and inventing a `payload` shape (`{ confirmed: false }` or similar) would be fabricating a protocol the agent never agreed to. This is the same status a denial gets today when the app discards an interrupt through `useAgUiSteerAway`.
- **A denial reason has no wire field**, so it is kept on the part's `approval.reason` and not sent. (Same limitation as ADK in #5816.)
- **No `options` are declared**, so the kit renders plain Allow/Deny rather than allow-always/reject-always; AG-UI has no scope or grant concept to back them.
- **No fabricated tool result** is written in either direction. The agent decides what the gated call returns.
- **Batching:** AG-UI resumes a run with one response per open interrupt, so a decision is held on the part until every gate in the batch is answered, then all of them are submitted together. A batch that also contains an interrupt the seam cannot answer (`input_required`, or a confirmation with no `toolCallId`) is never auto-resumed — those still belong to the bespoke hooks.
- A gate that closes without a decision reaching the part (answered through the bespoke hooks, or discarded by `steerAway`) is marked `resolution: "cancelled"` rather than left permanently pending.

## Surface

Additive only. The bespoke interrupt hooks are untouched and nothing new is exported — the wiring is reachable through the existing core API. `api-surface` and `api-reference` regenerate with zero drift.

## Tests

32 new tests, colocated:

- `runtime/adapter/tool-approval.test.ts` (24) — projection in both directions, stale/duplicate approval ids, deny mapping, batch completeness, and malformed interrupts/parts that must not throw.
- `useAgUiRuntime.approval.test.tsx` (8) — mounted runtime with a fake agent, driving the exact part-runtime method the default kit calls: the gate appears on the right tool call, Allow resumes with `resolved`, Deny resumes with `cancelled`, no fabricated result is ever written, a settled gate refuses a second decision, a two-gate batch waits for both, and a discarded interrupt closes its gate as cancelled.

Revert-proof: with only the runtime wiring reverted to `main` (aggregator, core method, adapter option) and the tests kept, 7 of the 8 mounted tests fail. The full `react-ag-ui` suite is 389 passing; `tsc`, `lint`, `api-surface:check` and the api-reference generator are clean.

Twin of #5816 (`react-google-adk`), which closes the same gap for ADK. The structure differs where the adapter does: ADK converts provider messages through `useExternalMessageConverter`, so its projection lives in the converter; AG-UI owns core `ThreadMessage`s in its own repository, so the projection lives in the run aggregator and the decisions live on the parts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pFzV8_uWpDsaZzF3mcUgU6CuSH7Gu1HNrMrYE4C4sPE-SsGt8IcPQqT6y1s?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->