### PR TITLE
fix(react-a2a): reload history after adapter changes

### DIFF
--- a/.changeset/fresh-a2a-history-scopes.md
+++ b/.changeset/fresh-a2a-history-scopes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: reload A2A history when its keyed adapter scope changes

--- a/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
@@ -589,7 +589,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
 
 The top-level `load`/`append` on the history adapter are required by the type but unused by `useChatRuntime`. The AI SDK code path always goes through `withFormat`.
 
-If one mounted runtime can switch between accounts or workspaces, set the adapter's optional `key` to that persistence scope. Keep it stable for the same scope and change it when the backing history changes; `useLocalRuntime` and the AI SDK runtimes then clear the previous scope, reload the new history, and ignore stale load responses. Adapters without a key retain the existing load-once behavior. React A2A and AG-UI runtimes currently require a remount when the backing history scope changes.
+If one mounted runtime can switch between accounts or workspaces, set the adapter's optional `key` to that persistence scope. Keep it stable for the same scope and change it when the backing history changes; `useLocalRuntime`, the AI SDK runtimes, and React A2A then clear the previous scope, reload the new history, and ignore stale load responses. Adapters without a key retain the existing load-once behavior. AG-UI currently requires a remount when the backing history scope changes.
 
 `undefined` is a distinct keyless scope. If the account or workspace ID is loaded asynchronously, wait to provide the history adapter or mount the runtime until the key is known; changing from `undefined` to a concrete key clears and reloads the thread.
 

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -176,6 +176,23 @@ describe("A2AThreadRuntimeCore", () => {
   });
 
   describe("history loading", () => {
+    it("settles synchronous history load failures", async () => {
+      const error = new Error("history unavailable");
+      const onError = vi.fn();
+      const history: ThreadHistoryAdapter = {
+        load: vi.fn(() => {
+          throw error;
+        }),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const core = createCore({}, { history, onError });
+
+      await expect(core.__internal_load()).resolves.toBeUndefined();
+
+      expect(core.isLoading).toBe(false);
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+
     it("does not restore an old task after the adapter key changes", async () => {
       let resolveCancellation!: (task: A2ATask) => void;
       const cancelTaskA = vi.fn(

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -176,6 +176,52 @@ describe("A2AThreadRuntimeCore", () => {
   });
 
   describe("history loading", () => {
+    it("does not restore an old task after the adapter key changes", async () => {
+      let resolveCancellation!: (task: A2ATask) => void;
+      const cancelTaskA = vi.fn(
+        () =>
+          new Promise<A2ATask>((resolve) => {
+            resolveCancellation = resolve;
+          }),
+      );
+      const clientA = createMockClient({ cancelTask: cancelTaskA });
+      const clientB = createMockClient();
+      const historyA: ThreadHistoryAdapter = {
+        key: "workspace-a",
+        load: vi.fn().mockResolvedValue({ messages: [] }),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const historyB: ThreadHistoryAdapter = {
+        key: "workspace-b",
+        load: vi.fn().mockResolvedValue({ messages: [] }),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const core = new A2AThreadRuntimeCore({
+        client: clientA,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+        history: historyA,
+      });
+      await core.__internal_load();
+      (core as any).currentTask = {
+        id: "task-a",
+        status: { state: "working" },
+      };
+      (core as any).abortController = new AbortController();
+      (core as any).abortControllerClient = clientA;
+
+      core.updateOptions({ client: clientB, history: historyB });
+      await core.__internal_load();
+      resolveCancellation({
+        id: "task-a",
+        status: { state: "canceled" },
+      });
+      await Promise.resolve();
+
+      expect(cancelTaskA).toHaveBeenCalledWith("task-a");
+      expect(clientB.cancelTask).not.toHaveBeenCalled();
+      expect(core.getTask()).toBeUndefined();
+    });
+
     it("ignores a stale history load after the adapter key changes", async () => {
       let resolveHistoryA!: (repo: ExportedMessageRepository) => void;
       const historyA: ThreadHistoryAdapter = {
@@ -222,6 +268,47 @@ describe("A2AThreadRuntimeCore", () => {
       expect(core.getMessages().map((message) => message.id)).toEqual([
         messageB.id,
       ]);
+    });
+
+    it("does not clear new persistence state when an old append fails", async () => {
+      let rejectAppendA!: (error: Error) => void;
+      const historyA: ThreadHistoryAdapter = {
+        key: "workspace-a",
+        load: vi.fn().mockResolvedValue({ messages: [] }),
+        append: vi.fn(
+          () =>
+            new Promise<void>((_, reject) => {
+              rejectAppendA = reject;
+            }),
+        ),
+      };
+      const historyB: ThreadHistoryAdapter = {
+        key: "workspace-b",
+        load: vi.fn().mockResolvedValue({ messages: [] }),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const client = createMockClient();
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+        history: historyA,
+      });
+      const message = {
+        ...createUserAppendMessage("shared"),
+        id: "shared-message",
+        startRun: false,
+      };
+      await core.__internal_load();
+      await core.append(message);
+
+      core.updateOptions({ client, history: historyB });
+      await core.__internal_load();
+      await core.append(message);
+      rejectAppendA(new Error("workspace A unavailable"));
+      await Promise.resolve();
+      await core.append(message);
+
+      expect(historyB.append).toHaveBeenCalledOnce();
     });
 
     it("preserves sibling branches and selects the persisted head", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { A2AThreadRuntimeCore } from "./A2AThreadRuntimeCore";
 import type { A2AClient } from "./A2AClient";
 import type { A2AMessage, A2AStreamEvent, A2ATask } from "./types";
-import type { AppendMessage, ThreadMessage } from "@assistant-ui/core";
+import type {
+  AppendMessage,
+  ExportedMessageRepository,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
 
 // --- Mock client factory ---
 
@@ -171,6 +176,54 @@ describe("A2AThreadRuntimeCore", () => {
   });
 
   describe("history loading", () => {
+    it("ignores a stale history load after the adapter key changes", async () => {
+      let resolveHistoryA!: (repo: ExportedMessageRepository) => void;
+      const historyA: ThreadHistoryAdapter = {
+        key: "workspace-a",
+        load: vi.fn(
+          () =>
+            new Promise<ExportedMessageRepository>((resolve) => {
+              resolveHistoryA = resolve;
+            }),
+        ),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const messageB = createHistoryMessage("message-b", "user", "B");
+      const historyB: ThreadHistoryAdapter = {
+        key: "workspace-b",
+        load: vi.fn().mockResolvedValue({
+          headId: messageB.id,
+          messages: [{ parentId: null, message: messageB }],
+        }),
+        append: vi.fn().mockResolvedValue(undefined),
+      };
+      const client = createMockClient();
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+        history: historyA,
+      });
+      const staleLoad = core.__internal_load();
+
+      core.updateOptions({ client, history: historyB });
+      await core.__internal_load();
+
+      resolveHistoryA({
+        headId: "message-a",
+        messages: [
+          {
+            parentId: null,
+            message: createHistoryMessage("message-a", "user", "A"),
+          },
+        ],
+      });
+      await staleLoad;
+
+      expect(core.getMessages().map((message) => message.id)).toEqual([
+        messageB.id,
+      ]);
+    });
+
     it("preserves sibling branches and selects the persisted head", async () => {
       const { user, firstAssistant, secondAssistant, history } =
         createBranchedHistory();

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -272,7 +272,9 @@ export class A2AThreadRuntimeCore {
     this._isLoading = true;
     this.notifyUpdate();
 
-    const historyPromise = history?.load() ?? Promise.resolve(null);
+    const historyPromise = Promise.resolve().then(
+      () => history?.load() ?? null,
+    );
     const agentCardPromise = this.client.getAgentCard().catch(() => undefined);
 
     request.promise = Promise.all([historyPromise, agentCardPromise])

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -41,6 +41,20 @@ export type A2AThreadRuntimeCoreOptions = {
   notifyUpdate: () => void;
 };
 
+const DEFAULT_HISTORY_ADAPTER_KEY = Symbol("history-adapter");
+const NO_HISTORY_ADAPTER_KEY = Symbol("no-history-adapter");
+type HistoryAdapterKey =
+  | NonNullable<ThreadHistoryAdapter["key"]>
+  | typeof DEFAULT_HISTORY_ADAPTER_KEY
+  | typeof NO_HISTORY_ADAPTER_KEY;
+
+const getHistoryAdapterKey = (
+  history: ThreadHistoryAdapter | undefined,
+): HistoryAdapterKey =>
+  history
+    ? (history.key ?? DEFAULT_HISTORY_ADAPTER_KEY)
+    : NO_HISTORY_ADAPTER_KEY;
+
 const FALLBACK_USER_STATUS = {
   type: "complete",
   reason: "unknown",
@@ -71,8 +85,16 @@ export class A2AThreadRuntimeCore {
   // History tracking
   private readonly assistantHistoryParents = new Map<string, string | null>();
   private readonly recordedHistoryIds = new Set<string>();
+  private historyScopeGeneration = 0;
   private _isLoading = false;
-  private _loadPromise: Promise<void> | undefined;
+  private _loadRequest:
+    | {
+        key: HistoryAdapterKey;
+        historyScopeGeneration: number;
+        promise: Promise<void>;
+      }
+    | undefined;
+  private lastHistoryAdapterKey: HistoryAdapterKey | undefined;
 
   constructor(options: A2AThreadRuntimeCoreOptions) {
     this.client = options.client;
@@ -81,6 +103,14 @@ export class A2AThreadRuntimeCore {
     this.onError = options.onError;
     this.onCancel = options.onCancel;
     this.onArtifactComplete = options.onArtifactComplete;
+    if (
+      !Object.is(
+        getHistoryAdapterKey(this.history),
+        getHistoryAdapterKey(options.history),
+      )
+    ) {
+      this.historyScopeGeneration += 1;
+    }
     this.history = options.history;
     this.notifyUpdate = options.notifyUpdate;
   }
@@ -199,15 +229,51 @@ export class A2AThreadRuntimeCore {
   }
 
   __internal_load(): Promise<void> {
-    if (this._loadPromise) return this._loadPromise;
+    const history = this.history;
+    const key = getHistoryAdapterKey(history);
+    const activeLoadRequest = this._loadRequest;
+    if (
+      activeLoadRequest &&
+      Object.is(activeLoadRequest.key, key) &&
+      activeLoadRequest.historyScopeGeneration === this.historyScopeGeneration
+    ) {
+      return activeLoadRequest.promise;
+    }
+
+    const replacingHistory =
+      this.lastHistoryAdapterKey !== undefined &&
+      !Object.is(this.lastHistoryAdapterKey, key);
+    if (replacingHistory) {
+      this.historyScopeGeneration += 1;
+      this.clearRepository();
+      this.assistantHistoryParents.clear();
+      this.recordedHistoryIds.clear();
+      this.pendingError = null;
+      void this.cancel();
+      this.currentTask = undefined;
+      this.currentArtifacts = [];
+    }
+
+    const request = {
+      key,
+      historyScopeGeneration: this.historyScopeGeneration,
+      promise: Promise.resolve(),
+    };
+    const isCurrentRequest = () =>
+      this._loadRequest === request &&
+      request.historyScopeGeneration === this.historyScopeGeneration;
+    this._loadRequest = request;
+    this.lastHistoryAdapterKey = key;
 
     this._isLoading = true;
+    this.notifyUpdate();
 
-    const historyPromise = this.history?.load() ?? Promise.resolve(null);
+    const historyPromise = history?.load() ?? Promise.resolve(null);
     const agentCardPromise = this.client.getAgentCard().catch(() => undefined);
 
-    this._loadPromise = Promise.all([historyPromise, agentCardPromise])
+    request.promise = Promise.all([historyPromise, agentCardPromise])
       .then(([repo, agentCard]) => {
+        if (!isCurrentRequest()) return;
         if (agentCard) {
           this.agentCardValue = agentCard;
         }
@@ -216,17 +282,18 @@ export class A2AThreadRuntimeCore {
         }
       })
       .catch((error) => {
+        if (!isCurrentRequest()) return;
         this.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       })
       .finally(() => {
+        if (!isCurrentRequest()) return;
         this._isLoading = false;
         this.notifyUpdate();
       });
 
-    this.notifyUpdate();
-    return this._loadPromise;
+    return request.promise;
   }
 
   async append(message: AppendMessage): Promise<void> {
@@ -782,9 +849,12 @@ export class A2AThreadRuntimeCore {
   }
 
   private appendHistoryItem(parentId: string | null, message: ThreadMessage) {
-    if (!this.history || this.recordedHistoryIds.has(message.id)) return;
+    const history = this.history;
+    if (!history || this.recordedHistoryIds.has(message.id)) return;
+    const historyScopeGeneration = this.historyScopeGeneration;
     this.recordedHistoryIds.add(message.id);
-    void this.history.append({ parentId, message }).catch(() => {
+    void history.append({ parentId, message }).catch(() => {
+      if (historyScopeGeneration !== this.historyScopeGeneration) return;
       this.recordedHistoryIds.delete(message.id);
     });
   }

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -75,6 +75,7 @@ export class A2AThreadRuntimeCore {
   private exportedRepository: ExportedMessageRepository | undefined;
   private isRunningFlag = false;
   private abortController: AbortController | null = null;
+  private abortControllerClient: A2AClient | null = null;
   private pendingError: Error | null = null;
 
   // A2A-specific state
@@ -249,7 +250,10 @@ export class A2AThreadRuntimeCore {
       this.assistantHistoryParents.clear();
       this.recordedHistoryIds.clear();
       this.pendingError = null;
-      void this.cancel();
+      void this.cancelWithClient(
+        this.abortControllerClient ?? this.client,
+        false,
+      );
       this.currentTask = undefined;
       this.currentArtifacts = [];
     }
@@ -340,16 +344,26 @@ export class A2AThreadRuntimeCore {
   }
 
   async cancel(): Promise<void> {
-    if (!this.abortController) return;
+    await this.cancelWithClient(
+      this.abortControllerClient ?? this.client,
+      true,
+    );
+  }
+
+  private async cancelWithClient(client: A2AClient, applyTaskUpdate: boolean) {
+    const abortController = this.abortController;
+    if (!abortController) return;
 
     // Abort locally first so the stream stops immediately
-    this.abortController.abort();
+    abortController.abort();
 
     // Then try to cancel the task on the server
     if (this.currentTask?.id) {
       try {
-        const updated = await this.client.cancelTask(this.currentTask.id);
-        this.currentTask = updated;
+        const updated = await client.cancelTask(this.currentTask.id);
+        if (applyTaskUpdate) {
+          this.currentTask = updated;
+        }
       } catch {
         // Server cancel failed; local abort already handled
       }
@@ -482,6 +496,7 @@ export class A2AThreadRuntimeCore {
     if (this.abortController) {
       this.abortController.abort();
       this.abortController = null;
+      this.abortControllerClient = null;
     }
 
     const a2aMessage = this.threadMessageToA2AMessage(userThreadMessage);
@@ -502,6 +517,7 @@ export class A2AThreadRuntimeCore {
 
     const abortController = new AbortController();
     this.abortController = abortController;
+    this.abortControllerClient = this.client;
 
     abortController.signal.addEventListener(
       "abort",
@@ -815,6 +831,7 @@ export class A2AThreadRuntimeCore {
   private finishRun(controller: AbortController | null) {
     if (this.abortController === controller) {
       this.abortController = null;
+      this.abortControllerClient = null;
     }
     this.setRunning(false);
   }

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadHistoryAdapter } from "@assistant-ui/core";
 import type { A2AClient } from "./A2AClient";
 import { useA2ARuntime } from "./useA2ARuntime";
 
@@ -138,5 +139,25 @@ describe("useA2ARuntime", () => {
     expect(streamRequest[1]?.headers).toMatchObject({
       Authorization: "Bearer second",
     });
+  });
+
+  it("reloads history when the adapter key changes", async () => {
+    const { client } = createMockClient();
+    const createHistory = (key: string): ThreadHistoryAdapter => ({
+      key,
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    });
+    const historyA = createHistory("workspace-a");
+    const historyB = createHistory("workspace-b");
+
+    const { rerender } = renderHook(
+      ({ history }) => useA2ARuntime({ client, adapters: { history } }),
+      { initialProps: { history: historyA } },
+    );
+
+    await waitFor(() => expect(historyA.load).toHaveBeenCalledOnce());
+    rerender({ history: historyB });
+    await waitFor(() => expect(historyB.load).toHaveBeenCalledOnce());
   });
 });

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -90,7 +90,7 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
     ...(options.onArtifactComplete && {
       onArtifactComplete: options.onArtifactComplete,
     }),
-    ...(historyAdapter && { history: historyAdapter }),
+    history: historyAdapter,
   });
 
   // Thread list
@@ -166,9 +166,11 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
     };
   }, [core, runtime]);
 
+  const hasHistoryAdapter = historyAdapter !== undefined;
+  const historyAdapterKey = historyAdapter?.key;
   useEffect(() => {
     core.__internal_load();
-  }, [core]);
+  }, [core, hasHistoryAdapter, historyAdapterKey]);
 
   return runtime;
 }


### PR DESCRIPTION
## Summary

- reload A2A history when the adapter's persistence-scope key changes
- clear messages and pending history bookkeeping from the previous scope
- ignore stale loads and append failures that settle after a scope switch

## Why

`useA2ARuntime` updated its history adapter on rerender, but `A2AThreadRuntimeCore` permanently reused the first history-load promise. Switching an account or workspace could therefore leave the previous scope's messages visible and never call the new adapter's `load()`.

The runtime now follows the keyed history contract introduced by #5481. A stable key preserves the existing load-once behavior even if an adapter object is recreated; changing the key clears the previous scope and loads the new one. Generation checks prevent a delayed load from workspace A from overwriting workspace B after the switch.

## Dependency

This is a focused follow-up to #5481 and is intentionally based on `fix/ai-sdk-history-adapter-switch`. It should merge after that PR, then be retargeted or rebased onto `main`.

## Testing

- added a hook regression proving adapter B loads after changing from `workspace-a` to `workspace-b`
- added a core regression proving a delayed workspace A response cannot overwrite workspace B
- `pnpm --filter @assistant-ui/react-a2a test` (190 tests)
- `pnpm --filter @assistant-ui/react-a2a... build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.849RTEBxGzZs_r2b2M7_iT0dscOZ32xQg_6bdZAo2LbhiqpQHVSCMKKlw6o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->