### PR TITLE
fix(core): reconcile cancelRun's resync with in-gap store updates

### DIFF
--- a/.changeset/cancel-resync-reads-current.md
+++ b/.changeset/cancel-resync-reads-current.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: reconcile cancelRun's deferred resync with store updates that land before it flushes, instead of stamping a pre-cancel snapshot over them

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -742,6 +742,11 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): boolean;
+  retractDraft(draft: {
+    text: string;
+    quote?: QuoteInfo | undefined;
+    attachments?: readonly Attachment[] | undefined;
+  }): void;
   private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];
@@ -1837,6 +1842,7 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   exportExternalState(): any;
   importExternalState(state: any): void;
   cancelRun(): void;
+  private dropEmptyOptimisticHead;
   addToolResult(options: AddToolResultOptions): void;
   resumeToolCall(options: ResumeToolCallOptions): void;
   respondToToolApproval(options: RespondToToolApprovalOptions): void;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -719,6 +719,11 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): boolean;
+  retractDraft(draft: {
+    text: string;
+    quote?: QuoteInfo | undefined;
+    attachments?: readonly Attachment[] | undefined;
+  }): void;
   private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -711,6 +711,11 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): boolean;
+  retractDraft(draft: {
+    text: string;
+    quote?: QuoteInfo | undefined;
+    attachments?: readonly Attachment[] | undefined;
+  }): void;
   private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1027,6 +1027,11 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): boolean;
+  retractDraft(draft: {
+    text: string;
+    quote?: QuoteInfo | undefined;
+    attachments?: readonly Attachment[] | undefined;
+  }): void;
   private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -341,6 +341,34 @@ export abstract class BaseComposerRuntimeCore
     return true;
   }
 
+  /**
+   * Inverse of `restoreDraft`: clears the composer while it still holds
+   * exactly the given draft. A draft the user has edited since is left
+   * untouched.
+   */
+  public retractDraft(draft: {
+    text: string;
+    quote?: QuoteInfo | undefined;
+    attachments?: readonly Attachment[] | undefined;
+  }): void {
+    const attachmentsUntouched =
+      draft.attachments !== undefined
+        ? this._attachments === draft.attachments
+        : this._attachments.length === 0;
+    if (
+      this._text !== draft.text ||
+      this._quote !== draft.quote ||
+      !attachmentsUntouched
+    )
+      return;
+
+    this._text = "";
+    this._rebaseDictation("");
+    this._quote = undefined;
+    this._attachments = [];
+    this._notifySubscribers();
+  }
+
   // The generation check is what a reset and a later send use to invalidate a
   // draft, so of several queued drafts only the most recent one is still
   // restorable.

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage, ThreadMessage } from "../../types/message";
+import type { Attachment } from "../../types/attachment";
 import type {
   AddToolResultOptions,
   ResumeRunConfig,
@@ -626,14 +627,9 @@ export class ExternalStoreThreadRuntimeCore
 
     this._store.onCancel();
 
-    // Drop an empty optimistic head (placeholder or pre-stream message); a
-    // partially-streamed one is kept and re-supplied by the store on resync.
-    const head = this.repository.getMessages().at(-1);
-    if (head && head.metadata.isOptimistic && head.content.length === 0) {
-      this.repository.deleteMessage(head.id);
-    }
+    this.dropEmptyOptimisticHead();
 
-    let messages = this.repository.getMessages();
+    const messages = this.repository.getMessages();
     const previousMessage = messages[messages.length - 1];
     const trailingUserLeaf =
       this._store.setMessages !== undefined &&
@@ -647,24 +643,57 @@ export class ExternalStoreThreadRuntimeCore
     // one move: the composer refuses while the user is writing, and removing
     // the message then would leave it nowhere. A message the composer cannot
     // hold whole, carrying content parts it has no home for, is not moved.
-    if (
-      trailingUserLeaf &&
-      this.composer.restoreDraft({
+    let movedLeaf:
+      | {
+          id: string;
+          draft: {
+            text: string;
+            attachments: readonly Attachment[];
+            quote: QuoteInfo | undefined;
+          };
+        }
+      | undefined;
+    if (trailingUserLeaf) {
+      const draft = {
         text: getThreadMessageText(trailingUserLeaf),
         attachments: trailingUserLeaf.attachments,
         quote: trailingUserLeaf.metadata.custom.quote as QuoteInfo | undefined,
-      })
-    ) {
-      this.repository.deleteMessage(trailingUserLeaf.id);
-      messages = this.repository.getMessages();
-    } else {
-      this._notifySubscribers();
+      };
+      if (this.composer.restoreDraft(draft)) {
+        this.repository.deleteMessage(trailingUserLeaf.id);
+        movedLeaf = { id: trailingUserLeaf.id, draft };
+      }
     }
+    if (!movedLeaf) this._notifySubscribers();
 
-    // resync messages (for reloading, to restore the previous branch)
+    // The resync commits what the cancel left (a kept optimistic message, the
+    // restored branch) back to the store a macrotask later. The store may move
+    // in that gap; a server settling the cancelled turn lands in the same
+    // tick. Read the repository at flush time and re-apply the rollbacks to
+    // it, instead of stamping a snapshot captured above over the newer state.
     setTimeout(() => {
-      this.updateMessages(messages);
+      this.dropEmptyOptimisticHead();
+      if (movedLeaf) {
+        const current = this.repository.getMessages();
+        if (current.at(-1)?.id === movedLeaf.id) {
+          // Unanswered tail: the removal has not reached the store yet.
+          this.repository.deleteMessage(movedLeaf.id);
+        } else if (current.some((m) => m.id === movedLeaf.id)) {
+          // Answered in the gap: keep the turn, take the untouched draft back.
+          this.composer.retractDraft(movedLeaf.draft);
+        }
+      }
+      this.updateMessages(this.repository.getMessages());
     }, 0);
+  }
+
+  // Placeholder or pre-stream message; a partially-streamed one is kept and
+  // committed to the store by the cancel resync.
+  private dropEmptyOptimisticHead(): void {
+    const head = this.repository.getMessages().at(-1);
+    if (head && head.metadata.isOptimistic && head.content.length === 0) {
+      this.repository.deleteMessage(head.id);
+    }
   }
 
   public addToolResult(options: AddToolResultOptions) {

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -679,7 +679,8 @@ export class ExternalStoreThreadRuntimeCore
           // Unanswered tail: the removal has not reached the store yet.
           this.repository.deleteMessage(movedLeaf.id);
         } else if (current.some((m) => m.id === movedLeaf.id)) {
-          // Answered in the gap: keep the turn, take the untouched draft back.
+          // The store kept the turn in the thread; take the untouched draft
+          // back so the same content does not sit in both places.
           this.composer.retractDraft(movedLeaf.draft);
         }
       }

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -460,3 +460,70 @@ describe("BaseComposerRuntimeCore.restoreDraft", () => {
     expect(composer.text).toBe("returned and this");
   });
 });
+
+describe("BaseComposerRuntimeCore.retractDraft", () => {
+  const makeCompleteAttachment = (id: string) => ({
+    id,
+    type: "file" as const,
+    name: "spec.pdf",
+    contentType: "application/pdf",
+    status: { type: "complete" as const },
+    content: [],
+  });
+
+  it("clears the composer while it still holds the exact draft", () => {
+    const composer = new TestComposerCore();
+    const draft = {
+      text: "returned",
+      quote: { text: "quoted", messageId: "m-1" },
+      attachments: [makeCompleteAttachment("a1")],
+    };
+
+    expect(composer.restoreDraft(draft)).toBe(true);
+    composer.retractDraft(draft);
+
+    expect(composer.text).toBe("");
+    expect(composer.quote).toBeUndefined();
+    expect(composer.attachments).toEqual([]);
+  });
+
+  it("leaves an edited text alone", () => {
+    const composer = new TestComposerCore();
+    const draft = { text: "returned" };
+
+    expect(composer.restoreDraft(draft)).toBe(true);
+    composer.setText("edited");
+    composer.retractDraft(draft);
+
+    expect(composer.text).toBe("edited");
+  });
+
+  it("leaves a changed quote alone", () => {
+    const composer = new TestComposerCore();
+    const draft = { text: "returned", quote: { text: "quoted" } };
+
+    expect(composer.restoreDraft(draft)).toBe(true);
+    composer.setQuote({ text: "other" });
+    composer.retractDraft(draft);
+
+    expect(composer.text).toBe("returned");
+    expect(composer.quote).toEqual({ text: "other" });
+  });
+
+  it("leaves changed attachments alone", () => {
+    const composer = new TestComposerCore();
+    const draft = {
+      text: "returned",
+      attachments: [makeCompleteAttachment("a1")],
+    };
+
+    expect(composer.restoreDraft(draft)).toBe(true);
+    composer.retractDraft({
+      ...draft,
+      attachments: [makeCompleteAttachment("a1")],
+    });
+
+    expect(composer.text).toBe("returned");
+    expect(composer.attachments).toHaveLength(1);
+  });
+});

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -237,6 +237,175 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(lastCall.map((m) => m.id)).toContain("server-msg");
     });
 
+    it("does not revert a store update that lands before the resync flushes", async () => {
+      const optimisticAssistant = {
+        ...createAssistantMessage("server-msg", "partial answer"),
+        status: { type: "running" as const },
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+          isOptimistic: true,
+        },
+      } as ThreadMessage;
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages: [createUserMessage("u1"), optimisticAssistant],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+
+      // The store settles the cancelled turn and re-supplies it in the same
+      // tick as the cancel.
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [
+            createUserMessage("u1"),
+            createAssistantMessage("server-msg", "partial answer (stopped)"),
+          ],
+          isRunning: false,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(setMessages).toHaveBeenCalled();
+      const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
+      const texts = lastCall.map(getThreadMessageText);
+      expect(texts).toContain("partial answer (stopped)");
+      expect(texts).not.toContain("partial answer");
+    });
+
+    it("re-applies the user leaf rollback when the store updates before the flush", async () => {
+      const messages = [createUserMessage("u1", "cancel me")];
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages,
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+
+      // The host flips isRunning after onCancel; the store still holds the
+      // rolled-back message because only the deferred resync removes it.
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages,
+          isRunning: false,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.composer.text).toBe("cancel me");
+      expect(setMessages).toHaveBeenCalled();
+      const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
+      expect(lastCall.map((m) => m.id)).not.toContain("u1");
+      expect(core.export().messages.map((m) => m.message.id)).not.toContain(
+        "u1",
+      );
+    });
+
+    it("keeps a rolled-back user leaf the store answered in the gap and takes the draft back", async () => {
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages: [createUserMessage("u1", "cancel me")],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+      expect(core.composer.text).toBe("cancel me");
+
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [
+            createUserMessage("u1", "cancel me"),
+            createAssistantMessage("a1", "answered anyway"),
+          ],
+          isRunning: false,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.composer.text).toBe("");
+      const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
+      expect(lastCall.map((m) => m.id)).toEqual(["u1", "a1"]);
+    });
+
+    it("leaves an edited draft alone when the store answered in the gap", async () => {
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages: [createUserMessage("u1", "cancel me")],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+      core.composer.setText("edited");
+
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [
+            createUserMessage("u1", "cancel me"),
+            createAssistantMessage("a1", "answered anyway"),
+          ],
+          isRunning: false,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.composer.text).toBe("edited");
+      const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
+      expect(lastCall.map((m) => m.id)).toEqual(["u1", "a1"]);
+    });
+
+    it("drops a placeholder regenerated between cancel and flush", async () => {
+      const setMessages = vi.fn();
+      const adapter = createBaseAdapter({
+        messages: [createUserMessage("u1", "cancel me")],
+        isRunning: true,
+        onCancel: vi.fn(),
+        setMessages,
+      });
+      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+
+      core.cancelRun();
+
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [createUserMessage("u1", "cancel me")],
+          isRunning: true,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(core.composer.text).toBe("cancel me");
+      const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
+      expect(lastCall).toEqual([]);
+    });
+
     it("evicts an empty optimistic head on cancel", async () => {
       const optimisticAssistant = {
         ...createAssistantMessage("server-msg", ""),


### PR DESCRIPTION
closes #5820

## summary

- `cancelRun()` captured the message array synchronously and wrote it back through `setMessages` a macrotask later; a store that settles the cancelled turn and re-supplies its content in that gap had the older snapshot stamped over it, so the settled partial answer painted, vanished, and only returned on reload
- the deferred resync now reads the repository at flush time and re-applies the cancel's rollbacks to whatever is current: an empty optimistic head is dropped again (a placeholder regenerated by an in-gap adapter update no longer leaks into `setMessages`), and a user leaf that was moved into the composer is re-deleted while it is still the unanswered tail, so the rollback survives the `isRunning` flip every host performs right after `onCancel`
- when the in-gap update shows the rolled-back user leaf was answered after all, the turn stays in the thread and the new `BaseComposerRuntimeCore.retractDraft` takes the restored draft back out of the composer, but only while the user has not edited it
- adds five cancelRun tests covering the settle-in-gap overwrite, rollback persistence across an interleaved adapter update, the answered-leaf keep with draft retraction (untouched and edited), and the regenerated-placeholder drop

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/core -> 100 files, 1047 tests green
- [x] `pnpm exec vitest run src/useEveAgentRuntime.test.tsx` in packages/eve -> 38 tests green (external store consumer without `setMessages`)
- [x] `pnpm build` in packages/core -> clean, and `oxlint`/`oxfmt --check` on the touched files -> clean
- [x] the settle-in-gap test fails on main and the interleaved-update test fails on the #5821 approach, and both pass here

### reviewer should verify

- [ ] with a `useExternalStoreRuntime` app whose store re-supplies the settled turn on cancel, press stop mid-stream: the settled partial answer must stay painted instead of reverting until reload
- [ ] press stop before the first token with a `setMessages` store: the user message must move into the composer and stay out of the thread after the run settles

## notes

- supersedes #5821, whose flush-time read fixed the overwrite but undid the trailing user leaf rollback whenever the host's `isRunning` flip re-ran the adapter path before the flush (the message came back into the thread while its text sat in the composer); the diagnosis and the settle-in-gap scenario there are @ozzaii's, carried into this suite
- supersedes #5371, which reported the same stale-snapshot defect earlier with a cancelled-id ledger, but predates the cancel path rework in #5798, #5799, and #5800 that this builds on

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nW1sVLshtXFz_IEQfLzQgFpQnn060f8tfOl-8i26XE8TV9buzutRhRxrFuw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->