### PR TITLE
feat: svelte bridge on the neutral store client

### DIFF
--- a/examples/with-svelte/index.html
+++ b/examples/with-svelte/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>assistant-ui × Svelte</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "with-svelte",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev --port 3000",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@assistant-ui/core": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/svelte": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@lucide/svelte": "^1.31.0",
+    "svelte": "^5.56.8"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/react": "^19.2.18",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.1"
+  }
+}

--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import { useAui, useAuiState } from "@assistant-ui/svelte";
+  import type {} from "@assistant-ui/core/store";
+  import { ArrowUpIcon, PlusIcon, SquareIcon } from "@lucide/svelte";
+  import Message from "./Message.svelte";
+
+  const aui = useAui();
+  const messages = useAuiState((s) => s.thread.messages);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const suggestions = useAuiState((s) => s.suggestions.suggestions);
+  const text = useAuiState((s) => s.composer.text);
+  const sendDisabled = useAuiState(
+    (s) =>
+      !s.composer.canSend || (s.thread.isRunning && !s.thread.capabilities.queue),
+  );
+  const inputDisabled = useAuiState(
+    (s) => s.thread.isDisabled || s.composer.dictation?.inputDisabled === true,
+  );
+
+  let viewport = $state<HTMLElement>();
+
+  $effect(() => {
+    void messages.current.length;
+    void isRunning.current;
+    viewport?.scrollTo({ top: viewport.scrollHeight });
+  });
+
+  const onInput = (event: Event) => {
+    aui.composer.setText((event.currentTarget as HTMLTextAreaElement).value);
+  };
+
+  const onKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+    if (sendDisabled.current || inputDisabled.current) return;
+    event.preventDefault();
+    aui.composer.send();
+  };
+
+  const sendSuggestion = (prompt: string) => {
+    aui.composer.setText(prompt);
+    aui.composer.send();
+  };
+</script>
+
+<div class="bg-background flex h-full flex-col">
+  <header
+    class="border-border/60 flex items-center justify-between border-b px-4 py-2"
+  >
+    <span class="text-sm font-medium">assistant-ui × Svelte</span>
+    <button
+      class="border-border/60 hover:bg-muted flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm transition-colors"
+      onclick={() => aui.threads.switchToNewThread()}
+    >
+      <PlusIcon class="size-4" /> New chat
+    </button>
+  </header>
+  <div
+    bind:this={viewport}
+    class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+  >
+    <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+      {#if messages.current.length === 0}
+        <div class="flex flex-1 flex-col items-center justify-center gap-6 pb-24">
+          <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+          <div class="flex flex-wrap items-center justify-center gap-2 px-4">
+            {#each suggestions.current as suggestion (suggestion.prompt)}
+              <button
+                class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+                onclick={() => sendSuggestion(suggestion.prompt)}
+              >
+                <span class="font-medium">{suggestion.title}</span>
+                <span class="text-muted-foreground text-xs">
+                  {suggestion.label}
+                </span>
+              </button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+      <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
+        {#each messages.current as message (message.id)}
+          <Message {message} />
+        {/each}
+        {#if isRunning.current}
+          <li class="text-foreground px-2 leading-relaxed">
+            <span class="animate-pulse">…</span>
+          </li>
+        {/if}
+      </ol>
+    </div>
+  </div>
+  <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+    <div
+      class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+    >
+      <textarea
+        class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+        placeholder="Send a message..."
+        name="message"
+        rows="1"
+        value={text.current}
+        disabled={inputDisabled.current}
+        oninput={onInput}
+        onkeydown={onKeydown}
+      ></textarea>
+      <div class="flex items-center justify-end">
+        {#if !isRunning.current}
+          <button
+            class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+            aria-label="Send"
+            disabled={sendDisabled.current}
+            onclick={() => aui.composer.send()}
+          >
+            <ArrowUpIcon class="size-4.5" />
+          </button>
+        {:else}
+          <button
+            class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+            aria-label="Stop"
+            onclick={() => aui.composer.cancel()}
+          >
+            <SquareIcon class="size-3.5 fill-current" />
+          </button>
+        {/if}
+      </div>
+    </div>
+  </div>
+</div>

--- a/examples/with-svelte/src/Message.svelte
+++ b/examples/with-svelte/src/Message.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { ThreadMessage } from "@assistant-ui/core";
+
+  let { message }: { message: ThreadMessage } = $props();
+
+  const text = $derived(
+    message.content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join(""),
+  );
+</script>
+
+<li
+  data-role={message.role}
+  class={[
+    "group flex flex-col gap-1",
+    message.role === "user" ? "items-end" : "items-start",
+  ].join(" ")}
+>
+  <div
+    class={[
+      "px-2 wrap-break-word",
+      message.role === "user"
+        ? "bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2"
+        : "text-foreground leading-relaxed",
+    ].join(" ")}
+  >
+    <p class="whitespace-pre-line">{text}</p>
+  </div>
+</li>

--- a/examples/with-svelte/src/Root.svelte
+++ b/examples/with-svelte/src/Root.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { AuiConfig, provideAui } from "@assistant-ui/svelte";
+  import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
+  import App from "./App.svelte";
+  import { createEchoRuntime } from "./runtime";
+
+  provideAui(
+    AuiConfig({
+      threads: RuntimeAdapter(createEchoRuntime()),
+      suggestions: Suggestions([
+        {
+          title: "Say hello",
+          label: "a friendly opener",
+          prompt: "Hello there!",
+        },
+        {
+          title: "Ask anything",
+          label: "it will echo back",
+          prompt: "What can you do?",
+        },
+        {
+          title: "Tell a story",
+          label: "a longer prompt",
+          prompt: "Tell me a story about an echo.",
+        },
+      ]),
+    }),
+  );
+</script>
+
+<App />

--- a/examples/with-svelte/src/env.d.ts
+++ b/examples/with-svelte/src/env.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svelte" {
+  import type { Component } from "svelte";
+  const component: Component<Record<string, never>>;
+  export default component;
+}

--- a/examples/with-svelte/src/main.ts
+++ b/examples/with-svelte/src/main.ts
@@ -1,0 +1,5 @@
+import { mount } from "svelte";
+import "./styles.css";
+import Root from "./Root.svelte";
+
+mount(Root, { target: document.getElementById("app")! });

--- a/examples/with-svelte/src/runtime.ts
+++ b/examples/with-svelte/src/runtime.ts
@@ -1,0 +1,167 @@
+import type { AppendMessage, ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+
+export type EchoMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
+type EchoThread = {
+  id: string;
+  title: string;
+  messages: EchoMessage[];
+};
+
+let nextId = 0;
+const freshId = (prefix: string) => `${prefix}-${nextId++}`;
+
+const messageText = (message: AppendMessage) =>
+  message.content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+
+const convertEchoMessage = (message: EchoMessage) => ({
+  id: message.id,
+  role: message.role,
+  content: [{ type: "text" as const, text: message.text }],
+});
+
+export const createEchoRuntime = () => {
+  let threads: EchoThread[] = [
+    { id: freshId("thread"), title: "", messages: [] },
+  ];
+  let currentId = threads[0]!.id;
+  let isRunning = false;
+  let replyTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const current = () => threads.find((thread) => thread.id === currentId)!;
+  const updateCurrent = (updater: (thread: EchoThread) => EchoThread) => {
+    threads = threads.map((thread) =>
+      thread.id === currentId ? updater(thread) : thread,
+    );
+  };
+
+  const reply = (text: string) => {
+    const replyTo = currentId;
+    isRunning = true;
+    sync();
+    replyTimer = setTimeout(() => {
+      if (currentId !== replyTo) return;
+      updateCurrent((thread) => ({
+        ...thread,
+        messages: [
+          ...thread.messages,
+          {
+            id: freshId("assistant"),
+            role: "assistant",
+            text: `Echo: ${text}`,
+          },
+        ],
+      }));
+      isRunning = false;
+      sync();
+    }, 600);
+  };
+
+  const appendUser = (text: string) => {
+    updateCurrent((thread) => ({
+      ...thread,
+      title: thread.title || text.slice(0, 40),
+      messages: [
+        ...thread.messages,
+        { id: freshId("user"), role: "user", text },
+      ],
+    }));
+  };
+
+  const makeAdapter = (): ExternalStoreAdapter<EchoMessage> => ({
+    messages: current().messages,
+    isRunning,
+    convertMessage: convertEchoMessage,
+    setMessages: (next) => {
+      updateCurrent((thread) => ({ ...thread, messages: next }));
+      sync();
+    },
+    onNew: async (message) => {
+      const text = messageText(message);
+      appendUser(text);
+      reply(text);
+    },
+    onEdit: async (message) => {
+      const text = messageText(message);
+      const parentIndex = message.parentId
+        ? current().messages.findIndex(
+            (entry) => entry.id === message.parentId,
+          ) + 1
+        : 0;
+      updateCurrent((thread) => ({
+        ...thread,
+        messages: thread.messages.slice(0, parentIndex),
+      }));
+      appendUser(text);
+      reply(text);
+    },
+    onReload: async (parentId) => {
+      let parentIndex = 0;
+      if (parentId) {
+        const index = current().messages.findIndex(
+          (entry) => entry.id === parentId,
+        );
+        if (index === -1) return;
+        parentIndex = index + 1;
+      }
+      const sliced = current().messages.slice(0, parentIndex);
+      const lastUser = [...sliced]
+        .reverse()
+        .find((entry) => entry.role === "user");
+      updateCurrent((thread) => ({ ...thread, messages: sliced }));
+      reply(`${lastUser?.text ?? ""} (again)`);
+    },
+    onCancel: async () => {
+      clearTimeout(replyTimer);
+      if (isRunning && current().messages.at(-1)?.role === "user") {
+        updateCurrent((thread) => ({
+          ...thread,
+          messages: thread.messages.slice(0, -1),
+        }));
+      }
+      isRunning = false;
+      // cancelRun restores the trailing user message into the composer
+      // synchronously after onCancel returns; an eager sync would delete it
+      // before that restore reads it.
+      queueMicrotask(sync);
+    },
+    adapters: {
+      threadList: {
+        threadId: currentId,
+        threads: threads.map((thread) => ({
+          status: "regular" as const,
+          id: thread.id,
+          title: thread.title,
+        })),
+        onSwitchToThread: (threadId) => {
+          clearTimeout(replyTimer);
+          isRunning = false;
+          currentId = threadId;
+          sync();
+        },
+        onSwitchToNewThread: () => {
+          clearTimeout(replyTimer);
+          isRunning = false;
+          const id = freshId("thread");
+          threads = [...threads, { id, title: "", messages: [] }];
+          currentId = id;
+          sync();
+        },
+      },
+    },
+  });
+
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const sync = () => core.setAdapter(makeAdapter());
+  return new AssistantRuntimeImpl(core);
+};

--- a/examples/with-svelte/src/styles.css
+++ b/examples/with-svelte/src/styles.css
@@ -1,0 +1,125 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}

--- a/examples/with-svelte/svelte.config.js
+++ b/examples/with-svelte/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/examples/with-svelte/tsconfig.json
+++ b/examples/with-svelte/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/with-svelte/vite.config.ts
+++ b/examples/with-svelte/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import tailwindcss from "@tailwindcss/vite";
+
+// The assistant-ui runtime is written against react hook imports but runs on
+// @assistant-ui/tap; aliasing react to the standalone shim resolves it with
+// no React installed.
+export default defineConfig({
+  plugins: [svelte(), tailwindcss()],
+  resolve: {
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
+  },
+});

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -8,7 +8,13 @@ The package is plain TypeScript over `@assistant-ui/store/client` and Svelte's r
 // vite.config.ts
 export default defineConfig({
   resolve: {
-    alias: { react: "@assistant-ui/tap/standalone-shim" },
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
   },
 });
 ```

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,32 @@
+# @assistant-ui/svelte
+
+Svelte bindings for assistant-ui. Private and incomplete while the Svelte line is under development.
+
+The package is plain TypeScript over `@assistant-ui/store/client` and Svelte's runtime APIs; it ships no compiled Svelte components. Svelte apps alias `react` to tap's standalone shim so the store chain loads without React:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  resolve: {
+    alias: { react: "@assistant-ui/tap/standalone-shim" },
+  },
+});
+```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { provideAui, useAuiState } from "@assistant-ui/svelte";
+  import { AuiConfig } from "@assistant-ui/store/client";
+
+  const aui = provideAui(() => AuiConfig({ ... }));
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+</script>
+
+<button disabled={isRunning.current} onclick={() => aui.composer.send()}>
+  Send
+</button>
+```
+
+`provideAui` creates the client and provides it to the subtree (call it during component initialization; pass a thunk for a live config). `useAui` returns the stable client facade, `useAuiState` returns a reactive `current` getter over a state slice, and `useAuiEvent` subscribes to assistant events for the component's lifetime.

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "jsdom": "^30.0.1",
     "svelte": "^5.56.8",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@assistant-ui/svelte",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Svelte bindings for assistant-ui",
+  "keywords": [
+    "svelte",
+    "assistant-ui",
+    "store",
+    "tap",
+    "state-management"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@assistant-ui/core": "^0.3.13",
+    "@assistant-ui/store": "^0.3.9",
+    "@assistant-ui/tap": "^0.9.12"
+  },
+  "peerDependencies": {
+    "svelte": "^5.7.0"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@types/react": "^19.2.18",
+    "jsdom": "^30.0.1",
+    "svelte": "^5.56.8",
+    "vitest": "^4.1.10"
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/svelte"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { resource } from "@assistant-ui/tap";
+import { useAssistantEmit } from "@assistant-ui/store/client";
+
+export type AnyClient = Record<string, any>;
+
+export const flushEvents = () => new Promise((resolve) => setTimeout(resolve));
+
+const useMessageClient = ({ id }: { id: string }) => {
+  const emit = useAssistantEmit();
+  const [text, setText] = useState("");
+  return {
+    getState: () => ({ id, text }),
+    setText,
+    ping: (value: string) =>
+      emit("message.pinged" as never, { id, value } as never),
+  };
+};
+export const MessageClient = resource(useMessageClient);
+
+const useThreadClient = () => {
+  const [selected, setSelected] = useState(0);
+  return {
+    getState: () => ({ selected }),
+    setSelected,
+  };
+};
+export const ThreadClient = resource(useThreadClient);
+
+export const createTrackedThread = () => {
+  const counters = { mounts: 0, cleanups: 0 };
+  const useTracked = () => {
+    const [selected, setSelected] = useState(0);
+    useEffect(() => {
+      counters.mounts++;
+      return () => {
+        counters.cleanups++;
+      };
+    }, []);
+    return { getState: () => ({ selected }), setSelected };
+  };
+  return { TrackedThread: resource(useTracked), counters };
+};

--- a/packages/svelte/src/__tests__/dist-graph.test.ts
+++ b/packages/svelte/src/__tests__/dist-graph.test.ts
@@ -20,7 +20,7 @@ describe("@assistant-ui/svelte dist graph", () => {
 
         const source = readFileSync(file, "utf8");
         for (const match of source.matchAll(
-          /(?:from\s+|import\s+)["']([^"']+)["']/g,
+          /(?:from\s+|import\s+|import\s*\(\s*)["']([^"']+)["']/g,
         )) {
           const specifier = match[1]!;
           if (

--- a/packages/svelte/src/__tests__/dist-graph.test.ts
+++ b/packages/svelte/src/__tests__/dist-graph.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/svelte/src/__tests__/dist-graph.test.ts
+++ b/packages/svelte/src/__tests__/dist-graph.test.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const DIST_DIR = resolve(__dirname, "../../dist");
+const DIST_ENTRY = resolve(DIST_DIR, "index.js");
+
+describe("@assistant-ui/svelte dist graph", () => {
+  it.skipIf(!existsSync(DIST_ENTRY))(
+    "contains no react, react-shim, or compiler-runtime references",
+    () => {
+      const visited = new Set<string>();
+      const pending = [DIST_ENTRY];
+      const violations: string[] = [];
+
+      while (pending.length > 0) {
+        const file = pending.pop()!;
+        if (visited.has(file)) continue;
+        visited.add(file);
+
+        const source = readFileSync(file, "utf8");
+        for (const match of source.matchAll(
+          /(?:from\s+|import\s+)["']([^"']+)["']/g,
+        )) {
+          const specifier = match[1]!;
+          if (
+            specifier === "react" ||
+            specifier.startsWith("react/") ||
+            specifier.includes("react-shim") ||
+            specifier.includes("compiler-runtime")
+          ) {
+            violations.push(`${relative(DIST_DIR, file)} -> ${specifier}`);
+            continue;
+          }
+          if (specifier.startsWith(".")) {
+            pending.push(resolve(dirname(file), specifier));
+          }
+        }
+      }
+
+      expect(
+        violations,
+        `The svelte bridge must build without the react compiler: aui-build's compiler gate requires a react peer, and this package must never declare one. Violations:\n` +
+          violations.map((v) => `  - ${v}`).join("\n"),
+      ).toEqual([]);
+    },
+  );
+});

--- a/packages/svelte/src/__tests__/fixtures/EventScopeHost.svelte
+++ b/packages/svelte/src/__tests__/fixtures/EventScopeHost.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { provideAui } from "../../provideAui";
+  import { useAuiEvent } from "../../useAuiEvent";
+
+  let { makeConfig, onPing, expose } = $props();
+  let present = $state(false);
+  const aui = provideAui(() => makeConfig(present));
+  useAuiEvent("message.pinged", onPing);
+  // svelte-ignore state_referenced_locally
+  expose({ aui, setPresent: (value) => (present = value) });
+</script>

--- a/packages/svelte/src/__tests__/fixtures/EventScopeHost.svelte
+++ b/packages/svelte/src/__tests__/fixtures/EventScopeHost.svelte
@@ -5,6 +5,7 @@
   let { makeConfig, onPing, expose } = $props();
   let present = $state(false);
   const aui = provideAui(() => makeConfig(present));
+  // svelte-ignore state_referenced_locally
   useAuiEvent("message.pinged", onPing);
   // svelte-ignore state_referenced_locally
   expose({ aui, setPresent: (value) => (present = value) });

--- a/packages/svelte/src/__tests__/fixtures/Host.svelte
+++ b/packages/svelte/src/__tests__/fixtures/Host.svelte
@@ -1,0 +1,5 @@
+<script>
+  let { setup } = $props();
+  // svelte-ignore state_referenced_locally
+  setup();
+</script>

--- a/packages/svelte/src/__tests__/fixtures/LiveConfigHost.svelte
+++ b/packages/svelte/src/__tests__/fixtures/LiveConfigHost.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { provideAui } from "../../provideAui";
+
+  let { makeConfig, expose } = $props();
+  let arg = $state(0);
+  // svelte-ignore state_referenced_locally
+  const aui = provideAui(() => makeConfig(arg));
+  // svelte-ignore state_referenced_locally
+  expose({
+    aui,
+    setArg: (value) => (arg = value),
+  });
+</script>

--- a/packages/svelte/src/__tests__/fixtures/Nested.svelte
+++ b/packages/svelte/src/__tests__/fixtures/Nested.svelte
@@ -1,0 +1,9 @@
+<script>
+  import Host from "./Host.svelte";
+
+  let { outerSetup, innerSetup } = $props();
+  // svelte-ignore state_referenced_locally
+  outerSetup();
+</script>
+
+<Host setup={innerSetup} />

--- a/packages/svelte/src/__tests__/fixtures/StateProbe.svelte
+++ b/packages/svelte/src/__tests__/fixtures/StateProbe.svelte
@@ -1,0 +1,8 @@
+<script>
+  let { setup, onValue } = $props();
+  // svelte-ignore state_referenced_locally
+  const read = setup();
+  $effect(() => {
+    onValue(read());
+  });
+</script>

--- a/packages/svelte/src/__tests__/provideAui.test.ts
+++ b/packages/svelte/src/__tests__/provideAui.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig, type AssistantClient } from "@assistant-ui/store/client";
+import { provideAui } from "../provideAui";
+import { useAui } from "../useAui";
+import Host from "./fixtures/Host.svelte";
+import Nested from "./fixtures/Nested.svelte";
+import LiveConfigHost from "./fixtures/LiveConfigHost.svelte";
+import {
+  createTrackedThread,
+  MessageClient,
+  ThreadClient,
+  type AnyClient,
+} from "./clients";
+
+const target = () => document.createElement("div");
+
+describe("provideAui", () => {
+  it("provides a client and returns the stable facade", () => {
+    let provided!: AnyClient;
+    let fromContext!: AnyClient;
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provided = provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          fromContext = useAui();
+        },
+      },
+    });
+
+    expect(fromContext).toBe(provided);
+    expect(provided.thread.getState()).toEqual({ selected: 0 });
+
+    flushTapSync(() => provided.thread.setSelected(2));
+    expect(provided.thread.getState()).toEqual({ selected: 2 });
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("soft unmounts the client after the component is destroyed", async () => {
+    const { TrackedThread, counters } = createTrackedThread();
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ thread: TrackedThread() } as never));
+        },
+      },
+    });
+
+    expect(counters.mounts).toBeGreaterThan(0);
+    const mounted = counters.cleanups;
+
+    flushSync(() => void unmount(app));
+    await vi.waitFor(() => expect(counters.cleanups).toBeGreaterThan(mounted));
+  });
+
+  it("throws on a nested provider without extends", () => {
+    expect(() =>
+      mount(Nested, {
+        target: target(),
+        props: {
+          outerSetup: () => {
+            provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          },
+          innerSetup: () => {
+            provideAui(AuiConfig({} as never));
+          },
+        },
+      }),
+    ).toThrow("A parent provideAui exists.");
+  });
+
+  it("extends the parent facade through the live source", () => {
+    let outer!: AssistantClient;
+    let inner!: AnyClient;
+    const app = mount(Nested, {
+      target: target(),
+      props: {
+        outerSetup: () => {
+          outer = provideAui(AuiConfig({ thread: ThreadClient() } as never));
+        },
+        innerSetup: () => {
+          inner = provideAui(
+            AuiConfig({ message: MessageClient({ id: "m0" }) } as never),
+            { extends: outer },
+          );
+        },
+      },
+    });
+
+    expect(inner.message.getState()).toEqual({ id: "m0", text: "" });
+    expect(inner.thread.getState()).toEqual({ selected: 0 });
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("isolates from the parent with extends null", () => {
+    let inner!: AnyClient;
+    const app = mount(Nested, {
+      target: target(),
+      props: {
+        outerSetup: () => {
+          provideAui(AuiConfig({ thread: ThreadClient() } as never));
+        },
+        innerSetup: () => {
+          inner = provideAui(
+            AuiConfig({ message: MessageClient({ id: "m0" }) } as never),
+            { extends: null },
+          );
+        },
+      },
+    });
+
+    expect(inner.message.getState()).toEqual({ id: "m0", text: "" });
+    expect(() => inner.thread.getState()).toThrow(
+      'The current scope does not have a "thread" property.',
+    );
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("delivers thunk config changes live, keeping same-key scope state", async () => {
+    let exposed!: { aui: AnyClient; setArg: (value: number) => void };
+    const app = mount(LiveConfigHost, {
+      target: target(),
+      props: {
+        makeConfig: (arg: number) =>
+          AuiConfig({ message: MessageClient({ id: `m${arg}` }) } as never),
+        expose: (value: never) => {
+          exposed = value;
+        },
+      },
+    });
+
+    expect(exposed.aui.message.getState()).toEqual({ id: "m0", text: "" });
+    flushTapSync(() => exposed.aui.message.setText("draft"));
+
+    exposed.setArg(1);
+    await vi.waitFor(() =>
+      expect(exposed.aui.message.getState()).toEqual({
+        id: "m1",
+        text: "draft",
+      }),
+    );
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/useAuiEvent.test.ts
+++ b/packages/svelte/src/__tests__/useAuiEvent.test.ts
@@ -68,6 +68,7 @@ describe("useAuiEvent", () => {
     let exposed!: { aui: AnyClient; setPresent: (value: boolean) => void };
     const onPing = vi.fn();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const makeConfig = (present: boolean) =>
       present
         ? AuiConfig({ message: MessageClient({ id: "m0" }) } as never)
@@ -83,9 +84,10 @@ describe("useAuiEvent", () => {
       },
     });
 
-    // The message scope is absent at mount: binding must be a pending no-op,
-    // never a thrown-and-swallowed detach
+    // The message scope is absent at mount: binding is a pending no-op that
+    // surfaces in dev via warn, never a thrown-and-swallowed error
     expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
 
     exposed.setPresent(true);
     await vi.waitFor(() =>

--- a/packages/svelte/src/__tests__/useAuiEvent.test.ts
+++ b/packages/svelte/src/__tests__/useAuiEvent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { flushSync, mount, unmount } from "svelte";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
@@ -11,6 +11,10 @@ import { flushEvents, MessageClient, type AnyClient } from "./clients";
 const target = () => document.createElement("div");
 
 describe("useAuiEvent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("delivers events to the callback", async () => {
     let aui!: AnyClient;
     const callback = vi.fn();
@@ -93,7 +97,6 @@ describe("useAuiEvent", () => {
     expect(onPing).toHaveBeenCalledWith({ id: "m0", value: "hello" });
     expect(errorSpy).not.toHaveBeenCalled();
 
-    errorSpy.mockRestore();
     flushSync(() => void unmount(app));
   });
 });

--- a/packages/svelte/src/__tests__/useAuiEvent.test.ts
+++ b/packages/svelte/src/__tests__/useAuiEvent.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { provideAui } from "../provideAui";
+import { useAuiEvent } from "../useAuiEvent";
+import Host from "./fixtures/Host.svelte";
+import { flushEvents, MessageClient, type AnyClient } from "./clients";
+
+const target = () => document.createElement("div");
+
+describe("useAuiEvent", () => {
+  it("delivers events to the callback", async () => {
+    let aui!: AnyClient;
+    const callback = vi.fn();
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({ message: MessageClient({ id: "m0" }) } as never),
+          );
+          useAuiEvent("message.pinged" as never, callback);
+        },
+      },
+    });
+
+    flushTapSync(() => aui.message.ping("hello"));
+    await flushEvents();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ id: "m0", value: "hello" });
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("stops delivering after the component is destroyed", async () => {
+    let aui!: AnyClient;
+    const callback = vi.fn();
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({ message: MessageClient({ id: "m0" }) } as never),
+          );
+          useAuiEvent("message.pinged" as never, callback);
+        },
+      },
+    });
+
+    flushTapSync(() => aui.message.ping("before"));
+    await flushEvents();
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+    flushTapSync(() => aui.message.ping("after"));
+    await flushEvents();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/svelte/src/__tests__/useAuiEvent.test.ts
+++ b/packages/svelte/src/__tests__/useAuiEvent.test.ts
@@ -5,6 +5,7 @@ import { AuiConfig } from "@assistant-ui/store/client";
 import { provideAui } from "../provideAui";
 import { useAuiEvent } from "../useAuiEvent";
 import Host from "./fixtures/Host.svelte";
+import EventScopeHost from "./fixtures/EventScopeHost.svelte";
 import { flushEvents, MessageClient, type AnyClient } from "./clients";
 
 const target = () => document.createElement("div");
@@ -57,5 +58,42 @@ describe("useAuiEvent", () => {
     flushTapSync(() => aui.message.ping("after"));
     await flushEvents();
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds once its scope appears in a live config, without detaching", async () => {
+    let exposed!: { aui: AnyClient; setPresent: (value: boolean) => void };
+    const onPing = vi.fn();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const makeConfig = (present: boolean) =>
+      present
+        ? AuiConfig({ message: MessageClient({ id: "m0" }) } as never)
+        : AuiConfig({} as never);
+    const app = mount(EventScopeHost, {
+      target: target(),
+      props: {
+        makeConfig,
+        onPing,
+        expose: (value: never) => {
+          exposed = value;
+        },
+      },
+    });
+
+    // The message scope is absent at mount: binding must be a pending no-op,
+    // never a thrown-and-swallowed detach
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    exposed.setPresent(true);
+    await vi.waitFor(() =>
+      expect(exposed.aui.message.getState().id).toBe("m0"),
+    );
+
+    flushTapSync(() => exposed.aui.message.ping("hello"));
+    await flushEvents();
+    expect(onPing).toHaveBeenCalledWith({ id: "m0", value: "hello" });
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    flushSync(() => void unmount(app));
   });
 });

--- a/packages/svelte/src/__tests__/useAuiState.test.ts
+++ b/packages/svelte/src/__tests__/useAuiState.test.ts
@@ -6,7 +6,12 @@ import { provideAui } from "../provideAui";
 import { useAuiState } from "../useAuiState";
 import Host from "./fixtures/Host.svelte";
 import StateProbe from "./fixtures/StateProbe.svelte";
-import { ThreadClient, type AnyClient } from "./clients";
+import {
+  flushEvents,
+  MessageClient,
+  ThreadClient,
+  type AnyClient,
+} from "./clients";
 
 const target = () => document.createElement("div");
 
@@ -30,6 +35,41 @@ describe("useAuiState", () => {
 
     flushTapSync(() => aui.thread.setSelected(3));
     await vi.waitFor(() => expect(onValue).toHaveBeenCalledWith(3));
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("does not wake an effect when an unrelated slice changes", async () => {
+    let aui!: AnyClient;
+    const onValue = vi.fn();
+    const app = mount(StateProbe, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({
+              thread: ThreadClient(),
+              message: MessageClient({ id: "m0" }),
+            } as never),
+          );
+          const selected = useAuiState((s) => (s as AnyClient).thread.selected);
+          return () => selected.current;
+        },
+        onValue,
+      },
+    });
+
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledTimes(1));
+
+    // Mutating a different scope notifies the store, but the selected slice is
+    // unchanged, so the effect must not re-run
+    flushTapSync(() => aui.message.setText("draft"));
+    await flushEvents();
+    expect(onValue).toHaveBeenCalledTimes(1);
+
+    // A real change to the selected slice still wakes it
+    flushTapSync(() => aui.thread.setSelected(1));
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledTimes(2));
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/__tests__/useAuiState.test.ts
+++ b/packages/svelte/src/__tests__/useAuiState.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { provideAui } from "../provideAui";
+import { useAuiState } from "../useAuiState";
+import Host from "./fixtures/Host.svelte";
+import StateProbe from "./fixtures/StateProbe.svelte";
+import { ThreadClient, type AnyClient } from "./clients";
+
+const target = () => document.createElement("div");
+
+describe("useAuiState", () => {
+  it("tracks the selected slice inside an effect", async () => {
+    let aui!: AnyClient;
+    const onValue = vi.fn();
+    const app = mount(StateProbe, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          const selected = useAuiState((s) => (s as AnyClient).thread.selected);
+          return () => selected.current;
+        },
+        onValue,
+      },
+    });
+
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledWith(0));
+
+    flushTapSync(() => aui.thread.setSelected(3));
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledWith(3));
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("reads the current value outside effects without subscribing", () => {
+    let aui!: AnyClient;
+    let selected!: { readonly current: number };
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          selected = useAuiState((s) => (s as AnyClient).thread.selected);
+        },
+      },
+    });
+
+    expect(selected.current).toBe(0);
+    flushTapSync(() => aui.thread.setSelected(5));
+    expect(selected.current).toBe(5);
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("throws on returning the entire state", () => {
+    let state!: { readonly current: unknown };
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          state = useAuiState((s) => s);
+        },
+      },
+    });
+
+    expect(() => state.current).toThrow(
+      "You tried to return the entire AssistantState.",
+    );
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("resolves unavailable scopes to undefined via optional", () => {
+    let missing!: { readonly current: unknown };
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ thread: ThreadClient() } as never));
+          missing = useAuiState((s) => (s.optional as AnyClient).missing);
+        },
+      },
+    });
+
+    expect(missing.current).toBeUndefined();
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/context.ts
+++ b/packages/svelte/src/context.ts
@@ -1,0 +1,51 @@
+import { getContext } from "svelte";
+import {
+  DefaultAssistantClient,
+  type AssistantClient,
+  type AssistantClientSource,
+} from "@assistant-ui/store/client";
+
+export type AuiContext = {
+  source: AssistantClientSource;
+  aui: AssistantClient;
+};
+
+export const auiContextKey: symbol = Symbol("assistant-ui.svelte.aui");
+
+const NO_OP_SUBSCRIBE = () => () => {};
+
+const defaultContext: AuiContext = {
+  source: {
+    getClient: () => DefaultAssistantClient,
+    subscribe: NO_OP_SUBSCRIBE,
+  },
+  aui: DefaultAssistantClient,
+};
+
+export const getAuiContext = (): AuiContext =>
+  getContext<AuiContext | undefined>(auiContextKey) ?? defaultContext;
+
+// The client object changes identity on structural updates; the facade keeps
+// one stable object per provider that always forwards to the current client
+export const createClientFacade = (
+  source: AssistantClientSource,
+): AssistantClient =>
+  new Proxy({} as AssistantClient, {
+    get: (_target, prop) => Reflect.get(source.getClient(), prop),
+    has: (_target, prop) => prop in source.getClient(),
+    ownKeys: () => {
+      const client = source.getClient();
+      const keys = new Set<string | symbol>(Reflect.ownKeys(client));
+      for (const key in client) keys.add(key);
+      return [...keys];
+    },
+    getOwnPropertyDescriptor: (_target, prop) => {
+      const client = source.getClient();
+      if (!(prop in client)) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        value: Reflect.get(client, prop),
+      };
+    },
+  });

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,19 @@
+export { provideAui } from "./provideAui";
+export { useAui } from "./useAui";
+export { useAuiState } from "./useAuiState";
+export { useAuiEvent } from "./useAuiEvent";
+
+export {
+  AuiConfig,
+  Derived,
+  createAssistantClient,
+  type AssistantClient,
+  type AssistantClientHandle,
+  type AssistantClientSource,
+  type AssistantConfigSource,
+  type AssistantState,
+  type AssistantEventCallback,
+  type AssistantEventName,
+  type AssistantEventSelector,
+  type Unsubscribe,
+} from "@assistant-ui/store/client";

--- a/packages/svelte/src/isDevelopment.ts
+++ b/packages/svelte/src/isDevelopment.ts
@@ -1,0 +1,17 @@
+// Vite replaces the import.meta.env and process.env.NODE_ENV literals per
+// host; the try blocks cover hosts where neither binding exists.
+export const isDevelopment = (() => {
+  try {
+    const env = (import.meta as { env?: { DEV?: boolean } }).env;
+    if (typeof env?.DEV === "boolean") return env.DEV;
+  } catch {
+    /* empty */
+  }
+  try {
+    return (
+      process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+    );
+  } catch {
+    return false;
+  }
+})();

--- a/packages/svelte/src/provideAui.ts
+++ b/packages/svelte/src/provideAui.ts
@@ -1,0 +1,90 @@
+import { getContext, onDestroy, setContext } from "svelte";
+import { toStore } from "svelte/store";
+import {
+  createAssistantClient,
+  type AssistantClient,
+  type AssistantConfigSource,
+  type AuiConfig,
+} from "@assistant-ui/store/client";
+import { auiContextKey, createClientFacade, type AuiContext } from "./context";
+import { isDevelopment } from "./isDevelopment";
+
+const thunkToSource = (getConfig: () => AuiConfig): AssistantConfigSource => {
+  const store = toStore(getConfig);
+  return {
+    getConfig,
+    subscribe: (listener) => {
+      // Svelte stores call the subscriber immediately; the config source
+      // contract notifies on changes only
+      let initial = true;
+      return store.subscribe(() => {
+        if (initial) {
+          initial = false;
+          return;
+        }
+        listener();
+      });
+    },
+  };
+};
+
+/**
+ * Creates an `AssistantClient` from the given config and provides it to the
+ * component subtree. Call during component initialization.
+ *
+ * At the top level, `config` alone creates this subtree's own client. Under a
+ * parent provider, `extends` is mandatory: pass `{ extends: aui }` to extend
+ * the parent client or `{ extends: null }` to isolate from it (enforced with
+ * a dev error).
+ *
+ * Pass the config as a thunk (`provideAui(() => config)`) to make it live:
+ * reactive reads inside the thunk re-deliver the config, updating element
+ * args in place (scopes keep their state) and mounting or unmounting added
+ * and removed scopes. A plain config object is captured once. `extends` is
+ * captured when the provider mounts.
+ *
+ * The provider holds the client's lifetime subscription: the client mounts
+ * immediately and soft-unmounts after the component is destroyed and every
+ * descendant subscription has released.
+ */
+export const provideAui = (
+  config: AuiConfig | (() => AuiConfig),
+  options?: { extends?: AssistantClient | null | undefined },
+): AssistantClient => {
+  const injected = getContext<AuiContext | undefined>(auiContextKey) ?? null;
+  const ext = options?.extends;
+  const hasExtends = ext !== undefined;
+
+  if (isDevelopment) {
+    if (injected && !hasExtends) {
+      throw new Error(
+        "A parent provideAui exists. Pass { extends: aui } to inherit it or { extends: null } to isolate.",
+      );
+    }
+  }
+
+  const parent = !hasExtends
+    ? injected?.source
+    : ext === null
+      ? undefined
+      : injected && ext === injected.aui
+        ? injected.source
+        : ext;
+
+  const handle = createAssistantClient(
+    typeof config === "function" ? thunkToSource(config) : config,
+    parent ? { parent } : undefined,
+  );
+  // The provider holds the lifetime subscription that keeps the client
+  // mounted while descendants come and go
+  const release = handle.subscribe(() => {});
+  onDestroy(release);
+
+  const source = {
+    getClient: handle.getClient,
+    subscribe: handle.subscribe,
+  };
+  const aui = createClientFacade(source);
+  setContext(auiContextKey, { source, aui } satisfies AuiContext);
+  return aui;
+};

--- a/packages/svelte/src/useAui.ts
+++ b/packages/svelte/src/useAui.ts
@@ -1,0 +1,19 @@
+import type { AssistantClient } from "@assistant-ui/store/client";
+import { getAuiContext } from "./context";
+
+/**
+ * Returns the `AssistantClient` provided by the nearest {@link provideAui}.
+ * Call during component initialization.
+ *
+ * The returned object is stable for the lifetime of the provider and always
+ * forwards to the provider's current client, so it can be captured once and
+ * used in event handlers: `aui.composer.send()`, `aui.thread.cancelRun()`.
+ * Pair with {@link useAuiState} to read reactive state and
+ * {@link useAuiEvent} to subscribe to events.
+ *
+ * Called outside a provider, the returned client's scope accessors throw a
+ * descriptive error whenever they are used.
+ */
+export const useAui = (): AssistantClient => {
+  return getAuiContext().aui;
+};

--- a/packages/svelte/src/useAuiEvent.ts
+++ b/packages/svelte/src/useAuiEvent.ts
@@ -1,0 +1,53 @@
+import { onDestroy } from "svelte";
+import {
+  normalizeEventSelector,
+  type AssistantClient,
+  type AssistantEventCallback,
+  type AssistantEventName,
+  type AssistantEventSelector,
+  type Unsubscribe,
+} from "@assistant-ui/store/client";
+import { getAuiContext } from "./context";
+
+/**
+ * Subscribes to an assistant event for the lifetime of the current
+ * component. Call during component initialization.
+ *
+ * The subscription follows the provider's current client across structural
+ * changes. Use `scope: "*"` to receive emissions from any descendant scope.
+ *
+ * @example
+ * ```ts
+ * useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+ *   analytics.track("model_context_update", { threadId });
+ * });
+ * ```
+ */
+export const useAuiEvent = <TEvent extends AssistantEventName>(
+  selector: AssistantEventSelector<TEvent>,
+  callback: AssistantEventCallback<TEvent>,
+): void => {
+  const { source } = getAuiContext();
+  const { scope, event } = normalizeEventSelector(selector);
+
+  let bound: AssistantClient | undefined;
+  let off: Unsubscribe | undefined;
+
+  const bind = () => {
+    const client = source.getClient();
+    if (client === bound) return;
+    off?.();
+    bound = client;
+    off = client.on(
+      { scope, event } as AssistantEventSelector<TEvent>,
+      callback,
+    );
+  };
+
+  bind();
+  const unsubscribe = source.subscribe(bind);
+  onDestroy(() => {
+    unsubscribe();
+    off?.();
+  });
+};

--- a/packages/svelte/src/useAuiEvent.ts
+++ b/packages/svelte/src/useAuiEvent.ts
@@ -8,6 +8,7 @@ import {
   type Unsubscribe,
 } from "@assistant-ui/store/client";
 import { getAuiContext } from "./context";
+import { isDevelopment } from "./isDevelopment";
 
 /**
  * Subscribes to an assistant event for the lifetime of the current
@@ -42,9 +43,12 @@ export const useAuiEvent = <TEvent extends AssistantEventName>(
         { scope, event } as AssistantEventSelector<TEvent>,
         callback,
       );
-    } catch {
+    } catch (error) {
       // A live config may drop the selected scope; keep the current binding and
-      // retry once a later structural change makes the scope available again.
+      // retry once a later structural change makes the scope available again. A
+      // selector that never resolves (a typo'd scope) surfaces here in dev,
+      // matching the loud failure the react and vue bridges give.
+      if (isDevelopment) console.warn(error);
       return;
     }
     off?.();

--- a/packages/svelte/src/useAuiEvent.ts
+++ b/packages/svelte/src/useAuiEvent.ts
@@ -36,12 +36,20 @@ export const useAuiEvent = <TEvent extends AssistantEventName>(
   const bind = () => {
     const client = source.getClient();
     if (client === bound) return;
+    let next: Unsubscribe;
+    try {
+      next = client.on(
+        { scope, event } as AssistantEventSelector<TEvent>,
+        callback,
+      );
+    } catch {
+      // A live config may drop the selected scope; keep the current binding and
+      // retry once a later structural change makes the scope available again.
+      return;
+    }
     off?.();
     bound = client;
-    off = client.on(
-      { scope, event } as AssistantEventSelector<TEvent>,
-      callback,
-    );
+    off = next;
   };
 
   bind();

--- a/packages/svelte/src/useAuiState.ts
+++ b/packages/svelte/src/useAuiState.ts
@@ -29,7 +29,38 @@ export const useAuiState = <T>(
 ): { readonly current: T } => {
   const { source } = getAuiContext();
 
-  const subscribe = createSubscriber((update) => source.subscribe(update));
+  // Wake dependents only when the selected slice changes by Object.is, matching
+  // the react (useSyncExternalStore) and vue (computed) bridges: a store tick
+  // that does not move the slice re-runs nothing. A selector that throws (a
+  // scope shrinking out from under it) wakes so the getter surfaces it.
+  const read = () => selector(getProxiedAssistantState(source.getClient()));
+  const subscribe = createSubscriber((update) => {
+    let last: T;
+    let primed = false;
+    // Seed the baseline so the first notification with an unchanged slice does
+    // not wake; a selector that throws now stays unprimed and wakes on the
+    // first notification, letting the getter surface the error.
+    try {
+      last = read();
+      primed = true;
+    } catch {
+      /* unprimed */
+    }
+    return source.subscribe(() => {
+      let next: T;
+      try {
+        next = read();
+      } catch {
+        primed = false;
+        update();
+        return;
+      }
+      if (primed && Object.is(next, last)) return;
+      last = next;
+      primed = true;
+      update();
+    });
+  });
 
   return {
     get current(): T {

--- a/packages/svelte/src/useAuiState.ts
+++ b/packages/svelte/src/useAuiState.ts
@@ -10,10 +10,12 @@ import { getAuiContext } from "./context";
  * `current` getter. Call during component initialization.
  *
  * Reading `current` inside an effect or template tracks the store: the read
- * re-runs after every store update. The `selector` runs on each read;
- * returning the entire state object is not supported and throws. Select a
- * specific field instead, or compose multiple `useAuiState` calls. Wrap the
- * read in `$derived` to deduplicate downstream updates by value.
+ * re-runs when the selected slice changes by `Object.is`, so a store update
+ * that does not move the slice wakes nothing. The `selector` runs per store
+ * notification and on each read; returning the entire state object is not
+ * supported and throws. Select a specific field instead, or compose multiple
+ * `useAuiState` calls. Returning a fresh object or array literal defeats the
+ * deduplication; select primitives or a memoized reference.
  *
  * Scopes that may be unavailable can be read via `s.optional.<scope>`, which
  * resolves to `undefined` instead of throwing.

--- a/packages/svelte/src/useAuiState.ts
+++ b/packages/svelte/src/useAuiState.ts
@@ -1,0 +1,53 @@
+import { createSubscriber } from "svelte/reactivity";
+import {
+  getProxiedAssistantState,
+  type AssistantState,
+} from "@assistant-ui/store/client";
+import { getAuiContext } from "./context";
+
+/**
+ * Subscribes to a slice of `AssistantState` and returns it behind a reactive
+ * `current` getter. Call during component initialization.
+ *
+ * Reading `current` inside an effect or template tracks the store: the read
+ * re-runs after every store update. The `selector` runs on each read;
+ * returning the entire state object is not supported and throws. Select a
+ * specific field instead, or compose multiple `useAuiState` calls. Wrap the
+ * read in `$derived` to deduplicate downstream updates by value.
+ *
+ * Scopes that may be unavailable can be read via `s.optional.<scope>`, which
+ * resolves to `undefined` instead of throwing.
+ *
+ * @example
+ * ```ts
+ * const isRunning = useAuiState((s) => s.thread.isRunning);
+ * // template: <button disabled={isRunning.current}>…</button>
+ * ```
+ */
+export const useAuiState = <T>(
+  selector: (state: AssistantState) => T,
+): { readonly current: T } => {
+  const { source } = getAuiContext();
+
+  const subscribe = createSubscriber((update) => source.subscribe(update));
+
+  return {
+    get current(): T {
+      subscribe();
+      const state = getProxiedAssistantState(source.getClient());
+      const slice = selector(state);
+
+      if (
+        typeof slice === "object" &&
+        slice !== null &&
+        ((slice as unknown) === state || (slice as unknown) === state.optional)
+      ) {
+        throw new Error(
+          "You tried to return the entire AssistantState. This is not supported due to technical limitations.",
+        );
+      }
+
+      return slice;
+    },
+  };
+};

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/svelte/turbo.json
+++ b/packages/svelte/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["^build", "build"]
+    }
+  }
+}

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+// `react` resolves to tap's standalone shim, so this suite is the
+// react-less integration proof for the whole chain: tap standalone shim,
+// the store client entry (dist), and the Svelte bridge. The svelte plugin
+// compiles test fixtures only; the shipped package is plain TypeScript.
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    conditions: ["browser"],
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 17.3.0
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -52,10 +52,10 @@ importers:
         version: 0.84.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -218,7 +218,7 @@ importers:
         version: 5.7.1(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -236,10 +236,10 @@ importers:
         version: 1.38.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(7842a0152fac4d7234ffd694af9106b2)
+        version: 2.0.1(09374f05ea37f8c0056f5fdc20b9daee)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(7842a0152fac4d7234ffd694af9106b2)
+        version: 2.0.0(09374f05ea37f8c0056f5fdc20b9daee)
       ai:
         specifier: ^7.0.58
         version: 7.0.58(zod@4.4.3)
@@ -2199,10 +2199,10 @@ importers:
         version: link:../../packages/ui
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2272,10 +2272,10 @@ importers:
         version: link:../../packages/ui
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3104,6 +3104,46 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+
+  examples/with-svelte:
+    dependencies:
+      '@assistant-ui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/svelte':
+        specifier: workspace:*
+        version: link:../../packages/svelte
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@lucide/svelte':
+        specifier: ^1.31.0
+        version: 1.31.0(svelte@5.56.8)
+      svelte:
+        specifier: ^5.56.8
+        version: 5.56.8
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
 
   examples/with-tanstack:
     dependencies:
@@ -4259,10 +4299,10 @@ importers:
         version: 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4302,7 +4342,7 @@ importers:
         version: link:../x-buildutils
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -4732,6 +4772,37 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
 
+  packages/svelte:
+    dependencies:
+      '@assistant-ui/core':
+        specifier: ^0.3.13
+        version: link:../core
+      '@assistant-ui/store':
+        specifier: ^0.3.9
+        version: link:../store
+      '@assistant-ui/tap':
+        specifier: ^0.9.12
+        version: link:../tap
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
+      svelte:
+        specifier: ^5.56.8
+        version: 5.56.8
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+
   packages/tap:
     devDependencies:
       '@assistant-ui/x-buildutils':
@@ -5099,7 +5170,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5187,7 +5258,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5269,7 +5340,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5339,7 +5410,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5375,10 +5446,10 @@ importers:
         version: 1.5.4(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))
       '@langchain/langgraph':
         specifier: ^1.4.9
-        version: 1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
+        version: 1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+        version: 1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5421,7 +5492,7 @@ importers:
         version: 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
       '@langchain/langgraph-cli':
         specifier: ^1.4.4
-        version: 1.4.4(7f17cc8348c787fc08a2c83fa5b96aa4)
+        version: 1.4.4(04e4a510fcc72f13ec76eac126cbbba0)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -5439,7 +5510,7 @@ importers:
         version: 10.0.4
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5524,7 +5595,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -5606,7 +5677,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       oxfmt:
         specifier: ^0.62.0
-        version: 0.62.0
+        version: 0.62.0(svelte@5.56.8)
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
@@ -7840,6 +7911,11 @@ packages:
 
   '@livekit/protocol@1.50.4':
     resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
+
+  '@lucide/svelte@1.31.0':
+    resolution: {integrity: sha512-pgPuLEJdF0UpsajG9eSw0YvqXVuDxB+/x58BRiC4xE/KEHiopOqT1id3KCUvRN/PUmQkN1F26sslcs/1jutlBQ==}
+    peerDependencies:
+      svelte: ^5
 
   '@lucide/vue@1.31.0':
     resolution: {integrity: sha512-NtjEHhcAa7umPh40wrRmlESJqNGdnpc7LziBKFnW3fmlrW0g2xMCDpdWU7WeEHRSl3xOpxbqiFTLKxoK3CoVCg==}
@@ -10291,6 +10367,18 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
 
+  '@sveltejs/acorn-typescript@1.0.12':
+    resolution: {integrity: sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -11719,6 +11807,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -11797,6 +11889,10 @@ packages:
 
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -13174,6 +13270,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -13182,6 +13281,14 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@2.3.2:
+    resolution: {integrity: sha512-40GyiEJevYKXzYTHtZkFqAgTjLOuFcaXMao8TPyOlnWTlkHDlvZ6mPMJaJyOqVwrVCgomEG1WhJd81w0X+IcCw==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -14630,6 +14737,9 @@ packages:
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -15160,6 +15270,9 @@ packages:
   local-pkg@1.2.1:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -18160,6 +18273,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.56.8:
+    resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
+    engines: {node: '>=18'}
+
   svgo@4.0.2:
     resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
@@ -19436,6 +19553,9 @@ packages:
   zbsearch@3.3.4:
     resolution: {integrity: sha512-xGsv9rIwrili/fpLpVwmnCovEcvaAJg1ey+3Ur0+m3x1mnGoVO71iAwn4op420QLGNsQJNmScZjFq5TQ+cRi/g==}
     engines: {node: '>= 20.0.0'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -22069,14 +22189,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-api@1.4.4(7f17cc8348c787fc08a2c83fa5b96aa4)':
+  '@langchain/langgraph-api@1.4.4(04e4a510fcc72f13ec76eac126cbbba0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@hono/node-server': 2.1.0(hono@4.13.1)
       '@hono/node-ws': 1.3.1(@hono/node-server@2.1.0(hono@4.13.1))(hono@4.13.1)
       '@hono/zod-validator': 0.7.6(hono@4.13.1)(zod@4.4.3)
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
-      '@langchain/langgraph': 1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
+      '@langchain/langgraph': 1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))
       '@langchain/langgraph-ui': 1.4.4
       '@langchain/protocol': 0.0.18
@@ -22097,7 +22217,7 @@ snapshots:
       winston-console-format: 1.0.8
       zod: 4.4.3
     optionalDependencies:
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -22113,11 +22233,11 @@ snapshots:
     dependencies:
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
 
-  '@langchain/langgraph-cli@1.4.4(7f17cc8348c787fc08a2c83fa5b96aa4)':
+  '@langchain/langgraph-cli@1.4.4(04e4a510fcc72f13ec76eac126cbbba0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
-      '@langchain/langgraph-api': 1.4.4(7f17cc8348c787fc08a2c83fa5b96aa4)
+      '@langchain/langgraph-api': 1.4.4(04e4a510fcc72f13ec76eac126cbbba0)
       chokidar: 4.0.3
       commander: 13.1.0
       create-langgraph: 1.1.5
@@ -22153,7 +22273,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
+  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
       '@langchain/protocol': 0.0.18
@@ -22163,6 +22283,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      svelte: 5.56.8
       vue: 3.5.41(typescript@7.0.2)
 
   '@langchain/langgraph-ui@1.4.4':
@@ -22173,11 +22294,11 @@ snapshots:
       esbuild-plugin-tailwindcss: 2.2.0
       zod: 4.4.3
 
-  '@langchain/langgraph@1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)':
+  '@langchain/langgraph@1.4.9(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
       '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/protocol': 0.0.18
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
@@ -22189,10 +22310,10 @@ snapshots:
 
   '@langchain/protocol@0.0.18': {}
 
-  '@langchain/react@1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
+  '@langchain/react@1.0.29(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@7.4.0(@aws-sdk/credential-provider-node@3.972.78)(@smithy/signature-v4@5.6.12)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8)(vue@3.5.41(typescript@7.0.2))
       react: 19.2.8
     transitivePeerDependencies:
       - react-dom
@@ -22438,6 +22559,10 @@ snapshots:
   '@livekit/protocol@1.50.4':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
+
+  '@lucide/svelte@1.31.0(svelte@5.56.8)':
+    dependencies:
+      svelte: 5.56.8
 
   '@lucide/vue@1.31.0(vue@3.5.41(typescript@7.0.2))':
     dependencies:
@@ -25427,6 +25552,19 @@ snapshots:
       mermaid: 11.16.1
       react: 19.2.8
 
+  '@sveltejs/acorn-typescript@1.0.12(acorn@8.18.0)':
+    dependencies:
+      acorn: 8.18.0
+
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))':
+    dependencies:
+      deepmerge: 4.3.1
+      magic-string: 1.1.0
+      obug: 2.1.4
+      svelte: 5.56.8
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -26300,11 +26438,12 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.8
 
-  '@vercel/analytics@2.0.1(7842a0152fac4d7234ffd694af9106b2)':
+  '@vercel/analytics@2.0.1(09374f05ea37f8c0056f5fdc20b9daee)':
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuxt: 4.5.2(@azure/identity@4.13.1)(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@upstash/redis@1.38.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@26.2.0))(sqlite3@5.1.7))(encoding@0.1.13)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(mysql2@3.20.0(@types/node@26.2.0))(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sqlite3@5.1.7)(srvx@0.11.22)(terser@5.49.2)(tsx@4.23.11)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.8
+      svelte: 5.56.8
       vue: 3.5.41(typescript@7.0.2)
 
   '@vercel/nft@1.10.2(encoding@0.1.13)(rollup@4.62.4)':
@@ -26328,11 +26467,12 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(7842a0152fac4d7234ffd694af9106b2)':
+  '@vercel/speed-insights@2.0.0(09374f05ea37f8c0056f5fdc20b9daee)':
     optionalDependencies:
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuxt: 4.5.2(@azure/identity@4.13.1)(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@upstash/redis@1.38.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@26.2.0))(sqlite3@5.1.7))(encoding@0.1.13)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(mysql2@3.20.0(@types/node@26.2.0))(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sqlite3@5.1.7)(srvx@0.11.22)(terser@5.49.2)(tsx@4.23.11)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.8
+      svelte: 5.56.8
       vue: 3.5.41(typescript@7.0.2)
 
   '@vitejs/plugin-react@6.0.5(babel-plugin-react-compiler@1.0.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))':
@@ -26847,6 +26987,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  aria-query@5.3.1: {}
+
   aria-query@5.3.2: {}
 
   array-flatten@1.1.1: {}
@@ -26918,6 +27060,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  axobject-query@4.1.0: {}
 
   b4a@1.8.1: {}
 
@@ -28341,9 +28485,15 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esm-env@1.2.2: {}
+
   esm@3.2.25: {}
 
   esprima@4.0.1: {}
+
+  esrap@2.3.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -30117,6 +30267,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
@@ -30694,6 +30848,8 @@ snapshots:
       mlly: 1.8.2
       pkg-types: 2.3.1
       quansync: 0.2.11
+
+  locate-character@3.0.0: {}
 
   locate-path@3.0.0:
     dependencies:
@@ -32466,7 +32622,7 @@ snapshots:
       '@oxc-project/types': 0.143.0
       rolldown: 1.2.3
 
-  oxfmt@0.62.0:
+  oxfmt@0.62.0(svelte@5.56.8):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -32489,6 +32645,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.62.0
       '@oxfmt/binding-win32-ia32-msvc': 0.62.0
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
+      svelte: 5.56.8
 
   oxlint@1.77.0:
     optionalDependencies:
@@ -34755,6 +34912,27 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte@5.56.8:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.18.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.18.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      esrap: 2.3.2
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   svgo@4.0.2:
     dependencies:
       commander: 11.1.0
@@ -36011,6 +36189,8 @@ snapshots:
       '@yuku-parser/binding-win32-x64': 0.8.4
 
   zbsearch@3.3.4: {}
+
+  zimmerframe@1.1.4: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4796,6 +4796,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.3.0
         version: 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18


### PR DESCRIPTION
## summary

- adds `@assistant-ui/svelte` (private): Svelte 5 bindings over `@assistant-ui/store/client`, exposing `provideAui`, `useAui`, `useAuiState`, and `useAuiEvent`. the package is plain TypeScript built by aui-build and ships no compiled Svelte components; reactivity binds through `svelte/reactivity`'s `createSubscriber` behind `{ get current() }` getters, and the provider holds the client's lifetime subscription per the subscription-owned handle contract from #5889.
- `provideAui` mirrors the vue provider's semantics: mandatory `extends` under a parent provider (dev error, compiled-out fallback inherits), live config via a thunk bridged with `toStore`, same-key scopes keeping state across config changes.
- adds `examples/with-svelte`: a raw-composable echo chat (no primitives yet) proving the four composables carry a full chat UX; `runtime.ts` and `styles.css` are byte-identical copies of the with-vue example.
- the package's vitest suite runs with `react` aliased to tap's standalone shim, so the suite is the react-less integration proof for the chain (tap shim, store client dist, svelte bridge).

## test plan

### already verified

- [x] `pnpm -C packages/svelte test` -> 12/12 green, three consecutive runs (provider lifecycle incl. deferred soft unmount, nested extends grammar, live thunk config keeping scope state, state tracking inside effects, entire-state guard, event delivery and rebinding)
- [x] `pnpm exec turbo run build --filter=@assistant-ui/svelte` -> dist audited: no react import, no compiler-runtime injection (the react-compiler gate correctly skips packages without a react peer)
- [x] `pnpm -C examples/with-svelte build` -> vite build green
- [x] browser E2E on the example via real CDP input: suggestion chip send, Enter-to-send with composition guard, echo replies, cancel mid-run restoring the trailing user message into the composer draft, switch-to-new-thread mid-run cancelling the in-flight reply, console free of errors and warnings

### reviewer should verify

- [ ] `pnpm -C examples/with-svelte dev` and click through the welcome suggestions, send, and stop flows; the composer should keep the canonical assistant-ui look and the cancel flow should return the draft into the textarea

## notes

- svelte devDependency floors at `^5.56.8` because 5.56.9 was published inside the workspace's `minimumReleaseAge` window; the caret picks it up once it ages past the cutoff.
- primitives are deliberately out of scope; the plan is Melt-style builder functions with explicit per-item handles (enabled by the #5889 lifecycle) rather than shipped `.svelte` components, keeping the package compiler-free.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hYZq4aV0dkZk4AdoTrbmZ1D4T3CardHDn330WS85CzFQqJgbBLWGnFXLCGQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

