### PR TITLE
fix(store): filter derived-only scoped delivery against the child's bindings

### DIFF
--- a/.changeset/derived-only-scoped-delivery.md
+++ b/.changeset/derived-only-scoped-delivery.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: scoped event listeners under a derived-only provider filter against the child's own bindings instead of the parent's, in both directions and through scope-less intermediate hosts

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -540,3 +540,150 @@ describe("Derived scopes", () => {
     expect(result.current).toBe("");
   });
 });
+
+describe("derived-only providers", () => {
+  const messageByIndex = (index: number) =>
+    Derived({
+      source: "thread",
+      query: { index },
+      get: (aui: AnyClient) => aui.thread.message({ index }),
+    } as never);
+
+  const Listener = ({ cb }: { cb: (payload: unknown) => void }) => {
+    useAuiEvent("message.pinged" as never, cb as never);
+    return null;
+  };
+
+  const DerivedChild = ({
+    index,
+    children,
+    capture,
+  }: {
+    index: number;
+    children?: ReactNode;
+    capture?: (aui: AnyClient) => void;
+  }) => {
+    const aui = useAui({ message: messageByIndex(index) } as never);
+    capture?.(aui);
+    return <AuiProvider value={aui as never}>{children}</AuiProvider>;
+  };
+
+  const mountRoot = (
+    rootConfig: Record<string, unknown>,
+    children: ReactNode,
+  ) => {
+    let root!: AnyClient;
+    const Root = () => {
+      root = useAui(rootConfig as never);
+      return <AuiProvider value={root as never}>{children}</AuiProvider>;
+    };
+    render(<Root />);
+    return { root: () => root };
+  };
+
+  it("delivers the child binding's event when the parent lacks the scope", async () => {
+    const cb = vi.fn();
+    const { root } = mountRoot(
+      { thread: ThreadClient() },
+      <DerivedChild index={1}>
+        <Listener cb={cb} />
+      </DerivedChild>,
+    );
+
+    root().thread.message({ index: 1 }).ping("hit");
+    await flushEvents();
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "hit" });
+  });
+
+  it("filters both directions when the parent holds a different instance", async () => {
+    const cb = vi.fn();
+    const { root } = mountRoot(
+      { thread: ThreadClient(), message: messageByIndex(0) },
+      <DerivedChild index={1}>
+        <Listener cb={cb} />
+      </DerivedChild>,
+    );
+
+    root().thread.message({ index: 0 }).ping("parent");
+    await flushEvents();
+    expect(cb).not.toHaveBeenCalled();
+
+    root().thread.message({ index: 1 }).ping("child");
+    await flushEvents();
+    expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "child" });
+  });
+
+  it("reaches the child listener through a scope-less intermediate host", async () => {
+    const cb = vi.fn();
+    let intermediate!: AnyClient;
+    const Intermediate = ({ children }: { children: ReactNode }) => {
+      intermediate = useAui({} as never);
+      return (
+        <AuiProvider value={intermediate as never}>{children}</AuiProvider>
+      );
+    };
+    const { root } = mountRoot(
+      { thread: ThreadClient() },
+      <Intermediate>
+        <DerivedChild index={1}>
+          <Listener cb={cb} />
+        </DerivedChild>
+      </Intermediate>,
+    );
+
+    root().thread.message({ index: 1 }).ping("deep");
+    await flushEvents();
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "deep" });
+  });
+
+  it("follows the committed selection across a structural swap", async () => {
+    const cb = vi.fn();
+    let setIndex!: (index: number) => void;
+    const Swapping = () => {
+      const [index, updateIndex] = useState(0);
+      setIndex = updateIndex;
+      return (
+        <DerivedChild index={index}>
+          <Listener cb={cb} />
+        </DerivedChild>
+      );
+    };
+    const { root } = mountRoot({ thread: ThreadClient() }, <Swapping />);
+
+    act(() => setIndex(1));
+
+    root().thread.message({ index: 0 }).ping("stale");
+    await flushEvents();
+    expect(cb).not.toHaveBeenCalled();
+
+    root().thread.message({ index: 1 }).ping("fresh");
+    await flushEvents();
+    expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "fresh" });
+  });
+
+  it("filters a direct aui.on subscription by the child binding", async () => {
+    const cb = vi.fn();
+    let child!: AnyClient;
+    const { root } = mountRoot(
+      { thread: ThreadClient(), message: messageByIndex(0) },
+      <DerivedChild
+        index={1}
+        capture={(aui) => {
+          child = aui;
+        }}
+      />,
+    );
+
+    act(() => {
+      child.on("message.pinged", cb);
+    });
+
+    root().thread.message({ index: 0 }).ping("parent");
+    root().thread.message({ index: 1 }).ping("child");
+    await flushEvents();
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "child" });
+  });
+});

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -708,9 +708,11 @@ describe("derived-only providers", () => {
       </DerivedChild>,
     );
 
-    // The chain above a derived-only level filters forwarded subscriptions
-    // with that level's ref; a shadowing descendant's own binding is not
-    // consulted above its own notification manager.
+    // A forwarded subscription crossing a derived-only level filters with
+    // that level's ref above it, so the leaking ancestor is now the
+    // derived-only level (previously the root, and only when it bound the
+    // scope); the descendant's own shadowed binding stays unreachable above
+    // its own notification manager.
     root().thread.message({ index: 0 }).ping("shadowed");
     root().thread.message({ index: 1 }).ping("ancestor");
     await flushEvents();

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -542,6 +542,9 @@ describe("Derived scopes", () => {
 });
 
 describe("derived-only providers", () => {
+  const useAnchorClient = () => ({ getState: () => ({}) });
+  const AnchorClient = resource(useAnchorClient);
+
   const messageByIndex = (index: number) =>
     Derived({
       source: "thread",
@@ -661,6 +664,61 @@ describe("derived-only providers", () => {
     root().thread.message({ index: 1 }).ping("fresh");
     await flushEvents();
     expect(cb).toHaveBeenCalledExactlyOnceWith({ id: "m1", value: "fresh" });
+  });
+
+  it("delivers to a hosted child inheriting the scope from a derived-only provider", async () => {
+    const cb = vi.fn();
+    const HostedChild = ({ children }: { children?: ReactNode }) => {
+      const aui = useAui({ anchor: AnchorClient() } as never);
+      return <AuiProvider value={aui as never}>{children}</AuiProvider>;
+    };
+    const { root } = mountRoot(
+      { thread: ThreadClient() },
+      <DerivedChild index={1}>
+        <HostedChild>
+          <Listener cb={cb} />
+        </HostedChild>
+      </DerivedChild>,
+    );
+
+    root().thread.message({ index: 1 }).ping("inherited");
+    await flushEvents();
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith({
+      id: "m1",
+      value: "inherited",
+    });
+  });
+
+  it("routes a shadowing hosted descendant through the derived-only ancestor's binding", async () => {
+    const cb = vi.fn();
+    const ShadowingChild = ({ children }: { children?: ReactNode }) => {
+      const aui = useAui({
+        anchor: AnchorClient(),
+        message: messageByIndex(0),
+      } as never);
+      return <AuiProvider value={aui as never}>{children}</AuiProvider>;
+    };
+    const { root } = mountRoot(
+      { thread: ThreadClient() },
+      <DerivedChild index={1}>
+        <ShadowingChild>
+          <Listener cb={cb} />
+        </ShadowingChild>
+      </DerivedChild>,
+    );
+
+    // The chain above a derived-only level filters forwarded subscriptions
+    // with that level's ref; a shadowing descendant's own binding is not
+    // consulted above its own notification manager.
+    root().thread.message({ index: 0 }).ping("shadowed");
+    root().thread.message({ index: 1 }).ping("ancestor");
+    await flushEvents();
+
+    expect(cb).toHaveBeenCalledExactlyOnceWith({
+      id: "m1",
+      value: "ancestor",
+    });
   });
 
   it("filters a direct aui.on subscription by the child binding", async () => {

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -112,7 +112,7 @@ type ClientFields = {
 // so every level filters delivery against the subscribing provider's own
 // committed bindings instead of its own. Module-internal; the public
 // selector shape is unchanged.
-const EVENT_RECEIVER_REF = Symbol("aui.event-receiver-ref");
+const EVENT_RECEIVER_REF = Symbol.for("aui.event-receiver-ref");
 
 type RiddenSelector = { [EVENT_RECEIVER_REF]?: ClientRef };
 

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -108,6 +108,14 @@ type ClientFields = {
   on: AssistantClient["on"];
 };
 
+// Rides on the selector object through the parent-chain forwarding in `on`,
+// so every level filters delivery against the subscribing provider's own
+// committed bindings instead of its own. Module-internal; the public
+// selector shape is unchanged.
+const EVENT_RECEIVER_REF = Symbol("aui.event-receiver-ref");
+
+type RiddenSelector = { [EVENT_RECEIVER_REF]?: ClientRef };
+
 const createClientObject = (
   parent: AssistantClient,
   fields: ClientFields,
@@ -143,8 +151,9 @@ const useClientFields = ({
         }
 
         const { scope, event } = normalizeEventSelector(selector);
+        const receiverRef = (selector as RiddenSelector)[EVENT_RECEIVER_REF];
 
-        if (scope !== "*") {
+        if (scope !== "*" && !receiverRef) {
           // A hand-built parent may lack the scope entirely; forward to it
           const source = this[scope as ClientNames]?.source;
           if (source === null) {
@@ -160,10 +169,11 @@ const useClientFields = ({
             return;
           }
 
-          // Resolved against the host's current client: a structural swap
-          // replaces the client identity, and a listener subscribed on an
-          // earlier generation still follows the scope's present binding
-          const boundScope = (clientRef.current ?? this)[
+          // Resolved against the subscribing provider's current client: a
+          // structural swap replaces the client identity, and a listener
+          // subscribed on an earlier generation still follows the scope's
+          // present binding
+          const boundScope = ((receiverRef ?? clientRef).current ?? this)[
             scope as ClientNames
           ] as AssistantClientAccessor<ClientNames> | undefined;
           // A scope removed by a structural change since subscription cannot
@@ -177,11 +187,16 @@ const useClientFields = ({
             callback(payload);
           }
         });
-        if (
-          scope !== "*" &&
-          clientRef.parent[scope as ClientNames]?.source === null
-        )
-          return localUnsub;
+        if (scope !== "*") {
+          // A ridden subscription filters against the subscriber's bindings,
+          // so an ancestor's own scope set says nothing about where the
+          // emission lands; forward until the chain leaves generated clients.
+          if (receiverRef) {
+            if (clientRef.parent === DefaultAssistantClient) return localUnsub;
+          } else if (clientRef.parent[scope as ClientNames]?.source === null) {
+            return localUnsub;
+          }
+        }
 
         const parentUnsub = clientRef.parent.on(selector, callback);
 
@@ -372,8 +387,9 @@ const useDerivedScopeMount = (
 
 // Derived-only hosts run without tap: each Derived scope is a plain React
 // hook call, so the scope count is fixed per call site (React throws on a
-// hook-count change). subscribe/on delegate wholesale to the parent, so
-// emissions and state updates flow through the parent's machinery.
+// hook-count change). subscribe delegates wholesale to the parent; on
+// delegates transport to the parent while riding the child's ClientRef on
+// the selector, so delivery filters against the child's own bindings.
 const useDerivedOnlyClient = (
   parent: AssistantClient,
   entries: ScopeEntry[],
@@ -397,16 +413,60 @@ const useDerivedOnlyClient = (
     }
   }
 
+  const clientRef = useRef<ClientRef>({ parent, current: null }).current;
+
+  const on = function <TEvent extends AssistantEventName>(
+    this: AssistantClient,
+    selector: AssistantEventSelector<TEvent>,
+    callback: AssistantEventCallback<TEvent>,
+  ) {
+    if (!this) {
+      throw new Error(
+        "const { on } = useAui() is not supported. Use aui.on() instead.",
+      );
+    }
+
+    const { scope, event } = normalizeEventSelector(selector);
+    if (scope === "*") return parent.on(selector, callback);
+
+    // A nested derived-only provider keeps the original subscriber's ref
+    const ridden = (selector as RiddenSelector)[EVENT_RECEIVER_REF];
+    if (!ridden) {
+      const source = this[scope as ClientNames]?.source;
+      if (source === null) {
+        throw new Error(
+          `Scope "${scope}" is not available. Use { scope: "*", event: "${event}" } to listen globally.`,
+        );
+      }
+    }
+
+    return parent.on(
+      {
+        scope,
+        event,
+        [EVENT_RECEIVER_REF]: ridden ?? clientRef,
+      } as AssistantEventSelector<TEvent>,
+      callback,
+    );
+  };
+
   const building = createClientObject(parent, {
     subscribe: parent.subscribe,
-    on: parent.on,
+    on,
   });
 
   const accessors = entries.map(([name, element]) =>
     // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site; React throws on a count change
     useDerivedScopeMount(parent, building, name, element),
   );
-  return useCommittedClient(building, [parent, ...accessors]);
+  const client = useCommittedClient(building, [parent, ...accessors]);
+
+  useInsertionEffect(() => {
+    clientRef.parent = parent;
+    clientRef.current = client;
+  }, [client, parent, clientRef]);
+
+  return client;
 };
 
 type ScopedAuiClient = { client: AssistantClient; effects?: () => void };


### PR DESCRIPTION
closes #5768

## summary

- scoped `useAuiEvent` and `aui.on` under a derived-only provider resolved the parent's bindings at delivery: `useDerivedOnlyClient` reused the parent's `on`, whose closure captures the parent's `ClientRef`, so the child's own derived selection never matched (silent misses) and the parent's binding leaked through as false positives
- the fix rides the subscriber's `ClientRef` on the selector object via a registry symbol (`Symbol.for`, so the rider survives duplicate store copies); the existing parent-chain forwarding passes the original selector object, so the rider crosses every generated level (and React-root boundaries, since `createAssistantClient` builds `on` from the same `useClientFields`) with no registries and no public shape change
- every level's local registration filters delivery against the rider when present; ridden subscriptions skip the per-level availability throw (the subscriber validated once against its own facade) and forward until the sentinel root instead of stopping at scope-lacking ancestors, which is what lets an emission reach the child through a scope-less intermediate host
- `useDerivedOnlyClient` now owns a child `ClientRef` published from `useInsertionEffect` (the commit-phase publication rule from #5795), wraps `on` to inject the rider, passes wildcards through untouched, and preserves an existing rider for nested derived-only providers
- subscriptions that never cross a derived-only level behave byte-for-byte as before; a forwarded subscription crossing one now filters against that level's binding above it, which fixes inherited-scope listeners under by-index providers, and a shadowing hosted descendant's interim semantic (the ancestor's binding, previously silence) is pinned in tests until hosted subscriptions ride their own ref

## test plan

### already verified

- [x] red first: the five core tests fail on unmodified main exactly per the issue's 2x2 matrix, including the false-positive direction (the parent's `m0` event reached a child bound to `m1`)
- [x] `pnpm exec vitest run` in packages/store -> 19 files, 153 tests green (seven new: parent lacks the scope, both directions under a different parent instance, scope-less intermediate host, structural swap, direct `aui.on`, hosted child inheriting under a derived-only provider, shadowing hosted descendant semantic)
- [x] downstream suites against the rebuilt store dist: react 406, vue 66, react-ink 244, all green
- [x] `pnpm build` in packages/store and `pnpm run test:react-compiler` -> clean, 1/1
- [x] `oxlint` and `oxfmt --check` on the touched files -> clean

### reviewer should verify

- [ ] under a by-index provider (`MessageByIndexProvider` and friends), a scoped `useAuiEvent("message.pinged")` fires for the provider's own bound message and stays silent for the parent's binding

## notes

- supersedes the derived-only half of #5770; the selector rider replaces its module-level `WeakMap` registries and prototype-chain traversal with per-subscription state that the existing forwarding already transports, and its commit-phase publication half already landed via #5795
- deliberately kept in the existing gap class, with a changed shape: a shadowing hosted descendant still cannot hear its own shadowed binding through the chain, and the leaking ancestor changes from the root (only when it bound the scope) to the derived-only level (always, including where the root had no binding); worth its own issue, fixable later by riding the hosted subscriber's ref the same way

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Xoi7hzVZmXckgb1abn9iIe4Vn_Y-G1Rw3BsnEYpm1Ol-yJ3f2GnyrOyVSdE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
