### PR TITLE
fix(x-buildutils): route reactless tap packages through the standalone-shim

### DIFF
--- a/.changeset/standalone-shim-reactless-remap.md
+++ b/.changeset/standalone-shim-reactless-remap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: remap bare react imports to the react-free standalone-shim for tap-dependent packages without a react peer, so non-React framework bridges never require React at runtime

--- a/.changeset/standalone-shim-reactless-remap.md
+++ b/.changeset/standalone-shim-reactless-remap.md
@@ -2,4 +2,4 @@
 "@assistant-ui/x-buildutils": patch
 ---
 
-fix: remap bare react imports to the react-free standalone-shim for tap-dependent packages without a react peer, so non-React framework bridges never require React at runtime
+fix: remap a package's own bare react imports to the react-free standalone-shim when it depends on tap without a react peer, so a reactless bridge's build output no longer imports React directly

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -32,9 +32,9 @@ if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 // packages with one get the react-shim (falls back to real React outside a tap
 // render), while reactless packages — non-React framework bridges like a vue
 // binding — get the standalone-shim, whose graph never imports react so the
-// published output stays loadable without React installed. Tap itself keeps
-// the react-shim: it declares an (optional) react peer and its React-facing
-// entry needs the real-React fallback.
+// published output stays loadable without React installed. Tap itself always
+// keeps the react-shim (`isReactless` requires a tap dependency, which tap
+// lacks) and its React-facing entry needs the real-React fallback.
 const dependsOnTap = ["dependencies", "peerDependencies"].some(
   (field) => pkg[field]?.["@assistant-ui/tap"],
 );

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -16,24 +16,34 @@ const pkg = JSON.parse(
 let onSuccess: string | undefined;
 if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 
-// Route bare `react` imports through tap's react-shim so resource code can
-// import hooks from "react" and have them resolve to tap inside a resource
-// render. Done with output `paths` (remap of the external specifier) so the
-// import stays external and only the specifier is rewritten — `alias` does not
-// affect unbundled external imports. Exact specifiers only ("react" and
+// Route bare `react` imports through a tap shim so resource code can import
+// hooks from "react" and have them resolve to tap inside a resource render.
+// Done with output `paths` (remap of the external specifier) so the import
+// stays external and only the specifier is rewritten — `alias` does not affect
+// unbundled external imports. Exact specifiers only ("react" and
 // "react/compiler-runtime", the latter so React Compiler output's memo cache
 // routes to tap inside a resource render), so "react/jsx-runtime" and
 // "react-dom" are untouched.
 //
 // Applied to packages that actually depend on `@assistant-ui/tap` (so the
-// remapped `@assistant-ui/tap/react-shim` specifier resolves for consumers) and
-// to `@assistant-ui/tap` itself so its React-facing hooks can share the same
-// React 18 compatibility shim.
+// remapped shim specifier resolves for consumers) and to `@assistant-ui/tap`
+// itself so its React-facing hooks can share the same React 18 compatibility
+// shim. The target depends on whether the package declares a react peer:
+// packages with one get the react-shim (falls back to real React outside a tap
+// render), while reactless packages — non-React framework bridges like a vue
+// binding — get the standalone-shim, whose graph never imports react so the
+// published output stays loadable without React installed. Tap itself keeps
+// the react-shim: it declares an (optional) react peer and its React-facing
+// entry needs the real-React fallback.
 const dependsOnTap = ["dependencies", "peerDependencies"].some(
   (field) => pkg[field]?.["@assistant-ui/tap"],
 );
 const isTapPackage = pkg.name === "@assistant-ui/tap";
 const remapReactToShim = dependsOnTap || isTapPackage;
+const isReactless = dependsOnTap && !pkg.peerDependencies?.react;
+const shimBase = isReactless
+  ? "@assistant-ui/tap/standalone-shim"
+  : "@assistant-ui/tap/react-shim";
 const packageImportExternals = Object.keys(pkg.imports ?? {});
 
 await build({
@@ -48,9 +58,8 @@ await build({
           ...options,
           paths: {
             ...(options.paths as Record<string, string>),
-            react: "@assistant-ui/tap/react-shim",
-            "react/compiler-runtime":
-              "@assistant-ui/tap/react-shim/compiler-runtime",
+            react: shimBase,
+            "react/compiler-runtime": `${shimBase}/compiler-runtime`,
           },
         }),
       }
@@ -80,9 +89,10 @@ await build({
 });
 
 // `output.paths` rewrites the `react` specifier in BOTH the emitted JS and the
-// declarations. Only the runtime (.js) should route through the shim; declared
-// types should reference real `react` (so published `.d.ts` stay clean and the
-// shim isn't an editor auto-import source). When building tap itself, the
+// declarations. Only the runtime (.js) should route through the shim (react-
+// or standalone-, whichever `shimBase` selected); declared types should
+// reference real `react` (so published `.d.ts` stay clean and the shim isn't
+// an editor auto-import source). When building tap itself, the
 // runtime shim files must also keep importing real `react` to avoid self-routing.
 if (remapReactToShim && !isDev && existsSync("dist")) {
   for (const rel of readdirSync("dist", {
@@ -103,16 +113,10 @@ if (remapReactToShim && !isDev && existsSync("dist")) {
     const file = resolve("dist", rel);
     const src = readFileSync(file, "utf8");
     const out = src
-      .replaceAll(
-        '"@assistant-ui/tap/react-shim/compiler-runtime"',
-        '"react/compiler-runtime"',
-      )
-      .replaceAll(
-        "'@assistant-ui/tap/react-shim/compiler-runtime'",
-        "'react/compiler-runtime'",
-      )
-      .replaceAll('"@assistant-ui/tap/react-shim"', '"react"')
-      .replaceAll("'@assistant-ui/tap/react-shim'", "'react'");
+      .replaceAll(`"${shimBase}/compiler-runtime"`, '"react/compiler-runtime"')
+      .replaceAll(`'${shimBase}/compiler-runtime'`, "'react/compiler-runtime'")
+      .replaceAll(`"${shimBase}"`, '"react"')
+      .replaceAll(`'${shimBase}'`, "'react'");
     if (out !== src) writeFileSync(file, out);
   }
 }


### PR DESCRIPTION
## Why

`aui-build` rewrites bare `react` imports in build output to `@assistant-ui/tap/react-shim` for every package that depends on `@assistant-ui/tap`. The react-shim falls back to real React outside a tap render, so it hard-requires React at runtime. For a non-React framework bridge (a package with, e.g., a `vue` peer and no `react` peer, like `@assistant-ui/vue`), that remap would reintroduce a React requirement into a package that must stay loadable without React installed. The react-compiler plugin gate in the same file already distinguishes these packages (`dependsOnTap && pkg.peerDependencies?.react`); the specifier remap did not.

## What

In `packages/x-buildutils/src/index.ts`:

- Compute `isReactless = dependsOnTap && !pkg.peerDependencies?.react` and select the shim base from it: reactless packages get `@assistant-ui/tap/standalone-shim` / `@assistant-ui/tap/standalone-shim/compiler-runtime`, packages with a react peer keep the `react-shim` targets. Tap itself is never reactless (it declares an optional react peer and `dependsOnTap` is false for it), so it keeps the react-shim.
- The `.d.ts` post-processing that rewrites the shim specifier back to `react` now operates on the selected shim base, so declarations stay clean for both targets.
- The react-compiler plugin gate is unchanged (it already excludes reactless packages).
- Comments updated to describe the two-target rule.

Changeset: patch for `@assistant-ui/x-buildutils`.

## Note on the tap standalone-shim itself

This work was originally scoped to also fix a `react` leak in `@assistant-ui/tap`'s standalone-shim (standalone-shim → useEffectEvent → react-shim/useReactEffectEvent → react). That leak does not exist in the published 0.9.12 or on main: the standalone shim shipped react-free in #5655 — `src/standalone-shim/index.ts` uses tap's pure `react-hooks/useEffectEvent` (tap `useRef`/`useCallback` + commit queue), never `react-shim/useReactEffectEvent`, and `standalone-shim.graph.test.ts` pins the src and dist graphs. Verified independently: a full import-graph walk of the freshly built `dist/standalone-shim/*` reaches zero external `react` (or `react-shim`) specifiers, and the published 0.9.12 tarball imports cleanly under Node with no `react` in `node_modules`. So no tap change (and no tap changeset) is included.

## Verification

- Scratch package with a tap dependency, a `vue` peer, and no `react` peer, built with the modified `aui-build`: emitted JS imports `@assistant-ui/tap/standalone-shim`; emitted `.d.ts` contains no shim specifier.
- Rebuilt `packages/store` (react peer): dist still targets `@assistant-ui/tap/react-shim` and `…/react-shim/compiler-runtime`; `.d.ts` clean.
- Rebuilt `packages/tap`: standalone dist graph still react-free; `dist/react-shim/index.js` still imports real `react` (self-routing guard intact).
- Rebuilt `packages/vue`: dist unchanged (its src has no bare react imports today; the gate protects future ones).
- `packages/tap`: `pnpm test` (515 passed) and `pnpm test:standalone` (1 passed). `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dafp9RfAiZNJQJDkZDd5u1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UmF2GgLs-i8Rd7hzj3m06g_OkXR6Ykl1ZYSIU5YICoblO6PFaLp8ouNVb2I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->