### PR TITLE
fix(react-ag-ui): handle streamed run errors

### DIFF
--- a/.changeset/fresh-ag-ui-run-errors.md
+++ b/.changeset/fresh-ag-ui-run-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: mark streamed AG-UI run errors as failed

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -147,6 +147,7 @@ export const createAgUiSubscriber = (
     onCustomEvent: ({ event }) => dispatchIfValid(event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
+      if (runFinishedDispatched) return;
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
       runFinishedDispatched = true;

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -35,6 +35,7 @@ type Subscriber = {
   onCustomEvent?: (payload: { event: unknown }) => void;
   onRawEvent?: (payload: { event: unknown }) => void;
   onRunFinishedEvent?: (payload: { event: unknown }) => void;
+  onRunErrorEvent?: (payload: { event: unknown }) => void;
   onRunFinalized?: () => void;
   onRunFailed?: (payload: { error: Error }) => void;
 };
@@ -150,6 +151,18 @@ export const createAgUiSubscriber = (
       if (!parsed) return;
       runFinishedDispatched = true;
       dispatch(parsed);
+    },
+    onRunErrorEvent: ({ event }) => {
+      const parsed = ensureEvent(event, "RUN_ERROR", logger);
+      if (!parsed || parsed.type !== "RUN_ERROR") return;
+      runFinishedDispatched = true;
+      dispatch(parsed);
+
+      const error = Object.assign(
+        new Error(parsed.message ?? "Run failed"),
+        parsed.code === undefined ? {} : { code: parsed.code },
+      );
+      onRunFailed?.(error);
     },
     onRunFinalized: () => {
       if (runFinishedDispatched) return;

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -55,7 +55,7 @@ describe("createAgUiSubscriber", () => {
     expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
   });
 
-  it("dispatches streamed RUN_ERROR events without synthesizing RUN_FINISHED", () => {
+  it("keeps streamed RUN_ERROR terminal when RUN_FINISHED follows", () => {
     const events: AgUiEvent[] = [];
     const onRunFailed = vi.fn();
     const subscriber = createAgUiSubscriber({
@@ -70,6 +70,9 @@ describe("createAgUiSubscriber", () => {
         message: "model unavailable",
         code: "model_disabled",
       },
+    });
+    subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: "run" },
     });
     subscriber.onRunFinalized?.();
 

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -55,6 +55,39 @@ describe("createAgUiSubscriber", () => {
     expect(events[0]).toMatchObject({ type: "RUN_ERROR", message: "boom" });
   });
 
+  it("dispatches streamed RUN_ERROR events without synthesizing RUN_FINISHED", () => {
+    const events: AgUiEvent[] = [];
+    const onRunFailed = vi.fn();
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => events.push(evt),
+      runId: "run",
+      onRunFailed,
+    });
+
+    subscriber.onRunErrorEvent?.({
+      event: {
+        type: "RUN_ERROR",
+        message: "model unavailable",
+        code: "model_disabled",
+      },
+    });
+    subscriber.onRunFinalized?.();
+
+    expect(onRunFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "model unavailable",
+        code: "model_disabled",
+      }),
+    );
+    expect(events).toEqual([
+      {
+        type: "RUN_ERROR",
+        message: "model unavailable",
+        code: "model_disabled",
+      },
+    ]);
+  });
+
   it.each([
     [
       "AbortError name",


### PR DESCRIPTION
## Summary

- handle typed `onRunErrorEvent` callbacks from the AG-UI client
- dispatch the validated `RUN_ERROR` and prevent finalization from replacing it with `RUN_FINISHED`
- surface the protocol failure through the runtime error callback while preserving its error code

## Why

A backend can end a stream normally after emitting `RUN_ERROR`. The AG-UI client delivers that event through `onRunErrorEvent`, but the runtime subscriber did not implement that handler. The event was dropped and finalization synthesized a successful `RUN_FINISHED`, leaving users with a blank completed response instead of the backend error.

Closes #5896

## Testing

- regression test for streamed `RUN_ERROR` followed by finalization
- `pnpm --dir packages/react-ag-ui test` (363 tests)
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fuOzgUfOJrLkh81YQowoRabkQzf9TJze5dzr30Wr7NM0peW-tFEyKcIeWSY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->