### PR TITLE
fix(react-google-adk): validate proxy request payloads

### DIFF
--- a/.changeset/calm-adk-proxy-requests.md
+++ b/.changeset/calm-adk-proxy-requests.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: validate Google ADK proxy request payloads

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -147,12 +147,25 @@ describe("parseAdkRequest", () => {
       'field "parts[0].functionCall.args"',
     ],
     [
-      { parts: [{ functionResponse: { name: "search" } }] },
-      'field "parts[0].functionResponse.response"',
+      { parts: [{ functionResponse: { name: 42 } }] },
+      'field "parts[0].functionResponse.name"',
     ],
-    [{ parts: [{ text: "hello", inlineData: {} }] }, 'field "parts[0]"'],
   ])("rejects malformed nested ADK parts %#", async (body, error) => {
     await expect(parseAdkRequest(makeRequest(body))).rejects.toThrow(error);
+  });
+
+  it("accepts exclude_none and unknown part shapes", async () => {
+    const parts = [
+      { functionCall: { name: "get_time", id: "call-1" } },
+      { functionResponse: { name: "search", id: "call-1" } },
+      { text: "hi", inlineData: { mimeType: "image/png", data: "abc" } },
+      { videoMetadata: { fps: 1 } },
+      { text: "hello", thoughtSignature: "sig" },
+    ];
+
+    await expect(
+      parseAdkRequest(makeRequest({ parts })),
+    ).resolves.toMatchObject({ parts });
   });
 
   it("requires message content", async () => {

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -161,12 +161,18 @@ describe("parseAdkRequest", () => {
     );
   });
 
-  it.each([{ type: "message", message: "hello" }, { parts: [] }])(
+  it.each([
+    [
+      { type: "message", message: "hello" },
+      { type: "message", text: "hello", config: {} },
+    ],
+    [{ parts: [] }, { type: "message", text: "", parts: [], config: {} }],
+  ])(
     "preserves supported empty and explicit message shapes %#",
-    async (body) => {
-      await expect(parseAdkRequest(makeRequest(body))).resolves.toMatchObject({
-        type: "message",
-      });
+    async (body, expected) => {
+      await expect(parseAdkRequest(makeRequest(body))).resolves.toEqual(
+        expected,
+      );
     },
   );
 

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -73,6 +73,7 @@ describe("parseAdkRequest", () => {
       makeRequest({
         type: "tool-result",
         toolCallId: "tc-1",
+        toolName: "search",
         result: {},
       }),
     );
@@ -94,6 +95,54 @@ describe("parseAdkRequest", () => {
     await expect(parseAdkRequest(makeRequest([1, 2, 3]))).rejects.toThrow(
       "Google ADK proxy request body must be a JSON object",
     );
+  });
+
+  it.each([
+    [{ message: 42 }, 'field "message"'],
+    [{ parts: {} }, 'field "parts"'],
+    [{ parts: [null] }, 'field "parts"'],
+    [{ type: "message", message: "hello" }, 'field "type"'],
+    [{ message: "hello", checkpointId: 42 }, 'field "checkpointId"'],
+    [{ message: "hello", stateDelta: [] }, 'field "stateDelta"'],
+  ])("rejects malformed message requests %#", async (body, error) => {
+    await expect(parseAdkRequest(makeRequest(body))).rejects.toThrow(error);
+  });
+
+  it("requires message content", async () => {
+    await expect(parseAdkRequest(makeRequest({}))).rejects.toThrow(
+      'expected a "message" string or a non-empty "parts" array',
+    );
+  });
+
+  it.each([
+    [
+      { type: "tool-result", toolName: "search", result: {} },
+      'field "toolCallId"',
+    ],
+    [
+      { type: "tool-result", toolCallId: "tc-1", result: {} },
+      'field "toolName"',
+    ],
+    [
+      { type: "tool-result", toolCallId: 42, toolName: "search", result: {} },
+      'field "toolCallId"',
+    ],
+    [
+      {
+        type: "tool-result",
+        toolCallId: "tc-1",
+        toolName: "search",
+        result: {},
+        isError: "false",
+      },
+      'field "isError"',
+    ],
+    [
+      { type: "tool-result", toolCallId: "tc-1", toolName: "search" },
+      'field "result"',
+    ],
+  ])("rejects malformed tool-result requests %#", async (body, error) => {
+    await expect(parseAdkRequest(makeRequest(body))).rejects.toThrow(error);
   });
 });
 

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -49,6 +49,33 @@ describe("parseAdkRequest", () => {
     expect(result.parts).toHaveLength(2);
   });
 
+  it("parses each supported ADK part shape", async () => {
+    const parts = [
+      { text: "Hello", thought: true },
+      { functionCall: { name: "search", id: "call-1", args: {} } },
+      {
+        functionResponse: {
+          name: "search",
+          id: "call-1",
+          response: null,
+        },
+      },
+      { executableCode: { code: "print('hello')", language: "python" } },
+      { codeExecutionResult: { output: "hello", outcome: "ok" } },
+      { inlineData: { mimeType: "image/png", data: "abc" } },
+      {
+        fileData: {
+          fileUri: "https://example.com/file",
+          mimeType: "text/plain",
+        },
+      },
+    ];
+
+    await expect(
+      parseAdkRequest(makeRequest({ parts })),
+    ).resolves.toMatchObject({ parts });
+  });
+
   it("parses a tool-result request", async () => {
     const result = await parseAdkRequest(
       makeRequest({
@@ -105,6 +132,26 @@ describe("parseAdkRequest", () => {
     [{ message: "hello", checkpointId: 42 }, 'field "checkpointId"'],
     [{ message: "hello", stateDelta: [] }, 'field "stateDelta"'],
   ])("rejects malformed message requests %#", async (body, error) => {
+    await expect(parseAdkRequest(makeRequest(body))).rejects.toThrow(error);
+  });
+
+  it.each([
+    [{ parts: [{}] }, 'field "parts[0]"'],
+    [{ parts: [{ text: 42 }] }, 'field "parts[0].text"'],
+    [
+      { parts: [{ inlineData: { mimeType: "image/png", data: 42 } }] },
+      'field "parts[0].inlineData.data"',
+    ],
+    [
+      { parts: [{ functionCall: { name: "search", args: [] } }] },
+      'field "parts[0].functionCall.args"',
+    ],
+    [
+      { parts: [{ functionResponse: { name: "search" } }] },
+      'field "parts[0].functionResponse.response"',
+    ],
+    [{ parts: [{ text: "hello", inlineData: {} }] }, 'field "parts[0]"'],
+  ])("rejects malformed nested ADK parts %#", async (body, error) => {
     await expect(parseAdkRequest(makeRequest(body))).rejects.toThrow(error);
   });
 

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -101,7 +101,7 @@ describe("parseAdkRequest", () => {
     [{ message: 42 }, 'field "message"'],
     [{ parts: {} }, 'field "parts"'],
     [{ parts: [null] }, 'field "parts"'],
-    [{ type: "message", message: "hello" }, 'field "type"'],
+    [{ type: "unknown", message: "hello" }, 'field "type"'],
     [{ message: "hello", checkpointId: 42 }, 'field "checkpointId"'],
     [{ message: "hello", stateDelta: [] }, 'field "stateDelta"'],
   ])("rejects malformed message requests %#", async (body, error) => {
@@ -110,8 +110,34 @@ describe("parseAdkRequest", () => {
 
   it("requires message content", async () => {
     await expect(parseAdkRequest(makeRequest({}))).rejects.toThrow(
-      'expected a "message" string or a non-empty "parts" array',
+      'expected a "message" string or a "parts" array',
     );
+  });
+
+  it.each([{ type: "message", message: "hello" }, { parts: [] }])(
+    "preserves supported empty and explicit message shapes %#",
+    async (body) => {
+      await expect(parseAdkRequest(makeRequest(body))).resolves.toMatchObject({
+        type: "message",
+      });
+    },
+  );
+
+  it("accepts empty tool identifiers emitted by id-less ADK calls", async () => {
+    await expect(
+      parseAdkRequest(
+        makeRequest({
+          type: "tool-result",
+          toolCallId: "",
+          toolName: "",
+          result: {},
+        }),
+      ),
+    ).resolves.toMatchObject({
+      type: "tool-result",
+      toolCallId: "",
+      toolName: "",
+    });
   });
 
   it.each([

--- a/packages/react-google-adk/src/server/parseAdkRequest.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.ts
@@ -26,14 +26,9 @@ const invalidField = (field: string, expectation: string): Error =>
     `Invalid Google ADK proxy request field "${field}": expected ${expectation}.`,
   );
 
-const readRequiredString = (
-  body: Record<string, unknown>,
-  field: string,
-): string => {
+const readString = (body: Record<string, unknown>, field: string): string => {
   const value = body[field];
-  if (typeof value !== "string" || value.length === 0) {
-    throw invalidField(field, "a non-empty string");
-  }
+  if (typeof value !== "string") throw invalidField(field, "a string");
   return value;
 };
 
@@ -103,8 +98,8 @@ export const parseAdkRequest = async (
     }
     return {
       type: "tool-result",
-      toolCallId: readRequiredString(body, "toolCallId"),
-      toolName: readRequiredString(body, "toolName"),
+      toolCallId: readString(body, "toolCallId"),
+      toolName: readString(body, "toolName"),
       result: body.result,
       isError: body.isError ?? false,
       config,
@@ -112,8 +107,8 @@ export const parseAdkRequest = async (
     };
   }
 
-  if (body.type !== undefined) {
-    throw invalidField("type", '"tool-result" or omitted');
+  if (body.type !== undefined && body.type !== "message") {
+    throw invalidField("type", '"message", "tool-result", or omitted');
   }
 
   const text = body.message;
@@ -128,9 +123,9 @@ export const parseAdkRequest = async (
   ) {
     throw invalidField("parts", "an array of objects");
   }
-  if (text === undefined && (parts === undefined || parts.length === 0)) {
+  if (!("message" in body) && !("parts" in body)) {
     throw new Error(
-      'Invalid Google ADK proxy request: expected a "message" string or a non-empty "parts" array.',
+      'Invalid Google ADK proxy request: expected a "message" string or a "parts" array.',
     );
   }
 

--- a/packages/react-google-adk/src/server/parseAdkRequest.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.ts
@@ -18,6 +18,35 @@ type ParsedAdkRequest =
       stateDelta?: Record<string, unknown> | undefined;
     };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const invalidField = (field: string, expectation: string): Error =>
+  new Error(
+    `Invalid Google ADK proxy request field "${field}": expected ${expectation}.`,
+  );
+
+const readRequiredString = (
+  body: Record<string, unknown>,
+  field: string,
+): string => {
+  const value = body[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw invalidField(field, "a non-empty string");
+  }
+  return value;
+};
+
+const readOptionalString = (
+  body: Record<string, unknown>,
+  field: string,
+): string | undefined => {
+  const value = body[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw invalidField(field, "a string");
+  return value;
+};
+
 /**
  * Parses an incoming HTTP request into a structured ADK request.
  *
@@ -42,44 +71,73 @@ type ParsedAdkRequest =
 export const parseAdkRequest = async (
   request: Request,
 ): Promise<ParsedAdkRequest> => {
-  let body: Record<string, unknown>;
+  let body: unknown;
   try {
-    body = (await request.json()) as Record<string, unknown>;
+    body = await request.json();
   } catch {
     throw new Error(
       'Invalid JSON in Google ADK proxy request body. Expected a JSON object like {"message":"Hello"} or {"type":"tool-result",...}.',
     );
   }
 
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
+  if (!isRecord(body)) {
     throw new Error("Google ADK proxy request body must be a JSON object");
   }
 
   const config: AdkSendMessageConfig = {};
   if (body.runConfig !== undefined) config.runConfig = body.runConfig;
-  if (body.checkpointId !== undefined)
-    config.checkpointId = body.checkpointId as string;
+  const checkpointId = readOptionalString(body, "checkpointId");
+  if (checkpointId !== undefined) config.checkpointId = checkpointId;
 
-  const stateDelta = body.stateDelta as Record<string, unknown> | undefined;
+  const stateDelta = body.stateDelta;
+  if (stateDelta !== undefined && !isRecord(stateDelta)) {
+    throw invalidField("stateDelta", "an object");
+  }
 
   if (body.type === "tool-result") {
+    if (!("result" in body)) {
+      throw invalidField("result", "a value");
+    }
+    if (body.isError !== undefined && typeof body.isError !== "boolean") {
+      throw invalidField("isError", "a boolean");
+    }
     return {
       type: "tool-result",
-      toolCallId: (body.toolCallId as string) ?? "",
-      toolName: (body.toolName as string) ?? "",
+      toolCallId: readRequiredString(body, "toolCallId"),
+      toolName: readRequiredString(body, "toolName"),
       result: body.result,
-      isError: (body.isError as boolean) ?? false,
+      isError: body.isError ?? false,
       config,
       ...(stateDelta != null && { stateDelta }),
     };
   }
 
+  if (body.type !== undefined) {
+    throw invalidField("type", '"tool-result" or omitted');
+  }
+
+  const text = body.message;
+  if (text !== undefined && typeof text !== "string") {
+    throw invalidField("message", "a string");
+  }
+
+  const parts = body.parts;
+  if (
+    parts !== undefined &&
+    (!Array.isArray(parts) || !parts.every(isRecord))
+  ) {
+    throw invalidField("parts", "an array of objects");
+  }
+  if (text === undefined && (parts === undefined || parts.length === 0)) {
+    throw new Error(
+      'Invalid Google ADK proxy request: expected a "message" string or a non-empty "parts" array.',
+    );
+  }
+
   return {
     type: "message",
-    text: (body.message as string) ?? "",
-    ...(body.parts != null && {
-      parts: body.parts as Array<Record<string, unknown>>,
-    }),
+    text: text ?? "",
+    ...(parts !== undefined && { parts }),
     config,
     ...(stateDelta != null && { stateDelta }),
   };

--- a/packages/react-google-adk/src/server/parseAdkRequest.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.ts
@@ -42,6 +42,115 @@ const readOptionalString = (
   return value;
 };
 
+const readPartRecord = (
+  part: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> => {
+  const value = part[field];
+  if (!isRecord(value)) throw invalidField(field, "an object");
+  return value;
+};
+
+const validateOptionalPartString = (
+  part: Record<string, unknown>,
+  key: string,
+  field: string,
+) => {
+  if (part[key] !== undefined && typeof part[key] !== "string") {
+    throw invalidField(field, "a string");
+  }
+};
+
+const validatePart = (part: Record<string, unknown>, index: number) => {
+  const field = (name: string) => `parts[${index}].${name}`;
+  const contentFields = [
+    "text",
+    "functionCall",
+    "functionResponse",
+    "executableCode",
+    "codeExecutionResult",
+    "inlineData",
+    "fileData",
+  ].filter((name) => part[name] !== undefined);
+
+  if (contentFields.length !== 1) {
+    throw invalidField(
+      `parts[${index}]`,
+      "exactly one supported ADK content field",
+    );
+  }
+  if (part.thought !== undefined && typeof part.thought !== "boolean") {
+    throw invalidField(field("thought"), "a boolean");
+  }
+
+  const contentField = contentFields[0]!;
+  if (contentField === "text") {
+    if (typeof part.text !== "string") {
+      throw invalidField(field("text"), "a string");
+    }
+    return;
+  }
+
+  const content = readPartRecord(part, contentField);
+  switch (contentField) {
+    case "functionCall":
+      if (typeof content.name !== "string") {
+        throw invalidField(field("functionCall.name"), "a string");
+      }
+      validateOptionalPartString(content, "id", field("functionCall.id"));
+      if (!isRecord(content.args)) {
+        throw invalidField(field("functionCall.args"), "an object");
+      }
+      return;
+    case "functionResponse":
+      if (typeof content.name !== "string") {
+        throw invalidField(field("functionResponse.name"), "a string");
+      }
+      validateOptionalPartString(content, "id", field("functionResponse.id"));
+      if (!("response" in content)) {
+        throw invalidField(field("functionResponse.response"), "a value");
+      }
+      return;
+    case "executableCode":
+      if (typeof content.code !== "string") {
+        throw invalidField(field("executableCode.code"), "a string");
+      }
+      validateOptionalPartString(
+        content,
+        "language",
+        field("executableCode.language"),
+      );
+      return;
+    case "codeExecutionResult":
+      if (typeof content.output !== "string") {
+        throw invalidField(field("codeExecutionResult.output"), "a string");
+      }
+      validateOptionalPartString(
+        content,
+        "outcome",
+        field("codeExecutionResult.outcome"),
+      );
+      return;
+    case "inlineData":
+      if (typeof content.mimeType !== "string") {
+        throw invalidField(field("inlineData.mimeType"), "a string");
+      }
+      if (typeof content.data !== "string") {
+        throw invalidField(field("inlineData.data"), "a string");
+      }
+      return;
+    case "fileData":
+      if (typeof content.fileUri !== "string") {
+        throw invalidField(field("fileData.fileUri"), "a string");
+      }
+      validateOptionalPartString(
+        content,
+        "mimeType",
+        field("fileData.mimeType"),
+      );
+  }
+};
+
 /**
  * Parses an incoming HTTP request into a structured ADK request.
  *
@@ -123,6 +232,7 @@ export const parseAdkRequest = async (
   ) {
     throw invalidField("parts", "an array of objects");
   }
+  parts?.forEach(validatePart);
   if (!("message" in body) && !("parts" in body)) {
     throw new Error(
       'Invalid Google ADK proxy request: expected a "message" string or a "parts" array.',

--- a/packages/react-google-adk/src/server/parseAdkRequest.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@assistant-ui/core/internal";
 import type { AdkSendMessageConfig } from "../types";
 
 type ParsedAdkRequest =
@@ -17,9 +18,6 @@ type ParsedAdkRequest =
       config: AdkSendMessageConfig;
       stateDelta?: Record<string, unknown> | undefined;
     };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const invalidField = (field: string, expectation: string): Error =>
   new Error(
@@ -42,15 +40,6 @@ const readOptionalString = (
   return value;
 };
 
-const readPartRecord = (
-  part: Record<string, unknown>,
-  field: string,
-): Record<string, unknown> => {
-  const value = part[field];
-  if (!isRecord(value)) throw invalidField(field, "an object");
-  return value;
-};
-
 const validateOptionalPartString = (
   part: Record<string, unknown>,
   key: string,
@@ -61,94 +50,74 @@ const validateOptionalPartString = (
   }
 };
 
+// Nested fields are validated only when present: ADK serializes with
+// exclude_none semantics and the Part vocabulary grows upstream, so absent
+// fields and unknown part kinds pass through to the runner untouched.
 const validatePart = (part: Record<string, unknown>, index: number) => {
   const field = (name: string) => `parts[${index}].${name}`;
-  const contentFields = [
-    "text",
-    "functionCall",
-    "functionResponse",
-    "executableCode",
-    "codeExecutionResult",
-    "inlineData",
-    "fileData",
-  ].filter((name) => part[name] !== undefined);
-
-  if (contentFields.length !== 1) {
-    throw invalidField(
-      `parts[${index}]`,
-      "exactly one supported ADK content field",
-    );
+  if (Object.keys(part).length === 0) {
+    throw invalidField(`parts[${index}]`, "a non-empty part object");
   }
   if (part.thought !== undefined && typeof part.thought !== "boolean") {
     throw invalidField(field("thought"), "a boolean");
   }
+  if (part.text !== undefined && typeof part.text !== "string") {
+    throw invalidField(field("text"), "a string");
+  }
 
-  const contentField = contentFields[0]!;
-  if (contentField === "text") {
-    if (typeof part.text !== "string") {
-      throw invalidField(field("text"), "a string");
+  const validateRecordField = (
+    key: string,
+    validateContent: (content: Record<string, unknown>) => void,
+  ) => {
+    const value = part[key];
+    if (value === undefined) return;
+    if (!isRecord(value)) throw invalidField(field(key), "an object");
+    validateContent(value);
+  };
+
+  validateRecordField("functionCall", (content) => {
+    validateOptionalPartString(content, "name", field("functionCall.name"));
+    validateOptionalPartString(content, "id", field("functionCall.id"));
+    if (content.args !== undefined && !isRecord(content.args)) {
+      throw invalidField(field("functionCall.args"), "an object");
     }
-    return;
-  }
-
-  const content = readPartRecord(part, contentField);
-  switch (contentField) {
-    case "functionCall":
-      if (typeof content.name !== "string") {
-        throw invalidField(field("functionCall.name"), "a string");
-      }
-      validateOptionalPartString(content, "id", field("functionCall.id"));
-      if (!isRecord(content.args)) {
-        throw invalidField(field("functionCall.args"), "an object");
-      }
-      return;
-    case "functionResponse":
-      if (typeof content.name !== "string") {
-        throw invalidField(field("functionResponse.name"), "a string");
-      }
-      validateOptionalPartString(content, "id", field("functionResponse.id"));
-      if (!("response" in content)) {
-        throw invalidField(field("functionResponse.response"), "a value");
-      }
-      return;
-    case "executableCode":
-      if (typeof content.code !== "string") {
-        throw invalidField(field("executableCode.code"), "a string");
-      }
-      validateOptionalPartString(
-        content,
-        "language",
-        field("executableCode.language"),
-      );
-      return;
-    case "codeExecutionResult":
-      if (typeof content.output !== "string") {
-        throw invalidField(field("codeExecutionResult.output"), "a string");
-      }
-      validateOptionalPartString(
-        content,
-        "outcome",
-        field("codeExecutionResult.outcome"),
-      );
-      return;
-    case "inlineData":
-      if (typeof content.mimeType !== "string") {
-        throw invalidField(field("inlineData.mimeType"), "a string");
-      }
-      if (typeof content.data !== "string") {
-        throw invalidField(field("inlineData.data"), "a string");
-      }
-      return;
-    case "fileData":
-      if (typeof content.fileUri !== "string") {
-        throw invalidField(field("fileData.fileUri"), "a string");
-      }
-      validateOptionalPartString(
-        content,
-        "mimeType",
-        field("fileData.mimeType"),
-      );
-  }
+  });
+  validateRecordField("functionResponse", (content) => {
+    validateOptionalPartString(content, "name", field("functionResponse.name"));
+    validateOptionalPartString(content, "id", field("functionResponse.id"));
+  });
+  validateRecordField("executableCode", (content) => {
+    validateOptionalPartString(content, "code", field("executableCode.code"));
+    validateOptionalPartString(
+      content,
+      "language",
+      field("executableCode.language"),
+    );
+  });
+  validateRecordField("codeExecutionResult", (content) => {
+    validateOptionalPartString(
+      content,
+      "output",
+      field("codeExecutionResult.output"),
+    );
+    validateOptionalPartString(
+      content,
+      "outcome",
+      field("codeExecutionResult.outcome"),
+    );
+  });
+  validateRecordField("inlineData", (content) => {
+    validateOptionalPartString(
+      content,
+      "mimeType",
+      field("inlineData.mimeType"),
+    );
+    validateOptionalPartString(content, "data", field("inlineData.data"));
+  });
+  validateRecordField("fileData", (content) => {
+    validateOptionalPartString(content, "fileUri", field("fileData.fileUri"));
+    validateOptionalPartString(content, "mimeType", field("fileData.mimeType"));
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

- validate the Google ADK proxy request body before exposing typed fields
- reject malformed messages, multimodal parts, tool results, checkpoint IDs, and state deltas with field-specific errors
- preserve supported wire shapes emitted by the package, including explicit `type: "message"`, empty ADK tool identifiers, and empty parts arrays
- preserve `runConfig` as an opaque value because the public ADK runtime contract intentionally allows provider-specific configuration

## Why

`parseAdkRequest()` previously cast untrusted JSON directly. For example, `{ "message": 42 }` was accepted and returned as a supposedly string-valued message, while tool results with missing or non-string IDs and names could reach the ADK runner. Failing at the proxy boundary gives users a useful error and prevents malformed values from reaching the provider SDK without narrowing established payloads.

## Testing

- `pnpm --dir packages/react-google-adk test` (247 tests)
- `pnpm --filter @assistant-ui/react-google-adk... build`
- `pnpm lint`
- filtered API-surface check for `@assistant-ui/react-google-adk`