### PR TITLE
test(tap): deterministic wait for scheduleTask flush ordering

### DIFF
--- a/.changeset/tap-schedule-task-test-wait.md
+++ b/.changeset/tap-schedule-task-test-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+test: wait deterministically for the scheduleTask flush instead of racing setTimeout against MessageChannel

--- a/packages/tap/src/__tests__/scheduler.schedule-task.test.ts
+++ b/packages/tap/src/__tests__/scheduler.schedule-task.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { scheduleTask, flushTapSync } from "../core/scheduler";
-
-const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+import { waitForNextTick } from "./test-utils";
 
 describe("scheduleTask", () => {
   it("runs tasks in order on the next flush", async () => {
@@ -10,7 +9,7 @@ describe("scheduleTask", () => {
     scheduleTask(() => order.push(2));
 
     expect(order).toEqual([]);
-    await nextTick();
+    await waitForNextTick();
     expect(order).toEqual([1, 2]);
   });
 


### PR DESCRIPTION
closes #5875

## summary

- `scheduler.schedule-task.test.ts > runs tasks in order on the next flush` waited a single `setTimeout(0)` turn while `scheduleTask` flushes through a MessageChannel macrotask, so on a loaded runner the assertion could run before the flush fired (`expected [] to deeply equal [ 1, 2 ]`); it failed twice consecutively on #5873's CI and reproduces locally at roughly 1 in 10 under load
- replaces the file-local `nextTick` with the shared `waitForNextTick` from test-utils, which bounces through a MessageChannel so it queues behind the pending flush message; this is the exact treatment #5856 applied to `scheduler.update-depth.test.ts` in the same directory, and this file landed in #5857 without picking it up

## test plan

### already verified

- [x] fixed test 20/20 green in a loop (previously roughly 1 in 10 red under load), full tap suite 539 green (`pnpm -C packages/tap test`)

### reviewer should verify

- [ ] `git revert` the test change locally and loop the file under load to observe the intermittent `[]` result, then re-apply

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.67wKvjhqQif6ZwgyLU3sMLVxFtpE1N4zNq7CD6K1qEi6tUyCT27SMYustpU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->