### PR TITLE
fix(ui): render image message parts in the shipped Thread (#5879)

### DIFF
--- a/apps/docs/content/docs/ui/image.mdx
+++ b/apps/docs/content/docs/ui/image.mdx
@@ -22,7 +22,7 @@ import { ImageSample } from "@/components/docs/samples/image";
 
 ### Use in your application
 
-Pass `Image` to `MessagePrimitive.Parts`:
+The shipped `Thread` component renders `image` parts through `Image` by default, in both assistant and user messages. In a custom thread, pass `Image` to `MessagePrimitive.Parts`:
 
 ```tsx title="/components/assistant-ui/thread.tsx" {1,8}
 import { Image } from "@/components/assistant-ui/image";

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1009,6 +1009,7 @@ export const registry: RegistryItem[] = [
       "https://r.assistant-ui.com/attachment.json",
       "https://r.assistant-ui.com/file.json",
       "https://r.assistant-ui.com/follow-up-suggestions.json",
+      "https://r.assistant-ui.com/image.json",
       "https://r.assistant-ui.com/markdown-text.json",
       "https://r.assistant-ui.com/reasoning.json",
       "https://r.assistant-ui.com/tooltip-icon-button.json",

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/assistant-ui/attachment";
 import { File } from "@/components/assistant-ui/file";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
+import { Image } from "@/components/assistant-ui/image";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
   Reasoning,
@@ -37,6 +38,7 @@ import {
   SuggestionPrimitive,
   ThreadPrimitive,
   type FileMessagePartComponent,
+  type ImageMessagePartComponent,
   type ToolCallMessagePartComponent,
   useAuiState,
 } from "@assistant-ui/react";
@@ -406,6 +408,12 @@ const AssistantMessage: FC = () => {
                     <File {...part} />
                   </div>
                 );
+              case "image":
+                return (
+                  <div data-slot="aui_assistant-message-image" className="py-1">
+                    <Image {...part} />
+                  </div>
+                );
               case "indicator":
                 return (
                   <span
@@ -490,6 +498,12 @@ const UserFilePart: FileMessagePartComponent = (part) => (
   </div>
 );
 
+const UserImagePart: ImageMessagePartComponent = (part) => (
+  <div data-slot="aui_user-message-image" className="py-1">
+    <Image {...part} />
+  </div>
+);
+
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -501,7 +515,9 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts components={{ File: UserFilePart }} />
+          <MessagePrimitive.Parts
+            components={{ File: UserFilePart, Image: UserImagePart }}
+          />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />


### PR DESCRIPTION
fixes #5879

`defaultComponents` maps `Image: () => null` and the shipped Thread overrode neither side, so an `image` message part rendered as nothing: the assistant GroupedParts switch had a `file` arm (#5548) but no `image` arm, and the user-side components map registered `File` only (#5553). restored langgraph history is the concrete case: `contentToParts` converts `image_url` blocks to `image` parts, and on a fresh reload there are no attachments to carry the preview, so a user message whose only content is an image collapsed through `empty:hidden`.

this mirrors the file arms exactly: an `image` arm in the assistant switch and `Image: UserImagePart` in the user-side components map, each wrapping the existing `Image` kit component in a block-level slot with the same vertical spacing as the file arms. no guards were added to `image.tsx`: unlike the file card, whose size line computed `getBase64Size` at render time, the image render path has no render-time throw; an invalid src lands in `ImagePreview`'s error state, and the download and copy actions are opt-in and not mounted by the default arm.

`image.json` joins the thread registry item's `registryDependencies` so `shadcn add thread` stays self-contained, and the image docs note the shipped default the same way the file docs do. no changeset: `@assistant-ui/ui`, the registry, and docs are private.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZWw59L_PgV9w9cvKAH0ySvOB031QAkF9I7gGsr8A1qZExlShQZ6yA1kBy-c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->