### PR TITLE
feat(tap): support suspension in useTapRoot and createTapRoot

### DIFF
--- a/.changeset/tap-host-suspense.md
+++ b/.changeset/tap-host-suspense.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: hold the committed value when a scheduler-driven update suspends in useTapRoot

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.suspense.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.suspense.test.ts
@@ -6,9 +6,11 @@ import { useState } from "../../react-hooks/useState";
 
 describe("createTapRoot suspense", () => {
   it("throws a clear error when the initial render suspends", () => {
-    expect(() => createTapRoot(() => use(new Promise(() => {})))).toThrow(
-      "createTapRoot suspended during its initial render",
-    );
+    expect(() =>
+      createTapRoot(function InitialSuspend() {
+        return use(new Promise(() => {}));
+      }),
+    ).toThrow("createTapRoot suspended during its initial render");
   });
 
   it("holds the committed value while an update suspends and converges on resolve", async () => {
@@ -18,7 +20,7 @@ describe("createTapRoot suspense", () => {
     });
     let bump!: (value: number) => void;
 
-    const root = createTapRoot(() => {
+    const root = createTapRoot(function UpdateSuspend() {
       const [count, setCount] = useState(0);
       bump = setCount;
       return count === 0 ? "sync" : (use(promise) as string);
@@ -38,5 +40,37 @@ describe("createTapRoot suspense", () => {
     expect(seen).toEqual(["async"]);
 
     root.unmount();
+  });
+
+  it("re-arms a suspended update when a mountOnSubscribe root reconnects", async () => {
+    let resolve!: (value: string) => void;
+    const promise = new Promise<string>((r) => {
+      resolve = r;
+    });
+    let bump!: (value: number) => void;
+
+    const root = createTapRoot(
+      function Reconnect() {
+        const [count, setCount] = useState(0);
+        bump = setCount;
+        return count === 0 ? "sync" : (use(promise) as string);
+      },
+      { mountOnSubscribe: true },
+    );
+
+    const unsubscribe = root.subscribe(() => {});
+    expect(root.getValue()).toBe("sync");
+
+    flushTapSync(() => bump(1));
+    unsubscribe();
+    await new Promise((r) => setTimeout(r, 10));
+
+    resolve("async");
+    await promise;
+    await new Promise((r) => setTimeout(r, 10));
+    expect(root.getValue()).toBe("sync");
+
+    root.subscribe(() => {});
+    await vi.waitFor(() => expect(root.getValue()).toBe("async"));
   });
 });

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.suspense.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.suspense.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTapRoot } from "../../core/createTapRoot";
+import { flushTapSync } from "../../core/scheduler";
+import { use } from "../../react-hooks/use";
+import { useState } from "../../react-hooks/useState";
+
+describe("createTapRoot suspense", () => {
+  it("throws a clear error when the initial render suspends", () => {
+    expect(() => createTapRoot(() => use(new Promise(() => {})))).toThrow(
+      "createTapRoot suspended during its initial render",
+    );
+  });
+
+  it("holds the committed value while an update suspends and converges on resolve", async () => {
+    let resolve!: (value: string) => void;
+    const promise = new Promise<string>((r) => {
+      resolve = r;
+    });
+    let bump!: (value: number) => void;
+
+    const root = createTapRoot(() => {
+      const [count, setCount] = useState(0);
+      bump = setCount;
+      return count === 0 ? "sync" : (use(promise) as string);
+    });
+
+    const seen: string[] = [];
+    root.subscribe(() => seen.push(root.getValue()));
+    expect(root.getValue()).toBe("sync");
+
+    flushTapSync(() => bump(1));
+    expect(root.getValue()).toBe("sync");
+    expect(seen).toEqual([]);
+
+    resolve("async");
+    await promise;
+    await vi.waitFor(() => expect(root.getValue()).toBe("async"));
+    expect(seen).toEqual(["async"]);
+
+    root.unmount();
+  });
+});

--- a/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Suspense } from "react";
+import { useSyncExternalStore } from "react";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { useTapRoot, flushTapSync } from "../../index";
+import { use } from "../../react-hooks/use";
+import { useState as useResourceState } from "../../react-hooks/useState";
+
+describe("useTapRoot suspense", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("an initial render suspension reaches the React Suspense boundary", async () => {
+    let resolve!: (value: string) => void;
+    const promise = new Promise<string>((r) => {
+      resolve = r;
+    });
+
+    function Host() {
+      const root = useTapRoot(function Data() {
+        return use(promise) as string;
+      });
+      return <div data-testid="out">{root.getValue()}</div>;
+    }
+
+    render(
+      <Suspense fallback={<div data-testid="fallback">loading</div>}>
+        <Host />
+      </Suspense>,
+    );
+    expect(screen.getByTestId("fallback")).toBeDefined();
+
+    await act(async () => {
+      resolve("ready");
+      await promise;
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(screen.getByTestId("out").textContent).toBe("ready");
+  });
+
+  it("an update suspension holds the committed value and converges on resolve", async () => {
+    let resolve!: (value: string) => void;
+    const promise = new Promise<string>((r) => {
+      resolve = r;
+    });
+    let bump!: (value: number) => void;
+
+    function Host() {
+      const root = useTapRoot(function Data() {
+        const [count, setCount] = useResourceState(0);
+        bump = setCount;
+        return count === 0 ? "sync" : (use(promise) as string);
+      });
+      const value = useSyncExternalStore(root.subscribe, root.getValue);
+      return <div data-testid="out">{value}</div>;
+    }
+
+    render(<Host />);
+    expect(screen.getByTestId("out").textContent).toBe("sync");
+
+    act(() => {
+      flushTapSync(() => bump(1));
+    });
+    expect(screen.getByTestId("out").textContent).toBe("sync");
+
+    await act(async () => {
+      resolve("async");
+      await promise;
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(screen.getByTestId("out").textContent).toBe("async");
+  });
+});

--- a/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { Suspense } from "react";
 import { useSyncExternalStore } from "react";
 import { render, screen, act, cleanup } from "@testing-library/react";
@@ -46,6 +46,7 @@ describe("useTapRoot suspense", () => {
       resolve = r;
     });
     let bump!: (value: number) => void;
+    let getValue!: () => string;
 
     function Host() {
       const root = useTapRoot(function Data() {
@@ -53,6 +54,7 @@ describe("useTapRoot suspense", () => {
         bump = setCount;
         return count === 0 ? "sync" : (use(promise) as string);
       });
+      getValue = root.getValue;
       const value = useSyncExternalStore(root.subscribe, root.getValue);
       return <div data-testid="out">{value}</div>;
     }
@@ -68,7 +70,7 @@ describe("useTapRoot suspense", () => {
     await act(async () => {
       resolve("async");
       await promise;
-      await new Promise((r) => setTimeout(r, 50));
+      await vi.waitFor(() => expect(getValue()).toBe("async"));
     });
 
     expect(screen.getByTestId("out").textContent).toBe("async");

--- a/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.suspense.test.tsx
@@ -31,13 +31,9 @@ describe("useTapRoot suspense", () => {
     );
     expect(screen.getByTestId("fallback")).toBeDefined();
 
-    await act(async () => {
-      resolve("ready");
-      await promise;
-      await new Promise((r) => setTimeout(r, 0));
-    });
-
-    expect(screen.getByTestId("out").textContent).toBe("ready");
+    resolve("ready");
+    const out = await screen.findByTestId("out");
+    expect(out.textContent).toBe("ready");
   });
 
   it("an update suspension holds the committed value and converges on resolve", async () => {

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -8,6 +8,7 @@ import { useTapRoot } from "../hooks/useTapRoot";
 import { isDevelopment } from "./helpers/env";
 import { flushTapSync, UpdateScheduler } from "./scheduler";
 import { createResourceFiberRoot } from "./helpers/root";
+import { isThenable } from "./helpers/thenable";
 
 export const createTapRoot = <R>(
   render: () => R,
@@ -24,10 +25,20 @@ export const createTapRoot = <R>(
 
   // In strict mode, render twice to detect side effects
   const renderFiber = () => {
-    if (isDevelopment && fiber.devStrictMode) {
-      void renderResourceFiber(fiber, [render]);
+    try {
+      if (isDevelopment && fiber.devStrictMode) {
+        void renderResourceFiber(fiber, [render]);
+      }
+      return renderResourceFiber(fiber, [render]) as useTapRoot.Root<R>;
+    } catch (error) {
+      if (isThenable(error)) {
+        throw new Error(
+          "createTapRoot suspended during its initial render. There is no " +
+            "value to hold; wrap the suspending use() in a suspense boundary.",
+        );
+      }
+      throw error;
     }
-    return renderResourceFiber(fiber, [render]) as useTapRoot.Root<R>;
   };
 
   const commitScheduler = new UpdateScheduler(() => commitResourceFiber(fiber));

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -34,7 +34,8 @@ export const createTapRoot = <R>(
       if (isThenable(error)) {
         throw new Error(
           "createTapRoot suspended during its initial render. There is no " +
-            "value to hold; wrap the suspending use() in a suspense boundary.",
+            "value to hold; resolve the data before creating the root, or " +
+            "host the resource with useTapRoot inside a React Suspense boundary.",
         );
       }
       throw error;

--- a/packages/tap/src/core/helpers/thenable.ts
+++ b/packages/tap/src/core/helpers/thenable.ts
@@ -1,3 +1,8 @@
+export const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+  value !== null &&
+  typeof value === "object" &&
+  typeof (value as PromiseLike<unknown>).then === "function";
+
 type TrackedThenable<T> = PromiseLike<T> & {
   status?: "pending" | "fulfilled" | "rejected";
   value?: T;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -12,6 +12,7 @@ import {
   setRootVersion,
 } from "../core/helpers/root";
 import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
+import { isThenable } from "../core/helpers/thenable";
 import type { ResourceContext } from "../core/types";
 import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
@@ -113,15 +114,29 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       fiber.root.committedVersion + fiber.root.changelog.length,
     );
 
-    if (isDevelopment && fiber.devStrictMode) {
-      void withTapContextRoot(stateRef.current.context, () => {
+    let render: R;
+    try {
+      if (isDevelopment && fiber.devStrictMode) {
+        void withTapContextRoot(stateRef.current.context, () => {
+          return renderResourceFiber(fiber, stateRef.current.committedArgs);
+        });
+      }
+
+      render = withTapContextRoot(stateRef.current.context, () => {
         return renderResourceFiber(fiber, stateRef.current.committedArgs);
       });
+    } catch (error) {
+      // Suspended outside a React render: hold the committed value and retry
+      // once the thenable settles (transition semantics).
+      if (isThenable(error)) {
+        const retry = () => {
+          if (stateRef.current.isMounted) scheduler.markDirty();
+        };
+        error.then(retry, retry);
+        return;
+      }
+      throw error;
     }
-
-    const render = withTapContextRoot(stateRef.current.context, () => {
-      return renderResourceFiber(fiber, stateRef.current.committedArgs);
-    });
 
     if (scheduler.isDirty)
       throw new Error("Scheduler is dirty, this should never happen");

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -163,7 +163,10 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
 
   useEffect(() => {
     if (processed) {
-      if (!fiber.isMounted) commitResourceFiber(fiber);
+      if (!fiber.isMounted) {
+        commitResourceFiber(fiber);
+        if (queue.length && !scheduler.isDirty) scheduler.markDirty();
+      }
       return;
     }
     processed = true;

--- a/packages/tap/src/react-hooks/use.ts
+++ b/packages/tap/src/react-hooks/use.ts
@@ -1,5 +1,5 @@
 import { useContext } from "../core/context";
-import { trackThenable } from "../core/helpers/thenable";
+import { isThenable, trackThenable } from "../core/helpers/thenable";
 
 /**
  * The tap equivalent of React's `use`. Accepts React contexts and thenables:
@@ -8,12 +8,8 @@ import { trackThenable } from "../core/helpers/thenable";
  * its rejection reason.
  */
 export const use = (usable: unknown): unknown => {
-  if (
-    usable !== null &&
-    typeof usable === "object" &&
-    typeof (usable as PromiseLike<unknown>).then === "function"
-  ) {
-    return trackThenable(usable as PromiseLike<unknown>);
+  if (isThenable(usable)) {
+    return trackThenable(usable);
   }
   return useContext(usable as never);
 };


### PR DESCRIPTION
## What

Phase 2.5 of tap suspense support (stacked on #5848): teaches both hosts what to do when a resource render throws a thenable.

- **`useTapRoot` scheduler-driven updates**: `handleUpdate` catches a thrown thenable, holds the committed value (no commit, no publish), and retries via `scheduler.markDirty()` once the thenable settles (guarded by `isMounted`). This is transition semantics — subscribers never observe an intermediate state and get exactly one notification after the suspension resolves.
- **React-render-driven suspensions**: no code needed — the thenable propagates to the nearest real `<Suspense>` boundary, and the Activity-parity effect reconciliation from #5833 handles disconnect/reconnect on hide/reveal. Covered by a contract test.
- **`createTapRoot` initial render**: there is no committed value to hold and no boundary to propagate to, so a suspension during construction throws a clear error instead of a raw promise. Update-path suspensions are handled for free because `createTapRoot`'s fiber hook *is* `useTapRoot`.
- Extracted `isThenable` into `core/helpers/thenable.ts` and reused it in `use()`.

## Why

`use(thenable)` (#5848) makes resources able to suspend, but without host support a scheduler-driven suspension would escape `handleUpdate` as an uncaught promise. `handleUpdate`'s existing entry rollback (`setRootVersion` + queue re-apply) already supports "pass ran but didn't commit", so the hold-and-retry adds no new state.

## How verified

4 new tests (3 fail without the implementation, verified via stash):
- React host: initial mount suspension shows the real `<Suspense>` fallback, then content (contract test — passes without this change, documents the free path).
- React host: scheduler-driven update suspension holds `getValue()` and converges after resolve.
- `createTapRoot`: initial suspension throws the clear error; update suspension holds the committed value and notifies subscribers exactly once after resolution.

Full tap suite: 529 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sYO4o4QHh3ov-bfbUPhBwcLclUnQOELs6DZWOfp1uj3p9-vjlDwIR_6h1dk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->