### PR TITLE
fix(tap): rebase reducer replays through committed history

### DIFF
--- a/.changeset/tap-committed-log-rewind.md
+++ b/.changeset/tap-committed-log-rewind.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: rewind reducer cells through committed history so React replays from any mid-chain base reduce from the oracle state

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { StrictMode, startTransition } from "react";
+import {
+  StrictMode,
+  startTransition,
+  useReducer as useReactReducer,
+} from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "@testing-library/react";
@@ -40,16 +44,41 @@ vi.mock("../../core/helpers/root", async (importOriginal) => {
 
 let reactRoot: Root | undefined;
 let container: HTMLElement | undefined;
+let oracleRoot: Root | undefined;
+let oracleContainer: HTMLElement | undefined;
 
 afterEach(async () => {
-  await act(async () => reactRoot?.unmount());
+  await act(async () => {
+    reactRoot?.unmount();
+    oracleRoot?.unmount();
+  });
   container?.remove();
+  oracleContainer?.remove();
   reactRoot = undefined;
   container = undefined;
+  oracleRoot = undefined;
+  oracleContainer = undefined;
   cleanupAllResources();
   probes.belowCommitted = 0;
   probes.changelogLengths.length = 0;
 });
+
+const mountOracle = (): ((chunk: string) => void) => {
+  let push!: (chunk: string) => void;
+  function Oracle() {
+    const [chunks, dispatch] = useReactReducer(
+      (s: readonly string[], c: string) => [...s, c],
+      [] as readonly string[],
+    );
+    push = dispatch;
+    return <div>{chunks.join(",")}</div>;
+  }
+  oracleContainer = document.createElement("div");
+  document.body.appendChild(oracleContainer);
+  oracleRoot = createRoot(oracleContainer);
+  act(() => oracleRoot!.render(<Oracle />));
+  return (chunk) => push(chunk);
+};
 
 const useStream = () => {
   const [chunks, push] = useResourceReducer(
@@ -265,5 +294,183 @@ describe("React-hosted reducer replay below the committed version", () => {
     setRootVersion(fiber.root, 2);
     expect(renderTest(fiber, 1)).toBe(committed);
     expect(computes).toBe(2);
+  });
+
+  it("rebases a mid-tick mixed-lane chain to the React oracle", async () => {
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream());
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    await act(async () => {
+      reactRoot!.render(<App />);
+    });
+    const oraclePush = mountOracle();
+
+    await act(async () => {
+      api.push("a");
+      oraclePush("a");
+      startTransition(() => {
+        api.push("t");
+        oraclePush("t");
+      });
+      flushSync(() => {
+        api.push("c");
+        oraclePush("c");
+      });
+    });
+
+    expect(oracleContainer!.textContent).toBe("a,t,c");
+    expect(container.textContent).toBe(oracleContainer!.textContent);
+  });
+
+  it("rebases a mid-tick mixed-lane chain under StrictMode", async () => {
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream());
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    await act(async () => {
+      reactRoot!.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      api.push("a");
+      startTransition(() => api.push("t"));
+      flushSync(() => api.push("c"));
+    });
+
+    expect(container.textContent).toBe("a,t,c");
+  });
+
+  it("rebases a transition across two flushSync commits to the React oracle", async () => {
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream());
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    await act(async () => {
+      reactRoot!.render(<App />);
+    });
+    const oraclePush = mountOracle();
+
+    await act(async () => {
+      startTransition(() => {
+        api.push("t1");
+        oraclePush("t1");
+      });
+      flushSync(() => {
+        api.push("s1");
+        oraclePush("s1");
+      });
+      flushSync(() => {
+        api.push("s2");
+        oraclePush("s2");
+      });
+    });
+
+    expect(oracleContainer!.textContent).toBe("t1,s1,s2");
+    expect(container.textContent).toBe(oracleContainer!.textContent);
+  });
+
+  it("rebases a mid-tick mixed-lane chain across two sync commits to the React oracle", async () => {
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream());
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    await act(async () => {
+      reactRoot!.render(<App />);
+    });
+    const oraclePush = mountOracle();
+
+    await act(async () => {
+      api.push("a");
+      oraclePush("a");
+      startTransition(() => {
+        api.push("t");
+        oraclePush("t");
+      });
+      flushSync(() => {
+        api.push("c1");
+        oraclePush("c1");
+      });
+      flushSync(() => {
+        api.push("c2");
+        oraclePush("c2");
+      });
+    });
+
+    expect(oracleContainer!.textContent).toBe("a,t,c1,c2");
+    expect(container.textContent).toBe(oracleContainer!.textContent);
+  });
+
+  it("rebases two interleaved transitions across sync commits to the React oracle", async () => {
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream());
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container);
+    await act(async () => {
+      reactRoot!.render(<App />);
+    });
+    const oraclePush = mountOracle();
+
+    await act(async () => {
+      api.push("a");
+      oraclePush("a");
+      startTransition(() => {
+        api.push("tA");
+        oraclePush("tA");
+      });
+      flushSync(() => {
+        api.push("c1");
+        oraclePush("c1");
+      });
+      startTransition(() => {
+        api.push("tB");
+        oraclePush("tB");
+      });
+      flushSync(() => {
+        api.push("c2");
+        oraclePush("c2");
+      });
+    });
+
+    expect(container.textContent).toBe(oracleContainer!.textContent);
   });
 });

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -9,8 +9,22 @@ import type { ChangelogRecord } from "../core/types";
 const makeRoot = () => createResourceFiberRoot(() => {});
 
 const pushRecord = (root: ReturnType<typeof makeRoot>) => {
-  root.changelog.push({} as ChangelogRecord);
+  root.changelog.push({ settled: true } as ChangelogRecord);
 };
+
+const committedRecord = (
+  root: ReturnType<typeof makeRoot>,
+  cell: object,
+  prevState: unknown,
+): ChangelogRecord =>
+  ({
+    fiber: { root, markDirty: undefined },
+    cell,
+    prevState,
+    settled: false,
+    queued: false,
+    logged: true,
+  }) as unknown as ChangelogRecord;
 
 describe("setRootVersion", () => {
   it("clears the changelog when rolling back to the committed version", () => {
@@ -27,14 +41,17 @@ describe("setRootVersion", () => {
 
   it("clears changelog membership when records are removed", () => {
     const root = makeRoot();
-    const committedRecord = { logged: true } as ChangelogRecord;
+    const committedRecord = { logged: true, settled: true } as ChangelogRecord;
     root.changelog.push(committedRecord);
     commitRoot(root);
     expect(committedRecord.logged).toBe(false);
 
     setRootVersion(root, 3);
     commitRoot(root);
-    const belowCommittedRecord = { logged: true } as ChangelogRecord;
+    const belowCommittedRecord = {
+      logged: true,
+      settled: true,
+    } as ChangelogRecord;
     root.changelog.push(belowCommittedRecord);
     setRootVersion(root, 1);
     expect(belowCommittedRecord.logged).toBe(false);
@@ -74,6 +91,7 @@ describe("setRootVersion", () => {
         cell: { isDirty: false, queue: null },
         queued: true,
         logged: true,
+        settled: true,
       }) as unknown as ChangelogRecord;
     const records = [
       trackedRecord(1),
@@ -88,6 +106,75 @@ describe("setRootVersion", () => {
     expect(root.committedVersion).toBe(6);
     expect(root.changelog.length).toBe(0);
     expect(records.every((record) => !record.logged)).toBe(true);
+  });
+
+  it("rewinds committed records to their pre-application state on a below-committed replay", () => {
+    const root = makeRoot();
+    const cell = {
+      isDirty: false,
+      queue: null,
+      workInProgress: "s1",
+      current: "s1",
+    };
+    const record = committedRecord(root, cell, "base");
+
+    root.unsettledCount = 2;
+    setRootVersion(root, 1);
+    root.changelog.push(record);
+    commitRoot(root);
+    expect(root.committedLog).toEqual([record]);
+
+    setRootVersion(root, 0);
+    expect(cell.workInProgress).toBe("base");
+    expect(cell.isDirty).toBe(true);
+    expect(root.committedLog.length).toBe(0);
+    expect(root.committedVersion).toBe(0);
+  });
+
+  it("restores the committed log and version when a rewound replay is discarded", () => {
+    const root = makeRoot();
+    const cell = {
+      isDirty: false,
+      queue: null,
+      workInProgress: "s2",
+      current: "s2",
+    };
+    const recordA = committedRecord(root, cell, "p1");
+    const recordB = committedRecord(root, cell, "p2");
+
+    root.unsettledCount = 3;
+    setRootVersion(root, 1);
+    root.changelog.push(recordA);
+    commitRoot(root);
+    setRootVersion(root, 2);
+    root.changelog.push(recordB);
+    commitRoot(root);
+    expect(root.committedLog).toEqual([recordA, recordB]);
+
+    setRootVersion(root, 1);
+    expect(cell.workInProgress).toBe("p2");
+    expect(root.committedLog).toEqual([recordA]);
+    expect(root.committedVersion).toBe(1);
+
+    setRootVersion(root, 0);
+    expect(root.committedVersion).toBe(0);
+    expect(cell.workInProgress).toBe("p1");
+    expect(root.committedLog.length).toBe(0);
+  });
+
+  it("drops committed history once every dispatched record settles", () => {
+    const root = makeRoot();
+    const record = {
+      settled: false,
+      logged: true,
+      queued: false,
+    } as ChangelogRecord;
+    root.unsettledCount = 1;
+    setRootVersion(root, 1);
+    root.changelog.push(record);
+    commitRoot(root);
+    expect(root.unsettledCount).toBe(0);
+    expect(root.committedLog.length).toBe(0);
   });
 
   it("runs rollback callbacks when replaying below the committed version", () => {

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -41,11 +41,24 @@ describe("setRootVersion", () => {
 
   it("clears changelog membership when records are removed", () => {
     const root = makeRoot();
-    const committedRecord = { logged: true, settled: true } as ChangelogRecord;
-    root.changelog.push(committedRecord);
+    const movedRecord = { logged: true, settled: true } as ChangelogRecord;
+    root.changelog.push(movedRecord);
     commitRoot(root);
-    expect(committedRecord.logged).toBe(false);
+    expect(movedRecord.logged).toBe(false);
 
+    const cell = {
+      isDirty: false,
+      queue: null,
+      workInProgress: "s",
+      current: "s",
+    };
+    root.unsettledCount = 3;
+    setRootVersion(root, 2);
+    root.changelog.push(
+      committedRecord(root, cell, "p1"),
+      committedRecord(root, cell, "p2"),
+    );
+    commitRoot(root);
     setRootVersion(root, 3);
     commitRoot(root);
     const belowCommittedRecord = {
@@ -59,7 +72,19 @@ describe("setRootVersion", () => {
 
   it("re-bases to a version below the committed version instead of throwing", () => {
     const root = makeRoot();
+    const cell = {
+      isDirty: false,
+      queue: null,
+      workInProgress: "s",
+      current: "s",
+    };
+    root.unsettledCount = 4;
     setRootVersion(root, 3);
+    root.changelog.push(
+      committedRecord(root, cell, "p1"),
+      committedRecord(root, cell, "p2"),
+      committedRecord(root, cell, "p3"),
+    );
     commitRoot(root);
     expect(root.committedVersion).toBe(3);
 
@@ -155,6 +180,12 @@ describe("setRootVersion", () => {
     expect(cell.workInProgress).toBe("p2");
     expect(root.committedLog).toEqual([recordA]);
     expect(root.committedVersion).toBe(1);
+
+    setRootVersion(root, 3);
+    setRootVersion(root, 1);
+    expect(root.committedVersion).toBe(1);
+    expect(cell.workInProgress).toBe("p2");
+    expect(root.committedLog).toEqual([recordA]);
 
     setRootVersion(root, 0);
     expect(root.committedVersion).toBe(0);

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -4,6 +4,7 @@ import type {
   ResourceFiber,
   TapRoot,
 } from "../types";
+import { isDevelopment } from "./env";
 export const createResourceFiberRoot = (
   dispatchUpdate: (evaluate: () => boolean, apply: () => boolean) => void,
 ): TapRoot => {
@@ -21,7 +22,8 @@ export const createResourceFiberRoot = (
 // The committed log retains committed records while any dispatched record is
 // still unsettled, so a below-committed replay can rewind cells to the state
 // at its base; once everything settles no replay can reach below and the
-// history is dropped.
+// history is dropped. Retention is one record, holding one state snapshot,
+// per commit that lands while a lane stays pending.
 export const commitRoot = (root: TapRoot): void => {
   root.committedVersion = root.version;
   for (const record of root.changelog) {
@@ -56,7 +58,14 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
       const rewound: ChangelogRecord[] = [];
       while (root.committedVersion - rewound.length > version) {
         const record = root.committedLog.pop();
-        if (record === undefined) break;
+        if (record === undefined) {
+          if (isDevelopment && rewound.length > 0) {
+            throw new Error(
+              "tap: committed history is shorter than the replay base.",
+            );
+          }
+          break;
+        }
         markReducerDirty(record.fiber, record.cell);
         record.cell.workInProgress = record.prevState;
         rewound.push(record);

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -12,14 +12,28 @@ export const createResourceFiberRoot = (
     committedVersion: 0,
     dispatchUpdate,
     changelog: [],
+    committedLog: [],
+    unsettledCount: 0,
     rollbackCallbacks: [],
   };
 };
 
+// The committed log retains committed records while any dispatched record is
+// still unsettled, so a below-committed replay can rewind cells to the state
+// at its base; once everything settles no replay can reach below and the
+// history is dropped.
 export const commitRoot = (root: TapRoot): void => {
   root.committedVersion = root.version;
-  for (const record of root.changelog) record.logged = false;
+  for (const record of root.changelog) {
+    record.logged = false;
+    if (!record.settled) {
+      record.settled = true;
+      root.unsettledCount--;
+    }
+    root.committedLog.push(record);
+  }
   root.changelog.length = 0;
+  if (root.unsettledCount === 0) root.committedLog.length = 0;
   root.rollbackCallbacks.length = 0;
 };
 
@@ -34,9 +48,28 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
 
     if (version <= root.committedVersion) {
       // A version below the last commit is a React concurrent reducer replay
-      // from an older base; the replayed chain re-supplies its updates. The
-      // committed version re-bases to keep the changelog's base derivation in
-      // the branch below correct; the next commit overwrites it.
+      // from an older base; the replayed chain re-supplies its updates.
+      // Committed records above that base are rewound so replayed updates
+      // reduce from the state at the base; the commit path drops the armed
+      // restore, while a discarded replay restores the log and the committed
+      // version through it.
+      const rewound: ChangelogRecord[] = [];
+      while (root.committedVersion - rewound.length > version) {
+        const record = root.committedLog.pop();
+        if (record === undefined) break;
+        markReducerDirty(record.fiber, record.cell);
+        record.cell.workInProgress = record.prevState;
+        rewound.push(record);
+      }
+      if (rewound.length > 0) {
+        const restoredVersion = root.committedVersion;
+        addRollback(root, () => {
+          for (let i = rewound.length - 1; i >= 0; i--) {
+            root.committedLog.push(rewound[i]!);
+          }
+          root.committedVersion = restoredVersion;
+        });
+      }
       root.committedVersion = version;
       for (const record of root.changelog) record.logged = false;
       root.changelog.length = 0;
@@ -56,18 +89,10 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
 };
 
 export const applyChangelogRecord = (record: ChangelogRecord): void => {
-  const { cell, fiber } = record;
-  // A replay's first re-applied record rewinds the cell to its dispatch-time
-  // base, valid exactly when that base is the current committed floor. A floor
-  // above the dispatch base has no snapshot and keeps committed state.
-  const restoreBase =
-    !cell.isDirty && record.baseVersion === fiber.root.committedVersion;
-
-  markReducerDirty(fiber, cell);
-  if (restoreBase) cell.workInProgress = record.baseState;
+  markReducerDirty(record.fiber, record.cell);
   if (!record.queued) {
     record.queued = true;
-    (cell.queue ??= []).push(record);
+    (record.cell.queue ??= []).push(record);
   }
 };
 

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -22,9 +22,8 @@ export interface ChangelogRecord {
 
   hasEagerState: boolean;
   eagerState: any;
-  eagerStateBase: any;
-  baseState: any;
-  baseVersion: number;
+  prevState: any;
+  settled: boolean;
   queued: boolean;
   logged: boolean;
 }
@@ -78,6 +77,8 @@ export interface TapRoot {
   version: number;
   committedVersion: number;
   readonly changelog: ChangelogRecord[];
+  readonly committedLog: ChangelogRecord[];
+  unsettledCount: number;
   readonly dispatchUpdate: (
     evaluate: () => boolean,
     apply: () => boolean,

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -39,7 +39,7 @@ const dispatchOnFiber = (
         !record.cell.isDirty &&
         !record.hasEagerState
       ) {
-        record.eagerStateBase = record.cell.workInProgress;
+        record.prevState = record.cell.workInProgress;
         record.eagerState = eagerReducer(
           record.cell.workInProgress,
           record.action,
@@ -47,6 +47,10 @@ const dispatchOnFiber = (
         record.hasEagerState = true;
 
         hasWork = !Object.is(record.cell.current, record.eagerState);
+        if (!hasWork && !record.settled) {
+          record.settled = true;
+          fiber.root.unsettledCount--;
+        }
       }
 
       return hasWork;
@@ -102,13 +106,13 @@ const createReducerCell = (
           action,
           hasEagerState: false,
           eagerState: undefined,
-          eagerStateBase: undefined,
-          baseState: cell.current,
-          baseVersion: fiber.root.committedVersion,
+          prevState: undefined,
+          settled: false,
           queued: false,
           logged: false,
         };
 
+        fiber.root.unsettledCount++;
         dispatchOnFiber(fiber, record, eagerBailout ? reducer : undefined);
       }
     },
@@ -158,9 +162,9 @@ export function useReducerImpl<S, A, I>(
       if (
         !item.hasEagerState ||
         !sameReducer ||
-        !Object.is(item.eagerStateBase, cell.workInProgress)
+        !Object.is(item.prevState, cell.workInProgress)
       ) {
-        item.eagerStateBase = cell.workInProgress;
+        item.prevState = cell.workInProgress;
         item.eagerState = reducer(cell.workInProgress, item.action);
         item.hasEagerState = true;
 

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -106,7 +106,7 @@ const createReducerCell = (
           action,
           hasEagerState: false,
           eagerState: undefined,
-          prevState: undefined,
+          prevState: cell.current,
           settled: false,
           queued: false,
           logged: false,


### PR DESCRIPTION
closes #5330

## summary

- a React-hosted reducer replay now reduces from the exact state at its base for every replay shape, instead of re-applying onto already-committed cell state; this closes the remaining mixed-lane half of #5330 after #5867 covered dispatch-floor replays
- `commitRoot` moves changelog records into `root.committedLog` instead of dropping them, retained only while a dispatched record is still unsettled (React can only replay while its baseQueue holds a skipped update, and that update is unsettled by definition); once everything settles the history is dropped, so useTapRoot hosts retain nothing
- the below-committed branch rewinds that log newest first (`committedVersion - popped > version`), restoring each cell's `workInProgress` to the popped record's `prevState`, captured at every application rather than at dispatch; the armed discard restore pushes the popped records back and restores `committedVersion` with them, because the (version, log) pair goes incoherent for a second deeper rollback otherwise
- `prevState` also replaces `eagerStateBase` as the eager memo validity key, and #5867's `restoreBase` branch plus its `baseState`/`baseVersion` fields are deleted: after the rewind runs, that branch is provably either shielded (the rewind marked the cell dirty) or an equal-value write, and its dispatch-time snapshots are exactly the data source that goes stale across double replays
- builds on #5884: the rewind arithmetic assumes one committed record per version bump, which the `logged` guard restored under StrictMode

## test plan

### already verified

- [x] five live-oracle bridge discriminators red on the previous head and green with the fix, with compounding corruption before: mixed-lane `a,t,c` (was `a,c,t,c`), its StrictMode variant, mixed-lane across two sync commits `a,t,c1,c2` (was `a,c1,c1,c2,t,c1,c2`), two interleaved transitions `a,tA,c1,tB,c2` (was `a,c1,c1,c2,tA,c1,tB,c2`), and the promoted deficit-2 `t1,s1,s2`
- [x] the double-transition case passes only because the drain refreshes `prevState` on every re-application; the second replay pops records the first replay rewrote
- [x] #5867's own bridge tests (`t1,s1` exact, cumulative eager counter) stay green through the rewind path, proving the deleted `restoreBase` branch is subsumed
- [x] three new root units: rewind restores pre-application state, a discarded rewind restores the log and the committed version, history drops once every record settles
- [x] full suites: tap 555, store 168 plus `test:react-compiler`, core 1076 plus `test:react-compiler`, zero regressions; oxlint and oxfmt clean

### reviewer should verify

- [ ] revert `packages/tap/src/core/helpers/root.ts` and `packages/tap/src/react-hooks/useReducer.ts` to the parent commit and confirm the four mixed-lane and double-transition tests fail against the live React oracle, then restore

## notes

- the 2026-07-29 scope addition on the issue (discarded low-lane dirty cells crossing into the next lane without a rollback) is resolved structurally: every next-lane entry re-derives the version chain from its base, so it either descends first (the rollback restores cells, the committed log, and the committed version before any branch logic reads them) or is the same chain continuing; the deficit-2 style tests drive exactly those interrupted-replay interleaves
- retention is bounded by React's own model: the committed log grows only while a lane is pending, mirroring React's baseQueue growth in the same window

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EclgkVp7OU0dsluhssuX554UqXCOK-Jnffeqge4tSWzBYuzAkrrY3sFqyBA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->