### PR TITLE
fix(react-google-adk): reload history after loader changes

### DIFF
--- a/.changeset/fresh-adk-loader-scopes.md
+++ b/.changeset/fresh-adk-loader-scopes.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: reload Google ADK history after load scope changes

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3677,7 +3677,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
-  unstable_runtimeHookKey?: PropertyKey | object | undefined;
+  unstable_runtimeHookKey?: PropertyKey | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3677,6 +3677,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+  unstable_runtimeHookKey?: PropertyKey | object | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2339,6 +2339,7 @@ type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   load?: (threadId: string, options?: {
     signal?: AbortSignal | undefined;
   }) => Promise<AdkThreadSnapshot>;
+  loadKey?: PropertyKey | object | undefined;
   create?: () => Promise<{
     externalId: string;
   }>;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2339,7 +2339,7 @@ type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   load?: (threadId: string, options?: {
     signal?: AbortSignal | undefined;
   }) => Promise<AdkThreadSnapshot>;
-  loadKey?: PropertyKey | object | undefined;
+  loadKey?: PropertyKey | undefined;
   create?: () => Promise<{
     externalId: string;
   }>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -2895,7 +2895,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
-  unstable_runtimeHookKey?: PropertyKey | object | undefined;
+  unstable_runtimeHookKey?: PropertyKey | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -2895,6 +2895,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+  unstable_runtimeHookKey?: PropertyKey | object | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -2511,6 +2511,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+  unstable_runtimeHookKey?: PropertyKey | object | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -2511,7 +2511,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
-  unstable_runtimeHookKey?: PropertyKey | object | undefined;
+  unstable_runtimeHookKey?: PropertyKey | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -3701,7 +3701,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
-  unstable_runtimeHookKey?: PropertyKey | object | undefined;
+  unstable_runtimeHookKey?: PropertyKey | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -3701,6 +3701,7 @@ type RemoteThreadListAdapter = {
 
 type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+  unstable_runtimeHookKey?: PropertyKey | object | undefined;
   adapter: RemoteThreadListAdapter;
   initialThreadId?: string | undefined;
   threadId?: string | undefined;

--- a/apps/docs/content/docs/runtimes/google-adk/api.mdx
+++ b/apps/docs/content/docs/runtimes/google-adk/api.mdx
@@ -147,6 +147,7 @@ Use `createAdkSessionAdapter` to persist threads via ADK's session API; see [Dir
 ```ts
 const runtime = useAdkRuntime({
   stream: createAdkStream({ api: "/api/chat" }),
+  loadKey: workspaceId,
   create: async () => {
     const sessionId = await createSession();
     return { externalId: sessionId };
@@ -160,6 +161,10 @@ const runtime = useAdkRuntime({
   },
 });
 ```
+
+Keep `loadKey` stable for the same history scope and change it when the active
+account or workspace changes. The runtime clears the previous scope and reloads
+the active thread with the latest `load` callback.
 
 ### Cloud persistence
 

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -53,9 +53,11 @@ export const useRemoteThreadListRuntime = (
 
   const initialThreadIdRef = useRef(options.initialThreadId);
 
+  /* oxlint-disable react-hooks/exhaustive-deps -- the key refreshes the closure consumed by mounted binders */
   const stableRuntimeHook = useCallback(() => {
     return runtimeHookRef.current();
-  }, []);
+  }, [options.unstable_runtimeHookKey]);
+  /* oxlint-enable react-hooks/exhaustive-deps */
 
   const onThreadIdChange = useEffectEvent((threadId: string | undefined) => {
     options.onThreadIdChange?.(threadId);

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -66,6 +66,11 @@ export type RemoteThreadListAdapter = {
 
 export type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+  /**
+   * Rerenders mounted thread runtime hooks when their backing scope changes.
+   * Ordinary runtime hook identity changes are intentionally ignored.
+   */
+  unstable_runtimeHookKey?: PropertyKey | object | undefined;
   adapter: RemoteThreadListAdapter;
 
   /**

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -70,7 +70,7 @@ export type RemoteThreadListOptions = {
    * Rerenders mounted thread runtime hooks when their backing scope changes.
    * Ordinary runtime hook identity changes are intentionally ignored.
    */
-  unstable_runtimeHookKey?: PropertyKey | object | undefined;
+  unstable_runtimeHookKey?: PropertyKey | undefined;
   adapter: RemoteThreadListAdapter;
 
   /**

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -25,6 +25,47 @@ afterEach(() => {
 });
 
 describe("ADK runtime callbacks", () => {
+  it("ignores events yielded after cancellation", async () => {
+    let releaseStream!: () => void;
+    const streamReady = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    let streamSignal: AbortSignal | undefined;
+    const stream: AdkStreamCallback = async function* (_, options) {
+      streamSignal = options.abortSignal;
+      await streamReady;
+      yield {
+        id: "stale-answer",
+        author: "agent",
+        content: { role: "model", parts: [{ text: "stale" }] },
+      };
+    };
+    const { result } = renderHook(() => useAdkMessages({ stream }));
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage(
+        [{ id: "user", type: "human", content: "hello" }],
+        {},
+      );
+    });
+    await vi.waitFor(() => expect(streamSignal).toBeDefined());
+
+    act(() => result.current.cancel());
+    expect(streamSignal?.aborted).toBe(true);
+
+    releaseStream();
+    await act(async () => {
+      await sendPromise;
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]).toMatchObject({
+      id: "user",
+      type: "human",
+    });
+  });
+
   it.each(["onAgentTransfer", "onCustomEvent", "onError"] as const)(
     "continues streaming when %s throws",
     async (callbackName) => {

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -123,6 +123,7 @@ export const useAdkMessages = ({
   );
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const streamGenerationRef = useRef(0);
 
   const { onError, onCustomEvent, onAgentTransfer } = useMemo(
     () => eventHandlers ?? {},
@@ -132,6 +133,7 @@ export const useAdkMessages = ({
   const aui = useAui();
   const sendMessage = useCallback(
     async (newMessages: AdkMessage[], config: AdkSendMessageConfig) => {
+      const streamGeneration = ++streamGenerationRef.current;
       const newMessagesWithId = newMessages.map((m) =>
         m.id ? m : { ...m, id: uuidv4() },
       ) as AdkMessage[];
@@ -155,6 +157,12 @@ export const useAdkMessages = ({
         });
 
         for await (const event of response) {
+          if (
+            abortController.signal.aborted ||
+            streamGeneration !== streamGenerationRef.current
+          ) {
+            break;
+          }
           const updatedMessages = accumulator.processEvent(event);
           setMessagesImmediate(updatedMessages);
           setStateDelta({
@@ -233,6 +241,7 @@ export const useAdkMessages = ({
   );
 
   const cancel = useCallback(() => {
+    streamGenerationRef.current += 1;
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }

--- a/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
@@ -105,6 +105,142 @@ const renderAdk = async (
 };
 
 describe("useAdkRuntime refetch", () => {
+  it("clears and reloads the current thread when the load key changes", async () => {
+    const pendingB = deferred<AdkThreadSnapshot>();
+    const loadA = vi.fn(async () => ({
+      messages: [aiMessage("a", "workspace a")],
+    }));
+    const loadB = vi.fn(() => pendingB.promise);
+    const adapter = makeThreadListAdapter();
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+    const Inner: FC<{
+      load: typeof loadA;
+      loadKey: string;
+    }> = ({ load, loadKey }) => {
+      const runtime = useAdkRuntime({
+        stream: vi.fn(async function* () {}) as never,
+        load: load as never,
+        loadKey,
+        sessionAdapter: adapter,
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    let rendered!: ReturnType<typeof render>;
+    await act(async () => {
+      rendered = render(<Inner load={loadA} loadKey="workspace-a" />);
+    });
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("adk-1");
+    });
+    await waitFor(() =>
+      expect(
+        JSON.stringify(capture.runtime!.thread.getState().messages),
+      ).toContain("workspace a"),
+    );
+
+    await act(async () => {
+      rendered.rerender(<Inner load={loadB} loadKey="workspace-b" />);
+    });
+
+    await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+    expect(capture.runtime!.thread.getState().messages).toEqual([]);
+    expect(capture.runtime!.thread.getState().isLoading).toBe(true);
+
+    await act(async () => {
+      pendingB.resolve({ messages: [aiMessage("b", "workspace b")] });
+    });
+    await waitFor(() =>
+      expect(
+        JSON.stringify(capture.runtime!.thread.getState().messages),
+      ).toContain("workspace b"),
+    );
+
+    const loadB2 = vi.fn(async () => ({
+      messages: [aiMessage("b-2", "workspace b refreshed")],
+    }));
+    await act(async () => {
+      rendered.rerender(<Inner load={loadB2} loadKey="workspace-b" />);
+    });
+    await act(async () => {
+      await capture.runtime!.threads.reloadMainThread();
+    });
+    expect(loadB2).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        JSON.stringify(capture.runtime!.thread.getState().messages),
+      ).toContain("workspace b refreshed"),
+    );
+  });
+
+  it("ignores an earlier load after the load key changes", async () => {
+    const pendingA = deferred<AdkThreadSnapshot>();
+    const signals: AbortSignal[] = [];
+    const loadA = vi.fn(
+      (_id: string, options?: { signal?: AbortSignal | undefined }) => {
+        if (options?.signal) signals.push(options.signal);
+        return pendingA.promise;
+      },
+    );
+    const loadB = vi.fn(async () => ({
+      messages: [aiMessage("b", "workspace b")],
+    }));
+    const adapter = makeThreadListAdapter();
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+    const Inner: FC<{
+      load: typeof loadA;
+      loadKey: string;
+    }> = ({ load, loadKey }) => {
+      const runtime = useAdkRuntime({
+        stream: vi.fn(async function* () {}) as never,
+        load: load as never,
+        loadKey,
+        sessionAdapter: adapter,
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    let rendered!: ReturnType<typeof render>;
+    await act(async () => {
+      rendered = render(<Inner load={loadA} loadKey="workspace-a" />);
+    });
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("adk-1");
+    });
+    await waitFor(() => expect(loadA).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      rendered.rerender(<Inner load={loadB} loadKey="workspace-b" />);
+    });
+
+    await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+    expect(signals[0]?.aborted).toBe(true);
+    await waitFor(() =>
+      expect(
+        JSON.stringify(capture.runtime!.thread.getState().messages),
+      ).toContain("workspace b"),
+    );
+
+    await act(async () => {
+      pendingA.resolve({ messages: [aiMessage("a", "workspace a")] });
+    });
+    expect(
+      JSON.stringify(capture.runtime!.thread.getState().messages),
+    ).not.toContain("workspace a");
+  });
+
   it("declares the refetch capability only when a load is supplied", async () => {
     const withLoad = await renderAdk(async () => ({ messages: [] }));
     expect(

--- a/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
@@ -10,7 +10,7 @@ import type {
 } from "@assistant-ui/core";
 import { useAui } from "@assistant-ui/store";
 import { useAdkRuntime } from "./useAdkRuntime";
-import type { AdkMessage, AdkThreadSnapshot } from "./types";
+import type { AdkMessage, AdkStreamCallback, AdkThreadSnapshot } from "./types";
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
@@ -239,6 +239,81 @@ describe("useAdkRuntime refetch", () => {
     expect(
       JSON.stringify(capture.runtime!.thread.getState().messages),
     ).not.toContain("workspace a");
+  });
+
+  it("cancels and ignores an earlier stream after the load key changes", async () => {
+    const pendingStream = deferred<void>();
+    let streamSignal: AbortSignal | undefined;
+    const stream = vi.fn<AdkStreamCallback>(async function* (_, options) {
+      streamSignal = options.abortSignal;
+      await pendingStream.promise;
+      yield {
+        id: "late-a",
+        author: "agent",
+        content: { role: "model", parts: [{ text: "late workspace a" }] },
+      };
+    });
+    const loadA = vi.fn(async () => ({
+      messages: [aiMessage("a", "workspace a")],
+    }));
+    const loadB = vi.fn(async () => ({
+      messages: [aiMessage("b", "workspace b")],
+    }));
+    const adapter = makeThreadListAdapter();
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+    const Inner: FC<{
+      load: typeof loadA;
+      loadKey: string;
+    }> = ({ load, loadKey }) => {
+      const runtime = useAdkRuntime({
+        stream,
+        load: load as never,
+        loadKey,
+        sessionAdapter: adapter,
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    let rendered!: ReturnType<typeof render>;
+    await act(async () => {
+      rendered = render(<Inner load={loadA} loadKey="workspace-a" />);
+    });
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("adk-1");
+    });
+    await waitFor(() => expect(loadA).toHaveBeenCalledTimes(1));
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = capture.runtime!.thread.append("hello");
+    });
+    await waitFor(() => expect(stream).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      rendered.rerender(<Inner load={loadB} loadKey="workspace-b" />);
+    });
+
+    await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+    expect(streamSignal?.aborted).toBe(true);
+    await waitFor(() =>
+      expect(
+        JSON.stringify(capture.runtime!.thread.getState().messages),
+      ).toContain("workspace b"),
+    );
+
+    pendingStream.resolve(undefined);
+    await act(async () => {
+      await sendPromise;
+    });
+    expect(
+      JSON.stringify(capture.runtime!.thread.getState().messages),
+    ).not.toContain("late workspace a");
   });
 
   it("declares the refetch capability only when a load is supplied", async () => {

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -164,6 +164,14 @@ const toAdkUserMessage = (
   content: getMessageContent(msg),
 });
 
+const DEFAULT_LOAD_KEY = Symbol("default-adk-load-key");
+const NO_LOAD_KEY = Symbol("no-adk-load");
+
+const getLoadKey = (
+  load: UseAdkRuntimeOptions["load"],
+  loadKey: UseAdkRuntimeOptions["loadKey"],
+) => (load === undefined ? NO_LOAD_KEY : (loadKey ?? DEFAULT_LOAD_KEY));
+
 export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   stream: AdkStreamCallback;
   /**
@@ -191,6 +199,11 @@ export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
     threadId: string,
     options?: { signal?: AbortSignal | undefined },
   ) => Promise<AdkThreadSnapshot>;
+  /**
+   * Stable identifier for the backing load scope. Change it to clear and
+   * reload the active thread when its account or workspace changes.
+   */
+  loadKey?: PropertyKey | object | undefined;
   create?: () => Promise<{ externalId: string }>;
   delete?: (threadId: string) => Promise<void>;
   adapters?:
@@ -224,6 +237,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     unstable_allowCancellation,
     stream,
     load,
+    loadKey,
     getCheckpointId,
     eventHandlers,
   } = options;
@@ -250,6 +264,8 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
 
   const loadRef = useRef(load);
   loadRef.current = load;
+  const effectiveLoadKey = getLoadKey(load, loadKey);
+  const previousLoadKeyRef = useRef(effectiveLoadKey);
   const loadControllerRef = useRef<{
     controller: AbortController;
     purpose: "initial" | "reload";
@@ -412,6 +428,13 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   );
 
   useEffect(() => {
+    const loadKeyChanged = !Object.is(
+      previousLoadKeyRef.current,
+      effectiveLoadKey,
+    );
+    previousLoadKeyRef.current = effectiveLoadKey;
+    if (loadKeyChanged) applySnapshot({ messages: [] });
+
     runLoad();
     return () => {
       // Whatever is current, not this effect's own controller: a refetch swaps
@@ -419,7 +442,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
       loadControllerRef.current?.controller.abort();
       setIsLoadingThread(false);
     };
-  }, [runLoad]);
+  }, [runLoad, effectiveLoadKey, applySnapshot]);
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
@@ -577,6 +600,21 @@ export const useAdkRuntime = ({
   onThreadIdChange,
   ...options
 }: UseAdkRuntimeOptions) => {
+  const latestLoadRef = useRef(options.load);
+  latestLoadRef.current = options.load;
+  const latestLoad = useCallback<NonNullable<UseAdkRuntimeOptions["load"]>>(
+    (threadId, loadOptions) => {
+      const load = latestLoadRef.current;
+      if (!load) {
+        throw new Error("Google ADK history loading is not configured.");
+      }
+      return load(threadId, loadOptions);
+    },
+    [],
+  );
+  const runtimeOptions =
+    options.load === undefined ? options : { ...options, load: latestLoad };
+
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
@@ -592,8 +630,9 @@ export const useAdkRuntime = ({
 
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      return useAdkRuntimeImpl(options);
+      return useAdkRuntimeImpl(runtimeOptions);
     },
+    unstable_runtimeHookKey: getLoadKey(options.load, options.loadKey),
     adapter,
     allowNesting: true,
     onThreadIdChange,

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -203,7 +203,7 @@ export type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
    * Stable identifier for the backing load scope. Change it to clear and
    * reload the active thread when its account or workspace changes.
    */
-  loadKey?: PropertyKey | object | undefined;
+  loadKey?: PropertyKey | undefined;
   create?: () => Promise<{ externalId: string }>;
   delete?: (threadId: string) => Promise<void>;
   adapters?:
@@ -433,7 +433,10 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
       effectiveLoadKey,
     );
     previousLoadKeyRef.current = effectiveLoadKey;
-    if (loadKeyChanged) applySnapshot({ messages: [] });
+    if (loadKeyChanged) {
+      cancel();
+      applySnapshot({ messages: [] });
+    }
 
     runLoad();
     return () => {
@@ -442,7 +445,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
       loadControllerRef.current?.controller.abort();
       setIsLoadingThread(false);
     };
-  }, [runLoad, effectiveLoadKey, applySnapshot]);
+  }, [runLoad, effectiveLoadKey, applySnapshot, cancel]);
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),


### PR DESCRIPTION
## Summary

- add an explicit `loadKey` to identify the active Google ADK history scope
- clear and reload mounted thread runtimes when that key changes
- abort and ignore a stale in-flight load so an earlier account or workspace cannot overwrite the new one
- keep same-scope manual refetches wired to the latest `load` callback
- document the account/workspace switching pattern

## Why

Mounted ADK thread runtimes retained the first history loader. In an A-to-B workspace switch, B's `load()` was never called and A's messages remained visible. Depending on the callback identity directly is unsafe because documented inline callbacks would reload history on ordinary rerenders, so this uses an explicit stable scope key instead.

The small core hook key only refreshes mounted remote-thread hook closures when the caller supplies a changed scope key; existing runtimes keep their current memoization behavior.

## Testing

- regression: A-to-B key changes clear and load B
- regression: a delayed A response is aborted and cannot overwrite B
- regression: same-key manual refetch uses the newest loader callback
- `pnpm --dir packages/react-google-adk test` (234 tests)
- `pnpm --filter @assistant-ui/react-google-adk... build`
- `pnpm lint`
- filtered API-surface generation and check for core and React Google ADK

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FLIkIawogXerAVxo2QZKyyyDqcJUToLWgy8DlHZi_qXpn1nuhUMl76ckuNk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->