### PR TITLE
fix(react-langgraph): reload history after loader changes

### DIFF
--- a/.changeset/fresh-langgraph-loader-scopes.md
+++ b/.changeset/fresh-langgraph-loader-scopes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: reload LangGraph history when its load scope changes

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -2210,6 +2210,7 @@ type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
     interrupts?: LangGraphInterruptState[];
     uiMessages?: UIMessage[];
   }>;
+  loadKey?: PropertyKey | undefined;
   create?: () => Promise<{
     externalId: string;
   }>;

--- a/apps/docs/content/docs/runtimes/langgraph/threads.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/threads.mdx
@@ -11,6 +11,7 @@ description: Basic thread support, AssistantCloud, and custom thread list adapte
 
 ```ts
 const runtime = useLangGraphRuntime({
+  loadKey: workspaceId,
   stream: async (messages, { initialize, ...config }) => {
     // initialize() creates or loads a thread and returns its IDs
     const { remoteId, externalId } = await initialize();
@@ -32,6 +33,10 @@ const runtime = useLangGraphRuntime({
   },
 });
 ```
+
+Keep `loadKey` stable for the same history scope and change it when the active
+account or workspace changes. The runtime clears the previous scope and reloads
+the active thread with the latest `load` callback.
 
 ## Cloud persistence
 

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -361,6 +361,11 @@ export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
      */
     uiMessages?: UIMessage[];
   }>;
+  /**
+   * Stable identifier for the backing load scope. Change it to clear and
+   * reload the active thread when its account or workspace changes.
+   */
+  loadKey?: PropertyKey | undefined;
   create?: () => Promise<{
     externalId: string;
   }>;

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -206,6 +206,47 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     onCustomEvent?: OnCustomEventCallback;
   };
 }) => {
+  const result = useLangGraphMessagesWithReset({
+    stream,
+    appendMessage,
+    eventHandlers,
+    uiStateKey,
+  });
+  const sendMessageInternal = result.sendMessage;
+  const sendMessage = useCallback(
+    async (
+      newMessages: TMessage[],
+      config: LangGraphSendMessageConfig,
+      onComplete?: () => void,
+    ) => sendMessageInternal(newMessages, config, onComplete),
+    [sendMessageInternal],
+  );
+  return {
+    interrupt: result.interrupt,
+    values: result.values,
+    messages: result.messages,
+    messageMetadata: result.messageMetadata,
+    uiMessages: result.uiMessages,
+    sendMessage,
+    cancel: result.cancel,
+    setInterrupt: result.setInterrupt,
+    setValues: result.setValues,
+    setMessages: result.setMessages,
+    setUIMessages: result.setUIMessages,
+    reconcileMessages: result.reconcileMessages,
+    reconcileUIMessages: result.reconcileUIMessages,
+    reconcileInterrupt: result.reconcileInterrupt,
+  };
+};
+
+export const useLangGraphMessagesWithReset = <
+  TMessage extends { id?: string },
+>({
+  stream,
+  appendMessage = DEFAULT_APPEND_MESSAGE,
+  eventHandlers,
+  uiStateKey = DEFAULT_UI_STATE_KEY,
+}: Parameters<typeof useLangGraphMessages<TMessage>>[0]) => {
   const interruptRef = useRef<LangGraphInterruptState | undefined>(undefined);
   const [interrupt, setInterrupt] = useState<
     LangGraphInterruptState | undefined
@@ -648,6 +689,17 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     }
   }, []);
 
+  const reset = useCallback(() => {
+    abortControllerRef.current?.abort();
+    activeAccumulatorRef.current = undefined;
+    interruptRef.current = undefined;
+    setMessagesImmediate([]);
+    setUIMessagesImmediate([]);
+    setInterrupt(undefined);
+    setValues(undefined);
+    setMessageMetadata(new Map());
+  }, [setMessagesImmediate, setUIMessagesImmediate]);
+
   return {
     interrupt,
     values,
@@ -656,6 +708,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     uiMessages,
     sendMessage,
     cancel,
+    reset,
     setInterrupt,
     setValues,
     setMessages: setMessagesImmediate,

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -12,7 +12,12 @@ import {
 import { getThreadMessageText } from "@assistant-ui/core/internal";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { useLangGraphRuntime } from "./useLangGraphRuntime";
-import { useLangGraphSend } from "./hooks";
+import {
+  useLangGraphMessageMetadata,
+  useLangGraphSend,
+  useLangGraphSetState,
+  useLangGraphState,
+} from "./hooks";
 import { mockStreamCallbackFactory } from "./testUtils";
 import type { LangChainMessage } from "./types";
 import type { LangGraphInterruptState } from "./useLangGraphMessages";
@@ -749,14 +754,19 @@ describe("useLangGraphRuntime", () => {
   it("clears and reloads history when the load key changes", async () => {
     const pendingA = deferred<LoadResult>();
     const pendingB = deferred<LoadResult>();
-    const loadA = vi.fn(
-      (_threadId: string, options?: { signal: AbortSignal }) => {
-        options?.signal.addEventListener("abort", () =>
-          pendingA.reject(options.signal.reason),
-        );
-        return pendingA.promise;
-      },
-    );
+    const loadA = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: [{ id: "a", type: "ai" as const, content: "workspace a" }],
+      })
+      .mockImplementationOnce(
+        (_threadId: string, options?: { signal: AbortSignal }) => {
+          options?.signal.addEventListener("abort", () =>
+            pendingA.reject(options.signal.reason),
+          );
+          return pendingA.promise;
+        },
+      );
     const loadB = vi.fn(() => pendingB.promise);
     const streamMock = vi
       .fn()
@@ -782,11 +792,19 @@ describe("useLangGraphRuntime", () => {
       void runtimeResult.current.threads.switchToThread("lg-thread-1");
     });
     await waitFor(() => expect(loadA).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(textsOf(runtimeResult.current)).toEqual(["workspace a"]),
+    );
+
+    act(() => {
+      void runtimeResult.current.threads.reloadMainThread();
+    });
+    await waitFor(() => expect(loadA).toHaveBeenCalledTimes(2));
 
     rerender({ load: loadB, loadKey: "workspace-b" });
 
     await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
-    expect(loadA.mock.calls[0]?.[1]?.signal.aborted).toBe(true);
+    expect(loadA.mock.calls[1]?.[1]?.signal.aborted).toBe(true);
     expect(runtimeResult.current.thread.getState().messages).toEqual([]);
 
     await act(async () => {
@@ -816,6 +834,119 @@ describe("useLangGraphRuntime", () => {
       expect(textsOf(runtimeResult.current).join("\n")).toContain(
         "workspace b refreshed",
       ),
+    );
+  });
+
+  it("resets nested runtime state and ignores late stream events after a load key change", async () => {
+    const parentStream = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+    const { result: parentRuntime } = renderHook(() =>
+      useLangGraphRuntime({
+        stream: parentStream,
+        unstable_threadListAdapter: makeThreadListAdapter(),
+      }),
+    );
+    const parentWrapper = wrapperFactory(parentRuntime.current);
+    renderHook(() => useAuiState((s) => s.threads.mainThreadId), {
+      wrapper: parentWrapper,
+    });
+    await act(async () => {
+      await parentRuntime.current.threads.switchToThread("lg-thread-1");
+    });
+
+    const streamGate = deferred<void>();
+    const streamStarted = deferred<void>();
+    const streamMock = vi.fn(async function* () {
+      yield {
+        event: "messages",
+        data: [
+          { id: "stream-a", type: "ai", content: "streamed in workspace a" },
+          { langgraph_node: "workspace-a-node" },
+        ],
+      };
+      streamStarted.resolve();
+      await streamGate.promise;
+      yield {
+        event: "messages/complete",
+        data: [{ id: "late-a", type: "ai", content: "late workspace a" }],
+      };
+    });
+    const pendingB = deferred<LoadResult>();
+    const loadA = vi.fn(async () => ({
+      messages: [
+        { id: "history-a", type: "ai" as const, content: "workspace a" },
+      ],
+    }));
+    const loadB = vi.fn(() => pendingB.promise);
+    const { result: nestedRuntime, rerender } = renderHook(
+      ({ load, loadKey }) =>
+        useLangGraphRuntime({ stream: streamMock, load, loadKey }),
+      {
+        wrapper: parentWrapper,
+        initialProps: { load: loadA, loadKey: "workspace-a" },
+      },
+    );
+
+    await waitFor(() =>
+      expect(textsOf(nestedRuntime.current)).toEqual(["workspace a"]),
+    );
+
+    const nestedWrapper = wrapperFactory(nestedRuntime.current);
+    const { result: sendResult } = renderHook(() => useLangGraphSend(), {
+      wrapper: nestedWrapper,
+    });
+    const { result: setStateResult } = renderHook(
+      () => useLangGraphSetState(),
+      { wrapper: nestedWrapper },
+    );
+    const { result: stateResult } = renderHook(() => useLangGraphState(), {
+      wrapper: nestedWrapper,
+    });
+    const { result: metadataResult } = renderHook(
+      () => useLangGraphMessageMetadata(),
+      { wrapper: nestedWrapper },
+    );
+
+    await act(async () => {
+      setStateResult.current({ workspace: "a" });
+      void sendResult.current(
+        [{ id: "human-a", type: "human", content: "hello" }],
+        {},
+      );
+      await streamStarted.promise;
+    });
+    await waitFor(() =>
+      expect(metadataResult.current.get("stream-a")).toMatchObject({
+        langgraph_node: "workspace-a-node",
+      }),
+    );
+    expect(stateResult.current).toEqual({ workspace: "a" });
+
+    rerender({ load: loadB, loadKey: "workspace-b" });
+
+    await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(nestedRuntime.current.thread.getState().messages).toEqual([]);
+      expect(stateResult.current).toBeUndefined();
+      expect(metadataResult.current.size).toBe(0);
+    });
+
+    await act(async () => {
+      streamGate.resolve();
+      await Promise.resolve();
+    });
+    expect(nestedRuntime.current.thread.getState().messages).toEqual([]);
+
+    await act(async () => {
+      pendingB.resolve({
+        messages: [
+          { id: "history-b", type: "ai" as const, content: "workspace b" },
+        ],
+      });
+    });
+    await waitFor(() =>
+      expect(textsOf(nestedRuntime.current)).toEqual(["workspace b"]),
     );
   });
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -746,6 +746,79 @@ describe("useLangGraphRuntime", () => {
     unmount();
   });
 
+  it("clears and reloads history when the load key changes", async () => {
+    const pendingA = deferred<LoadResult>();
+    const pendingB = deferred<LoadResult>();
+    const loadA = vi.fn(
+      (_threadId: string, options?: { signal: AbortSignal }) => {
+        options?.signal.addEventListener("abort", () =>
+          pendingA.reject(options.signal.reason),
+        );
+        return pendingA.promise;
+      },
+    );
+    const loadB = vi.fn(() => pendingB.promise);
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+    const adapter = makeThreadListAdapter();
+
+    const { result: runtimeResult, rerender } = renderHook(
+      ({ load, loadKey }) =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          load,
+          loadKey,
+          unstable_threadListAdapter: adapter,
+        }),
+      {
+        initialProps: { load: loadA, loadKey: "workspace-a" },
+      },
+    );
+    const wrapper = wrapperFactory(runtimeResult.current);
+    renderHook(() => useAuiState((s) => s.thread.isLoading), { wrapper });
+
+    act(() => {
+      void runtimeResult.current.threads.switchToThread("lg-thread-1");
+    });
+    await waitFor(() => expect(loadA).toHaveBeenCalledTimes(1));
+
+    rerender({ load: loadB, loadKey: "workspace-b" });
+
+    await waitFor(() => expect(loadB).toHaveBeenCalledTimes(1));
+    expect(loadA.mock.calls[0]?.[1]?.signal.aborted).toBe(true);
+    expect(runtimeResult.current.thread.getState().messages).toEqual([]);
+
+    await act(async () => {
+      pendingB.resolve({
+        messages: [{ id: "b", type: "ai" as const, content: "workspace b" }],
+      });
+    });
+
+    await waitFor(() =>
+      expect(textsOf(runtimeResult.current)).toEqual(["workspace b"]),
+    );
+
+    const loadB2 = vi.fn(async () => ({
+      messages: [
+        { id: "b-2", type: "ai" as const, content: "workspace b refreshed" },
+      ],
+    }));
+    rerender({ load: loadB2, loadKey: "workspace-b" });
+    expect(loadB2).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await runtimeResult.current.threads.reloadMainThread();
+    });
+
+    expect(loadB2).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(textsOf(runtimeResult.current).join("\n")).toContain(
+        "workspace b refreshed",
+      ),
+    );
+  });
+
   it("should reset thread.isLoading to false and surface the error when load rejects", async () => {
     const consoleWarnSpy = vi
       .spyOn(console, "warn")

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -35,7 +35,7 @@ import {
 } from "./convertLangChainMessages";
 import {
   type LangGraphSendMessageConfig,
-  useLangGraphMessages,
+  useLangGraphMessagesWithReset,
 } from "./useLangGraphMessages";
 import { appendLangChainChunk } from "./appendLangChainChunk";
 import { useLangGraphStreamingTiming } from "./useLangGraphStreamingTiming";
@@ -198,13 +198,14 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     uiMessages,
     sendMessage,
     cancel,
+    reset: resetLangGraphMessages,
     setMessages,
     setValues,
     setUIMessages,
     reconcileMessages,
     reconcileUIMessages,
     reconcileInterrupt,
-  } = useLangGraphMessages({
+  } = useLangGraphMessagesWithReset({
     appendMessage: appendLangChainChunk,
     stream,
     eventHandlers: wrappedEventHandlers,
@@ -575,6 +576,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     previousLoadKeyRef.current = effectiveLoadKey;
     if (loadKeyChanged) {
       cancelActiveRun();
+      pendingStateRef.current = undefined;
+      effectiveStateRef.current = undefined;
+      setOptimisticState(undefined);
       attachmentsByMessageIdRef.current.clear();
       stagedMessagesRef.current.clear();
       toolArgsKeyOrderCacheRef.current.clear();
@@ -584,9 +588,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       uiMessagesRef.current = [];
       interruptRef.current = undefined;
       setStagedMessageCount(0);
-      setMessages([]);
-      setUIMessages([]);
-      setInterrupt(undefined);
+      resetLangGraphMessages();
       setToolStatuses({});
     }
 
@@ -597,14 +599,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       loadControllerRef.current?.controller.abort();
       setIsLoadingThread(false);
     };
-  }, [
-    runLoad,
-    effectiveLoadKey,
-    cancelActiveRun,
-    setMessages,
-    setUIMessages,
-    setInterrupt,
-  ]);
+  }, [runLoad, effectiveLoadKey, cancelActiveRun, resetLangGraphMessages]);
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -55,6 +55,13 @@ import {
 
 const EMPTY_QUEUE_ITEMS: readonly QueueItemState[] = Object.freeze([]);
 const subscribeNoop = () => () => {};
+const DEFAULT_LOAD_KEY = Symbol("default-langgraph-load-key");
+const NO_LOAD_KEY = Symbol("no-langgraph-load");
+
+const getLoadKey = (
+  load: UseLangGraphRuntimeOptions["load"],
+  loadKey: UseLangGraphRuntimeOptions["loadKey"],
+) => (load === undefined ? NO_LOAD_KEY : (loadKey ?? DEFAULT_LOAD_KEY));
 
 const toLangGraphUserMessage = (
   msg: AppendMessage,
@@ -73,6 +80,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     unstable_enableMessageQueue,
     stream,
     load,
+    loadKey,
     getCheckpointId,
     eventHandlers,
     uiStateKey,
@@ -474,9 +482,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   uiMessagesRef.current = uiMessages;
 
   const loadRef = useRef(load);
-  useEffect(() => {
-    loadRef.current = load;
-  });
+  loadRef.current = load;
+  const effectiveLoadKey = getLoadKey(load, loadKey);
+  const previousLoadKeyRef = useRef(effectiveLoadKey);
 
   const threadListItem =
     aui.threadListItem.source !== null ? aui.threadListItem : undefined;
@@ -560,6 +568,28 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   );
 
   useEffect(() => {
+    const loadKeyChanged = !Object.is(
+      previousLoadKeyRef.current,
+      effectiveLoadKey,
+    );
+    previousLoadKeyRef.current = effectiveLoadKey;
+    if (loadKeyChanged) {
+      cancelActiveRun();
+      attachmentsByMessageIdRef.current.clear();
+      stagedMessagesRef.current.clear();
+      toolArgsKeyOrderCacheRef.current.clear();
+      toolResultBufferRef.current.clear();
+      runErrorBalanceRef.current = 0;
+      langGraphMessagesRef.current = [];
+      uiMessagesRef.current = [];
+      interruptRef.current = undefined;
+      setStagedMessageCount(0);
+      setMessages([]);
+      setUIMessages([]);
+      setInterrupt(undefined);
+      setToolStatuses({});
+    }
+
     runLoad();
     return () => {
       // Whatever is current, not this effect's own controller: a refetch swaps
@@ -567,7 +597,14 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       loadControllerRef.current?.controller.abort();
       setIsLoadingThread(false);
     };
-  }, [runLoad]);
+  }, [
+    runLoad,
+    effectiveLoadKey,
+    cancelActiveRun,
+    setMessages,
+    setUIMessages,
+    setInterrupt,
+  ]);
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
@@ -754,6 +791,20 @@ export const useLangGraphRuntime = ({
   initialThreadId,
   ...options
 }: UseLangGraphRuntimeOptions) => {
+  const latestLoadRef = useRef(options.load);
+  latestLoadRef.current = options.load;
+  const latestLoad = useCallback<
+    NonNullable<UseLangGraphRuntimeOptions["load"]>
+  >((externalId, loadOptions) => {
+    const load = latestLoadRef.current;
+    if (!load) {
+      throw new Error("LangGraph history loading is not configured.");
+    }
+    return load(externalId, loadOptions);
+  }, []);
+  const runtimeOptions =
+    options.load === undefined ? options : { ...options, load: latestLoad };
+
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
@@ -775,8 +826,9 @@ export const useLangGraphRuntime = ({
 
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      return useLangGraphRuntimeImpl(options);
+      return useLangGraphRuntimeImpl(runtimeOptions);
     },
+    unstable_runtimeHookKey: getLoadKey(options.load, options.loadKey),
     adapter,
     allowNesting: true,
     onThreadIdChange,


### PR DESCRIPTION
## Summary

- add a stable `loadKey` that identifies the active LangGraph history scope
- abort stale loads, clear the previous scope, and reload the mounted thread when the key changes
- keep same-scope manual refetches connected to the latest `load` callback
- document the account and workspace switching pattern and update the API surface

## Why

Mounted LangGraph thread runtimes retain their existing history load. Switching from workspace A to B can therefore leave A's messages visible, and a delayed A response can overwrite the active workspace. Depending on the `load` callback identity is unsafe because inline callbacks change during ordinary renders, so this uses an explicit stable scope key.

This is a focused follow-up to #5854 and uses its shared runtime-hook key mechanism. It is stacked on that PR so this diff contains only the LangGraph changes.

## Testing

- regression: a key change aborts loader A, clears A history, and loads B
- regression: same-key rerenders do not reload, while manual refetch uses the latest callback
- `pnpm --dir packages/react-langgraph test` (266 tests)
- `pnpm --filter @assistant-ui/react-langgraph build`
- `pnpm lint`
- filtered API-surface generation and check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Sa-P4JAoooncfIad7yQ0Sk13kwP4TphdOY6v9bV_xDHotQiyxN09kUrWSe0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->