### PR TITLE
docs: stop calling Slack Text, Header, and Divider faithful when styling is dropped

### DIFF
--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -45,12 +45,12 @@ type SlackConversionWarning = {
 
 | Component | Slack output | Fidelity |
 |---|---|---|
-| `Header` | `header` block | Faithful |
-| `Text` | `section` block with `mrkdwn` text | Faithful |
+| `Header` | `header` block | Only `text` survives; `size` is dropped silently, since Slack's `header` block has no size |
+| `Text` | `section` block with `mrkdwn` text | Only `value` survives; `size`, `weight`, and `color` are dropped silently |
 | `Markdown` | `markdown` block | Downgrades to a `section` once the payload's markdown budget is spent |
 | `Caption`, `Badge` | `context` block with one element | The two become identical output and cannot be told apart coming back |
 | `Image` | `image` block | Only `src` and `alt` survive; `size` and `round` are dropped silently |
-| `Divider` | `divider` block | Faithful |
+| `Divider` | `divider` block | `flush` is dropped silently |
 | `Fact` | Merged into one `section`'s `fields`, as `*label*` then value | Consecutive facts merge; every 10 fields start a new section |
 | `Table` | `data_table` block, first row as header | Cells become `raw_number` or `raw_text`; rows are padded to a uniform width; a column without a string label keeps its position with an empty header and warns |
 | `Card` | Native `card` block, or a header plus inline blocks | See [Cards](#cards) |
@@ -71,6 +71,8 @@ type SlackConversionWarning = {
 | `Spacer`, `Icon` | Dropped | Silently, since neither has a Slack equivalent |
 
 An unknown component and a bare string child are both handled: the unknown one is dropped with a warning, and the string becomes a `section`.
+
+Presentation props that Block Kit has no field for are dropped silently, without a warning, because the node itself still renders. That covers `Box`'s `width`, `height`, `radius`, and `background`; `Card`'s `padding`, `background`, and `asForm`; `gap`, `align`, and `justify` on `Row`, `Col`, and `Form`; `Badge`'s `variant`; `Carousel`'s `label`; and `Button`'s `block`. `Button`'s `submit` is dropped for a different reason: Slack has no client-side form model to submit into, so a submit button and a click button both convert to the same `button` element carrying the node's `$action`.
 
 ### Cards
 

--- a/apps/docs/content/docs/tools/generative-ui-slack.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-slack.mdx
@@ -72,7 +72,7 @@ type SlackConversionWarning = {
 
 An unknown component and a bare string child are both handled: the unknown one is dropped with a warning, and the string becomes a `section`.
 
-Presentation props that Block Kit has no field for are dropped silently, without a warning, because the node itself still renders. That covers `Box`'s `width`, `height`, `radius`, and `background`; `Card`'s `padding`, `background`, and `asForm`; `gap`, `align`, and `justify` on `Row`, `Col`, and `Form`; `Badge`'s `variant`; `Carousel`'s `label`; and `Button`'s `block`. `Button`'s `submit` is dropped for a different reason: Slack has no client-side form model to submit into, so a submit button and a click button both convert to the same `button` element carrying the node's `$action`.
+Presentation props the converter does not map are dropped silently, without a warning, because the node itself still renders. That covers `Box`'s `width`, `height`, `radius`, and `background`; `Card`'s `padding` and `background`; `gap` on `Row`, `Col`, and `Form`, `align` on `Row` and `Col`, and `justify` on `Row`; `Badge`'s `variant`; `Carousel`'s `label`; and `Button`'s `block`. `Card`'s `asForm` and `Button`'s `submit` are dropped for a different reason: Slack has no client-side form model to submit into, so a submit button and a click button both convert to the same `button` element carrying the node's `$action`, and a card marked `asForm` converts exactly like one that is not.
 
 ### Cards
 


### PR DESCRIPTION
The Slack generative-UI guide's component-mapping table marks `Header`, `Text`, and `Divider` as **Faithful**. They are not. Each of those components declares presentation props that `toSlackBlocks` never reads, so the props vanish with no warning and the reader has no way to learn it except by diffing a posted message against the browser.

This is also an internal contradiction: the Teams guide already documents that `Text`'s size, weight, and color collapse, so the two sibling pages currently disagree about the same vocabulary component.

## What's actually dropped

`Text` (`packages/react-generative-ui/src/slack/toSlackBlocks.ts:1045-1060`) reads only `props["value"]` into a `mrkdwn` section. `size`, `weight`, and `color` — all declared on the component (`src/vocabulary/text.tsx:21-31`) — are never touched.

`Header` (`toSlackBlocks.ts:1030-1044`) reads only `props["text"]`. Its `size` prop (`text.tsx:6-13`) has nowhere to go: Slack's `header` block carries a `plain_text` field and no size.

`Divider` (`toSlackBlocks.ts:1090-1091`) returns a bare `{ type: "divider" }`, discarding `flush` (`src/vocabulary/media.tsx:44-55`).

None of these emits a warning, so `warnings` comes back empty and the loss is invisible even to a caller that logs every downgrade — the exact debugging path the Warnings section recommends.

Verified by running the converter on `upstream/main`:

```
{ $type: "Text", value: "hi", size: "3xl", weight: "bold", color: "emphasis" }
  -> { type: "section", text: { type: "mrkdwn", text: "hi" } }
{ $type: "Header", text: "H", size: "sm" }
  -> { type: "header", text: { type: "plain_text", text: "H" } }
{ $type: "Divider", flush: true }
  -> { type: "divider" }

warnings: []
```

## Changes

The three `Faithful` cells now say what survives, matching the phrasing the `Image` row already uses ("Only `src` and `alt` survive").

One paragraph after the table also collects the purely decorative props the converter discards across the rest of the vocabulary, so this page stops implying that anything not called out in the table round-trips. A grep of `toSlackBlocks.ts` confirms none of `padding`, `background`, `asForm`, `gap`, `align`, `justify`, `variant`, `block`, `submit`, `width`, `height`, `radius`, or `flush` appears anywhere in the file. `Button`'s `submit` gets a separate sentence because it is dropped for a structural reason rather than a cosmetic one: Slack has no client-side form model, so a submit button and a click button produce the same element.

I deliberately kept this to prose rather than adding table columns — the fidelity column is already the widest thing on the page.

## Notes

The claims here come from two independent audits of the converter source done tonight, and I re-verified every one against `upstream/main` before writing, both by reading the source and by executing the converter (transcript above).

Docs-only; `apps/docs` is private, so no changeset. `pnpm -C apps/docs generate:api-reference --strict` produces zero drift (this page is not under the generator-owned `(reference)/api-reference/` tree), and `pnpm lint` is clean.

Sibling PR for the Teams guide, which has its own set of wrong claims: (opening next). Both align this page with the fidelity matrix in #5632.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OWbLRZKbGHm0rLhT_qZN8UpbQAPfxmU8l1pwMIcsVukjGdDy6kfKlQ8Xc8w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->