### PR TITLE
feat(store): resolve scope availability through aui.optional

### DIFF
--- a/.changeset/client-optional-view.md
+++ b/.changeset/client-optional-view.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: `aui.optional.<scope>` resolves an unavailable scope to `undefined` instead of a throwing accessor, mirroring `s.optional` on the state side; the documented availability check moves off `source != null`

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -63,9 +63,10 @@ declare namespace Assistant {
   }
 }
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -1049,6 +1050,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {

--- a/api-surface/assistant-ui__react-devtools.ts
+++ b/api-surface/assistant-ui__react-devtools.ts
@@ -23,9 +23,10 @@ interface ApiInfo {
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -104,6 +105,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -132,9 +132,10 @@ type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K ex
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -264,6 +265,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type Color = (typeof COLORS)[number];

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -64,9 +64,10 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -974,6 +975,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CloudMessage = {

--- a/api-surface/assistant-ui__react-markdown.ts
+++ b/api-surface/assistant-ui__react-markdown.ts
@@ -14,9 +14,10 @@ import "zustand";
 
 type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -82,6 +83,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -62,9 +62,10 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -927,6 +928,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CloudMessage = {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -32,9 +32,10 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -237,6 +238,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CompleteAttachment = BaseAttachment & {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -32,9 +32,10 @@ type AppendMessage = Omit<ThreadMessage, "id"> & {
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -237,6 +238,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CompleteAttachment = BaseAttachment & {

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -20,9 +20,10 @@ type AllowedTags = Record<string, string[]>;
 
 type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -100,6 +101,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CodeHeaderProps = {

--- a/api-surface/assistant-ui__react-syntax-highlighter.ts
+++ b/api-surface/assistant-ui__react-syntax-highlighter.ts
@@ -14,9 +14,10 @@ import "zustand";
 
 type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -82,6 +83,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -225,9 +225,10 @@ declare namespace Assistant$1 {
   }
 }
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -1283,6 +1284,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -2,9 +2,10 @@ import React, { FC, PropsWithChildren, ReactNode } from "react";
 
 type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
@@ -145,6 +146,10 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
 } : {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
 declare const DefaultAssistantClient: AssistantClient;

--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -304,6 +304,9 @@ Union of all registered scope names.
 type AssistantClient = {
   [K in ClientNames]: AssistantClientAccessor<K>;
 } & {
+  readonly optional: {
+    readonly [K in ClientNames]: AssistantClientAccessor<K> | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(
     selector: AssistantEventSelector<TEvent>,
@@ -312,7 +315,7 @@ type AssistantClient = {
 };
 ```
 
-The store object returned by `useAui()`. Each scope is an accessor. `subscribe` fires on any state change. `on` subscribes to typed events.
+The store object returned by `useAui()`. Each scope is an accessor. `optional` exposes the same scopes, resolving an unavailable one to `undefined` instead of a throwing accessor: `aui.optional.counter?.increment()`. `subscribe` fires on any state change. `on` subscribes to typed events.
 
 ### AssistantClientAccessor
 
@@ -328,7 +331,7 @@ type AssistantClientAccessor<K extends ClientNames> =
   ) & { name: K };
 ```
 
-A scope accessor exposing the scope's methods as properties (`aui.counter.increment()`). Read `.source`, `.query`, and `.name` for metadata. The call signature (`aui.counter()`) is deprecated and returns the same accessor.
+A scope accessor exposing the scope's methods as properties (`aui.counter.increment()`). Read `.source`, `.query`, and `.name` for metadata; check availability via `aui.optional.counter`. The call signature (`aui.counter()`) is deprecated and returns the same accessor.
 
 ### AssistantState
 

--- a/apps/docs/content/tap-docs/store/meta.mdx
+++ b/apps/docs/content/tap-docs/store/meta.mdx
@@ -74,10 +74,10 @@ aui.message.name; // "message"
 aui.message.getState(); // throws
 ```
 
-The accessor itself is always truthy, so `if (aui.message)` does not tell you anything. Check availability with:
+The accessor itself is always truthy, so `if (aui.message)` does not tell you anything. Check availability through the `optional` view, which resolves an unavailable scope to `undefined`:
 
 ```tsx
-if (aui.message.source != null) {
+if (aui.optional.message) {
   // scope is available
 }
 ```

--- a/apps/docs/content/tap-docs/store/methods.mdx
+++ b/apps/docs/content/tap-docs/store/methods.mdx
@@ -104,18 +104,15 @@ const Counter = () => {
 
 ## Checking if a scope exists
 
-Accessing `aui.counter` never throws, and the accessor is always truthy — `if (aui.counter)` does not tell you anything. When the scope hasn't been provided by any `AuiProvider` above, the accessor still answers `source` (`null`), `query`, and `name`; calling it or reading any other property throws. Check `source`:
+Accessing `aui.counter` never throws, and the accessor is always truthy — `if (aui.counter)` does not tell you anything. When the scope hasn't been provided by any `AuiProvider` above, the accessor still answers `source` (`null`), `query`, and `name`; calling it or reading any other property throws. Read the scope through `aui.optional`, which resolves to the same accessor when available and `undefined` when not:
 
 ```tsx
 const aui = useAui();
 
-if (aui.counter.source != null) {
-  // safe to use
-  aui.counter.increment();
-}
+aui.optional.counter?.increment();
 ```
 
-`source` is `null` when the scope isn't available. Any other value (`"root"`, a parent scope name) means the scope is bound.
+This mirrors `s.optional` on the state side. The accessor metadata keeps working (`source` is `null` exactly when `aui.optional.counter` is `undefined`), but `optional` is the availability check to reach for.
 
 ## Subscribing to scope identity
 

--- a/apps/docs/content/tap-docs/store/methods.mdx
+++ b/apps/docs/content/tap-docs/store/methods.mdx
@@ -112,7 +112,7 @@ const aui = useAui();
 aui.optional.counter?.increment();
 ```
 
-This mirrors `s.optional` on the state side. The accessor metadata keeps working (`source` is `null` exactly when `aui.optional.counter` is `undefined`), but `optional` is the availability check to reach for.
+This mirrors `s.optional` on the state side. The accessor metadata keeps working, and `aui.optional.counter` is `undefined` whenever the scope is not available, whether its accessor reports `source: null` or the scope is entirely absent from a hand-built parent chain.
 
 ## Subscribing to scope identity
 

--- a/apps/docs/content/tap-docs/store/state.mdx
+++ b/apps/docs/content/tap-docs/store/state.mdx
@@ -105,7 +105,7 @@ Accessing `s.counter` in a selector throws if the `counter` scope hasn't been pr
 const count = useAuiState((s) => s.optional.counter?.count);
 ```
 
-To branch on availability outside a selector, check the accessor's `source` via `useAui()` — it's `null` when the scope isn't available.
+To branch on availability outside a selector, use the client's mirror of this view: `useAui().optional.counter` is the bound accessor when available and `undefined` when not.
 
 ## AuiIf
 

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -141,6 +141,33 @@ describe("scope-filtered on", () => {
     );
   });
 
+  it("on forwards to a hand-built parent when the scope is absent from the chain", () => {
+    const parentUnsub = vi.fn();
+    const parentOn = vi.fn(() => parentUnsub);
+    const handBuilt = {
+      subscribe: () => () => {},
+      on: parentOn,
+    };
+
+    let child!: AnyClient;
+    const Child = () => {
+      child = useAui({ thread: ThreadClient() } as unknown as useAui.Props);
+      return null;
+    };
+    render(
+      <AuiProvider value={handBuilt as never}>
+        <Child />
+      </AuiProvider>,
+    );
+
+    const cb = vi.fn();
+    const unsub = child.on("composer.pinged", cb);
+    expect(parentOn).toHaveBeenCalledExactlyOnceWith("composer.pinged", cb);
+
+    unsub();
+    expect(parentUnsub).toHaveBeenCalledOnce();
+  });
+
   it("scoped listeners follow the scope's binding at delivery time", async () => {
     const { getAui } = setup();
     const early = vi.fn();

--- a/packages/store/src/__tests__/optional-client-view.test.tsx
+++ b/packages/store/src/__tests__/optional-client-view.test.tsx
@@ -113,6 +113,7 @@ describe("optional client view", () => {
     expect(Object.keys({ ...aui })).not.toContain("optional");
     expect("optional" in aui.optional).toBe(false);
     expect(Object.keys(aui.optional)).toContain("thread");
+    expect((aui.optional as AnyClient).__proto__).toBeUndefined();
   });
 
   it("keeps the view referentially stable per client", () => {

--- a/packages/store/src/__tests__/optional-client-view.test.tsx
+++ b/packages/store/src/__tests__/optional-client-view.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { cleanup, render, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { resource } from "@assistant-ui/tap";
+import { useAui } from "../useAui";
+import { AuiProvider } from "../AuiProvider";
+import { Derived } from "../Derived";
+import type { AssistantClient } from "../types/client";
+
+type AnyClient = Record<string, any>;
+
+const useThreadClient = () => {
+  const [title] = useState("hello");
+  return {
+    getState: () => ({ title }),
+    rename: () => {},
+  };
+};
+
+const ThreadClient = resource(useThreadClient);
+
+const setup = () => {
+  let aui!: AnyClient;
+  const Harness = () => {
+    aui = useAui({ thread: ThreadClient() } as unknown as useAui.Props);
+    return null;
+  };
+  render(<Harness />);
+  return aui as AssistantClient & AnyClient;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("optional client view", () => {
+  it("returns the same bound accessor for available scopes", () => {
+    const aui = setup();
+
+    expect(aui.optional.thread).toBe(aui.thread);
+    expect(aui.optional.thread?.getState().title).toBe("hello");
+  });
+
+  it("resolves unavailable scopes to undefined while the base client throws", () => {
+    const aui = setup();
+
+    expect(aui.optional.threadListItem).toBeUndefined();
+    expect(aui.optional.threadListItem?.remoteId).toBeUndefined();
+    expect(aui.optional.notARegisteredScope).toBeUndefined();
+    expect(() => aui.threadListItem.remoteId).toThrow(
+      'The current scope does not have a "threadListItem" property.',
+    );
+  });
+
+  it("resolves every scope to undefined outside an AuiProvider", () => {
+    const { result } = renderHook(() => useAui() as AnyClient);
+
+    expect(result.current.optional.thread).toBeUndefined();
+    expect(result.current.optional.thread?.cancelRun()).toBeUndefined();
+  });
+
+  it("resolves inherited and derived scopes on a child provider", () => {
+    const parent = setup();
+    let child!: AnyClient;
+    const Child = () => {
+      child = useAui({
+        message: Derived({
+          source: "thread",
+          query: {},
+          get: (aui: AnyClient) => aui.thread,
+        } as never),
+      } as never);
+      return null;
+    };
+    render(
+      <AuiProvider value={parent}>
+        <Child />
+      </AuiProvider>,
+    );
+
+    expect(child.optional.message).toBe(child.message);
+    expect(child.optional.thread).toBe(child.thread);
+    expect(child.optional.composer).toBeUndefined();
+  });
+
+  it("resolves absent scopes on a hand-built parent chain to undefined", () => {
+    const handBuilt = {
+      subscribe: () => () => {},
+      on: () => () => {},
+    };
+    let child!: AnyClient;
+    const Child = () => {
+      child = useAui({ thread: ThreadClient() } as unknown as useAui.Props);
+      return null;
+    };
+    render(
+      <AuiProvider value={handBuilt as never}>
+        <Child />
+      </AuiProvider>,
+    );
+
+    expect(child.optional.thread).toBe(child.thread);
+    expect(child.optional.composer).toBeUndefined();
+  });
+
+  it("keeps optional out of enumeration while reporting it via in", () => {
+    const aui = setup();
+
+    expect("optional" in aui).toBe(true);
+    expect(Object.keys(aui)).not.toContain("optional");
+    expect(Object.keys({ ...aui })).not.toContain("optional");
+    expect("optional" in aui.optional).toBe(false);
+    expect(Object.keys(aui.optional)).toContain("thread");
+  });
+
+  it("keeps the view referentially stable per client", () => {
+    const aui = setup();
+
+    expect(aui.optional).toBe(aui.optional);
+  });
+
+  it("reports the same shape on the no-provider client", () => {
+    const { result } = renderHook(() => useAui() as AnyClient);
+    const aui = result.current;
+
+    expect("optional" in aui).toBe(true);
+    expect(Object.keys(aui)).not.toContain("optional");
+    expect(aui.optional).toBe(aui.optional);
+  });
+});

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -196,7 +196,7 @@ export type AssistantState = ScopeStates & {
  *
  * An unavailable scope's accessor has `source: null` and throws when any
  * other property is read or the accessor is called. The accessor itself is
- * always truthy — check availability via `aui.thread.source != null`.
+ * always truthy — check availability via `aui.optional.thread`.
  */
 export type AssistantClientAccessor<K extends ClientNames> =
   ClientSchemas[K]["methods"] & {
@@ -208,12 +208,21 @@ export type AssistantClientAccessor<K extends ClientNames> =
       | { source: null; query: null }
     ) & { name: K };
 
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+};
+
 /**
  * The assistant client type with all registered clients.
+ *
+ * `optional` exposes the same scopes, but an unavailable scope resolves to
+ * `undefined` instead of a throwing accessor:
+ * `aui.optional.thread?.cancelRun()`.
  */
-export type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
+export type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
   subscribe(listener: () => void): Unsubscribe;
   on<TEvent extends AssistantEventName>(
     selector: AssistantEventSelector<TEvent>,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -48,7 +48,13 @@ import {
 import { useAssistantTapContextProvider } from "./utils/tap-assistant-context";
 import { ClientResource } from "./useClientResource";
 import { useShallowStable } from "./utils/useShallowStable";
-import { createClientAccessor, getClientId } from "./utils/client-accessor";
+import {
+  createClientAccessor,
+  getClientId,
+  isScopeAvailable,
+  isScopeUnavailable,
+} from "./utils/client-accessor";
+import { createOptionalClientView } from "./utils/optional-client-view";
 import { getClientIndex } from "./utils/tap-client-stack-context";
 
 const isDevelopment =
@@ -126,6 +132,11 @@ const createClientObject = (
 
   const client = Object.create(proto) as AssistantClient;
   Object.assign(client, fields);
+  let optional: AssistantClient["optional"] | undefined;
+  Object.defineProperty(client, "optional", {
+    get: () => (optional ??= createOptionalClientView(client)),
+    enumerable: false,
+  });
   return client;
 };
 
@@ -155,8 +166,7 @@ const useClientFields = ({
 
         if (scope !== "*" && !receiverRef) {
           // A hand-built parent may lack the scope entirely; forward to it
-          const source = this[scope as ClientNames]?.source;
-          if (source === null) {
+          if (isScopeUnavailable(this[scope as ClientNames])) {
             throw new Error(
               `Scope "${scope}" is not available. Use { scope: "*", event: "${event}" } to listen globally.`,
             );
@@ -178,7 +188,7 @@ const useClientFields = ({
           ] as AssistantClientAccessor<ClientNames> | undefined;
           // A scope removed by a structural change since subscription cannot
           // match; resolving its identity would throw
-          if (!boundScope || boundScope.source === null) return;
+          if (!isScopeAvailable(boundScope)) return;
           const scopeClient = getClientId(
             boundScope,
           ) as unknown as ClientMethods;
@@ -193,7 +203,9 @@ const useClientFields = ({
           // emission lands; forward until the chain leaves generated clients.
           if (receiverRef) {
             if (clientRef.parent === DefaultAssistantClient) return localUnsub;
-          } else if (clientRef.parent[scope as ClientNames]?.source === null) {
+          } else if (
+            isScopeUnavailable(clientRef.parent[scope as ClientNames])
+          ) {
             return localUnsub;
           }
         }
@@ -432,8 +444,7 @@ const useDerivedOnlyClient = (
     // A nested derived-only provider keeps the original subscriber's ref
     const ridden = (selector as RiddenSelector)[EVENT_RECEIVER_REF];
     if (!ridden) {
-      const source = this[scope as ClientNames]?.source;
-      if (source === null) {
+      if (isScopeUnavailable(this[scope as ClientNames])) {
         throw new Error(
           `Scope "${scope}" is not available. Use { scope: "*", event: "${event}" } to listen globally.`,
         );

--- a/packages/store/src/utils/client-accessor.ts
+++ b/packages/store/src/utils/client-accessor.ts
@@ -84,6 +84,21 @@ export const createErrorClientAccessor = (
 };
 
 /**
+ * Scope resolution is tri-state: available (a bound accessor), present but
+ * unavailable (an error accessor with `source: null`), or absent entirely (a
+ * hand-built parent chain without the scope). `isScopeAvailable` collapses
+ * the last two; event subscription keeps them apart because an absent scope
+ * still forwards to the parent.
+ */
+export const isScopeAvailable = (
+  accessor: AssistantClientAccessor<ClientNames> | undefined,
+): boolean => accessor?.source != null;
+
+export const isScopeUnavailable = (
+  accessor: AssistantClientAccessor<ClientNames> | undefined,
+): boolean => accessor?.source === null;
+
+/**
  * Returns the opaque identity of a bound client instance.
  *
  * The identity is stable for the lifetime of the bound client: the same

--- a/packages/store/src/utils/client-accessor.ts
+++ b/packages/store/src/utils/client-accessor.ts
@@ -90,12 +90,14 @@ export const createErrorClientAccessor = (
  * the last two; event subscription keeps them apart because an absent scope
  * still forwards to the parent.
  */
-export const isScopeAvailable = (
-  accessor: AssistantClientAccessor<ClientNames> | undefined,
-): boolean => accessor?.source != null;
+export const isScopeAvailable = <
+  T extends { source: ClientNames | "root" | null },
+>(
+  accessor: T | undefined,
+): accessor is T => accessor?.source != null;
 
 export const isScopeUnavailable = (
-  accessor: AssistantClientAccessor<ClientNames> | undefined,
+  accessor: { source: ClientNames | "root" | null } | undefined,
 ): boolean => accessor?.source === null;
 
 /**

--- a/packages/store/src/utils/client-keys.ts
+++ b/packages/store/src/utils/client-keys.ts
@@ -2,11 +2,13 @@ import type { AssistantClient } from "../types/client";
 
 export const isIgnoredClientKey = (
   key: string | symbol,
-): key is "optional" | "subscribe" | "on" | symbol => {
+): key is "optional" | "subscribe" | "on" | "__proto__" | symbol => {
   return (
     key === "optional" ||
     key === "subscribe" ||
     key === "on" ||
+    // Resolving it against the client would answer with the prototype object
+    key === "__proto__" ||
     typeof key === "symbol"
   );
 };

--- a/packages/store/src/utils/client-keys.ts
+++ b/packages/store/src/utils/client-keys.ts
@@ -1,0 +1,22 @@
+import type { AssistantClient } from "../types/client";
+
+export const isIgnoredClientKey = (
+  key: string | symbol,
+): key is "optional" | "subscribe" | "on" | symbol => {
+  return (
+    key === "optional" ||
+    key === "subscribe" ||
+    key === "on" ||
+    typeof key === "symbol"
+  );
+};
+
+// Derived clients hold inherited scopes on the prototype chain, so
+// enumeration must use for..in rather than Object.keys
+export const clientScopeKeys = (client: AssistantClient): string[] => {
+  const keys: string[] = [];
+  for (const key in client) {
+    if (!isIgnoredClientKey(key)) keys.push(key);
+  }
+  return keys;
+};

--- a/packages/store/src/utils/optional-client-view.ts
+++ b/packages/store/src/utils/optional-client-view.ts
@@ -1,0 +1,43 @@
+import type { AssistantClient, ClientNames } from "../types/client";
+import { BaseProxyHandler, handleIntrospectionProp } from "./BaseProxyHandler";
+import { isScopeAvailable } from "./client-accessor";
+import { clientScopeKeys, isIgnoredClientKey } from "./client-keys";
+
+class OptionalClientViewProxyHandler
+  extends BaseProxyHandler
+  implements ProxyHandler<AssistantClient["optional"]>
+{
+  readonly #client: AssistantClient;
+
+  constructor(client: AssistantClient) {
+    super();
+    this.#client = client;
+  }
+
+  get(_: unknown, prop: string | symbol) {
+    const introspection = handleIntrospectionProp(
+      prop,
+      "OptionalAssistantClient",
+    );
+    if (introspection !== false) return introspection;
+    if (isIgnoredClientKey(prop)) return undefined;
+    const accessor = this.#client[prop as ClientNames];
+    return isScopeAvailable(accessor) ? accessor : undefined;
+  }
+
+  ownKeys(): ArrayLike<string | symbol> {
+    return clientScopeKeys(this.#client);
+  }
+
+  has(_: unknown, prop: string | symbol): boolean {
+    return !isIgnoredClientKey(prop) && prop in this.#client;
+  }
+}
+
+export const createOptionalClientView = (
+  client: AssistantClient,
+): AssistantClient["optional"] =>
+  new Proxy<AssistantClient["optional"]>(
+    {} as AssistantClient["optional"],
+    new OptionalClientViewProxyHandler(client),
+  );

--- a/packages/store/src/utils/proxied-assistant-state.ts
+++ b/packages/store/src/utils/proxied-assistant-state.ts
@@ -2,20 +2,8 @@
 import { getClientState } from "../useClientResource";
 import type { AssistantClient, AssistantState } from "../types/client";
 import { BaseProxyHandler, handleIntrospectionProp } from "./BaseProxyHandler";
-
-const isIgnoredKey = (key: string | symbol): key is "on" | "subscribe" => {
-  return key === "on" || key === "subscribe" || typeof key === "symbol";
-};
-
-// Derived clients hold inherited scopes on the prototype chain, so
-// enumeration must use for..in rather than Object.keys
-const clientScopeKeys = (client: AssistantClient): string[] => {
-  const keys: string[] = [];
-  for (const key in client) {
-    if (!isIgnoredKey(key)) keys.push(key);
-  }
-  return keys;
-};
+import { isScopeAvailable } from "./client-accessor";
+import { clientScopeKeys, isIgnoredClientKey } from "./client-keys";
 
 /**
  * Proxied state that lazily accesses scope states
@@ -36,8 +24,10 @@ const createProxiedAssistantState = (
       );
       if (introspection !== false) return introspection;
       const scope = prop as keyof AssistantClient;
-      if (isIgnoredKey(scope)) return undefined;
-      if (client[scope].source === null) return undefined;
+      if (isIgnoredClientKey(scope)) return undefined;
+      // Collapses absent (a hand-built parent chain without the scope) and
+      // unavailable into undefined; only the base state throws for those
+      if (!isScopeAvailable(client[scope])) return undefined;
       return getClientState(client[scope]());
     }
 
@@ -46,7 +36,7 @@ const createProxiedAssistantState = (
     }
 
     has(_: unknown, prop: string | symbol): boolean {
-      return !isIgnoredKey(prop) && prop in client;
+      return !isIgnoredClientKey(prop) && prop in client;
     }
   }
 
@@ -64,7 +54,7 @@ const createProxiedAssistantState = (
         ));
       }
       const scope = prop as keyof AssistantClient;
-      if (isIgnoredKey(scope)) return undefined;
+      if (isIgnoredClientKey(scope)) return undefined;
       return getClientState(client[scope]());
     }
 
@@ -73,7 +63,9 @@ const createProxiedAssistantState = (
     }
 
     has(_: unknown, prop: string | symbol): boolean {
-      return prop === "optional" || (!isIgnoredKey(prop) && prop in client);
+      return (
+        prop === "optional" || (!isIgnoredClientKey(prop) && prop in client)
+      );
     }
   }
 

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -3,6 +3,7 @@ import { useContextProvider } from "@assistant-ui/tap";
 import type { AssistantClient } from "../types/client";
 import { BaseProxyHandler, handleIntrospectionProp } from "./BaseProxyHandler";
 import { createErrorClientAccessor } from "./client-accessor";
+import { createOptionalClientView } from "./optional-client-view";
 
 const NO_OP_SUBSCRIBE = () => () => {};
 
@@ -15,16 +16,26 @@ class EmptyAssistantClientProxyHandler
 {
   readonly #displayName: string;
   readonly #messageOf: (prop: string) => string;
+  readonly #getClient: () => AssistantClient;
+  #optional: AssistantClient["optional"] | undefined;
 
-  constructor(displayName: string, messageOf: (prop: string) => string) {
+  constructor(
+    displayName: string,
+    messageOf: (prop: string) => string,
+    getClient: () => AssistantClient,
+  ) {
     super();
     this.#displayName = displayName;
     this.#messageOf = messageOf;
+    this.#getClient = getClient;
   }
 
   get(_: unknown, prop: string | symbol) {
     if (prop === "subscribe") return NO_OP_SUBSCRIBE;
     if (prop === "on") return NO_OP_SUBSCRIBE;
+    if (prop === "optional") {
+      return (this.#optional ??= createOptionalClientView(this.#getClient()));
+    }
     const introspection = handleIntrospectionProp(prop, this.#displayName);
     if (introspection !== false) return introspection;
     return createErrorClientAccessor(
@@ -34,22 +45,39 @@ class EmptyAssistantClientProxyHandler
   }
 
   ownKeys(): ArrayLike<string | symbol> {
-    return ["subscribe", "on"];
+    return ["subscribe", "on", "optional"];
+  }
+
+  // Built clients define `optional` as a non-enumerable own property; the
+  // proxy flavors report the same shape so spreads and Object.keys stay
+  // uniform across every client the library hands out.
+  getOwnPropertyDescriptor(_: unknown, prop: string | symbol) {
+    if (prop === "optional") {
+      return {
+        value: this.get(_, prop),
+        writable: false,
+        enumerable: false,
+        configurable: true,
+      };
+    }
+    return super.getOwnPropertyDescriptor(_, prop);
   }
 
   has(_: unknown, prop: string | symbol): boolean {
-    return prop === "subscribe" || prop === "on";
+    return prop === "subscribe" || prop === "on" || prop === "optional";
   }
 }
 
 const createEmptyAssistantClient = (
   displayName: string,
   messageOf: (prop: string) => string,
-): AssistantClient =>
-  new Proxy<AssistantClient>(
+): AssistantClient => {
+  const client: AssistantClient = new Proxy<AssistantClient>(
     {} as AssistantClient,
-    new EmptyAssistantClientProxyHandler(displayName, messageOf),
+    new EmptyAssistantClientProxyHandler(displayName, messageOf, () => client),
   );
+  return client;
+};
 
 /** Default context value - throws "wrap in AuiProvider" error */
 export const DefaultAssistantClient: AssistantClient =

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -51,16 +51,11 @@ class EmptyAssistantClientProxyHandler
   // Built clients define `optional` as a non-enumerable own property; the
   // proxy flavors report the same shape so spreads and Object.keys stay
   // uniform across every client the library hands out.
-  getOwnPropertyDescriptor(_: unknown, prop: string | symbol) {
-    if (prop === "optional") {
-      return {
-        value: this.get(_, prop),
-        writable: false,
-        enumerable: false,
-        configurable: true,
-      };
-    }
-    return super.getOwnPropertyDescriptor(_, prop);
+  override getOwnPropertyDescriptor(_: unknown, prop: string | symbol) {
+    if (prop !== "optional") return super.getOwnPropertyDescriptor(_, prop);
+    const value = this.get(_, prop);
+    if (value === undefined) return undefined;
+    return { value, writable: false, enumerable: false, configurable: true };
   }
 
   has(_: unknown, prop: string | symbol): boolean {


### PR DESCRIPTION
closes #5594

## summary

- adds `aui.optional.<scope>` to `AssistantClient`: the same bound accessor when the scope is available, `undefined` when it is not, mirroring `s.optional` on the state side; `aui.<scope>` keeps its throwing behavior so missing-provider mistakes still surface at the point of use
- the view is a lazy, referentially stable proxy defined as a non-enumerable property on every client the library builds (hosted, derived-only, and `createAssistantClient` roots all flow through `createClientObject`) and on the no-provider default client, whose proxy reports the same non-enumerable shape so `Object.keys` and spreads stay uniform across flavors
- scope-key enumeration and the ignored-key set move to a shared `client-keys` module now that the state proxy and the client view both need them, and the availability predicates (`isScopeAvailable`, `isScopeUnavailable`) live beside `createErrorClientAccessor`, where the `source: null` representation is born; their JSDoc records the tri-state (available, present but unavailable, absent on a hand-built chain) and why event subscription keeps the last two apart
- the four `source === null` reads in `on()` (both availability throws, the delivery guard, the non-ridden forward stop) route through the predicates; behavior is unchanged and the rider paths from #5829 are untouched
- incidental fix, same concern: `s.optional.<scope>` no longer throws a TypeError for a scope entirely absent from a hand-built parent chain, and a scoped subscription absent from such a chain now has regression coverage for its forward-to-parent path
- the type derives `optional` from a named `ClientScopes` map (`keyof`/indexed access), the same construction-guaranteed parity idiom `AssistantState` uses with `ScopeStates`
- docs: `meta`, `methods`, `state`, and `api-reference` tap-docs pages now teach `aui.optional` as the availability check; the accessor metadata stays documented and working; `sibling-scopes` and core's probe sites are a separate follow-up per the issue's scoping

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/store -> 20 files, 162 tests green, including the new `optional-client-view` contract (accessor identity, unavailable and unregistered scopes, no-provider client, derived and inherited scopes on a child provider, hand-built chains, enumeration and `in` traps, referential stability) and the hand-built forward regression in the events suite
- [x] downstream suites against the rebuilt store dist: react 406, vue 66, react-ink 244, all green
- [x] `pnpm build` in packages/store and `pnpm run test:react-compiler` -> clean, 1/1
- [x] `oxlint` and `oxfmt --check` on the touched files -> clean

### reviewer should verify

- [ ] under a component without any provider for a scope, `aui.optional.thread?.cancelRun()` is a no-op instead of a throw, and `aui.thread.cancelRun()` still throws

## notes

- supersedes #5601, whose review rounds surfaced the tri-state distinction this PR's predicates document; it predates the delivery-time rider work and sits CONFLICTING against main
- `optional` was already in `ReservedScopeNames`, so no registered scope can collide

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DqxB1K8jU0wehGyWkZHPMdhauD2Z9rwk9sjpemaXpDvX9xR_4ZM7mgCVwNc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->