### PR TITLE
refactor(tap): shared scheduleTask for one-off deferred work

### DIFF
--- a/.changeset/tap-default-task-scheduler.md
+++ b/.changeset/tap-default-task-scheduler.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+refactor: add a shared scheduleTask for one-off deferred work instead of allocating single-purpose UpdateScheduler instances

--- a/packages/tap/src/__tests__/scheduler.schedule-task.test.ts
+++ b/packages/tap/src/__tests__/scheduler.schedule-task.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { scheduleTask, flushTapSync } from "../core/scheduler";
+
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("scheduleTask", () => {
+  it("runs tasks in order on the next flush", async () => {
+    const order: number[] = [];
+    scheduleTask(() => order.push(1));
+    scheduleTask(() => order.push(2));
+
+    expect(order).toEqual([]);
+    await nextTick();
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("runs inside flushTapSync", () => {
+    let ran = false;
+    flushTapSync(() => scheduleTask(() => (ran = true)));
+    expect(ran).toBe(true);
+  });
+
+  it("runs a task scheduled by another task in the same flush", () => {
+    const order: number[] = [];
+    flushTapSync(() =>
+      scheduleTask(() => {
+        order.push(1);
+        scheduleTask(() => order.push(2));
+      }),
+    );
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("keeps running later tasks when one throws and rethrows aggregated", () => {
+    const order: number[] = [];
+    expect(() =>
+      flushTapSync(() => {
+        scheduleTask(() => {
+          throw new Error("boom");
+        });
+        scheduleTask(() => order.push(2));
+      }),
+    ).toThrow(/boom/);
+    expect(order).toEqual([2]);
+  });
+
+  it("trips the update depth limit on a self-rescheduling task", () => {
+    let runs = 0;
+    const loop = () => {
+      runs++;
+      scheduleTask(loop);
+    };
+
+    expect(() => flushTapSync(() => scheduleTask(loop))).toThrow(
+      /Maximum update depth exceeded/,
+    );
+    expect(runs).toBeGreaterThan(0);
+    expect(runs).toBeLessThanOrEqual(50);
+  });
+});

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -58,8 +58,6 @@ export const createTapRoot = <R>(
   }
 
   let subscriberCount = 0;
-  // isMounted guards against double-unmount: unlike a dedicated scheduler,
-  // queued one-off tasks do not dedupe across unsubscribe/resubscribe cycles
   const scheduleUnmount = () =>
     scheduleTask(() => {
       if (subscriberCount === 0 && fiber.isMounted) unmountResourceFiber(fiber);

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -6,7 +6,7 @@ import {
 } from "./ResourceFiber";
 import { useTapRoot } from "../hooks/useTapRoot";
 import { isDevelopment } from "./helpers/env";
-import { flushTapSync, UpdateScheduler } from "./scheduler";
+import { flushTapSync, scheduleTask } from "./scheduler";
 import { createResourceFiberRoot } from "./helpers/root";
 import { isThenable } from "./helpers/thenable";
 
@@ -41,8 +41,8 @@ export const createTapRoot = <R>(
     }
   };
 
-  const commitScheduler = new UpdateScheduler(() => commitResourceFiber(fiber));
-  const commitFiber = () => flushTapSync(() => commitScheduler.markDirty());
+  const commitFiber = () =>
+    flushTapSync(() => scheduleTask(() => commitResourceFiber(fiber)));
 
   let root: useTapRoot.Root<R> | undefined;
   const ensureRoot = () => (root ??= renderFiber());
@@ -58,9 +58,12 @@ export const createTapRoot = <R>(
   }
 
   let subscriberCount = 0;
-  const unmountScheduler = new UpdateScheduler(() => {
-    if (subscriberCount === 0) unmountResourceFiber(fiber);
-  });
+  // isMounted guards against double-unmount: unlike a dedicated scheduler,
+  // queued one-off tasks do not dedupe across unsubscribe/resubscribe cycles
+  const scheduleUnmount = () =>
+    scheduleTask(() => {
+      if (subscriberCount === 0 && fiber.isMounted) unmountResourceFiber(fiber);
+    });
 
   return {
     getValue: () => ensureRoot().getValue(),
@@ -85,7 +88,7 @@ export const createTapRoot = <R>(
         if (!isSubscribed) return;
         isSubscribed = false;
         unsubscribe();
-        if (--subscriberCount === 0) unmountScheduler.markDirty();
+        if (--subscriberCount === 0) scheduleUnmount();
       };
     },
     unmount: () => {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -54,6 +54,29 @@ export class UpdateScheduler {
   }
 }
 
+const scheduledTasks: Task[] = [];
+const taskScheduler = new UpdateScheduler(() => {
+  const tasks = scheduledTasks.splice(0);
+  const errors: unknown[] = [];
+  for (const task of tasks) {
+    try {
+      task();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  throwAggregated(errors, "Errors occurred while running scheduled tasks");
+});
+
+// One-off deferred work rides a single shared scheduler so a task loop still
+// trips the per-scheduler update depth limit.
+export const scheduleTask = (task: Task): void => {
+  // markDirty first: at the update depth limit it throws, and the task must
+  // not stay queued for an unrelated later flush
+  taskScheduler.markDirty();
+  scheduledTasks.push(task);
+};
+
 export const scheduleNotify = (notify: () => void): void => {
   if (activeDrainRuns !== null) {
     pendingNotifies.push(notify);

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -68,11 +68,7 @@ const taskScheduler = new UpdateScheduler(() => {
   throwAggregated(errors, "Errors occurred while running scheduled tasks");
 });
 
-// One-off deferred work rides a single shared scheduler so a task loop still
-// trips the per-scheduler update depth limit.
 export const scheduleTask = (task: Task): void => {
-  // markDirty first: at the update depth limit it throws, and the task must
-  // not stay queued for an unrelated later flush
   taskScheduler.markDirty();
   scheduledTasks.push(task);
 };


### PR DESCRIPTION
## What

Adds a module-level `scheduleTask(task)` to tap's scheduler for one-off deferred work, and migrates `createTapRoot`'s two single-purpose `UpdateScheduler` instances (`commitScheduler`, `unmountScheduler`) onto it.

## Why

Allocating an `UpdateScheduler` whose only job is "run this callback inside a flush" is a hack: the class exists for recurring, deduped tasks (a root's render/update loop), not for firing a one-off. `scheduleTask` names the actual intent.

## How

- `scheduleTask` enqueues onto a single shared internal `UpdateScheduler` that drains a task queue. Sharing one instance is deliberate: the update-depth limit counts per scheduler, so a self-rescheduling task still trips `Maximum update depth exceeded` (a per-call `new UpdateScheduler(task).markDirty()` would evade the loop guard). Errors aggregate per task so one throwing task doesn't starve the rest.
- `markDirty()` runs before the push so a task rejected at the depth limit is never left queued for an unrelated later flush.
- `createTapRoot`'s unmount path gains an `fiber.isMounted` guard: queued one-off tasks don't dedupe across rapid unsubscribe/resubscribe cycles the way a dedicated scheduler's dirty flag did.
- `useTapRoot`'s scheduler stays: its task is recurring and the dirty-dedup is the point.

Not exported from the package barrel; internal to tap for now.

## Tests

New `scheduler.schedule-task.test.ts` contract suite: ordering, flushTapSync integration, task-scheduled-during-task, error aggregation, and the depth-limit trip. Full tap suite passes (539 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.x_17cCk-_DCDvDNqOqmQtWUEnVHl3Trbh2bbJmztf5hmJEhKxqkc8aYxvXs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->