### PR TITLE
feat(tap): reconcile effects at commit time (Activity parity)

### DIFF
--- a/.changeset/tap-commit-reconcile.md
+++ b/.changeset/tap-commit-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: reconcile effects at commit time so mount, update, and Activity reveal share one mechanism

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -270,9 +270,6 @@ describe("useResources - Basic Functionality", () => {
       });
 
       renderTest(testFiber);
-      // Renders queue, they don't nest: the dispatch must not re-enter
-      // render/commit while the setup is on the stack; it converges
-      // sequentially after the commit pass completes.
       expect(events).toEqual(["setup:0", "after-dispatch:0", "setup:1"]);
       expect(getCommittedValue(testFiber)).toEqual({ n: 1, value: 2 });
 
@@ -297,9 +294,6 @@ describe("useResources - Basic Functionality", () => {
         return n;
       });
 
-      // First-mount effects double-invoke under dev strict mode; the pinned
-      // property is that after-flush always precedes setup:1 — the flush
-      // never re-entered render/commit from inside the setup.
       expect(events).toEqual([
         "setup:0",
         "after-flush:0",
@@ -330,7 +324,6 @@ describe("useResources - Basic Functionality", () => {
       void renderResourceFiber(fiber, [2]);
       discardWipRender(fiber);
 
-      // The reconnect must run the committed closure, not the discarded one.
       unmountResourceFiber(fiber);
       commitResourceFiber(fiber);
       expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
@@ -354,14 +347,11 @@ describe("useResources - Basic Functionality", () => {
       commitResourceFiber(fiber);
       expect(events).toEqual(["setup:1"]);
 
-      // An abandoned pass rendered the child with n=2; its commit never ran.
-      // The committed pass bails back to n=1, superseding that render.
       void renderResourceFiber(fiber, [2]);
       void renderResourceFiber(fiber, [1]);
       commitResourceFiber(fiber);
       expect(events).toEqual(["setup:1"]);
 
-      // A later reconnect must not commit the superseded n=2 render.
       unmountResourceFiber(fiber);
       commitResourceFiber(fiber);
       expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
@@ -387,9 +377,6 @@ describe("useResources - Basic Functionality", () => {
       commitResourceFiber(fiber);
       expect(events).toEqual(["mount:a"]);
 
-      // The host tears down after a render added "b" but before the commit
-      // effect ran: "b" was never mounted, and its presence must not abort
-      // the cleanup of the mounted children.
       void renderResourceFiber(fiber, [["a", "b"]]);
       unmountResourceFiber(fiber);
       expect(events).toEqual(["mount:a", "unmount:a"]);

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -8,6 +8,8 @@ import {
 import { useState } from "../../react-hooks/useState";
 import { useEffect } from "../../react-hooks/useEffect";
 import { resource } from "../../core/resource";
+import { createTapRoot } from "../../core/createTapRoot";
+import { flushTapSync } from "../../core/scheduler";
 import { withKey } from "../../core/withKey";
 import {
   createTestResource,
@@ -238,8 +240,9 @@ describe("useResources - Basic Functionality", () => {
     });
   });
 
-  describe("Reentrant commits", () => {
-    it("does not clobber a nested commit triggered by a child setup dispatch", () => {
+  describe("Dispatch during commit", () => {
+    it("defers a child setup dispatch until the current commit completes", () => {
+      const events: string[] = [];
       let childRenders = 0;
       let dispatched = false;
       let setParentN: ((n: number) => void) | null = null;
@@ -247,9 +250,11 @@ describe("useResources - Basic Functionality", () => {
       const useChild = ({ n }: { n: number }) => {
         childRenders++;
         useEffect(() => {
+          events.push(`setup:${n}`);
           if (!dispatched && n === 0) {
             dispatched = true;
             setParentN!(1);
+            events.push(`after-dispatch:${n}`);
           }
         }, [n]);
         return childRenders;
@@ -263,15 +268,46 @@ describe("useResources - Basic Functionality", () => {
         return { n, value };
       });
 
-      // The child's mount effect dispatches synchronously, nesting a parent
-      // re-render + commit inside the outer commit loop.
       renderTest(testFiber);
+      // Renders queue, they don't nest: the dispatch must not re-enter
+      // render/commit while the setup is on the stack; it converges
+      // sequentially after the commit pass completes.
+      expect(events).toEqual(["setup:0", "after-dispatch:0", "setup:1"]);
       expect(getCommittedValue(testFiber)).toEqual({ n: 1, value: 2 });
 
-      // Returning to n=0 must re-render the child (committed deps are [1]);
-      // a clobbered commit record would serve the stale value from render 1.
       setParentN!(0);
       expect(getCommittedValue(testFiber)).toEqual({ n: 0, value: 3 });
+    });
+
+    it("flushTapSync inside an effect defers until the pass completes", () => {
+      const events: string[] = [];
+      let setN: ((n: number) => void) | null = null;
+
+      const root = createTapRoot(function FlushRoot() {
+        const [n, setN_] = useState(0);
+        setN = setN_;
+        useEffect(() => {
+          events.push(`setup:${n}`);
+          if (n === 0) {
+            flushTapSync(() => setN!(1));
+            events.push(`after-flush:${n}`);
+          }
+        }, [n]);
+        return n;
+      });
+
+      // First-mount effects double-invoke under dev strict mode; the pinned
+      // property is that after-flush always precedes setup:1 — the flush
+      // never re-entered render/commit from inside the setup.
+      expect(events).toEqual([
+        "setup:0",
+        "after-flush:0",
+        "setup:0",
+        "after-flush:0",
+        "setup:1",
+      ]);
+      expect(root.getValue()).toBe(1);
+      root.unmount();
     });
   });
 

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { useResources } from "../../hooks/useResources";
 import { useState } from "../../react-hooks/useState";
+import { useEffect } from "../../react-hooks/useEffect";
 import { resource } from "../../core/resource";
 import { withKey } from "../../core/withKey";
 import {
@@ -8,6 +9,7 @@ import {
   renderTest,
   cleanupAllResources,
   createCounterResource,
+  getCommittedValue,
 } from "../test-utils";
 
 const SimpleCounter = resource(createCounterResource());
@@ -228,6 +230,43 @@ describe("useResources - Basic Functionality", () => {
       // Switch back to Counter (new instance)
       const result3 = renderTest(testFiber, { useCounter: true });
       expect(result3).toEqual([{ count: 42 }]);
+    });
+  });
+
+  describe("Reentrant commits", () => {
+    it("does not clobber a nested commit triggered by a child setup dispatch", () => {
+      let childRenders = 0;
+      let dispatched = false;
+      let setParentN: ((n: number) => void) | null = null;
+
+      const useChild = ({ n }: { n: number }) => {
+        childRenders++;
+        useEffect(() => {
+          if (!dispatched && n === 0) {
+            dispatched = true;
+            setParentN!(1);
+          }
+        }, [n]);
+        return childRenders;
+      };
+      const Child = resource(useChild);
+
+      const testFiber = createTestResource(() => {
+        const [n, setN] = useState(0);
+        setParentN = setN;
+        const [value] = useResources([withKey("k", Child({ n }), [n])]);
+        return { n, value };
+      });
+
+      // The child's mount effect dispatches synchronously, nesting a parent
+      // re-render + commit inside the outer commit loop.
+      renderTest(testFiber);
+      expect(getCommittedValue(testFiber)).toEqual({ n: 1, value: 2 });
+
+      // Returning to n=0 must re-render the child (committed deps are [1]);
+      // a clobbered commit record would serve the stale value from render 1.
+      setParentN!(0);
+      expect(getCommittedValue(testFiber)).toEqual({ n: 0, value: 3 });
     });
   });
 });

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { useResources } from "../../hooks/useResources";
+import {
+  commitResourceFiber,
+  renderResourceFiber,
+  unmountResourceFiber,
+} from "../../core/ResourceFiber";
 import { useState } from "../../react-hooks/useState";
 import { useEffect } from "../../react-hooks/useEffect";
 import { resource } from "../../core/resource";
@@ -267,6 +272,34 @@ describe("useResources - Basic Functionality", () => {
       // a clobbered commit record would serve the stale value from render 1.
       setParentN!(0);
       expect(getCommittedValue(testFiber)).toEqual({ n: 0, value: 3 });
+    });
+  });
+
+  describe("Teardown", () => {
+    it("unmounts cleanly when a child rendered but never committed", () => {
+      const events: string[] = [];
+      const useChild = (key: string) => {
+        useEffect(() => {
+          events.push(`mount:${key}`);
+          return () => events.push(`unmount:${key}`);
+        }, []);
+        return key;
+      };
+      const Child = resource(useChild);
+      const useParent = (keys: string[]) =>
+        useResources(keys.map((k) => withKey(k, Child(k))));
+
+      const fiber = createTestResource(useParent);
+      void renderResourceFiber(fiber, [["a"]]);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["mount:a"]);
+
+      // The host tears down after a render added "b" but before the commit
+      // effect ran: "b" was never mounted, and its presence must not abort
+      // the cleanup of the mounted children.
+      void renderResourceFiber(fiber, [["a", "b"]]);
+      unmountResourceFiber(fiber);
+      expect(events).toEqual(["mount:a", "unmount:a"]);
     });
   });
 });

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { useResources } from "../../hooks/useResources";
 import {
   commitResourceFiber,
+  discardWipRender,
   renderResourceFiber,
   unmountResourceFiber,
 } from "../../core/ResourceFiber";
@@ -308,6 +309,62 @@ describe("useResources - Basic Functionality", () => {
       ]);
       expect(root.getValue()).toBe(1);
       root.unmount();
+    });
+  });
+
+  describe("Discarded renders", () => {
+    it("discardWipRender reverts an uncommitted render's effect closures", () => {
+      const events: string[] = [];
+      const fiber = createTestResource((n: number) => {
+        useEffect(() => {
+          events.push(`setup:${n}`);
+          return () => events.push(`cleanup:${n}`);
+        }, [n]);
+        return n;
+      });
+
+      void renderResourceFiber(fiber, [1]);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1"]);
+
+      void renderResourceFiber(fiber, [2]);
+      discardWipRender(fiber);
+
+      // The reconnect must run the committed closure, not the discarded one.
+      unmountResourceFiber(fiber);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
+    });
+
+    it("a bailout discards the child render an abandoned pass produced", () => {
+      const events: string[] = [];
+      const useChild = ({ n }: { n: number }) => {
+        useEffect(() => {
+          events.push(`setup:${n}`);
+          return () => events.push(`cleanup:${n}`);
+        }, [n]);
+        return n;
+      };
+      const Child = resource(useChild);
+      const useParent = (n: number) =>
+        useResources([withKey("k", Child({ n }), [n])]);
+      const fiber = createTestResource(useParent);
+
+      void renderResourceFiber(fiber, [1]);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1"]);
+
+      // An abandoned pass rendered the child with n=2; its commit never ran.
+      // The committed pass bails back to n=1, superseding that render.
+      void renderResourceFiber(fiber, [2]);
+      void renderResourceFiber(fiber, [1]);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1"]);
+
+      // A later reconnect must not commit the superseded n=2 render.
+      unmountResourceFiber(fiber);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
     });
   });
 

--- a/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { createResourceFiberRoot } from "../../core/helpers/root";
+import {
+  createResourceFiber,
+  renderResourceFiber,
+  commitResourceFiber,
+  unmountResourceFiber,
+} from "../../core/ResourceFiber";
+import { useEffect } from "../../react-hooks/useEffect";
+import { useState } from "../../react-hooks/useState";
+
+// Every shipped host defers dispatches past the current pass; a host that
+// synchronously re-renders and commits from inside a setup is the remaining
+// reachable shape (flushTapSync during a React-driven commit). The superseded
+// frame's cleanup must run instead of overwriting the nested frame's.
+describe("commit reentrancy", () => {
+  it("a nested commit from inside a setup supersedes the outer frame's cleanup", () => {
+    const events: string[] = [];
+
+    const hook = () => {
+      const [count, setCount] = useState(0);
+      useEffect(() => {
+        events.push(`setup:${count}`);
+        if (count === 0) setCount(1);
+        return () => events.push(`cleanup:${count}`);
+      }, [count]);
+      return count;
+    };
+
+    const root = createResourceFiberRoot((evaluate, apply) => {
+      if (!evaluate()) return;
+      apply();
+      renderResourceFiber(fiber, []);
+      commitResourceFiber(fiber);
+    });
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    renderResourceFiber(fiber, []);
+    commitResourceFiber(fiber);
+
+    expect(events).toEqual(["setup:0", "setup:1", "cleanup:0"]);
+
+    unmountResourceFiber(fiber);
+
+    expect(events).toEqual(["setup:0", "setup:1", "cleanup:0", "cleanup:1"]);
+  });
+});

--- a/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
@@ -44,4 +44,42 @@ describe("commit reentrancy", () => {
 
     expect(events).toEqual(["setup:0", "setup:1", "cleanup:0", "cleanup:1"]);
   });
+
+  it("supersedes the outer frame even when the setup callback is referentially stable", () => {
+    const events: string[] = [];
+    let current = 0;
+    let setCurrent: (value: number) => void;
+
+    const setup = () => {
+      const count = current;
+      events.push(`setup:${count}`);
+      if (count === 0) setCurrent(1);
+      return () => events.push(`cleanup:${count}`);
+    };
+
+    const hook = () => {
+      const [count, setCount] = useState(0);
+      current = count;
+      setCurrent = setCount;
+      useEffect(setup, [count]);
+      return count;
+    };
+
+    const root = createResourceFiberRoot((evaluate, apply) => {
+      if (!evaluate()) return;
+      apply();
+      renderResourceFiber(fiber, []);
+      commitResourceFiber(fiber);
+    });
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    renderResourceFiber(fiber, []);
+    commitResourceFiber(fiber);
+
+    expect(events).toEqual(["setup:0", "setup:1", "cleanup:0"]);
+
+    unmountResourceFiber(fiber);
+
+    expect(events).toEqual(["setup:0", "setup:1", "cleanup:0", "cleanup:1"]);
+  });
 });

--- a/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/commit.reentrant-setup.test.ts
@@ -9,10 +9,6 @@ import {
 import { useEffect } from "../../react-hooks/useEffect";
 import { useState } from "../../react-hooks/useState";
 
-// Every shipped host defers dispatches past the current pass; a host that
-// synchronously re-renders and commits from inside a setup is the remaining
-// reachable shape (flushTapSync during a React-driven commit). The superseded
-// frame's cleanup must run instead of overwriting the nested frame's.
 describe("commit reentrancy", () => {
   it("a nested commit from inside a setup supersedes the outer frame's cleanup", () => {
     const events: string[] = [];

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
@@ -114,7 +114,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     unsubscribe();
     await flushUpdates();
     root.subscribe(() => {});
-    expect(body).toHaveBeenCalledTimes(mountRuns * 2);
+    expect(body).toHaveBeenCalledTimes(mountRuns);
     expect(effect).toHaveBeenCalledTimes(mountRuns + 1);
   });
 
@@ -209,6 +209,59 @@ describe("createTapRoot mountOnSubscribe", () => {
     await flushUpdates();
     root.subscribe(() => {});
     expect(root.getValue()).toBe(5);
+  });
+
+  it("remounts with fresh state after updates while soft-unmounted", async () => {
+    const body = vi.fn();
+    const seen: number[] = [];
+    const root = createTapRoot(
+      function Fresh() {
+        body();
+        const [count, setCount] = useState(0);
+        useEffect(() => {
+          seen.push(count);
+        }, [count]);
+        return { count, setCount };
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    unsubscribe();
+    await flushUpdates();
+
+    root.getValue().setCount(5);
+    await flushUpdates();
+    expect(root.getValue().count).toBe(5);
+
+    const renders = body.mock.calls.length;
+    root.subscribe(() => {});
+    expect(root.getValue().count).toBe(5);
+    expect(seen[seen.length - 1]).toBe(5);
+    expect(body).toHaveBeenCalledTimes(renders);
+  });
+
+  it("remounts without re-rendering when nothing changed while soft-unmounted", async () => {
+    const body = vi.fn();
+    const effect = vi.fn();
+    const root = createTapRoot(
+      function Idle() {
+        body();
+        useEffect(effect);
+        return null;
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    unsubscribe();
+    await flushUpdates();
+
+    const renders = body.mock.calls.length;
+    const effects = effect.mock.calls.length;
+    root.subscribe(() => {});
+    expect(body).toHaveBeenCalledTimes(renders);
+    expect(effect).toHaveBeenCalledTimes(effects + 1);
   });
 
   it("preserves ref and memo cells across an unsubscribe/resubscribe cycle", async () => {

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
@@ -10,6 +10,7 @@ import { useState } from "../../react-hooks/useState";
 import { isDevelopment } from "../../core/helpers/env";
 
 const mountRuns = isDevelopment ? 2 : 1;
+const remountEvents = isDevelopment ? ["mount", "unmount", "mount"] : ["mount"];
 
 const flushUpdates = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -95,7 +96,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     expect(effect).toHaveBeenCalledTimes(mountRuns);
   });
 
-  it("dev strict mode double invokes effects on the first mount only", async () => {
+  it("dev strict mode double invokes effects on every connect", async () => {
     const body = vi.fn();
     const effect = vi.fn();
     const root = createTapRoot(
@@ -115,7 +116,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     await flushUpdates();
     root.subscribe(() => {});
     expect(body).toHaveBeenCalledTimes(mountRuns);
-    expect(effect).toHaveBeenCalledTimes(mountRuns + 1);
+    expect(effect).toHaveBeenCalledTimes(mountRuns * 2);
   });
 
   it("notifies the first subscriber of updates dispatched during its own mount", () => {
@@ -149,7 +150,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     expect(events).toEqual(["unmount"]);
 
     root.subscribe(() => {});
-    expect(events).toEqual(["unmount", "mount"]);
+    expect(events).toEqual(["unmount", ...remountEvents]);
   });
 
   it("keeps effects mounted while any subscriber remains", async () => {
@@ -261,7 +262,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     const effects = effect.mock.calls.length;
     root.subscribe(() => {});
     expect(body).toHaveBeenCalledTimes(renders);
-    expect(effect).toHaveBeenCalledTimes(effects + 1);
+    expect(effect).toHaveBeenCalledTimes(effects + mountRuns);
   });
 
   it("preserves ref and memo cells across an unsubscribe/resubscribe cycle", async () => {
@@ -305,7 +306,13 @@ describe("createTapRoot mountOnSubscribe", () => {
       await flushUpdates();
     }
 
-    expect(events).toEqual(["unmount", "mount", "unmount", "mount", "unmount"]);
+    expect(events).toEqual([
+      "unmount",
+      ...remountEvents,
+      "unmount",
+      ...remountEvents,
+      "unmount",
+    ]);
   });
 
   it("applies state updates while soft-unmounted without running effects", async () => {
@@ -322,7 +329,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     expect(events).toEqual([]);
 
     root.subscribe(() => {});
-    expect(events).toEqual(["mount"]);
+    expect(events).toEqual(remountEvents);
     expect(root.getValue()).toBe(7);
   });
 
@@ -394,7 +401,7 @@ describe("createTapRoot mountOnSubscribe", () => {
     shouldThrow = false;
     events.length = 0;
     root.subscribe(() => {});
-    expect(events).toEqual(["mount"]);
+    expect(events).toEqual(Array(mountRuns).fill("mount"));
     expect(root.getValue()).toBe(1);
   });
 

--- a/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/lifecycle.mount-unmount.test.ts
@@ -207,4 +207,39 @@ describe("Lifecycle - Mount/Unmount", () => {
     expect(effect).toHaveBeenCalledTimes(1);
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
+
+  it("reconnects effects that bailed in a render committed after an unmount", () => {
+    const events: string[] = [];
+
+    const resource = createTestResource((dep: number) => {
+      useEffect(() => {
+        events.push("stable:setup");
+        return () => events.push("stable:cleanup");
+      }, []);
+      useEffect(() => {
+        events.push(`dep:setup:${dep}`);
+        return () => events.push("dep:cleanup");
+      }, [dep]);
+      return null;
+    });
+
+    renderResourceFiber(resource, [0]);
+    commitResourceFiber(resource);
+    expect(events).toEqual(["stable:setup", "dep:setup:0"]);
+
+    renderResourceFiber(resource, [1]);
+    unmountResourceFiber(resource);
+    expect(events).toEqual([
+      "stable:setup",
+      "dep:setup:0",
+      "stable:cleanup",
+      "dep:cleanup",
+    ]);
+
+    events.length = 0;
+    commitResourceFiber(resource);
+    expect(events).toEqual(["stable:setup", "dep:setup:1"]);
+
+    unmountResourceFiber(resource);
+  });
 });

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -225,6 +225,7 @@ describe("resources under <Activity>", () => {
   });
 
   it("useTapRoot does not replay a hidden re-render's record over a later tap update", () => {
+    const events: string[] = [];
     let handle: {
       getValue: () => {
         label: string;
@@ -236,6 +237,10 @@ describe("resources under <Activity>", () => {
     const Inner = memo(function Inner({ label }: { label: string }) {
       handle = useTapRoot(function CounterRoot() {
         const [count, setCount] = useResourceState(0);
+        useResourceEffect(() => {
+          events.push(`mount:${label}:${count}`);
+          return () => events.push("unmount");
+        }, [label, count]);
         return { label, count, setCount };
       });
       return null;
@@ -255,9 +260,13 @@ describe("resources under <Activity>", () => {
     act(() => flushTapSync(() => handle!.getValue().setCount(5)));
     expect(handle!.getValue().count).toBe(5);
 
+    events.length = 0;
     rerender(<App hidden={false} label="b" />);
     expect(handle!.getValue().count).toBe(5);
     expect(handle!.getValue().label).toBe("b");
+    // The reveal must not first commit the superseded hidden render (a churn
+    // of mount:a:5 / unmount before the converged commit).
+    expect(events).toEqual(["mount:b:5"]);
   });
 
   it("useTapRoot keeps values updated while hidden across a reveal", () => {

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -146,8 +146,6 @@ describe("resources under <Activity>", () => {
     const First = resource(useFirst);
     const Second = resource(useSecond);
 
-    // memo so hide/reveal do not re-render Inner: the reveal must replay the
-    // commit effect without a render, hitting the stale remount decision
     const Inner = memo(function Inner({ swapped }: { swapped: boolean }) {
       const [value] = useResources([
         withKey("x", swapped ? Second() : First()),
@@ -233,7 +231,6 @@ describe("resources under <Activity>", () => {
         setCount: (n: number) => void;
       };
     } | null = null;
-    // memo so the reveal replays the commit effect without a render
     const Inner = memo(function Inner({ label }: { label: string }) {
       handle = useTapRoot(function CounterRoot() {
         const [count, setCount] = useResourceState(0);
@@ -264,8 +261,6 @@ describe("resources under <Activity>", () => {
     rerender(<App hidden={false} label="b" />);
     expect(handle!.getValue().count).toBe(5);
     expect(handle!.getValue().label).toBe("b");
-    // The reveal must not first commit the superseded hidden render (a churn
-    // of mount:a:5 / unmount before the converged commit).
     expect(events).toEqual(["mount:b:5"]);
   });
 

--- a/packages/tap/src/__tests__/react/activity.test.tsx
+++ b/packages/tap/src/__tests__/react/activity.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import { Activity, memo } from "react";
+import { resource } from "../../core/resource";
+import {
+  useResource,
+  useResources,
+  useTapRoot,
+  flushTapSync,
+  withKey,
+} from "../../index";
+import { useState as useResourceState } from "../../react-hooks/useState";
+import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
+
+describe("resources under <Activity>", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("re-runs effects with fresh state after an update while hidden", () => {
+    const events: string[] = [];
+    const useCounter = () => {
+      const [count, setCount] = useResourceState(0);
+      useResourceEffect(() => {
+        events.push(`mount:${count}`);
+        return () => events.push("unmount");
+      }, [count]);
+      return { count, setCount };
+    };
+    const Counter = resource(useCounter);
+
+    let api: { count: number; setCount: (n: number) => void } | null = null;
+    function Inner() {
+      api = useResource(Counter());
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(events).toEqual(["mount:0"]);
+
+    rerender(<App hidden={true} />);
+    expect(events).toEqual(["mount:0", "unmount"]);
+
+    act(() => api!.setCount(5));
+
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount:0", "unmount", "mount:5"]);
+    expect(api!.count).toBe(5);
+  });
+
+  it("reveals without re-rendering when nothing changed while hidden", () => {
+    const events: string[] = [];
+    let renders = 0;
+    const useIdle = () => {
+      renders++;
+      useResourceEffect(() => {
+        events.push("mount");
+        return () => events.push("unmount");
+      }, []);
+      return null;
+    };
+    const Idle = resource(useIdle);
+
+    function Inner() {
+      return useResource(Idle());
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    rerender(<App hidden={true} />);
+    expect(events).toEqual(["mount", "unmount"]);
+
+    const rendersBeforeReveal = renders;
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount", "unmount", "mount"]);
+    expect(renders).toBe(rendersBeforeReveal);
+  });
+
+  it("useResources children re-run effects with fresh state after an update while hidden", () => {
+    const events: string[] = [];
+    const useCounter = (key: string) => {
+      const [count, setCount] = useResourceState(0);
+      useResourceEffect(() => {
+        events.push(`mount:${key}:${count}`);
+        return () => events.push(`unmount:${key}`);
+      }, [key, count]);
+      return { count, setCount };
+    };
+    const Counter = resource(useCounter);
+
+    let apis: { count: number; setCount: (n: number) => void }[] = [];
+    function Inner() {
+      apis = useResources([
+        withKey("a", Counter("a")),
+        withKey("b", Counter("b")),
+      ]);
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(events).toEqual(["mount:a:0", "mount:b:0"]);
+
+    rerender(<App hidden={true} />);
+    expect(events).toEqual([
+      "mount:a:0",
+      "mount:b:0",
+      "unmount:a",
+      "unmount:b",
+    ]);
+
+    act(() => apis[1]!.setCount(5));
+
+    events.length = 0;
+    rerender(<App hidden={false} />);
+    expect(events).toEqual(["mount:a:0", "mount:b:5"]);
+    expect(apis[1]!.count).toBe(5);
+  });
+
+  it("useResources survives a reveal after a hook swap", () => {
+    const events: string[] = [];
+    const useFirst = () => {
+      useResourceEffect(() => {
+        events.push("mount:first");
+        return () => events.push("unmount:first");
+      }, []);
+      return "first";
+    };
+    const useSecond = () => {
+      useResourceEffect(() => {
+        events.push("mount:second");
+        return () => events.push("unmount:second");
+      }, []);
+      return "second";
+    };
+    const First = resource(useFirst);
+    const Second = resource(useSecond);
+
+    // memo so hide/reveal do not re-render Inner: the reveal must replay the
+    // commit effect without a render, hitting the stale remount decision
+    const Inner = memo(function Inner({ swapped }: { swapped: boolean }) {
+      const [value] = useResources([
+        withKey("x", swapped ? Second() : First()),
+      ]);
+      return <>{value}</>;
+    });
+    function App({ hidden, swapped }: { hidden: boolean; swapped: boolean }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Inner swapped={swapped} />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} swapped={false} />);
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:first", "unmount:first", "mount:second"]);
+
+    rerender(<App hidden={true} swapped={true} />);
+    expect(events).toEqual([
+      "mount:first",
+      "unmount:first",
+      "mount:second",
+      "unmount:second",
+    ]);
+
+    events.length = 0;
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:second"]);
+  });
+
+  it("useResources swaps hooks while hidden and mounts the replacement on reveal", () => {
+    const events: string[] = [];
+    const useFirst = () => {
+      useResourceEffect(() => {
+        events.push("mount:first");
+        return () => events.push("unmount:first");
+      }, []);
+      return "first";
+    };
+    const useSecond = () => {
+      useResourceEffect(() => {
+        events.push("mount:second");
+        return () => events.push("unmount:second");
+      }, []);
+      return "second";
+    };
+    const First = resource(useFirst);
+    const Second = resource(useSecond);
+
+    const Inner = memo(function Inner({ swapped }: { swapped: boolean }) {
+      const [value] = useResources([
+        withKey("x", swapped ? Second() : First()),
+      ]);
+      return <>{value}</>;
+    });
+    function App({ hidden, swapped }: { hidden: boolean; swapped: boolean }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Inner swapped={swapped} />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} swapped={false} />);
+    rerender(<App hidden={true} swapped={false} />);
+    expect(events).toEqual(["mount:first", "unmount:first"]);
+
+    rerender(<App hidden={true} swapped={true} />);
+    expect(events).toEqual(["mount:first", "unmount:first"]);
+
+    events.length = 0;
+    rerender(<App hidden={false} swapped={true} />);
+    expect(events).toEqual(["mount:second"]);
+  });
+
+  it("useTapRoot does not replay a hidden re-render's record over a later tap update", () => {
+    let handle: {
+      getValue: () => {
+        label: string;
+        count: number;
+        setCount: (n: number) => void;
+      };
+    } | null = null;
+    // memo so the reveal replays the commit effect without a render
+    const Inner = memo(function Inner({ label }: { label: string }) {
+      handle = useTapRoot(function CounterRoot() {
+        const [count, setCount] = useResourceState(0);
+        return { label, count, setCount };
+      });
+      return null;
+    });
+    function App({ hidden, label }: { hidden: boolean; label: string }) {
+      return (
+        <Activity mode={hidden ? "hidden" : "visible"}>
+          <Inner label={label} />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<App hidden={false} label="a" />);
+    rerender(<App hidden={true} label="a" />);
+    rerender(<App hidden={true} label="b" />);
+
+    act(() => flushTapSync(() => handle!.getValue().setCount(5)));
+    expect(handle!.getValue().count).toBe(5);
+
+    rerender(<App hidden={false} label="b" />);
+    expect(handle!.getValue().count).toBe(5);
+    expect(handle!.getValue().label).toBe("b");
+  });
+
+  it("useTapRoot keeps values updated while hidden across a reveal", () => {
+    let handle: {
+      getValue: () => { count: number; setCount: (n: number) => void };
+    } | null = null;
+    function Inner() {
+      handle = useTapRoot(function CounterRoot() {
+        const [count, setCount] = useResourceState(0);
+        return { count, setCount };
+      });
+      return null;
+    }
+    const inner = <Inner />;
+    function App({ hidden }: { hidden: boolean }) {
+      return <Activity mode={hidden ? "hidden" : "visible"}>{inner}</Activity>;
+    }
+
+    const { rerender } = render(<App hidden={false} />);
+    expect(handle!.getValue().count).toBe(0);
+
+    rerender(<App hidden={true} />);
+    act(() => flushTapSync(() => handle!.getValue().setCount(5)));
+    expect(handle!.getValue().count).toBe(5);
+
+    rerender(<App hidden={false} />);
+    expect(handle!.getValue().count).toBe(5);
+  });
+});

--- a/packages/tap/src/__tests__/react/useTapRoot.nested-flush.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.nested-flush.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { useTapRoot, flushTapSync } from "../../index";
+import { useState as useResourceState } from "../../react-hooks/useState";
+import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
+
+// flushTapSync from an effect during a React-driven commit runs handleUpdate
+// nested inside the outer commit; the outer frame's publish must not regress
+// the root to its superseded render.
+describe("useTapRoot nested flush", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not publish a render superseded by a nested handleUpdate", () => {
+    const seen: number[] = [];
+    let handle: useTapRoot.Root<{ count: number }> | null = null;
+
+    function Host() {
+      handle = useTapRoot(function CounterRoot() {
+        const [count, setCount] = useResourceState(0);
+        useResourceEffect(() => {
+          if (count === 0) flushTapSync(() => setCount(1));
+        }, [count]);
+        return { count };
+      });
+      return null;
+    }
+
+    render(<Host />);
+    handle!.subscribe(() => seen.push(handle!.getValue().count));
+
+    expect(handle!.getValue().count).toBe(1);
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/tap/src/__tests__/react/useTapRoot.nested-flush.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.nested-flush.test.tsx
@@ -4,9 +4,6 @@ import { useTapRoot, flushTapSync } from "../../index";
 import { useState as useResourceState } from "../../react-hooks/useState";
 import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
 
-// flushTapSync from an effect during a React-driven commit runs handleUpdate
-// nested inside the outer commit; the outer frame's publish must not regress
-// the root to its superseded render.
 describe("useTapRoot nested flush", () => {
   afterEach(() => {
     cleanup();

--- a/packages/tap/src/__tests__/scheduler.notify.test.ts
+++ b/packages/tap/src/__tests__/scheduler.notify.test.ts
@@ -24,4 +24,50 @@ describe("scheduleNotify", () => {
 
     expect(events).toEqual(["notify"]);
   });
+
+  it("keeps draining when a notification throws and aggregates the errors", () => {
+    const events: string[] = [];
+    const scheduler = new UpdateScheduler(() => {
+      scheduleNotify(() => {
+        throw new Error("notify-boom");
+      });
+      scheduleNotify(() => events.push("second"));
+    });
+
+    let caught: unknown;
+    try {
+      flushTapSync(() => scheduler.markDirty());
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(events).toEqual(["second"]);
+    expect((caught as Error).message).toBe("notify-boom");
+  });
+
+  it("aggregates a task error with a notification error", () => {
+    const notifier = new UpdateScheduler(() =>
+      scheduleNotify(() => {
+        throw new Error("notify-boom");
+      }),
+    );
+    const thrower = new UpdateScheduler(() => {
+      throw new Error("task-boom");
+    });
+
+    let caught: unknown;
+    try {
+      flushTapSync(() => {
+        notifier.markDirty();
+        thrower.markDirty();
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect(
+      (caught as AggregateError).errors.map((e) => (e as Error).message),
+    ).toEqual(["task-boom", "notify-boom"]);
+  });
 });

--- a/packages/tap/src/__tests__/scheduler.notify.test.ts
+++ b/packages/tap/src/__tests__/scheduler.notify.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import {
+  UpdateScheduler,
+  flushTapSync,
+  scheduleNotify,
+} from "../core/scheduler";
+
+describe("scheduleNotify", () => {
+  it("delivers queued notifications when another drain task throws", () => {
+    const events: string[] = [];
+    const notifier = new UpdateScheduler(() =>
+      scheduleNotify(() => events.push("notify")),
+    );
+    const thrower = new UpdateScheduler(() => {
+      throw new Error("boom");
+    });
+
+    expect(() =>
+      flushTapSync(() => {
+        notifier.markDirty();
+        thrower.markDirty();
+      }),
+    ).toThrow("boom");
+
+    expect(events).toEqual(["notify"]);
+  });
+});

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -12,9 +12,6 @@ export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
   readonly __args?: (args: A) => void;
 };
 
-// Renders never nest, they queue: a dispatch made while a render or commit is
-// on the stack is parked here and drained sequentially after the pass. The
-// harness is a host, so it tracks its own passes (core carries no guard).
 const pendingRerenders = new Set<ResourceFiber<any>>();
 let isPassOnStack = false;
 
@@ -96,8 +93,6 @@ export function renderTest<R, A extends readonly unknown[]>(
     commitResourceFiber(fiber);
     return rendered;
   });
-  // Dispatches made during the commit converge sequentially, React-style;
-  // the converged result is observable via getCommittedValue.
   drainPendingRerenders();
 
   return value;

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -6,11 +6,38 @@ import {
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import type { ResourceFiber } from "../core/types";
+import { isReconciling } from "../core/scheduler";
 import { useState } from "../react-hooks/useState";
 
 export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
   readonly __args?: (args: A) => void;
 };
+
+// Renders never nest, they queue: a dispatch made while a render or commit is
+// on the stack is parked here and drained sequentially after the pass.
+const pendingRerenders = new Set<ResourceFiber<any>>();
+let isDraining = false;
+
+function drainPendingRerenders() {
+  if (isDraining || isReconciling()) return;
+  isDraining = true;
+  try {
+    let passes = 0;
+    for (const fiber of pendingRerenders) {
+      pendingRerenders.delete(fiber);
+      if (++passes > 50) {
+        throw new Error("Too many re-render passes in test harness");
+      }
+      if (!activeResources.has(fiber)) continue;
+      const lastArgs = propsMap.get(fiber);
+      const value = renderResourceFiber(fiber, lastArgs);
+      lastRenderValueMap.set(fiber, value);
+      commitResourceFiber(fiber);
+    }
+  } finally {
+    isDraining = false;
+  }
+}
 
 /**
  * Creates a test resource fiber for unit testing.
@@ -24,13 +51,8 @@ export function createTestResource<R, A extends readonly unknown[]>(
     if (!evaluate()) return;
     apply();
 
-    // Re-render when state changes
-    if (activeResources.has(fiber)) {
-      const lastArgs = propsMap.get(fiber);
-      const value = renderResourceFiber(fiber, lastArgs);
-      lastRenderValueMap.set(fiber, value);
-      commitResourceFiber(fiber);
-    }
+    pendingRerenders.add(fiber);
+    drainPendingRerenders();
   };
 
   const fiber = createResourceFiber(
@@ -61,15 +83,13 @@ export function renderTest<R, A extends readonly unknown[]>(
   // Track resource for cleanup
   activeResources.add(fiber);
 
-  // Render with new args. Record the result before committing: the commit can
-  // synchronously trigger a nested re-render whose newer result must not be
-  // clobbered afterwards.
   const value = renderResourceFiber(fiber, args);
   lastRenderValueMap.set(fiber, value);
   commitResourceFiber(fiber);
+  // Dispatches made during the commit converge sequentially, React-style;
+  // the converged result is observable via getCommittedValue.
+  drainPendingRerenders();
 
-  // Return the committed state from the result
-  // This accounts for any re-renders that happened during commit
   return value;
 }
 
@@ -119,6 +139,7 @@ export class TestSubscriber<T> {
     const lastArgs = propsMap.get(fiber) ?? [];
     const initialValue = renderResourceFiber(fiber, lastArgs as any);
     commitResourceFiber(fiber);
+    drainPendingRerenders();
     this.lastState = initialValue;
     lastRenderValueMap.set(fiber, initialValue);
     activeResources.add(fiber);
@@ -154,8 +175,9 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
     activeResources.add(this.fiber);
     propsMap.set(this.fiber, args);
     const value = renderResourceFiber(this.fiber, args);
-    commitResourceFiber(this.fiber);
     lastRenderValueMap.set(this.fiber, value);
+    commitResourceFiber(this.fiber);
+    drainPendingRerenders();
     return value;
   }
 

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -6,7 +6,6 @@ import {
   commitResourceFiber,
 } from "../core/ResourceFiber";
 import type { ResourceFiber } from "../core/types";
-import { isReconciling } from "../core/scheduler";
 import { useState } from "../react-hooks/useState";
 
 export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
@@ -14,14 +13,24 @@ export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
 };
 
 // Renders never nest, they queue: a dispatch made while a render or commit is
-// on the stack is parked here and drained sequentially after the pass.
+// on the stack is parked here and drained sequentially after the pass. The
+// harness is a host, so it tracks its own passes (core carries no guard).
 const pendingRerenders = new Set<ResourceFiber<any>>();
-let isDraining = false;
+let isPassOnStack = false;
+
+function runPass<T>(fn: () => T): T {
+  const prev = isPassOnStack;
+  isPassOnStack = true;
+  try {
+    return fn();
+  } finally {
+    isPassOnStack = prev;
+  }
+}
 
 function drainPendingRerenders() {
-  if (isDraining || isReconciling()) return;
-  isDraining = true;
-  try {
+  if (isPassOnStack) return;
+  runPass(() => {
     let passes = 0;
     for (const fiber of pendingRerenders) {
       pendingRerenders.delete(fiber);
@@ -34,9 +43,7 @@ function drainPendingRerenders() {
       lastRenderValueMap.set(fiber, value);
       commitResourceFiber(fiber);
     }
-  } finally {
-    isDraining = false;
-  }
+  });
 }
 
 /**
@@ -83,9 +90,12 @@ export function renderTest<R, A extends readonly unknown[]>(
   // Track resource for cleanup
   activeResources.add(fiber);
 
-  const value = renderResourceFiber(fiber, args);
-  lastRenderValueMap.set(fiber, value);
-  commitResourceFiber(fiber);
+  const value = runPass(() => {
+    const rendered = renderResourceFiber(fiber, args);
+    lastRenderValueMap.set(fiber, rendered);
+    commitResourceFiber(fiber);
+    return rendered;
+  });
   // Dispatches made during the commit converge sequentially, React-style;
   // the converged result is observable via getCommittedValue.
   drainPendingRerenders();
@@ -136,9 +146,12 @@ export class TestSubscriber<T> {
   constructor(fiber: ResourceFiber<any>) {
     this.fiber = fiber;
     // Need to render once to get initial state
-    const lastArgs = propsMap.get(fiber) ?? [];
-    const initialValue = renderResourceFiber(fiber, lastArgs as any);
-    commitResourceFiber(fiber);
+    const initialValue = runPass(() => {
+      const lastArgs = propsMap.get(fiber) ?? [];
+      const value = renderResourceFiber(fiber, lastArgs as any);
+      commitResourceFiber(fiber);
+      return value;
+    });
     drainPendingRerenders();
     this.lastState = initialValue;
     lastRenderValueMap.set(fiber, initialValue);
@@ -174,9 +187,12 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
     this.isActive = true;
     activeResources.add(this.fiber);
     propsMap.set(this.fiber, args);
-    const value = renderResourceFiber(this.fiber, args);
-    lastRenderValueMap.set(this.fiber, value);
-    commitResourceFiber(this.fiber);
+    const value = runPass(() => {
+      const rendered = renderResourceFiber(this.fiber, args);
+      lastRenderValueMap.set(this.fiber, rendered);
+      commitResourceFiber(this.fiber);
+      return rendered;
+    });
     drainPendingRerenders();
     return value;
   }

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -32,7 +32,6 @@ export function createResourceFiber<R>(
       index: 0,
     },
     renderPendingCells: null,
-    renderCount: 0,
     currentIndex: 0,
     isFirstRender: true,
     isMounted: false,
@@ -57,7 +56,6 @@ export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
 ): R {
-  fiber.renderCount++;
   fiber.memoCache.workInProgress = null;
 
   // Discard render-phase actions left by a previous render

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -9,6 +9,7 @@ import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
 import { commitRoot } from "./helpers/root";
+import { withReconcileScope } from "./scheduler";
 
 export function createResourceFiber<R>(
   hook: (...args: any[]) => R,
@@ -43,70 +44,78 @@ export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isMounted) return;
 
   fiber.isMounted = false;
-  cleanupAllEffects(fiber);
+  withReconcileScope(() => cleanupAllEffects(fiber));
 }
 
 export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
 ): R {
-  fiber.memoCache.workInProgress = null;
+  return withReconcileScope(() => {
+    fiber.memoCache.workInProgress = null;
 
-  // Discard render-phase actions left by a previous render
-  if (fiber.renderPendingCells !== null) {
-    for (const cell of fiber.renderPendingCells) cell.renderQueue = null;
-    fiber.renderPendingCells.clear();
-  }
-
-  let passes = 0;
-  let value: R;
-  do {
-    if (++passes > 25) {
-      throw new Error(
-        "Too many re-renders. tap limits the number of renders to prevent " +
-          "an infinite loop.",
-      );
+    // Discard render-phase actions left by a previous render
+    if (fiber.renderPendingCells !== null) {
+      for (const cell of fiber.renderPendingCells) cell.renderQueue = null;
+      fiber.renderPendingCells.clear();
     }
-    fiber.memoCache.index = 0;
 
-    withResourceFiber(fiber, () => {
-      value = withReactDispatcher(() => fiber.hook(...args));
-    });
-  } while ((fiber.renderPendingCells?.size ?? 0) > 0);
+    let passes = 0;
+    let value: R;
+    do {
+      if (++passes > 25) {
+        throw new Error(
+          "Too many re-renders. tap limits the number of renders to prevent " +
+            "an infinite loop.",
+        );
+      }
+      fiber.memoCache.index = 0;
 
-  bubbleContextDeps(fiber);
+      withResourceFiber(fiber, () => {
+        value = withReactDispatcher(() => fiber.hook(...args));
+      });
+    } while ((fiber.renderPendingCells?.size ?? 0) > 0);
 
-  return value!;
+    bubbleContextDeps(fiber);
+
+    return value!;
+  });
 }
 
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
-  const commitCallbacks = fiber.wipCommitCallbacks;
-  fiber.wipCommitCallbacks = null;
-  // null means no render since the last commit (StrictMode replay, Activity
-  // reveal): render-scoped state stays, the reconcile walk below re-runs any
-  // disconnected effects.
-  const rendered = commitCallbacks !== null;
+  withReconcileScope(() => {
+    const commitCallbacks = fiber.wipCommitCallbacks;
+    fiber.wipCommitCallbacks = null;
+    // null means no render since the last commit (StrictMode replay, Activity
+    // reveal): render-scoped state stays, the reconcile walk below re-runs any
+    // disconnected effects.
+    const rendered = commitCallbacks !== null;
 
-  fiber.isMounted = true;
-  if (rendered) {
-    fiber.contextDeps = fiber.wipContextDeps;
-    commitRoot(fiber.root);
+    fiber.isMounted = true;
+    if (rendered) {
+      fiber.contextDeps = fiber.wipContextDeps;
+      commitRoot(fiber.root);
 
-    if (fiber.memoCache.workInProgress !== null) {
-      fiber.memoCache.current = fiber.memoCache.workInProgress;
-      fiber.memoCache.workInProgress = null;
+      if (fiber.memoCache.workInProgress !== null) {
+        fiber.memoCache.current = fiber.memoCache.workInProgress;
+        fiber.memoCache.workInProgress = null;
+      }
     }
-  }
 
-  if (isDevelopment && fiber.isNeverMounted && fiber.devStrictMode === "root") {
+    if (
+      isDevelopment &&
+      fiber.isNeverMounted &&
+      fiber.devStrictMode === "root"
+    ) {
+      fiber.isNeverMounted = false;
+
+      if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
+      reconcileEffects(fiber, rendered);
+      cleanupAllEffects(fiber);
+    }
+
     fiber.isNeverMounted = false;
-
     if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
     reconcileEffects(fiber, rendered);
-    cleanupAllEffects(fiber);
-  }
-
-  fiber.isNeverMounted = false;
-  if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
-  reconcileEffects(fiber, rendered);
+  });
 }

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -40,8 +40,7 @@ export function createResourceFiber<R>(
 }
 
 export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
-  if (!fiber.isMounted)
-    throw new Error("Tried to unmount a fiber that is already unmounted");
+  if (!fiber.isMounted) return;
 
   fiber.isMounted = false;
   cleanupAllEffects(fiber);

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -88,12 +88,13 @@ export function renderResourceFiber<R>(
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
   const commitCallbacks = fiber.wipCommitCallbacks;
   fiber.wipCommitCallbacks = null;
-  const rendered = commitCallbacks !== null;
   const strictReplay =
     isDevelopment && !fiber.isMounted && fiber.devStrictMode === "root";
 
   fiber.isMounted = true;
-  if (rendered) {
+  fiber.isNeverMounted = false;
+
+  if (commitCallbacks !== null) {
     fiber.contextDeps = fiber.wipContextDeps;
     commitRoot(fiber.root);
 
@@ -101,11 +102,9 @@ export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
       fiber.memoCache.current = fiber.memoCache.workInProgress;
       fiber.memoCache.workInProgress = null;
     }
+
+    commitAllCallbacks(commitCallbacks);
   }
-
-  fiber.isNeverMounted = false;
-
-  if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
   if (strictReplay) {
     reconcileEffects(fiber);
     cleanupAllEffects(fiber);

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -1,6 +1,10 @@
 import type { ResourceFiber, TapRoot } from "./types";
 import { bubbleContextDeps } from "./context";
-import { commitAllCallbacks, cleanupAllEffects } from "./helpers/commit";
+import {
+  commitAllCallbacks,
+  cleanupAllEffects,
+  reconcileEffects,
+} from "./helpers/commit";
 import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
@@ -20,7 +24,6 @@ export function createResourceFiber<R>(
     cells: [],
     contextDeps: null,
     wipContextDeps: null,
-    commitCallbacks: null,
     wipCommitCallbacks: null,
     memoCache: {
       current: null,
@@ -77,27 +80,33 @@ export function renderResourceFiber<R>(
 }
 
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
-  const commitCallbacks =
-    fiber.wipCommitCallbacks ?? fiber.commitCallbacks ?? [];
+  const commitCallbacks = fiber.wipCommitCallbacks;
   fiber.wipCommitCallbacks = null;
-  fiber.commitCallbacks = commitCallbacks;
+  // null means no render since the last commit (StrictMode replay, Activity
+  // reveal): render-scoped state stays, the reconcile walk below re-runs any
+  // disconnected effects.
+  const rendered = commitCallbacks !== null;
 
   fiber.isMounted = true;
-  fiber.contextDeps = fiber.wipContextDeps;
-  commitRoot(fiber.root);
+  if (rendered) {
+    fiber.contextDeps = fiber.wipContextDeps;
+    commitRoot(fiber.root);
 
-  if (fiber.memoCache.workInProgress !== null) {
-    fiber.memoCache.current = fiber.memoCache.workInProgress;
-    fiber.memoCache.workInProgress = null;
+    if (fiber.memoCache.workInProgress !== null) {
+      fiber.memoCache.current = fiber.memoCache.workInProgress;
+      fiber.memoCache.workInProgress = null;
+    }
   }
 
   if (isDevelopment && fiber.isNeverMounted && fiber.devStrictMode === "root") {
     fiber.isNeverMounted = false;
 
-    commitAllCallbacks(commitCallbacks);
+    if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
+    reconcileEffects(fiber, rendered);
     cleanupAllEffects(fiber);
   }
 
   fiber.isNeverMounted = false;
-  commitAllCallbacks(commitCallbacks);
+  if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
+  reconcileEffects(fiber, rendered);
 }

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -40,6 +40,15 @@ export function createResourceFiber<R>(
   };
 }
 
+// Discards an uncommitted render, reverting the fiber to its committed state
+// — the equivalent of React dropping a work-in-progress fiber. Only valid
+// when the discarded render applied no state update (reducer rollback is the
+// root's job, keyed to versions).
+export function discardWipRender<R>(fiber: ResourceFiber<R>): void {
+  fiber.wipCommitCallbacks = null;
+  fiber.memoCache.workInProgress = null;
+}
+
 export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isMounted) return;
 

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -32,6 +32,7 @@ export function createResourceFiber<R>(
       index: 0,
     },
     renderPendingCells: null,
+    renderCount: 0,
     currentIndex: 0,
     isFirstRender: true,
     isMounted: false,
@@ -59,6 +60,7 @@ export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
 ): R {
+  fiber.renderCount++;
   fiber.memoCache.workInProgress = null;
 
   // Discard render-phase actions left by a previous render

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -22,6 +22,7 @@ export function createResourceFiber<R>(
     markDirty,
     devStrictMode: strictMode,
     cells: [],
+    effectCells: [],
     contextDeps: null,
     wipContextDeps: null,
     wipCommitCallbacks: null,

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -40,10 +40,7 @@ export function createResourceFiber<R>(
   };
 }
 
-// Discards an uncommitted render, reverting the fiber to its committed state
-// — the equivalent of React dropping a work-in-progress fiber. Only valid
-// when the discarded render applied no state update (reducer rollback is the
-// root's job, keyed to versions).
+// Only valid when the discarded render applied no state update
 export function discardWipRender<R>(fiber: ResourceFiber<R>): void {
   fiber.wipCommitCallbacks = null;
   fiber.memoCache.workInProgress = null;
@@ -93,11 +90,7 @@ export function renderResourceFiber<R>(
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
   const commitCallbacks = fiber.wipCommitCallbacks;
   fiber.wipCommitCallbacks = null;
-  // null means no render since the last commit (StrictMode replay, Activity
-  // reveal): render-scoped state stays untouched.
   const rendered = commitCallbacks !== null;
-  // Strict-mode connect (first mount or reconnect): setup, cleanup, then the
-  // real setup, mirroring React's StrictMode replay on mount and reveal.
   const strictReplay =
     isDevelopment && !fiber.isMounted && fiber.devStrictMode === "root";
 

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -87,9 +87,12 @@ export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
     const commitCallbacks = fiber.wipCommitCallbacks;
     fiber.wipCommitCallbacks = null;
     // null means no render since the last commit (StrictMode replay, Activity
-    // reveal): render-scoped state stays, the reconcile walk below re-runs any
-    // disconnected effects.
+    // reveal): render-scoped state stays untouched.
     const rendered = commitCallbacks !== null;
+    // Strict-mode connect (first mount or reconnect): setup, cleanup, then the
+    // real setup, mirroring React's StrictMode replay on mount and reveal.
+    const strictReplay =
+      isDevelopment && !fiber.isMounted && fiber.devStrictMode === "root";
 
     fiber.isMounted = true;
     if (rendered) {
@@ -102,20 +105,13 @@ export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
       }
     }
 
-    if (
-      isDevelopment &&
-      fiber.isNeverMounted &&
-      fiber.devStrictMode === "root"
-    ) {
-      fiber.isNeverMounted = false;
+    fiber.isNeverMounted = false;
 
-      if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
-      reconcileEffects(fiber, rendered);
+    if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
+    if (strictReplay) {
+      reconcileEffects(fiber);
       cleanupAllEffects(fiber);
     }
-
-    fiber.isNeverMounted = false;
-    if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
-    reconcileEffects(fiber, rendered);
+    reconcileEffects(fiber);
   });
 }

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -9,7 +9,6 @@ import { withResourceFiber } from "./helpers/execution-context";
 import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
 import { commitRoot } from "./helpers/root";
-import { withReconcileScope } from "./scheduler";
 
 export function createResourceFiber<R>(
   hook: (...args: any[]) => R,
@@ -53,74 +52,70 @@ export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isMounted) return;
 
   fiber.isMounted = false;
-  withReconcileScope(() => cleanupAllEffects(fiber));
+  cleanupAllEffects(fiber);
 }
 
 export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
 ): R {
-  return withReconcileScope(() => {
-    fiber.memoCache.workInProgress = null;
+  fiber.memoCache.workInProgress = null;
 
-    // Discard render-phase actions left by a previous render
-    if (fiber.renderPendingCells !== null) {
-      for (const cell of fiber.renderPendingCells) cell.renderQueue = null;
-      fiber.renderPendingCells.clear();
+  // Discard render-phase actions left by a previous render
+  if (fiber.renderPendingCells !== null) {
+    for (const cell of fiber.renderPendingCells) cell.renderQueue = null;
+    fiber.renderPendingCells.clear();
+  }
+
+  let passes = 0;
+  let value: R;
+  do {
+    if (++passes > 25) {
+      throw new Error(
+        "Too many re-renders. tap limits the number of renders to prevent " +
+          "an infinite loop.",
+      );
     }
+    fiber.memoCache.index = 0;
 
-    let passes = 0;
-    let value: R;
-    do {
-      if (++passes > 25) {
-        throw new Error(
-          "Too many re-renders. tap limits the number of renders to prevent " +
-            "an infinite loop.",
-        );
-      }
-      fiber.memoCache.index = 0;
+    withResourceFiber(fiber, () => {
+      value = withReactDispatcher(() => fiber.hook(...args));
+    });
+  } while ((fiber.renderPendingCells?.size ?? 0) > 0);
 
-      withResourceFiber(fiber, () => {
-        value = withReactDispatcher(() => fiber.hook(...args));
-      });
-    } while ((fiber.renderPendingCells?.size ?? 0) > 0);
+  bubbleContextDeps(fiber);
 
-    bubbleContextDeps(fiber);
-
-    return value!;
-  });
+  return value!;
 }
 
 export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
-  withReconcileScope(() => {
-    const commitCallbacks = fiber.wipCommitCallbacks;
-    fiber.wipCommitCallbacks = null;
-    // null means no render since the last commit (StrictMode replay, Activity
-    // reveal): render-scoped state stays untouched.
-    const rendered = commitCallbacks !== null;
-    // Strict-mode connect (first mount or reconnect): setup, cleanup, then the
-    // real setup, mirroring React's StrictMode replay on mount and reveal.
-    const strictReplay =
-      isDevelopment && !fiber.isMounted && fiber.devStrictMode === "root";
+  const commitCallbacks = fiber.wipCommitCallbacks;
+  fiber.wipCommitCallbacks = null;
+  // null means no render since the last commit (StrictMode replay, Activity
+  // reveal): render-scoped state stays untouched.
+  const rendered = commitCallbacks !== null;
+  // Strict-mode connect (first mount or reconnect): setup, cleanup, then the
+  // real setup, mirroring React's StrictMode replay on mount and reveal.
+  const strictReplay =
+    isDevelopment && !fiber.isMounted && fiber.devStrictMode === "root";
 
-    fiber.isMounted = true;
-    if (rendered) {
-      fiber.contextDeps = fiber.wipContextDeps;
-      commitRoot(fiber.root);
+  fiber.isMounted = true;
+  if (rendered) {
+    fiber.contextDeps = fiber.wipContextDeps;
+    commitRoot(fiber.root);
 
-      if (fiber.memoCache.workInProgress !== null) {
-        fiber.memoCache.current = fiber.memoCache.workInProgress;
-        fiber.memoCache.workInProgress = null;
-      }
+    if (fiber.memoCache.workInProgress !== null) {
+      fiber.memoCache.current = fiber.memoCache.workInProgress;
+      fiber.memoCache.workInProgress = null;
     }
+  }
 
-    fiber.isNeverMounted = false;
+  fiber.isNeverMounted = false;
 
-    if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
-    if (strictReplay) {
-      reconcileEffects(fiber);
-      cleanupAllEffects(fiber);
-    }
+  if (commitCallbacks !== null) commitAllCallbacks(commitCallbacks);
+  if (strictReplay) {
     reconcileEffects(fiber);
-  });
+    cleanupAllEffects(fiber);
+  }
+  reconcileEffects(fiber);
 }

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -54,9 +54,7 @@ export const attachDefaultValueToContext = <T>(
   (context as TapContext<T>)[defaultContextValue] = defaultValue;
 };
 
-export const isTapContext = (
-  context: unknown,
-): context is TapContext<unknown> =>
+const isTapContext = (context: unknown): context is TapContext<unknown> =>
   typeof context === "object" &&
   context !== null &&
   defaultContextValue in context;

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -30,7 +30,6 @@ export const createTapRoot = <R>(
     return renderResourceFiber(fiber, [render]) as useTapRoot.Root<R>;
   };
 
-  // The commit runs as a drain task so effects execute inside the flush.
   const commitScheduler = new UpdateScheduler(() => commitResourceFiber(fiber));
   const commitFiber = () => flushTapSync(() => commitScheduler.markDirty());
 

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -55,7 +55,7 @@ export const createTapRoot = <R>(
 
   let subscriberCount = 0;
   const unmountScheduler = new UpdateScheduler(() => {
-    if (subscriberCount === 0 && fiber.isMounted) unmountResourceFiber(fiber);
+    if (subscriberCount === 0) unmountResourceFiber(fiber);
   });
 
   return {
@@ -67,7 +67,7 @@ export const createTapRoot = <R>(
           flushTapSync(() => commitResourceFiber(fiber));
         } catch (error) {
           try {
-            if (fiber.isMounted) unmountResourceFiber(fiber);
+            unmountResourceFiber(fiber);
           } finally {
             subscriberCount--;
             unsubscribe();

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -64,8 +64,6 @@ export const createTapRoot = <R>(
       const unsubscribe = ensureRoot().subscribe(listener);
       if (subscriberCount++ === 0 && !fiber.isMounted) {
         try {
-          // Remounts re-render first so the commit sees fresh effect closures
-          if (!fiber.isNeverMounted) void renderFiber();
           flushTapSync(() => commitResourceFiber(fiber));
         } catch (error) {
           try {

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -40,12 +40,16 @@ export const createTapRoot = <R>(
     return renderResourceFiber(fiber, [render]) as useTapRoot.Root<R>;
   };
 
+  // The commit runs as a drain task so effects execute inside the flush.
+  const commitScheduler = new UpdateScheduler(() => commitResourceFiber(fiber));
+  const commitFiber = () => flushTapSync(() => commitScheduler.markDirty());
+
   let root: useTapRoot.Root<R> | undefined;
   const ensureRoot = () => (root ??= renderFiber());
 
   if (!options?.mountOnSubscribe) {
     const root = ensureRoot();
-    flushTapSync(() => commitResourceFiber(fiber));
+    commitFiber();
 
     return {
       ...root,
@@ -64,7 +68,7 @@ export const createTapRoot = <R>(
       const unsubscribe = ensureRoot().subscribe(listener);
       if (subscriberCount++ === 0 && !fiber.isMounted) {
         try {
-          flushTapSync(() => commitResourceFiber(fiber));
+          commitFiber();
         } catch (error) {
           try {
             unmountResourceFiber(fiber);

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -13,20 +13,10 @@ export const createTapRoot = <R>(
   render: () => R,
   options?: { mountOnSubscribe?: boolean },
 ): useTapRoot.Root<R> & { unmount: () => void } => {
-  const pendingEvaluates: (() => boolean)[] = [];
-  const scheduler = new UpdateScheduler(() => {
-    for (const evaluate of pendingEvaluates.splice(0)) {
-      if (evaluate()) {
-        throw new Error("Unexpected rerender of createTapRoot outer fiber");
-      }
-    }
-  });
-
   const fiber = createResourceFiber(
     useTapRoot,
-    createResourceFiberRoot((evaluate) => {
-      pendingEvaluates.push(evaluate);
-      scheduler.markDirty();
+    createResourceFiberRoot(() => {
+      throw new Error("Unexpected update on createTapRoot outer fiber");
     }),
     undefined,
     isDevelopment ? "root" : null,

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -80,7 +80,7 @@ export function reconcileEffects<R>(fiber: ResourceFiber<R>): void {
 export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {
   const errors: unknown[] = [];
   for (const cell of executionContext.effectCells) {
-    cell.deps = null; // Reset deps so effect runs again on next mount
+    cell.deps = null;
 
     if (cell.cleanup) {
       try {

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -31,14 +31,15 @@ function setupEffect(cell: EffectCell): void {
   }
 }
 
-// deps === null (new or disconnected) runs on any commit; a render-less
-// commit (Activity reveal) runs nothing else; a rendered commit follows
-// React semantics: dep-less every render, dep'd on shallow inequality.
-// useEffect keeps dep arity stable once committed, so setupDeps and deps
-// are undefined together past the null check.
 const effectNeedsRun = (cell: EffectCell, rendered: boolean): boolean => {
+  // Mount/reconnect leg: a cell that never ran or was disconnected runs on
+  // any commit, rendered or not (the zero-render Activity reveal).
   if (cell.deps === null) return true;
+  // Update leg: a connected cell only responds to a new render — this also
+  // makes replayed commits of an already-committed render no-ops.
   if (!rendered) return false;
+  // React dep semantics. Dep arity is stable once committed, so
+  // setupDeps === undefined implies the committed deps are dep-less too.
   if (cell.setupDeps === undefined) return true;
   return !depsShallowEqual(cell.deps!, cell.setupDeps);
 };

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -48,8 +48,7 @@ export function reconcileEffects<R>(
   const errors: unknown[] = [];
   const pending: EffectCell[] = [];
 
-  for (const cell of fiber.cells) {
-    if (cell?.type !== "effect") continue;
+  for (const cell of fiber.effectCells) {
     if (effectNeedsRun(cell, rendered)) pending.push(cell);
   }
 
@@ -76,18 +75,16 @@ export function reconcileEffects<R>(
 
 export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {
   const errors: unknown[] = [];
-  for (const cell of executionContext.cells) {
-    if (cell?.type === "effect") {
-      cell.deps = null; // Reset deps so effect runs again on next mount
+  for (const cell of executionContext.effectCells) {
+    cell.deps = null; // Reset deps so effect runs again on next mount
 
-      if (cell.cleanup) {
-        try {
-          cell.cleanup?.();
-        } catch (e) {
-          errors.push(e);
-        } finally {
-          cell.cleanup = undefined;
-        }
+    if (cell.cleanup) {
+      try {
+        cell.cleanup?.();
+      } catch (e) {
+        errors.push(e);
+      } finally {
+        cell.cleanup = undefined;
       }
     }
   }

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -2,31 +2,14 @@ import type { CommitCallbacks, EffectCell, ResourceFiber } from "../types";
 import { throwAggregated } from "./throwAggregated";
 import { depsShallowEqual } from "../../hooks/utils/depsShallowEqual";
 
-export const CommitPriority = {
-  HookState: 0,
-  EffectEvent: 1,
-} as const;
-export type CommitPriority =
-  (typeof CommitPriority)[keyof typeof CommitPriority];
-
-const COMMIT_PRIORITIES = [
-  CommitPriority.HookState,
-  CommitPriority.EffectEvent,
-] as const;
-
 export function commitAllCallbacks(callbacks: CommitCallbacks): void {
   const errors: unknown[] = [];
 
-  for (const priority of COMMIT_PRIORITIES) {
-    const lane = callbacks[priority];
-    if (lane === undefined) continue;
-
-    for (let i = 0; i < lane.length; i++) {
-      try {
-        lane[i]!();
-      } catch (error) {
-        errors.push(error);
-      }
+  for (let i = 0; i < callbacks.length; i++) {
+    try {
+      callbacks[i]!();
+    } catch (error) {
+      errors.push(error);
     }
   }
 

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -31,28 +31,22 @@ function setupEffect(cell: EffectCell): void {
   }
 }
 
-const effectNeedsRun = (cell: EffectCell, rendered: boolean): boolean => {
-  // Mount/reconnect leg: a cell that never ran or was disconnected runs on
-  // any commit, rendered or not (the zero-render Activity reveal).
+const effectNeedsRun = (cell: EffectCell): boolean => {
+  // A cell that never ran or was disconnected runs on any commit (first
+  // mount, the zero-render Activity reveal).
   if (cell.deps === null) return true;
-  // Update leg: a connected cell only responds to a new render — this also
-  // makes replayed commits of an already-committed render no-ops.
-  if (!rendered) return false;
   // React dep semantics. Dep arity is stable once committed, so
   // setupDeps === undefined implies the committed deps are dep-less too.
   if (cell.setupDeps === undefined) return true;
   return !depsShallowEqual(cell.deps!, cell.setupDeps);
 };
 
-export function reconcileEffects<R>(
-  fiber: ResourceFiber<R>,
-  rendered: boolean,
-): void {
+export function reconcileEffects<R>(fiber: ResourceFiber<R>): void {
   const errors: unknown[] = [];
   const pending: EffectCell[] = [];
 
   for (const cell of fiber.effectCells) {
-    if (effectNeedsRun(cell, rendered)) pending.push(cell);
+    if (effectNeedsRun(cell)) pending.push(cell);
   }
 
   for (const cell of pending) {

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -17,17 +17,25 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
 }
 
 function setupEffect(cell: EffectCell): void {
+  const setup = cell.setup!;
+  const deps = cell.setupDeps;
+  let cleanup: (() => void) | undefined;
   try {
-    const cleanup = cell.setup!();
-    if (cleanup !== undefined && typeof cleanup !== "function") {
+    const result = setup();
+    if (result !== undefined && typeof result !== "function") {
       throw new Error(
         "An effect function must either return a cleanup function or nothing. " +
-          `Received: ${typeof cleanup}`,
+          `Received: ${typeof result}`,
       );
     }
-    cell.cleanup = cleanup;
+    cleanup = result;
   } finally {
-    cell.deps = cell.setupDeps;
+    if (cell.setup === setup) {
+      cell.cleanup = cleanup;
+      cell.deps = deps;
+    } else {
+      cleanup?.();
+    }
   }
 }
 

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -32,6 +32,9 @@ function setupEffect(cell: EffectCell): void {
 }
 
 const effectNeedsRun = (cell: EffectCell): boolean => {
+  // No committed render ever promoted a setup: the cell's creating render
+  // was discarded, so on the committed fiber this hook does not exist yet.
+  if (cell.setup === undefined) return false;
   // A cell that never ran or was disconnected runs on any commit (first
   // mount, the zero-render Activity reveal).
   if (cell.deps === null) return true;

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -32,14 +32,8 @@ function setupEffect(cell: EffectCell): void {
 }
 
 const effectNeedsRun = (cell: EffectCell): boolean => {
-  // No committed render ever promoted a setup: the cell's creating render
-  // was discarded, so on the committed fiber this hook does not exist yet.
   if (cell.setup === undefined) return false;
-  // A cell that never ran or was disconnected runs on any commit (first
-  // mount, the zero-render Activity reveal).
   if (cell.deps === null) return true;
-  // React dep semantics. Dep arity is stable once committed, so
-  // setupDeps === undefined implies the committed deps are dep-less too.
   if (cell.setupDeps === undefined) return true;
   return !depsShallowEqual(cell.deps!, cell.setupDeps);
 };

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -19,6 +19,7 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
 function setupEffect(cell: EffectCell): void {
   const setup = cell.setup!;
   const deps = cell.setupDeps;
+  const generation = cell.generation;
   let cleanup: (() => void) | undefined;
   try {
     const result = setup();
@@ -30,7 +31,7 @@ function setupEffect(cell: EffectCell): void {
     }
     cleanup = result;
   } finally {
-    if (cell.setup === setup) {
+    if (cell.generation === generation) {
       cell.cleanup = cleanup;
       cell.deps = deps;
     } else {
@@ -55,6 +56,7 @@ export function reconcileEffects<R>(fiber: ResourceFiber<R>): void {
   }
 
   for (const cell of pending) {
+    cell.deps = null;
     if (cell.cleanup === undefined) continue;
     try {
       cell.cleanup();

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -1,11 +1,10 @@
-import type { CommitCallbacks, ResourceFiber } from "../types";
+import type { CommitCallbacks, EffectCell, ResourceFiber } from "../types";
 import { throwAggregated } from "./throwAggregated";
+import { depsShallowEqual } from "../../hooks/utils/depsShallowEqual";
 
 export const CommitPriority = {
   HookState: 0,
   EffectEvent: 1,
-  PassiveEffectCleanup: 2,
-  PassiveEffectSetup: 3,
 } as const;
 export type CommitPriority =
   (typeof CommitPriority)[keyof typeof CommitPriority];
@@ -13,11 +12,7 @@ export type CommitPriority =
 const COMMIT_PRIORITIES = [
   CommitPriority.HookState,
   CommitPriority.EffectEvent,
-  CommitPriority.PassiveEffectCleanup,
-  CommitPriority.PassiveEffectSetup,
 ] as const;
-
-export const createCommitCallbacks = (): CommitCallbacks => [];
 
 export function commitAllCallbacks(callbacks: CommitCallbacks): void {
   const errors: unknown[] = [];
@@ -32,6 +27,64 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
       } catch (error) {
         errors.push(error);
       }
+    }
+  }
+
+  throwAggregated(errors, "Errors during commit");
+}
+
+function setupEffect(cell: EffectCell): void {
+  try {
+    const cleanup = cell.setup!();
+    if (cleanup !== undefined && typeof cleanup !== "function") {
+      throw new Error(
+        "An effect function must either return a cleanup function or nothing. " +
+          `Received: ${typeof cleanup}`,
+      );
+    }
+    cell.cleanup = cleanup;
+  } finally {
+    cell.deps = cell.setupDeps;
+  }
+}
+
+const effectNeedsRun = (cell: EffectCell, rendered: boolean): boolean => {
+  if (cell.deps === null) return true;
+  if (!rendered) return false;
+  return (
+    cell.deps === undefined ||
+    cell.setupDeps === undefined ||
+    !depsShallowEqual(cell.deps, cell.setupDeps)
+  );
+};
+
+export function reconcileEffects<R>(
+  fiber: ResourceFiber<R>,
+  rendered: boolean,
+): void {
+  const errors: unknown[] = [];
+  const pending: EffectCell[] = [];
+
+  for (const cell of fiber.cells) {
+    if (cell?.type !== "effect") continue;
+    if (effectNeedsRun(cell, rendered)) pending.push(cell);
+  }
+
+  for (const cell of pending) {
+    if (cell.cleanup === undefined) continue;
+    try {
+      cell.cleanup();
+    } catch (e) {
+      errors.push(e);
+    } finally {
+      cell.cleanup = undefined;
+    }
+  }
+  for (const cell of pending) {
+    try {
+      setupEffect(cell);
+    } catch (e) {
+      errors.push(e);
     }
   }
 

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -31,14 +31,16 @@ function setupEffect(cell: EffectCell): void {
   }
 }
 
+// deps === null (new or disconnected) runs on any commit; a render-less
+// commit (Activity reveal) runs nothing else; a rendered commit follows
+// React semantics: dep-less every render, dep'd on shallow inequality.
+// useEffect keeps dep arity stable once committed, so setupDeps and deps
+// are undefined together past the null check.
 const effectNeedsRun = (cell: EffectCell, rendered: boolean): boolean => {
   if (cell.deps === null) return true;
   if (!rendered) return false;
-  return (
-    cell.deps === undefined ||
-    cell.setupDeps === undefined ||
-    !depsShallowEqual(cell.deps, cell.setupDeps)
-  );
+  if (cell.setupDeps === undefined) return true;
+  return !depsShallowEqual(cell.deps!, cell.setupDeps);
 };
 
 export function reconcileEffects<R>(

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -4,15 +4,12 @@ import type {
   ResourceFiber,
   TapRoot,
 } from "../types";
-import { cloneCurrentTapContext } from "../context";
-
 export const createResourceFiberRoot = (
   dispatchUpdate: (evaluate: () => boolean, apply: () => boolean) => void,
 ): TapRoot => {
   return {
     version: 0,
     committedVersion: 0,
-    context: cloneCurrentTapContext(),
     dispatchUpdate,
     changelog: [],
     rollbackCallbacks: [],

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -5,7 +5,6 @@ import type {
   TapRoot,
 } from "../types";
 import { cloneCurrentTapContext } from "../context";
-import { CommitPriority } from "./commit";
 
 export const createResourceFiberRoot = (
   dispatchUpdate: (evaluate: () => boolean, apply: () => boolean) => void,
@@ -67,11 +66,9 @@ export const applyChangelogRecord = (record: ChangelogRecord): void => {
 
 export const addCommit = (
   fiber: ResourceFiber<any>,
-  priority: CommitPriority,
   callback: () => void,
 ): void => {
-  const callbacks = fiber.wipCommitCallbacks!;
-  (callbacks[priority] ??= []).push(callback);
+  fiber.wipCommitCallbacks!.push(callback);
 };
 
 export const addRollback = (root: TapRoot, callback: () => void): void => {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -1,8 +1,7 @@
 import { throwAggregated } from "./helpers/throwAggregated";
+import { isDevelopment } from "./helpers/env";
 
 type Task = () => void;
-
-let isFlushing = false;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
@@ -15,6 +14,7 @@ let flushState: GlobalFlushState = {
   isScheduled: false,
 };
 let activeDrainRuns: Map<UpdateScheduler, number> | null = null;
+const pendingNotifies: (() => void)[] = [];
 
 export class UpdateScheduler {
   private _isDirty = false;
@@ -54,6 +54,16 @@ export class UpdateScheduler {
   }
 }
 
+// Subscriber notifications are delivered after the drain converges, so
+// listeners never observe mid-flush state and may flushTapSync freely.
+export const scheduleNotify = (notify: () => void): void => {
+  if (activeDrainRuns !== null) {
+    pendingNotifies.push(notify);
+    return;
+  }
+  notify();
+};
+
 const scheduleFlush = () => {
   if (flushState.isScheduled) return;
   flushState.isScheduled = true;
@@ -63,9 +73,7 @@ const scheduleFlush = () => {
 const flushScheduled = () => {
   // save/restore: flushTapSync re-enters flushScheduled with its own flushState
   const prevDrainRuns = activeDrainRuns;
-  const prevIsFlushing = isFlushing;
   activeDrainRuns = new Map();
-  isFlushing = true;
   try {
     const errors = [];
 
@@ -83,9 +91,12 @@ const flushScheduled = () => {
     throwAggregated(errors, "Errors occurred during flushSync");
   } finally {
     activeDrainRuns = prevDrainRuns;
-    isFlushing = prevIsFlushing;
     flushState.schedulers.clear();
     flushState.isScheduled = false;
+  }
+
+  if (activeDrainRuns === null) {
+    while (pendingNotifies.length > 0) pendingNotifies.shift()!();
   }
 };
 
@@ -118,17 +129,24 @@ const scheduleMacrotask = (() => {
   return () => setTimeout(flushScheduled, 0);
 })();
 
-// Inside a flush, the callback's dispatches fold into it and drain after the
-// current pass completes.
 export const flushTapSync = <T>(callback: () => T): T => {
-  if (isFlushing) return callback();
+  // Mirrors React's flushSync rule: inside a render or commit the flush is
+  // impossible, so the dispatches fold into the enclosing drain instead.
+  if (activeDrainRuns !== null) {
+    if (isDevelopment) {
+      console.warn(
+        "flushTapSync was called from inside a render or commit. " +
+          "The flush is deferred until the current pass completes.",
+      );
+    }
+    return callback();
+  }
 
   const prev = flushState;
   flushState = {
     schedulers: new Set([]),
     isScheduled: true,
   };
-  isFlushing = true;
 
   try {
     const value = callback();
@@ -136,7 +154,6 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
     return value;
   } finally {
-    isFlushing = false;
     flushState = prev;
   }
 };

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -10,7 +10,7 @@ type GlobalFlushState = {
 
 const MAX_UPDATE_DEPTH = 50;
 let flushState: GlobalFlushState = {
-  schedulers: new Set([]),
+  schedulers: new Set(),
   isScheduled: false,
 };
 let activeDrainRuns: Map<UpdateScheduler, number> | null = null;
@@ -144,7 +144,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
   const prev = flushState;
   flushState = {
-    schedulers: new Set([]),
+    schedulers: new Set(),
     isScheduled: true,
   };
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -93,10 +93,10 @@ const flushScheduled = () => {
     activeDrainRuns = prevDrainRuns;
     flushState.schedulers.clear();
     flushState.isScheduled = false;
-  }
 
-  if (activeDrainRuns === null) {
-    while (pendingNotifies.length > 0) pendingNotifies.shift()!();
+    if (activeDrainRuns === null) {
+      while (pendingNotifies.length > 0) pendingNotifies.shift()!();
+    }
   }
 };
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -3,20 +3,12 @@ import { isDevelopment } from "./helpers/env";
 
 type Task = () => void;
 
-let reconcileDepth = 0;
-
-// Renders never nest, they queue: dispatches made while a render or commit is
-// on the stack must not synchronously re-enter the work loop.
-export const isReconciling = () => reconcileDepth > 0;
-
-export const withReconcileScope = <T>(fn: () => T): T => {
-  reconcileDepth++;
-  try {
-    return fn();
-  } finally {
-    reconcileDepth--;
-  }
-};
+// Renders never nest, they queue. The scheduler is the tap-root work loop,
+// so it enforces the rule for the passes it drives: while a flush is on the
+// stack (a scheduled drain or a flushTapSync callback), a nested flushTapSync
+// defers instead of re-entering. React-hosted fibers are driven by React's
+// work loop, which enforces the same rule itself — they pay no cost here.
+let isFlushing = false;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
@@ -77,7 +69,9 @@ const scheduleFlush = () => {
 const flushScheduled = () => {
   // save/restore: flushTapSync re-enters flushScheduled with its own flushState
   const prevDrainRuns = activeDrainRuns;
+  const prevIsFlushing = isFlushing;
   activeDrainRuns = new Map();
+  isFlushing = true;
   try {
     const errors = [];
 
@@ -95,6 +89,7 @@ const flushScheduled = () => {
     throwAggregated(errors, "Errors occurred during flushSync");
   } finally {
     activeDrainRuns = prevDrainRuns;
+    isFlushing = prevIsFlushing;
     flushState.schedulers.clear();
     flushState.isScheduled = false;
   }
@@ -131,9 +126,9 @@ const scheduleMacrotask = (() => {
 
 export const flushTapSync = <T>(callback: () => T): T => {
   // Mirrors React's flushSync-inside-lifecycle rule: never flush while a
-  // render or commit is on the stack. The callback's dispatches land in the
+  // pass is already on the stack. The callback's dispatches land in the
   // enclosing flush state and drain after the current pass.
-  if (reconcileDepth > 0) {
+  if (isFlushing) {
     if (isDevelopment) {
       console.warn(
         "flushTapSync was called from inside a render or commit. " +
@@ -148,6 +143,9 @@ export const flushTapSync = <T>(callback: () => T): T => {
     schedulers: new Set([]),
     isScheduled: true,
   };
+  // The callback itself is part of the flush: tap roots run their commits
+  // inside it, so effects dispatching here must not re-enter.
+  isFlushing = true;
 
   try {
     const value = callback();
@@ -155,6 +153,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
     return value;
   } finally {
+    isFlushing = false;
     flushState = prev;
   }
 };

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -1,6 +1,22 @@
 import { throwAggregated } from "./helpers/throwAggregated";
+import { isDevelopment } from "./helpers/env";
 
 type Task = () => void;
+
+let reconcileDepth = 0;
+
+// Renders never nest, they queue: dispatches made while a render or commit is
+// on the stack must not synchronously re-enter the work loop.
+export const isReconciling = () => reconcileDepth > 0;
+
+export const withReconcileScope = <T>(fn: () => T): T => {
+  reconcileDepth++;
+  try {
+    return fn();
+  } finally {
+    reconcileDepth--;
+  }
+};
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
@@ -114,6 +130,19 @@ const scheduleMacrotask = (() => {
 })();
 
 export const flushTapSync = <T>(callback: () => T): T => {
+  // Mirrors React's flushSync-inside-lifecycle rule: never flush while a
+  // render or commit is on the stack. The callback's dispatches land in the
+  // enclosing flush state and drain after the current pass.
+  if (reconcileDepth > 0) {
+    if (isDevelopment) {
+      console.warn(
+        "flushTapSync was called from inside a render or commit. " +
+          "The flush is deferred until the current pass completes.",
+      );
+    }
+    return callback();
+  }
+
   const prev = flushState;
   flushState = {
     schedulers: new Set([]),

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -3,11 +3,6 @@ import { isDevelopment } from "./helpers/env";
 
 type Task = () => void;
 
-// Renders never nest, they queue. The scheduler is the tap-root work loop,
-// so it enforces the rule for the passes it drives: while a flush is on the
-// stack (a scheduled drain or a flushTapSync callback), a nested flushTapSync
-// defers instead of re-entering. React-hosted fibers are driven by React's
-// work loop, which enforces the same rule itself — they pay no cost here.
 let isFlushing = false;
 
 type GlobalFlushState = {
@@ -125,9 +120,6 @@ const scheduleMacrotask = (() => {
 })();
 
 export const flushTapSync = <T>(callback: () => T): T => {
-  // Mirrors React's flushSync-inside-lifecycle rule: never flush while a
-  // pass is already on the stack. The callback's dispatches land in the
-  // enclosing flush state and drain after the current pass.
   if (isFlushing) {
     if (isDevelopment) {
       console.warn(
@@ -143,8 +135,6 @@ export const flushTapSync = <T>(callback: () => T): T => {
     schedulers: new Set([]),
     isScheduled: true,
   };
-  // The callback itself is part of the flush: tap roots run their commits
-  // inside it, so effects dispatching here must not re-enter.
   isFlushing = true;
 
   try {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -54,8 +54,6 @@ export class UpdateScheduler {
   }
 }
 
-// Subscriber notifications are delivered after the drain converges, so
-// listeners never observe mid-flush state and may flushTapSync freely.
 export const scheduleNotify = (notify: () => void): void => {
   if (activeDrainRuns !== null) {
     pendingNotifies.push(notify);
@@ -134,8 +132,6 @@ const scheduleMacrotask = (() => {
 })();
 
 export const flushTapSync = <T>(callback: () => T): T => {
-  // Mirrors React's flushSync rule: inside a render or commit the flush is
-  // impossible, so the dispatches fold into the enclosing drain instead.
   if (activeDrainRuns !== null) {
     if (isDevelopment) {
       console.warn(

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -1,5 +1,4 @@
 import { throwAggregated } from "./helpers/throwAggregated";
-import { isDevelopment } from "./helpers/env";
 
 type Task = () => void;
 
@@ -119,16 +118,10 @@ const scheduleMacrotask = (() => {
   return () => setTimeout(flushScheduled, 0);
 })();
 
+// Inside a flush, the callback's dispatches fold into it and drain after the
+// current pass completes.
 export const flushTapSync = <T>(callback: () => T): T => {
-  if (isFlushing) {
-    if (isDevelopment) {
-      console.warn(
-        "flushTapSync was called from inside a render or commit. " +
-          "The flush is deferred until the current pass completes.",
-      );
-    }
-    return callback();
-  }
+  if (isFlushing) return callback();
 
   const prev = flushState;
   flushState = {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -74,9 +74,8 @@ const flushScheduled = () => {
   // save/restore: flushTapSync re-enters flushScheduled with its own flushState
   const prevDrainRuns = activeDrainRuns;
   activeDrainRuns = new Map();
+  const errors: unknown[] = [];
   try {
-    const errors = [];
-
     for (const scheduler of flushState.schedulers) {
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
@@ -87,17 +86,22 @@ const flushScheduled = () => {
         errors.push(error);
       }
     }
-
-    throwAggregated(errors, "Errors occurred during flushSync");
   } finally {
     activeDrainRuns = prevDrainRuns;
     flushState.schedulers.clear();
     flushState.isScheduled = false;
 
     if (activeDrainRuns === null) {
-      while (pendingNotifies.length > 0) pendingNotifies.shift()!();
+      while (pendingNotifies.length > 0) {
+        try {
+          pendingNotifies.shift()!();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
     }
   }
+  throwAggregated(errors, "Errors occurred during flushSync");
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -49,7 +49,11 @@ export type MemoCell<T = any> = {
 
 export type EffectCell = {
   readonly type: "effect";
+  // Latest rendered effect + deps; committed by the reconcile walk.
+  setup: (() => (() => void) | undefined) | undefined;
+  setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;
+  // Committed deps: null = never ran or disconnected, undefined = deps-less.
   deps: readonly unknown[] | null | undefined;
 };
 
@@ -89,7 +93,8 @@ export interface ResourceFiber<R> {
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;
-  commitCallbacks: CommitCallbacks | null;
+  // Reset to [] at every render start, consumed (set null) by commit — so
+  // non-null also means "rendered since the last commit".
   wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -52,9 +52,8 @@ export type EffectCell = {
   setup: (() => (() => void) | undefined) | undefined;
   setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;
-  // null = not active (never ran, disconnected, or mid-recommit), undefined = deps-less
+  // null = never ran or disconnected, undefined = deps-less
   deps: readonly unknown[] | null | undefined;
-  // bumped on every commit promotion; a stale setup frame observes a bump
   generation: number;
 };
 

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -52,8 +52,10 @@ export type EffectCell = {
   setup: (() => (() => void) | undefined) | undefined;
   setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;
-  // null = never ran or disconnected, undefined = deps-less
+  // null = not active (never ran, disconnected, or mid-recommit), undefined = deps-less
   deps: readonly unknown[] | null | undefined;
+  // bumped on every commit promotion; a setup frame that observes a bump is superseded
+  generation: number;
 };
 
 export type Cell = ReducerCell | MemoCell | EffectCell;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -60,7 +60,7 @@ export type EffectCell = {
 export type Cell = ReducerCell | MemoCell | EffectCell;
 
 export type CommitCallback = () => void;
-export type CommitCallbacks = Array<CommitCallback[] | undefined>;
+export type CommitCallbacks = CommitCallback[];
 
 export type ResourceContext = Map<object, ResourceContextValue>;
 export type ResourceContextDeps = Map<object, ResourceFiber<any> | null>;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -49,13 +49,10 @@ export type MemoCell<T = any> = {
 
 export type EffectCell = {
   readonly type: "effect";
-  // Last committed render's effect + deps, promoted by a commit callback so
-  // a discarded render's closures never become visible; undefined setup =
-  // the cell's creating render was never committed.
   setup: (() => (() => void) | undefined) | undefined;
   setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;
-  // Committed deps: null = never ran or disconnected, undefined = deps-less.
+  // null = never ran or disconnected, undefined = deps-less
   deps: readonly unknown[] | null | undefined;
 };
 
@@ -92,14 +89,10 @@ export interface ResourceFiber<R> {
   readonly devStrictMode: "root" | "child" | null;
 
   cells: Cell[];
-  // Effect cells in declaration order; append-only, populated at cell
-  // creation so commit walks effects without filtering every cell.
   effectCells: EffectCell[];
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;
-  // Reset to [] at every render start, consumed (set null) by commit — so
-  // non-null also means "rendered since the last commit".
   wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;
@@ -111,8 +104,6 @@ export interface ResourceFiber<R> {
 
   renderPendingCells: Set<ReducerCell> | null;
 
-  // Bumped on every render. Lets a host detect that the fiber rendered past
-  // a render it captured (its record is superseded and must not commit).
   renderCount: number;
 
   isMounted: boolean;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -72,7 +72,6 @@ export interface ResourceContextValue {
 export interface TapRoot {
   version: number;
   committedVersion: number;
-  context: ResourceContext;
   readonly changelog: ChangelogRecord[];
   readonly dispatchUpdate: (
     evaluate: () => boolean,

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -49,7 +49,9 @@ export type MemoCell<T = any> = {
 
 export type EffectCell = {
   readonly type: "effect";
-  // Latest rendered effect + deps; committed by the reconcile walk.
+  // Last committed render's effect + deps, promoted by a commit callback so
+  // a discarded render's closures never become visible; undefined setup =
+  // the cell's creating render was never committed.
   setup: (() => (() => void) | undefined) | undefined;
   setupDeps: readonly unknown[] | undefined;
   cleanup: (() => void) | undefined;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -111,6 +111,10 @@ export interface ResourceFiber<R> {
 
   renderPendingCells: Set<ReducerCell> | null;
 
+  // Bumped on every render. Lets a host detect that the fiber rendered past
+  // a render it captured (its record is superseded and must not commit).
+  renderCount: number;
+
   isMounted: boolean;
   isFirstRender: boolean;
   isNeverMounted: boolean;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -90,6 +90,9 @@ export interface ResourceFiber<R> {
   readonly devStrictMode: "root" | "child" | null;
 
   cells: Cell[];
+  // Effect cells in declaration order; append-only, populated at cell
+  // creation so commit walks effects without filtering every cell.
+  effectCells: EffectCell[];
 
   wipContextDeps: ResourceContextDeps | null;
   contextDeps: ResourceContextDeps | null;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -104,8 +104,6 @@ export interface ResourceFiber<R> {
 
   renderPendingCells: Set<ReducerCell> | null;
 
-  renderCount: number;
-
   isMounted: boolean;
   isFirstRender: boolean;
   isNeverMounted: boolean;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -54,7 +54,7 @@ export type EffectCell = {
   cleanup: (() => void) | undefined;
   // null = not active (never ran, disconnected, or mid-recommit), undefined = deps-less
   deps: readonly unknown[] | null | undefined;
-  // bumped on every commit promotion; a setup frame that observes a bump is superseded
+  // bumped on every commit promotion; a stale setup frame observes a bump
   generation: number;
 };
 

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -125,9 +125,6 @@ export function useResources<E extends ResourceElement<any>>(
           const value = renderResourceFiber(fiber, element.args);
           state.next = { value: value, deps: element.deps, remount: fiber };
         } else if (canReuse(state, element.deps)) {
-          // Superseding a pending record (a render whose commit effect never
-          // ran — an abandoned React pass): drop the child's wip render too,
-          // or a later reconnect would commit it past this bailout.
           if (typeof state.next === "object") {
             discardWipRender(state.fiber);
           }
@@ -181,7 +178,6 @@ export function useResources<E extends ResourceElement<any>>(
         fibers.delete(key);
       } else if (next === "skip") {
         // Bailed this render: nothing to commit, keep committed deps/value.
-        // A disconnected child (commit replayed without a render) reconnects.
         if (!state.fiber.isNeverMounted && !state.fiber.isMounted) {
           commitResourceFiber(state.fiber);
         }

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -159,11 +159,7 @@ export function useResources<E extends ResourceElement<any>>(
   useEffect(() => {
     return () => {
       for (const key of fibers.keys()) {
-        const fiber = fibers.get(key)!.fiber;
-        // A child rendered but not yet committed (host torn down before the
-        // commit effect ran) was never mounted; unmounting it would throw and
-        // abort the cleanup of the remaining children.
-        if (fiber.isMounted) unmountResourceFiber(fiber);
+        unmountResourceFiber(fibers.get(key)!.fiber);
       }
     };
   }, [fibers]);
@@ -174,9 +170,7 @@ export function useResources<E extends ResourceElement<any>>(
     for (const [key, state] of fibers.entries()) {
       const next = state.next;
       if (next === "delete") {
-        if (state.fiber.isMounted) {
-          unmountResourceFiber(state.fiber);
-        }
+        unmountResourceFiber(state.fiber);
         fibers.delete(key);
       } else if (next === "skip") {
         // Bailed this render: nothing to commit, keep committed deps/value.
@@ -186,7 +180,7 @@ export function useResources<E extends ResourceElement<any>>(
         }
       } else {
         if (next.remount) {
-          if (state.fiber.isMounted) unmountResourceFiber(state.fiber);
+          unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -160,7 +160,10 @@ export function useResources<E extends ResourceElement<any>>(
     return () => {
       for (const key of fibers.keys()) {
         const fiber = fibers.get(key)!.fiber;
-        unmountResourceFiber(fiber);
+        // A child rendered but not yet committed (host torn down before the
+        // commit effect ran) was never mounted; unmounting it would throw and
+        // abort the cleanup of the remaining children.
+        if (fiber.isMounted) unmountResourceFiber(fiber);
       }
     };
   }, [fibers]);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -4,6 +4,7 @@ import type {
   ResourceFiber,
 } from "../core/types";
 import {
+  discardWipRender,
   unmountResourceFiber,
   renderResourceFiber,
   commitResourceFiber,
@@ -124,6 +125,12 @@ export function useResources<E extends ResourceElement<any>>(
           const value = renderResourceFiber(fiber, element.args);
           state.next = { value: value, deps: element.deps, remount: fiber };
         } else if (canReuse(state, element.deps)) {
+          // Superseding a pending record (a render whose commit effect never
+          // ran — an abandoned React pass): drop the child's wip render too,
+          // or a later reconnect would commit it past this bailout.
+          if (typeof state.next === "object") {
+            discardWipRender(state.fiber);
+          }
           if (state.fiber.contextDeps) {
             bubbleContextDeps(state.fiber, state.fiber.contextDeps);
           }

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -184,15 +184,10 @@ export function useResources<E extends ResourceElement<any>>(
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);
-        // A child setup can dispatch and, under a synchronous host, nest a
-        // newer render + commit; finalize only while this record is still the
-        // latest so the nested result is not clobbered.
-        if (state.next === next) {
-          state.committedDeps = next.deps;
-          state.committedValue = next.value;
-          state.isDirty = false;
-          state.next = "skip";
-        }
+        state.committedDeps = next.deps;
+        state.committedValue = next.value;
+        state.isDirty = false;
+        state.next = "skip";
       }
     }
   }, [val, fibers]);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -177,15 +177,25 @@ export function useResources<E extends ResourceElement<any>>(
         fibers.delete(key);
       } else if (next === "skip") {
         // Bailed this render: nothing to commit, keep committed deps/value.
+        // A disconnected child (commit replayed without a render) reconnects.
+        if (!state.fiber.isNeverMounted && !state.fiber.isMounted) {
+          commitResourceFiber(state.fiber);
+        }
       } else {
         if (next.remount) {
-          unmountResourceFiber(state.fiber);
+          if (state.fiber.isMounted) unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);
-        state.committedDeps = next.deps;
-        state.committedValue = next.value;
-        state.isDirty = false;
+        // A child setup can dispatch and, under a synchronous host, nest a
+        // newer render + commit; finalize only while this record is still the
+        // latest so the nested result is not clobbered.
+        if (state.next === next) {
+          state.committedDeps = next.deps;
+          state.committedValue = next.value;
+          state.isDirty = false;
+          state.next = "skip";
+        }
       }
     }
   }, [val, fibers]);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -148,7 +148,16 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   useEffect(() => {
     const current = stateRef.current;
     current.isMounted = true;
-    if (!fiber.isNeverMounted && !fiber.isMounted) commitResourceFiber(fiber);
+    // Reconnect only on a zero-render reveal. When a pendingCommit record
+    // exists, the commit effect below runs in the same flush and commits (or
+    // converges past) it; reconnecting here first would commit a render the
+    // host may have already superseded.
+    if (
+      !fiber.isNeverMounted &&
+      !fiber.isMounted &&
+      current.pendingCommit === null
+    )
+      commitResourceFiber(fiber);
     return () => {
       current.isMounted = false;
       unmountResourceFiber(fiber);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -12,6 +12,7 @@ import {
   setRootVersion,
 } from "../core/helpers/root";
 import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
+import type { ResourceContext } from "../core/types";
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
@@ -74,10 +75,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const stateRef = useRef<{
     isMounted: boolean;
     committedArgs: readonly [() => R];
+    context: ResourceContext;
     value: R;
   }>({
     isMounted: false,
     committedArgs: args,
+    context,
     value,
   });
   const [subscribers] = useState(() => new Set<() => void>());
@@ -105,12 +108,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     );
 
     if (isDevelopment && fiber.devStrictMode) {
-      void withTapContextRoot(fiber.root.context, () => {
+      void withTapContextRoot(stateRef.current.context, () => {
         return renderResourceFiber(fiber, stateRef.current.committedArgs);
       });
     }
 
-    const render = withTapContextRoot(fiber.root.context, () => {
+    const render = withTapContextRoot(stateRef.current.context, () => {
       return renderResourceFiber(fiber, stateRef.current.committedArgs);
     });
 
@@ -145,7 +148,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     processed = true;
 
     stateRef.current.committedArgs = args;
-    fiber.root.context = context;
+    stateRef.current.context = context;
     // handleUpdate rendered past this render (consumed or replaced its wip):
     // this closure's snapshot is superseded, converge by rendering fresh.
     if (fiber.wipCommitCallbacks !== wip) {

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -36,11 +36,6 @@ const useHostRoot = <R>(render: () => R): R => render();
 export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   // oxlint-disable-next-line react-hooks/rules-of-hooks -- updates run through the component's Effect Event after the scheduler is initialized
   const [scheduler] = useState(() => new UpdateScheduler(() => handleUpdate()));
-  // Replay log for React's update semantics (StrictMode double-apply,
-  // concurrent rebasing). Mirrors React's eagerState rule: only the first
-  // update on a clean queue applies eagerly; `appliedAt` records the root
-  // version an eager apply produced (null = queued unapplied), so retirement
-  // is derivable at any time instead of a captured count.
   const [queue] = useState<
     { apply: () => boolean; appliedAt: number | null }[]
   >(() => []);
@@ -76,18 +71,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     isMounted: boolean;
     committedArgs: readonly [() => R];
     value: R;
-    // Snapshot of the latest React render, overwritten every render and read
-    // by the commit effect. All uses are idempotent, so nothing is consumed.
     renderedArgs: readonly [() => R];
     renderedValue: R;
     renderedContext: ReturnType<typeof cloneCurrentTapContext>;
-    // fiber.renderCount at the time of this React render; a mismatch at
-    // commit time means the fiber rendered past it (a tap update while
-    // hidden) and the snapshot describes a superseded render.
     renderedAt: number;
-    // Reset every render, set by the first commit that follows: a commit
-    // replayed without a render (StrictMode, Activity reveal, tap reconnect)
-    // must not restore render-scoped state or publish again.
     processed: boolean;
   }>({
     isMounted: false,
@@ -154,11 +141,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   useEffect(() => {
     const current = stateRef.current;
     current.isMounted = true;
-    // Reconnect only when no fresh React render awaits the commit effect
-    // below (it commits or converges past it in this same flush; committing
-    // here would bypass the host bookkeeping). An unretired handleUpdate
-    // render may exist (rendered while hidden): its host bookkeeping already
-    // ran, so committing it here is exactly right.
     if (!fiber.isNeverMounted && !fiber.isMounted && current.processed)
       commitResourceFiber(fiber);
     return () => {
@@ -173,10 +155,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     current.processed = true;
 
     current.committedArgs = current.renderedArgs;
-    // handleUpdate advanced the fiber past this render (e.g. a hidden
-    // Activity re-render followed by a tap update): its value and queue
-    // bookkeeping describe a superseded render. Converge by rendering fresh
-    // with the render's args and context instead of committing it.
     if (current.renderedAt !== fiber.renderCount) {
       fiber.root.context = current.renderedContext;
       if (!scheduler.isDirty) handleUpdate();
@@ -185,8 +163,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
     fiber.root.context = current.renderedContext;
     commitResourceFiber(fiber);
-    // Retire the dispatches the committed render included; entries applied
-    // after it (or never applied) stay queued for the next flush.
     for (let i = queue.length - 1; i >= 0; i--) {
       const entry = queue[i]!;
       if (

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -86,8 +86,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   });
   const [subscribers] = useState(() => new Set<() => void>());
 
-  // The version check drops a publish superseded by a nested handleUpdate
-  // (flushTapSync from an effect during a React-driven commit).
   const publish = (output: R, version: number) => {
     if (
       scheduler.isDirty ||
@@ -158,8 +156,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
     stateRef.current.committedArgs = args;
     stateRef.current.context = context;
-    // handleUpdate rendered past this render (consumed or replaced its wip):
-    // this closure's snapshot is superseded, converge by rendering fresh.
+    // handleUpdate rendered past this render: this closure is superseded
     if (fiber.wipCommitCallbacks !== wip) {
       if (!scheduler.isDirty) handleUpdate();
       return;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -4,7 +4,7 @@ import {
   renderResourceFiber,
   unmountResourceFiber,
 } from "../core/ResourceFiber";
-import { UpdateScheduler } from "../core/scheduler";
+import { scheduleNotify, UpdateScheduler } from "../core/scheduler";
 import { isDevelopment } from "../core/helpers/env";
 import {
   commitRoot,
@@ -63,40 +63,29 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   const context = cloneCurrentTapContext();
 
-  const render2 = withTapContextRoot(context, () => {
+  const value = withTapContextRoot(context, () => {
     return renderResourceFiber(fiber, [render]);
   });
+
+  const args: readonly [() => R] = [render];
+  const wip = fiber.wipCommitCallbacks;
+  let processed = false;
 
   const stateRef = useRef<{
     isMounted: boolean;
     committedArgs: readonly [() => R];
     value: R;
-    renderedArgs: readonly [() => R];
-    renderedValue: R;
-    renderedContext: ReturnType<typeof cloneCurrentTapContext>;
-    renderedAt: number;
-    processed: boolean;
   }>({
     isMounted: false,
-    committedArgs: [render],
-    value: render2,
-    renderedArgs: [render],
-    renderedValue: render2,
-    renderedContext: context,
-    renderedAt: fiber.renderCount,
-    processed: false,
+    committedArgs: args,
+    value,
   });
-  stateRef.current.renderedArgs = [render];
-  stateRef.current.renderedValue = render2;
-  stateRef.current.renderedContext = context;
-  stateRef.current.renderedAt = fiber.renderCount;
-  stateRef.current.processed = false;
   const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
     if (scheduler.isDirty || stateRef.current.value === output) return;
     stateRef.current.value = output;
-    subscribers.forEach((listener) => listener());
+    scheduleNotify(() => subscribers.forEach((listener) => listener()));
   };
 
   const handleUpdate = useEffectEvent(() => {
@@ -141,8 +130,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   useEffect(() => {
     const current = stateRef.current;
     current.isMounted = true;
-    if (!fiber.isNeverMounted && !fiber.isMounted && current.processed)
-      commitResourceFiber(fiber);
     return () => {
       current.isMounted = false;
       unmountResourceFiber(fiber);
@@ -150,18 +137,22 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   }, [fiber]);
 
   useEffect(() => {
-    const current = stateRef.current;
-    if (current.processed) return;
-    current.processed = true;
+    if (processed) {
+      // Replayed without a render (StrictMode, Activity reveal): reconnect.
+      if (!fiber.isMounted) commitResourceFiber(fiber);
+      return;
+    }
+    processed = true;
 
-    current.committedArgs = current.renderedArgs;
-    if (current.renderedAt !== fiber.renderCount) {
-      fiber.root.context = current.renderedContext;
+    stateRef.current.committedArgs = args;
+    fiber.root.context = context;
+    // handleUpdate rendered past this render (consumed or replaced its wip):
+    // this closure's snapshot is superseded, converge by rendering fresh.
+    if (fiber.wipCommitCallbacks !== wip) {
       if (!scheduler.isDirty) handleUpdate();
       return;
     }
 
-    fiber.root.context = current.renderedContext;
     commitResourceFiber(fiber);
     for (let i = queue.length - 1; i >= 0; i--) {
       const entry = queue[i]!;
@@ -173,7 +164,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       }
     }
 
-    publish(current.renderedValue);
+    publish(value);
   });
 
   return useMemo(

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -148,7 +148,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useEffect(() => {
     if (processed) {
-      // Replayed without a render (StrictMode, Activity reveal): reconnect.
       if (!fiber.isMounted) commitResourceFiber(fiber);
       return;
     }
@@ -156,7 +155,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
     stateRef.current.committedArgs = args;
     stateRef.current.context = context;
-    // handleUpdate rendered past this render: this closure is superseded
     if (fiber.wipCommitCallbacks !== wip) {
       if (!scheduler.isDirty) handleUpdate();
       return;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -65,14 +65,43 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     return renderResourceFiber(fiber, [render]);
   });
 
-  const isMountedRef = useRef(false);
-  const committedArgsRef = useRef([render] as const);
-  const valueRef = useRef<R>(render2);
+  const stateRef = useRef<{
+    isMounted: boolean;
+    committedArgs: readonly [() => R];
+    value: R;
+    // Bumped on every fiber render (React or handleUpdate) so a pending
+    // record can tell whether the fiber has moved past it.
+    generation: number;
+    // Written every render, consumed by the first commit that follows. A
+    // commit replayed without a render (StrictMode, Activity reveal, tap
+    // reconnect) finds it null and must not restore render-scoped state or
+    // publish.
+    pendingCommit: {
+      args: readonly [() => R];
+      value: R;
+      drainedCount: number;
+      context: ReturnType<typeof cloneCurrentTapContext>;
+      generation: number;
+    } | null;
+  }>({
+    isMounted: false,
+    committedArgs: [render],
+    value: render2,
+    generation: 0,
+    pendingCommit: null,
+  });
+  stateRef.current.pendingCommit = {
+    args: [render],
+    value: render2,
+    drainedCount,
+    context,
+    generation: ++stateRef.current.generation,
+  };
   const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
-    if (scheduler.isDirty || valueRef.current === output) return;
-    valueRef.current = output;
+    if (scheduler.isDirty || stateRef.current.value === output) return;
+    stateRef.current.value = output;
     subscribers.forEach((listener) => listener());
   };
 
@@ -94,13 +123,14 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
     if (isDevelopment && fiber.devStrictMode) {
       void withTapContextRoot(fiber.root.context, () => {
-        return renderResourceFiber(fiber, committedArgsRef.current);
+        return renderResourceFiber(fiber, stateRef.current.committedArgs);
       });
     }
 
     const render = withTapContextRoot(fiber.root.context, () => {
-      return renderResourceFiber(fiber, committedArgsRef.current);
+      return renderResourceFiber(fiber, stateRef.current.committedArgs);
     });
+    stateRef.current.generation++;
 
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");
@@ -108,7 +138,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     commitRoot(fiber.root);
     queue.length = 0;
 
-    if (isMountedRef.current) {
+    if (stateRef.current.isMounted) {
       commitResourceFiber(fiber);
     }
 
@@ -116,26 +146,42 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   });
 
   useEffect(() => {
-    isMountedRef.current = true;
+    const current = stateRef.current;
+    current.isMounted = true;
+    if (!fiber.isNeverMounted && !fiber.isMounted) commitResourceFiber(fiber);
     return () => {
-      isMountedRef.current = false;
+      current.isMounted = false;
       unmountResourceFiber(fiber);
     };
   }, [fiber]);
 
   useEffect(() => {
-    committedArgsRef.current = [render];
+    const pending = stateRef.current.pendingCommit;
+    if (pending === null) return;
+    stateRef.current.pendingCommit = null;
+
+    stateRef.current.committedArgs = pending.args;
+    // handleUpdate advanced the fiber while this record sat unconsumed (e.g.
+    // a hidden Activity re-render followed by a tap update): its value and
+    // queue bookkeeping describe a superseded render. Converge by rendering
+    // fresh with the record's args and context instead of committing it.
+    if (pending.generation !== stateRef.current.generation) {
+      fiber.root.context = pending.context;
+      if (!scheduler.isDirty) handleUpdate();
+      return;
+    }
+
     commitRoot(fiber.root);
-    queue.splice(0, drainedCount);
-    fiber.root.context = context;
+    queue.splice(0, pending.drainedCount);
+    fiber.root.context = pending.context;
     commitResourceFiber(fiber);
 
-    publish(render2);
+    publish(pending.value);
   });
 
   return useMemo(
     () => ({
-      getValue: () => valueRef.current,
+      getValue: () => stateRef.current.value,
       subscribe: (listener: () => void) => {
         subscribers.add(listener);
         return () => subscribers.delete(listener);

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -70,6 +70,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   const args: readonly [() => R] = [render];
   const wip = fiber.wipCommitCallbacks;
+  const version = fiber.root.version;
   let processed = false;
 
   const stateRef = useRef<{
@@ -85,8 +86,15 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   });
   const [subscribers] = useState(() => new Set<() => void>());
 
-  const publish = (output: R) => {
-    if (scheduler.isDirty || stateRef.current.value === output) return;
+  // The version check drops a publish superseded by a nested handleUpdate
+  // (flushTapSync from an effect during a React-driven commit).
+  const publish = (output: R, version: number) => {
+    if (
+      scheduler.isDirty ||
+      fiber.root.committedVersion !== version ||
+      stateRef.current.value === output
+    )
+      return;
     stateRef.current.value = output;
     scheduleNotify(() => subscribers.forEach((listener) => listener()));
   };
@@ -120,6 +128,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");
 
+    const version = fiber.root.version;
     commitRoot(fiber.root);
     queue.length = 0;
 
@@ -127,7 +136,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       commitResourceFiber(fiber);
     }
 
-    publish(render);
+    publish(render, version);
   });
 
   useEffect(() => {
@@ -167,7 +176,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       }
     }
 
-    publish(value);
+    publish(value, version);
   });
 
   return useMemo(

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -36,18 +36,26 @@ const useHostRoot = <R>(render: () => R): R => render();
 export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   // oxlint-disable-next-line react-hooks/rules-of-hooks -- updates run through the component's Effect Event after the scheduler is initialized
   const [scheduler] = useState(() => new UpdateScheduler(() => handleUpdate()));
-  const [queue] = useState<(() => boolean)[]>(() => []);
+  // Replay log for React's update semantics (StrictMode double-apply,
+  // concurrent rebasing). Mirrors React's eagerState rule: only the first
+  // update on a clean queue applies eagerly; `appliedAt` records the root
+  // version an eager apply produced (null = queued unapplied), so retirement
+  // is derivable at any time instead of a captured count.
+  const [queue] = useState<
+    { apply: () => boolean; appliedAt: number | null }[]
+  >(() => []);
 
   const getDevStrictMode = useDevStrictMode();
   const [fiber] = useState(() => {
     const root = createResourceFiberRoot((evaluate, apply) => {
-      if (!scheduler.isDirty) {
+      const isEager = !scheduler.isDirty;
+      if (isEager) {
         if (!evaluate()) return;
         apply();
       }
 
       setRootVersion(root, root.committedVersion + root.changelog.length);
-      queue.push(apply);
+      queue.push({ apply, appliedAt: isEager ? root.version : null });
       scheduler.markDirty();
     });
     return createResourceFiber(
@@ -60,7 +68,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   const context = cloneCurrentTapContext();
 
-  const drainedCount = fiber.root.version - fiber.root.committedVersion;
   const render2 = withTapContextRoot(context, () => {
     return renderResourceFiber(fiber, [render]);
   });
@@ -69,34 +76,34 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     isMounted: boolean;
     committedArgs: readonly [() => R];
     value: R;
-    // Bumped on every fiber render (React or handleUpdate) so a pending
-    // record can tell whether the fiber has moved past it.
-    generation: number;
-    // Written every render, consumed by the first commit that follows. A
-    // commit replayed without a render (StrictMode, Activity reveal, tap
-    // reconnect) finds it null and must not restore render-scoped state or
-    // publish.
-    pendingCommit: {
-      args: readonly [() => R];
-      value: R;
-      drainedCount: number;
-      context: ReturnType<typeof cloneCurrentTapContext>;
-      generation: number;
-    } | null;
+    // Snapshot of the latest React render, overwritten every render and read
+    // by the commit effect. All uses are idempotent, so nothing is consumed.
+    renderedArgs: readonly [() => R];
+    renderedValue: R;
+    renderedContext: ReturnType<typeof cloneCurrentTapContext>;
+    // fiber.renderCount at the time of this React render; a mismatch at
+    // commit time means the fiber rendered past it (a tap update while
+    // hidden) and the snapshot describes a superseded render.
+    renderedAt: number;
+    // Reset every render, set by the first commit that follows: a commit
+    // replayed without a render (StrictMode, Activity reveal, tap reconnect)
+    // must not restore render-scoped state or publish again.
+    processed: boolean;
   }>({
     isMounted: false,
     committedArgs: [render],
     value: render2,
-    generation: 0,
-    pendingCommit: null,
+    renderedArgs: [render],
+    renderedValue: render2,
+    renderedContext: context,
+    renderedAt: fiber.renderCount,
+    processed: false,
   });
-  stateRef.current.pendingCommit = {
-    args: [render],
-    value: render2,
-    drainedCount,
-    context,
-    generation: ++stateRef.current.generation,
-  };
+  stateRef.current.renderedArgs = [render];
+  stateRef.current.renderedValue = render2;
+  stateRef.current.renderedContext = context;
+  stateRef.current.renderedAt = fiber.renderCount;
+  stateRef.current.processed = false;
   const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
@@ -108,12 +115,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const handleUpdate = useEffectEvent(() => {
     setRootVersion(fiber.root, fiber.root.committedVersion);
 
-    queue.forEach((callback) => {
+    queue.forEach((entry) => {
       if (isDevelopment && fiber.devStrictMode) {
-        callback();
+        entry.apply();
       }
 
-      callback();
+      entry.apply();
     });
 
     setRootVersion(
@@ -130,7 +137,6 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
     const render = withTapContextRoot(fiber.root.context, () => {
       return renderResourceFiber(fiber, stateRef.current.committedArgs);
     });
-    stateRef.current.generation++;
 
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");
@@ -148,15 +154,12 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   useEffect(() => {
     const current = stateRef.current;
     current.isMounted = true;
-    // Reconnect only on a zero-render reveal. When a pendingCommit record
-    // exists, the commit effect below runs in the same flush and commits (or
-    // converges past) it; reconnecting here first would commit a render the
-    // host may have already superseded.
-    if (
-      !fiber.isNeverMounted &&
-      !fiber.isMounted &&
-      current.pendingCommit === null
-    )
+    // Reconnect only when no fresh React render awaits the commit effect
+    // below (it commits or converges past it in this same flush; committing
+    // here would bypass the host bookkeeping). An unretired handleUpdate
+    // render may exist (rendered while hidden): its host bookkeeping already
+    // ran, so committing it here is exactly right.
+    if (!fiber.isNeverMounted && !fiber.isMounted && current.processed)
       commitResourceFiber(fiber);
     return () => {
       current.isMounted = false;
@@ -165,27 +168,36 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   }, [fiber]);
 
   useEffect(() => {
-    const pending = stateRef.current.pendingCommit;
-    if (pending === null) return;
-    stateRef.current.pendingCommit = null;
+    const current = stateRef.current;
+    if (current.processed) return;
+    current.processed = true;
 
-    stateRef.current.committedArgs = pending.args;
-    // handleUpdate advanced the fiber while this record sat unconsumed (e.g.
-    // a hidden Activity re-render followed by a tap update): its value and
-    // queue bookkeeping describe a superseded render. Converge by rendering
-    // fresh with the record's args and context instead of committing it.
-    if (pending.generation !== stateRef.current.generation) {
-      fiber.root.context = pending.context;
+    current.committedArgs = current.renderedArgs;
+    // handleUpdate advanced the fiber past this render (e.g. a hidden
+    // Activity re-render followed by a tap update): its value and queue
+    // bookkeeping describe a superseded render. Converge by rendering fresh
+    // with the render's args and context instead of committing it.
+    if (current.renderedAt !== fiber.renderCount) {
+      fiber.root.context = current.renderedContext;
       if (!scheduler.isDirty) handleUpdate();
       return;
     }
 
-    commitRoot(fiber.root);
-    queue.splice(0, pending.drainedCount);
-    fiber.root.context = pending.context;
+    fiber.root.context = current.renderedContext;
     commitResourceFiber(fiber);
+    // Retire the dispatches the committed render included; entries applied
+    // after it (or never applied) stay queued for the next flush.
+    for (let i = queue.length - 1; i >= 0; i--) {
+      const entry = queue[i]!;
+      if (
+        entry.appliedAt !== null &&
+        entry.appliedAt <= fiber.root.committedVersion
+      ) {
+        queue.splice(i, 1);
+      }
+    }
 
-    publish(pending.value);
+    publish(current.renderedValue);
   });
 
   return useMemo(

--- a/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
+++ b/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
@@ -17,7 +17,7 @@ const useResourceFiberHostUtilsTap = () => {
   const markDirty = useMemo(
     () => () => {
       versionRef.current++;
-      parent?.markDirty?.();
+      parent.markDirty?.();
     },
     [parent],
   );

--- a/packages/tap/src/react-hooks/index.ts
+++ b/packages/tap/src/react-hooks/index.ts
@@ -8,7 +8,3 @@ export { useEffectEvent } from "./useEffectEvent";
 export { use } from "./use";
 export { useSyncExternalStore } from "./useSyncExternalStore";
 export { useDebugValue } from "./useDebugValue";
-export { useMemoCache } from "./useMemoCache";
-export { useResource } from "../hooks/useResource";
-export { useResources } from "../hooks/useResources";
-export { useTapRoot } from "../hooks/useTapRoot";

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,12 +1,7 @@
-import { isReadableTapContext, useTapContext } from "../core/context";
+import { useTapContext } from "../core/context";
 
 /**
  * Reads a context from inside a resource render, the tap equivalent of React's
  * `use(Context)` / `useContext(Context)`. Accepts React contexts.
  */
-export const use = (usable: unknown): unknown => {
-  if (!isReadableTapContext(usable))
-    throw new Error("A tap resource's `use()` only accepts a tap context.");
-
-  return useTapContext(usable as never);
-};
+export const use = (usable: unknown): unknown => useTapContext(usable as never);

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -44,6 +44,7 @@ export function useEffect(
     }
 
     fiber.cells[index] = cell;
+    fiber.effectCells.push(cell);
   }
 
   if (cell.deps !== null && !!deps !== !!cell.deps)

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -1,15 +1,14 @@
 import { getCurrentResourceFiber } from "../core/helpers/execution-context";
-import { CommitPriority } from "../core/helpers/commit";
-import { addCommit } from "../core/helpers/root";
-import type { Cell } from "../core/types";
-import { depsShallowEqual } from "../hooks/utils/depsShallowEqual";
+import type { EffectCell } from "../core/types";
 import {
   throwHookOrderChanged,
   throwRenderedMoreHooks,
 } from "./utils/hookErrors";
 
-const newEffect = (): Cell & { type: "effect" } => ({
+const newEffect = (): EffectCell => ({
   type: "effect",
+  setup: undefined,
+  setupDeps: undefined,
   cleanup: undefined,
   deps: null, // null means the effect has never been run
 });
@@ -32,7 +31,7 @@ export function useEffect(
   const index = fiber.currentIndex++;
 
   const existing = fiber.cells[index];
-  const cell: Cell & { type: "effect" } =
+  const cell: EffectCell =
     existing === undefined
       ? newEffect()
       : existing.type === "effect"
@@ -47,33 +46,11 @@ export function useEffect(
     fiber.cells[index] = cell;
   }
 
-  if (deps && cell.deps && depsShallowEqual(cell.deps, deps)) return;
   if (cell.deps !== null && !!deps !== !!cell.deps)
     throw new Error(
       "useEffect called with and without dependencies across re-renders",
     );
 
-  addCommit(fiber, CommitPriority.PassiveEffectCleanup, () => {
-    try {
-      cell.cleanup?.();
-    } finally {
-      cell.cleanup = undefined;
-    }
-  });
-  addCommit(fiber, CommitPriority.PassiveEffectSetup, () => {
-    try {
-      const cleanup = effect();
-
-      if (cleanup !== undefined && typeof cleanup !== "function") {
-        throw new Error(
-          "An effect function must either return a cleanup function or nothing. " +
-            `Received: ${typeof cleanup}`,
-        );
-      }
-
-      cell.cleanup = cleanup;
-    } finally {
-      cell.deps = deps;
-    }
-  });
+  cell.setup = effect;
+  cell.setupDeps = deps;
 }

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -1,4 +1,5 @@
 import { getCurrentResourceFiber } from "../core/helpers/execution-context";
+import { addCommit } from "../core/helpers/root";
 import type { EffectCell } from "../core/types";
 import {
   throwHookOrderChanged,
@@ -52,6 +53,10 @@ export function useEffect(
       "useEffect called with and without dependencies across re-renders",
     );
 
-  cell.setup = effect;
-  cell.setupDeps = deps;
+  // Promoted at commit so an uncommitted render's closures never become
+  // visible: a discarded render (wipCommitCallbacks reset) reverts fully.
+  addCommit(fiber, () => {
+    cell.setup = effect;
+    cell.setupDeps = deps;
+  });
 }

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -40,7 +40,7 @@ export function useEffect(
         : throwHookOrderChanged();
 
   if (existing === undefined) {
-    if (!fiber.isFirstRender && index >= fiber.cells.length) {
+    if (!fiber.isFirstRender) {
       throwRenderedMoreHooks();
     }
 

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -53,8 +53,6 @@ export function useEffect(
       "useEffect called with and without dependencies across re-renders",
     );
 
-  // Promoted at commit so an uncommitted render's closures never become
-  // visible: a discarded render (wipCommitCallbacks reset) reverts fully.
   addCommit(fiber, () => {
     cell.setup = effect;
     cell.setupDeps = deps;

--- a/packages/tap/src/react-hooks/useEffect.ts
+++ b/packages/tap/src/react-hooks/useEffect.ts
@@ -12,6 +12,7 @@ const newEffect = (): EffectCell => ({
   setupDeps: undefined,
   cleanup: undefined,
   deps: null, // null means the effect has never been run
+  generation: 0,
 });
 
 export namespace useEffect {
@@ -56,5 +57,6 @@ export function useEffect(
   addCommit(fiber, () => {
     cell.setup = effect;
     cell.setupDeps = deps;
+    cell.generation++;
   });
 }

--- a/packages/tap/src/react-hooks/useEffectEvent.ts
+++ b/packages/tap/src/react-hooks/useEffectEvent.ts
@@ -5,7 +5,6 @@ import {
   getCurrentResourceFiber,
   peekResourceFiber,
 } from "../core/helpers/execution-context";
-import { CommitPriority } from "../core/helpers/commit";
 import { addCommit } from "../core/helpers/root";
 
 /**
@@ -30,7 +29,7 @@ export function useEffectEvent<T extends (...args: any[]) => any>(
   const callbackRef = useRef(callback);
 
   if (callbackRef.current !== callback) {
-    addCommit(fiber, CommitPriority.EffectEvent, () => {
+    addCommit(fiber, () => {
       callbackRef.current = callback;
     });
   }

--- a/packages/tap/src/react-hooks/useMemo.ts
+++ b/packages/tap/src/react-hooks/useMemo.ts
@@ -22,7 +22,7 @@ export const useMemo = <T>(fn: () => T, deps: readonly unknown[]): T => {
   let cell = fiber.cells[index];
 
   if (cell === undefined) {
-    if (!fiber.isFirstRender && index >= fiber.cells.length) {
+    if (!fiber.isFirstRender) {
       throwRenderedMoreHooks();
     }
 

--- a/packages/tap/src/react-hooks/useMemo.ts
+++ b/packages/tap/src/react-hooks/useMemo.ts
@@ -1,7 +1,6 @@
 import { isDevelopment } from "../core/helpers/env";
 import { getCurrentResourceFiber } from "../core/helpers/execution-context";
 import { addCommit, addRollback } from "../core/helpers/root";
-import { CommitPriority } from "../core/helpers/commit";
 import type { MemoCell, ResourceFiber } from "../core/types";
 import { depsShallowEqual } from "../hooks/utils/depsShallowEqual";
 import {
@@ -10,7 +9,7 @@ import {
 } from "./utils/hookErrors";
 
 const addMemoCommit = <T>(fiber: ResourceFiber<any>, cell: MemoCell<T>) => {
-  addCommit(fiber, CommitPriority.HookState, () => {
+  addCommit(fiber, () => {
     cell.current = cell.wip;
     cell.currentDeps = cell.wipDeps;
     cell.isDirty = false;

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -9,7 +9,6 @@ import {
   applyChangelogRecord,
   markReducerDirty,
 } from "../core/helpers/root";
-import { CommitPriority } from "../core/helpers/commit";
 import {
   throwHookOrderChanged,
   throwRenderedMoreHooks,
@@ -184,7 +183,7 @@ export function useReducerImpl<S, A, I>(
   }
 
   if (cell.isDirty) {
-    addCommit(fiber, CommitPriority.HookState, () => {
+    addCommit(fiber, () => {
       cell.current = cell.workInProgress;
       cell.isDirty = false;
     });

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -123,7 +123,7 @@ export function useReducerImpl<S, A, I>(
       return existing.type === "reducer" ? existing : throwHookOrderChanged();
     }
 
-    if (!fiber.isFirstRender && index >= fiber.cells.length) {
+    if (!fiber.isFirstRender) {
       throwRenderedMoreHooks();
     }
 


### PR DESCRIPTION
## What

Makes tap resources survive React `<Activity>` hide/reveal (and `createTapRoot`'s `mountOnSubscribe` remounts) by replacing render-time effect queuing with commit-time reconciliation. Supersedes #5830 with a simpler design: instead of adding a reconnect path beside the commit path, dep comparison moves to commit time so **first mount, update commit, and reveal are one mechanism**.

## Why

React resumes a hidden Activity without re-rendering: it re-runs the latest committed effect functions. tap's commit previously replayed callbacks queued during a render — closures over render-scoped values — so a commit replayed without a render (StrictMode, Activity reveal) ran a stale, *partial* subset: only the effects whose deps changed in that particular render, plus host callbacks that published stale values (observed: `setCount(5)` while hidden → reveal → `getValue()` returns `0`).

## How

- `useEffect` stores the latest `setup` + `setupDeps` on its cell and queues nothing. `commitResourceFiber` runs `reconcileEffects`: a cell walk that cleans up and re-runs every effect whose committed `deps` are `null` (new or disconnected) or — when a render happened since the last commit — dep-changed / dep-less. One cleanup pass, one setup pass, declaration order on every path.
- `fiber.wipCommitCallbacks !== null` doubles as the "rendered since last commit" signal (reset to `[]` at render start, consumed by commit); no-render commits skip `commitRoot`/contextDeps/memoCache. HookState/EffectEvent commits keep the wip queue — they are render-scoped by design and self-healing (re-queued while dirty/stale).
- The `fiber.commitCallbacks` replay fallback is deleted. Commit is idempotent; `createTapRoot` remounts drop their forced re-render (zero renders per reveal, like React's `reconnectPassiveEffects`).
- Hosts: `useTapRoot` replaces its render-closure commit effect with a per-render `pendingCommit` record + generation stamp; a record superseded by a tap-side update converges by re-rendering with the record's args instead of publishing a stale value. `useResources` reconnects disconnected children on its skip branch, guards remount unmounts against double-unmount, and finalizes commit records only while still the latest (reentrancy under synchronous hosts).

## Tests

New `__tests__/react/activity.test.tsx` (7 tests: fresh-state re-mounts after updates while hidden, no-render reveals, `useResources` keyed lists / hook swaps hidden and visible, `useTapRoot` stale-publish and hidden-re-render races) plus remount-without-render + reentrancy + post-unmount-commit coverage in the lifecycle suites. **9 of the new tests fail on main's replay mechanism and pass here**; full suite 505 green. `useResources` bench shows no regression.

Dev strict-mode double-invoke on every reconnect (Activity+StrictMode parity) remains a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bQHm-HrcPCpa3NbuFUmsij82L5j-XGrzmHrLzQ9qgL1HTemfI0ayAtweSIk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

