### PR TITLE
fix(react-ag-ui): stop a server-sent RUN_ERROR from rendering as a successful run

### DIFF
--- a/.changeset/agui-run-error-dropped.md
+++ b/.changeset/agui-run-error-dropped.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): surface a server-sent RUN_ERROR instead of rendering the run as a success

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1109,6 +1109,7 @@ export class AgUiThreadRuntimeCore {
           dispatch,
           runId,
           logger: this.logger,
+          abortSignal,
           onRunSettled: () => {
             runSettled = true;
           },

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1125,11 +1125,14 @@ export class AgUiThreadRuntimeCore {
         await runAgent(input, subscriber, { signal: abortSignal });
       }
     } catch (error) {
-      if (!abortSignal.aborted) {
+      // A run that already reported a terminal failure through the subscriber
+      // rethrows that same collapse here; reporting it again would fire onError
+      // twice and replace the business error with the transport one.
+      if (!abortSignal.aborted && !this.pendingError) {
         const err = error instanceof Error ? error : new Error(String(error));
         dispatch({ type: "RUN_ERROR", message: err.message });
         invokeRuntimeCallback("onError", this.onError, err);
-        this.pendingError = this.pendingError ?? err;
+        this.pendingError = err;
       }
     } finally {
       this.finishRun(abortController);

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1079,6 +1079,8 @@ export class AgUiThreadRuntimeCore {
 
     this.setRunning(true);
 
+    let runSettled = false;
+
     try {
       if (resumeStream) {
         // Cancel flips only the status; an aggregator RUN_CANCELLED would emit an empty snapshot and wipe the replayed content.
@@ -1107,6 +1109,9 @@ export class AgUiThreadRuntimeCore {
           dispatch,
           runId,
           logger: this.logger,
+          onRunSettled: () => {
+            runSettled = true;
+          },
           onRunFailed: (error) => {
             if (abortSignal.aborted) return;
             this.pendingError = error;
@@ -1125,14 +1130,18 @@ export class AgUiThreadRuntimeCore {
         await runAgent(input, subscriber, { signal: abortSignal });
       }
     } catch (error) {
-      // A run that already reported a terminal failure through the subscriber
-      // rethrows that same collapse here; reporting it again would fire onError
-      // twice and replace the business error with the transport one.
-      if (!abortSignal.aborted && !this.pendingError) {
+      if (!abortSignal.aborted) {
         const err = error instanceof Error ? error : new Error(String(error));
-        dispatch({ type: "RUN_ERROR", message: err.message });
-        invokeRuntimeCallback("onError", this.onError, err);
-        this.pendingError = err;
+        // A run that already reached a terminal outcome through the subscriber
+        // rethrows that same collapse here; reporting it again would fire
+        // onError twice and replace the settled outcome with the transport one.
+        // The rejection still propagates, so a dead stream never resolves the
+        // append or fires a deferred resume against it.
+        if (!runSettled && !this.pendingError) {
+          dispatch({ type: "RUN_ERROR", message: err.message });
+          invokeRuntimeCallback("onError", this.onError, err);
+        }
+        this.pendingError ??= err;
       }
     } finally {
       this.finishRun(abortController);

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
@@ -138,14 +138,22 @@ describe("createAgUiSubscriber", () => {
     });
 
     it("falls back to a generic message when the event carries none", () => {
-      const { dispatched, onRunFailed, subscriber } = setup();
+      const { dispatched, updates, onRunFailed, subscriber } = setup();
 
       subscriber.onRunErrorEvent?.({ event: { type: "RUN_ERROR" } });
 
-      expect(dispatched).toContainEqual({ type: "RUN_ERROR" });
+      expect(dispatched).toContainEqual({
+        type: "RUN_ERROR",
+        message: "Run failed",
+      });
       expect((onRunFailed.mock.calls[0]![0] as Error).message).toBe(
         "Run failed",
       );
+      expect(lastStatus(updates)).toMatchObject({
+        type: "incomplete",
+        reason: "error",
+        error: "Run failed",
+      });
     });
   });
 

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatModelRunResult } from "@assistant-ui/core";
+import { createAgUiSubscriber } from "./subscriber";
+import { RunAggregator } from "./run-aggregator";
+import { makeLogger } from "../logger";
+import type { AgUiEvent } from "../types";
+
+const setup = () => {
+  const dispatched: AgUiEvent[] = [];
+  const updates: ChatModelRunResult[] = [];
+  const onRunFailed = vi.fn();
+  const aggregator = new RunAggregator({
+    showThinking: false,
+    logger: makeLogger(),
+    emit: (update) => updates.push(update),
+  });
+  const subscriber = createAgUiSubscriber({
+    dispatch: (event) => {
+      dispatched.push(event);
+      aggregator.handle(event);
+    },
+    runId: "run-1",
+    onRunFailed,
+  });
+  aggregator.handle({ type: "RUN_STARTED", runId: "run-1" });
+  return { dispatched, updates, onRunFailed, subscriber };
+};
+
+const lastStatus = (updates: ChatModelRunResult[]) => updates.at(-1)?.status;
+
+describe("createAgUiSubscriber", () => {
+  describe("server-sent RUN_ERROR", () => {
+    it("reaches the aggregator as an errored run", () => {
+      const { dispatched, updates, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: { type: "RUN_ERROR", message: "upstream exploded", code: "500" },
+      });
+      subscriber.onRunFinalized?.();
+
+      expect(dispatched).toContainEqual({
+        type: "RUN_ERROR",
+        message: "upstream exploded",
+        code: "500",
+      });
+      expect(lastStatus(updates)).toEqual({
+        type: "incomplete",
+        reason: "error",
+        error: "upstream exploded",
+      });
+    });
+
+    it("does not let onRunFinalized synthesize a RUN_FINISHED afterwards", () => {
+      const { dispatched, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: { type: "RUN_ERROR", message: "upstream exploded" },
+      });
+      subscriber.onRunFinalized?.();
+
+      expect(dispatched.map((event) => event.type)).not.toContain(
+        "RUN_FINISHED",
+      );
+    });
+
+    it("reports the failure to the run-failed callback", () => {
+      const { onRunFailed, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: { type: "RUN_ERROR", message: "upstream exploded", code: "500" },
+      });
+
+      expect(onRunFailed).toHaveBeenCalledTimes(1);
+      const error = onRunFailed.mock.calls[0]![0] as Error;
+      expect(error.message).toBe("upstream exploded");
+      expect((error as Error & { code?: string }).code).toBe("500");
+    });
+
+    it("settles an aborted request as a cancellation, not an error", () => {
+      const { dispatched, updates, onRunFailed, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: {
+          type: "RUN_ERROR",
+          message: "Request aborted",
+          code: "abort",
+        },
+      });
+      subscriber.onRunFinalized?.();
+
+      expect(dispatched).toEqual([{ type: "RUN_CANCELLED" }]);
+      expect(lastStatus(updates)).toEqual({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+      expect(onRunFailed).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a generic message when the event carries none", () => {
+      const { dispatched, onRunFailed, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({ event: { type: "RUN_ERROR" } });
+
+      expect(dispatched).toContainEqual({ type: "RUN_ERROR" });
+      expect((onRunFailed.mock.calls[0]![0] as Error).message).toBe(
+        "Run failed",
+      );
+    });
+  });
+
+  it("still synthesizes RUN_FINISHED when a run ends without a terminal event", () => {
+    const { dispatched, subscriber } = setup();
+
+    subscriber.onRunFinalized?.();
+
+    expect(dispatched).toContainEqual({ type: "RUN_FINISHED", runId: "run-1" });
+  });
+});

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.test.ts
@@ -96,6 +96,47 @@ describe("createAgUiSubscriber", () => {
       expect(onRunFailed).not.toHaveBeenCalled();
     });
 
+    it("keeps the business error when a transport failure follows", () => {
+      const { dispatched, updates, onRunFailed, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: { type: "RUN_ERROR", message: "upstream exploded", code: "500" },
+      });
+      subscriber.onRunFailed?.({ error: new Error("socket died") });
+      subscriber.onRunFinalized?.();
+
+      expect(onRunFailed).toHaveBeenCalledTimes(1);
+      expect((onRunFailed.mock.calls[0]![0] as Error).message).toBe(
+        "upstream exploded",
+      );
+      expect(dispatched).toEqual([
+        { type: "RUN_ERROR", message: "upstream exploded", code: "500" },
+      ]);
+      expect(lastStatus(updates)).toEqual({
+        type: "incomplete",
+        reason: "error",
+        error: "upstream exploded",
+      });
+    });
+
+    it("ignores a RUN_FINISHED that arrives after the error", () => {
+      const { dispatched, updates, subscriber } = setup();
+
+      subscriber.onRunErrorEvent?.({
+        event: { type: "RUN_ERROR", message: "upstream exploded" },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: { type: "RUN_FINISHED", runId: "run-1" },
+      });
+
+      expect(dispatched.map((event) => event.type)).toEqual(["RUN_ERROR"]);
+      expect(lastStatus(updates)).toEqual({
+        type: "incomplete",
+        reason: "error",
+        error: "upstream exploded",
+      });
+    });
+
     it("falls back to a generic message when the event carries none", () => {
       const { dispatched, onRunFailed, subscriber } = setup();
 

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -35,6 +35,7 @@ type Subscriber = {
   onCustomEvent?: (payload: { event: unknown }) => void;
   onRawEvent?: (payload: { event: unknown }) => void;
   onRunFinishedEvent?: (payload: { event: unknown }) => void;
+  onRunErrorEvent?: (payload: { event: unknown }) => void;
   onRunFinalized?: () => void;
   onRunFailed?: (payload: { error: Error }) => void;
 };
@@ -149,6 +150,23 @@ export const createAgUiSubscriber = (
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
       runFinishedDispatched = true;
+      dispatch(parsed);
+    },
+    onRunErrorEvent: ({ event }) => {
+      const parsed = ensureEvent(event, "RUN_ERROR", logger);
+      if (parsed?.type !== "RUN_ERROR") return;
+      runFinishedDispatched = true;
+      // The HTTP agent reports an aborted request as a RUN_ERROR carrying this
+      // code rather than as a failed run, so it must settle as a cancellation.
+      if (parsed.code === "abort") {
+        dispatch({ type: "RUN_CANCELLED" } satisfies AgUiEvent);
+        return;
+      }
+      const error: Error & { code?: string } = new Error(
+        parsed.message ?? "Run failed",
+      );
+      if (parsed.code !== undefined) error.code = parsed.code;
+      onRunFailed?.(error);
       dispatch(parsed);
     },
     onRunFinalized: () => {

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -74,6 +74,7 @@ type SubscriberOptions = {
   dispatch: Dispatch;
   runId: string;
   logger?: Logger;
+  abortSignal?: AbortSignal;
   onRunFailed?: (error: Error) => void;
   onRunSettled?: () => void;
 };
@@ -81,10 +82,14 @@ type SubscriberOptions = {
 export const createAgUiSubscriber = (
   options: SubscriberOptions,
 ): Subscriber => {
-  const { dispatch, runId, logger, onRunFailed, onRunSettled } = options;
+  const { dispatch, runId, logger, abortSignal, onRunFailed, onRunSettled } =
+    options;
   // A run settles once. A transport failure that follows any terminal event
   // describes the same collapse, so the first terminal event owns the outcome.
+  // A cancellation is terminal too: the runtime dispatches it from the abort
+  // listener, so an aborted signal counts as settled here.
   let runSettled = false;
+  const isSettled = () => runSettled || abortSignal?.aborted === true;
   const settle = () => {
     runSettled = true;
     onRunSettled?.();
@@ -154,14 +159,14 @@ export const createAgUiSubscriber = (
     onCustomEvent: ({ event }) => dispatchIfValid(event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
-      if (runSettled) return;
+      if (isSettled()) return;
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
       settle();
       dispatch(parsed);
     },
     onRunErrorEvent: ({ event }) => {
-      if (runSettled) return;
+      if (isSettled()) return;
       const parsed = ensureEvent(event, "RUN_ERROR", logger);
       if (parsed?.type !== "RUN_ERROR") return;
       settle();
@@ -178,12 +183,12 @@ export const createAgUiSubscriber = (
       dispatch({ ...parsed, message });
     },
     onRunFinalized: () => {
-      if (runSettled) return;
+      if (isSettled()) return;
       settle();
       dispatch({ type: "RUN_FINISHED", runId });
     },
     onRunFailed: ({ error }) => {
-      if (runSettled) return;
+      if (isSettled()) return;
       settle();
       onRunFailed?.(error);
       if (isAbortError(error)) {

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -81,7 +81,9 @@ export const createAgUiSubscriber = (
   options: SubscriberOptions,
 ): Subscriber => {
   const { dispatch, runId, logger, onRunFailed } = options;
-  let runFinishedDispatched = false;
+  // A run settles once. A transport failure that follows a wire RUN_ERROR
+  // describes the same collapse, so the first terminal event owns the outcome.
+  let runSettled = false;
   const dispatchIfValid = (raw: unknown, type: AgUiEvent["type"]) => {
     const event = ensureEvent(raw, type, logger);
     if (!event) return;
@@ -147,15 +149,17 @@ export const createAgUiSubscriber = (
     onCustomEvent: ({ event }) => dispatchIfValid(event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
     onRunFinishedEvent: ({ event }) => {
+      if (runSettled) return;
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
-      runFinishedDispatched = true;
+      runSettled = true;
       dispatch(parsed);
     },
     onRunErrorEvent: ({ event }) => {
+      if (runSettled) return;
       const parsed = ensureEvent(event, "RUN_ERROR", logger);
       if (parsed?.type !== "RUN_ERROR") return;
-      runFinishedDispatched = true;
+      runSettled = true;
       // The HTTP agent reports an aborted request as a RUN_ERROR carrying this
       // code rather than as a failed run, so it must settle as a cancellation.
       if (parsed.code === "abort") {
@@ -170,11 +174,13 @@ export const createAgUiSubscriber = (
       dispatch(parsed);
     },
     onRunFinalized: () => {
-      if (runFinishedDispatched) return;
+      if (runSettled) return;
+      runSettled = true;
       dispatch({ type: "RUN_FINISHED", runId });
     },
     onRunFailed: ({ error }) => {
-      runFinishedDispatched = true;
+      if (runSettled) return;
+      runSettled = true;
       onRunFailed?.(error);
       if (isAbortError(error)) {
         dispatch({ type: "RUN_CANCELLED" } satisfies AgUiEvent);

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -75,15 +75,20 @@ type SubscriberOptions = {
   runId: string;
   logger?: Logger;
   onRunFailed?: (error: Error) => void;
+  onRunSettled?: () => void;
 };
 
 export const createAgUiSubscriber = (
   options: SubscriberOptions,
 ): Subscriber => {
-  const { dispatch, runId, logger, onRunFailed } = options;
-  // A run settles once. A transport failure that follows a wire RUN_ERROR
+  const { dispatch, runId, logger, onRunFailed, onRunSettled } = options;
+  // A run settles once. A transport failure that follows any terminal event
   // describes the same collapse, so the first terminal event owns the outcome.
   let runSettled = false;
+  const settle = () => {
+    runSettled = true;
+    onRunSettled?.();
+  };
   const dispatchIfValid = (raw: unknown, type: AgUiEvent["type"]) => {
     const event = ensureEvent(raw, type, logger);
     if (!event) return;
@@ -152,14 +157,14 @@ export const createAgUiSubscriber = (
       if (runSettled) return;
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);
       if (!parsed) return;
-      runSettled = true;
+      settle();
       dispatch(parsed);
     },
     onRunErrorEvent: ({ event }) => {
       if (runSettled) return;
       const parsed = ensureEvent(event, "RUN_ERROR", logger);
       if (parsed?.type !== "RUN_ERROR") return;
-      runSettled = true;
+      settle();
       // The HTTP agent reports an aborted request as a RUN_ERROR carrying this
       // code rather than as a failed run, so it must settle as a cancellation.
       if (parsed.code === "abort") {
@@ -175,12 +180,12 @@ export const createAgUiSubscriber = (
     },
     onRunFinalized: () => {
       if (runSettled) return;
-      runSettled = true;
+      settle();
       dispatch({ type: "RUN_FINISHED", runId });
     },
     onRunFailed: ({ error }) => {
       if (runSettled) return;
-      runSettled = true;
+      settle();
       onRunFailed?.(error);
       if (isAbortError(error)) {
         dispatch({ type: "RUN_CANCELLED" } satisfies AgUiEvent);

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -171,12 +171,11 @@ export const createAgUiSubscriber = (
         dispatch({ type: "RUN_CANCELLED" } satisfies AgUiEvent);
         return;
       }
-      const error: Error & { code?: string } = new Error(
-        parsed.message ?? "Run failed",
-      );
+      const message = parsed.message ?? "Run failed";
+      const error: Error & { code?: string } = new Error(message);
       if (parsed.code !== undefined) error.code = parsed.code;
       onRunFailed?.(error);
-      dispatch(parsed);
+      dispatch({ ...parsed, message });
     },
     onRunFinalized: () => {
       if (runSettled) return;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -841,6 +841,39 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(onError).toHaveBeenCalledTimes(1);
   });
 
+  it("reports a wire RUN_ERROR once when the transport then collapses", async () => {
+    const transportError = new Error("socket died");
+    const agent = {
+      runAgent: vi.fn(async (_input: any, subscriber: any) => {
+        subscriber.onRunErrorEvent?.({
+          event: {
+            type: "RUN_ERROR",
+            message: "upstream exploded",
+            code: "500",
+          },
+        });
+        subscriber.onRunFailed?.({ error: transportError });
+        throw transportError;
+      }),
+    } as unknown as HttpAgent;
+
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+
+    await expect(core.append(createAppendMessage())).rejects.toThrow(
+      "upstream exploded",
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]![0] as Error).message).toBe(
+      "upstream exploded",
+    );
+    expect(core.getMessages().at(-1)?.status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "upstream exploded",
+    });
+  });
+
   it.each(["throws", "rejects"] as const)(
     "preserves the run error when onError %s",
     async (failureMode) => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -902,6 +902,43 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("keeps a cancellation when a queued RUN_ERROR arrives after it", async () => {
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const agent = {
+      abortRun: vi.fn(),
+      runAgent: vi.fn(async (_input: any, subscriber: any, options: any) => {
+        const signal: AbortSignal = options.signal;
+        resolveStarted();
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        subscriber.onRunErrorEvent?.({
+          event: { type: "RUN_ERROR", message: "upstream exploded" },
+        });
+        const abortError = Object.assign(new Error("aborted"), {
+          name: "AbortError",
+        });
+        throw abortError;
+      }),
+    } as unknown as HttpAgent;
+
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+    const promise = core.append(createAppendMessage());
+    await started;
+    await core.cancel();
+    await promise.catch(() => {});
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(core.getMessages().at(-1)?.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
   it("keeps a completed run when the transport then collapses", async () => {
     const agent = {
       runAgent: vi.fn(async (input: any, subscriber: any) => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -874,6 +874,64 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("keeps a server-sent cancellation when the transport then collapses", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    const agent = {
+      runAgent: vi.fn(async (_input: any, subscriber: any) => {
+        subscriber.onRunErrorEvent?.({
+          event: { type: "RUN_ERROR", message: "aborted", code: "abort" },
+        });
+        subscriber.onRunFailed?.({ error: abortError });
+        throw abortError;
+      }),
+    } as unknown as HttpAgent;
+
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+
+    await expect(core.append(createAppendMessage())).rejects.toThrow(
+      "The operation was aborted",
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(core.getMessages().at(-1)?.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("keeps a completed run when the transport then collapses", async () => {
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        subscriber.onTextMessageContentEvent?.({
+          event: { type: "TEXT_MESSAGE_CONTENT", delta: "Done." },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+        throw new Error("socket died");
+      }),
+    } as unknown as HttpAgent;
+
+    const onError = vi.fn();
+    const core = createCore(agent, { onError });
+
+    await expect(core.append(createAppendMessage())).rejects.toThrow(
+      "socket died",
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({ type: "complete" });
+    expect(assistantText(assistant)).toBe("Done.");
+  });
+
   it.each(["throws", "rejects"] as const)(
     "preserves the run error when onError %s",
     async (failureMode) => {


### PR DESCRIPTION
When an AG-UI agent reports a failure over the wire, the run renders as a success. The error message never reaches the UI, `onError` never fires, and the message settles into the same "complete" state a healthy run would produce — so a user watching the thread cannot tell a failed run from a finished one.

Closes #5896.

## Why it happens

`createAgUiSubscriber` handles most AG-UI event types with a dedicated `on<Type>Event` callback, and its generic `onEvent` deliberately early-returns for anything carrying a `type` string on the assumption that a typed handler will pick it up:

```ts
if (typeof typeCandidate === "string") {
  // Typed handlers will receive this via the discriminated callbacks; avoid duplicates.
  return;
}
```

`RUN_ERROR` is the exception: the subscriber never defined `onRunErrorEvent`, so both paths drop it. `onRunFinalized` then runs with `runFinishedDispatched` still `false` and synthesizes a `RUN_FINISHED`, which is what the aggregator turns into a successful run.

The event itself is not the problem — everything downstream of the subscriber already handles it. `event-parser.ts` parses `RUN_ERROR`, `types.ts` types it, and `run-aggregator.ts` maps it to `{ type: "incomplete", reason: "error" }`. The subscriber is the only layer that loses it, so the fix is local to it.

Confirmed against the installed `@ag-ui/client@0.0.57` rather than assumed: in its event pipeline `case RUN_ERROR` dispatches to `onRunErrorEvent` only. It does not throw and does not call `onRunFailed`, so neither the subscriber's `onRunFailed` handler nor the `try/catch` around `runAgent` in `AgUiThreadRuntimeCore` compensates for the missing handler.

## The fix

Add the missing `onRunErrorEvent`, mirroring the discipline the two existing terminal handlers already follow — `onRunFinishedEvent` sets `runFinishedDispatched` before dispatching, and `onRunFailed` reports the error before dispatching:

- mark the run settled so `onRunFinalized` no longer synthesizes a `RUN_FINISHED` behind it,
- report the failure through the `onRunFailed` option, which is how the runtime already routes `onError` and `pendingError`,
- dispatch the parsed event so the aggregator settles the message as `incomplete` / `error` with the server's message.

One case needs care: the AG-UI HTTP agent reports an aborted request as a `RUN_ERROR` carrying `code: "abort"` rather than as a failed run. Dispatching that as an error would turn every cancellation into a rendered failure, so it settles as `RUN_CANCELLED` instead — the same branch the existing `onRunFailed` handler takes for an `AbortError`.

## Making the terminal event idempotent

A wire `RUN_ERROR` is usually followed by the transport collapsing on the same failure, and the subscriber's flag guarded only the `onRunFinalized` synthesis. So `RUN_ERROR("upstream exploded")` followed by a transport `Error("socket died")` fired `onError` three times — once from the wire handler, once from `onRunFailed`, once from the `try/catch` around `runAgent` — and the business error the user needs to see was overwritten by the transport error the runtime finally threw.

A run settles once, and the first terminal event owns the outcome. The flag is now `runSettled` and every terminal path in `subscriber.ts` checks it before acting: `onRunErrorEvent`, `onRunFinishedEvent`, `onRunFailed`, and `onRunFinalized`. That also covers a `RUN_FINISHED` arriving after a `RUN_ERROR`, which the installed client verifier turns into a second failure.

The subscriber cannot close it alone: the rejection from `runAgent` never passes through the subscriber, so the runtime's outer `catch` reported the same collapse a second time. The right discriminator there is "this run already reached a terminal outcome", not "this run already reported an error" — cancellation (an abort-coded `RUN_ERROR`) and success (`RUN_FINISHED`) are terminal too, and neither sets `pendingError`, so a later transport rejection would sail past an error-only check and rewrite a stored cancellation or a completed message as `incomplete` / `error`.

The subscriber already knows this, so it reports it: `settle()` sets `runSettled` and calls a new `onRunSettled` option on every terminal path. The runtime keeps a run-scoped `runSettled` flag and the outer `catch` now dispatches `RUN_ERROR` and fires `onError` only for a rejection that arrives before any terminal event. The rejection itself still propagates and still rejects `append`: the stream really did die, and swallowing it would resolve the append and let a deferred tool-result resume fire against a dead transport (the existing "does not leak a deferred resume into a later run when the run errors" test pins that). The pre-existing abort check stays for pre-terminal aborts. The added guard does not overlap the hunks `feat/agui-tool-approval-parity` changes in the same file.

## Two follow-ups from review

Both stay inside the same concern — a terminal outcome must own the run and describe itself.

A cancellation is dispatched by the runtime's abort listener without passing through the subscriber, so the subscriber's `runSettled` stayed `false` and a `RUN_ERROR` still queued on the dying stream rewrote the cancelled message as errored. The subscriber now reads the run's `abortSignal` and treats an aborted run as settled on every terminal path, covered by "keeps a cancellation when a queued RUN_ERROR arrives after it".

A `RUN_ERROR` carrying no `message` reached the aggregator as-is, and the aggregator records an error string only when the event has one — so the message rendered as errored with no reason while `onError` received `"Run failed"`. The handler now dispatches the same fallback it hands the callback, keeping the two in sync.

## Scope

Deliberately one concern. `RUN_STARTED`, `STEP_STARTED`, and `STEP_FINISHED` share the same drop path, but none of them causes a failed run to render as a success, so they belong in a separate change rather than riding along here.

## Size anatomy

| | lines |
|---|---|
| implementation (`subscriber.ts`) | +38 / -5 |
| implementation (`AgUiThreadRuntimeCore.ts`) | +16 / -3 |
| tests (`subscriber.test.ts`, new) | +167 |
| tests (`ag-ui-thread-runtime-core.spec.ts`) | +128 |
| changeset | +5 |

No new public exports. `AgUiSubscriber` is derived from `createAgUiSubscriber`'s return type but is not exported from the package index, so the published surface is unchanged and `api-surface` needs no regeneration.

## Verification

Observed, not inferred. The regression tests were written first and run against unmodified `upstream/main`, where the errored run's only dispatched event is the synthesized `RUN_FINISHED`:

```
 ❯ src/runtime/adapter/subscriber.test.ts (6 tests | 5 failed)
       × reaches the aggregator as an errored run
       × does not let onRunFinalized synthesize a RUN_FINISHED afterwards
       × reports the failure to the run-failed callback
       × settles an aborted request as a cancellation, not an error
       × falls back to a generic message when the event carries none

AssertionError: expected [ { type: 'RUN_FINISHED', …(1) } ] to deep equally
  contain { type: 'RUN_ERROR', …(2) }
```

With the handler in place all six pass, and the whole package is green: `pnpm --filter @assistant-ui/react-ag-ui test` → 12 files, 373 tests passed. `tsc --noEmit` and `oxlint` are clean on the changed files.

The idempotency guard carries its own five regressions: the reviewer's exact sequence at the subscriber seam (`onRunFailed` called once with `"upstream exploded"`, one dispatched event, aggregator status still the business error), a `RUN_FINISHED` arriving after the `RUN_ERROR`, the same failure sequence driven end-to-end through `AgUiThreadRuntimeCore` (`append` rejects with `"upstream exploded"`, `onError` fires exactly once, the message settles on the business error rather than `"socket died"`), and the two non-error terminals: an abort-coded `RUN_ERROR` followed by a transport `AbortError` keeps the message `incomplete` / `cancelled` with `onError` never fired, and a `RUN_FINISHED` followed by a transport `Error("socket died")` keeps the message `complete` with its streamed text intact.

Revert-proof: removing only the `onRunErrorEvent` handler from `subscriber.ts` and leaving the tests untouched fails 5 of the original 6 (the sixth asserts the unrelated `RUN_FINISHED` synthesis still works when a run ends with no terminal event, which is the behavior this change must not break). Reverting only the terminal discriminator — dropping `!runSettled` from the outer `catch` so it discriminates on `pendingError` alone — fails exactly the two new terminal-outcome tests and nothing else (373 → 2 failed / 371 passed).

The tests drive the real consumer seam — a wire event enters through the subscriber callback the AG-UI agent actually invokes and is asserted on the `RunAggregator` snapshot the runtime renders from — rather than checking the handler in isolation.

No video: this is an internal event-routing fix whose only honest demo would require rigging a server to fail, so test output stands as the evidence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BZ87eA-uwKYmrFk_54rBNz17pNxFsKmqdtoOjjz7Gu9FeNvYNBisKqhMJIc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
