### PR TITLE
fix(core): retain MessagePartChildrenProps in declarations

### DIFF
--- a/.changeset/fix-core-message-parts-declaration.md
+++ b/.changeset/fix-core-message-parts-declaration.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: retain the message part children props in published declarations

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -726,7 +726,6 @@ const EMPTY_RUNNING_TEXT_PART: Extract<EnrichedPartState, { type: "text" }> =
   });
 
 /**
- * @internal
  * Renders a single part by index, calling `children` with the
  * {@link EnrichedPartState} (tool/data UI enrichments + addResult/resume
  * for tool calls). Shared between `<MessagePrimitive.Parts>` and


### PR DESCRIPTION
## Summary

Retain `MessagePartChildrenProps` in the declarations published by
`@assistant-ui/core`.

## Problem

`@assistant-ui/core@0.3.13` publishes `MessageParts.d.ts` with this declaration:

```ts
declare const MessagePartChildren: FC<MessagePartChildrenProps>;
```

However, `MessagePartChildrenProps` is missing from the published declaration,
causing TypeScript to fail with:

```text
node_modules/@assistant-ui/core/dist/react/primitives/message/MessageParts.d.ts(232,39): error TS2304: Cannot find name 'MessagePartChildrenProps'.
```

## Reproduction

A standalone reproduction was created and verified locally using:

- `@assistant-ui/core@0.3.13`
- TypeScript 5.9.3
- `isolatedModules: true`
- `skipLibCheck: false`

The reproduction imports the React entry point:

```ts
import "@assistant-ui/core/react";
```

Running:

```sh
pnpm typecheck
```

exits with code 2 and produces the exact `TS2304` error shown above.

## Root cause

`MessagePartChildrenProps` was marked `@internal`, while the declaration build
uses `stripInternal`. Declaration generation therefore removed the props type
but retained the exported `MessagePartChildren` component declaration that
references it.

## Fix

Remove the `@internal` marker from `MessagePartChildrenProps`, allowing the type
to remain in the generated declaration.

This corrects the published declaration without changing runtime behavior,
widening the public API, or requiring a consumer-side workaround.

A patch changeset for `@assistant-ui/core` is included.

## Validation

- Confirmed the standalone reproduction fails with the exact reported error on
  `@assistant-ui/core@0.3.13`.
- Confirmed the generated declaration after this fix contains both
  `MessagePartChildrenProps` and `MessagePartChildren`.
- `@assistant-ui/core` production build passes.
- Core tests pass: 105 files, 1,077 tests.
- React Compiler tests pass: 1 file, 7 tests.
- Changed source passes oxlint and oxfmt.
- Resource memoization check passes.
- `git diff --check` passes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YQAht_H7x01njh6BmrdiOLBohyWX5bqmniLW3QqUlv1DZiT2UN7ppvktSCA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->