### PR TITLE
fix(cloud): persist data message parts in aui/v0 (#5866)

### DIFF
--- a/.changeset/aui-v0-data-message-parts.md
+++ b/.changeset/aui-v0-data-message-parts.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: persist data message parts in aui/v0 cloud history

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -213,7 +213,7 @@ useAssistantDataUI({
 });
 ```
 
-Data parts stay in the assistant-ui message but are not sent back to the agent, since the AG-UI assistant record has no field for them. A custom history adapter persists them as part of the message JSON; the assistant-cloud history adapter does not accept `data` parts yet and fails to persist an assistant message that contains one. Framework integrations emit their own plumbing over this channel (`on_interrupt`, `PredictState`, `Exit`, `hook_error`, `state_update_error`, `system:*`, `MultiAgentHandoff`), and those names surface as data parts like any other, so only register renderers for names your backend owns.
+Data parts stay in the assistant-ui message but are not sent back to the agent, since the AG-UI assistant record has no field for them. History adapters, including the assistant-cloud one, persist them as part of the message JSON. Framework integrations emit their own plumbing over this channel (`on_interrupt`, `PredictState`, `Exit`, `hook_error`, `state_update_error`, `system:*`, `MultiAgentHandoff`), and those names surface as data parts like any other, so only register renderers for names your backend owns.
 
 ## Feature support
 

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -79,6 +79,11 @@ type AuiV0MessagePart =
       readonly mimeType: string;
       readonly filename?: string;
       readonly sourceType?: "url" | "id";
+    }
+  | {
+      readonly type: "data";
+      readonly name: string;
+      readonly data: ReadonlyJSONValue;
     };
 
 type AuiV0AttachmentPart =
@@ -296,8 +301,19 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             ...(part.sourceType ? { sourceType: part.sourceType } : undefined),
           };
 
+        case "data": {
+          if (!isJSONValue(part.data)) {
+            console.warn(`data part is not JSON! ${JSON.stringify(part)}`);
+          }
+          return {
+            type: "data",
+            name: part.name,
+            data: part.data as ReadonlyJSONValue,
+          };
+        }
+
         default: {
-          const unhandledType: "audio" | "data" | "generative-ui" = type;
+          const unhandledType: "audio" | "generative-ui" = type;
           throw new Error(
             `Message part type not supported by aui/v0: ${unhandledType}`,
           );

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -330,6 +330,33 @@ describe("auiV0Encode", () => {
       { type: "data", name: "telemetry", data: { runs: 3 } },
     ]);
   });
+
+  it("preserves data message parts verbatim in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        { type: "text", text: "planned" },
+        { type: "data", name: "PredictState", data: { steps: ["a"] } },
+        { type: "data", name: "PredictState", data: '{"steps":["a","b"]}' },
+      ],
+    });
+
+    expect(encoded.content).toEqual([
+      { type: "text", text: "planned" },
+      { type: "data", name: "PredictState", data: { steps: ["a"] } },
+      { type: "data", name: "PredictState", data: '{"steps":["a","b"]}' },
+    ]);
+  });
 });
 
 describe("auiV0Decode", () => {
@@ -572,5 +599,44 @@ describe("auiV0Decode", () => {
 
     const toolCall = message.content.find((p) => p.type === "tool-call");
     expect(toolCall).toHaveProperty("result", false);
+  });
+
+  it("round-trips data message parts, keeping repeated names in order", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        { type: "text", text: "planned" },
+        { type: "data", name: "PredictState", data: { steps: ["a"] } },
+        { type: "data", name: "PredictState", data: '{"steps":["a","b"]}' },
+      ],
+    });
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      height: 0,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+      updated_at: new Date("2026-03-15T00:00:00.000Z"),
+      format: "aui/v0",
+      content: content as never,
+    });
+
+    if (decoded.message.role !== "assistant")
+      throw new Error("expected assistant");
+    expect(decoded.message.content).toEqual([
+      { type: "text", text: "planned" },
+      { type: "data", name: "PredictState", data: { steps: ["a"] } },
+      { type: "data", name: "PredictState", data: '{"steps":["a","b"]}' },
+    ]);
   });
 });

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -79,6 +79,11 @@ type AuiV0MessagePart =
       readonly mimeType: string;
       readonly filename?: string;
       readonly sourceType?: "url" | "id";
+    }
+  | {
+      readonly type: "data";
+      readonly name: string;
+      readonly data: ReadonlyJSONValue;
     };
 
 type AuiV0AttachmentPart =
@@ -296,8 +301,19 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             ...(part.sourceType ? { sourceType: part.sourceType } : undefined),
           };
 
+        case "data": {
+          if (!isJSONValue(part.data)) {
+            console.warn(`data part is not JSON! ${JSON.stringify(part)}`);
+          }
+          return {
+            type: "data",
+            name: part.name,
+            data: part.data as ReadonlyJSONValue,
+          };
+        }
+
         default: {
-          const unhandledType: "audio" | "data" | "generative-ui" = type;
+          const unhandledType: "audio" | "generative-ui" = type;
           throw new Error(
             `Message part type not supported by aui/v0: ${unhandledType}`,
           );


### PR DESCRIPTION
fixes #5866

`auiV0Encode` had no message-level `data` case: `AuiV0MessagePart` declared text, reasoning, source, tool-call, image, and file members only, and the switch default threw `Message part type not supported by aui/v0: data`. `AssistantCloudThreadHistoryAdapter.append` encodes before it posts, and runtime history paths treat the append as best effort (react-ag-ui logs and continues, the LocalRuntime queue swallows outright), so an assistant message containing any `data` part was silently never persisted; the whole message disappeared on reload, not just the data part. since #5843 react-ag-ui emits a `data` part for every AG-UI `CUSTOM` event, so backends emitting `PredictState` or similar plumbing hit this on every such run.

the fix is an additive extension of the `aui/v0` format: a `data` member on `AuiV0MessagePart` and a matching encode case, mirroring the attachment `data` case the format already carries (`isJSONValue` warn, value passed through verbatim). the encode default narrows to `"audio" | "generative-ui"`. both codec copies are updated (`packages/core/src/react/runtimes/cloud/auiV0.ts` and the legacy-runtime copy in `packages/react`). the decode side needs no changes: `fromThreadMessageLike` already passes `data` parts through for both roles, so stored messages round-trip. the cloud API stores message content as opaque JSON keyed by the format string, so no server change is involved.

two contract tests pin the new surface: encode preserves `data` parts verbatim (including string values, which LangGraph TS and Mastra send), and a decode round trip keeps repeated names as distinct parts in arrival order. the ag-ui docs caveat from #5843 ("the assistant-cloud history adapter does not accept `data` parts yet") is updated accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DceWcf5KUhRHwD-3yQXlZs2taSDv6y_B4UdsA0rz1Or0i64_ZsZvVX8YiD8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->