### PR TITLE
fix(react-mcp): isolate add form submission callbacks

### DIFF
--- a/.changeset/calm-mcp-callbacks.md
+++ b/.changeset/calm-mcp-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: keep successful server additions successful when callbacks fail

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -1,36 +1,7 @@
 import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
 import { useAui } from "@assistant-ui/store";
 import { decodeServerIdFromState } from "../auth/createOAuthProvider";
-
-type McpOAuthCallbackName = "onComplete" | "onError";
-
-const reportCallbackError = (name: McpOAuthCallbackName, error: unknown) => {
-  console.error(`[react-mcp] ${name} callback threw an error`, error);
-};
-
-const invokeMcpOAuthCallback = <TArgs extends unknown[]>(
-  name: McpOAuthCallbackName,
-  callback: ((...args: TArgs) => void) | undefined,
-  ...args: TArgs
-) => {
-  if (!callback) return;
-
-  try {
-    const result = callback(...args) as unknown;
-    if (
-      result !== null &&
-      (typeof result === "object" || typeof result === "function") &&
-      "then" in result &&
-      typeof result.then === "function"
-    ) {
-      void Promise.resolve(result).catch((error) => {
-        reportCallbackError(name, error);
-      });
-    }
-  } catch (error) {
-    reportCallbackError(name, error);
-  }
-};
+import { invokeMcpCallback } from "../utils/invokeMcpCallback";
 
 export const createMcpOAuthCallbackError = (
   err: unknown,
@@ -104,15 +75,11 @@ export function useMcpOAuthCallback(
       } catch (err) {
         const error = createMcpOAuthCallbackError(err, serverId);
         setResult({ status: "error", serverId, error });
-        invokeMcpOAuthCallback("onError", optsRef.current.onError, error);
+        invokeMcpCallback("onError", optsRef.current.onError, error);
         return;
       }
 
-      invokeMcpOAuthCallback(
-        "onComplete",
-        optsRef.current.onComplete,
-        serverId,
-      );
+      invokeMcpCallback("onComplete", optsRef.current.onComplete, serverId);
     })();
   }, [aui, opts.url]);
 

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.test.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addCustomServer: vi.fn(),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => ({
+    mcp: { addCustomServer: mocks.addCustomServer },
+  }),
+}));
+
+import { McpAddFormPrimitiveError } from "./McpAddFormError";
+import { McpAddFormPrimitiveNameField } from "./McpAddFormNameField";
+import { McpAddFormPrimitiveRoot } from "./McpAddFormRoot";
+import { McpAddFormPrimitiveSubmit } from "./McpAddFormSubmit";
+import { McpAddFormPrimitiveUrlField } from "./McpAddFormUrlField";
+
+describe("McpAddFormPrimitiveRoot", () => {
+  beforeEach(() => {
+    mocks.addCustomServer.mockReset();
+    mocks.addCustomServer.mockResolvedValue("server-1");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["throws", "rejects"] as const)(
+    "does not turn a successful add into an error when onSubmitted %s",
+    async (mode) => {
+      const callbackError = new Error("navigation failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      render(
+        <McpAddFormPrimitiveRoot
+          onSubmitted={() => {
+            if (mode === "throws") throw callbackError;
+            return Promise.reject(callbackError);
+          }}
+        >
+          <McpAddFormPrimitiveNameField aria-label="Name" />
+          <McpAddFormPrimitiveUrlField aria-label="URL" />
+          <McpAddFormPrimitiveError />
+          <McpAddFormPrimitiveSubmit>Submit</McpAddFormPrimitiveSubmit>
+        </McpAddFormPrimitiveRoot>,
+      );
+
+      fireEvent.change(screen.getByLabelText("Name"), {
+        target: { value: "Docs" },
+      });
+      fireEvent.change(screen.getByLabelText("URL"), {
+        target: { value: "https://example.com/mcp" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+      await waitFor(() => expect(mocks.addCustomServer).toHaveBeenCalledOnce());
+      expect(screen.queryByText(callbackError.message)).toBeNull();
+      await waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-mcp] onSubmitted callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
+});

--- a/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.tsx
+++ b/packages/react-mcp/src/primitives/addForm/McpAddFormRoot.tsx
@@ -11,6 +11,7 @@ import { Primitive } from "@radix-ui/react-primitive";
 import { useAui } from "@assistant-ui/store";
 import { AddFormContext, type AddFormState } from "./context";
 import type { MCPAuthConfig } from "../../mcp-scope";
+import { invokeMcpCallback } from "../../utils/invokeMcpCallback";
 
 const INITIAL: AddFormState = {
   name: "",
@@ -106,7 +107,7 @@ export const McpAddFormPrimitiveRoot = forwardRef<
         auth: buildAuth(),
       });
       setState(INITIAL);
-      onSubmitted?.(id);
+      invokeMcpCallback("onSubmitted", onSubmitted, id);
     } catch (err) {
       setState((p) => ({
         ...p,

--- a/packages/react-mcp/src/utils/invokeMcpCallback.ts
+++ b/packages/react-mcp/src/utils/invokeMcpCallback.ts
@@ -1,0 +1,27 @@
+const reportCallbackError = (name: string, error: unknown) => {
+  console.error(`[react-mcp] ${name} callback threw an error`, error);
+};
+
+export const invokeMcpCallback = <TArgs extends unknown[]>(
+  name: string,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};


### PR DESCRIPTION
## Summary

- keep a successful custom MCP server addition successful when `onSubmitted` throws or returns a rejected promise
- report callback failures without showing them as form submission failures
- reuse the existing callback isolation behavior from the OAuth lifecycle

## Why

`addCustomServer()` persists the server before `onSubmitted` runs. The callback previously ran inside the same `try` block, so a navigation or telemetry callback failure was caught as though persistence had failed. The form then displayed an error even though the server existed, and retrying could create a duplicate server.

A focused regression test failed before the fix with the callback error rendered by the form. It now covers both synchronous throws and rejected callback promises.

## Testing

- `vitest run` in `packages/react-mcp` (109 tests)
- targeted `oxlint` and `oxfmt --check`
- `aui-build` in `packages/react-mcp`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lvfjnahbG2M_AC7JoPTiLwTxAwIjzdNlTL-KIMjiSUPQrWpgaTl2vm4Xj2Y?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->