### PR TITLE
fix(store,core,react-mcp): migrate scope registrations across structural replacements

### DIFF
--- a/.changeset/scope-registrations-migrate.md
+++ b/.changeset/scope-registrations-migrate.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/store": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react-mcp": patch
+---
+
+fix: model-context registrations follow the committed scope across structural replacements. The new `useAssistantScopeEffect(scope, effect, deps)` re-runs a registration when the scope's bound client is replaced (cleaning up against the old one first) while ignoring value updates, and the toolkit, runtime-adapter, interactables, and MCP registration sites now use it instead of registering once against a stable client ref.

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -240,7 +240,7 @@ declare const auiConfigBrand: unique symbol;
 declare const clientIdBrand: unique symbol;
 
 declare namespace entry_client_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantConfigSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, createAssistantClient, getProxiedAssistantState, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useClientLookup, useClientResource };
+  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantConfigSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, createAssistantClient, getProxiedAssistantState, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAssistantScopeEffect, useClientLookup, useClientResource };
 }
 
 declare const createAssistantClient: (config: AuiConfig.Input | AssistantConfigSource, options?: {
@@ -274,6 +274,8 @@ declare const useAssistantClientRef: () => {
 };
 
 declare const useAssistantEmit: () => <TEvent extends Exclude<AssistantEventName, "*">>(event: TEvent, payload: AssistantEventPayload[TEvent]) => void;
+
+declare const useAssistantScopeEffect: (scope: ClientNames, effect: () => (() => void) | void, deps: readonly unknown[]) => void;
 
 declare namespace useAui {
   type Props = AuiConfig.Input;

--- a/packages/core/src/react/RuntimeAdapter.ts
+++ b/packages/core/src/react/RuntimeAdapter.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useResource, resource } from "@assistant-ui/tap";
 import type { AssistantRuntime } from "..";
 import {
@@ -8,6 +7,7 @@ import {
 import {
   attachTransformScopes,
   useAssistantClientRef,
+  useAssistantScopeEffect,
 } from "@assistant-ui/store/client";
 import { DataRenderers } from "./client/DataRenderers";
 import { Tools } from "./client/Tools";
@@ -15,11 +15,12 @@ import { Tools } from "./client/Tools";
 const useRuntimeAdapter = (runtime: AssistantRuntime) => {
   const clientRef = useAssistantClientRef();
 
-  useEffect(() => {
-    return runtime.registerModelContextProvider(
-      clientRef.current!.modelContext(),
-    );
-  }, [runtime, clientRef]);
+  useAssistantScopeEffect(
+    "modelContext",
+    () =>
+      runtime.registerModelContextProvider(clientRef.current!.modelContext()),
+    [runtime],
+  );
 
   return useResource(
     ThreadListClient({

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -12,6 +12,18 @@ const clientHolder: { client: unknown } = { client: null };
 vi.mock("@assistant-ui/store/client", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@assistant-ui/store/client")>();
+  const { useEffect } = await import("react");
+  const useScopeEffectShim = (
+    _scope: string,
+    effect: () => (() => void) | void,
+    deps: readonly unknown[],
+  ) => {
+    useEffect(() => {
+      const cleanup = effect();
+      return typeof cleanup === "function" ? cleanup : undefined;
+      // oxlint-disable-next-line react-hooks/exhaustive-deps -- caller-provided deps, mirrors the real hook
+    }, deps);
+  };
   return {
     ...actual,
     useAssistantClientRef: () => ({
@@ -19,6 +31,7 @@ vi.mock("@assistant-ui/store/client", async (importOriginal) => {
         return clientHolder.client;
       },
     }),
+    useAssistantScopeEffect: useScopeEffectShim,
   };
 });
 

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -4,6 +4,7 @@ import type { ClientOutput } from "@assistant-ui/store";
 import {
   attachTransformScopes,
   useAssistantClientRef,
+  useAssistantScopeEffect,
 } from "@assistant-ui/store/client";
 import type {
   Unstable_InteractablesState,
@@ -387,9 +388,11 @@ const useInteractablesResource = ({
     for (const cb of subscribersRef.current) cb();
   }, [state]);
 
-  useEffect(() => {
-    return clientRef.current!.modelContext().register(provider);
-  }, [clientRef, provider]);
+  useAssistantScopeEffect(
+    "modelContext",
+    () => clientRef.current!.modelContext().register(provider),
+    [provider],
+  );
 
   const register = useCallback(
     (def: InternalInteractableRegistration) => {

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   useResources,
   resource,
@@ -88,30 +88,37 @@ const useTools = ({
     [],
   );
 
+  useEffect(() => {
+    if (!toolkit) return;
+    const unsubscribes: (() => void)[] = [];
+
+    // Register tool UIs (exclude symbols)
+    for (const [toolName, tool] of Object.entries(toolkit)) {
+      const toolRender = "render" in tool ? tool.render : undefined;
+      const toolRenderText = "renderText" in tool ? tool.renderText : undefined;
+      const render =
+        toolRender ??
+        (toolRenderText
+          ? makeToolCallTextComponent(toolRenderText)
+          : undefined);
+      if (render) {
+        unsubscribes.push(
+          setToolUI(toolName, render, {
+            standalone: isStandaloneToolDisplay(tool),
+          }),
+        );
+      }
+    }
+
+    return () => {
+      unsubscribes.forEach((fn) => fn());
+    };
+  }, [toolkit, setToolUI]);
+
   useAssistantScopeEffect(
     "modelContext",
     () => {
       if (!toolkit) return;
-      const unsubscribes: (() => void)[] = [];
-
-      // Register tool UIs (exclude symbols)
-      for (const [toolName, tool] of Object.entries(toolkit)) {
-        const toolRender = "render" in tool ? tool.render : undefined;
-        const toolRenderText =
-          "renderText" in tool ? tool.renderText : undefined;
-        const render =
-          toolRender ??
-          (toolRenderText
-            ? makeToolCallTextComponent(toolRenderText)
-            : undefined);
-        if (render) {
-          unsubscribes.push(
-            setToolUI(toolName, render, {
-              standalone: isStandaloneToolDisplay(tool),
-            }),
-          );
-        }
-      }
 
       // Register tools with model context (exclude symbols). `render`,
       // `renderText`, and `display` are client-only presentation concerns and
@@ -137,15 +144,9 @@ const useTools = ({
         }),
       };
 
-      unsubscribes.push(
-        clientRef.current!.modelContext().register(modelContextProvider),
-      );
-
-      return () => {
-        unsubscribes.forEach((fn) => fn());
-      };
+      return clientRef.current!.modelContext().register(modelContextProvider);
     },
-    [toolkit, setToolUI],
+    [toolkit],
   );
 
   return {

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   useResources,
   resource,
@@ -9,6 +9,7 @@ import type { ClientOutput } from "@assistant-ui/store";
 import {
   attachTransformScopes,
   useAssistantClientRef,
+  useAssistantScopeEffect,
 } from "@assistant-ui/store/client";
 import type { McpAppResourceOutput, ToolsState } from "../types/scopes/tools";
 import type { Tool } from "assistant-stream";
@@ -87,60 +88,65 @@ const useTools = ({
     [],
   );
 
-  useEffect(() => {
-    if (!toolkit) return;
-    const unsubscribes: (() => void)[] = [];
+  useAssistantScopeEffect(
+    "modelContext",
+    () => {
+      if (!toolkit) return;
+      const unsubscribes: (() => void)[] = [];
 
-    // Register tool UIs (exclude symbols)
-    for (const [toolName, tool] of Object.entries(toolkit)) {
-      const toolRender = "render" in tool ? tool.render : undefined;
-      const toolRenderText = "renderText" in tool ? tool.renderText : undefined;
-      const render =
-        toolRender ??
-        (toolRenderText
-          ? makeToolCallTextComponent(toolRenderText)
-          : undefined);
-      if (render) {
-        unsubscribes.push(
-          setToolUI(toolName, render, {
-            standalone: isStandaloneToolDisplay(tool),
-          }),
-        );
+      // Register tool UIs (exclude symbols)
+      for (const [toolName, tool] of Object.entries(toolkit)) {
+        const toolRender = "render" in tool ? tool.render : undefined;
+        const toolRenderText =
+          "renderText" in tool ? tool.renderText : undefined;
+        const render =
+          toolRender ??
+          (toolRenderText
+            ? makeToolCallTextComponent(toolRenderText)
+            : undefined);
+        if (render) {
+          unsubscribes.push(
+            setToolUI(toolName, render, {
+              standalone: isStandaloneToolDisplay(tool),
+            }),
+          );
+        }
       }
-    }
 
-    // Register tools with model context (exclude symbols). `render`,
-    // `renderText`, and `display` are client-only presentation concerns and
-    // never reach the model.
-    const toolsWithoutRender = Object.entries(toolkit).reduce(
-      (acc, [name, tool]) => {
-        if (tool.type === "mcp") return acc;
-        const {
-          display: _display,
-          render: _render,
-          renderText: _renderText,
-          ...rest
-        } = tool as typeof tool & { renderText?: unknown };
-        acc[name] = rest as Tool<any, any>;
-        return acc;
-      },
-      {} as Record<string, Tool<any, any>>,
-    );
+      // Register tools with model context (exclude symbols). `render`,
+      // `renderText`, and `display` are client-only presentation concerns and
+      // never reach the model.
+      const toolsWithoutRender = Object.entries(toolkit).reduce(
+        (acc, [name, tool]) => {
+          if (tool.type === "mcp") return acc;
+          const {
+            display: _display,
+            render: _render,
+            renderText: _renderText,
+            ...rest
+          } = tool as typeof tool & { renderText?: unknown };
+          acc[name] = rest as Tool<any, any>;
+          return acc;
+        },
+        {} as Record<string, Tool<any, any>>,
+      );
 
-    const modelContextProvider = {
-      getModelContext: () => ({
-        tools: toolsWithoutRender,
-      }),
-    };
+      const modelContextProvider = {
+        getModelContext: () => ({
+          tools: toolsWithoutRender,
+        }),
+      };
 
-    unsubscribes.push(
-      clientRef.current!.modelContext().register(modelContextProvider),
-    );
+      unsubscribes.push(
+        clientRef.current!.modelContext().register(modelContextProvider),
+      );
 
-    return () => {
-      unsubscribes.forEach((fn) => fn());
-    };
-  }, [toolkit, setToolUI, clientRef]);
+      return () => {
+        unsubscribes.forEach((fn) => fn());
+      };
+    },
+    [toolkit, setToolUI],
+  );
 
   return {
     getState: () => state,

--- a/packages/core/src/react/interactables-legacy/Interactables.ts
+++ b/packages/core/src/react/interactables-legacy/Interactables.ts
@@ -5,6 +5,7 @@ import {
   type ClientOutput,
   attachTransformScopes,
 } from "@assistant-ui/store";
+import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import type {
   InteractablesState,
   InteractableRegistration,
@@ -251,9 +252,11 @@ const useInteractables = (): ClientOutput<"interactables"> => {
     for (const cb of subscribersRef.current) cb();
   }, [state]);
 
-  useEffect(() => {
-    return clientRef.current!.modelContext().register(provider);
-  }, [clientRef, provider]);
+  useAssistantScopeEffect(
+    "modelContext",
+    () => clientRef.current!.modelContext().register(provider),
+    [provider],
+  );
 
   const register = useCallback(
     (def: InteractableRegistration) => {

--- a/packages/core/src/tests/tools-scope-migration.test.tsx
+++ b/packages/core/src/tests/tools-scope-migration.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { withKey } from "@assistant-ui/tap";
+import { useAui } from "@assistant-ui/store";
+import { Tools } from "../react/client/Tools";
+import { ModelContext } from "../store/clients/model-context-client";
+import type { Toolkit } from "../react/model-context/toolbox";
+
+type AnyClient = Record<string, any>;
+
+const toolkit = {
+  lookup: {
+    description: "look something up",
+    parameters: { type: "object", properties: {} },
+    execute: async () => "ok",
+  },
+} as unknown as Toolkit;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Tools model-context registration", () => {
+  it("migrates to a structurally replaced modelContext scope", async () => {
+    let aui!: AnyClient;
+    const Harness = ({ generation }: { generation: number }) => {
+      aui = useAui({
+        tools: Tools({ toolkit }),
+        modelContext: withKey(String(generation), ModelContext()),
+      } as never);
+      return null;
+    };
+    const view = render(<Harness generation={0} />);
+
+    expect(
+      Object.keys(aui.modelContext().getModelContext().tools ?? {}),
+    ).toContain("lookup");
+
+    // The registration lands one scheduler macrotask after the swap: the
+    // mount-time register marks the tap scheduler dirty, which defers the
+    // structural publish to the scheduler's drain
+    await act(async () => {
+      view.rerender(<Harness generation={1} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // The remounted scope starts from fresh state, so the tools reappearing
+    // proves the registration migrated to the replacement instance
+    expect(
+      Object.keys(aui.modelContext().getModelContext().tools ?? {}),
+    ).toContain("lookup");
+  });
+});

--- a/packages/core/src/tests/tools-scope-migration.test.tsx
+++ b/packages/core/src/tests/tools-scope-migration.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withKey } from "@assistant-ui/tap";
 import { useAui } from "@assistant-ui/store";
 import { Tools } from "../react/client/Tools";
@@ -40,16 +40,16 @@ describe("Tools model-context registration", () => {
 
     // The registration lands one scheduler macrotask after the swap: the
     // mount-time register marks the tap scheduler dirty, which defers the
-    // structural publish to the scheduler's drain
+    // structural publish to the scheduler's drain. The remounted scope
+    // starts from fresh state, so the tools reappearing proves the
+    // registration migrated to the replacement instance.
     await act(async () => {
       view.rerender(<Harness generation={1} />);
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await vi.waitFor(() =>
+        expect(
+          Object.keys(aui.modelContext().getModelContext().tools ?? {}),
+        ).toContain("lookup"),
+      );
     });
-
-    // The remounted scope starts from fresh state, so the tools reappearing
-    // proves the registration migrated to the replacement instance
-    expect(
-      Object.keys(aui.modelContext().getModelContext().tools ?? {}),
-    ).toContain("lookup");
   });
 });

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -36,6 +36,27 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   useAssistantClientRef: () => ({ current: null }),
 }));
 
+vi.mock("@assistant-ui/store/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@assistant-ui/store/client")>();
+  const { useEffect } = await import("react");
+  const useScopeEffectShim = (
+    _scope: string,
+    effect: () => (() => void) | void,
+    deps: readonly unknown[],
+  ) => {
+    useEffect(() => {
+      const cleanup = effect();
+      return typeof cleanup === "function" ? cleanup : undefined;
+      // oxlint-disable-next-line react-hooks/exhaustive-deps -- caller-provided deps, mirrors the real hook
+    }, deps);
+  };
+  return {
+    ...actual,
+    useAssistantScopeEffect: useScopeEffectShim,
+  };
+});
+
 const connector = (id: string, name = id): MCPConnector =>
   defineConnector({
     id,

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -6,6 +6,7 @@ import {
   attachTransformScopes,
   type ClientOutput,
 } from "@assistant-ui/store";
+import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import { ModelContext } from "@assistant-ui/core/store";
 import type { Tool } from "assistant-stream";
 import { McpServerResource } from "./McpServerResource";
@@ -234,13 +235,17 @@ const useMcpManagerResource = (
 
   const clientRef = useAssistantClientRef();
 
-  useEffect(() => {
-    const client = clientRef.current;
-    if (!client) return;
-    return client.modelContext.register({
-      getModelContext: () => ({ tools: toolkit }),
-    });
-  }, [toolkit, clientRef]);
+  useAssistantScopeEffect(
+    "modelContext",
+    () => {
+      const client = clientRef.current;
+      if (!client) return;
+      return client.modelContext.register({
+        getModelContext: () => ({ tools: toolkit }),
+      });
+    },
+    [toolkit],
+  );
 
   const serverByKind = (kind: "connector" | "custom", index: number) => {
     const list = kind === "connector" ? state.connectors : state.customServers;

--- a/packages/store/src/__tests__/scope-effect.test.tsx
+++ b/packages/store/src/__tests__/scope-effect.test.tsx
@@ -48,11 +48,9 @@ const makeHarness = () => {
     const clientRef = useAssistantClientRef();
     useAssistantScopeEffect(
       "target" as never,
-      () => {
-        const target = (clientRef.current as AnyClient | null)?.optional.target;
-        if (!target) return;
-        return target.register(tag);
-      },
+      // The effect only runs while the scope is available, so the accessor
+      // can be used directly
+      () => (clientRef.current as AnyClient).target.register(tag),
       [tag],
     );
     return { getState: () => ({}) };

--- a/packages/store/src/__tests__/scope-effect.test.tsx
+++ b/packages/store/src/__tests__/scope-effect.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { flushTapSync, resource } from "@assistant-ui/tap";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { Derived } from "../Derived";
+import { useClientResource } from "../useClientResource";
+import {
+  useAssistantClientRef,
+  useAssistantScopeEffect,
+} from "../utils/tap-assistant-context";
+
+type AnyClient = Record<string, any>;
+
+const makeHarness = () => {
+  const log: string[] = [];
+
+  const useTargetClient = ({ id }: { id: string }) => {
+    const [generation, setGeneration] = useState(0);
+    return {
+      getState: () => ({ id, generation }),
+      poke: () => setGeneration((n) => n + 1),
+      register: (tag: string) => {
+        log.push(`+${id}:${tag}`);
+        return () => log.push(`-${id}:${tag}`);
+      },
+    };
+  };
+  const TargetClient = resource(useTargetClient);
+
+  const useThreadClient = () => {
+    const [selected, setSelected] = useState(0);
+    const t0 = useClientResource(TargetClient({ id: "t0" }));
+    const t1 = useClientResource(TargetClient({ id: "t1" }));
+    const targets = [t0, t1];
+    return {
+      getState: () => ({ selected }),
+      setSelected,
+      target: ({ index }: { index: number }) => targets[index]!.methods,
+    };
+  };
+  const ThreadClient = resource(useThreadClient);
+
+  const useRegistrarClient = ({ tag }: { tag: string }) => {
+    const clientRef = useAssistantClientRef();
+    useAssistantScopeEffect(
+      "target" as never,
+      () => {
+        const target = (clientRef.current as AnyClient | null)?.optional.target;
+        if (!target) return;
+        return target.register(tag);
+      },
+      [tag],
+    );
+    return { getState: () => ({}) };
+  };
+  const RegistrarClient = resource(useRegistrarClient);
+
+  const targetDerived = () =>
+    Derived({
+      source: "thread",
+      query: {},
+      get: (aui: AnyClient) =>
+        aui.thread.target({ index: aui.thread.getState().selected }),
+    } as never);
+
+  return { log, ThreadClient, RegistrarClient, targetDerived };
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useAssistantScopeEffect", () => {
+  it("migrates the registration when the scope's binding is structurally replaced", () => {
+    const { log, ThreadClient, RegistrarClient, targetDerived } = makeHarness();
+    let aui!: AnyClient;
+    const Harness = ({ tag }: { tag: string }) => {
+      aui = useAui({
+        thread: ThreadClient(),
+        target: targetDerived(),
+        registrar: RegistrarClient({ tag }),
+      } as never);
+      return <AuiProvider value={aui as never} />;
+    };
+    const view = render(<Harness tag="a" />);
+
+    expect(log).toEqual(["+t0:a"]);
+
+    // A value update on the same binding does not re-register
+    act(() => flushTapSync(() => aui.thread.target({ index: 0 }).poke()));
+    expect(log).toEqual(["+t0:a"]);
+
+    // A structural replacement migrates: cleanup on the old, setup on the new
+    act(() => flushTapSync(() => aui.thread.setSelected(1)));
+    expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a"]);
+
+    // A deps change re-runs against the current binding
+    view.rerender(<Harness tag="b" />);
+    expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a", "-t1:a", "+t1:b"]);
+
+    view.unmount();
+    expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a", "-t1:a", "+t1:b", "-t1:b"]);
+  });
+
+  it("sets up once the scope appears in a later structural change", () => {
+    const { log, ThreadClient, RegistrarClient, targetDerived } = makeHarness();
+    const Harness = ({ hasTarget }: { hasTarget: boolean }) => {
+      const aui = useAui(
+        (hasTarget
+          ? {
+              thread: ThreadClient(),
+              target: targetDerived(),
+              registrar: RegistrarClient({ tag: "a" }),
+            }
+          : {
+              thread: ThreadClient(),
+              registrar: RegistrarClient({ tag: "a" }),
+            }) as never,
+      );
+      return <AuiProvider value={aui as never} />;
+    };
+    const view = render(<Harness hasTarget={false} />);
+    expect(log).toEqual([]);
+
+    view.rerender(<Harness hasTarget />);
+    expect(log).toEqual(["+t0:a"]);
+
+    view.rerender(<Harness hasTarget={false} />);
+    expect(log).toEqual(["+t0:a", "-t0:a"]);
+  });
+});

--- a/packages/store/src/__tests__/scope-effect.test.tsx
+++ b/packages/store/src/__tests__/scope-effect.test.tsx
@@ -70,6 +70,7 @@ const makeHarness = () => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("useAssistantScopeEffect", () => {
@@ -142,7 +143,6 @@ describe("useAssistantScopeEffect", () => {
     act(() => flushTapSync(() => aui.thread.setSelected(1)));
     expect(log).toEqual(["+t0:a", "-t0:a"]);
     expect(consoleError).toHaveBeenCalled();
-    consoleError.mockRestore();
 
     // Once the effect can succeed, any later notification retries the
     // unapplied migration, including a value update that changes no identity

--- a/packages/store/src/__tests__/scope-effect.test.tsx
+++ b/packages/store/src/__tests__/scope-effect.test.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
-import { flushTapSync, resource } from "@assistant-ui/tap";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushTapSync, resource, withKey } from "@assistant-ui/tap";
 import { AuiProvider } from "../AuiProvider";
 import { useAui } from "../useAui";
 import { Derived } from "../Derived";
@@ -65,7 +65,7 @@ const makeHarness = () => {
         aui.thread.target({ index: aui.thread.getState().selected }),
     } as never);
 
-  return { log, ThreadClient, RegistrarClient, targetDerived };
+  return { log, TargetClient, ThreadClient, RegistrarClient, targetDerived };
 };
 
 afterEach(() => {
@@ -102,6 +102,74 @@ describe("useAssistantScopeEffect", () => {
 
     view.unmount();
     expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a", "-t1:a", "+t1:b", "-t1:b"]);
+  });
+
+  it("retries a failed migration on a later notification", () => {
+    const { log, ThreadClient, targetDerived } = makeHarness();
+    let failing = false;
+    const useFlakyRegistrarClient = ({ tag }: { tag: string }) => {
+      const clientRef = useAssistantClientRef();
+      useAssistantScopeEffect(
+        "target" as never,
+        () => {
+          if (failing) throw new Error("setup failed");
+          return (clientRef.current as AnyClient).target.register(tag);
+        },
+        [tag],
+      );
+      return { getState: () => ({}) };
+    };
+    const FlakyRegistrarClient = resource(useFlakyRegistrarClient);
+
+    let aui!: AnyClient;
+    const Harness = () => {
+      aui = useAui({
+        thread: ThreadClient(),
+        target: targetDerived(),
+        registrar: FlakyRegistrarClient({ tag: "a" }),
+      } as never);
+      return <AuiProvider value={aui as never} />;
+    };
+    render(<Harness />);
+    expect(log).toEqual(["+t0:a"]);
+
+    // The migration to t1 fails; the old registration is cleaned up exactly
+    // once and the failure is reported through the notification manager
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    failing = true;
+    act(() => flushTapSync(() => aui.thread.setSelected(1)));
+    expect(log).toEqual(["+t0:a", "-t0:a"]);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+
+    // Once the effect can succeed, any later notification retries the
+    // unapplied migration, including a value update that changes no identity
+    failing = false;
+    act(() => flushTapSync(() => aui.thread.target({ index: 1 }).poke()));
+    expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a"]);
+  });
+
+  it("migrates when a root scope is remounted in place via withKey", () => {
+    const { log, TargetClient, RegistrarClient } = makeHarness();
+    const Harness = ({ generation }: { generation: number }) => {
+      const aui = useAui({
+        target: withKey(
+          String(generation),
+          TargetClient({ id: `t${generation}` }),
+        ),
+        registrar: RegistrarClient({ tag: "a" }),
+      } as never);
+      return <AuiProvider value={aui as never} />;
+    };
+    const view = render(<Harness generation={0} />);
+    expect(log).toEqual(["+t0:a"]);
+
+    // The remount resets the instance's state while the client facade stays
+    // identity-stable, so the registration must follow the instance
+    view.rerender(<Harness generation={1} />);
+    expect(log).toEqual(["+t0:a", "-t0:a", "+t1:a"]);
   });
 
   it("sets up once the scope appears in a later structural change", () => {

--- a/packages/store/src/client.ts
+++ b/packages/store/src/client.ts
@@ -14,6 +14,7 @@ export { getProxiedAssistantState } from "./utils/proxied-assistant-state";
 export {
   useAssistantClientRef,
   useAssistantEmit,
+  useAssistantScopeEffect,
 } from "./utils/tap-assistant-context";
 export { useClientResource } from "./useClientResource";
 export { useClientLookup } from "./useClientLookup";

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -148,9 +148,10 @@ export const useClientResource = <TMethods extends ClientMethods>(
   // The fiber behind useResource is keyed on (hook, key), so the underlying
   // instance is replaced exactly when either changes. The tag mirrors that
   // lifetime while the methods facade below deliberately stays stable across
-  // remounts. The ref is committed during render because notifications can
-  // deliver in a microtask before passive effects run.
-  tagRef.current = useMemo(() => ({}), [element.hook, element.key]);
+  // remounts. It advances in the same commit effect as valueRef: a
+  // notification delivered before the commit then observes the previous tag
+  // together with the previous instance instead of a torn pair.
+  const instanceTag = useMemo(() => ({}), [element.hook, element.key]);
 
   const index = useClientStack().length;
   const methods = useMemo(
@@ -168,10 +169,12 @@ export const useClientResource = <TMethods extends ClientMethods>(
 
   if (!valueRef.current) {
     valueRef.current = value;
+    tagRef.current = instanceTag;
   }
 
   useEffect(() => {
     valueRef.current = value;
+    tagRef.current = instanceTag;
   });
 
   const state = (value as any).getState?.();

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -10,6 +10,7 @@ import {
   BaseProxyHandler,
   handleIntrospectionProp,
 } from "./utils/BaseProxyHandler";
+import { INSTANCE_TAG_SYMBOL } from "./utils/client-accessor";
 
 /**
  * Symbol used internally to get state from ClientProxy.
@@ -81,22 +82,26 @@ class ClientProxyHandler
   private readonly outputRef: {
     current: ClientMethods;
   };
+  private readonly tagRef: { current: object };
   private readonly index: number;
 
   constructor(
     outputRef: {
       current: ClientMethods;
     },
+    tagRef: { current: object },
     index: number,
   ) {
     super();
     this.outputRef = outputRef;
+    this.tagRef = tagRef;
     this.index = index;
   }
 
   get(_: unknown, prop: string | symbol, receiver: unknown) {
     if (prop === SYMBOL_GET_OUTPUT) return this.outputRef.current;
     if (prop === SYMBOL_CLIENT_INDEX) return this.index;
+    if (prop === INSTANCE_TAG_SYMBOL) return this.tagRef.current;
     const introspection = handleIntrospectionProp(prop, "ClientProxy");
     if (introspection !== false) return introspection;
     const value = this.outputRef.current[prop];
@@ -125,6 +130,7 @@ class ClientProxyHandler
   has(_: unknown, prop: string | symbol) {
     if (prop === SYMBOL_GET_OUTPUT) return true;
     if (prop === SYMBOL_CLIENT_INDEX) return true;
+    if (prop === INSTANCE_TAG_SYMBOL) return true;
     return prop in this.outputRef.current;
   }
 }
@@ -137,13 +143,21 @@ export const useClientResource = <TMethods extends ClientMethods>(
   key: string | number | undefined;
 } => {
   const valueRef = useRef(null as unknown as TMethods);
+  const tagRef = useRef(null as unknown as object);
+
+  // The fiber behind useResource is keyed on (hook, key), so the underlying
+  // instance is replaced exactly when either changes. The tag mirrors that
+  // lifetime while the methods facade below deliberately stays stable across
+  // remounts. The ref is committed during render because notifications can
+  // deliver in a microtask before passive effects run.
+  tagRef.current = useMemo(() => ({}), [element.hook, element.key]);
 
   const index = useClientStack().length;
   const methods = useMemo(
     () =>
       new Proxy<TMethods>(
         {} as TMethods,
-        new ClientProxyHandler(valueRef, index),
+        new ClientProxyHandler(valueRef, tagRef, index),
       ),
     [index],
   );

--- a/packages/store/src/utils/client-accessor.ts
+++ b/packages/store/src/utils/client-accessor.ts
@@ -7,6 +7,8 @@ import { handleIntrospectionProp } from "./BaseProxyHandler";
 
 const CLIENT_ID_SYMBOL = Symbol("assistant-ui.store.clientId");
 
+export const INSTANCE_TAG_SYMBOL = Symbol("assistant-ui.store.instanceTag");
+
 declare const clientIdBrand: unique symbol;
 
 type AccessorMeta = {
@@ -114,3 +116,16 @@ export const getClientId = (client: object): getClientId.ClientId =>
 export namespace getClientId {
   export type ClientId = { readonly [clientIdBrand]: never };
 }
+
+/**
+ * Returns the identity of the underlying client instance.
+ *
+ * `getClientId` follows the stable client facade, which survives a remount
+ * of the resource behind it, so it cannot distinguish a structurally
+ * replaced instance whose state was reset. This identity changes exactly
+ * when that instance is remounted or replaced; clients without an instance
+ * tag (hand-built parent chains) fall back to the facade identity.
+ */
+export const getClientInstanceId = (client: object): getClientId.ClientId =>
+  ((client as AnyRecord)[INSTANCE_TAG_SYMBOL] ??
+    getClientId(client)) as getClientId.ClientId;

--- a/packages/store/src/utils/tap-assistant-context.ts
+++ b/packages/store/src/utils/tap-assistant-context.ts
@@ -45,9 +45,12 @@ export const useAssistantClientRef = () => {
  * Runs a registration effect that follows the committed identity of one
  * scope: when a structural change replaces the scope's bound client, the
  * previous cleanup runs and the effect runs again against the replacement.
- * Value updates on the same binding do not re-run it. The client ref is
- * committed before effects run, so reads through it inside the effect see
- * the finalized client.
+ * Value updates on the same binding do not re-run it, and while the scope is
+ * unavailable only cleanup runs, so the effect always executes against a
+ * bound scope. A migration whose effect throws keeps the previous identity,
+ * so the next notification retries it. The client ref is committed before
+ * effects run, so reads through it inside the effect see the finalized
+ * client.
  */
 export const useAssistantScopeEffect = (
   scope: ClientNames,
@@ -66,20 +69,25 @@ export const useAssistantScopeEffect = (
         ? getClientId(accessor)
         : undefined;
     };
-    const setup = () => {
-      const cleanup = effect();
-      return typeof cleanup === "function" ? cleanup : undefined;
+
+    let identity: ReturnType<typeof identityOf>;
+    let cleanup: (() => void) | undefined;
+    const apply = (next: ReturnType<typeof identityOf>) => {
+      cleanup?.();
+      cleanup = undefined;
+      if (next !== undefined) {
+        const result = effect();
+        cleanup = typeof result === "function" ? result : undefined;
+      }
+      identity = next;
     };
 
-    let identity = identityOf();
-    let cleanup = setup();
+    apply(identityOf());
 
     const unsubscribe = subscribe(() => {
       const next = identityOf();
       if (next === identity) return;
-      identity = next;
-      cleanup?.();
-      cleanup = setup();
+      apply(next);
     });
 
     return () => {

--- a/packages/store/src/utils/tap-assistant-context.ts
+++ b/packages/store/src/utils/tap-assistant-context.ts
@@ -1,10 +1,11 @@
-import { useEffectEvent, use, createContext } from "react";
+import { useEffect, useEffectEvent, use, createContext } from "react";
 import { useContextProvider } from "@assistant-ui/tap";
 import type {
   AssistantEventName,
   AssistantEventPayload,
 } from "../types/events";
-import type { AssistantClient } from "../types/client";
+import type { AssistantClient, ClientNames } from "../types/client";
+import { getClientId, isScopeAvailable } from "./client-accessor";
 import { useClientStack, type ClientStack } from "./tap-client-stack-context";
 
 type EmitFn = <TEvent extends Exclude<AssistantEventName, "*">>(
@@ -38,6 +39,55 @@ const useAssistantTapContext = () => {
 
 export const useAssistantClientRef = () => {
   return useAssistantTapContext().clientRef;
+};
+
+/**
+ * Runs a registration effect that follows the committed identity of one
+ * scope: when a structural change replaces the scope's bound client, the
+ * previous cleanup runs and the effect runs again against the replacement.
+ * Value updates on the same binding do not re-run it. The client ref is
+ * committed before effects run, so reads through it inside the effect see
+ * the finalized client.
+ */
+export const useAssistantScopeEffect = (
+  scope: ClientNames,
+  effect: () => (() => void) | void,
+  deps: readonly unknown[],
+) => {
+  const { clientRef } = useAssistantTapContext();
+
+  useEffect(() => {
+    const subscribe = clientRef.current?.subscribe;
+    if (!subscribe) return;
+
+    const identityOf = () => {
+      const accessor = clientRef.current?.[scope];
+      return accessor !== undefined && isScopeAvailable(accessor)
+        ? getClientId(accessor)
+        : undefined;
+    };
+    const setup = () => {
+      const cleanup = effect();
+      return typeof cleanup === "function" ? cleanup : undefined;
+    };
+
+    let identity = identityOf();
+    let cleanup = setup();
+
+    const unsubscribe = subscribe(() => {
+      const next = identityOf();
+      if (next === identity) return;
+      identity = next;
+      cleanup?.();
+      cleanup = setup();
+    });
+
+    return () => {
+      unsubscribe();
+      cleanup?.();
+    };
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- deps is the caller's dependency list; the effect closure is intentionally read per deps generation
+  }, [clientRef, scope, ...deps]);
 };
 
 export const useAssistantEmit = () => {

--- a/packages/store/src/utils/tap-assistant-context.ts
+++ b/packages/store/src/utils/tap-assistant-context.ts
@@ -5,7 +5,7 @@ import type {
   AssistantEventPayload,
 } from "../types/events";
 import type { AssistantClient, ClientNames } from "../types/client";
-import { getClientId, isScopeAvailable } from "./client-accessor";
+import { getClientInstanceId, isScopeAvailable } from "./client-accessor";
 import { useClientStack, type ClientStack } from "./tap-client-stack-context";
 
 type EmitFn = <TEvent extends Exclude<AssistantEventName, "*">>(
@@ -22,6 +22,8 @@ export type AssistantTapContextValue = {
 const AssistantTapContext = createContext<AssistantTapContextValue | null>(
   null,
 );
+
+const UNAPPLIED = Symbol("aui.scope-effect-unapplied");
 
 export const useAssistantTapContextProvider = <TResult>(
   value: AssistantTapContextValue,
@@ -42,15 +44,14 @@ export const useAssistantClientRef = () => {
 };
 
 /**
- * Runs a registration effect that follows the committed identity of one
- * scope: when a structural change replaces the scope's bound client, the
+ * Runs a registration effect that follows the bound client instance of one
+ * scope: when a structural change remounts or replaces that instance, the
  * previous cleanup runs and the effect runs again against the replacement.
- * Value updates on the same binding do not re-run it, and while the scope is
- * unavailable only cleanup runs, so the effect always executes against a
- * bound scope. A migration whose effect throws keeps the previous identity,
- * so the next notification retries it. The client ref is committed before
- * effects run, so reads through it inside the effect see the finalized
- * client.
+ * Value updates on the same instance do not re-run it, and while the scope
+ * is unavailable only cleanup runs, so the effect always executes against a
+ * bound scope. A migration whose effect throws stays unapplied, so the next
+ * notification retries it. The client ref is committed before effects run,
+ * so reads through it inside the effect see the finalized client.
  */
 export const useAssistantScopeEffect = (
   scope: ClientNames,
@@ -60,33 +61,42 @@ export const useAssistantScopeEffect = (
   const { clientRef } = useAssistantTapContext();
 
   useEffect(() => {
-    const subscribe = clientRef.current?.subscribe;
-    if (!subscribe) return;
+    const client = clientRef.current;
+    if (client === null) {
+      throw new Error(
+        "useAssistantScopeEffect ran before the client was committed. This is likely an internal bug in assistant-ui.",
+      );
+    }
 
     const identityOf = () => {
       const accessor = clientRef.current?.[scope];
       return accessor !== undefined && isScopeAvailable(accessor)
-        ? getClientId(accessor)
+        ? getClientInstanceId(accessor)
         : undefined;
     };
 
-    let identity: ReturnType<typeof identityOf>;
+    // Distinguishes "this identity has a live registration" from "this
+    // identity was last seen": a migration whose effect threw records
+    // UNAPPLIED, so the next notification retries even when the identity
+    // swings back to a previously registered client.
+    let applied: ReturnType<typeof identityOf> | typeof UNAPPLIED = UNAPPLIED;
     let cleanup: (() => void) | undefined;
     const apply = (next: ReturnType<typeof identityOf>) => {
       cleanup?.();
       cleanup = undefined;
+      applied = UNAPPLIED;
       if (next !== undefined) {
         const result = effect();
         cleanup = typeof result === "function" ? result : undefined;
       }
-      identity = next;
+      applied = next;
     };
 
     apply(identityOf());
 
-    const unsubscribe = subscribe(() => {
+    const unsubscribe = client.subscribe(() => {
       const next = identityOf();
-      if (next === identity) return;
+      if (next === applied) return;
       apply(next);
     });
 


### PR DESCRIPTION
closes assistant-ui/assistant-ui#5381

## summary

* long-lived registrations made through `useAssistantClientRef` (toolkit and MCP tools into `modelContext`, the runtime model-context provider, both interactables providers) depended on the stable ref object, so a structural replacement of the target scope never re-ran them: the old `CompositeContextProvider` kept the registration and its subscription while the replacement scope never received it
* adds `useAssistantScopeEffect(scope, effect, deps)` on the store's `./client` resource-authoring surface: one effect that tracks the committed identity of a single scope via `getClientId`, cleans up the previous registration and re-runs the effect when a structural change replaces the scope's bound client, ignores value updates on the same binding, and re-runs on caller deps like a plain effect; the identity is tracked imperatively inside the effect through `client.subscribe`, so no state updates or extra renders are involved
* the commit-order half of the issue (registration reading a pre-commit client in the same commit, and `on()` binding during a parent swap) is not addressed here because it no longer reproduces: assistant-ui/assistant-ui#5795 publishes the client ref from an insertion effect ahead of every layout and passive effect, and assistant-ui/assistant-ui#5769 resolves scoped delivery at delivery time
* the five registration sites migrate to the primitive with their scope pinned to `modelContext`; `useAssistantClientRef` stays untouched and append-only, per the issue's constraint
* deliberately out of scope: the interactables tool-UI registrations created inside `register()` callbacks (the issue's less-problematic callback-time pattern), which need an imperative-lifetime design rather than an effect

## test plan

### already verified

- [X] new store contract test: registers once on mount, ignores a value update on the same binding, migrates cleanup-then-setup on a structural swap, re-runs on deps change, cleans up on unmount, and sets up once a previously missing scope appears in a later structural change
- [X] `pnpm exec vitest run` -> store 21 files / 164 tests, core 101 / 1055, react-mcp 8 / 107, react 51 / 406, vue 11 / 66, react-ink 23 / 244, all green (the existing Interactables and MCP unit tests keep their module-boundary isolation through a faithful shim of the new hook)
- [X] `pnpm turbo build --filter=with-elevenlabs-conversational` -> green (workspace-level typecheck; it caught a missed legacy import during development)
- [X] `pnpm build` in packages/store and packages/core, `oxlint`, `oxfmt --check` -> clean

### reviewer should verify

- [ ] with a toolkit mounted and the `modelContext` scope structurally replaced (for example a provider remount that swaps the scope's backing client), the tools reappear in the new model context and the old one stops receiving updates

## notes

* supersedes the foundation half of assistant-ui/assistant-ui#5512, which predates the client-ref commit-phase work and sits CONFLICTING against main; its committed-client effect direction and the three-part split of the migration informed this change
* follow-ups on record: oxlint `additionalHooks` coverage so the new hook's deps arrays are lint-checked, and the interactables callback-time tool-UI migration

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

![Track in Rupic](https://camo.githubusercontent.com/35ad877989bf2ab419d9ac7f06c11a3b70a2b0e1d585ec6aba1649066e396507/68747470733a2f2f72757069632e6465762f6261646765732f747261636b2d6c696768742d76312e737667)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MV4PAjv-TaZRBORcX1Qftx6wg-PTC-2cJmWxkGIAq_8YN8m_0b6a-dkxFus?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->