### PR TITLE
feat(react): validate mcp app resource responses

### DIFF
--- a/.changeset/bright-mcp-app-resources.md
+++ b/.changeset/bright-mcp-app-resources.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: validate MCP App resource responses

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
@@ -130,20 +130,23 @@ describe("McpAppsRemoteHost", () => {
     }
   });
 
-  it("rejects malformed successful resource responses", async () => {
-    const fetch = vi.fn(async () =>
-      Response.json({}),
-    ) as unknown as typeof globalThis.fetch;
-    const root = mount(fetch);
+  it.each([{}, { uri: " ", html: "" }])(
+    "rejects malformed successful resource responses",
+    async (response) => {
+      const fetch = vi.fn(async () =>
+        Response.json(response),
+      ) as unknown as typeof globalThis.fetch;
+      const root = mount(fetch);
 
-    try {
-      await expect(
-        root.getValue().loadResource({ uri: "ui://example/search" }),
-      ).rejects.toThrow(
-        /Invalid MCP App host response "mcp-apps\/read-resource" from "\/api\/mcp-apps"/,
-      );
-    } finally {
-      root.unmount();
-    }
-  });
+      try {
+        await expect(
+          root.getValue().loadResource({ uri: "ui://example/search" }),
+        ).rejects.toThrow(
+          /Invalid MCP App host response "mcp-apps\/read-resource" from "\/api\/mcp-apps"/,
+        );
+      } finally {
+        root.unmount();
+      }
+    },
+  );
 });

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
@@ -1,7 +1,6 @@
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import { describe, expect, it, vi } from "vitest";
 import { McpAppsRemoteHost } from "./McpAppsRemoteHost";
-import { MCP_APP_MIME_TYPE } from "./types";
 
 const mount = (fetch: typeof globalThis.fetch) =>
   createTapRoot(function Root() {
@@ -47,7 +46,6 @@ describe("McpAppsRemoteHost", () => {
       return request.method === "mcp-apps/read-resource"
         ? Response.json({
             uri: "ui://example/search",
-            mimeType: MCP_APP_MIME_TYPE,
             html: "<main>Search</main>",
           })
         : Response.json({ content: [{ type: "text", text: "ok" }] });
@@ -142,7 +140,7 @@ describe("McpAppsRemoteHost", () => {
       await expect(
         root.getValue().loadResource({ uri: "ui://example/search" }),
       ).rejects.toThrow(
-        'Invalid MCP App host response "mcp-apps/read-resource" from "/api/mcp-apps": expected a resource with string "uri" and "html" fields and MIME type "text/html;profile=mcp-app"',
+        /Invalid MCP App host response "mcp-apps\/read-resource" from "\/api\/mcp-apps"/,
       );
     } finally {
       root.unmount();

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
@@ -1,6 +1,7 @@
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import { describe, expect, it, vi } from "vitest";
 import { McpAppsRemoteHost } from "./McpAppsRemoteHost";
+import { MCP_APP_MIME_TYPE } from "./types";
 
 const mount = (fetch: typeof globalThis.fetch) =>
   createTapRoot(function Root() {
@@ -41,9 +42,16 @@ describe("McpAppsRemoteHost", () => {
   });
 
   it("posts serverId params verbatim for tool calls and resource loads", async () => {
-    const fetch = vi.fn(async () =>
-      Response.json({ content: [{ type: "text", text: "ok" }] }),
-    ) as unknown as typeof globalThis.fetch;
+    const fetch = vi.fn(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as { method: string };
+      return request.method === "mcp-apps/read-resource"
+        ? Response.json({
+            uri: "ui://example/search",
+            mimeType: MCP_APP_MIME_TYPE,
+            html: "<main>Search</main>",
+          })
+        : Response.json({ content: [{ type: "text", text: "ok" }] });
+    }) as unknown as typeof globalThis.fetch;
     const root = mount(fetch);
 
     try {
@@ -118,6 +126,23 @@ describe("McpAppsRemoteHost", () => {
     try {
       await expect(root.getValue().listResources()).rejects.toThrow(
         'MCP App host request "resources/list" to "/api/mcp-apps" failed with 400 Bad Request: resources/list is not supported',
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("rejects malformed successful resource responses", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({}),
+    ) as unknown as typeof globalThis.fetch;
+    const root = mount(fetch);
+
+    try {
+      await expect(
+        root.getValue().loadResource({ uri: "ui://example/search" }),
+      ).rejects.toThrow(
+        'Invalid MCP App host response "mcp-apps/read-resource" from "/api/mcp-apps": expected a resource with string "uri" and "html" fields and MIME type "text/html;profile=mcp-app"',
       );
     } finally {
       root.unmount();

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -41,7 +41,7 @@ const readErrorBody = async (res: Response): Promise<string | undefined> => {
 
 const invalidMcpAppResource = (options: McpAppsRemoteHostOptions): never => {
   throw new Error(
-    `Invalid MCP App host response "mcp-apps/read-resource" from "${options.url}": expected a resource with string "uri" and "html" fields`,
+    `Invalid MCP App host response "mcp-apps/read-resource" from "${options.url}": expected a resource with non-empty string "uri" and "html" fields`,
   );
 };
 
@@ -54,7 +54,12 @@ const parseMcpAppResource = (
   }
 
   const resource = value as Record<string, unknown>;
-  if (typeof resource.uri !== "string" || typeof resource.html !== "string") {
+  if (
+    typeof resource.uri !== "string" ||
+    resource.uri.trim() === "" ||
+    typeof resource.html !== "string" ||
+    resource.html.trim() === ""
+  ) {
     return invalidMcpAppResource(options);
   }
 

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -5,6 +5,7 @@ import type {
   McpAppsHost,
   McpAppsRemoteHostOptions,
 } from "./types";
+import { MCP_APP_MIME_TYPE } from "./types";
 
 const truncateBody = (body: string) =>
   body.length > 500 ? `${body.slice(0, 500)}...` : body;
@@ -39,6 +40,36 @@ const readErrorBody = async (res: Response): Promise<string | undefined> => {
   }
 };
 
+const invalidMcpAppResource = (options: McpAppsRemoteHostOptions): never => {
+  throw new Error(
+    `Invalid MCP App host response "mcp-apps/read-resource" from "${options.url}": expected a resource with string "uri" and "html" fields and MIME type "${MCP_APP_MIME_TYPE}"`,
+  );
+};
+
+const parseMcpAppResource = (
+  value: unknown,
+  options: McpAppsRemoteHostOptions,
+): McpAppResource => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalidMcpAppResource(options);
+  }
+
+  const resource = value as Record<string, unknown>;
+  if (
+    typeof resource.uri !== "string" ||
+    typeof resource.html !== "string" ||
+    resource.mimeType !== MCP_APP_MIME_TYPE ||
+    (resource.meta !== undefined &&
+      (typeof resource.meta !== "object" ||
+        resource.meta === null ||
+        Array.isArray(resource.meta)))
+  ) {
+    return invalidMcpAppResource(options);
+  }
+
+  return value as McpAppResource;
+};
+
 async function postToHost(
   options: McpAppsRemoteHostOptions,
   method: string,
@@ -63,7 +94,14 @@ async function postToHost(
       `MCP App host request "${method}" to "${options.url}" failed with ${status}${body ? `: ${body}` : ""}`,
     );
   }
-  return res.json();
+  try {
+    return await res.json();
+  } catch (cause) {
+    throw new Error(
+      `Invalid MCP App host response "${method}" from "${options.url}": expected valid JSON`,
+      { cause },
+    );
+  }
 }
 
 /**
@@ -91,12 +129,13 @@ const useMcpAppsRemoteHost = (
       };
     };
     return {
-      loadResource: (params) =>
-        postToHost(
-          getCurrentOptions(),
-          "mcp-apps/read-resource",
-          params,
-        ) as Promise<McpAppResource>,
+      loadResource: async (params) => {
+        const options = getCurrentOptions();
+        return parseMcpAppResource(
+          await postToHost(options, "mcp-apps/read-resource", params),
+          options,
+        );
+      },
       callTool: (params) =>
         postToHost(getCurrentOptions(), "tools/call", params),
       readResource: (params) =>

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -5,7 +5,6 @@ import type {
   McpAppsHost,
   McpAppsRemoteHostOptions,
 } from "./types";
-import { MCP_APP_MIME_TYPE } from "./types";
 
 const truncateBody = (body: string) =>
   body.length > 500 ? `${body.slice(0, 500)}...` : body;
@@ -42,7 +41,7 @@ const readErrorBody = async (res: Response): Promise<string | undefined> => {
 
 const invalidMcpAppResource = (options: McpAppsRemoteHostOptions): never => {
   throw new Error(
-    `Invalid MCP App host response "mcp-apps/read-resource" from "${options.url}": expected a resource with string "uri" and "html" fields and MIME type "${MCP_APP_MIME_TYPE}"`,
+    `Invalid MCP App host response "mcp-apps/read-resource" from "${options.url}": expected a resource with string "uri" and "html" fields`,
   );
 };
 
@@ -55,15 +54,7 @@ const parseMcpAppResource = (
   }
 
   const resource = value as Record<string, unknown>;
-  if (
-    typeof resource.uri !== "string" ||
-    typeof resource.html !== "string" ||
-    resource.mimeType !== MCP_APP_MIME_TYPE ||
-    (resource.meta !== undefined &&
-      (typeof resource.meta !== "object" ||
-        resource.meta === null ||
-        Array.isArray(resource.meta)))
-  ) {
+  if (typeof resource.uri !== "string" || typeof resource.html !== "string") {
     return invalidMcpAppResource(options);
   }
 


### PR DESCRIPTION
## Problem

`McpAppsRemoteHost.loadResource()` trusted any JSON returned with a successful HTTP status. I reproduced a `200 {}` response resolving as an `McpAppResource`, allowing missing or empty HTML and URI data to reach the renderer as a blank or broken widget. Invalid JSON also surfaced only as a low-context parser error.

## Fix

- validate that resource responses contain the non-empty string `uri` and `html` fields required by the renderer
- report malformed JSON and malformed resource payloads with the host method and URL
- preserve compatibility with currently renderable responses that omit or differently format MIME and metadata fields
- leave generic tool, resource-read, and resource-list payloads unchanged

## Verification

- `pnpm --filter @assistant-ui/react... build`
- full `@assistant-ui/react` Vitest suite: 51 files, 408 tests
- focused missing/empty response regression tests, typecheck, oxlint, and `git diff --check`