### PR TITLE
fix(core): snapshot composer state before attachment uploads

### DIFF
--- a/.changeset/cool-waves-smile.md
+++ b/.changeset/cool-waves-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: snapshot composer role and run configuration before uploading attachments

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -240,6 +240,8 @@ export abstract class BaseComposerRuntimeCore
     const originalAttachments = this.attachments;
     const text = this.text;
     const quote = this._quote;
+    const role = this.role;
+    const runConfig = this.runConfig;
     this._quote = undefined;
     this._text = "";
     this._isSending = true;
@@ -291,10 +293,10 @@ export abstract class BaseComposerRuntimeCore
 
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
       createdAt: new Date(),
-      role: this.role,
+      role,
       content: text ? [{ type: "text", text }] : [],
       attachments: finalAttachments,
-      runConfig: this.runConfig,
+      runConfig,
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
 

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -158,6 +158,36 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     expect(append).toHaveBeenCalledTimes(1);
   });
 
+  it("snapshots role and run config before uploading attachments", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    composer.setRole("assistant");
+    composer.setRunConfig({ modelName: "model-a" });
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    composer.setRole("system");
+    composer.setRunConfig({ modelName: "model-b" });
+    resolveSend();
+    await sendPromise;
+
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "assistant",
+        runConfig: { modelName: "model-a" },
+      }),
+    );
+  });
+
   it("keeps an attachment added while the upload was in flight", async () => {
     let resolveSend!: () => void;
     const adapter = makeAdapter({

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -171,19 +171,19 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     composer.setText("hello");
     composer.setRole("assistant");
-    composer.setRunConfig({ modelName: "model-a" });
+    composer.setRunConfig({ custom: { modelName: "model-a" } });
     await composer.addAttachment(textFile());
 
     const sendPromise = composer.send();
     composer.setRole("system");
-    composer.setRunConfig({ modelName: "model-b" });
+    composer.setRunConfig({ custom: { modelName: "model-b" } });
     resolveSend();
     await sendPromise;
 
     expect(append).toHaveBeenCalledWith(
       expect.objectContaining({
         role: "assistant",
-        runConfig: { modelName: "model-a" },
+        runConfig: { custom: { modelName: "model-a" } },
       }),
     );
   });


### PR DESCRIPTION
## Summary

- capture the composer role and run configuration when send starts
- use that snapshot after pending attachment uploads finish
- cover role and model changes made while an upload is in flight

## Why

Composer sends already snapshot text, quote, and attachments before awaiting uploads, but they previously read `role` and `runConfig` from the live composer after the upload completed. If a user changed the role, model, or other run configuration for their next draft during that wait, those new values were incorrectly applied to the message already being sent.

The outgoing message now uses one consistent send-time snapshot for all composer state.

## Testing

- `vitest run packages/core/src/tests/base-composer-runtime-core-send.test.ts` (27 tests passed)
- `oxlint packages/core/src/runtime/base/base-composer-runtime-core.ts packages/core/src/tests/base-composer-runtime-core-send.test.ts`
- `aui-build` in `packages/core`
- broad Core run: 1,077 tests passed; Vitest still reports the unrelated empty `PartMessages.test.tsx` on main as a failed suite

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.V1QMjGlGq2GlbJSBIM5W3bB6hxZ7_OUeQl71v4KvH7nj0Dbgsb2jxDnXhmI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->