### PR TITLE
fix(core): gate queued external-store appends on thread initialization

### DIFF
--- a/.changeset/queued-appends-wait-for-thread.md
+++ b/.changeset/queued-appends-wait-for-thread.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: gate queued external-store appends on thread initialization

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -504,6 +504,8 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.sourceId != null ||
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
+    const message = this.enrichAppendMetadata(rawMessage);
+
     // The queue driver dispatches through the host adapter, outside this
     // core, so the initialization barrier must run before a message can
     // enter the queue.
@@ -522,16 +524,12 @@ export class ExternalStoreThreadRuntimeCore
       // Skip only for the queue this core actually installed on: another
       // core's transform would gate against its own thread's messages.
       const queued =
-        this._store.queue === this._transformedQueue
-          ? rawMessage
-          : this.enrichAppendMetadata(rawMessage);
+        this._store.queue === this._transformedQueue ? rawMessage : message;
       if (queued.steer ?? this._store.isRunning ?? false)
         this._store.queue.steer(queued);
       else this._store.queue.enqueue(queued);
       return;
     }
-
-    const message = this.enrichAppendMetadata(rawMessage);
 
     // Auto-abort in-flight client-side tool executions when a new run is
     // about to start. Without this, a tool that finishes after the new turn

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -504,7 +504,14 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.sourceId != null ||
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
-    const message = this.enrichAppendMetadata(rawMessage);
+    // The dispatch transform re-stamps a transformed-queue message at flush,
+    // so send-time stamping applies to every other path.
+    const message =
+      !isEdit &&
+      this._store.queue &&
+      this._store.queue === this._transformedQueue
+        ? rawMessage
+        : this.enrichAppendMetadata(rawMessage);
 
     // The queue driver dispatches through the host adapter, outside this
     // core, so the initialization barrier must run before a message can

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -505,13 +505,17 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
     // The dispatch transform re-stamps a transformed-queue message at flush,
-    // so send-time stamping applies to every other path.
-    const message =
+    // so a send headed there skips the send-time stamp. Every other consumer
+    // stamps at send, or on first use when the store's queue was replaced
+    // across the barrier and the send-time decision no longer matches.
+    let stamped =
       !isEdit &&
       this._store.queue &&
       this._store.queue === this._transformedQueue
-        ? rawMessage
+        ? undefined
         : this.enrichAppendMetadata(rawMessage);
+    const stampedMessage = () =>
+      (stamped ??= this.enrichAppendMetadata(rawMessage));
 
     // The queue driver dispatches through the host adapter, outside this
     // core, so the initialization barrier must run before a message can
@@ -531,12 +535,16 @@ export class ExternalStoreThreadRuntimeCore
       // Skip only for the queue this core actually installed on: another
       // core's transform would gate against its own thread's messages.
       const queued =
-        this._store.queue === this._transformedQueue ? rawMessage : message;
+        this._store.queue === this._transformedQueue
+          ? rawMessage
+          : stampedMessage();
       if (queued.steer ?? this._store.isRunning ?? false)
         this._store.queue.steer(queued);
       else this._store.queue.enqueue(queued);
       return;
     }
+
+    const message = stampedMessage();
 
     // Auto-abort in-flight client-side tool executions when a new run is
     // about to start. Without this, a tool that finishes after the new turn

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -504,6 +504,18 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.sourceId != null ||
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
+    // The queue driver dispatches through the host adapter, outside this
+    // core, so the initialization barrier must run before a message can
+    // enter the queue.
+    const generation = captureThreadRuntimeGeneration(this);
+    this.ensureInitialized();
+
+    const initPromise = this._getInitializePromise?.();
+    if (initPromise) {
+      await initPromise;
+    }
+    if (!isThreadRuntimeGenerationCurrent(this, generation)) return;
+
     // Buffering does not start a run, so the tool-abort below must wait until
     // the queue flushes. By then the prior run (and its tools) has settled.
     if (!isEdit && this._store.queue) {
@@ -519,15 +531,7 @@ export class ExternalStoreThreadRuntimeCore
       return;
     }
 
-    const generation = captureThreadRuntimeGeneration(this);
     const message = this.enrichAppendMetadata(rawMessage);
-    this.ensureInitialized();
-
-    const initPromise = this._getInitializePromise?.();
-    if (initPromise) {
-      await initPromise;
-    }
-    if (!isThreadRuntimeGenerationCurrent(this, generation)) return;
 
     // Auto-abort in-flight client-side tool executions when a new run is
     // about to start. Without this, a tool that finishes after the new turn

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -504,18 +504,15 @@ export class ExternalStoreThreadRuntimeCore
       rawMessage.sourceId != null ||
       rawMessage.parentId !== (this.messages.at(-1)?.id ?? null);
 
-    // The dispatch transform re-stamps a transformed-queue message at flush,
-    // so a send headed there skips the send-time stamp. Every other consumer
-    // stamps at send, or on first use when the store's queue was replaced
-    // across the barrier and the send-time decision no longer matches.
-    let stamped =
+    // A transformed-queue send is stamped at flush; any other queue's
+    // transform would gate against its own thread's messages, so those stamp
+    // at send.
+    const message =
       !isEdit &&
       this._store.queue &&
       this._store.queue === this._transformedQueue
-        ? undefined
+        ? rawMessage
         : this.enrichAppendMetadata(rawMessage);
-    const stampedMessage = () =>
-      (stamped ??= this.enrichAppendMetadata(rawMessage));
 
     // The queue driver dispatches through the host adapter, outside this
     // core, so the initialization barrier must run before a message can
@@ -532,19 +529,11 @@ export class ExternalStoreThreadRuntimeCore
     // Buffering does not start a run, so the tool-abort below must wait until
     // the queue flushes. By then the prior run (and its tools) has settled.
     if (!isEdit && this._store.queue) {
-      // Skip only for the queue this core actually installed on: another
-      // core's transform would gate against its own thread's messages.
-      const queued =
-        this._store.queue === this._transformedQueue
-          ? rawMessage
-          : stampedMessage();
-      if (queued.steer ?? this._store.isRunning ?? false)
-        this._store.queue.steer(queued);
-      else this._store.queue.enqueue(queued);
+      if (message.steer ?? this._store.isRunning ?? false)
+        this._store.queue.steer(message);
+      else this._store.queue.enqueue(message);
       return;
     }
-
-    const message = stampedMessage();
 
     // Auto-abort in-flight client-side tool executions when a new run is
     // about to start. Without this, a tool that finishes after the new turn

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -869,6 +869,53 @@ describe("ExternalStoreThreadRuntimeCore - message queue", () => {
     expect(withoutQueue.capabilities.queue).toBe(false);
   });
 
+  it("waits for thread initialization before enqueueing into the queue adapter", async () => {
+    let resolveInitialization!: () => void;
+    const initialization = new Promise<void>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    const queue = makeQueue();
+    const onNew = vi.fn(async () => {});
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ onNew, queue }),
+    );
+    runtime.__internal_setGetInitializePromise(() => initialization);
+
+    const appendPromise = runtime.append(appendMessage());
+    await Promise.resolve();
+
+    expect(queue.enqueue).not.toHaveBeenCalled();
+
+    resolveInitialization();
+    await appendPromise;
+
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    expect(onNew).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when the thread is invalidated during initialization", async () => {
+    let resolveInitialization!: () => void;
+    const initialization = new Promise<void>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    const queue = makeQueue();
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ onNew: vi.fn(), queue }),
+    );
+    runtime.__internal_setGetInitializePromise(() => initialization);
+
+    const appendPromise = runtime.append(appendMessage());
+    await Promise.resolve();
+    invalidateThreadRuntime(runtime);
+    resolveInitialization();
+
+    await appendPromise;
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(queue.steer).not.toHaveBeenCalled();
+  });
+
   it("waits for thread initialization before dispatching an append", async () => {
     let resolveInitialization!: () => void;
     const initialization = new Promise<void>((resolve) => {


### PR DESCRIPTION
## problem

since #5864, `ExternalStoreThreadRuntimeCore.append` waits for remote thread initialization before dispatching, but the queue branch returned before that barrier: with a queue adapter installed, every non-edit append was enqueued (or steered) immediately and dispatched by the queue driver. unlike `LocalThreadRuntimeCore`, whose queue driver re-enters `_runAppend` and passes the same barrier, the external-store queue driver dispatches through the host adapter's own run function (`react-langgraph`'s `runUserMessageRef.current(message)`), which never touches this core again. so for an external-store adapter with `unstable_enableMessageQueue` under a remote thread list with an asynchronous `initialize()`, the first message on a new thread still dispatched before initialization resolved, which is exactly the #5862 race the direct path no longer has.

## approach

move the initialization barrier (generation capture, `ensureInitialized()`, the awaited getter, and the invalidation check) above the queue routing, so a message cannot enter the queue before the thread has its identity. once a message is enqueued, its eventual dispatch through the host driver runs against an initialized thread, whatever the queue's timing. the generation check now also guards enqueue, so an append whose thread is invalidated during initialization is discarded instead of buffered. edit sends and the direct dispatch path keep their existing semantics; for an already-initialized thread the added cost on the queue path is one await of a settled promise.

gating enqueue rather than wrapping the host driver keeps the fix inside the core seam: the driver callback is host-owned and wrapping it would need either a per-adapter change in every queue-enabled host or a new queue API.

## verification

- new: `waits for thread initialization before enqueueing into the queue adapter` (enqueue not called while initialize is pending, called once after it resolves, `onNew` untouched) and `does not enqueue when the thread is invalidated during initialization`, both in `external-store-thread-runtime-core.test.ts`.
- `pnpm --filter @assistant-ui/core test`: 105 files, 1076 tests passed.
- `pnpm --filter @assistant-ui/react-langgraph exec vitest run`: 274 tests passed (the affected adapter; its queue suites exercise the moved barrier).
- `pnpm --filter @assistant-ui/react-langchain exec vitest run`: 109 tests passed.
- focused `oxlint` and `oxfmt --check` on the touched files passed.

fixes #5869


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bRUizLHPeGEVgaDdM3hRJFSIbSYwnRkv3PH03TUEGWyxuu3zSzjyw_70Amw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->