### PR TITLE
fix(react): refresh live completions after source changes

### DIFF
--- a/.changeset/fresh-rice-smile.md
+++ b/.changeset/fresh-rice-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: refresh live completion results after their data source changes

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -5732,6 +5732,7 @@ type Unstable_UseComposerInputOptions = {
 
 type Unstable_UseLiveCompletionAdapterOptions = {
   readonly fetcher: (query: string) => Promise<readonly Unstable_TriggerItem[]>;
+  readonly cacheKey?: string | number | undefined;
   readonly debounceMs?: number | undefined;
   readonly enabled?: boolean | undefined;
 };

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -82,6 +82,8 @@ const myAdapter: Unstable_TriggerAdapter = {
 
 The built-in `unstable_useLiveCompletionAdapter` wraps an async fetcher with debouncing, stale-request cancellation (results for an outdated query are dropped), and a single-entry cache. Its `search` returns the last results synchronously and schedules a debounced fetch when the query changes; when results arrive the returned `adapter` re-creates, which re-runs the popover lookup so the fresh items render. It also reports `isLoading`, which you pass to the popover to show a loading state.
 
+When the fetcher reads from an account- or workspace-specific source, pass that source ID as `cacheKey`. Changing the key clears cached results and cancels any pending result from the previous source.
+
 ```tsx
 import {
   unstable_useLiveCompletionAdapter,

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -129,6 +129,80 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
   });
 
+  it("refreshes cached results when the fetcher cache key changes", async () => {
+    const fetcherA = vi.fn(async () => [item("workspace-a")]);
+    const fetcherB = vi.fn(async () => [item("workspace-b")]);
+    const { result, rerender } = renderHook(
+      ({ fetcher, cacheKey }) =>
+        unstable_useLiveCompletionAdapter({
+          fetcher,
+          cacheKey,
+          debounceMs: 0,
+        }),
+      { initialProps: { fetcher: fetcherA, cacheKey: "workspace-a" } },
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.adapter.search!("alice")).toEqual([
+      item("workspace-a"),
+    ]);
+
+    await act(async () => {
+      rerender({ fetcher: fetcherB, cacheKey: "workspace-b" });
+    });
+    expect(result.current.adapter.search!("alice")).toEqual([]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcherB).toHaveBeenCalledWith("alice");
+    expect(result.current.adapter.search!("alice")).toEqual([
+      item("workspace-b"),
+    ]);
+  });
+
+  it("drops pending results after the fetcher cache key changes", async () => {
+    let resolveA!: (items: readonly Unstable_TriggerItem[]) => void;
+    const fetcherA = vi.fn(
+      () =>
+        new Promise<readonly Unstable_TriggerItem[]>((resolve) => {
+          resolveA = resolve;
+        }),
+    );
+    const fetcherB = vi.fn(async () => [item("workspace-b")]);
+    const { result, rerender } = renderHook(
+      ({ fetcher, cacheKey }) =>
+        unstable_useLiveCompletionAdapter({
+          fetcher,
+          cacheKey,
+          debounceMs: 0,
+        }),
+      { initialProps: { fetcher: fetcherA, cacheKey: "workspace-a" } },
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      rerender({ fetcher: fetcherB, cacheKey: "workspace-b" });
+    });
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      resolveA([item("workspace-a")]);
+    });
+
+    expect(result.current.adapter.search!("alice")).toEqual([
+      item("workspace-b"),
+    ]);
+  });
+
   it("allows a failed query to be retried", async () => {
     const fetcher = vi
       .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   Unstable_TriggerAdapter,
   Unstable_TriggerItem,
@@ -13,6 +20,11 @@ export type Unstable_UseLiveCompletionAdapterOptions = {
    * next render.
    */
   readonly fetcher: (query: string) => Promise<readonly Unstable_TriggerItem[]>;
+  /**
+   * Identifies the fetcher's data source. Change this when switching accounts,
+   * workspaces, or another boundary that should invalidate cached results.
+   */
+  readonly cacheKey?: string | number | undefined;
   /** Debounce applied before a fetch fires, in milliseconds. @default 60 */
   readonly debounceMs?: number | undefined;
   /** When `false`, no fetch is scheduled and the adapter stays empty. @default true */
@@ -52,7 +64,7 @@ const NO_QUERY = "\u0000";
 export function unstable_useLiveCompletionAdapter(
   options: Unstable_UseLiveCompletionAdapterOptions,
 ): { adapter: Unstable_TriggerAdapter; isLoading: boolean } {
-  const { fetcher, debounceMs = 60, enabled = true } = options;
+  const { fetcher, cacheKey, debounceMs = 60, enabled = true } = options;
 
   const [state, setState] = useState<{
     query: string;
@@ -128,6 +140,16 @@ export function unstable_useLiveCompletionAdapter(
     tokenRef.current += 1;
     setIsLoading(false);
   }, [cancelTimer, rearmPendingRetry]);
+
+  const cacheKeyRef = useRef(cacheKey);
+  useLayoutEffect(() => {
+    if (cacheKeyRef.current === cacheKey) return;
+    cacheKeyRef.current = cacheKey;
+    invalidatePending();
+    retryableQueryRef.current = null;
+    pendingRetryQueryRef.current = null;
+    setState({ query: NO_QUERY, items: [], failed: false });
+  }, [cacheKey, invalidatePending]);
 
   useEffect(() => {
     if (enabled) return;


### PR DESCRIPTION
## Summary

- add an optional `cacheKey` for identifying a live-completion data source
- clear cached results and invalidate pending requests when that key changes
- document account/workspace switching and cover cached plus late-result regressions

## Why

Live completions cache the last query. After an account or workspace switch, the same query could continue showing the previous source's suggestions and never call the new fetcher. A pending request from the previous source could also settle after the switch.

Using the fetcher function itself as the cache boundary is unsafe because documented inline fetchers are recreated on ordinary renders. The explicit `cacheKey` gives consumers a stable source identity without causing refetch loops; changing it clears the old cache before paint and invalidates in-flight settlement.

## Testing

- `vitest run packages/react/src/unstable/useLiveCompletionAdapter.test.tsx` (11 tests passed)
- `oxlint packages/react/src/unstable/useLiveCompletionAdapter.ts packages/react/src/unstable/useLiveCompletionAdapter.test.tsx`
- `aui-build` in `packages/react`
- broad ad hoc React run exposed unrelated shared-DOM cleanup failures across existing suites; the changed suite passes in isolation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.0DYaM9OB9yMvbh52nP9p16OzpQGjLpwEfCaiDLhqw9ObHRArWB2ArAbmDgs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->