### PR TITLE
feat(react): handle synchronous live completion failures

### DIFF
--- a/.changeset/tidy-live-completions.md
+++ b/.changeset/tidy-live-completions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: handle synchronous live completion failures

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -156,6 +156,32 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
   });
 
+  it("allows a synchronously failed query to be retried", async () => {
+    const fetcher = vi
+      .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()
+      .mockImplementationOnce(() => {
+        throw new Error("invalid request configuration");
+      })
+      .mockResolvedValueOnce([item("alice")]);
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
+  });
+
   it("does not automatically retry when search runs during every render", async () => {
     const fetcher = vi
       .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -99,21 +99,23 @@ export function unstable_useLiveCompletionAdapter(
       setIsLoading(true);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        fetcherRef.current(query).then(
-          (items) => {
-            if (token !== tokenRef.current) return;
-            pendingRetryQueryRef.current = null;
-            setState({ query, items, failed: false });
-            setIsLoading(false);
-          },
-          () => {
-            if (token !== tokenRef.current) return;
-            pendingQueryRef.current = null;
-            pendingRetryQueryRef.current = null;
-            setState({ query, items: [], failed: true });
-            setIsLoading(false);
-          },
-        );
+        Promise.resolve()
+          .then(() => fetcherRef.current(query))
+          .then(
+            (items) => {
+              if (token !== tokenRef.current) return;
+              pendingRetryQueryRef.current = null;
+              setState({ query, items, failed: false });
+              setIsLoading(false);
+            },
+            () => {
+              if (token !== tokenRef.current) return;
+              pendingQueryRef.current = null;
+              pendingRetryQueryRef.current = null;
+              setState({ query, items: [], failed: true });
+              setIsLoading(false);
+            },
+          );
       }, debounceMs);
     },
     [enabled, debounceMs, cancelTimer, rearmPendingRetry],


### PR DESCRIPTION
## Problem

`unstable_useLiveCompletionAdapter` invoked its fetcher directly inside the debounce timer. If request setup threw synchronously, the exception bypassed the promise rejection handler, leaving `isLoading` true and preventing the same query from being retried.

I reproduced this with a fetcher that throws before returning a promise: the error escaped the timer and the retry path never ran.

## Fix

- invoke the fetcher from a resolved promise so synchronous throws and rejected promises share the same failure settlement
- clear the pending query and loading state through the existing failure path
- add a regression test proving the same query succeeds when retried after a synchronous failure

## Verification

- `pnpm --filter @assistant-ui/react... build`
- full `@assistant-ui/react` Vitest suite: 51 files, 407 tests
- focused regression test, typecheck, oxlint, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TjgAxQyYnFYNQpW2HmBQ_pcok4HrfH0nbHDqS1aW9kvuBO-fWlwHIkQ76lA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->