### PR TITLE
fix(tap): preserve the compiler memo cache across uncommitted replays

### DIFF
--- a/.changeset/tap-memocache-replay.md
+++ b/.changeset/tap-memocache-replay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: keep the compiler memo cache across uncommitted render replays, matching React's renderWithHooksAgain semantics

--- a/.changeset/tap-memocache-replay.md
+++ b/.changeset/tap-memocache-replay.md
@@ -2,4 +2,4 @@
 "@assistant-ui/tap": patch
 ---
 
-fix: keep the compiler memo cache across uncommitted render replays, matching React's renderWithHooksAgain semantics
+fix: keep the compiler memo cache across uncommitted render replays so a StrictMode double invoke observes one memoized instance

--- a/packages/tap/src/__tests__/react/react-shim.test.tsx
+++ b/packages/tap/src/__tests__/react/react-shim.test.tsx
@@ -16,7 +16,10 @@ import {
   useEffect,
 } from "../../react-shim";
 import { useContextProvider } from "../../core/context";
-import { renderResourceFiber } from "../../core/ResourceFiber";
+import {
+  commitResourceFiber,
+  renderResourceFiber,
+} from "../../core/ResourceFiber";
 import { use as tapUse } from "../../react-hooks/use";
 import { c as _c } from "../../react-shim/compiler-runtime";
 
@@ -138,6 +141,55 @@ describe("@assistant-ui/tap/react-shim", () => {
       expect(computes).toBe(1);
       expect(renderTest(testFiber, { x: 2 })).toBe(4);
       expect(computes).toBe(1);
+      expect(renderTest(testFiber, { x: 3 })).toBe(6);
+      expect(computes).toBe(2);
+    });
+
+    it("c() keeps memoized values across an uncommitted replay", () => {
+      let computes = 0;
+      const testFiber = createTestResource(() => {
+        const $ = _c(1);
+        let owner;
+        if ($[0] === SENTINEL) {
+          computes++;
+          owner = { listeners: new Set<() => void>() };
+          $[0] = owner;
+        } else {
+          owner = $[0];
+        }
+        return owner;
+      });
+
+      const first = renderResourceFiber(testFiber, []);
+      const replay = renderResourceFiber(testFiber, []);
+      commitResourceFiber(testFiber);
+
+      expect(replay).toBe(first);
+      expect(computes).toBe(1);
+      expect(renderTest(testFiber)).toBe(first);
+      expect(computes).toBe(1);
+    });
+
+    it("c() recomputes across an uncommitted replay when deps change", () => {
+      let computes = 0;
+      const testFiber = createTestResource((p: { x: number }) => {
+        const $ = _c(2);
+        let double;
+        if ($[0] !== p.x) {
+          computes++;
+          double = p.x * 2;
+          $[0] = p.x;
+          $[1] = double;
+        } else {
+          double = $[1];
+        }
+        return double;
+      });
+
+      expect(renderResourceFiber(testFiber, [{ x: 2 }])).toBe(4);
+      expect(renderResourceFiber(testFiber, [{ x: 3 }])).toBe(6);
+      commitResourceFiber(testFiber);
+      expect(computes).toBe(2);
       expect(renderTest(testFiber, { x: 3 })).toBe(6);
       expect(computes).toBe(2);
     });

--- a/packages/tap/src/__tests__/strictmode/compiled-memo-identity.test.tsx
+++ b/packages/tap/src/__tests__/strictmode/compiled-memo-identity.test.tsx
@@ -1,0 +1,42 @@
+import { StrictMode } from "react";
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { useTapHost } from "../../index";
+import { c as _c } from "../../react-shim/compiler-runtime";
+
+const SENTINEL = Symbol.for("react.memo_cache_sentinel");
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("compiled memo identity under StrictMode", () => {
+  it("keeps one memoized instance across the StrictMode render replay", () => {
+    const instances: object[] = [];
+
+    function Harness() {
+      useTapHost(function CompiledHost() {
+        const $ = _c(1);
+        let owner;
+        if ($[0] === SENTINEL) {
+          owner = { listeners: new Set<() => void>() };
+          $[0] = owner;
+        } else {
+          owner = $[0];
+        }
+        instances.push(owner as object);
+        return null;
+      });
+      return null;
+    }
+
+    render(
+      <StrictMode>
+        <Harness />
+      </StrictMode>,
+    );
+
+    expect(instances.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(instances)).toHaveLength(1);
+  });
+});

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -58,8 +58,6 @@ export function renderResourceFiber<R>(
   fiber: ResourceFiber<R>,
   args: readonly unknown[],
 ): R {
-  fiber.memoCache.workInProgress = null;
-
   // Discard render-phase actions left by a previous render
   if (fiber.renderPendingCells !== null) {
     for (const cell of fiber.renderPendingCells) cell.renderQueue = null;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -96,8 +96,9 @@ export interface ResourceFiber<R> {
   wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;
-  // workInProgress persists across uncommitted renders so replays observe the
-  // same memoized values as React; commit promotes it, discardWipRender drops it.
+  // workInProgress persists across uncommitted renders: a StrictMode double
+  // invoke reaches tap as separate renderResourceFiber calls with no attempt
+  // boundary, so an entry discard would re-run every compiled memo factory.
   memoCache: {
     current: unknown[][] | null;
     workInProgress: unknown[][] | null;

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -96,6 +96,8 @@ export interface ResourceFiber<R> {
   wipCommitCallbacks: CommitCallbacks | null;
 
   currentIndex: number;
+  // workInProgress persists across uncommitted renders so replays observe the
+  // same memoized values as React; commit promotes it, discardWipRender drops it.
   memoCache: {
     current: unknown[][] | null;
     workInProgress: unknown[][] | null;


### PR DESCRIPTION
closes #5505

## summary

- a React useMemo that owns a mutable instance (manager, registry, provider) no longer produces two instances under a StrictMode uncommitted replay when the React Compiler compiles it into tap's memo cache; this is the mechanism behind #5422/#5502, which #5411 only patched at the one known call site
- the root cause was a one line divergence from React's own semantics: React's renderWithHooksAgain (the shared path for StrictMode double invocation and render phase updates) resets only memoCache.index and preserves the cache data across replay passes, while tap discarded workInProgress at every renderResourceFiber entry, so the second uncommitted pass re-seeded from an empty cache and re-ran every memo factory
- the fix deletes that render entry discard: workInProgress now persists across uncommitted renders, is promoted to current at commit (existing code), and is still dropped by discardWipRender on a thrown render and on the useResources bailout path
- two contract tests pin the new semantics: replay keeps memoized instance identity, and changed deps still recompute across a replay

## test plan

### already verified

- [x] new contract test red on main, green with the fix (`pnpm -C packages/tap exec vitest run src/__tests__/react/react-shim.test.tsx`)
- [x] end to end against built dist: NotificationManager temporarily reverted to its pre #5411 inline useMemo form compiles to `c(1)` and `packages/store` `test:react-compiler` fails on unfixed tap (two managers) and passes with this fix (one manager); the committed tree keeps the useState form and stays green
- [x] full suites green: tap 540, core 1063 plus `test:react-compiler`, store full plus `test:react-compiler`; oxlint and oxfmt clean

### reviewer should verify

- [ ] re-add `fiber.memoCache.workInProgress = null;` at the top of `renderResourceFiber` and confirm `c() keeps memoized values across an uncommitted replay` fails, then remove it again

## notes

- this supersedes the static checker direction proposed in #5505 and drafted in #5510: the premise there was that replay discarding is correct memo behavior, but React itself keeps memoized values stable across the replay (react-dom 19.2.8, renderWithHooksAgain), so the fix belongs in the mechanism rather than in policing call sites
- with this in place, useState versus useMemo for lifetime owned state in tap hosted code is a style choice again instead of a correctness rule

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9HlSrzPTkrt-Z-TehRKUvIlgfVr5EsBLHh4JwMc1gH1HBaVEf92dNj_lCUU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->