### PR TITLE
docs(tap): repitch README around the hook-dispatch engine

### DIFF
--- a/.changeset/tap-readme-pitch.md
+++ b/.changeset/tap-readme-pitch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+docs: repitch the README around the hook-dispatch engine and its two use cases

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -7,7 +7,7 @@
 
 React's hook engine, reimplemented. Hooks can run standalone, which unlocks:
 
-1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
+1. **Hooks for state management** — use React hooks to power an external store, outside your UI tree or outside React entirely.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.
 
 Documentation: [assistant-ui.com/tap](https://www.assistant-ui.com/tap)

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,7 +5,7 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-A separate implementation of React's hook-dispatch engine, unlocking two use cases:
+React's hook engine, reimplemented. Hooks no longer need a React tree, which unlocks:
 
 1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -10,8 +10,6 @@ A separate implementation of React's hook-dispatch engine, unlocking two use cas
 1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.
 
-You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
-
 Documentation: [assistant-ui.com/tap](https://www.assistant-ui.com/tap)
 
 ## Installation
@@ -22,35 +20,9 @@ npm install @assistant-ui/tap
 
 ## Built on tap
 
-### [`tap-vue`](https://www.npmjs.com/package/tap-vue) — React hooks in Vue
-
-`toComposable(hook)` turns a React hook into a Vue composable. tap runs the hook — state, effects, cleanup — and tap-vue bridges the result into Vue's reactivity as a `ShallowRef`.
-
-```ts
-import { useState } from "react";
-import { toComposable } from "tap-vue";
-
-const useCount = (initialValue: number) => {
-  const [count, setCount] = useState(initialValue);
-  return { count, bump: () => setCount((c) => c + 1) };
-};
-
-const useVueCount = toComposable(useCount);
-```
-
-### [`jotai-tap`](https://www.npmjs.com/package/jotai-tap) — React hooks as Jotai atoms
-
-`atomWithHook(hook)` runs a React hook and exposes its return value as a read-only atom. The hook follows the atom's lifecycle: it renders lazily on first read, mounts with the first subscriber, and unmounts with the last one.
-
-```tsx
-import { atomWithHook } from "jotai-tap";
-
-const clockAtom = atomWithHook(useClock);
-```
-
-### [`@assistant-ui/store`](https://www.npmjs.com/package/@assistant-ui/store) — the state layer of assistant-ui
-
-The client tree behind `@assistant-ui/react`: every scope (thread, composer, message, ...) is a hook-powered resource, hosted inside React by the provider or standalone via `createAssistantClient`. tap is what lets the same runtime code run in both worlds.
+- [`tap-vue`](https://github.com/assistant-ui/tap-vue) — use React hooks in Vue
+- [`jotai-tap`](https://github.com/assistant-ui/jotai-tap) — use React hooks to power Jotai atoms
+- [`@assistant-ui/store`](https://github.com/assistant-ui/assistant-ui/tree/main/packages/store) — the state layer of assistant-ui
 
 ## Resources
 

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,7 +5,7 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-React's hook engine, reimplemented. Hooks no longer need a React tree, which unlocks:
+React's hook engine, reimplemented. Hooks can run standalone, which unlocks:
 
 1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,9 +5,14 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-React's hooks, headless. Write a **resource** the same way you write a component, with the same hooks (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules, except a resource returns a plain value instead of JSX. It runs inside a React component, inside another resource, or standalone with no React tree at all.
+A separate implementation of React's hook-dispatch engine. You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
 
-`tap` powers the runtime layer of assistant-ui. Most users do not install it directly; reach for `@assistant-ui/react` instead.
+That unlocks two use cases:
+
+1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
+2. **Resources** — render hooks dynamically inside React, changing the number and type of hooks a component renders.
+
+`tap` powers the runtime layer of assistant-ui.
 
 ## Installation
 
@@ -15,7 +20,9 @@ React's hooks, headless. Write a **resource** the same way you write a component
 npm install @assistant-ui/tap
 ```
 
-## Usage
+## Standalone hooks
+
+Use React hooks to power an external store. `createTapRoot` hosts a hook with no React tree at all, drives its render/effect lifecycle, and exposes the result as a subscribable store:
 
 ```typescript
 import { resource, createTapRoot, useResource } from "@assistant-ui/tap";
@@ -47,7 +54,21 @@ const unsubscribe = counter.subscribe(() => {
 counter.getValue().increment();
 ```
 
-In React, host a resource with `useResource`:
+Libraries built on this:
+
+- [`tap-vue`](https://www.npmjs.com/package/tap-vue) — use React hooks in Vue
+- [`jotai-tap`](https://www.npmjs.com/package/jotai-tap) — use React hooks to power Jotai atoms
+- [`@assistant-ui/store`](https://www.npmjs.com/package/@assistant-ui/store) — the state layer of assistant-ui, a client tree powered by hooks
+
+## Resources
+
+A **resource** is written like a component — same hooks, same rules — except it returns a plain value instead of JSX. Each resource is its own hook boundary, so a component can change the number and type of hooks it renders between renders. That unlocks what the rules of hooks normally forbid:
+
+- **Conditionally rendering hooks** — mount a resource only when a condition holds
+- **Rendering hooks in a list** — one resource per item, keyed like elements
+- **Safely consuming hooks from props** — accept a resource element as a prop and mount it
+
+Host a single resource with `useResource`:
 
 ```tsx
 import { useResource } from "@assistant-ui/tap";
@@ -55,6 +76,19 @@ import { useResource } from "@assistant-ui/tap";
 function CounterButton() {
   const { count, increment } = useResource(Counter({ incrementBy: 1 }));
   return <button onClick={increment}>{count}</button>;
+}
+```
+
+Render a dynamic list of hooks with `useResources`:
+
+```tsx
+import { useResources, withKey } from "@assistant-ui/tap";
+
+function Counters({ ids }: { ids: string[] }) {
+  const counters = useResources(
+    ids.map((id) => withKey(id, Counter({ incrementBy: 1 }))),
+  );
+  return <div>{counters.map((c) => c.count).join(", ")}</div>;
 }
 ```
 

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,12 +5,27 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
+A separate implementation of React's hook-dispatch engine, unlocking two use cases:
+
 1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.
 
-Under the hood, tap is a separate implementation of React's hook-dispatch engine. You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
+You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
 
-`tap` powers the runtime layer of assistant-ui.
+A resource is a hook wrapped in its own hook boundary, so mounting one conditionally is allowed:
+
+```tsx
+import { resource, useResources } from "@assistant-ui/tap";
+
+const Session = resource(useSession);
+
+function App({ user }: { user: User | null }) {
+  const [session] = useResources(user ? [Session({ userId: user.id })] : []);
+  // ...
+}
+```
+
+Documentation: [assistant-ui.com/tap](https://www.assistant-ui.com/tap)
 
 ## Installation
 
@@ -18,83 +33,37 @@ Under the hood, tap is a separate implementation of React's hook-dispatch engine
 npm install @assistant-ui/tap
 ```
 
-## Standalone hooks
+## Built on tap
 
-Use React hooks to power an external store. `createTapRoot` hosts a hook with no React tree at all, drives its render/effect lifecycle, and exposes the result as a subscribable store:
+### [`tap-vue`](https://www.npmjs.com/package/tap-vue) — React hooks in Vue
 
-```typescript
-import { resource, createTapRoot, useResource } from "@assistant-ui/tap";
-import { useState, useEffect } from "react";
+`toComposable(hook)` turns a React hook into a Vue composable. tap runs the hook — state, effects, cleanup — and tap-vue bridges the result into Vue's reactivity as a `ShallowRef`.
 
-const useCounter = ({ incrementBy = 1 }: { incrementBy?: number }) => {
-  const [count, setCount] = useState(0);
+```ts
+import { useState } from "react";
+import { toComposable } from "tap-vue";
 
-  useEffect(() => {
-    console.log("count:", count);
-  }, [count]);
-
-  return {
-    count,
-    increment: () => setCount((c) => c + incrementBy),
-  };
+const useCount = (initialValue: number) => {
+  const [count, setCount] = useState(initialValue);
+  return { count, bump: () => setCount((c) => c + 1) };
 };
 
-const Counter = resource(useCounter);
-
-const counter = createTapRoot(function CounterRoot() {
-  return useResource(Counter({ incrementBy: 2 }));
-});
-
-const unsubscribe = counter.subscribe(() => {
-  console.log("counter updated:", counter.getValue().count);
-});
-
-counter.getValue().increment();
+const useVueCount = toComposable(useCount);
 ```
 
-Libraries built on this:
+### [`jotai-tap`](https://www.npmjs.com/package/jotai-tap) — React hooks as Jotai atoms
 
-- [`tap-vue`](https://www.npmjs.com/package/tap-vue) — use React hooks in Vue
-- [`jotai-tap`](https://www.npmjs.com/package/jotai-tap) — use React hooks to power Jotai atoms
-- [`@assistant-ui/store`](https://www.npmjs.com/package/@assistant-ui/store) — the state layer of assistant-ui, a client tree powered by hooks
-
-## Resources
-
-A **resource** is written like a component — same hooks, same rules — except it returns a plain value instead of JSX. Each resource is its own hook boundary, so a component can change the number and type of hooks it renders between renders. That unlocks what the rules of hooks normally forbid:
-
-- **Conditionally rendering hooks** — mount a resource only when a condition holds
-- **Rendering hooks in a list** — one resource per item, keyed like elements
-- **Safely consuming hooks from props** — accept a resource element as a prop and mount it
-
-Host a single resource with `useResource`:
+`atomWithHook(hook)` runs a React hook and exposes its return value as a read-only atom. The hook follows the atom's lifecycle: it renders lazily on first read, mounts with the first subscriber, and unmounts with the last one.
 
 ```tsx
-import { useResource } from "@assistant-ui/tap";
+import { atomWithHook } from "jotai-tap";
 
-function CounterButton() {
-  const { count, increment } = useResource(Counter({ incrementBy: 1 }));
-  return <button onClick={increment}>{count}</button>;
-}
+const clockAtom = atomWithHook(useClock);
 ```
 
-Render a dynamic list of hooks with `useResources`:
+### [`@assistant-ui/store`](https://www.npmjs.com/package/@assistant-ui/store) — the state layer of assistant-ui
 
-```tsx
-import { useResources, withKey } from "@assistant-ui/tap";
-
-function Counters({ ids }: { ids: string[] }) {
-  const counters = useResources(
-    ids.map((id) => withKey(id, Counter({ incrementBy: 1 }))),
-  );
-  return <div>{counters.map((c) => c.count).join(", ")}</div>;
-}
-```
-
-## Hooks
-
-Inside a resource you use React's hooks (`useState`, `useEffect`, `useMemo`, `useCallback`, `useRef`, `use`, ...) imported from `"react"`. tap adds `useResource` / `useResources` / `useTapRoot` for composition and `useContextProvider` for context.
-
-Full API reference at [assistant-ui.com/tap/docs](https://www.assistant-ui.com/tap/docs).
+The client tree behind `@assistant-ui/react`: every scope (thread, composer, message, ...) is a hook-powered resource, hosted inside React by the provider or standalone via `createAssistantClient`. tap is what lets the same runtime code run in both worlds.
 
 ## License
 

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,12 +5,10 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-A separate implementation of React's hook-dispatch engine. You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
-
-That unlocks two use cases:
-
 1. **Standalone hooks** — use React hooks to power an external store, outside your UI tree or outside React entirely.
-2. **Resources** — render hooks dynamically inside React, changing the number and type of hooks a component renders.
+2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.
+
+Under the hood, tap is a separate implementation of React's hook-dispatch engine. You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
 
 `tap` powers the runtime layer of assistant-ui.
 

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,9 +5,9 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-React's hook engine, reimplemented. Hooks can run standalone, which unlocks:
+React's hook engine, reimplemented. Same hooks, same rules, no React tree required:
 
-1. **Hooks for state management** — use React hooks to power an external store, outside your UI tree or outside React entirely.
+1. **Hooks for state management** — use React hooks to power an external store, even outside React.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.
 
 Documentation: [assistant-ui.com/tap](https://www.assistant-ui.com/tap)
@@ -22,22 +22,7 @@ npm install @assistant-ui/tap
 
 - [`tap-vue`](https://github.com/assistant-ui/tap-vue) — use React hooks in Vue
 - [`jotai-tap`](https://github.com/assistant-ui/jotai-tap) — use React hooks to power Jotai atoms
-- [`@assistant-ui/store`](https://github.com/assistant-ui/assistant-ui/tree/main/packages/store) — the state layer of assistant-ui
-
-## Resources
-
-A resource is a hook wrapped in its own hook boundary, so mounting one conditionally is allowed:
-
-```tsx
-import { resource, useResources } from "@assistant-ui/tap";
-
-const Session = resource(useSession);
-
-function App({ user }: { user: User | null }) {
-  const [session] = useResources(user ? [Session({ userId: user.id })] : []);
-  // ...
-}
-```
+- [`@assistant-ui/store`](https://github.com/assistant-ui/assistant-ui/tree/main/packages/store) — use React hooks to power assistant-ui's client state
 
 ## License
 

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -5,7 +5,7 @@
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@assistant-ui/tap)](https://bundlephobia.com/package/@assistant-ui/tap)
 [![GitHub stars](https://img.shields.io/github/stars/assistant-ui/assistant-ui)](https://github.com/assistant-ui/assistant-ui)
 
-React's hook engine, reimplemented. Same hooks, same rules, no React tree required:
+React's hook engine, reimplemented. Same hooks, same rules, no React tree required. It enables:
 
 1. **Hooks for state management** — use React hooks to power an external store, even outside React.
 2. **Resources** — render hooks dynamically inside React: conditionally, in a list, or from props.

--- a/packages/tap/README.md
+++ b/packages/tap/README.md
@@ -12,19 +12,6 @@ A separate implementation of React's hook-dispatch engine, unlocking two use cas
 
 You write hooks with the same primitives (`useState`, `useEffect`, `useMemo`, ...) imported from `"react"` and the same rules — tap supplies its own dispatcher underneath, so the hooks no longer depend on a React tree to run.
 
-A resource is a hook wrapped in its own hook boundary, so mounting one conditionally is allowed:
-
-```tsx
-import { resource, useResources } from "@assistant-ui/tap";
-
-const Session = resource(useSession);
-
-function App({ user }: { user: User | null }) {
-  const [session] = useResources(user ? [Session({ userId: user.id })] : []);
-  // ...
-}
-```
-
 Documentation: [assistant-ui.com/tap](https://www.assistant-ui.com/tap)
 
 ## Installation
@@ -64,6 +51,21 @@ const clockAtom = atomWithHook(useClock);
 ### [`@assistant-ui/store`](https://www.npmjs.com/package/@assistant-ui/store) — the state layer of assistant-ui
 
 The client tree behind `@assistant-ui/react`: every scope (thread, composer, message, ...) is a hook-powered resource, hosted inside React by the provider or standalone via `createAssistantClient`. tap is what lets the same runtime code run in both worlds.
+
+## Resources
+
+A resource is a hook wrapped in its own hook boundary, so mounting one conditionally is allowed:
+
+```tsx
+import { resource, useResources } from "@assistant-ui/tap";
+
+const Session = resource(useSession);
+
+function App({ user }: { user: User | null }) {
+  const [session] = useResources(user ? [Session({ userId: user.id })] : []);
+  // ...
+}
+```
 
 ## License
 


### PR DESCRIPTION
## What

Rewrites the tap README pitch: tap is a separate implementation of React's hook-dispatch engine, with two use cases —

1. **Standalone hooks** — use React hooks to power an external store (outside the UI tree, or outside React entirely), with `tap-vue`, `jotai-tap`, and `@assistant-ui/store` listed as libraries built on it.
2. **Resources** — render hooks dynamically: conditionally, in a list, and safely from props.

Code examples reuse the existing counter and add a `useResources` + `withKey` list example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.N5iP4o8uIK9IqrohNJruZKVyLdeV5VHmxZq3aN9P8z0AK2l13kVy_OWEUrw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->