### PR TITLE
fix(react-mcp): handle server connection action failures

### DIFF
--- a/.changeset/tidy-mice-connect.md
+++ b/.changeset/tidy-mice-connect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: handle rejected MCP server connect and disconnect actions

--- a/packages/react-mcp/src/primitives/server/McpServerConnectButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerConnectButton.tsx
@@ -29,7 +29,7 @@ export const McpServerPrimitiveConnectButton = forwardRef<
       onClick={(e) => {
         props.onClick?.(e);
         if (e.defaultPrevented) return;
-        void aui.mcpServer.connect();
+        void aui.mcpServer.connect().catch(() => undefined);
       }}
     />
   );

--- a/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
@@ -1,5 +1,6 @@
 import type { AssistantState } from "@assistant-ui/store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { captureUnhandledRejections } from "./test-utils";
 
 const mocks = vi.hoisted(() => ({
   connect: vi.fn<() => Promise<void>>(),
@@ -32,19 +33,6 @@ const { McpServerPrimitiveConnectButton } =
   await import("./McpServerConnectButton");
 const { McpServerPrimitiveDisconnectButton } =
   await import("./McpServerDisconnectButton");
-
-const captureUnhandledRejections = async (callback: () => void) => {
-  const reasons: unknown[] = [];
-  const listener = (reason: unknown) => reasons.push(reason);
-  process.on("unhandledRejection", listener);
-  try {
-    callback();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    return reasons;
-  } finally {
-    process.off("unhandledRejection", listener);
-  }
-};
 
 type Button = {
   props: {

--- a/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
@@ -33,6 +33,19 @@ const { McpServerPrimitiveConnectButton } =
 const { McpServerPrimitiveDisconnectButton } =
   await import("./McpServerDisconnectButton");
 
+const captureUnhandledRejections = async (callback: () => void) => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
+
 type Button = {
   props: {
     onClick: (event: { defaultPrevented: boolean }) => void;
@@ -53,32 +66,42 @@ describe("MCP server connection buttons", () => {
     mocks.connectionState = "disconnected";
   });
 
-  it("handles rejected connect actions", () => {
-    const action = Promise.reject(new Error("connection failed"));
-    const catchSpy = vi.spyOn(action, "catch");
-    void action.then(undefined, () => undefined);
-    mocks.connect.mockReturnValueOnce(action);
+  it("renders only the connect action while disconnected", () => {
+    expect(renderButton(McpServerPrimitiveConnectButton)).not.toBeNull();
+    expect(renderButton(McpServerPrimitiveDisconnectButton)).toBeNull();
+  });
 
-    renderButton(McpServerPrimitiveConnectButton)?.props.onClick({
-      defaultPrevented: false,
+  it("renders only the disconnect action while connected", () => {
+    mocks.connectionState = "connected";
+
+    expect(renderButton(McpServerPrimitiveConnectButton)).toBeNull();
+    expect(renderButton(McpServerPrimitiveDisconnectButton)).not.toBeNull();
+  });
+
+  it("handles rejected connect actions", async () => {
+    mocks.connect.mockRejectedValueOnce(new Error("connection failed"));
+
+    const unhandledRejections = await captureUnhandledRejections(() => {
+      renderButton(McpServerPrimitiveConnectButton)!.props.onClick({
+        defaultPrevented: false,
+      });
     });
 
     expect(mocks.connect).toHaveBeenCalledOnce();
-    expect(catchSpy).toHaveBeenCalledOnce();
+    expect(unhandledRejections).toEqual([]);
   });
 
-  it("handles rejected disconnect actions", () => {
+  it("handles rejected disconnect actions", async () => {
     mocks.connectionState = "connected";
-    const action = Promise.reject(new Error("cleanup failed"));
-    const catchSpy = vi.spyOn(action, "catch");
-    void action.then(undefined, () => undefined);
-    mocks.disconnect.mockReturnValueOnce(action);
+    mocks.disconnect.mockRejectedValueOnce(new Error("cleanup failed"));
 
-    renderButton(McpServerPrimitiveDisconnectButton)?.props.onClick({
-      defaultPrevented: false,
+    const unhandledRejections = await captureUnhandledRejections(() => {
+      renderButton(McpServerPrimitiveDisconnectButton)!.props.onClick({
+        defaultPrevented: false,
+      });
     });
 
     expect(mocks.disconnect).toHaveBeenCalledOnce();
-    expect(catchSpy).toHaveBeenCalledOnce();
+    expect(unhandledRejections).toEqual([]);
   });
 });

--- a/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerConnectionButtons.test.tsx
@@ -1,0 +1,84 @@
+import type { AssistantState } from "@assistant-ui/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn<() => Promise<void>>(),
+  disconnect: vi.fn<() => Promise<void>>(),
+  connectionState: "disconnected" as
+    | "disconnected"
+    | "connected"
+    | "connecting"
+    | "authPending"
+    | "authRequired"
+    | "error",
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => ({
+    mcpServer: {
+      connect: mocks.connect,
+      disconnect: mocks.disconnect,
+    },
+  }),
+  useAuiState: function useAuiState<T>(selector: (state: AssistantState) => T) {
+    return selector({
+      mcpServer: { connectionState: mocks.connectionState },
+    } as AssistantState);
+  },
+}));
+
+const { McpServerPrimitiveConnectButton } =
+  await import("./McpServerConnectButton");
+const { McpServerPrimitiveDisconnectButton } =
+  await import("./McpServerDisconnectButton");
+
+type Button = {
+  props: {
+    onClick: (event: { defaultPrevented: boolean }) => void;
+  };
+};
+
+const renderButton = (component: unknown): Button | null =>
+  (
+    component as {
+      render: (props: Record<string, unknown>, ref: null) => Button | null;
+    }
+  ).render({}, null);
+
+describe("MCP server connection buttons", () => {
+  beforeEach(() => {
+    mocks.connect.mockReset();
+    mocks.disconnect.mockReset();
+    mocks.connectionState = "disconnected";
+  });
+
+  it("handles rejected connect actions", () => {
+    const action = Promise.reject(new Error("connection failed"));
+    const catchSpy = vi.spyOn(action, "catch");
+    void action.then(undefined, () => undefined);
+    mocks.connect.mockReturnValueOnce(action);
+
+    renderButton(McpServerPrimitiveConnectButton)?.props.onClick({
+      defaultPrevented: false,
+    });
+
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(catchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("handles rejected disconnect actions", () => {
+    mocks.connectionState = "connected";
+    const action = Promise.reject(new Error("cleanup failed"));
+    const catchSpy = vi.spyOn(action, "catch");
+    void action.then(undefined, () => undefined);
+    mocks.disconnect.mockReturnValueOnce(action);
+
+    renderButton(McpServerPrimitiveDisconnectButton)?.props.onClick({
+      defaultPrevented: false,
+    });
+
+    expect(mocks.disconnect).toHaveBeenCalledOnce();
+    expect(catchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-mcp/src/primitives/server/McpServerDisconnectButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerDisconnectButton.tsx
@@ -28,7 +28,7 @@ export const McpServerPrimitiveDisconnectButton = forwardRef<
       onClick={(e) => {
         props.onClick?.(e);
         if (e.defaultPrevented) return;
-        void aui.mcpServer.disconnect();
+        void aui.mcpServer.disconnect().catch(() => undefined);
       }}
     />
   );

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
@@ -1,5 +1,6 @@
 import type { AssistantState } from "@assistant-ui/store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { captureUnhandledRejections } from "./test-utils";
 
 const mocks = vi.hoisted(() => ({
   remove: vi.fn<() => Promise<void>>(),
@@ -18,19 +19,6 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 
 const { McpServerPrimitiveRemoveButton } =
   await import("./McpServerRemoveButton");
-
-const captureUnhandledRejections = async (callback: () => void) => {
-  const reasons: unknown[] = [];
-  const listener = (reason: unknown) => reasons.push(reason);
-  process.on("unhandledRejection", listener);
-  try {
-    callback();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    return reasons;
-  } finally {
-    process.off("unhandledRejection", listener);
-  }
-};
 
 const renderButton = () =>
   (

--- a/packages/react-mcp/src/primitives/server/test-utils.ts
+++ b/packages/react-mcp/src/primitives/server/test-utils.ts
@@ -1,0 +1,12 @@
+export const captureUnhandledRejections = async (callback: () => void) => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};


### PR DESCRIPTION
## Summary

- consume rejected promises from the MCP Connect and Disconnect primitives
- keep the fire-and-forget button behavior aligned with the existing Remove primitive
- add regressions covering both rejected actions

## Why

The Connect and Disconnect buttons invoked their async runtime actions without observing rejection. If transport setup or cleanup rejected, a click could produce a global `unhandledRejection`. The runtime APIs remain unchanged for programmatic callers; only the button boundary now handles the promise it intentionally does not return.

## Testing

- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm lint`
- `pnpm api-surface:check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tXWN2sHel5CbwwTNf06L0xL8vzT9aMHVcF_hGzZ3zG5r36zCMDDSANaCsPQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->