### PR TITLE
feat(tap): useSuspenseResource suspense boundary hook

### DIFF
--- a/.changeset/tap-use-suspense-resource.md
+++ b/.changeset/tap-use-suspense-resource.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: useSuspenseResource suspense boundary hook

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -20,7 +20,7 @@ declare const createTapRoot: <R>(render: () => R, options?: {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResources, useSuspenseResource, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
@@ -32,6 +32,8 @@ declare const useMemoCache: (size: number) => unknown[];
 declare function useResource<E extends ResourceElement<any>>(element: E): ExtractResourceReturnType<E>;
 
 declare function useResources<E extends ResourceElement<any>>(elements: readonly E[]): ExtractResourceReturnType<E>[];
+
+declare function useSuspenseResource<E extends ResourceElement<any>, F extends ResourceElement<any>>(element: E, fallbackElement: F): ExtractResourceReturnType<E> | ExtractResourceReturnType<F>;
 
 declare namespace useTapHost {
   interface Result<R> {

--- a/packages/tap/src/__tests__/react/useSuspenseResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useSuspenseResource.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Component, Suspense, type ReactNode } from "react";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import {
+  createTestResource,
+  renderTest,
+  getCommittedValue,
+  cleanupAllResources,
+  waitFor as waitForCondition,
+} from "../test-utils";
+import { resource } from "../../core/resource";
+import { useSuspenseResource } from "../../index";
+import { use } from "../../react-hooks/use";
+import { useState as useResourceState } from "../../react-hooks/useState";
+import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: unknown }
+> {
+  override state = { error: null as unknown };
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+  override render() {
+    if (this.state.error !== null)
+      return <div data-testid="error">{String(this.state.error)}</div>;
+    return this.props.children;
+  }
+}
+
+describe("useSuspenseResource", () => {
+  afterEach(() => {
+    cleanupAllResources();
+    cleanup();
+  });
+
+  it("returns the fallback value while suspended and the primary value after resolve, without reaching the React Suspense boundary", async () => {
+    const { promise, resolve } = deferred<string>();
+    const Primary = resource(() => use(promise) as string);
+    const Fallback = resource((props: { label: string }) => {
+      return `loading:${props.label}`;
+    });
+
+    function App() {
+      const value = useSuspenseResource(Primary(), Fallback({ label: "x" }));
+      return <div data-testid="out">{value as string}</div>;
+    }
+
+    render(
+      <Suspense fallback={<div data-testid="react-fallback" />}>
+        <App />
+      </Suspense>,
+    );
+
+    expect(screen.queryByTestId("react-fallback")).toBeNull();
+    expect(screen.getByTestId("out").textContent).toBe("loading:x");
+
+    await act(async () => {
+      resolve("done");
+      await promise;
+    });
+    expect(screen.getByTestId("out").textContent).toBe("done");
+  });
+
+  it("mounts fallback effects while suspended and cleans them up on recovery", async () => {
+    const { promise, resolve } = deferred<string>();
+    const log: string[] = [];
+    const Primary = resource(() => use(promise) as string);
+    const Fallback = resource(() => {
+      useResourceEffect(() => {
+        log.push("fallback:setup");
+        return () => log.push("fallback:cleanup");
+      }, []);
+      return "loading";
+    });
+
+    function App() {
+      const value = useSuspenseResource(Primary(), Fallback());
+      return <div data-testid="out">{value as string}</div>;
+    }
+
+    render(<App />);
+    expect(log).toEqual(["fallback:setup"]);
+
+    await act(async () => {
+      resolve("done");
+      await promise;
+    });
+    expect(screen.getByTestId("out").textContent).toBe("done");
+    expect(log).toEqual(["fallback:setup", "fallback:cleanup"]);
+  });
+
+  it("preserves primary state across an update suspension and remounts its effects on recovery", async () => {
+    const { promise, resolve } = deferred<string>();
+    const log: string[] = [];
+
+    const Primary = resource(() => {
+      const [count, setCount] = useResourceState(0);
+      const [mode, setMode] = useResourceState<"sync" | "async">("sync");
+      useResourceEffect(() => {
+        log.push("primary:setup");
+        return () => log.push("primary:cleanup");
+      }, []);
+      const suffix = mode === "async" ? (use(promise) as string) : "sync";
+      return { text: `${count}:${suffix}`, setCount, setMode };
+    });
+    const Fallback = resource(() => "loading");
+
+    let api!: {
+      text?: string;
+      setCount?: (n: number) => void;
+      setMode?: (m: "sync" | "async") => void;
+    };
+    function App() {
+      const value = useSuspenseResource(Primary(), Fallback());
+      api = typeof value === "string" ? {} : value;
+      return (
+        <div data-testid="out">
+          {typeof value === "string" ? value : value.text}
+        </div>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("out").textContent).toBe("0:sync");
+    expect(log).toEqual(["primary:setup"]);
+
+    act(() => api.setCount!(5));
+    expect(screen.getByTestId("out").textContent).toBe("5:sync");
+
+    act(() => api.setMode!("async"));
+    expect(screen.getByTestId("out").textContent).toBe("loading");
+    expect(log).toEqual(["primary:setup", "primary:cleanup"]);
+
+    await act(async () => {
+      resolve("async");
+      await promise;
+    });
+    expect(screen.getByTestId("out").textContent).toBe("5:async");
+    expect(log).toEqual(["primary:setup", "primary:cleanup", "primary:setup"]);
+  });
+
+  it("creates a fresh fallback fiber for each suspension cycle", async () => {
+    const first = deferred<string>();
+    const second = deferred<string>();
+
+    const Primary = resource(() => {
+      const [step, setStep] = useResourceState(0);
+      const value =
+        step === 0
+          ? "initial"
+          : step === 1
+            ? (use(first.promise) as string)
+            : (use(second.promise) as string);
+      return { kind: "primary" as const, value, setStep };
+    });
+    const Fallback = resource(() => {
+      const [n, setN] = useResourceState(0);
+      return { kind: "fallback" as const, n, bump: () => setN((v) => v + 1) };
+    });
+
+    let current!:
+      | { kind: "primary"; value: string; setStep: (n: number) => void }
+      | { kind: "fallback"; n: number; bump: () => void };
+    let primary!: { setStep: (n: number) => void };
+    function App() {
+      current = useSuspenseResource(Primary(), Fallback());
+      if (current.kind === "primary") primary = current;
+      return (
+        <div data-testid="out">
+          {current.kind === "primary" ? current.value : `fb:${current.n}`}
+        </div>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId("out").textContent).toBe("initial");
+
+    act(() => primary.setStep(1));
+    expect(screen.getByTestId("out").textContent).toBe("fb:0");
+
+    act(() => (current as { bump: () => void }).bump());
+    expect(screen.getByTestId("out").textContent).toBe("fb:1");
+
+    await act(async () => {
+      first.resolve("one");
+      await first.promise;
+    });
+    expect(screen.getByTestId("out").textContent).toBe("one");
+
+    act(() => primary.setStep(2));
+    expect(screen.getByTestId("out").textContent).toBe("fb:0");
+
+    await act(async () => {
+      second.resolve("two");
+      await second.promise;
+    });
+    expect(screen.getByTestId("out").textContent).toBe("two");
+  });
+
+  it("propagates a rejected thenable as a render error on retry", async () => {
+    const { promise, reject } = deferred<string>();
+    const Primary = resource(() => use(promise) as string);
+    const Fallback = resource(() => "loading");
+
+    function App() {
+      const value = useSuspenseResource(Primary(), Fallback());
+      return <div data-testid="out">{value as string}</div>;
+    }
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      render(
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>,
+      );
+      expect(screen.getByTestId("out").textContent).toBe("loading");
+
+      await act(async () => {
+        reject(new Error("boom"));
+        await promise.catch(() => {});
+      });
+      expect(screen.getByTestId("error").textContent).toBe("Error: boom");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("works inside a tap-hosted resource", async () => {
+    const { promise, resolve } = deferred<string>();
+    const Primary = resource(() => use(promise) as string);
+    const Fallback = resource(() => "loading");
+
+    const parent = createTestResource(() =>
+      useSuspenseResource(Primary(), Fallback()),
+    );
+
+    expect(renderTest(parent)).toBe("loading");
+
+    resolve("done");
+    await waitForCondition(() => getCommittedValue(parent) === "done");
+  });
+});

--- a/packages/tap/src/hooks/useSuspenseResource.ts
+++ b/packages/tap/src/hooks/useSuspenseResource.ts
@@ -1,0 +1,139 @@
+import type {
+  ExtractResourceReturnType,
+  ResourceElement,
+  ResourceFiber,
+} from "../core/types";
+import {
+  unmountResourceFiber,
+  renderResourceFiber,
+  commitResourceFiber,
+} from "../core/ResourceFiber";
+import { hasContextDepsChanged } from "../core/context";
+import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
+import { useEffect, useMemo, useState } from "react";
+import { useRenderMemo } from "./utils/useRenderMemo";
+import { isThenable } from "../core/helpers/thenable";
+
+type BoundaryState = {
+  fallbackFiber: ResourceFiber<unknown> | null;
+  fallbackHook: ((...args: any[]) => unknown) | null;
+  retiredFallbackFibers: ResourceFiber<unknown>[];
+  subscribedTo: PromiseLike<unknown> | null;
+  disposed: boolean;
+};
+
+type BoundaryResult =
+  | { suspended: false; value: unknown }
+  | { suspended: true; value: unknown; thenable: PromiseLike<unknown> };
+
+export function useSuspenseResource<
+  E extends ResourceElement<any>,
+  F extends ResourceElement<any>,
+>(
+  element: E,
+  fallbackElement: F,
+): ExtractResourceReturnType<E> | ExtractResourceReturnType<F> {
+  const { version, createFiber } = useResourceFiberHost();
+  const fiber = useMemo(() => {
+    return createFiber(element.hook, element.key);
+  }, [element.hook, element.key, createFiber]);
+
+  const [state] = useState<BoundaryState>(() => ({
+    fallbackFiber: null,
+    fallbackHook: null,
+    retiredFallbackFibers: [],
+    subscribedTo: null,
+    disposed: false,
+  }));
+  const [retryCount, setRetryCount] = useState(0);
+
+  const result = useRenderMemo(
+    (): BoundaryResult => {
+      void version;
+      void retryCount;
+
+      try {
+        return {
+          suspended: false,
+          value: renderResourceFiber(fiber, element.args),
+        };
+      } catch (error) {
+        if (!isThenable(error)) throw error;
+
+        if (
+          state.fallbackFiber !== null &&
+          state.fallbackHook !== fallbackElement.hook
+        ) {
+          state.retiredFallbackFibers.push(state.fallbackFiber);
+          state.fallbackFiber = null;
+        }
+        state.fallbackFiber ??= createFiber(
+          fallbackElement.hook,
+          fallbackElement.key,
+        );
+        state.fallbackHook = fallbackElement.hook;
+
+        return {
+          suspended: true,
+          thenable: error,
+          value: renderResourceFiber(state.fallbackFiber, fallbackElement.args),
+        };
+      }
+    },
+    [
+      fiber,
+      version,
+      retryCount,
+      element.args,
+      fallbackElement.hook,
+      fallbackElement.key,
+      fallbackElement.args,
+    ],
+    hasContextDepsChanged(fiber) ||
+      (state.fallbackFiber !== null &&
+        hasContextDepsChanged(state.fallbackFiber)),
+  );
+
+  useEffect(
+    () => () => {
+      state.disposed = true;
+      if (state.fallbackFiber !== null)
+        unmountResourceFiber(state.fallbackFiber);
+      for (const retired of state.retiredFallbackFibers)
+        unmountResourceFiber(retired);
+    },
+    [state],
+  );
+  useEffect(() => () => unmountResourceFiber(fiber), [fiber]);
+  useEffect(() => {
+    while (state.retiredFallbackFibers.length > 0)
+      unmountResourceFiber(state.retiredFallbackFibers.pop()!);
+
+    if (result.suspended) {
+      unmountResourceFiber(fiber);
+      commitResourceFiber(state.fallbackFiber!);
+
+      const thenable = result.thenable;
+      if (state.subscribedTo !== thenable) {
+        state.subscribedTo = thenable;
+        const retry = () => {
+          if (state.disposed) return;
+          setRetryCount((count) => count + 1);
+        };
+        thenable.then(retry, retry);
+      }
+    } else {
+      if (state.fallbackFiber !== null) {
+        unmountResourceFiber(state.fallbackFiber);
+        state.fallbackFiber = null;
+        state.fallbackHook = null;
+        state.subscribedTo = null;
+      }
+      commitResourceFiber(fiber);
+    }
+  }, [fiber, state, result]);
+
+  return result.value as
+    | ExtractResourceReturnType<E>
+    | ExtractResourceReturnType<F>;
+}

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -16,6 +16,7 @@ import { useMemoCache as useMemoCacheInternal } from "./react-hooks/useMemoCache
 export const useMemoCache = useMemoCacheInternal;
 export { useResource } from "./hooks/useResource";
 export { useResources } from "./hooks/useResources";
+export { useSuspenseResource } from "./hooks/useSuspenseResource";
 export { useTapRoot } from "./hooks/useTapRoot";
 export { useTapHost } from "./hooks/useTapHost";
 


### PR DESCRIPTION
## What

Phase 3 of the tap suspense roadmap (after #5847, #5848, #5850): a suspense boundary hook for resources.

```ts
const value = useSuspenseResource(Primary(props), Fallback(props));
```

Renders the primary resource; if its render throws a thenable (e.g. via `use()`), the boundary catches it and returns the fallback resource's value instead of propagating the suspension to the host. Works in both hosts — inside React components and inside tap-hosted resources.

## How

- **Activity-style disconnect of the suspended primary.** While suspended, the primary fiber's effects are cleaned up (`unmountResourceFiber`) but its state cells survive; on recovery the fiber re-commits and `reconcileEffects` remounts every effect (cleanup nulls `cell.deps`, so no new primitive was needed).
- **Fresh fallback fiber per suspension cycle.** The fallback fiber is created on entering suspension and unmounted on recovery, so fallback state never leaks between cycles. A fallback hook swap mid-suspension retires the old fiber (unmounted in the next commit).
- **Retry on settle.** The boundary subscribes once per thenable and bumps a retry counter when it settles; a rejection then surfaces as a render error on the retry pass (reaching the host's error handling).
- Built on the same primitives as `useResource`: `useResourceFiberHost`, `useRenderMemo` (invalidated by either fiber's context deps), and commit-in-effect.

Exported from the package barrel. The /tap docs page follows in the next phase.

## Tests

6 contract tests in `__tests__/react/useSuspenseResource.test.tsx`: fallback served without reaching the React `<Suspense>` boundary, fallback effect lifecycle, primary state preservation + effect remount across an update suspension, fresh fallback per cycle, rejection-as-error, and tap-hosted usage. Full tap suite: 545/545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSu2Ci68pCWJWEMwY5jvKn

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.emuTOaIpeEiyfAZ7EJzSMnPC-iHkwc4hYub8hFGrixbd3s3lPqGLfET-bSk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->