### PR TITLE
fix(cloud-ai-sdk): isolate sync error callbacks

### DIFF
--- a/.changeset/soft-clouds-report.md
+++ b/.changeset/soft-clouds-report.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: isolate Cloud synchronization error callbacks

--- a/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
+++ b/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
@@ -135,6 +135,45 @@ describe("Contract: Thread lifecycle", () => {
     expect(meta.loading).toBeNull();
   });
 
+  it("settles a failed load when onSyncError throws", async () => {
+    const callbackFailure = new Error("telemetry failed");
+    const onSyncError = vi.fn(() => {
+      throw callbackFailure;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { core } = createCore();
+    core.options.onSyncError = onSyncError;
+
+    const loadFailure = new Error("network error");
+    loadMessagesMock.mockRejectedValue(loadFailure);
+
+    const meta = {
+      threadId: "thread-1",
+      loading: Promise.resolve() as Promise<void> | null,
+      loaded: false,
+    };
+    const registry = {
+      getOrCreateMeta: vi.fn().mockReturnValue(meta),
+      getOrCreate: vi.fn().mockReturnValue({ messages: [] }),
+    } as never;
+
+    await expect(
+      core.loadThreadMessages("thread-1", "chat-1", registry, {
+        cancelled: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onSyncError).toHaveBeenCalledWith(loadFailure);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[cloud-ai-sdk] onSyncError callback threw an error",
+      callbackFailure,
+    );
+    expect(meta.loading).toBeNull();
+    consoleError.mockRestore();
+  });
+
   it("load error is suppressed when cancelled", async () => {
     const onSyncError = vi.fn();
     const { core } = createCore();

--- a/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
+++ b/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudChatCore } from "../../core/CloudChatCore";
 
 const { persistMock, loadMessagesMock, MessagePersistenceMock } = vi.hoisted(
@@ -56,6 +56,10 @@ describe("Contract: Thread lifecycle", () => {
     vi.clearAllMocks();
     persistMock.mockResolvedValue(undefined);
     loadMessagesMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("deduplicates concurrent thread creation for same chatKey", async () => {
@@ -171,7 +175,6 @@ describe("Contract: Thread lifecycle", () => {
       callbackFailure,
     );
     expect(meta.loading).toBeNull();
-    consoleError.mockRestore();
   });
 
   it("load error is suppressed when cancelled", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -126,4 +126,30 @@ describe("CloudChatCore", () => {
     expect(result).toBeUndefined();
     await vi.waitFor(() => expect(onSyncError).toHaveBeenCalledWith(error));
   });
+
+  it("handles rejected sync error callbacks", async () => {
+    const persistenceError = new Error("persistence failed");
+    const callbackError = new Error("telemetry failed");
+    const onSyncError = vi.fn(() => Promise.reject(callbackError));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const core = createCore({ onSyncError });
+    vi.spyOn(core, "persistChatMessages").mockRejectedValue(persistenceError);
+
+    core.createChat("chat-1", {} as never);
+
+    const wrappedOnFinish = chatOptionsRef.current?.onFinish;
+    expect(wrappedOnFinish).toBeTypeOf("function");
+    (wrappedOnFinish as (event: unknown) => unknown)({});
+
+    await vi.waitFor(() => {
+      expect(onSyncError).toHaveBeenCalledWith(persistenceError);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[cloud-ai-sdk] onSyncError callback threw an error",
+        callbackError,
+      );
+    });
+    consoleError.mockRestore();
+  });
 });

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudChatCore } from "./CloudChatCore";
 
 const { persistMock, loadMessagesMock, MessagePersistenceMock } = vi.hoisted(
@@ -67,6 +67,10 @@ describe("CloudChatCore", () => {
     persistMock.mockResolvedValue(undefined);
     loadMessagesMock.mockResolvedValue([]);
     chatOptionsRef.current = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("forwards async tool call completion to the AI SDK chat", () => {
@@ -150,6 +154,5 @@ describe("CloudChatCore", () => {
         callbackError,
       );
     });
-    consoleError.mockRestore();
   });
 });

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -221,6 +221,28 @@ export class CloudChatCore {
 
   private handleSyncError(err: unknown): void {
     const error = err instanceof Error ? err : new Error(String(err));
-    this.options.onSyncError?.(error);
+    const onSyncError = this.options.onSyncError;
+    if (!onSyncError) return;
+
+    const reportCallbackError = (callbackError: unknown) => {
+      console.error(
+        "[cloud-ai-sdk] onSyncError callback threw an error",
+        callbackError,
+      );
+    };
+
+    try {
+      const result = onSyncError(error) as unknown;
+      if (
+        result !== null &&
+        (typeof result === "object" || typeof result === "function") &&
+        "then" in result &&
+        typeof result.then === "function"
+      ) {
+        void Promise.resolve(result).catch(reportCallbackError);
+      }
+    } catch (callbackError) {
+      reportCallbackError(callbackError);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- isolate synchronous throws and rejected promises from `onSyncError`
- preserve background thread-load settlement and loading cleanup when the observer fails
- report callback failures without replacing the original Cloud synchronization error

## Why

`useCloudChat` starts thread history loading from an effect. A Cloud load failure is routed to `onSyncError`, but if that observer throws, `loadThreadMessages()` rejects and skips clearing `meta.loading`. Because the effect does not consume that promise, the callback failure can also surface as a global unhandled rejection.

The same callback is used for fire-and-forget persistence failures, where an async callback rejection could likewise escape. `onSyncError` is an observer, so its own failure should be reported without changing Cloud synchronization control flow.

The isolation logic intentionally mirrors core's event-listener helper. `@assistant-ui/cloud-ai-sdk` cannot import `@assistant-ui/core` without adding an otherwise unnecessary package dependency, so the small helper remains local.

A focused regression reproduced the current behavior as:

```
AssertionError: promise rejected "Error: telemetry failed" instead of resolving
```

## Testing

- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk... build`
- `pnpm api-surface:check`
- targeted Oxlint and Oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RaQu0gX_8OlDVRwoBkRGjfDG5c4QYlIzQyBx-4R2HZt8bKaZktpSr-KA70A?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->