### PR TITLE
fix(core): migrate interactables update-tool UIs across scope swaps

### DIFF
--- a/.changeset/interactables-toolui-migrate.md
+++ b/.changeset/interactables-toolui-migrate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: migrate interactables update-tool UIs across a tools scope replacement

--- a/.changeset/interactables-toolui-migrate.md
+++ b/.changeset/interactables-toolui-migrate.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: migrate interactables update-tool UIs across a tools scope replacement
+fix: migrate interactables update-tool UIs across tools scope replacements and install pending ones once the scope appears

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -14,11 +14,17 @@ vi.mock("@assistant-ui/store/client", async (importOriginal) => {
     await importOriginal<typeof import("@assistant-ui/store/client")>();
   const { useEffect } = await import("react");
   const useScopeEffectShim = (
-    _scope: string,
+    scope: string,
     effect: () => (() => void) | void,
     deps: readonly unknown[],
   ) => {
     useEffect(() => {
+      // Mirrors the real hook's guarantee: the effect only runs while the
+      // scope is available on the client.
+      const accessor = (
+        clientHolder.client as Record<string, { source?: unknown }> | null
+      )?.[scope];
+      if (accessor?.source == null) return;
       const cleanup = effect();
       return typeof cleanup === "function" ? cleanup : undefined;
       // oxlint-disable-next-line react-hooks/exhaustive-deps -- caller-provided deps, mirrors the real hook
@@ -51,7 +57,9 @@ const makeClient = (
   setToolUI?: (...args: unknown[]) => () => void,
   threadId?: string,
 ) => ({
-  modelContext: () => ({ register: () => () => {} }),
+  modelContext: Object.assign(() => ({ register: () => () => {} }), {
+    source: "root",
+  }),
   thread: threadMessages
     ? Object.assign(
         () => ({ getState: () => ({ messages: threadMessages }) }),

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -8,25 +8,43 @@ import type {
 import type { ThreadMessage } from "../../types/message";
 
 const clientHolder: { client: unknown } = { client: null };
+const clientListeners = new Set<() => void>();
+
+const replaceClient = (client: unknown) => {
+  clientHolder.client = client;
+  for (const listener of clientListeners) listener();
+};
 
 vi.mock("@assistant-ui/store/client", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@assistant-ui/store/client")>();
   const { useEffect } = await import("react");
+  // Mirrors the real hook's guarantees: the effect only runs while the scope
+  // is available, and a client replacement migrates the registration.
   const useScopeEffectShim = (
     scope: string,
     effect: () => (() => void) | void,
     deps: readonly unknown[],
   ) => {
     useEffect(() => {
-      // Mirrors the real hook's guarantee: the effect only runs while the
-      // scope is available on the client.
-      const accessor = (
-        clientHolder.client as Record<string, { source?: unknown }> | null
-      )?.[scope];
-      if (accessor?.source == null) return;
-      const cleanup = effect();
-      return typeof cleanup === "function" ? cleanup : undefined;
+      let cleanup: (() => void) | undefined;
+      const apply = () => {
+        cleanup?.();
+        cleanup = undefined;
+        const accessor = (
+          clientHolder.client as Record<string, { source?: unknown }> | null
+        )?.[scope];
+        if (accessor?.source == null) return;
+        const result = effect();
+        cleanup = typeof result === "function" ? result : undefined;
+      };
+
+      apply();
+      clientListeners.add(apply);
+      return () => {
+        clientListeners.delete(apply);
+        cleanup?.();
+      };
       // oxlint-disable-next-line react-hooks/exhaustive-deps -- caller-provided deps, mirrors the real hook
     }, deps);
   };
@@ -261,6 +279,57 @@ describe("Interactables registration", () => {
     first();
     expect(removeToolUI).not.toHaveBeenCalled();
     second();
+    expect(removeToolUI).toHaveBeenCalledTimes(1);
+  });
+
+  it("migrates update tool UIs when the tools scope is replaced", () => {
+    const removeFirst = vi.fn();
+    const setFirst = vi.fn(() => removeFirst);
+    const removeSecond = vi.fn();
+    const setSecond = vi.fn(() => removeSecond);
+    root = mount({ setToolUI: setFirst });
+
+    const render = () => null;
+    const unregister = root
+      .getValue()
+      .register(reg("n1", { updateRender: render }));
+
+    replaceClient(makeClient(undefined, setSecond));
+
+    expect(removeFirst).toHaveBeenCalledTimes(1);
+    expect(setSecond).toHaveBeenCalledWith("update_note", render, {
+      standalone: true,
+    });
+
+    unregister();
+    expect(removeSecond).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs a pending update tool UI when the tools scope becomes available", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const removeToolUI = vi.fn();
+    const setToolUI = vi.fn(() => removeToolUI);
+    root = mount();
+
+    const unregister = root
+      .getValue()
+      .register(reg("n1", { updateRender: () => null }));
+    expect(warn).toHaveBeenCalledWith(
+      '[Interactables] "note" supplied an updateRender, but no ' +
+        "tools scope is available to install it into.",
+    );
+    warn.mockRestore();
+
+    replaceClient(makeClient(undefined, setToolUI));
+
+    expect(setToolUI).toHaveBeenCalledWith(
+      "update_note",
+      expect.any(Function),
+      {
+        standalone: true,
+      },
+    );
+    unregister();
     expect(removeToolUI).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -316,7 +316,7 @@ describe("Interactables registration", () => {
       .register(reg("n1", { updateRender: () => null }));
     expect(warn).toHaveBeenCalledWith(
       '[Interactables] "note" supplied an updateRender, but no ' +
-        "tools scope is available to install it into.",
+        "tools scope is available yet; it will be installed once one appears.",
     );
     warn.mockRestore();
 

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -13,7 +13,6 @@ import type {
   Unstable_InteractablePersistenceAdapter,
   Unstable_InteractablesConfig,
 } from "../types/scopes/interactables";
-import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import { toJSONSchema, toPartialJSONSchema } from "assistant-stream";
 import { ModelContext } from "../../store/clients/model-context-client";
 import {
@@ -49,6 +48,12 @@ type MessageLike = {
 
 type InternalInteractableRegistration = Unstable_InteractableRegistration & {
   scope?: "thread" | undefined;
+};
+
+type UpdateToolUIEntry = {
+  count: number;
+  render: NonNullable<Unstable_InteractableRegistration["updateRender"]>;
+  unsubscribe: (() => void) | undefined;
 };
 
 const hasInteractableCreateCall = (
@@ -94,16 +99,7 @@ const useInteractablesResource = ({
   const registrationCountsRef = useRef(new Map<string, number>());
   // One update-tool UI per interactable name, alive while any registrant
   // that supplied an updateRender is mounted.
-  const updateToolUIsRef = useRef(
-    new Map<
-      string,
-      {
-        count: number;
-        render: ToolCallMessagePartComponent;
-        unsubscribe: () => void;
-      }
-    >(),
-  );
+  const updateToolUIsRef = useRef(new Map<string, UpdateToolUIEntry>());
   // App-scoped state restored via adapter.load(), consumed as components register.
   const loadedStateRef = useRef(new Map<string, unknown>());
   // Ids edited locally this session — a local edit always wins over a slow load.
@@ -403,28 +399,37 @@ const useInteractablesResource = ({
   );
 
   const installUpdateToolUI = useCallback(
-    (name: string, render: ToolCallMessagePartComponent) =>
-      clientRef.current!.tools().setToolUI(interactableToolName(name), render, {
-        standalone: true,
-      }),
+    (name: string, entry: UpdateToolUIEntry) => {
+      const toolsAccessor = clientRef.current?.tools;
+      if (!toolsAccessor || toolsAccessor.source == null) return false;
+      entry.unsubscribe = toolsAccessor().setToolUI(
+        interactableToolName(name),
+        entry.render,
+        { standalone: true },
+      );
+      return true;
+    },
     [clientRef],
   );
 
   // register() installs update-tool UIs against the tools instance bound at
   // call time; this re-applies the retained entries when that instance is
-  // structurally replaced. Each re-apply releases the entry's previous
+  // structurally replaced and installs entries recorded while no tools
+  // scope was available. Each re-apply releases the entry's previous
   // install first, so it is an orphaned no-op against a replaced instance
   // and an idempotent replacement against a live one.
   useAssistantScopeEffect(
     "tools",
     () => {
       for (const [name, entry] of updateToolUIsRef.current) {
-        entry.unsubscribe();
-        entry.unsubscribe = installUpdateToolUI(name, entry.render);
+        entry.unsubscribe?.();
+        entry.unsubscribe = undefined;
+        installUpdateToolUI(name, entry);
       }
       return () => {
         for (const entry of updateToolUIsRef.current.values()) {
-          entry.unsubscribe();
+          entry.unsubscribe?.();
+          entry.unsubscribe = undefined;
         }
       };
     },
@@ -463,32 +468,35 @@ const useInteractablesResource = ({
 
       let releaseUpdateToolUI: (() => void) | undefined;
       if (def.updateRender) {
-        const toolsAccessor = clientRef.current?.tools;
-        if (toolsAccessor && toolsAccessor.source != null) {
-          const existing = updateToolUIsRef.current.get(def.name);
-          if (existing) {
-            existing.count++;
-          } else {
-            updateToolUIsRef.current.set(def.name, {
-              count: 1,
-              render: def.updateRender,
-              unsubscribe: installUpdateToolUI(def.name, def.updateRender),
-            });
-          }
-          releaseUpdateToolUI = () => {
-            const entry = updateToolUIsRef.current.get(def.name);
-            if (!entry) return;
-            if (--entry.count === 0) {
-              updateToolUIsRef.current.delete(def.name);
-              entry.unsubscribe();
-            }
-          };
-        } else if (process.env.NODE_ENV !== "production") {
+        const existing = updateToolUIsRef.current.get(def.name);
+        const entry = existing ?? {
+          count: 0,
+          render: def.updateRender,
+          unsubscribe: undefined,
+        };
+        entry.count++;
+        if (!existing) updateToolUIsRef.current.set(def.name, entry);
+
+        if (
+          !entry.unsubscribe &&
+          !installUpdateToolUI(def.name, entry) &&
+          process.env.NODE_ENV !== "production"
+        ) {
           console.warn(
             `[Interactables] "${def.name}" supplied an updateRender, but no ` +
               `tools scope is available to install it into.`,
           );
         }
+
+        releaseUpdateToolUI = () => {
+          const entry = updateToolUIsRef.current.get(def.name);
+          if (!entry) return;
+          if (--entry.count === 0) {
+            updateToolUIsRef.current.delete(def.name);
+            entry.unsubscribe?.();
+            entry.unsubscribe = undefined;
+          }
+        };
       }
 
       // The same id re-registers once per anchor (its create call + each update_*).

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -484,7 +484,7 @@ const useInteractablesResource = ({
         ) {
           console.warn(
             `[Interactables] "${def.name}" supplied an updateRender, but no ` +
-              `tools scope is available to install it into.`,
+              `tools scope is available yet; it will be installed once one appears.`,
           );
         }
 

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -13,6 +13,7 @@ import type {
   Unstable_InteractablePersistenceAdapter,
   Unstable_InteractablesConfig,
 } from "../types/scopes/interactables";
+import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
 import { toJSONSchema, toPartialJSONSchema } from "assistant-stream";
 import { ModelContext } from "../../store/clients/model-context-client";
 import {
@@ -94,7 +95,14 @@ const useInteractablesResource = ({
   // One update-tool UI per interactable name, alive while any registrant
   // that supplied an updateRender is mounted.
   const updateToolUIsRef = useRef(
-    new Map<string, { count: number; unsubscribe: () => void }>(),
+    new Map<
+      string,
+      {
+        count: number;
+        render: ToolCallMessagePartComponent;
+        unsubscribe: () => void;
+      }
+    >(),
   );
   // App-scoped state restored via adapter.load(), consumed as components register.
   const loadedStateRef = useRef(new Map<string, unknown>());
@@ -394,6 +402,30 @@ const useInteractablesResource = ({
     [provider],
   );
 
+  // register() installs update-tool UIs against the tools instance bound at
+  // call time; this re-applies the retained entries when that instance is
+  // structurally replaced. Disposers pointing at the replaced instance are
+  // orphaned no-ops.
+  useAssistantScopeEffect(
+    "tools",
+    () => {
+      const tools = clientRef.current!.tools;
+      for (const [name, entry] of updateToolUIsRef.current) {
+        entry.unsubscribe = tools().setToolUI(
+          interactableToolName(name),
+          entry.render,
+          { standalone: true },
+        );
+      }
+      return () => {
+        for (const entry of updateToolUIsRef.current.values()) {
+          entry.unsubscribe();
+        }
+      };
+    },
+    [],
+  );
+
   const register = useCallback(
     (def: InternalInteractableRegistration) => {
       const threadAccessor = clientRef.current?.thread;
@@ -435,6 +467,7 @@ const useInteractablesResource = ({
           } else {
             updateToolUIsRef.current.set(def.name, {
               count: 1,
+              render: def.updateRender,
               unsubscribe: toolsAccessor().setToolUI(
                 toolName,
                 def.updateRender,

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -402,6 +402,14 @@ const useInteractablesResource = ({
     [provider],
   );
 
+  const installUpdateToolUI = useCallback(
+    (name: string, render: ToolCallMessagePartComponent) =>
+      clientRef.current!.tools().setToolUI(interactableToolName(name), render, {
+        standalone: true,
+      }),
+    [clientRef],
+  );
+
   // register() installs update-tool UIs against the tools instance bound at
   // call time; this re-applies the retained entries when that instance is
   // structurally replaced. Disposers pointing at the replaced instance are
@@ -409,13 +417,8 @@ const useInteractablesResource = ({
   useAssistantScopeEffect(
     "tools",
     () => {
-      const tools = clientRef.current!.tools;
       for (const [name, entry] of updateToolUIsRef.current) {
-        entry.unsubscribe = tools().setToolUI(
-          interactableToolName(name),
-          entry.render,
-          { standalone: true },
-        );
+        entry.unsubscribe = installUpdateToolUI(name, entry.render);
       }
       return () => {
         for (const entry of updateToolUIsRef.current.values()) {
@@ -423,7 +426,7 @@ const useInteractablesResource = ({
         }
       };
     },
-    [],
+    [installUpdateToolUI],
   );
 
   const register = useCallback(
@@ -460,7 +463,6 @@ const useInteractablesResource = ({
       if (def.updateRender) {
         const toolsAccessor = clientRef.current?.tools;
         if (toolsAccessor && toolsAccessor.source != null) {
-          const toolName = interactableToolName(def.name);
           const existing = updateToolUIsRef.current.get(def.name);
           if (existing) {
             existing.count++;
@@ -468,11 +470,7 @@ const useInteractablesResource = ({
             updateToolUIsRef.current.set(def.name, {
               count: 1,
               render: def.updateRender,
-              unsubscribe: toolsAccessor().setToolUI(
-                toolName,
-                def.updateRender,
-                { standalone: true },
-              ),
+              unsubscribe: installUpdateToolUI(def.name, def.updateRender),
             });
           }
           releaseUpdateToolUI = () => {
@@ -588,7 +586,13 @@ const useInteractablesResource = ({
         });
       };
     },
-    [flushIfPending, clientRef, getCurrentThreadId, setStateAndRef],
+    [
+      flushIfPending,
+      clientRef,
+      getCurrentThreadId,
+      installUpdateToolUI,
+      setStateAndRef,
+    ],
   );
 
   return {

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -412,12 +412,14 @@ const useInteractablesResource = ({
 
   // register() installs update-tool UIs against the tools instance bound at
   // call time; this re-applies the retained entries when that instance is
-  // structurally replaced. Disposers pointing at the replaced instance are
-  // orphaned no-ops.
+  // structurally replaced. Each re-apply releases the entry's previous
+  // install first, so it is an orphaned no-op against a replaced instance
+  // and an idempotent replacement against a live one.
   useAssistantScopeEffect(
     "tools",
     () => {
       for (const [name, entry] of updateToolUIsRef.current) {
+        entry.unsubscribe();
         entry.unsubscribe = installUpdateToolUI(name, entry.render);
       }
       return () => {

--- a/packages/core/src/tests/interactables-toolui-migration.test.tsx
+++ b/packages/core/src/tests/interactables-toolui-migration.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withKey } from "@assistant-ui/tap";
+import { useAui } from "@assistant-ui/store";
+import { Tools } from "../react/client/Tools";
+import { unstable_Interactables } from "../react/client/Interactables";
+
+type AnyClient = Record<string, any>;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("interactables update-tool UI registration", () => {
+  it("migrates to a structurally replaced tools scope", async () => {
+    let aui!: AnyClient;
+    const Harness = ({ generation }: { generation: number }) => {
+      aui = useAui({
+        tools: withKey(String(generation), Tools({})),
+        unstable_interactables: unstable_Interactables({}),
+      } as never);
+      return null;
+    };
+    const view = render(<Harness generation={0} />);
+
+    const toolUIs = () =>
+      (aui.tools().getState().toolUIs ?? {}) as Record<string, unknown[]>;
+    // setToolUI lands after the tap scheduler drains its macrotask
+    await act(async () => {
+      aui.unstable_interactables.register({
+        id: "call-1",
+        name: "note",
+        description: "a note",
+        stateSchema: { type: "object", properties: {} },
+        initialState: {},
+        updateRender: () => null,
+      });
+      await vi.waitFor(() => expect(Object.keys(toolUIs())).toHaveLength(1));
+    });
+    const [toolName] = Object.keys(toolUIs());
+    const firstRegistration = toolUIs()[toolName!]![0];
+
+    // A rerender inside an outer act would not land until that act exits,
+    // so the swap happens first and only the scheduler wait is wrapped
+    view.rerender(<Harness generation={1} />);
+
+    // The remounted tools scope starts from fresh state; a registration
+    // object distinct from the pre-swap one proves the retained entry was
+    // re-applied on the replacement instance rather than read stale. It
+    // lands one scheduler macrotask after the swap, once the tap scheduler
+    // drains.
+    await act(async () => {
+      await vi.waitFor(() => {
+        const registration = toolUIs()[toolName!]?.[0];
+        expect(registration).toBeDefined();
+        expect(registration).not.toBe(firstRegistration);
+      });
+    });
+  });
+});

--- a/packages/core/src/tests/interactables-toolui-migration.test.tsx
+++ b/packages/core/src/tests/interactables-toolui-migration.test.tsx
@@ -58,5 +58,9 @@ describe("interactables update-tool UI registration", () => {
         expect(registration).not.toBe(firstRegistration);
       });
     });
+
+    // Post-settle cardinality: a duplicate re-apply would leave a second
+    // registration whose disposer was dropped
+    expect(toolUIs()[toolName!]).toHaveLength(1);
   });
 });

--- a/packages/core/src/tests/tools-scope-migration.test.tsx
+++ b/packages/core/src/tests/tools-scope-migration.test.tsx
@@ -38,13 +38,16 @@ describe("Tools model-context registration", () => {
       Object.keys(aui.modelContext().getModelContext().tools ?? {}),
     ).toContain("lookup");
 
+    // A rerender inside an outer act would not land until that act exits,
+    // so the swap happens first and only the scheduler wait is wrapped
+    view.rerender(<Harness generation={1} />);
+
     // The registration lands one scheduler macrotask after the swap: the
     // mount-time register marks the tap scheduler dirty, which defers the
     // structural publish to the scheduler's drain. The remounted scope
     // starts from fresh state, so the tools reappearing proves the
     // registration migrated to the replacement instance.
     await act(async () => {
-      view.rerender(<Harness generation={1} />);
       await vi.waitFor(() =>
         expect(
           Object.keys(aui.modelContext().getModelContext().tools ?? {}),


### PR DESCRIPTION
closes #5835

## summary

- an interactable's `updateRender` tool UI was installed against the tools instance bound at register() time, with one disposer stored per name; a structural replacement of the tools scope started the new instance from fresh `toolUIs` state, so the renderer was lost and the stored disposer targeted the dead instance
- `updateToolUIsRef` entries now retain their `render` with a nullable disposer, and a `useAssistantScopeEffect("tools", ...)` re-applies them against the replacement instance; each re-apply releases the entry's previous install first, so it is an orphaned no-op against a replaced instance and an idempotent replacement against a live one
- register() records the entry unconditionally and a shared availability-checked `installUpdateToolUI` owns the install path, so an interactable that mounts while no tools scope is available gets its update-tool UI installed once the scope appears (previously it warned and never installed); registrations also survive a temporary scope removal
- the Interactables test shim now mirrors the real primitive (availability gating plus migration on client replacement via `replaceClient`), and the mock client's modelContext accessor carries `source: "root"` like a real accessor
- also hardens the tools-scope-migration integration test from #5834: a rerender inside an outer `act` does not land until that act exits, so its waitFor polled the pre-swap world and the test passed with the fix deleted; the rerender now lands before the wrapped scheduler wait, and the new interactables integration test uses a registration-object identity discriminator for the same reason

## test plan

### already verified

- [x] `pnpm exec vitest run src/react/client/Interactables.test.ts src/tests/interactables-toolui-migration.test.tsx src/tests/tools-scope-migration.test.tsx` -> 18/18 green (unit migration + pending-install cases, real-store integration)
- [x] both integration tests proven non-vacuous: degrading `getClientInstanceId` to the facade identity in dist fails both; short-circuiting the tools scope effect fails the interactables test
- [x] full core suite 1059/1059, react suite 406/406 + typecheck, `pnpm turbo build --filter=with-elevenlabs-conversational`, oxfmt

### reviewer should verify

- [ ] with a mounted interactable that supplies `updateRender`, structurally replace the tools scope (e.g. a `withKey` change) and confirm the update tool's renderer still resolves afterwards

## notes

- #5836 proposed the same fix concurrently; its unconditional entry recording, pending-install-on-appearance behavior, availability-checked install helper, and mock upgrade are adopted here, on top of this branch's idempotent re-apply, real-store integration coverage, and the #5834 test hardening

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.m5xFU_OdA9tKRDo8hoY30UfMvf83h3BEI2Sj503R0RayOztuC6Jmel-oLlE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->