### PR TITLE
test(tap): deterministic waits for scheduler flushes

### DIFF
--- a/.changeset/tap-deterministic-flush-wait.md
+++ b/.changeset/tap-deterministic-flush-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+test: wait deterministically for scheduler flushes instead of racing setTimeout against MessageChannel

--- a/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
+++ b/packages/tap/src/__tests__/lifecycle/createTapRoot.mount-on-subscribe.test.ts
@@ -8,11 +8,10 @@ import { useMemo } from "../../react-hooks/useMemo";
 import { useRef } from "../../react-hooks/useRef";
 import { useState } from "../../react-hooks/useState";
 import { isDevelopment } from "../../core/helpers/env";
+import { waitForNextTick as flushUpdates } from "../test-utils";
 
 const mountRuns = isDevelopment ? 2 : 1;
 const remountEvents = isDevelopment ? ["mount", "unmount", "mount"] : ["mount"];
-
-const flushUpdates = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const createCounterRoot = () => {
   let setCount: (value: number) => void;

--- a/packages/tap/src/__tests__/scheduler.update-depth.test.ts
+++ b/packages/tap/src/__tests__/scheduler.update-depth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { UpdateScheduler, flushTapSync } from "../core/scheduler";
+import { waitForNextTick } from "./test-utils";
 
 describe("scheduler update depth", () => {
   it("runs many independent schedulers in one flush without tripping the limit", async () => {
@@ -10,7 +11,7 @@ describe("scheduler update depth", () => {
     );
 
     for (const scheduler of schedulers) scheduler.markDirty();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitForNextTick();
 
     expect(runCount).toBe(60);
     expect(schedulers.every((scheduler) => !scheduler.isDirty)).toBe(true);

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -206,9 +206,6 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
  * Useful for testing async state updates.
  */
 export function waitForNextTick(): Promise<void> {
-  // The scheduler flushes via MessageChannel; under CI load a bare
-  // setTimeout(0) can fire before an already-posted flush message. Round-trip
-  // the message queue first (FIFO behind any pending flush), then a timer tick
   return new Promise((resolve) => {
     const channel = new MessageChannel();
     channel.port1.onmessage = () => {

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -206,7 +206,17 @@ export class TestResourceManager<R, A extends readonly unknown[]> {
  * Useful for testing async state updates.
  */
 export function waitForNextTick(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
+  // The scheduler flushes via MessageChannel; under CI load a bare
+  // setTimeout(0) can fire before an already-posted flush message. Round-trip
+  // the message queue first (FIFO behind any pending flush), then a timer tick
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      setTimeout(resolve, 0);
+    };
+    channel.port2.postMessage(null);
+  });
 }
 
 /**


### PR DESCRIPTION
## What

Hardens the two tap test sites that wait for a scheduler flush with a bare `setTimeout(0)`:

- `waitForNextTick` in `test-utils.ts` now round-trips a `MessageChannel` message before the timer tick. The scheduler posts its flush on a MessageChannel; a message posted afterward is FIFO behind it, so awaiting our own round-trip guarantees any pending flush has run. The trailing `setTimeout(0)` keeps the old timer-queue semantics for callers that depend on them.
- `createTapRoot.mount-on-subscribe.test.ts` drops its local `flushUpdates` (a bare timer) for the hardened helper; `scheduler.update-depth.test.ts` likewise.

The `scheduler.lazy-channel.test.ts` waits are untouched — that file stubs `MessageChannel` with microtask delivery, so its timer waits are already deterministic.

## Why

Two CI-only flakes came from the same race: under CI load, `setTimeout(0)` can fire before an already-posted MessageChannel flush message, so the test observes the pre-flush state.

- `scheduler.update-depth.test.ts` "runs many independent schedulers in one flush" failed with `expected +0 to be 60` (PR #5848 CI).
- `createTapRoot.mount-on-subscribe.test.ts` "dev strict mode double invokes effects on every connect" failed with `expected ... 4 times, but got 2 times` (PR #5850 CI) — `flushUpdates()` returned before the unmount flush landed, so the resubscribe found the fiber still mounted.

Both pass reliably locally (5/5) and are pre-existing tests; the race is in the wait, not the scheduler.

## How verified

Full tap suite green (528 tests). The failure mode is CI-load-dependent, so there is no local repro to flip; the argument is ordering: the HTML/Node message task source is FIFO, so a round-trip posted after the scheduler's flush post cannot resolve before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YFsjQbyhQBm3b5o67wzxrQ46vpfkLhBuMLeZrOx7LajoZeoS7We8GYEkcQM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->