### PR TITLE
fix(x-buildutils): count direct react deps when picking the tap shim

### DIFF
--- a/.changeset/x-buildutils-react-direct-deps.md
+++ b/.changeset/x-buildutils-react-direct-deps.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: count direct react dependencies when selecting the tap shim target

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -10,32 +10,14 @@ const pkg = JSON.parse(
   readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
 );
 
-// In dev mode, run the package's `start` script after each successful build.
-// tsdown tree-kills the previous process and re-runs the command on every
-// rebuild, giving us watch + reload.
+// Dev mode: re-run the package's `start` script after every rebuild.
 let onSuccess: string | undefined;
 if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 
-// Route bare `react` imports through a tap shim so resource code can import
-// hooks from "react" and have them resolve to tap inside a resource render.
-// Done with output `paths` (remap of the external specifier) so the import
-// stays external and only the specifier is rewritten — `alias` does not affect
-// unbundled external imports. Exact specifiers only ("react" and
-// "react/compiler-runtime", the latter so React Compiler output's memo cache
-// routes to tap inside a resource render), so "react/jsx-runtime" and
-// "react-dom" are untouched.
-//
-// Applied to packages that actually depend on `@assistant-ui/tap` (so the
-// remapped shim specifier resolves for consumers) and to `@assistant-ui/tap`
-// itself so its React-facing hooks can share the same React 18 compatibility
-// shim. The target depends on whether the package declares react (peer or
-// direct): packages with one get the react-shim (falls back to real React
-// outside a tap render), while reactless packages — non-React framework
-// bridges like a vue binding — get the standalone-shim, whose graph never
-// imports react so the published output stays loadable without React
-// installed. Tap itself always keeps the react-shim (`isReactless` requires a
-// tap dependency, which tap lacks) and its React-facing entry needs the
-// real-React fallback.
+// Bare "react" imports in tap-dependent packages route to a tap shim via
+// output `paths` (`alias` can't rewrite unbundled external imports); exact
+// specifiers only, so "react/jsx-runtime" and "react-dom" stay untouched.
+// Reactless packages get the standalone-shim, whose graph never imports react.
 const dependsOnTap = ["dependencies", "peerDependencies"].some(
   (field) => pkg[field]?.["@assistant-ui/tap"],
 );
@@ -74,30 +56,20 @@ await build({
     neverBundle: [/^node:/, ...packageImportExternals],
     skipNodeModulesBundle: true,
   },
-  // Skip declaration files in dev for faster reloads.
   dts: isDev ? false : { sourcemap: true },
   sourcemap: true,
   watch: isDev,
   ...(onSuccess ? { onSuccess } : {}),
-  // React Compiler shares the dependency gate, narrowed to packages that
-  // declare a react peer: compiled output's memo cache only works inside tap
-  // renders through the shimmed `react/compiler-runtime`. Tap itself (which
-  // implements the hooks the compiler output runs on) must never be compiled,
-  // and neither must a non-React framework bridge, whose use-prefixed
-  // composables would otherwise gain memo caches that run outside any render
-  // the compiler understands.
+  // React Compiler only for tap+react packages: its memo cache needs the
+  // shimmed compiler-runtime, and tap itself must never be compiled.
   plugins: [
-    ...(dependsOnTap && pkg.peerDependencies?.react ? [reactCompiler()] : []),
+    ...(dependsOnTap && dependsOnReact ? [reactCompiler()] : []),
     preserveReferenceDirectives(),
   ],
 });
 
-// `output.paths` rewrites the `react` specifier in BOTH the emitted JS and the
-// declarations. Only the runtime (.js) should route through the shim (react-
-// or standalone-, whichever `shimBase` selected); declared types should
-// reference real `react` (so published `.d.ts` stay clean and the shim isn't
-// an editor auto-import source). When building tap itself, the
-// runtime shim files must also keep importing real `react` to avoid self-routing.
+// `output.paths` also rewrites declarations; published `.d.ts` must reference
+// real `react`, and tap's own shim runtime must not self-route.
 if (remapReactToShim && !isDev && existsSync("dist")) {
   for (const rel of readdirSync("dist", {
     recursive: true,

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -28,19 +28,23 @@ if (isDev && pkg.scripts?.start) onSuccess = pkg.scripts.start;
 // Applied to packages that actually depend on `@assistant-ui/tap` (so the
 // remapped shim specifier resolves for consumers) and to `@assistant-ui/tap`
 // itself so its React-facing hooks can share the same React 18 compatibility
-// shim. The target depends on whether the package declares a react peer:
-// packages with one get the react-shim (falls back to real React outside a tap
-// render), while reactless packages — non-React framework bridges like a vue
-// binding — get the standalone-shim, whose graph never imports react so the
-// published output stays loadable without React installed. Tap itself always
-// keeps the react-shim (`isReactless` requires a tap dependency, which tap
-// lacks) and its React-facing entry needs the real-React fallback.
+// shim. The target depends on whether the package declares react (peer or
+// direct): packages with one get the react-shim (falls back to real React
+// outside a tap render), while reactless packages — non-React framework
+// bridges like a vue binding — get the standalone-shim, whose graph never
+// imports react so the published output stays loadable without React
+// installed. Tap itself always keeps the react-shim (`isReactless` requires a
+// tap dependency, which tap lacks) and its React-facing entry needs the
+// real-React fallback.
 const dependsOnTap = ["dependencies", "peerDependencies"].some(
   (field) => pkg[field]?.["@assistant-ui/tap"],
 );
+const dependsOnReact = ["dependencies", "peerDependencies"].some(
+  (field) => pkg[field]?.react,
+);
 const isTapPackage = pkg.name === "@assistant-ui/tap";
 const remapReactToShim = dependsOnTap || isTapPackage;
-const isReactless = dependsOnTap && !pkg.peerDependencies?.react;
+const isReactless = dependsOnTap && !dependsOnReact;
 const shimBase = isReactless
   ? "@assistant-ui/tap/standalone-shim"
   : "@assistant-ui/tap/react-shim";


### PR DESCRIPTION
`isReactless` decided the shim target from `peerDependencies.react` alone, so a tap-dependent package declaring react as a direct dependency was wrongly routed through the standalone-shim. It now checks both `dependencies` and `peerDependencies`, mirroring the `dependsOnTap` probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uG9PSajneBuOVuefoUEgcvLQvw0ueWfj3hWFAuRac6o0jzbJI7aE9f76Vd4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->