### PR TITLE
fix(tap): discard the work-in-progress render when a render throws

### DIFF
--- a/.changeset/tap-render-abort-safety.md
+++ b/.changeset/tap-render-abort-safety.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: discard the work-in-progress render when a resource render throws

--- a/packages/tap/src/__tests__/lifecycle/render-abort.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/render-abort.test.ts
@@ -95,7 +95,7 @@ describe("render abort", () => {
     expect(renderResourceFiber(fiber, [])).toBe(1);
   });
 
-  it("a render-phase dispatch in an aborted render does not leak into the retry", () => {
+  it("an undrained render-phase dispatch does not leak into the retry", () => {
     const root = createResourceFiberRoot(() => {});
 
     let explode = false;
@@ -114,5 +114,27 @@ describe("render abort", () => {
     explode = false;
     expect(renderResourceFiber(fiber, [false])).toBe(0);
     commitResourceFiber(fiber);
+  });
+
+  it("render-phase state drained before the abort survives to the retry", () => {
+    const root = createResourceFiberRoot(() => {});
+
+    let explode = false;
+    const hook = (bump: boolean) => {
+      const [count, setCount] = useState(0);
+      if (bump && count === 0) setCount(1);
+      if (explode && count === 1) throw new Error("boom");
+      return count;
+    };
+
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    explode = true;
+    expect(() => renderResourceFiber(fiber, [true])).toThrow("boom");
+
+    explode = false;
+    expect(renderResourceFiber(fiber, [false])).toBe(1);
+    commitResourceFiber(fiber);
+    expect(renderResourceFiber(fiber, [false])).toBe(1);
   });
 });

--- a/packages/tap/src/__tests__/lifecycle/render-abort.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/render-abort.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { createResourceFiberRoot } from "../../core/helpers/root";
+import {
+  createResourceFiber,
+  renderResourceFiber,
+  commitResourceFiber,
+  unmountResourceFiber,
+} from "../../core/ResourceFiber";
+import { useEffect } from "../../react-hooks/useEffect";
+import { useState } from "../../react-hooks/useState";
+
+describe("render abort", () => {
+  it("a stray commit after a throwing render does not consume the aborted render's work", () => {
+    const events: string[] = [];
+    const hook = (n: number, explode: boolean) => {
+      useEffect(() => {
+        events.push(`setup:${n}`);
+        return () => events.push(`cleanup:${n}`);
+      }, [n]);
+      if (explode) throw new Error("boom");
+      return n;
+    };
+
+    const root = createResourceFiberRoot(() => {});
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    renderResourceFiber(fiber, [0, false]);
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup:0"]);
+
+    expect(() => renderResourceFiber(fiber, [1, true])).toThrow("boom");
+
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup:0"]);
+
+    renderResourceFiber(fiber, [2, false]);
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup:0", "cleanup:0", "setup:2"]);
+  });
+
+  it("a throwing first render leaves the fiber unrendered and retryable", () => {
+    const events: string[] = [];
+    const hook = (explode: boolean) => {
+      const [state] = useState(0);
+      useEffect(() => {
+        events.push("setup");
+        return () => events.push("cleanup");
+      }, []);
+      if (explode) throw new Error("boom");
+      return state;
+    };
+
+    const root = createResourceFiberRoot(() => {});
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    expect(() => renderResourceFiber(fiber, [true])).toThrow("boom");
+
+    commitResourceFiber(fiber);
+    expect(events).toEqual([]);
+
+    expect(renderResourceFiber(fiber, [false])).toBe(0);
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup"]);
+
+    unmountResourceFiber(fiber);
+    expect(events).toEqual(["setup", "cleanup"]);
+  });
+
+  it("state applied before an aborted render survives to the retry", () => {
+    const root = createResourceFiberRoot((evaluate, apply) => {
+      if (!evaluate()) return;
+      apply();
+    });
+
+    let setter!: (value: number) => void;
+    let explode = false;
+    const hook = () => {
+      const [count, setCount] = useState(0);
+      setter = setCount;
+      if (explode && count === 1) throw new Error("boom");
+      return count;
+    };
+
+    const fiber = createResourceFiber(hook, root, undefined, null);
+    renderResourceFiber(fiber, []);
+    commitResourceFiber(fiber);
+
+    setter(1);
+    explode = true;
+    expect(() => renderResourceFiber(fiber, [])).toThrow("boom");
+
+    explode = false;
+    expect(renderResourceFiber(fiber, [])).toBe(1);
+    commitResourceFiber(fiber);
+    expect(renderResourceFiber(fiber, [])).toBe(1);
+  });
+
+  it("a render-phase dispatch in an aborted render does not leak into the retry", () => {
+    const root = createResourceFiberRoot(() => {});
+
+    let explode = false;
+    const hook = (bump: boolean) => {
+      const [count, setCount] = useState(0);
+      if (bump && count === 0) setCount(1);
+      if (explode) throw new Error("boom");
+      return count;
+    };
+
+    const fiber = createResourceFiber(hook, root, undefined, null);
+
+    explode = true;
+    expect(() => renderResourceFiber(fiber, [true])).toThrow("boom");
+
+    explode = false;
+    expect(renderResourceFiber(fiber, [false])).toBe(0);
+    commitResourceFiber(fiber);
+  });
+});

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -39,9 +39,11 @@ export function createResourceFiber<R>(
   };
 }
 
-// Only valid when the discarded render applied no state update
+// Applied state survives in cells: bailout callers must have none, abort
+// callers re-render before the next value-bearing commit
 export function discardWipRender<R>(fiber: ResourceFiber<R>): void {
   fiber.wipCommitCallbacks = null;
+  fiber.wipContextDeps = null;
   fiber.memoCache.workInProgress = null;
 }
 

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -66,19 +66,24 @@ export function renderResourceFiber<R>(
 
   let passes = 0;
   let value: R;
-  do {
-    if (++passes > 25) {
-      throw new Error(
-        "Too many re-renders. tap limits the number of renders to prevent " +
-          "an infinite loop.",
-      );
-    }
-    fiber.memoCache.index = 0;
+  try {
+    do {
+      if (++passes > 25) {
+        throw new Error(
+          "Too many re-renders. tap limits the number of renders to prevent " +
+            "an infinite loop.",
+        );
+      }
+      fiber.memoCache.index = 0;
 
-    withResourceFiber(fiber, () => {
-      value = withReactDispatcher(() => fiber.hook(...args));
-    });
-  } while ((fiber.renderPendingCells?.size ?? 0) > 0);
+      withResourceFiber(fiber, () => {
+        value = withReactDispatcher(() => fiber.hook(...args));
+      });
+    } while ((fiber.renderPendingCells?.size ?? 0) > 0);
+  } catch (error) {
+    discardWipRender(fiber);
+    throw error;
+  }
 
   bubbleContextDeps(fiber);
 


### PR DESCRIPTION
## What

When a resource render throws, the fiber now discards its work-in-progress render (commit callbacks, wip context deps, and memo cache) before the exception propagates. Previously the aborted render's `wipCommitCallbacks` stayed on the fiber, so a later commit that ran without a fresh render — the Activity reveal / StrictMode remount path added in #5833 — consumed the aborted render's promotions and ran effects from a render that never completed.

## Why

This is the first slice of suspense groundwork: `use(promise)` will abort renders by throwing, so an aborted render must leave the fiber safe to commit, retry, or unmount. It also closes the standing review-bot finding on #5833 that any non-null `wipCommitCallbacks` is treated as a completed render.

Render entry already resets the other half of the state (`currentIndex`, `wipContextDeps`, `renderPendingCells`, `memoCache.workInProgress`), and `isFirstRender` only flips after the hook body returns, so a discarded render retries cleanly against the existing cells prefix.

## Deliberate contract: applied state survives the abort

Reducer state drained into `workInProgress` before the throw (external dispatches, and render-phase dispatches drained on an earlier pass) survives to the retry; `isDirty` re-adds the promotion callback on the next render, so nothing ships without a completed render. This diverges from React, which discards a WIP fiber's hook state wholesale — restoring per-cell snapshots would add per-render bookkeeping for a state that is deterministic and converges on retry. Both sides of the line are pinned as contract tests (undrained dispatches do not leak; drained state survives).

## How

`renderResourceFiber` wraps the render loop and calls `discardWipRender` on the way out of a throw. Contract tests cover the stray-commit-after-abort path (fails without the fix), first-render aborts, state applied before an aborted render, and render-phase dispatches on both sides of the drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9XN8q3No5LSJfeUh5ynu4-eiBRCYVKpqVk2H5aKV7qCa_y0CYhRkWqwIxQU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->