### PR TITLE
feat(tap): support thenables in use()

### DIFF
--- a/.changeset/tap-use-thenable.md
+++ b/.changeset/tap-use-thenable.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: use(promise) suspends resource renders

--- a/packages/tap/src/__tests__/basic/use.thenable.test.ts
+++ b/packages/tap/src/__tests__/basic/use.thenable.test.ts
@@ -43,6 +43,33 @@ describe("use(thenable)", () => {
     expect(renderResourceFiber(fiber, [])).toBe("sync");
   });
 
+  it("returns synchronously from a thenable that settles while subscribing", () => {
+    const thenable = {
+      then: (onFulfilled: (value: string) => void) => {
+        onFulfilled("sync-settle");
+      },
+    };
+    const hook = () => use(thenable);
+    const fiber = createFiber(hook);
+
+    expect(renderResourceFiber(fiber, [])).toBe("sync-settle");
+  });
+
+  it("attaches handlers to a pre-stamped pending thenable", () => {
+    let handlerCount = 0;
+    const thenable = {
+      status: "pending" as const,
+      then: () => {
+        handlerCount++;
+      },
+    };
+    const hook = () => use(thenable);
+    const fiber = createFiber(hook);
+
+    expect(() => renderResourceFiber(fiber, [])).toThrow();
+    expect(handlerCount).toBe(1);
+  });
+
   it("throws the rejection reason once the promise rejects", async () => {
     const reason = new Error("denied");
     const promise = Promise.reject(reason);

--- a/packages/tap/src/__tests__/basic/use.thenable.test.ts
+++ b/packages/tap/src/__tests__/basic/use.thenable.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { createResourceFiberRoot } from "../../core/helpers/root";
+import {
+  createResourceFiber,
+  renderResourceFiber,
+  commitResourceFiber,
+} from "../../core/ResourceFiber";
+import { use } from "../../react-hooks/use";
+import { useEffect } from "../../react-hooks/useEffect";
+
+const createFiber = <R>(hook: (...args: any[]) => R) => {
+  const root = createResourceFiberRoot(() => {});
+  return createResourceFiber(hook, root, undefined, null);
+};
+
+describe("use(thenable)", () => {
+  it("suspends on a pending promise and resolves on retry", async () => {
+    const promise = Promise.resolve(42);
+    const hook = () => use(promise);
+    const fiber = createFiber(hook);
+
+    let thrown: unknown;
+    try {
+      renderResourceFiber(fiber, []);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBe(promise);
+
+    await promise;
+    expect(renderResourceFiber(fiber, [])).toBe(42);
+  });
+
+  it("returns synchronously from a userland-fulfilled thenable", () => {
+    const thenable = {
+      status: "fulfilled" as const,
+      value: "sync",
+      then: () => {},
+    };
+    const hook = () => use(thenable);
+    const fiber = createFiber(hook);
+
+    expect(renderResourceFiber(fiber, [])).toBe("sync");
+  });
+
+  it("throws the rejection reason once the promise rejects", async () => {
+    const reason = new Error("denied");
+    const promise = Promise.reject(reason);
+    const hook = () => use(promise);
+    const fiber = createFiber(hook);
+
+    expect(() => renderResourceFiber(fiber, [])).toThrow();
+
+    await promise.catch(() => {});
+    expect(() => renderResourceFiber(fiber, [])).toThrow(reason);
+  });
+
+  it("a suspended render leaves no work behind and commits cleanly after retry", async () => {
+    const events: string[] = [];
+    const promise = Promise.resolve("ready");
+    const hook = () => {
+      const value = use(promise);
+      useEffect(() => {
+        events.push(`setup:${value}`);
+        return () => events.push(`cleanup:${value}`);
+      }, [value]);
+      return value;
+    };
+    const fiber = createFiber(hook);
+
+    expect(() => renderResourceFiber(fiber, [])).toThrow();
+    commitResourceFiber(fiber);
+    expect(events).toEqual([]);
+
+    await promise;
+    expect(renderResourceFiber(fiber, [])).toBe("ready");
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup:ready"]);
+  });
+
+  it("suspending conditionally after other hooks preserves hook state", async () => {
+    const events: string[] = [];
+    let promise: Promise<string> | null = null;
+    const hook = () => {
+      useEffect(() => {
+        events.push("setup");
+      }, []);
+      return promise === null ? "no-data" : use(promise);
+    };
+    const fiber = createFiber(hook);
+
+    expect(renderResourceFiber(fiber, [])).toBe("no-data");
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup"]);
+
+    promise = Promise.resolve("data");
+    expect(() => renderResourceFiber(fiber, [])).toThrow();
+
+    await promise;
+    expect(renderResourceFiber(fiber, [])).toBe("data");
+    commitResourceFiber(fiber);
+    expect(events).toEqual(["setup"]);
+  });
+});

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -81,12 +81,17 @@ describe("@assistant-ui/tap/react-shim", () => {
       useSpy.mockRestore();
     });
 
-    it("rejects non-context values in tap's direct use hook", () => {
-      const testFiber = createTestResource(() => tapUse(Promise.resolve()));
+    it("suspends on promises in tap's direct use hook", () => {
+      const promise = Promise.resolve();
+      const testFiber = createTestResource(() => tapUse(promise));
 
-      expect(() => renderResourceFiber(testFiber, [])).toThrow(
-        "A tap resource's `use()` only accepts a tap context.",
-      );
+      let thrown: unknown;
+      try {
+        renderResourceFiber(testFiber, []);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBe(promise);
     });
 
     it("useState routes to useState and useEffect to useEffect", async () => {

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -149,7 +149,7 @@ const withChangedContext = <T>(
   }
 };
 
-export const useTapContext = <T>(context: ReactContext<T>) => {
+export const useContext = <T>(context: ReactContext<T>) => {
   assertTapContext(context);
 
   const key = context as object;

--- a/packages/tap/src/core/helpers/thenable.ts
+++ b/packages/tap/src/core/helpers/thenable.ts
@@ -1,0 +1,34 @@
+type TrackedThenable<T> = PromiseLike<T> & {
+  status?: "pending" | "fulfilled" | "rejected";
+  value?: T;
+  reason?: unknown;
+};
+
+export const trackThenable = <T>(thenable: PromiseLike<T>): T => {
+  const tracked = thenable as TrackedThenable<T>;
+  switch (tracked.status) {
+    case "fulfilled":
+      return tracked.value as T;
+    case "rejected":
+      throw tracked.reason;
+    case "pending":
+      throw thenable;
+    default:
+      tracked.status = "pending";
+      thenable.then(
+        (value) => {
+          if (tracked.status === "pending") {
+            tracked.status = "fulfilled";
+            tracked.value = value;
+          }
+        },
+        (reason) => {
+          if (tracked.status === "pending") {
+            tracked.status = "rejected";
+            tracked.reason = reason;
+          }
+        },
+      );
+      throw thenable;
+  }
+};

--- a/packages/tap/src/core/helpers/thenable.ts
+++ b/packages/tap/src/core/helpers/thenable.ts
@@ -4,31 +4,38 @@ type TrackedThenable<T> = PromiseLike<T> & {
   reason?: unknown;
 };
 
+const noop = () => {};
+
 export const trackThenable = <T>(thenable: PromiseLike<T>): T => {
   const tracked = thenable as TrackedThenable<T>;
+  if (typeof tracked.status !== "string") {
+    tracked.status = "pending";
+    thenable.then(
+      (value) => {
+        if (tracked.status === "pending") {
+          tracked.status = "fulfilled";
+          tracked.value = value;
+        }
+      },
+      (reason) => {
+        if (tracked.status === "pending") {
+          tracked.status = "rejected";
+          tracked.reason = reason;
+        }
+      },
+    );
+  } else if (tracked.status === "pending") {
+    // A thenable that arrived pre-stamped pending was never given handlers;
+    // without one its rejection is unhandled
+    thenable.then(noop, noop);
+  }
+
   switch (tracked.status) {
     case "fulfilled":
       return tracked.value as T;
     case "rejected":
       throw tracked.reason;
-    case "pending":
-      throw thenable;
     default:
-      tracked.status = "pending";
-      thenable.then(
-        (value) => {
-          if (tracked.status === "pending") {
-            tracked.status = "fulfilled";
-            tracked.value = value;
-          }
-        },
-        (reason) => {
-          if (tracked.status === "pending") {
-            tracked.status = "rejected";
-            tracked.reason = reason;
-          }
-        },
-      );
       throw thenable;
   }
 };

--- a/packages/tap/src/core/helpers/thenable.ts
+++ b/packages/tap/src/core/helpers/thenable.ts
@@ -24,7 +24,7 @@ export const trackThenable = <T>(thenable: PromiseLike<T>): T => {
         }
       },
     );
-  } else if (tracked.status === "pending") {
+  } else if (tracked.status !== "fulfilled" && tracked.status !== "rejected") {
     // A thenable that arrived pre-stamped pending was never given handlers;
     // without one its rejection is unhandled
     thenable.then(noop, noop);

--- a/packages/tap/src/core/react-dispatcher.ts
+++ b/packages/tap/src/core/react-dispatcher.ts
@@ -8,7 +8,7 @@ import { useCallback } from "../react-hooks/useCallback";
 import { useEffect } from "../react-hooks/useEffect";
 import { useEffectEvent } from "../react-hooks/useEffectEvent";
 import { use } from "../react-hooks/use";
-import { useTapContext } from "./context";
+import { useContext } from "./context";
 import { useSyncExternalStore } from "../react-hooks/useSyncExternalStore";
 import { useDebugValue } from "../react-hooks/useDebugValue";
 import { useMemoCache } from "../react-hooks/useMemoCache";
@@ -27,7 +27,7 @@ const tapDispatcher = {
   useLayoutEffect: useEffect,
   useInsertionEffect: useEffect,
   useEffectEvent,
-  useContext: useTapContext,
+  useContext,
   use,
   useSyncExternalStore,
   useDebugValue,

--- a/packages/tap/src/core/react-dispatcher.ts
+++ b/packages/tap/src/core/react-dispatcher.ts
@@ -8,6 +8,7 @@ import { useCallback } from "../react-hooks/useCallback";
 import { useEffect } from "../react-hooks/useEffect";
 import { useEffectEvent } from "../react-hooks/useEffectEvent";
 import { use } from "../react-hooks/use";
+import { useTapContext } from "./context";
 import { useSyncExternalStore } from "../react-hooks/useSyncExternalStore";
 import { useDebugValue } from "../react-hooks/useDebugValue";
 import { useMemoCache } from "../react-hooks/useMemoCache";
@@ -26,7 +27,7 @@ const tapDispatcher = {
   useLayoutEffect: useEffect,
   useInsertionEffect: useEffect,
   useEffectEvent,
-  useContext: use,
+  useContext: useTapContext,
   use,
   useSyncExternalStore,
   useDebugValue,

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,4 +1,4 @@
-import { useTapContext } from "../core/context";
+import { useContext } from "../core/context";
 import { trackThenable } from "../core/helpers/thenable";
 
 /**
@@ -15,5 +15,5 @@ export const use = (usable: unknown): unknown => {
   ) {
     return trackThenable(usable as PromiseLike<unknown>);
   }
-  return useTapContext(usable as never);
+  return useContext(usable as never);
 };

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,7 +1,19 @@
 import { useTapContext } from "../core/context";
+import { trackThenable } from "../core/helpers/thenable";
 
 /**
- * Reads a context from inside a resource render, the tap equivalent of React's
- * `use(Context)` / `useContext(Context)`. Accepts React contexts.
+ * The tap equivalent of React's `use`. Accepts React contexts and thenables:
+ * a context read returns its current value; a pending promise suspends the
+ * render by throwing the thenable, a settled one returns its value or throws
+ * its rejection reason.
  */
-export const use = (usable: unknown): unknown => useTapContext(usable as never);
+export const use = (usable: unknown): unknown => {
+  if (
+    usable !== null &&
+    typeof usable === "object" &&
+    typeof (usable as PromiseLike<unknown>).then === "function"
+  ) {
+    return trackThenable(usable as PromiseLike<unknown>);
+  }
+  return useTapContext(usable as never);
+};

--- a/packages/tap/src/standalone-shim/index.ts
+++ b/packages/tap/src/standalone-shim/index.ts
@@ -2,7 +2,10 @@
 /* oxlint-disable react/exhaustive-deps -- dependency arrays are forwarded verbatim from the caller */
 // React-free runtime drop-in for "react": route supported hooks to tap inside a resource render and throw outside one. Alias `react` to this module in code hosted inside `createTapRoot`.
 import { peekResourceFiber } from "../core/helpers/execution-context";
-import { attachDefaultValueToContext } from "../core/context";
+import {
+  attachDefaultValueToContext,
+  useContext as useTapContext,
+} from "../core/context";
 import { useState as useTapState } from "../react-hooks/useState";
 import { useReducer as useTapReducer } from "../react-hooks/useReducer";
 import { useRef as useTapRef } from "../react-hooks/useRef";
@@ -73,7 +76,7 @@ export const use = (usable: any) =>
   inTap() ? useTap(usable) : throwOutsideTap("use");
 
 export const useContext = (context: any) =>
-  inTap() ? useTap(context) : throwOutsideTap("useContext");
+  inTap() ? useTapContext(context) : throwOutsideTap("useContext");
 
 const StandaloneRuntime = Object.freeze({
   useState,

--- a/packages/tap/src/standalone-shim/standalone-shim.behavior.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.behavior.test.ts
@@ -50,6 +50,34 @@ describe("@assistant-ui/tap/standalone-shim behavior", () => {
     root.unmount();
   });
 
+  it("rejects non-context values in useContext while use accepts thenables", () => {
+    const promise = new Promise(() => {});
+    const root = createTapRoot(function Root() {
+      return {
+        contextError: (() => {
+          try {
+            shim.useContext(promise);
+            return null;
+          } catch (error) {
+            return error;
+          }
+        })(),
+        useThrown: (() => {
+          try {
+            shim.use(promise);
+            return null;
+          } catch (error) {
+            return error;
+          }
+        })(),
+      };
+    });
+
+    expect(root.getValue().contextError).toBeInstanceOf(Error);
+    expect(root.getValue().useThrown).toBe(promise);
+    root.unmount();
+  });
+
   it("throws outside a tap resource fiber", () => {
     expect(() => shim.useState(0)).toThrow("standalone-shim");
     expect(() => shim.default.useState(0)).toThrow("standalone-shim");


### PR DESCRIPTION
## What

`use()` now accepts thenables alongside contexts, mirroring React's `use`: a pending promise suspends the render by throwing the thenable, a fulfilled one returns its value synchronously, a rejected one throws its reason. Untracked thenables are instrumented with React's `status`/`value`/`reason` convention, and userland pre-fulfilled thenables (`{ status: 'fulfilled', value }`) resolve without a suspension cycle.

The dispatcher's `useContext` now maps to `useTapContext` directly instead of sharing `use`, so `useContext(promise)` keeps rejecting like React's does.

## Why

Phase 2 of suspense groundwork (following #5847, which made throwing renders abort-safe). A suspended render aborts via the phase-1 discard path, so the fiber stays safe to commit, retry, or unmount — pinned by the new tests. The upcoming `useSuspenseResource` boundary builds on this; until then an unhandled suspension propagates to the host, which inside a React render means a real `<Suspense>` boundary.

One shipped contract changes: `use(promise)` inside a resource previously threw "only accepts a tap context"; it now suspends. The react-shim contract test is updated accordingly.

## How

A `trackThenable` helper (`core/helpers/thenable.ts`) implements the status-stamping state machine; `use` branches on `.then`. Tests cover all three thenable states, userland-fulfilled thenables, clean commit after a suspended render, and conditional `use` after other hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OGKHH2yPh-srE6zF-NZ652Tzb4Jhtjoby86WFTbkL0sy_kYKvC3Ad2QMVPs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->