### PR TITLE
fix(tap): remount disconnected resources by reconnect, not commit replay

### DIFF
--- a/.changeset/tap-reconnect-effects.md
+++ b/.changeset/tap-reconnect-effects.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: remount disconnected resources by re-running their latest committed effects instead of replaying stale commit closures (React Activity parity)

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
@@ -114,7 +114,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     unsubscribe();
     await flushUpdates();
     root.subscribe(() => {});
-    expect(body).toHaveBeenCalledTimes(mountRuns * 2);
+    expect(body).toHaveBeenCalledTimes(mountRuns);
     expect(effect).toHaveBeenCalledTimes(mountRuns + 1);
   });
 
@@ -209,6 +209,59 @@ describe("createTapRoot mountOnSubscribe", () => {
     await flushUpdates();
     root.subscribe(() => {});
     expect(root.getValue()).toBe(5);
+  });
+
+  it("remounts with fresh state after updates while soft-unmounted", async () => {
+    const body = vi.fn();
+    const seen: number[] = [];
+    const root = createTapRoot(
+      function Fresh() {
+        body();
+        const [count, setCount] = useState(0);
+        useEffect(() => {
+          seen.push(count);
+        }, [count]);
+        return { count, setCount };
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    unsubscribe();
+    await flushUpdates();
+
+    root.getValue().setCount(5);
+    await flushUpdates();
+    expect(root.getValue().count).toBe(5);
+
+    const renders = body.mock.calls.length;
+    root.subscribe(() => {});
+    expect(root.getValue().count).toBe(5);
+    expect(seen[seen.length - 1]).toBe(5);
+    expect(body).toHaveBeenCalledTimes(renders);
+  });
+
+  it("remounts without re-rendering when nothing changed while soft-unmounted", async () => {
+    const body = vi.fn();
+    const effect = vi.fn();
+    const root = createTapRoot(
+      function Idle() {
+        body();
+        useEffect(effect);
+        return null;
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    unsubscribe();
+    await flushUpdates();
+
+    const renders = body.mock.calls.length;
+    const effects = effect.mock.calls.length;
+    root.subscribe(() => {});
+    expect(body).toHaveBeenCalledTimes(renders);
+    expect(effect).toHaveBeenCalledTimes(effects + 1);
   });
 
   it("preserves ref and memo cells across an unsubscribe/resubscribe cycle", async () => {

--- a/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
@@ -207,4 +207,39 @@ describe("Lifecycle - Mount/Unmount", () => {
     expect(effect).toHaveBeenCalledTimes(1);
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
+
+  it("reconnects effects that bailed in a render committed after an unmount", () => {
+    const events: string[] = [];
+
+    const resource = createTestResource((dep: number) => {
+      useEffect(() => {
+        events.push("stable:setup");
+        return () => events.push("stable:cleanup");
+      }, []);
+      useEffect(() => {
+        events.push(`dep:setup:${dep}`);
+        return () => events.push("dep:cleanup");
+      }, [dep]);
+      return null;
+    });
+
+    renderResourceFiber(resource, [0]);
+    commitResourceFiber(resource);
+    expect(events).toEqual(["stable:setup", "dep:setup:0"]);
+
+    renderResourceFiber(resource, [1]);
+    unmountResourceFiber(resource);
+    expect(events).toEqual([
+      "stable:setup",
+      "dep:setup:0",
+      "stable:cleanup",
+      "dep:cleanup",
+    ]);
+
+    events.length = 0;
+    commitResourceFiber(resource);
+    expect(events.sort()).toEqual(["dep:setup:1", "stable:setup"]);
+
+    unmountResourceFiber(resource);
+  });
 });

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import { Activity } from "react";
+import { resource } from "../../core/resource";
+import { useResource, useTapRoot, flushTapSync } from "../../index";
+import { useState as useResourceState } from "../../react-hooks/useState";
+import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
+
+describe("resources under <Activity>", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("re-runs effects with fresh state after an update while hidden", () => {
+    const events: string[] = [];
+    const useCounter = () => {
+      const [count, setCount] = useResourceState(0);
+      useResourceEffect(() => {
+        events.push(`mount:${count}`);
+        return () => events.push("unmount");
+      }, [count]);
+      return { count, setCount };
+    };
+    const Counter = resource(useCounter);
+
+    let api: { count: number; setCount: (n: number) => void } | null = null;
+    function Inner() {
+      api = useResource(Counter());
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(events).toEqual(["mount:0"]);
+
+    rerender(<App hidden={true} />);
+    expect(events).toEqual(["mount:0", "unmount"]);
+
+    act(() => api!.setCount(5));
+
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount:0", "unmount", "mount:5"]);
+    expect(api!.count).toBe(5);
+  });
+
+  it("reveals without re-rendering when nothing changed while hidden", () => {
+    const events: string[] = [];
+    let renders = 0;
+    const useIdle = () => {
+      renders++;
+      useResourceEffect(() => {
+        events.push("mount");
+        return () => events.push("unmount");
+      }, []);
+      return null;
+    };
+    const Idle = resource(useIdle);
+
+    function Inner() {
+      return useResource(Idle());
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    rerender(<App hidden={true} />);
+    expect(events).toEqual(["mount", "unmount"]);
+
+    const rendersBeforeReveal = renders;
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount", "unmount", "mount"]);
+    expect(renders).toBe(rendersBeforeReveal);
+  });
+
+  it("useTapRoot keeps values updated while hidden across a reveal", () => {
+    let handle: {
+      getValue: () => { count: number; setCount: (n: number) => void };
+    } | null = null;
+    function Inner() {
+      handle = useTapRoot(function CounterRoot() {
+        const [count, setCount] = useResourceState(0);
+        return { count, setCount };
+      });
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(handle!.getValue().count).toBe(0);
+
+    rerender(<App hidden={true} />);
+    act(() => flushTapSync(() => handle!.getValue().setCount(5)));
+    expect(handle!.getValue().count).toBe(5);
+
+    rerender(<App hidden={false} />);
+    expect(handle!.getValue().count).toBe(5);
+  });
+});

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -179,6 +179,51 @@ describe("resources under <Activity>", () => {
     expect(events).toEqual(["mount:second"]);
   });
 
+  it("useResources swaps hooks while hidden and mounts the replacement on reveal", () => {
+    const events: string[] = [];
+    const useFirst = () => {
+      useResourceEffect(() => {
+        events.push("mount:first");
+        return () => events.push("unmount:first");
+      }, []);
+      return "first";
+    };
+    const useSecond = () => {
+      useResourceEffect(() => {
+        events.push("mount:second");
+        return () => events.push("unmount:second");
+      }, []);
+      return "second";
+    };
+    const First = resource(useFirst);
+    const Second = resource(useSecond);
+
+    const Inner = memo(function Inner({ swapped }: { swapped: boolean }) {
+      const [value] = useResources([
+        withKey("x", swapped ? Second() : First()),
+      ]);
+      return <>{value}</>;
+    });
+    function App({ hidden, swapped }: { hidden: boolean; swapped: boolean }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Inner swapped={swapped} />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} swapped={false} />);
+    rerender(<App hidden={true} swapped={false} />);
+    expect(events).toEqual(["mount:first", "unmount:first"]);
+
+    rerender(<App hidden={true} swapped={true} />);
+    expect(events).toEqual(["mount:first", "unmount:first"]);
+
+    events.length = 0;
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:second"]);
+  });
+
   it("useTapRoot keeps values updated while hidden across a reveal", () => {
     let handle: {
       getValue: () => { count: number; setCount: (n: number) => void };

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -1,8 +1,14 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, act, cleanup } from "@testing-library/react";
-import { Activity } from "react";
+import { Activity, memo } from "react";
 import { resource } from "../../core/resource";
-import { useResource, useTapRoot, flushTapSync } from "../../index";
+import {
+  useResource,
+  useResources,
+  useTapRoot,
+  flushTapSync,
+  withKey,
+} from "../../index";
 import { useState as useResourceState } from "../../react-hooks/useState";
 import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
 
@@ -75,6 +81,102 @@ describe("resources under <Activity>", () => {
     rerender(<App hidden={false} />);
     expect(events).toEqual(["mount", "unmount", "mount"]);
     expect(renders).toBe(rendersBeforeReveal);
+  });
+
+  it("useResources children re-run effects with fresh state after an update while hidden", () => {
+    const events: string[] = [];
+    const useCounter = (key: string) => {
+      const [count, setCount] = useResourceState(0);
+      useResourceEffect(() => {
+        events.push(`mount:${key}:${count}`);
+        return () => events.push(`unmount:${key}`);
+      }, [key, count]);
+      return { count, setCount };
+    };
+    const Counter = resource(useCounter);
+
+    let apis: { count: number; setCount: (n: number) => void }[] = [];
+    function Inner() {
+      apis = useResources([
+        withKey("a", Counter("a")),
+        withKey("b", Counter("b")),
+      ]);
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(events).toEqual(["mount:a:0", "mount:b:0"]);
+
+    rerender(<App hidden={true} />);
+    expect(events).toEqual([
+      "mount:a:0",
+      "mount:b:0",
+      "unmount:a",
+      "unmount:b",
+    ]);
+
+    act(() => apis[1]!.setCount(5));
+
+    events.length = 0;
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount:a:0", "mount:b:5"]);
+    expect(apis[1]!.count).toBe(5);
+  });
+
+  it("useResources survives a reveal after a hook swap", () => {
+    const events: string[] = [];
+    const useFirst = () => {
+      useResourceEffect(() => {
+        events.push("mount:first");
+        return () => events.push("unmount:first");
+      }, []);
+      return "first";
+    };
+    const useSecond = () => {
+      useResourceEffect(() => {
+        events.push("mount:second");
+        return () => events.push("unmount:second");
+      }, []);
+      return "second";
+    };
+    const First = resource(useFirst);
+    const Second = resource(useSecond);
+
+    // memo so hide/reveal do not re-render Inner: the reveal must replay the
+    // commit effect without a render, hitting the stale remount decision
+    const Inner = memo(function Inner({ swapped }: { swapped: boolean }) {
+      const [value] = useResources([
+        withKey("x", swapped ? Second() : First()),
+      ]);
+      return <>{value}</>;
+    });
+    function App({ hidden, swapped }: { hidden: boolean; swapped: boolean }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Inner swapped={swapped} />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} swapped={false} />);
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:first", "unmount:first", "mount:second"]);
+
+    rerender(<App hidden={true} swapped={true} />);
+    expect(events).toEqual([
+      "mount:first",
+      "unmount:first",
+      "mount:second",
+      "unmount:second",
+    ]);
+
+    events.length = 0;
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:second"]);
   });
 
   it("useTapRoot keeps values updated while hidden across a reveal", () => {

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -1,6 +1,10 @@
 import type { ResourceFiber, TapRoot } from "./types";
 import { bubbleContextDeps } from "./context";
-import { commitAllCallbacks, cleanupAllEffects } from "./helpers/commit";
+import {
+  commitAllCallbacks,
+  cleanupAllEffects,
+  reconnectAllEffects,
+} from "./helpers/commit";
 import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
@@ -20,7 +24,6 @@ export function createResourceFiber<R>(
     cells: [],
     contextDeps: null,
     wipContextDeps: null,
-    commitCallbacks: null,
     wipCommitCallbacks: null,
     memoCache: {
       current: null,
@@ -76,11 +79,25 @@ export function renderResourceFiber<R>(
   return value!;
 }
 
+export function reconnectResourceFiber<R>(fiber: ResourceFiber<R>): void {
+  if (fiber.isNeverMounted)
+    throw new Error("Tried to reconnect a fiber that was never mounted");
+  if (fiber.isMounted)
+    throw new Error("Tried to reconnect a fiber that is already mounted");
+
+  fiber.isMounted = true;
+  reconnectAllEffects(fiber);
+}
+
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
-  const commitCallbacks =
-    fiber.wipCommitCallbacks ?? fiber.commitCallbacks ?? [];
+  const commitCallbacks = fiber.wipCommitCallbacks;
+  // null means no render since the last commit: a mounted fiber has nothing
+  // to do, a disconnected one re-runs its latest committed effects
+  if (commitCallbacks === null) {
+    if (!fiber.isMounted) reconnectResourceFiber(fiber);
+    return;
+  }
   fiber.wipCommitCallbacks = null;
-  fiber.commitCallbacks = commitCallbacks;
 
   fiber.isMounted = true;
   fiber.contextDeps = fiber.wipContextDeps;

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -99,6 +99,7 @@ export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
   }
   fiber.wipCommitCallbacks = null;
 
+  const wasDisconnected = !fiber.isNeverMounted && !fiber.isMounted;
   fiber.isMounted = true;
   fiber.contextDeps = fiber.wipContextDeps;
   commitRoot(fiber.root);
@@ -117,4 +118,10 @@ export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
 
   fiber.isNeverMounted = false;
   commitAllCallbacks(commitCallbacks);
+
+  // A render that predates the disconnect queued only the dep-changed subset;
+  // cells that bailed in it still sit at deps === null after cleanupAllEffects
+  // and must be reconnected. No-op when the wip was rendered while
+  // disconnected, since that re-queues every effect.
+  if (wasDisconnected) reconnectAllEffects(fiber);
 }

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -64,8 +64,6 @@ export const createTapRoot = <R>(
       const unsubscribe = ensureRoot().subscribe(listener);
       if (subscriberCount++ === 0 && !fiber.isMounted) {
         try {
-          // Remounts re-render first so the commit sees fresh effect closures
-          if (!fiber.isNeverMounted) void renderFiber();
           flushTapSync(() => commitResourceFiber(fiber));
         } catch (error) {
           try {

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -1,4 +1,4 @@
-import type { CommitCallbacks, ResourceFiber } from "../types";
+import type { CommitCallbacks, EffectCell, ResourceFiber } from "../types";
 import { throwAggregated } from "./throwAggregated";
 
 export const CommitPriority = {
@@ -36,6 +36,37 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
   }
 
   throwAggregated(errors, "Errors during commit");
+}
+
+export function setupEffect(cell: EffectCell): void {
+  try {
+    const cleanup = cell.setup!();
+
+    if (cleanup !== undefined && typeof cleanup !== "function") {
+      throw new Error(
+        "An effect function must either return a cleanup function or nothing. " +
+          `Received: ${typeof cleanup}`,
+      );
+    }
+
+    cell.cleanup = cleanup;
+  } finally {
+    cell.deps = cell.setupDeps;
+  }
+}
+
+export function reconnectAllEffects<R>(fiber: ResourceFiber<R>): void {
+  const errors: unknown[] = [];
+  for (const cell of fiber.cells) {
+    if (cell?.type !== "effect" || cell.deps !== null) continue;
+
+    try {
+      setupEffect(cell);
+    } catch (e) {
+      errors.push(e);
+    }
+  }
+  throwAggregated(errors, "Errors during reconnect");
 }
 
 export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -49,6 +49,8 @@ export type MemoCell<T = any> = {
 
 export type EffectCell = {
   readonly type: "effect";
+  setup: (() => (() => void) | undefined) | undefined;
+  setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;
   deps: readonly unknown[] | null | undefined;
 };
@@ -89,7 +91,6 @@ export interface ResourceFiber<R> {
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;
-  commitCallbacks: CommitCallbacks | null;
   wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -177,15 +177,20 @@ export function useResources<E extends ResourceElement<any>>(
         fibers.delete(key);
       } else if (next === "skip") {
         // Bailed this render: nothing to commit, keep committed deps/value.
+        // A disconnected child (commit replayed without a render) reconnects.
+        if (!state.fiber.isNeverMounted && !state.fiber.isMounted) {
+          commitResourceFiber(state.fiber);
+        }
       } else {
         if (next.remount) {
-          unmountResourceFiber(state.fiber);
+          if (state.fiber.isMounted) unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);
         state.committedDeps = next.deps;
         state.committedValue = next.value;
         state.isDirty = false;
+        state.next = "skip";
       }
     }
   }, [val, fibers]);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -65,19 +65,27 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     return renderResourceFiber(fiber, [render]);
   });
 
-  const isMountedRef = useRef(false);
-  const committedArgsRef = useRef([render] as const);
-  const valueRef = useRef<R>(render2);
-  // Written every render, consumed by the first commit that follows. A commit
-  // replayed without a render (StrictMode, Activity reveal, tap reconnect)
-  // finds it null and must not restore render-scoped state or publish.
-  const pendingCommitRef = useRef<{
-    args: readonly [() => R];
+  const stateRef = useRef<{
+    isMounted: boolean;
+    committedArgs: readonly [() => R];
     value: R;
-    drainedCount: number;
-    context: ReturnType<typeof cloneCurrentTapContext>;
-  } | null>(null);
-  pendingCommitRef.current = {
+    // Written every render, consumed by the first commit that follows. A
+    // commit replayed without a render (StrictMode, Activity reveal, tap
+    // reconnect) finds it null and must not restore render-scoped state or
+    // publish.
+    pendingCommit: {
+      args: readonly [() => R];
+      value: R;
+      drainedCount: number;
+      context: ReturnType<typeof cloneCurrentTapContext>;
+    } | null;
+  }>({
+    isMounted: false,
+    committedArgs: [render],
+    value: render2,
+    pendingCommit: null,
+  });
+  stateRef.current.pendingCommit = {
     args: [render],
     value: render2,
     drainedCount,
@@ -86,8 +94,8 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
-    if (scheduler.isDirty || valueRef.current === output) return;
-    valueRef.current = output;
+    if (scheduler.isDirty || stateRef.current.value === output) return;
+    stateRef.current.value = output;
     subscribers.forEach((listener) => listener());
   };
 
@@ -109,12 +117,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
     if (isDevelopment && fiber.devStrictMode) {
       void withTapContextRoot(fiber.root.context, () => {
-        return renderResourceFiber(fiber, committedArgsRef.current);
+        return renderResourceFiber(fiber, stateRef.current.committedArgs);
       });
     }
 
     const render = withTapContextRoot(fiber.root.context, () => {
-      return renderResourceFiber(fiber, committedArgsRef.current);
+      return renderResourceFiber(fiber, stateRef.current.committedArgs);
     });
 
     if (scheduler.isDirty)
@@ -123,7 +131,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     commitRoot(fiber.root);
     queue.length = 0;
 
-    if (isMountedRef.current) {
+    if (stateRef.current.isMounted) {
       commitResourceFiber(fiber);
     }
 
@@ -131,20 +139,21 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   });
 
   useEffect(() => {
-    isMountedRef.current = true;
+    const current = stateRef.current;
+    current.isMounted = true;
     if (!fiber.isNeverMounted && !fiber.isMounted) commitResourceFiber(fiber);
     return () => {
-      isMountedRef.current = false;
+      current.isMounted = false;
       unmountResourceFiber(fiber);
     };
   }, [fiber]);
 
   useEffect(() => {
-    const pending = pendingCommitRef.current;
+    const pending = stateRef.current.pendingCommit;
     if (pending === null) return;
-    pendingCommitRef.current = null;
+    stateRef.current.pendingCommit = null;
 
-    committedArgsRef.current = pending.args;
+    stateRef.current.committedArgs = pending.args;
     commitRoot(fiber.root);
     queue.splice(0, pending.drainedCount);
     fiber.root.context = pending.context;
@@ -155,7 +164,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   return useMemo(
     () => ({
-      getValue: () => valueRef.current,
+      getValue: () => stateRef.current.value,
       subscribe: (listener: () => void) => {
         subscribers.add(listener);
         return () => subscribers.delete(listener);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -68,6 +68,21 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
   const valueRef = useRef<R>(render2);
+  // Written every render, consumed by the first commit that follows. A commit
+  // replayed without a render (StrictMode, Activity reveal, tap reconnect)
+  // finds it null and must not restore render-scoped state or publish.
+  const pendingCommitRef = useRef<{
+    args: readonly [() => R];
+    value: R;
+    drainedCount: number;
+    context: ReturnType<typeof cloneCurrentTapContext>;
+  } | null>(null);
+  pendingCommitRef.current = {
+    args: [render],
+    value: render2,
+    drainedCount,
+    context,
+  };
   const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
@@ -117,6 +132,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useEffect(() => {
     isMountedRef.current = true;
+    if (!fiber.isNeverMounted && !fiber.isMounted) commitResourceFiber(fiber);
     return () => {
       isMountedRef.current = false;
       unmountResourceFiber(fiber);
@@ -124,13 +140,17 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   }, [fiber]);
 
   useEffect(() => {
-    committedArgsRef.current = [render];
+    const pending = pendingCommitRef.current;
+    if (pending === null) return;
+    pendingCommitRef.current = null;
+
+    committedArgsRef.current = pending.args;
     commitRoot(fiber.root);
-    queue.splice(0, drainedCount);
-    fiber.root.context = context;
+    queue.splice(0, pending.drainedCount);
+    fiber.root.context = pending.context;
     commitResourceFiber(fiber);
 
-    publish(render2);
+    publish(pending.value);
   });
 
   return useMemo(

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -1,15 +1,17 @@
 import { getCurrentResourceFiber } from "../core/helpers/execution-context";
-import { CommitPriority } from "../core/helpers/commit";
+import { CommitPriority, setupEffect } from "../core/helpers/commit";
 import { addCommit } from "../core/helpers/root";
-import type { Cell } from "../core/types";
+import type { EffectCell } from "../core/types";
 import { depsShallowEqual } from "../hooks/utils/depsShallowEqual";
 import {
   throwHookOrderChanged,
   throwRenderedMoreHooks,
 } from "./utils/hookErrors";
 
-const newEffect = (): Cell & { type: "effect" } => ({
+const newEffect = (): EffectCell => ({
   type: "effect",
+  setup: undefined,
+  setupDeps: undefined,
   cleanup: undefined,
   deps: null, // null means the effect has never been run
 });
@@ -32,7 +34,7 @@ export function useEffect(
   const index = fiber.currentIndex++;
 
   const existing = fiber.cells[index];
-  const cell: Cell & { type: "effect" } =
+  const cell: EffectCell =
     existing === undefined
       ? newEffect()
       : existing.type === "effect"
@@ -47,6 +49,9 @@ export function useEffect(
     fiber.cells[index] = cell;
   }
 
+  cell.setup = effect;
+  cell.setupDeps = deps;
+
   if (deps && cell.deps && depsShallowEqual(cell.deps, deps)) return;
   if (cell.deps !== null && !!deps !== !!cell.deps)
     throw new Error(
@@ -60,20 +65,5 @@ export function useEffect(
       cell.cleanup = undefined;
     }
   });
-  addCommit(fiber, CommitPriority.PassiveEffectSetup, () => {
-    try {
-      const cleanup = effect();
-
-      if (cleanup !== undefined && typeof cleanup !== "function") {
-        throw new Error(
-          "An effect function must either return a cleanup function or nothing. " +
-            `Received: ${typeof cleanup}`,
-        );
-      }
-
-      cell.cleanup = cleanup;
-    } finally {
-      cell.deps = deps;
-    }
-  });
+  addCommit(fiber, CommitPriority.PassiveEffectSetup, () => setupEffect(cell));
 }


### PR DESCRIPTION
## What

Remounting a disconnected resource fiber (an `Activity`-style hide/reveal, a `mountOnSubscribe` resubscribe, a StrictMode effect replay) previously replayed the previous commit's callbacks. Those closures captured render-scoped values, so a remount without a fresh render could publish a stale value, restore a stale context clone, or drain the wrong number of queued updates. `createTapRoot` worked around this by force re-rendering before every remount — a divergence from React's Activity model, which resumes with zero renders by re-running the latest committed effect functions (`reconnectPassiveEffects`).

This PR makes tap follow the Activity model:

- **Effect cells store their latest setup function.** `useEffect` writes `cell.setup`/`cell.setupDeps` on every render (including dependency-equal bailouts), mirroring React always updating `create` on the effect object.
- **`reconnectResourceFiber`** re-runs the stored setups of all disconnected effect cells (`deps === null`, the marker `cleanupAllEffects` already leaves). Zero renders.
- **`commitResourceFiber` dispatches** on `wipCommitCallbacks`: pending render → normal commit; no render + disconnected → reconnect; no render + mounted → no-op. The stale-replay fallback (`wip ?? commitCallbacks`) is gone, and the now-dead `fiber.commitCallbacks` field is deleted.
- **`createTapRoot`'s remount re-render is deleted** — `mountOnSubscribe` resubscribes now cost zero renders.
- **`useTapRoot`'s commit effect is replay-safe** via a per-render `pendingCommitRef`: a commit replayed without a render (StrictMode, Activity reveal, tap reconnect) finds it null and skips the render-scoped restores and the stale `publish`. Its connection effect reconnects the inner fiber. This fixes stale values on Activity reveal in React hosts too, not just `createTapRoot`.
- **`useResources`** clears `state.next` after committing and reconnects disconnected children in its bail-out branch (also fixes a latent double-unmount when a hook-swap remount decision was replayed).

## Why it works with no state-lane replay

Two existing invariants carry the design: `wipCommitCallbacks` is reset at every render start, so `wip === null` means exactly "no render since the last commit"; and after a disconnect every effect cell has `deps === null`, so any render while disconnected re-queues *all* effects with fresh closures — a pending wip is always complete. The HookState and EffectEvent lanes are self-healing (dirty-gated / re-queued while stale), so the reconnect walk needs only the effect cells. `useResource` and `useTapHost` needed no changes at all: their replayed `commitResourceFiber` calls land on the dispatch and become the reconnect triggers, recursing down the tree.

## How verified

- New `<Activity>` integration tests (`__tests__/react/activity.test.tsx`): effects re-run with fresh state after updates while hidden; reveal without re-render; `useTapRoot` keeps values updated while hidden across a reveal — that last test fails on the old code (observed `5 → 0` stale publish).
- New mount-on-subscribe tests: remount with fresh state after updates while soft-unmounted, and remount without re-rendering; the existing dev-strict test now asserts zero remount renders.
- Full suite: 499 tests green (dev and production modes; prod failures on base are pre-existing and unchanged).

No public surface change (all touched fiber APIs are internal). Follow-up PR planned: dev strict mode double-invoking effects on every reconnect (Activity + StrictMode parity), per the measured React 19.2 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.v0vbA6MhFgPXKDrCmRPLOnOZ6iR789ZSc4IxD8H3uhqEKNsAraD9bmvXqLA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->