### PR TITLE
fix(core): cancelRun resyncs current messages, not a pre-cancel snapshot

### DIFF
--- a/.changeset/olive-pans-shave.md
+++ b/.changeset/olive-pans-shave.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: `cancelRun()` resyncs the current repository instead of a snapshot captured before the cancel. The deferred `updateMessages` lands a macrotask after the cancel, and a store that settles the cancelled turn and re-supplies its content in that gap had the older array written back over it — the settled turn painted, then reverted, returning only on reload. Re-reading at flush time keeps the resync (including committing a kept optimistic message) while letting anything that arrived in between stand.

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -633,7 +633,7 @@ export class ExternalStoreThreadRuntimeCore
       this.repository.deleteMessage(head.id);
     }
 
-    let messages = this.repository.getMessages();
+    const messages = this.repository.getMessages();
     const previousMessage = messages[messages.length - 1];
     const trailingUserLeaf =
       this._store.setMessages !== undefined &&
@@ -656,14 +656,23 @@ export class ExternalStoreThreadRuntimeCore
       })
     ) {
       this.repository.deleteMessage(trailingUserLeaf.id);
-      messages = this.repository.getMessages();
     } else {
       this._notifySubscribers();
     }
 
     // resync messages (for reloading, to restore the previous branch)
+    //
+    // Read the repository at flush time rather than writing the snapshot
+    // captured above. The write lands a macrotask later, and the store can
+    // legitimately move in that gap — a server-driven store that settles the
+    // cancelled turn and re-supplies its content does so in the same tick as
+    // the cancel. Writing the captured array then stamps a pre-cancel snapshot
+    // over that newer state, and it comes back only on reload. The repository
+    // already reflects whatever arrived in the meantime, so re-reading resyncs
+    // the current truth while still committing a kept optimistic message when
+    // nothing else arrived.
     setTimeout(() => {
-      this.updateMessages(messages);
+      this.updateMessages(this.repository.getMessages());
     }, 0);
   }
 

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -237,6 +237,60 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(lastCall.map((m) => m.id)).toContain("server-msg");
     });
 
+    it("does not revert a store update that lands before the resync flushes", async () => {
+      const optimisticAssistant = {
+        ...createAssistantMessage("server-msg", "partial answer"),
+        status: { type: "running" as const },
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+          isOptimistic: true,
+        },
+      } as ThreadMessage;
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages: [createUserMessage("u1"), optimisticAssistant],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+
+      // The store settles the cancelled turn and re-supplies it, in the same
+      // tick as the cancel — the normal shape for a server-driven store.
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [
+            createUserMessage("u1"),
+            createAssistantMessage("server-msg", "partial answer — stopped"),
+          ],
+          isRunning: false,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The deferred resync must not stamp the pre-cancel snapshot back over
+      // the settled turn.
+      const lastCall = setMessages.mock.lastCall?.[0] as
+        | ThreadMessage[]
+        | undefined;
+      if (lastCall) {
+        const settled = lastCall.find((m) => m.id === "server-msg");
+        expect(getThreadMessageText(settled!)).toBe("partial answer — stopped");
+      }
+      expect(getThreadMessageText(core.messages.at(-1)!)).toBe(
+        "partial answer — stopped",
+      );
+    });
+
     it("evicts an empty optimistic head on cancel", async () => {
       const optimisticAssistant = {
         ...createAssistantMessage("server-msg", ""),


### PR DESCRIPTION
Fixes #5820.

`cancelRun()` captures `messages` synchronously and writes it back through `updateMessages` a macrotask later:

```ts
// resync messages (for reloading, to restore the previous branch)
setTimeout(() => {
  this.updateMessages(messages);
}, 0);
```

The store can legitimately move in that gap. On a server-driven runtime it routinely does: the server settles the cancelled turn and re-supplies its content in the same tick as the cancel. Writing the captured array then stamps the pre-cancel snapshot over that newer state, and it comes back only on reload — which is what makes it read as a client bug rather than a lost response.

This reads the repository at flush time instead. Every existing behaviour is kept: the resync still restores the branch after a rollback, and still commits a kept partially-streamed optimistic message when nothing else arrived. What changes is only that state which arrived in between is allowed to stand.

### A correction, since the first push of this branch was wrong

My first attempt gated the resync on whether a rollback had actually happened. That broke `keeps a partially-streamed optimistic message on cancel` — which is exactly the no-rollback case that genuinely needs the resync, and your suite caught it. Thanks for the test; it changed the fix. The staleness was the defect, not the resync.

### Test

Added `does not revert a store update that lands before the resync flushes`: cancel, then the store settles and re-supplies the turn in the same tick, then the flush. It fails on the previous code and passes here.

Full `@assistant-ui/core` suite locally: 100 files / 1043 tests pass. `oxlint` and `oxfmt` clean.

Happy to reshape this however you prefer.
