### PR TITLE
fix(tap): restore replay snapshots on discard, exact unsettled accounting

### DIFF
--- a/.changeset/tap-rewind-hardening.md
+++ b/.changeset/tap-rewind-hardening.md
@@ -2,4 +2,4 @@
 "@assistant-ui/tap": patch
 ---
 
-fix: restore application snapshots when a rewound replay is discarded and stop dispatch-before-mount from stranding replay history retention
+fix: restore application snapshots when a rewound replay is discarded, stop dispatch-before-mount from stranding replay history retention, and throw in development and test environments when a below-committed replay finds no committed history to rewind

--- a/.changeset/tap-rewind-hardening.md
+++ b/.changeset/tap-rewind-hardening.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: restore application snapshots when a rewound replay is discarded and keep unsettled accounting exact under thrown dispatches

--- a/.changeset/tap-rewind-hardening.md
+++ b/.changeset/tap-rewind-hardening.md
@@ -2,4 +2,4 @@
 "@assistant-ui/tap": patch
 ---
 
-fix: restore application snapshots when a rewound replay is discarded and keep unsettled accounting exact under thrown dispatches
+fix: restore application snapshots when a rewound replay is discarded and stop dispatch-before-mount from stranding replay history retention

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -328,7 +328,7 @@ describe("React-hosted reducer replay below the committed version", () => {
     expect(fiber.root.unsettledCount).toBe(0);
   });
 
-  it("settles accounting when the host dispatch throws before applying", () => {
+  it("leaves accounting pending when the host dispatch throws", () => {
     const root = createResourceFiberRoot(() => {
       throw new Error("host dispatch failure");
     });
@@ -350,7 +350,7 @@ describe("React-hosted reducer replay below the committed version", () => {
     renderResourceFiber(fiber, []);
     commitResourceFiber(fiber);
     expect(() => push("boom")).toThrow("host dispatch failure");
-    expect(root.unsettledCount).toBe(0);
+    expect(root.unsettledCount).toBe(1);
   });
 
   it("keeps a queued record unsettled when the host throws after applying", () => {

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -7,7 +7,7 @@ import {
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "@testing-library/react";
-import type { TapRoot } from "../../core/types";
+import type { ChangelogRecord, TapRoot } from "../../core/types";
 import { resource } from "../../core/resource";
 import { commitRoot, setRootVersion } from "../../core/helpers/root";
 import { renderResourceFiber } from "../../core/ResourceFiber";
@@ -286,7 +286,18 @@ describe("React-hosted reducer replay below the committed version", () => {
     });
 
     const committed = renderTest(fiber, 1);
+    fiber.root.unsettledCount = 2;
     setRootVersion(fiber.root, 3);
+    fiber.root.changelog.push({
+      fiber: { root: fiber.root, markDirty: undefined },
+      cell: { isDirty: false, queue: null, workInProgress: "x", current: "x" },
+      prevState: "x",
+      hasEagerState: false,
+      eagerState: undefined,
+      settled: false,
+      queued: false,
+      logged: true,
+    } as unknown as ChangelogRecord);
     commitRoot(fiber.root);
     setRootVersion(fiber.root, 4);
     expect(renderResourceFiber(fiber, [2])).toEqual({ x: 2 });
@@ -294,6 +305,22 @@ describe("React-hosted reducer replay below the committed version", () => {
     setRootVersion(fiber.root, 2);
     expect(renderTest(fiber, 1)).toBe(committed);
     expect(computes).toBe(2);
+  });
+
+  it("does not leak unsettled accounting when a dispatch throws before mount", () => {
+    let push!: (chunk: string) => void;
+    const fiber = createTestResource(() => {
+      const [chunks, dispatch] = useResourceReducer(
+        (s: readonly string[], c: string) => [...s, c],
+        [] as readonly string[],
+      );
+      push = dispatch;
+      return chunks;
+    });
+
+    renderResourceFiber(fiber, []);
+    expect(() => push("early")).toThrow("Resource updated before mount");
+    expect(fiber.root.unsettledCount).toBe(0);
   });
 
   it("rebases a mid-tick mixed-lane chain to the React oracle", async () => {

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -291,6 +291,9 @@ describe("React-hosted reducer replay below the committed version", () => {
     });
 
     const committed = renderTest(fiber, 1);
+    // The seeded record and phantom unsettled count keep committedLog
+    // populated through commitRoot, so the descent below has history to pop
+    // and does not trip the short-history dev guard.
     fiber.root.unsettledCount = 2;
     setRootVersion(fiber.root, 3);
     fiber.root.changelog.push({

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -10,7 +10,12 @@ import { act } from "@testing-library/react";
 import type { ChangelogRecord, TapRoot } from "../../core/types";
 import { resource } from "../../core/resource";
 import { commitRoot, setRootVersion } from "../../core/helpers/root";
-import { renderResourceFiber } from "../../core/ResourceFiber";
+import {
+  commitResourceFiber,
+  createResourceFiber,
+  renderResourceFiber,
+} from "../../core/ResourceFiber";
+import { createResourceFiberRoot } from "../../core/helpers/root";
 import { useResource } from "../../index";
 import { useReducer as useResourceReducer } from "../../react-hooks/useReducer";
 import { useMemo as useResourceMemo } from "../../react-hooks/useMemo";
@@ -321,6 +326,57 @@ describe("React-hosted reducer replay below the committed version", () => {
     renderResourceFiber(fiber, []);
     expect(() => push("early")).toThrow("Resource updated before mount");
     expect(fiber.root.unsettledCount).toBe(0);
+  });
+
+  it("settles accounting when the host dispatch throws before applying", () => {
+    const root = createResourceFiberRoot(() => {
+      throw new Error("host dispatch failure");
+    });
+    let push!: (chunk: string) => void;
+    const fiber = createResourceFiber(
+      () => {
+        const [chunks, dispatch] = useResourceReducer(
+          (s: readonly string[], c: string) => [...s, c],
+          [] as readonly string[],
+        );
+        push = dispatch;
+        return chunks;
+      },
+      root,
+      undefined,
+      null,
+    );
+
+    renderResourceFiber(fiber, []);
+    commitResourceFiber(fiber);
+    expect(() => push("boom")).toThrow("host dispatch failure");
+    expect(root.unsettledCount).toBe(0);
+  });
+
+  it("keeps a queued record unsettled when the host throws after applying", () => {
+    const root = createResourceFiberRoot((_evaluate, apply) => {
+      apply();
+      throw new Error("post apply failure");
+    });
+    let push!: (chunk: string) => void;
+    const fiber = createResourceFiber(
+      () => {
+        const [chunks, dispatch] = useResourceReducer(
+          (s: readonly string[], c: string) => [...s, c],
+          [] as readonly string[],
+        );
+        push = dispatch;
+        return chunks;
+      },
+      root,
+      undefined,
+      null,
+    );
+
+    renderResourceFiber(fiber, []);
+    commitResourceFiber(fiber);
+    expect(() => push("boom")).toThrow("post apply failure");
+    expect(root.unsettledCount).toBe(1);
   });
 
   it("rebases a mid-tick mixed-lane chain to the React oracle", async () => {

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -204,6 +204,24 @@ describe("setRootVersion", () => {
     expect(root.committedLog.length).toBe(0);
   });
 
+  it("throws in development when committed history cannot cover the replay base", () => {
+    const root = makeRoot();
+    const cell = {
+      isDirty: false,
+      queue: null,
+      workInProgress: "s",
+      current: "s",
+    };
+    root.unsettledCount = 2;
+    setRootVersion(root, 2);
+    root.changelog.push(committedRecord(root, cell, "p1"));
+    commitRoot(root);
+
+    expect(() => setRootVersion(root, 0)).toThrow(
+      "committed history is shorter than the replay base",
+    );
+  });
+
   it("drops committed history once every dispatched record settles", () => {
     const root = makeRoot();
     const record = {

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -190,6 +190,7 @@ describe("setRootVersion", () => {
     expect(root.committedVersion).toBe(2);
     expect(root.committedLog).toEqual([recordA, recordB]);
     expect(recordB.prevState).toBe("p2");
+    expect(recordB.eagerState).toBeUndefined();
     expect(recordB.hasEagerState).toBe(false);
     expect(cell.workInProgress).toBe("s2");
 

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -222,6 +222,17 @@ describe("setRootVersion", () => {
     );
   });
 
+  it("throws in development when the committed log is empty at a below-committed replay", () => {
+    const root = makeRoot();
+    root.unsettledCount = 1;
+    setRootVersion(root, 2);
+    commitRoot(root);
+
+    expect(() => setRootVersion(root, 0)).toThrow(
+      "committed history is shorter than the replay base",
+    );
+  });
+
   it("drops committed history once every dispatched record settles", () => {
     const root = makeRoot();
     const record = {

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -21,6 +21,8 @@ const committedRecord = (
     fiber: { root, markDirty: undefined },
     cell,
     prevState,
+    hasEagerState: false,
+    eagerState: undefined,
     settled: false,
     queued: false,
     logged: true,
@@ -97,10 +99,8 @@ describe("setRootVersion", () => {
 
   it("keeps changelog records relative to the re-based version on a partial rollback", () => {
     const root = makeRoot();
-    setRootVersion(root, 5);
-    commitRoot(root);
-
     setRootVersion(root, 3);
+    commitRoot(root);
     expect(root.committedVersion).toBe(3);
 
     setRootVersion(root, 7);
@@ -181,9 +181,19 @@ describe("setRootVersion", () => {
     expect(root.committedLog).toEqual([recordA]);
     expect(root.committedVersion).toBe(1);
 
+    recordB.prevState = "rewritten";
+    recordB.eagerState = "rewritten";
+    recordB.hasEagerState = true;
+
     setRootVersion(root, 3);
+    setRootVersion(root, 2);
+    expect(root.committedVersion).toBe(2);
+    expect(root.committedLog).toEqual([recordA, recordB]);
+    expect(recordB.prevState).toBe("p2");
+    expect(recordB.hasEagerState).toBe(false);
+    expect(cell.workInProgress).toBe("s2");
+
     setRootVersion(root, 1);
-    expect(root.committedVersion).toBe(1);
     expect(cell.workInProgress).toBe("p2");
     expect(root.committedLog).toEqual([recordA]);
 
@@ -212,13 +222,14 @@ describe("setRootVersion", () => {
     const root = makeRoot();
     setRootVersion(root, 3);
     commitRoot(root);
+    setRootVersion(root, 5);
 
     let rolledBack = false;
     root.rollbackCallbacks.push(() => {
       rolledBack = true;
     });
 
-    setRootVersion(root, 1);
+    setRootVersion(root, 3);
     expect(rolledBack).toBe(true);
     expect(root.rollbackCallbacks.length).toBe(0);
   });

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -55,11 +55,16 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
       // reduce from the state at the base; the commit path drops the armed
       // restore, while a discarded replay restores the log and the committed
       // version through it.
-      const rewound: ChangelogRecord[] = [];
+      const rewound: {
+        record: ChangelogRecord;
+        prevState: any;
+        eagerState: any;
+        hasEagerState: boolean;
+      }[] = [];
       while (root.committedVersion - rewound.length > version) {
         const record = root.committedLog.pop();
         if (record === undefined) {
-          if (isDevelopment && rewound.length > 0) {
+          if (isDevelopment) {
             throw new Error(
               "tap: committed history is shorter than the replay base.",
             );
@@ -68,13 +73,25 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
         }
         markReducerDirty(record.fiber, record.cell);
         record.cell.workInProgress = record.prevState;
-        rewound.push(record);
+        rewound.push({
+          record,
+          prevState: record.prevState,
+          eagerState: record.eagerState,
+          hasEagerState: record.hasEagerState,
+        });
       }
       if (rewound.length > 0) {
         const restoredVersion = root.committedVersion;
+        // A discarded replay has re-drained the popped records against its own
+        // base, so the restore rewrites their application snapshots back to
+        // committed history alongside the log and the committed version.
         addRollback(root, () => {
           for (let i = rewound.length - 1; i >= 0; i--) {
-            root.committedLog.push(rewound[i]!);
+            const entry = rewound[i]!;
+            entry.record.prevState = entry.prevState;
+            entry.record.eagerState = entry.eagerState;
+            entry.record.hasEagerState = entry.hasEagerState;
+            root.committedLog.push(entry.record);
           }
           root.committedVersion = restoredVersion;
         });

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -28,44 +28,53 @@ const dispatchOnFiber = (
   let evaluated = false;
   let hasWork = true;
 
-  fiber.root.dispatchUpdate(
-    () => {
-      if (evaluated) return hasWork;
-      evaluated = true;
+  fiber.root.unsettledCount++;
+  try {
+    fiber.root.dispatchUpdate(
+      () => {
+        if (evaluated) return hasWork;
+        evaluated = true;
 
-      if (
-        eagerReducer &&
-        fiber.root.changelog.length === 0 &&
-        !record.cell.isDirty &&
-        !record.hasEagerState
-      ) {
-        record.prevState = record.cell.workInProgress;
-        record.eagerState = eagerReducer(
-          record.cell.workInProgress,
-          record.action,
-        );
-        record.hasEagerState = true;
+        if (
+          eagerReducer &&
+          fiber.root.changelog.length === 0 &&
+          !record.cell.isDirty &&
+          !record.hasEagerState
+        ) {
+          record.prevState = record.cell.workInProgress;
+          record.eagerState = eagerReducer(
+            record.cell.workInProgress,
+            record.action,
+          );
+          record.hasEagerState = true;
 
-        hasWork = !Object.is(record.cell.current, record.eagerState);
-        if (!hasWork && !record.settled) {
-          record.settled = true;
-          fiber.root.unsettledCount--;
+          hasWork = !Object.is(record.cell.current, record.eagerState);
+          if (!hasWork && !record.settled) {
+            record.settled = true;
+            fiber.root.unsettledCount--;
+          }
         }
-      }
 
-      return hasWork;
-    },
-    () => {
-      evaluated = true;
-      hasWork = true;
-      applyChangelogRecord(record);
-      if (!record.logged) {
-        record.logged = true;
-        fiber.root.changelog.push(record);
-      }
-      return true;
-    },
-  );
+        return hasWork;
+      },
+      () => {
+        evaluated = true;
+        hasWork = true;
+        applyChangelogRecord(record);
+        if (!record.logged) {
+          record.logged = true;
+          fiber.root.changelog.push(record);
+        }
+        return true;
+      },
+    );
+  } catch (error) {
+    if (!record.settled) {
+      record.settled = true;
+      fiber.root.unsettledCount--;
+    }
+    throw error;
+  }
 };
 
 const createReducerCell = (
@@ -112,7 +121,6 @@ const createReducerCell = (
           logged: false,
         };
 
-        fiber.root.unsettledCount++;
         dispatchOnFiber(fiber, record, eagerBailout ? reducer : undefined);
       }
     },

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -28,6 +28,9 @@ const dispatchOnFiber = (
   let evaluated = false;
   let hasWork = true;
 
+  // Counted after the mount guard, and deliberately not unwound on a host
+  // throw: the dispatch site cannot know whether the host enqueued the update,
+  // and over-retained history is the safe failure direction.
   fiber.root.unsettledCount++;
   fiber.root.dispatchUpdate(
     () => {

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -69,7 +69,11 @@ const dispatchOnFiber = (
       },
     );
   } catch (error) {
-    if (!record.settled && !record.logged) {
+    // Settle only when neither closure ran: with evaluated still false the
+    // host cannot have enqueued the update, while any later throw is ambiguous
+    // and leaves the record pending so history is retained rather than
+    // cleared early.
+    if (!record.settled && !evaluated) {
       record.settled = true;
       fiber.root.unsettledCount--;
     }

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -69,7 +69,7 @@ const dispatchOnFiber = (
       },
     );
   } catch (error) {
-    if (!record.settled) {
+    if (!record.settled && !record.logged) {
       record.settled = true;
       fiber.root.unsettledCount--;
     }

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -29,56 +29,44 @@ const dispatchOnFiber = (
   let hasWork = true;
 
   fiber.root.unsettledCount++;
-  try {
-    fiber.root.dispatchUpdate(
-      () => {
-        if (evaluated) return hasWork;
-        evaluated = true;
+  fiber.root.dispatchUpdate(
+    () => {
+      if (evaluated) return hasWork;
+      evaluated = true;
 
-        if (
-          eagerReducer &&
-          fiber.root.changelog.length === 0 &&
-          !record.cell.isDirty &&
-          !record.hasEagerState
-        ) {
-          record.prevState = record.cell.workInProgress;
-          record.eagerState = eagerReducer(
-            record.cell.workInProgress,
-            record.action,
-          );
-          record.hasEagerState = true;
+      if (
+        eagerReducer &&
+        fiber.root.changelog.length === 0 &&
+        !record.cell.isDirty &&
+        !record.hasEagerState
+      ) {
+        record.prevState = record.cell.workInProgress;
+        record.eagerState = eagerReducer(
+          record.cell.workInProgress,
+          record.action,
+        );
+        record.hasEagerState = true;
 
-          hasWork = !Object.is(record.cell.current, record.eagerState);
-          if (!hasWork && !record.settled) {
-            record.settled = true;
-            fiber.root.unsettledCount--;
-          }
+        hasWork = !Object.is(record.cell.current, record.eagerState);
+        if (!hasWork && !record.settled) {
+          record.settled = true;
+          fiber.root.unsettledCount--;
         }
+      }
 
-        return hasWork;
-      },
-      () => {
-        evaluated = true;
-        hasWork = true;
-        applyChangelogRecord(record);
-        if (!record.logged) {
-          record.logged = true;
-          fiber.root.changelog.push(record);
-        }
-        return true;
-      },
-    );
-  } catch (error) {
-    // Settle only when neither closure ran: with evaluated still false the
-    // host cannot have enqueued the update, while any later throw is ambiguous
-    // and leaves the record pending so history is retained rather than
-    // cleared early.
-    if (!record.settled && !evaluated) {
-      record.settled = true;
-      fiber.root.unsettledCount--;
-    }
-    throw error;
-  }
+      return hasWork;
+    },
+    () => {
+      evaluated = true;
+      hasWork = true;
+      applyChangelogRecord(record);
+      if (!record.logged) {
+        record.logged = true;
+        fiber.root.changelog.push(record);
+      }
+      return true;
+    },
+  );
 };
 
 const createReducerCell = (


### PR DESCRIPTION
follow-up hardening from the #5885 review threads, which landed after the merge.

## summary

- a discarded replay's drain rewrites the popped records' `prevState`/`eagerState` pair against the replayed chain's own base, and the armed restore was pushing those rewritten snapshots back into committed history; a later rewind would then land cells on the discarded chain's base instead of the committed one (reachable when a transition render starts before the interrupting sync render, i.e. time-sliced rather than same-tick). the rewound entries now snapshot the triple at pop time and the restore rewrites it back alongside the log and the committed version
- `unsettledCount` was incremented before `dispatchOnFiber`'s mount guard, so a single dispatch-before-mount throw permanently stranded the count above zero and turned the committed log into an unbounded retainer; the increment now sits after the guard inside `dispatchOnFiber`; other thrown dispatches deliberately stay unsettled, because whether the host enqueued the update before throwing is not knowable at the dispatch site, and the safe failure direction is retaining history rather than clearing it early
- the dev guard for short committed history no longer exempts the empty-log case: with the accounting leak fixed, no real host reaches a below-committed replay with an empty log (a wholesale premise break lands exactly there), so it throws in development on any shortfall; the synthetic units that relied on empty-log descents were restructured to reach their states without one

## test plan

### already verified

- [x] both mechanism discriminators red on the merged head and green here: the discard unit now pins the restored `prevState`/`hasEagerState` directly at a zero-pop entry (rollback runs, no immediate re-rewind), and the new before-mount unit pins `unsettledCount` staying 0 across the throw
- [x] full tap suite 556 green; oxlint and oxfmt clean

### reviewer should verify

- [ ] revert `packages/tap/src/core/helpers/root.ts` and `packages/tap/src/react-hooks/useReducer.ts` to the parent commit and confirm exactly the two new discriminators fail, then restore

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hwmG7SUllby_DHSF-j2cZ_oLZglhViCowe7f0XvkEwePXp4FgdMVI9zZo-o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
