### PR TITLE
fix(react-google-adk): answer ADK tool confirmations through core's approval seam instead of writing a fabricated tool result

### DIFF
--- a/.changeset/adk-tool-approval-parity.md
+++ b/.changeset/adk-tool-approval-parity.md
@@ -2,4 +2,8 @@
 "@assistant-ui/react-google-adk": patch
 ---
 
-fix: answer ADK tool confirmations through the core tool-approval seam instead of writing a fabricated tool result
+fix: answer ADK tool confirmations through the core tool-approval seam instead of writing a fabricated tool result, and replay client-supplied tool results when a thread is reloaded
+
+A confirmation is now decided through `onRespondToToolApproval`, and both the synthetic `adk_request_confirmation` call and the call it gates carry that one approval, so answering either replies to the gate ADK resumes on.
+
+Loading a thread also replays the tool results the client supplied — confirmation replies, `useAdkSubmitInput` answers, `useAdkSubmitAuth` credentials, and `onAddToolResult` results. These were previously dropped on reload, so their tool calls came back result-less and re-rendered as `requires-action`.

--- a/.changeset/adk-tool-approval-parity.md
+++ b/.changeset/adk-tool-approval-parity.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: answer ADK tool confirmations through the core tool-approval seam instead of writing a fabricated tool result

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -240,6 +240,29 @@ describe("AdkEventAccumulator - function responses", () => {
     });
   });
 
+  it("skips a user function response that answers no call", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "user",
+        content: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                name: "adk_request_confirmation",
+                response: { confirmed: true },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    // Without an id it answers no call: core drops it as an orphan, and
+    // keeping it would let it settle the confirmation batch it grouped into.
+    expect(msgs.filter((m) => m.type === "tool")).toEqual([]);
+  });
+
   // A session load replays the stored events through a fresh accumulator.
   it("gives a tool message the same id on every replay of an event", () => {
     const event = makeEvent({

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -1091,6 +1091,60 @@ describe("AdkEventAccumulator - user message handling", () => {
     });
   });
 
+  it("creates a tool message for a user-authored function response", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "user",
+        content: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "tc-1",
+                name: "adk_request_confirmation",
+                response: { confirmed: true },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatchObject({
+      type: "tool",
+      tool_call_id: "tc-1",
+      name: "adk_request_confirmation",
+      content: JSON.stringify({ confirmed: true }),
+      status: "success",
+    });
+  });
+
+  it("orders function responses from one user event before its text", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "user",
+        content: {
+          role: "user",
+          parts: [
+            { text: "go ahead" },
+            {
+              functionResponse: {
+                id: "tc-1",
+                name: "adk_request_confirmation",
+                response: { confirmed: true },
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toMatchObject({ type: "tool", tool_call_id: "tc-1" });
+    expect(msgs[1]).toMatchObject({ type: "human", content: "go ahead" });
+  });
+
   it("creates separate human and AI messages for a user/agent turn", () => {
     const acc = new AdkEventAccumulator();
     acc.processEvent(

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -331,7 +331,8 @@ export class AdkEventAccumulator {
     if (event.author === "user") {
       this.finalizeCurrentMessage();
       const humanParts: AdkMessageContentPart[] = [];
-      for (const part of parts) {
+      const toolMessages: AdkMessage[] = [];
+      for (const [index, part] of parts.entries()) {
         if (part.text != null && !part.thought) {
           humanParts.push({ type: "text", text: part.text });
         } else if (part.inlineData) {
@@ -342,7 +343,27 @@ export class AdkEventAccumulator {
           humanParts.push(
             fileDataToPart(part.fileData.fileUri, part.fileData.mimeType),
           );
+        } else if (part.functionResponse) {
+          // ADK records tool confirmation and other client-supplied tool
+          // results as user-authored function responses, and its request
+          // confirmation processors search user events for them. Dropping
+          // them here would replay a settled gate as pending.
+          toolMessages.push({
+            id: toolMessageId(event, index),
+            type: "tool",
+            tool_call_id: part.functionResponse.id ?? "",
+            name: part.functionResponse.name,
+            content: JSON.stringify(part.functionResponse.response),
+            status: "success",
+          });
         }
+      }
+      // The replies answer the preceding assistant turn, so they are emitted
+      // before any user content in the same event. A human message between the
+      // tool call and its reply splits them into separate converted messages,
+      // orphaning the reply and leaving its gate unsettled.
+      for (const toolMsg of toolMessages) {
+        this.messagesMap.set(toolMsg.id, toolMsg);
       }
       if (humanParts.length > 0) {
         const id = event.id ?? uuidv4();

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -343,15 +343,17 @@ export class AdkEventAccumulator {
           humanParts.push(
             fileDataToPart(part.fileData.fileUri, part.fileData.mimeType),
           );
-        } else if (part.functionResponse) {
+        } else if (part.functionResponse?.id) {
           // ADK records tool confirmation and other client-supplied tool
           // results as user-authored function responses, and its request
           // confirmation processors search user events for them. Dropping
-          // them here would replay a settled gate as pending.
+          // them here would replay a settled gate as pending. A response
+          // carrying no id answers no call: core drops it as an orphan, and
+          // keeping it would let it settle the batch it was grouped into.
           toolMessages.push({
             id: toolMessageId(event, index),
             type: "tool",
-            tool_call_id: part.functionResponse.id ?? "",
+            tool_call_id: part.functionResponse.id,
             name: part.functionResponse.name,
             content: JSON.stringify(part.functionResponse.response),
             status: "success",

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createAdkSessionAdapter } from "./AdkSessionAdapter";
+import { projectAdkToolApprovals } from "./adkToolApproval";
 
 // ── Helpers ──
 
@@ -445,6 +446,110 @@ describe("createAdkSessionAdapter - load", () => {
     expect((init.headers as Record<string, string>).Authorization).toBe(
       "Bearer tok",
     );
+  });
+});
+
+describe("createAdkSessionAdapter - load replays tool confirmations", () => {
+  const CONFIRMATION_CALL = "conf-1";
+
+  const confirmationSession = (response: unknown) => ({
+    id: "s1",
+    events: [
+      {
+        id: "e1",
+        author: "agent",
+        longRunningToolIds: [CONFIRMATION_CALL],
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: CONFIRMATION_CALL,
+                name: "adk_request_confirmation",
+                args: {
+                  originalFunctionCall: { id: "tc-1", name: "delete_file" },
+                  toolConfirmation: { hint: "Delete /tmp/a?" },
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        id: "e2",
+        author: "user",
+        content: {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: CONFIRMATION_CALL,
+                name: "adk_request_confirmation",
+                response,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  const loadApprovals = async (response: unknown) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(confirmationSession(response)), {
+        status: 200,
+      }),
+    );
+    const { load } = createAdkSessionAdapter(baseOptions);
+    const result = await load("s1");
+    return {
+      messages: result.messages,
+      approvals: projectAdkToolApprovals(result.messages).approvals,
+    };
+  };
+
+  it("keeps a user-authored confirmation reply as a tool message", async () => {
+    const { messages } = await loadApprovals({ confirmed: true });
+
+    expect(messages.map((m) => m.type)).toEqual(["ai", "tool"]);
+    expect(messages[1]).toMatchObject({
+      type: "tool",
+      tool_call_id: CONFIRMATION_CALL,
+      name: "adk_request_confirmation",
+    });
+  });
+
+  it.each([
+    ["direct", { confirmed: true }, { approved: true }],
+    ["direct denial", { confirmed: false }, { approved: false }],
+    [
+      "wrapped",
+      { response: JSON.stringify({ confirmed: true }) },
+      { approved: true },
+    ],
+    [
+      "wrapped denial",
+      { response: JSON.stringify({ confirmed: false }) },
+      { approved: false },
+    ],
+  ])(
+    "projects a settled gate from a replayed %s reply",
+    async (_name, response, expected) => {
+      const { approvals } = await loadApprovals(response);
+
+      expect(approvals.get(CONFIRMATION_CALL)).toEqual({
+        id: CONFIRMATION_CALL,
+        ...expected,
+      });
+    },
+  );
+
+  it("leaves the gate pending when the replayed reply is unreadable", async () => {
+    const { approvals } = await loadApprovals({ response: "not json" });
+
+    expect(approvals.get(CONFIRMATION_CALL)).toEqual({
+      id: CONFIRMATION_CALL,
+    });
   });
 });
 

--- a/packages/react-google-adk/src/adkToolApproval.test.ts
+++ b/packages/react-google-adk/src/adkToolApproval.test.ts
@@ -105,11 +105,14 @@ describe("projectAdkToolApprovals", () => {
       { id: CONFIRMATION_CALL },
     ],
   ])(
-    "projects only the synthetic confirmation call: %s",
+    "gates the confirmation and the call it gates: %s",
     (_name, messages, expected) => {
       const { approvals, key } = projectAdkToolApprovals(messages);
-      expect([...approvals.keys()]).toEqual([CONFIRMATION_CALL]);
+      // Both calls are in the transcript, so both would otherwise render an
+      // approval control; the gated one carries the answerable synthetic id.
+      expect([...approvals.keys()]).toEqual([CONFIRMATION_CALL, GATED_CALL]);
       expect(approvals.get(CONFIRMATION_CALL)).toEqual(expected);
+      expect(approvals.get(GATED_CALL)).toEqual(expected);
       expect(key).not.toBe("");
     },
   );
@@ -232,4 +235,38 @@ describe("toAdkConfirmationReply", () => {
       });
     },
   );
+});
+
+describe("projectAdkToolApprovals gated call", () => {
+  it("answers through the gated call with the synthetic id", () => {
+    // ADK yields the gated call before the confirmation request, so it is in
+    // the transcript too; answering from its control must still quote the id
+    // ADK is waiting on.
+    const { approvals } = projectAdkToolApprovals(requestedThread());
+
+    const gated = approvals.get(GATED_CALL);
+    expect(gated).toEqual({ id: CONFIRMATION_CALL });
+    expect(
+      toAdkToolConfirmationReply(
+        { approvalId: gated!.id, approved: true },
+        approvals,
+      ),
+    ).toMatchObject({
+      tool_call_id: CONFIRMATION_CALL,
+      name: "adk_request_confirmation",
+      content: JSON.stringify({ confirmed: true }),
+    });
+  });
+
+  it("leaves a confirmation whose original call has no id ungated", () => {
+    const messages: AdkMessage[] = [
+      aiCall(CONFIRMATION_CALL, "adk_request_confirmation", {
+        toolConfirmation: { hint: "Delete /tmp/a?" },
+      }),
+    ];
+
+    expect([...projectAdkToolApprovals(messages).approvals.keys()]).toEqual([
+      CONFIRMATION_CALL,
+    ]);
+  });
 });

--- a/packages/react-google-adk/src/adkToolApproval.test.ts
+++ b/packages/react-google-adk/src/adkToolApproval.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectAdkToolApprovals,
+  toAdkConfirmationReply,
+  toAdkToolConfirmationReply,
+} from "./adkToolApproval";
+import type { AdkMessage } from "./types";
+
+const GATED_CALL = "adk-original-1";
+const CONFIRMATION_CALL = "adk-confirmation-1";
+
+const aiCall = (id: string, name: string, args = {}): AdkMessage => ({
+  id: `ai-${id}`,
+  type: "ai",
+  content: [],
+  tool_calls: [{ id, name, args }],
+});
+
+/**
+ * The shape ADK actually emits: the gated tool call, then a synthetic
+ * `adk_request_confirmation` call with an id of its own quoting the original.
+ */
+const requestedThread = (...tail: AdkMessage[]): AdkMessage[] => [
+  aiCall(GATED_CALL, "delete_file", { path: "/tmp/a" }),
+  aiCall(CONFIRMATION_CALL, "adk_request_confirmation", {
+    originalFunctionCall: { id: GATED_CALL, name: "delete_file" },
+    toolConfirmation: { hint: "Delete /tmp/a?" },
+  }),
+  ...tail,
+];
+
+const reply = (
+  content: string,
+  name = "adk_request_confirmation",
+): AdkMessage => ({
+  id: "tool-1",
+  type: "tool",
+  tool_call_id: CONFIRMATION_CALL,
+  name,
+  content,
+  status: "success",
+});
+
+describe("projectAdkToolApprovals", () => {
+  it.each([
+    ["pending", requestedThread(), { id: CONFIRMATION_CALL }],
+    [
+      "approved",
+      requestedThread(reply(JSON.stringify({ confirmed: true }))),
+      { id: CONFIRMATION_CALL, approved: true },
+    ],
+    [
+      "denied",
+      requestedThread(reply(JSON.stringify({ confirmed: false }))),
+      { id: CONFIRMATION_CALL, approved: false },
+    ],
+    [
+      "approved through the ADK client wrapper",
+      requestedThread(
+        reply(
+          JSON.stringify({ response: JSON.stringify({ confirmed: true }) }),
+        ),
+      ),
+      { id: CONFIRMATION_CALL, approved: true },
+    ],
+    [
+      "denied through the ADK client wrapper",
+      requestedThread(
+        reply(
+          JSON.stringify({ response: JSON.stringify({ confirmed: false }) }),
+        ),
+      ),
+      { id: CONFIRMATION_CALL, approved: false },
+    ],
+    [
+      "still pending on an unreadable reply",
+      requestedThread(reply("not json")),
+      { id: CONFIRMATION_CALL },
+    ],
+    [
+      "still pending on an unreadable wrapped reply",
+      requestedThread(reply(JSON.stringify({ response: "not json" }))),
+      { id: CONFIRMATION_CALL },
+    ],
+    [
+      "still pending when some other tool answers",
+      requestedThread(
+        reply(JSON.stringify({ confirmed: true }), "delete_file"),
+      ),
+      { id: CONFIRMATION_CALL },
+    ],
+  ])(
+    "projects only the synthetic confirmation call: %s",
+    (_name, messages, expected) => {
+      const { approvals, key } = projectAdkToolApprovals(messages);
+      expect([...approvals.keys()]).toEqual([CONFIRMATION_CALL]);
+      expect(approvals.get(CONFIRMATION_CALL)).toEqual(expected);
+      expect(key).not.toBe("");
+    },
+  );
+
+  it("gates nothing when no confirmation was requested", () => {
+    const { approvals, key } = projectAdkToolApprovals([
+      aiCall("tc-9", "search"),
+    ]);
+    expect(approvals.size).toBe(0);
+    expect(key).toBe("");
+  });
+});
+
+describe("toAdkToolConfirmationReply", () => {
+  const pending = projectAdkToolApprovals(requestedThread()).approvals;
+
+  it.each([
+    [true, JSON.stringify({ confirmed: true })],
+    [false, JSON.stringify({ confirmed: false })],
+  ])(
+    "serializes approved=%s as an ADK confirmation reply",
+    (approved, content) => {
+      expect(
+        toAdkToolConfirmationReply(
+          { approvalId: CONFIRMATION_CALL, approved, reason: "ignored" },
+          pending,
+        ),
+      ).toMatchObject({
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content,
+        status: "success",
+      });
+    },
+  );
+
+  it.each([
+    ["unknown", "no-such-id", pending],
+    [
+      "already settled",
+      CONFIRMATION_CALL,
+      projectAdkToolApprovals(
+        requestedThread(reply(JSON.stringify({ confirmed: true }))),
+      ).approvals,
+    ],
+  ])("rejects an approval id that is %s", (_name, approvalId, approvals) => {
+    expect(() =>
+      toAdkToolConfirmationReply({ approvalId, approved: true }, approvals),
+    ).toThrow("No pending ADK tool confirmation");
+  });
+
+  it("still answers a gate whose earlier reply was unreadable", () => {
+    const approvals = projectAdkToolApprovals(
+      requestedThread(reply("not json")),
+    ).approvals;
+
+    expect(
+      toAdkToolConfirmationReply(
+        { approvalId: CONFIRMATION_CALL, approved: true },
+        approvals,
+      ),
+    ).toMatchObject({
+      tool_call_id: CONFIRMATION_CALL,
+      content: JSON.stringify({ confirmed: true }),
+    });
+  });
+});
+
+describe("toAdkConfirmationReply", () => {
+  it.each([
+    [undefined, JSON.stringify({ confirmed: true })],
+    [
+      { note: "ok" },
+      JSON.stringify({ confirmed: true, payload: { note: "ok" } }),
+    ],
+  ])(
+    "preserves useAdkConfirmTool payload serialization: %s",
+    (payload, content) => {
+      expect(toAdkConfirmationReply(CONFIRMATION_CALL, true, payload)).toEqual({
+        id: expect.any(String),
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content,
+        status: "success",
+      });
+    },
+  );
+});

--- a/packages/react-google-adk/src/adkToolApproval.test.ts
+++ b/packages/react-google-adk/src/adkToolApproval.test.ts
@@ -87,14 +87,50 @@ describe("projectAdkToolApprovals", () => {
       ),
       { id: CONFIRMATION_CALL, approved: false },
     ],
+    // ADK reads a truthy response it cannot take a `confirmed` off — raw text,
+    // a scalar, an array — as a tool it resumes unconfirmed, so the gate is
+    // denied rather than left answerable.
     [
-      "still pending on an unreadable reply",
+      "denied on a reply ADK resumes unconfirmed",
       requestedThread(reply("not json")),
+      { id: CONFIRMATION_CALL, approved: false },
+    ],
+    [
+      "denied on a scalar reply",
+      requestedThread(reply("5")),
+      { id: CONFIRMATION_CALL, approved: false },
+    ],
+    [
+      "denied on a wrapped reply ADK parses to a scalar",
+      requestedThread(reply(JSON.stringify({ response: "5" }))),
+      { id: CONFIRMATION_CALL, approved: false },
+    ],
+    // A falsy response records no confirmation at all, so the gate stays open.
+    [
+      "still pending on a reply ADK records nothing for",
+      requestedThread(reply("false")),
       { id: CONFIRMATION_CALL },
     ],
     [
+      "still pending on an empty reply",
+      requestedThread(reply("")),
+      { id: CONFIRMATION_CALL },
+    ],
+    // ADK parses the wrapped text without a `try`, so these raise.
+    [
       "still pending on an unreadable wrapped reply",
       requestedThread(reply(JSON.stringify({ response: "not json" }))),
+      { id: CONFIRMATION_CALL },
+    ],
+    [
+      "still pending on a wrapped reply ADK cannot stringify to JSON",
+      requestedThread(reply(JSON.stringify({ response: { confirmed: true } }))),
+      { id: CONFIRMATION_CALL },
+    ],
+    // `"response" in "x"` raises on a one-character response.
+    [
+      "still pending on a one-character reply",
+      requestedThread(reply("x")),
       { id: CONFIRMATION_CALL },
     ],
     [
@@ -122,12 +158,14 @@ describe("projectAdkToolApprovals", () => {
    * the unreadable reply aborts its whole event and the readable sibling never
    * executes either. Both gates stay answerable.
    */
+  const UNREADABLE = JSON.stringify({ response: "not json" });
+
   it("keeps every confirmation from one event pending when one reply is unreadable", () => {
     const { approvals } = projectAdkToolApprovals([
       aiCall("conf-a", "adk_request_confirmation"),
       aiCall("conf-b", "adk_request_confirmation"),
       eventReply("evt-1", 0, "conf-a", JSON.stringify({ confirmed: true })),
-      eventReply("evt-1", 1, "conf-b", "not json"),
+      eventReply("evt-1", 1, "conf-b", UNREADABLE),
     ]);
 
     expect([...approvals.values()]).toEqual([
@@ -141,13 +179,48 @@ describe("projectAdkToolApprovals", () => {
       aiCall("conf-a", "adk_request_confirmation"),
       aiCall("conf-b", "adk_request_confirmation"),
       eventReply("evt-1", 0, "conf-a", JSON.stringify({ confirmed: true })),
-      eventReply("evt-2", 0, "conf-b", "not json"),
+      eventReply("evt-2", 0, "conf-b", UNREADABLE),
     ]);
 
     expect([...approvals.values()]).toEqual([
       { id: "conf-a", approved: true },
       { id: "conf-b" },
     ]);
+  });
+
+  /**
+   * A reply ADK records nothing for does not raise, so its siblings in the same
+   * event are parsed and resumed as usual and keep their decisions.
+   */
+  it("settles a sibling when the unrecorded reply came from the same event", () => {
+    const { approvals } = projectAdkToolApprovals([
+      aiCall("conf-a", "adk_request_confirmation"),
+      aiCall("conf-b", "adk_request_confirmation"),
+      eventReply("evt-1", 0, "conf-a", JSON.stringify({ confirmed: true })),
+      eventReply("evt-1", 1, "conf-b", "false"),
+    ]);
+
+    expect([...approvals.values()]).toEqual([
+      { id: "conf-a", approved: true },
+      { id: "conf-b" },
+    ]);
+  });
+
+  /**
+   * ADK Python spells the confirmation args in snake_case, which the event
+   * accumulator already reads both ways.
+   */
+  it("gates the call named by a snake_case confirmation request", () => {
+    const { approvals } = projectAdkToolApprovals([
+      aiCall(GATED_CALL, "delete_file", { path: "/tmp/a" }),
+      aiCall(CONFIRMATION_CALL, "adk_request_confirmation", {
+        original_function_call: { id: GATED_CALL, name: "delete_file" },
+        tool_confirmation: { hint: "Delete /tmp/a?" },
+      }),
+    ]);
+
+    expect([...approvals.keys()]).toEqual([CONFIRMATION_CALL, GATED_CALL]);
+    expect(approvals.get(GATED_CALL)).toEqual({ id: CONFIRMATION_CALL });
   });
 
   it("gates nothing when no confirmation was requested", () => {
@@ -200,7 +273,7 @@ describe("toAdkToolConfirmationReply", () => {
 
   it("still answers a gate whose earlier reply was unreadable", () => {
     const approvals = projectAdkToolApprovals(
-      requestedThread(reply("not json")),
+      requestedThread(reply(JSON.stringify({ response: "not json" }))),
     ).approvals;
 
     expect(

--- a/packages/react-google-adk/src/adkToolApproval.test.ts
+++ b/packages/react-google-adk/src/adkToolApproval.test.ts
@@ -41,6 +41,21 @@ const reply = (
   status: "success",
 });
 
+/** The id the accumulator mints for a function response: `<eventId>:<part>`. */
+const eventReply = (
+  eventId: string,
+  partIndex: number,
+  toolCallId: string,
+  content: string,
+): AdkMessage => ({
+  id: `${eventId}:${partIndex}`,
+  type: "tool",
+  tool_call_id: toolCallId,
+  name: "adk_request_confirmation",
+  content,
+  status: "success",
+});
+
 describe("projectAdkToolApprovals", () => {
   it.each([
     ["pending", requestedThread(), { id: CONFIRMATION_CALL }],
@@ -98,6 +113,39 @@ describe("projectAdkToolApprovals", () => {
       expect(key).not.toBe("");
     },
   );
+
+  /**
+   * ADK parses every function response in an event before running any tool, so
+   * the unreadable reply aborts its whole event and the readable sibling never
+   * executes either. Both gates stay answerable.
+   */
+  it("keeps every confirmation from one event pending when one reply is unreadable", () => {
+    const { approvals } = projectAdkToolApprovals([
+      aiCall("conf-a", "adk_request_confirmation"),
+      aiCall("conf-b", "adk_request_confirmation"),
+      eventReply("evt-1", 0, "conf-a", JSON.stringify({ confirmed: true })),
+      eventReply("evt-1", 1, "conf-b", "not json"),
+    ]);
+
+    expect([...approvals.values()]).toEqual([
+      { id: "conf-a" },
+      { id: "conf-b" },
+    ]);
+  });
+
+  it("settles a readable reply when the unreadable one came from another event", () => {
+    const { approvals } = projectAdkToolApprovals([
+      aiCall("conf-a", "adk_request_confirmation"),
+      aiCall("conf-b", "adk_request_confirmation"),
+      eventReply("evt-1", 0, "conf-a", JSON.stringify({ confirmed: true })),
+      eventReply("evt-2", 0, "conf-b", "not json"),
+    ]);
+
+    expect([...approvals.values()]).toEqual([
+      { id: "conf-a", approved: true },
+      { id: "conf-b" },
+    ]);
+  });
 
   it("gates nothing when no confirmation was requested", () => {
     const { approvals, key } = projectAdkToolApprovals([

--- a/packages/react-google-adk/src/adkToolApproval.ts
+++ b/packages/react-google-adk/src/adkToolApproval.ts
@@ -18,30 +18,59 @@ const parseJson = (raw: string): unknown => {
   }
 };
 
+type AdkConfirmationRead = {
+  /**
+   * False only where ADK raises reading the reply, which aborts every function
+   * response in the same event rather than denying this one.
+   */
+  readable: boolean;
+  /** Undefined where ADK records no confirmation and the gate stays open. */
+  confirmed: boolean | undefined;
+};
+
 /**
- * ADK reads a confirmation reply either directly as `{confirmed}` or through
- * its client wrapper, a lone `response` key holding the JSON text. It rejects a
- * tool whose confirmation is not explicitly truthy, so a readable reply that is
- * not `confirmed: true` is a denial. A reply it cannot read raises instead of
- * denying, leaving the gate answerable, so that projects as undecided rather
- * than settling it and blocking the retry.
+ * The value the transport puts on `functionResponse.response`: the reply
+ * content parsed, or the raw text where it is not JSON.
  */
-const readConfirmed = (content: unknown): boolean | undefined => {
-  if (typeof content !== "string") return undefined;
-  const response = parseJson(content);
-  if (typeof response !== "object" || response === null) return undefined;
+const wireResponseOf = (content: string): unknown => {
+  const parsed = parseJson(content);
+  return parsed === undefined ? content : parsed;
+};
 
-  const record = response as Record<string, unknown>;
-  const keys = Object.keys(record);
-  if (keys.length === 1 && keys[0] === "response") {
-    const wrapped = record.response;
-    if (typeof wrapped !== "string") return undefined;
-    const inner = parseJson(wrapped);
-    if (typeof inner !== "object" || inner === null) return undefined;
-    return (inner as { confirmed?: unknown }).confirmed === true;
+/**
+ * Mirrors ADK's own reading of a confirmation reply, whose three outcomes the
+ * gate has to distinguish. A falsy response records nothing, so the gate stays
+ * open and its siblings are untouched. Otherwise ADK either unwraps its client
+ * wrapper — a lone `response` key whose value it parses as JSON text — or reads
+ * `confirmed` off the response directly, and resumes the tool unconfirmed
+ * (a denial) for anything that is not explicitly `true`; a bare string, number,
+ * or array is such a denial, not an unreadable reply. Only where that reading
+ * raises is the reply unreadable, and the raise is uncaught in ADK, so the
+ * whole event it belongs to is abandoned.
+ */
+const readConfirmation = (content: unknown): AdkConfirmationRead => {
+  if (typeof content !== "string")
+    return { readable: false, confirmed: undefined };
+  const response = wireResponseOf(content);
+  try {
+    if (!response) return { readable: true, confirmed: undefined };
+    const record = response as Record<string, unknown>;
+    const decide = (value: unknown) =>
+      typeof value === "object" &&
+      value !== null &&
+      (value as { confirmed?: unknown }).confirmed === true;
+    // `in` raises on a primitive response, as ADK's own wrapper test does.
+    if (Object.keys(record).length === 1 && "response" in record) {
+      const inner = parseJson(String(record.response));
+      // ADK parses the wrapped text without a `try`, so it raises here.
+      if (inner === undefined) return { readable: false, confirmed: undefined };
+      if (!inner) return { readable: true, confirmed: undefined };
+      return { readable: true, confirmed: decide(inner) };
+    }
+    return { readable: true, confirmed: decide(record) };
+  } catch {
+    return { readable: false, confirmed: undefined };
   }
-
-  return record.confirmed === true;
 };
 
 /**
@@ -57,12 +86,16 @@ const sourceEventOf = (toolMessageId: string): string =>
 
 /**
  * ADK builds the confirmation request around the call it gates, carrying that
- * call verbatim in `originalFunctionCall`.
+ * call verbatim in `originalFunctionCall` — spelled `original_function_call` by
+ * ADK Python, which the accumulator reads the same way.
  */
 const gatedCallIdOf = (args: unknown): string | undefined => {
   if (typeof args !== "object" || args === null) return undefined;
-  const original = (args as { originalFunctionCall?: unknown })
-    .originalFunctionCall;
+  const record = args as {
+    originalFunctionCall?: unknown;
+    original_function_call?: unknown;
+  };
+  const original = record.originalFunctionCall ?? record.original_function_call;
   if (typeof original !== "object" || original === null) return undefined;
   const id = (original as { id?: unknown }).id;
   return typeof id === "string" && id.length > 0 ? id : undefined;
@@ -104,8 +137,8 @@ export const projectAdkToolApprovals = (
       batch = { readable: true, entries: [] };
       batches.set(key, batch);
     }
-    const confirmed = readConfirmed(message.content);
-    if (confirmed === undefined) batch.readable = false;
+    const { readable, confirmed } = readConfirmation(message.content);
+    if (!readable) batch.readable = false;
     batch.entries.push([message.tool_call_id, confirmed]);
   }
 

--- a/packages/react-google-adk/src/adkToolApproval.ts
+++ b/packages/react-google-adk/src/adkToolApproval.ts
@@ -1,0 +1,129 @@
+import type {
+  RespondToToolApprovalOptions,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import { v4 as uuidv4 } from "uuid";
+import type { AdkMessage } from "./types";
+
+export type AdkToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
+
+const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
+
+const parseJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * ADK reads a confirmation reply either directly as `{confirmed}` or through
+ * its client wrapper, a lone `response` key holding the JSON text. It rejects a
+ * tool whose confirmation is not explicitly truthy, so a readable reply that is
+ * not `confirmed: true` is a denial. A reply it cannot read raises instead of
+ * denying, leaving the gate answerable, so that projects as undecided rather
+ * than settling it and blocking the retry.
+ */
+const readConfirmed = (content: unknown): boolean | undefined => {
+  if (typeof content !== "string") return undefined;
+  const response = parseJson(content);
+  if (typeof response !== "object" || response === null) return undefined;
+
+  const record = response as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length === 1 && keys[0] === "response") {
+    const wrapped = record.response;
+    if (typeof wrapped !== "string") return undefined;
+    const inner = parseJson(wrapped);
+    if (typeof inner !== "object" || inner === null) return undefined;
+    return (inner as { confirmed?: unknown }).confirmed === true;
+  }
+
+  return record.confirmed === true;
+};
+
+export type AdkToolApprovalProjection = {
+  approvals: ReadonlyMap<string, AdkToolApproval>;
+  /**
+   * Identity of the decision state. Core re-converts a cached message object
+   * only when the converter callback changes, so the callback is rebuilt when
+   * this key moves rather than on every render.
+   */
+  key: string;
+};
+
+/**
+ * ADK requests a confirmation by emitting a synthetic `adk_request_confirmation`
+ * tool call carrying a fresh id, and resumes only when a reply quotes that id.
+ * The gated tool's own id appears in `requestedToolConfirmations` as metadata
+ * and is never answerable, so only the synthetic calls are gated.
+ */
+export const projectAdkToolApprovals = (
+  messages: readonly AdkMessage[],
+): AdkToolApprovalProjection => {
+  const replies = new Map<string, boolean>();
+  for (const message of messages) {
+    if (message.type !== "tool") continue;
+    if (message.name !== ADK_REQUEST_CONFIRMATION) continue;
+    const confirmed = readConfirmed(message.content);
+    if (confirmed === undefined) {
+      replies.delete(message.tool_call_id);
+      continue;
+    }
+    replies.set(message.tool_call_id, confirmed);
+  }
+
+  const approvals = new Map<string, AdkToolApproval>();
+  for (const message of messages) {
+    if (message.type !== "ai") continue;
+    for (const call of message.tool_calls ?? []) {
+      if (call.name !== ADK_REQUEST_CONFIRMATION) continue;
+      const approved = replies.get(call.id);
+      approvals.set(call.id, {
+        id: call.id,
+        ...(approved !== undefined && { approved }),
+      });
+    }
+  }
+
+  return {
+    approvals,
+    key: approvals.size === 0 ? "" : JSON.stringify([...approvals]),
+  };
+};
+
+export const toAdkConfirmationReply = (
+  toolCallId: string,
+  confirmed: boolean,
+  payload?: ReadonlyJSONValue,
+): AdkMessage & { type: "tool" } => ({
+  id: uuidv4(),
+  type: "tool",
+  tool_call_id: toolCallId,
+  name: ADK_REQUEST_CONFIRMATION,
+  content: JSON.stringify({
+    confirmed,
+    ...(payload != null && { payload }),
+  }),
+  status: "success",
+});
+
+/**
+ * ADK confirmations are a plain confirm/reject pair, so no option or reason
+ * from core has a field to land in. An id that is not an open gate would send a
+ * reply ADK silently ignores, so it throws instead.
+ */
+export const toAdkToolConfirmationReply = (
+  { approvalId, approved }: RespondToToolApprovalOptions,
+  approvals: ReadonlyMap<string, AdkToolApproval>,
+): AdkMessage & { type: "tool" } => {
+  const approval = approvals.get(approvalId);
+  if (approval === undefined || approval.approved !== undefined)
+    throw new Error(
+      `No pending ADK tool confirmation for approval id "${approvalId}"`,
+    );
+
+  return toAdkConfirmationReply(approvalId, approved);
+};

--- a/packages/react-google-adk/src/adkToolApproval.ts
+++ b/packages/react-google-adk/src/adkToolApproval.ts
@@ -8,7 +8,7 @@ import type { AdkMessage } from "./types";
 
 export type AdkToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
 
-const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
+export const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
 
 const parseJson = (raw: string): unknown => {
   try {
@@ -55,6 +55,19 @@ const readConfirmed = (content: unknown): boolean | undefined => {
 const sourceEventOf = (toolMessageId: string): string =>
   toolMessageId.replace(/:\d+$/, "");
 
+/**
+ * ADK builds the confirmation request around the call it gates, carrying that
+ * call verbatim in `originalFunctionCall`.
+ */
+const gatedCallIdOf = (args: unknown): string | undefined => {
+  if (typeof args !== "object" || args === null) return undefined;
+  const original = (args as { originalFunctionCall?: unknown })
+    .originalFunctionCall;
+  if (typeof original !== "object" || original === null) return undefined;
+  const id = (original as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+};
+
 export type AdkToolApprovalProjection = {
   approvals: ReadonlyMap<string, AdkToolApproval>;
   /**
@@ -68,8 +81,12 @@ export type AdkToolApprovalProjection = {
 /**
  * ADK requests a confirmation by emitting a synthetic `adk_request_confirmation`
  * tool call carrying a fresh id, and resumes only when a reply quotes that id.
- * The gated tool's own id appears in `requestedToolConfirmations` as metadata
- * and is never answerable, so only the synthetic calls are gated.
+ * The gated tool's own id is never answerable, so every approval carries the
+ * synthetic id — but ADK yields the gated call to the client first, in its own
+ * event, so both calls sit result-less in the transcript and both would render
+ * an approval control. The gated call is therefore mapped to the same approval
+ * rather than left bare, which would let it answer by writing a tool result the
+ * agent never produced.
  */
 export const projectAdkToolApprovals = (
   messages: readonly AdkMessage[],
@@ -107,10 +124,20 @@ export const projectAdkToolApprovals = (
     for (const call of message.tool_calls ?? []) {
       if (call.name !== ADK_REQUEST_CONFIRMATION) continue;
       const approved = replies.get(call.id);
-      approvals.set(call.id, {
+      const approval: AdkToolApproval = {
         id: call.id,
         ...(approved !== undefined && { approved }),
-      });
+      };
+      approvals.set(call.id, approval);
+      // ADK yields the gated call in its own event before the confirmation is
+      // requested, so that call is also in the transcript, result-less, and
+      // inherits the message's `requires-action` status. Left ungated it
+      // renders a second approval control with no approval behind it, which
+      // answers by writing a tool result the agent never produced. The same
+      // approval carries the synthetic id, so answering either one replies to
+      // the gate ADK is actually waiting on.
+      const gatedId = gatedCallIdOf(call.args);
+      if (gatedId !== undefined) approvals.set(gatedId, approval);
     }
   }
 

--- a/packages/react-google-adk/src/adkToolApproval.ts
+++ b/packages/react-google-adk/src/adkToolApproval.ts
@@ -44,6 +44,17 @@ const readConfirmed = (content: unknown): boolean | undefined => {
   return record.confirmed === true;
 };
 
+/**
+ * ADK's confirmation processor parses every function response in an event
+ * before running any tool, so one unreadable reply aborts the event and none of
+ * its siblings execute. The accumulator mints a tool message id of
+ * `<eventId>:<partIndex>` per response, so that prefix is the batch ADK either
+ * runs whole or not at all; a locally minted reply carries a bare uuid and is
+ * its own batch.
+ */
+const sourceEventOf = (toolMessageId: string): string =>
+  toolMessageId.replace(/:\d+$/, "");
+
 export type AdkToolApprovalProjection = {
   approvals: ReadonlyMap<string, AdkToolApproval>;
   /**
@@ -63,16 +74,31 @@ export type AdkToolApprovalProjection = {
 export const projectAdkToolApprovals = (
   messages: readonly AdkMessage[],
 ): AdkToolApprovalProjection => {
-  const replies = new Map<string, boolean>();
+  const batches = new Map<
+    string,
+    { readable: boolean; entries: [string, boolean | undefined][] }
+  >();
   for (const message of messages) {
     if (message.type !== "tool") continue;
     if (message.name !== ADK_REQUEST_CONFIRMATION) continue;
-    const confirmed = readConfirmed(message.content);
-    if (confirmed === undefined) {
-      replies.delete(message.tool_call_id);
-      continue;
+    const key = sourceEventOf(message.id);
+    let batch = batches.get(key);
+    if (batch === undefined) {
+      batch = { readable: true, entries: [] };
+      batches.set(key, batch);
     }
-    replies.set(message.tool_call_id, confirmed);
+    const confirmed = readConfirmed(message.content);
+    if (confirmed === undefined) batch.readable = false;
+    batch.entries.push([message.tool_call_id, confirmed]);
+  }
+
+  const replies = new Map<string, boolean>();
+  for (const batch of batches.values()) {
+    for (const [toolCallId, confirmed] of batch.entries) {
+      if (batch.readable && confirmed !== undefined)
+        replies.set(toolCallId, confirmed);
+      else replies.delete(toolCallId);
+    }
   }
 
   const approvals = new Map<string, AdkToolApproval>();

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -2,7 +2,10 @@
 
 import type { ToolCallMessagePart } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
-import type { AdkToolApproval } from "./adkToolApproval";
+import {
+  ADK_REQUEST_CONFIRMATION,
+  type AdkToolApproval,
+} from "./adkToolApproval";
 import type { AdkMessage, AdkMessageContentPart } from "./types";
 
 type ContentPart =
@@ -130,9 +133,15 @@ export const createAdkMessageConverter =
       case "tool": {
         // A confirmation reply ADK could not read leaves its gate undecided.
         // Any result settles the tool call in core, so the reply is dropped
-        // here to keep the gate requiring action and answerable again.
+        // here to keep the gate requiring action and answerable again. Only a
+        // reply to the confirmation itself is dropped: the gated call carries
+        // the same approval, and its own result is the agent's real output.
         const approval = approvals.get(message.tool_call_id);
-        if (approval !== undefined && approval.approved === undefined)
+        if (
+          message.name === ADK_REQUEST_CONFIRMATION &&
+          approval !== undefined &&
+          approval.approved === undefined
+        )
           return [];
 
         return {

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -2,6 +2,7 @@
 
 import type { ToolCallMessagePart } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
+import type { AdkToolApproval } from "./adkToolApproval";
 import type { AdkMessage, AdkMessageContentPart } from "./types";
 
 type ContentPart =
@@ -81,50 +82,69 @@ const contentToParts = (
     .filter((p): p is NonNullable<typeof p> => p !== null);
 };
 
-export const convertAdkMessage: useExternalMessageConverter.Callback<
-  AdkMessage
-> = (message) => {
-  switch (message.type) {
-    case "human":
-      return {
-        role: "user",
-        id: message.id,
-        content: contentToParts(message.content, "user"),
-      };
+const EMPTY_APPROVALS: ReadonlyMap<string, AdkToolApproval> = new Map();
 
-    case "ai": {
-      const toolCallParts: ToolCallMessagePart[] =
-        message.tool_calls?.map((tc) => ({
-          type: "tool-call",
-          toolCallId: tc.id,
-          toolName: tc.name,
-          args: tc.args,
-          argsText: tc.argsText ?? JSON.stringify(tc.args),
-        })) ?? [];
+export const createAdkMessageConverter =
+  (
+    approvals: ReadonlyMap<string, AdkToolApproval>,
+  ): useExternalMessageConverter.Callback<AdkMessage> =>
+  (message) => {
+    switch (message.type) {
+      case "human":
+        return {
+          role: "user",
+          id: message.id,
+          content: contentToParts(message.content, "user"),
+        };
 
-      return {
-        role: "assistant",
-        id: message.id,
-        content: [
-          ...contentToParts(message.content, "assistant"),
-          ...toolCallParts,
-        ],
-        ...(message.status && { status: message.status }),
-        ...(message.author && {
-          metadata: {
-            custom: { author: message.author, branch: message.branch },
-          },
-        }),
-      };
+      case "ai": {
+        const toolCallParts: ToolCallMessagePart[] =
+          message.tool_calls?.map((tc) => {
+            const approval = approvals.get(tc.id);
+            return {
+              type: "tool-call",
+              toolCallId: tc.id,
+              toolName: tc.name,
+              args: tc.args,
+              argsText: tc.argsText ?? JSON.stringify(tc.args),
+              ...(approval && { approval }),
+            };
+          }) ?? [];
+
+        return {
+          role: "assistant",
+          id: message.id,
+          content: [
+            ...contentToParts(message.content, "assistant"),
+            ...toolCallParts,
+          ],
+          ...(message.status && { status: message.status }),
+          ...(message.author && {
+            metadata: {
+              custom: { author: message.author, branch: message.branch },
+            },
+          }),
+        };
+      }
+
+      case "tool": {
+        // A confirmation reply ADK could not read leaves its gate undecided.
+        // Any result settles the tool call in core, so the reply is dropped
+        // here to keep the gate requiring action and answerable again.
+        const approval = approvals.get(message.tool_call_id);
+        if (approval !== undefined && approval.approved === undefined)
+          return [];
+
+        return {
+          role: "tool",
+          toolCallId: message.tool_call_id,
+          toolName: message.name,
+          result: message.content,
+          isError: message.status === "error",
+        };
+      }
     }
+  };
 
-    case "tool":
-      return {
-        role: "tool",
-        toolCallId: message.tool_call_id,
-        toolName: message.name,
-        result: message.content,
-        isError: message.status === "error",
-      };
-  }
-};
+export const convertAdkMessage: useExternalMessageConverter.Callback<AdkMessage> =
+  createAdkMessageConverter(EMPTY_APPROVALS);

--- a/packages/react-google-adk/src/hooks.ts
+++ b/packages/react-google-adk/src/hooks.ts
@@ -2,6 +2,7 @@ import { useAui } from "@assistant-ui/store";
 import { v4 as uuidv4 } from "uuid";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { adkExtras } from "./adkExtras";
+import { toAdkConfirmationReply } from "./adkToolApproval";
 import type {
   AdkMessage,
   AdkSendMessageConfig,
@@ -66,22 +67,9 @@ export const useAdkConfirmTool = () => {
     confirmed: boolean,
     payload?: ReadonlyJSONValue,
   ) =>
-    adkExtras.get(aui).send(
-      [
-        {
-          id: uuidv4(),
-          type: "tool",
-          tool_call_id: toolCallId,
-          name: "adk_request_confirmation",
-          content: JSON.stringify({
-            confirmed,
-            ...(payload != null && { payload }),
-          }),
-          status: "success",
-        },
-      ],
-      {},
-    );
+    adkExtras
+      .get(aui)
+      .send([toAdkConfirmationReply(toolCallId, confirmed, payload)], {});
 };
 
 /** Returns a function to submit auth credentials for a pending auth request. */

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -20,10 +20,13 @@ import {
   type UseAdkMessagesOptions,
 } from "./useAdkMessages";
 import { projectAdkToolApprovals } from "./adkToolApproval";
+import { createAdkStream } from "./AdkClient";
+import { AdkEventAccumulator } from "./AdkEventAccumulator";
 import type { AdkEvent, AdkMessage, AdkStreamCallback } from "./types";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("ADK runtime callbacks", () => {
@@ -268,6 +271,49 @@ describe("messagesToEvents", () => {
       events[0]?.content?.parts?.map((p) => p.functionResponse?.id),
     ).toEqual(["conf-a", "conf-b"]);
     expect(events[1]?.id).toBe("ai-interleaved");
+  });
+
+  it("mirrors the transport's empty user content for an ai-only batch", async () => {
+    const aiOnly: AdkMessage[] = [
+      { id: "ai-1", type: "ai", content: "one" },
+      { id: "ai-2", type: "ai", content: "two" },
+    ];
+
+    let sentBody = "";
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      sentBody = init.body as string;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start: (controller) => controller.close(),
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+    });
+    const stream = createAdkStream({
+      api: "http://localhost:8000",
+      appName: "app",
+      userId: "user-1",
+    });
+    for await (const _ of await stream(aiOnly, {
+      abortSignal: new AbortController().signal,
+      initialize: async () => ({ remoteId: "r1", externalId: "s1" }),
+    })) {
+      /* drain */
+    }
+    const sent = JSON.parse(sentBody);
+
+    const events = messagesToEvents(aiOnly);
+    const userEvent = events.find((e) => e.author === "user");
+    expect(sent.newMessage.parts).toEqual([{ text: "" }]);
+    expect(userEvent?.content?.parts).toEqual(sent.newMessage.parts);
+    expect(events.map((e) => e.id)).toEqual(["ai-1", "ai-2", userEvent?.id]);
+
+    const accumulator = new AdkEventAccumulator([]);
+    let messages: AdkMessage[] = [];
+    for (const event of events) messages = accumulator.processEvent(event);
+    expect(messages.filter((m) => m.type === "human")).toEqual([
+      { id: userEvent?.id, type: "human", content: "" },
+    ]);
   });
 
   it("emits the merged event at the position of the run it replaces", () => {

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -147,6 +147,12 @@ describe("optimistic confirmation replies", () => {
     ],
   });
 
+  /**
+   * ADK parses the text inside its client wrapper without a `try`, so a wrapper
+   * holding text that is not JSON raises and abandons the whole event.
+   */
+  const UNREADABLE_REPLY = JSON.stringify({ response: "not json" });
+
   const confirmationReply = (
     id: string,
     toolCallId: string,
@@ -186,7 +192,7 @@ describe("optimistic confirmation replies", () => {
             "conf-a",
             JSON.stringify({ confirmed: true }),
           ),
-          confirmationReply("reply-b", "conf-b", "not json"),
+          confirmationReply("reply-b", "conf-b", UNREADABLE_REPLY),
         ],
         {},
       );
@@ -212,7 +218,7 @@ describe("optimistic confirmation replies", () => {
             JSON.stringify({ confirmed: true }),
           ),
           { id: "ai-interleaved", type: "ai", content: "thinking" },
-          confirmationReply("reply-b", "conf-b", "not json"),
+          confirmationReply("reply-b", "conf-b", UNREADABLE_REPLY),
         ],
         {},
       );
@@ -243,7 +249,7 @@ describe("optimistic confirmation replies", () => {
     });
     await act(async () => {
       await result.current.sendMessage(
-        [confirmationReply("reply-b", "conf-b", "not json")],
+        [confirmationReply("reply-b", "conf-b", UNREADABLE_REPLY)],
         {},
       );
     });

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -15,6 +15,7 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 
 import {
   messageToEvent,
+  messagesToEvents,
   useAdkMessages,
   type UseAdkMessagesOptions,
 } from "./useAdkMessages";
@@ -193,6 +194,29 @@ describe("optimistic confirmation replies", () => {
     ]).toEqual([{ id: "conf-a" }, { id: "conf-b" }]);
   });
 
+  it("keeps both gates pending when an ai message sits between the replies", async () => {
+    const result = await renderWithGates();
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [
+          confirmationReply(
+            "reply-a",
+            "conf-a",
+            JSON.stringify({ confirmed: true }),
+          ),
+          { id: "ai-interleaved", type: "ai", content: "thinking" },
+          confirmationReply("reply-b", "conf-b", "not json"),
+        ],
+        {},
+      );
+    });
+
+    expect([
+      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+    ]).toEqual([{ id: "conf-a" }, { id: "conf-b" }]);
+  });
+
   it("settles the readable reply when the two replies were sent separately", async () => {
     const result = await renderWithGates();
 
@@ -218,6 +242,96 @@ describe("optimistic confirmation replies", () => {
     expect([
       ...projectAdkToolApprovals(result.current.messages).approvals.values(),
     ]).toEqual([{ id: "conf-a", approved: true }, { id: "conf-b" }]);
+  });
+});
+
+describe("messagesToEvents", () => {
+  const toolReply = (id: string, toolCallId: string): AdkMessage => ({
+    id,
+    type: "tool",
+    tool_call_id: toolCallId,
+    name: "adk_request_confirmation",
+    content: JSON.stringify({ confirmed: true }),
+    status: "success",
+  });
+
+  it("merges the human/tool run across an interleaved ai message", () => {
+    const events = messagesToEvents([
+      toolReply("reply-a", "conf-a"),
+      { id: "ai-interleaved", type: "ai", content: "thinking" },
+      toolReply("reply-b", "conf-b"),
+    ]);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]?.id).toBe("reply-a");
+    expect(
+      events[0]?.content?.parts?.map((p) => p.functionResponse?.id),
+    ).toEqual(["conf-a", "conf-b"]);
+    expect(events[1]?.id).toBe("ai-interleaved");
+  });
+
+  it("emits the merged event at the position of the run it replaces", () => {
+    const events = messagesToEvents([
+      { id: "ai-first", type: "ai", content: "thinking" },
+      { id: "human-a", type: "human", content: "a" },
+    ]);
+
+    expect(events.map((e) => e.id)).toEqual(["ai-first", "human-a"]);
+  });
+});
+
+describe("optimistic multi-message sends", () => {
+  const emptyStream: AdkStreamCallback = async function* () {};
+
+  it("does not duplicate later messages of a staged multi-human send", async () => {
+    const staged: AdkMessage[] = [
+      { id: "human-a", type: "human", content: "a" },
+      { id: "human-b", type: "human", content: "b" },
+    ];
+    const { result } = renderHook(() =>
+      useAdkMessages({ stream: emptyStream }),
+    );
+    await act(async () => {
+      result.current.setMessages(staged);
+    });
+
+    await act(async () => {
+      await result.current.sendMessage(staged, {});
+    });
+
+    expect(result.current.messages).toEqual([
+      {
+        id: "human-a",
+        type: "human",
+        content: [
+          { type: "text", text: "a" },
+          { type: "text", text: "b" },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps messages that are not part of the send", async () => {
+    const { result } = renderHook(() =>
+      useAdkMessages({ stream: emptyStream }),
+    );
+    await act(async () => {
+      result.current.setMessages([
+        { id: "earlier", type: "human", content: "earlier" },
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ id: "human-a", type: "human", content: "a" }],
+        {},
+      );
+    });
+
+    expect(result.current.messages.map((m) => m.id)).toEqual([
+      "earlier",
+      "human-a",
+    ]);
   });
 });
 

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -18,6 +18,7 @@ import {
   useAdkMessages,
   type UseAdkMessagesOptions,
 } from "./useAdkMessages";
+import { projectAdkToolApprovals } from "./adkToolApproval";
 import type { AdkEvent, AdkMessage, AdkStreamCallback } from "./types";
 
 afterEach(() => {
@@ -122,6 +123,101 @@ describe("ADK runtime callbacks", () => {
         callbackError,
       );
     });
+  });
+});
+
+describe("optimistic confirmation replies", () => {
+  const confirmationCall = (id: string): AdkMessage => ({
+    id: `ai-${id}`,
+    type: "ai",
+    content: [],
+    tool_calls: [
+      {
+        id,
+        name: "adk_request_confirmation",
+        args: {
+          originalFunctionCall: { id: `orig-${id}`, name: "delete_file" },
+          toolConfirmation: { hint: "Delete?" },
+        },
+      },
+    ],
+  });
+
+  const confirmationReply = (
+    id: string,
+    toolCallId: string,
+    content: string,
+  ): AdkMessage => ({
+    id,
+    type: "tool",
+    tool_call_id: toolCallId,
+    name: "adk_request_confirmation",
+    content,
+    status: "success",
+  });
+
+  const emptyStream: AdkStreamCallback = async function* () {};
+
+  const renderWithGates = async () => {
+    const { result } = renderHook(() =>
+      useAdkMessages({ stream: emptyStream }),
+    );
+    await act(async () => {
+      result.current.setMessages([
+        confirmationCall("conf-a"),
+        confirmationCall("conf-b"),
+      ]);
+    });
+    return result;
+  };
+
+  it("keeps both gates pending when one send carries an unreadable reply", async () => {
+    const result = await renderWithGates();
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [
+          confirmationReply(
+            "reply-a",
+            "conf-a",
+            JSON.stringify({ confirmed: true }),
+          ),
+          confirmationReply("reply-b", "conf-b", "not json"),
+        ],
+        {},
+      );
+    });
+
+    expect([
+      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+    ]).toEqual([{ id: "conf-a" }, { id: "conf-b" }]);
+  });
+
+  it("settles the readable reply when the two replies were sent separately", async () => {
+    const result = await renderWithGates();
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [
+          confirmationReply(
+            "reply-a",
+            "conf-a",
+            JSON.stringify({ confirmed: true }),
+          ),
+        ],
+        {},
+      );
+    });
+    await act(async () => {
+      await result.current.sendMessage(
+        [confirmationReply("reply-b", "conf-b", "not json")],
+        {},
+      );
+    });
+
+    expect([
+      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+    ]).toEqual([{ id: "conf-a", approved: true }, { id: "conf-b" }]);
   });
 });
 

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -193,7 +193,10 @@ describe("optimistic confirmation replies", () => {
     });
 
     expect([
-      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+      // The confirmation and the call it gates share one approval object.
+      ...new Set(
+        projectAdkToolApprovals(result.current.messages).approvals.values(),
+      ),
     ]).toEqual([{ id: "conf-a" }, { id: "conf-b" }]);
   });
 
@@ -216,7 +219,10 @@ describe("optimistic confirmation replies", () => {
     });
 
     expect([
-      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+      // The confirmation and the call it gates share one approval object.
+      ...new Set(
+        projectAdkToolApprovals(result.current.messages).approvals.values(),
+      ),
     ]).toEqual([{ id: "conf-a" }, { id: "conf-b" }]);
   });
 
@@ -243,7 +249,10 @@ describe("optimistic confirmation replies", () => {
     });
 
     expect([
-      ...projectAdkToolApprovals(result.current.messages).approvals.values(),
+      // The confirmation and the call it gates share one approval object.
+      ...new Set(
+        projectAdkToolApprovals(result.current.messages).approvals.values(),
+      ),
     ]).toEqual([{ id: "conf-a", approved: true }, { id: "conf-b" }]);
   });
 });
@@ -256,6 +265,13 @@ describe("messagesToEvents", () => {
     name: "adk_request_confirmation",
     content: JSON.stringify({ confirmed: true }),
     status: "success",
+  });
+
+  it("emits nothing for an empty batch", () => {
+    // `onReload` sends no messages. The transport still puts an empty user
+    // content on the wire, but projecting one here would append an empty user
+    // bubble above every regenerated turn.
+    expect(messagesToEvents([])).toEqual([]);
   });
 
   it("merges the human/tool run across an interleaved ai message", () => {

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -137,8 +137,8 @@ export const useAdkMessages = ({
       ) as AdkMessage[];
 
       const accumulator = new AdkEventAccumulator(messagesRef.current);
-      for (const msg of newMessagesWithId) {
-        accumulator.processEvent(messageToEvent(msg));
+      for (const event of messagesToEvents(newMessagesWithId)) {
+        accumulator.processEvent(event);
       }
       setMessagesImmediate(accumulator.getMessages());
 
@@ -254,6 +254,42 @@ export const useAdkMessages = ({
     replaceMessages,
     applySnapshot,
   };
+};
+
+/**
+ * Transport sends every human and tool message of one `send` call as a single
+ * ADK `Content`, and ADK parses that event's function responses before running
+ * any tool, so the batch runs whole or not at all. The optimistic projection
+ * has to sit on the same boundary, so a run of those messages becomes one
+ * synthetic event whose parts come from the same per-message conversion.
+ *
+ * @internal — exported for unit tests.
+ */
+export const messagesToEvents = (messages: AdkMessage[]): AdkEvent[] => {
+  const events: AdkEvent[] = [];
+  let run: AdkMessage[] = [];
+  const flushRun = () => {
+    if (run.length === 0) return;
+    const parts = run.flatMap((m) => messageToEvent(m).content?.parts ?? []);
+    const human = run.find((m) => m.type === "human");
+    const event: AdkEvent = { id: (human ?? run[0]!).id ?? uuidv4() };
+    if (human) event.author = "user";
+    event.content = { role: "user", parts };
+    events.push(event);
+    run = [];
+  };
+
+  for (const msg of messages) {
+    if (msg.type === "ai") {
+      flushRun();
+      events.push(messageToEvent(msg));
+    } else {
+      run.push(msg);
+    }
+  }
+  flushRun();
+
+  return events;
 };
 
 /** @internal — exported for unit tests. */

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -278,6 +278,11 @@ export const useAdkMessages = ({
  * @internal — exported for unit tests.
  */
 export const messagesToEvents = (messages: AdkMessage[]): AdkEvent[] => {
+  // A reload sends no messages at all, and the empty user content the transport
+  // puts on the wire for it is not part of the optimistic view: projecting one
+  // would put an empty user bubble above every regenerated turn.
+  if (messages.length === 0) return [];
+
   const events: AdkEvent[] = [];
   const run: AdkMessage[] = [];
   let runIndex = 0;

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -136,7 +136,14 @@ export const useAdkMessages = ({
         m.id ? m : { ...m, id: uuidv4() },
       ) as AdkMessage[];
 
-      const accumulator = new AdkEventAccumulator(messagesRef.current);
+      // A staged message is already in the thread under its own id, and the
+      // merged event below re-emits the whole batch under the first one. Seeding
+      // with the originals would leave every later staged id beside the merged
+      // copy of itself.
+      const resentIds = new Set(newMessagesWithId.map((m) => m.id));
+      const accumulator = new AdkEventAccumulator(
+        messagesRef.current.filter((m) => !resentIds.has(m.id)),
+      );
       for (const event of messagesToEvents(newMessagesWithId)) {
         accumulator.processEvent(event);
       }
@@ -263,31 +270,35 @@ export const useAdkMessages = ({
  * has to sit on the same boundary, so a run of those messages becomes one
  * synthetic event whose parts come from the same per-message conversion.
  *
+ * The transport drops `ai` messages from that `Content`, so one interleaved
+ * between two replies does not split the batch on the wire and must not split
+ * it here either. It still becomes its own event, placed after the merged one,
+ * so the optimistic projection keeps the assistant turn.
+ *
  * @internal — exported for unit tests.
  */
 export const messagesToEvents = (messages: AdkMessage[]): AdkEvent[] => {
   const events: AdkEvent[] = [];
-  let run: AdkMessage[] = [];
-  const flushRun = () => {
-    if (run.length === 0) return;
+  const run: AdkMessage[] = [];
+  let runIndex = 0;
+
+  for (const msg of messages) {
+    if (msg.type === "ai") {
+      events.push(messageToEvent(msg));
+    } else {
+      if (run.length === 0) runIndex = events.length;
+      run.push(msg);
+    }
+  }
+
+  if (run.length > 0) {
     const parts = run.flatMap((m) => messageToEvent(m).content?.parts ?? []);
     const human = run.find((m) => m.type === "human");
     const event: AdkEvent = { id: (human ?? run[0]!).id ?? uuidv4() };
     if (human) event.author = "user";
     event.content = { role: "user", parts };
-    events.push(event);
-    run = [];
-  };
-
-  for (const msg of messages) {
-    if (msg.type === "ai") {
-      flushRun();
-      events.push(messageToEvent(msg));
-    } else {
-      run.push(msg);
-    }
+    events.splice(runIndex, 0, event);
   }
-  flushRun();
 
   return events;
 };

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -291,14 +291,18 @@ export const messagesToEvents = (messages: AdkMessage[]): AdkEvent[] => {
     }
   }
 
-  if (run.length > 0) {
-    const parts = run.flatMap((m) => messageToEvent(m).content?.parts ?? []);
-    const human = run.find((m) => m.type === "human");
-    const event: AdkEvent = { id: (human ?? run[0]!).id ?? uuidv4() };
-    if (human) event.author = "user";
-    event.content = { role: "user", parts };
-    events.splice(runIndex, 0, event);
-  }
+  const parts = run.flatMap((m) => messageToEvent(m).content?.parts ?? []);
+  const human = run.find((m) => m.type === "human");
+
+  // A batch that contributes no part still reaches the wire: the transport
+  // sends an empty user `Content`, which a reload replays as an empty human
+  // message. Emitting it here keeps the optimistic view equal to that replay.
+  if (parts.length === 0) parts.push({ text: "" });
+
+  const event: AdkEvent = { id: (human ?? run[0])?.id ?? uuidv4() };
+  if (human || run.length === 0) event.author = "user";
+  event.content = { role: "user", parts };
+  events.splice(run.length > 0 ? runIndex : events.length, 0, event);
 
   return events;
 };

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getExternalStoreMessages,
   pickExternalStoreSharedOptions,
@@ -33,7 +33,14 @@ import type {
   OnAdkAgentTransferCallback,
 } from "./types";
 import { useAdkMessages } from "./useAdkMessages";
-import { convertAdkMessage } from "./convertAdkMessages";
+import {
+  convertAdkMessage,
+  createAdkMessageConverter,
+} from "./convertAdkMessages";
+import {
+  projectAdkToolApprovals,
+  toAdkToolConfirmationReply,
+} from "./adkToolApproval";
 import { adkExtras } from "./adkExtras";
 import { v4 as uuidv4 } from "uuid";
 
@@ -285,8 +292,21 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     }
   };
 
+  const { approvals: toolApprovals, key: toolApprovalsKey } =
+    projectAdkToolApprovals(messages);
+  const toolApprovalsRef = useRef(toolApprovals);
+  toolApprovalsRef.current = toolApprovals;
+
+  const messageConverter = useMemo(
+    () =>
+      toolApprovalsKey === ""
+        ? convertAdkMessage
+        : createAdkMessageConverter(toolApprovalsRef.current),
+    [toolApprovalsKey],
+  );
+
   const threadMessages = useExternalMessageConverter({
-    callback: convertAdkMessage,
+    callback: messageConverter,
     messages,
     isRunning: effectiveIsRunning,
   });
@@ -553,6 +573,12 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
             status: isError ? "error" : "success",
           },
         ],
+        {},
+      );
+    },
+    onRespondToToolApproval: async (options) => {
+      await handleSendMessage(
+        [toAdkToolConfirmationReply(options, toolApprovalsRef.current)],
         {},
       );
     },

--- a/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
@@ -204,6 +204,76 @@ describe("useAdkRuntime tool approvals", () => {
     ]);
   });
 
+  it("keeps both gates of an event retryable when one reply is unreadable", () => {
+    const accumulator = new AdkEventAccumulator();
+    const confirmationCall = (id: string, tool: string) => ({
+      functionCall: {
+        id,
+        name: "adk_request_confirmation",
+        args: {
+          originalFunctionCall: { id: `original-${id}`, name: tool },
+          toolConfirmation: { hint: `Run ${tool}?` },
+        },
+      },
+    });
+    accumulator.processEvent({
+      id: "evt-request",
+      author: "agent",
+      longRunningToolIds: ["conf-a", "conf-b"],
+      content: {
+        role: "model",
+        parts: [
+          confirmationCall("conf-a", "delete_file"),
+          confirmationCall("conf-b", "send_email"),
+        ],
+      },
+    });
+    mocks.messages = accumulator.processEvent({
+      id: "evt-reply",
+      author: "user",
+      content: {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              id: "conf-a",
+              name: "adk_request_confirmation",
+              response: { confirmed: true },
+            },
+          },
+          {
+            functionResponse: {
+              id: "conf-b",
+              name: "adk_request_confirmation",
+              response: { response: "not json" },
+            },
+          },
+        ],
+      },
+    });
+
+    renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+
+    const assistant = latestAdapter().messages.find(
+      (message): message is Extract<ThreadMessage, { role: "assistant" }> =>
+        message.role === "assistant",
+    )!;
+    const gates = assistant.content.filter(
+      (part): part is ToolCallMessagePart =>
+        part.type === "tool-call" && part.approval !== undefined,
+    );
+
+    expect(gates.map((gate) => gate.approval)).toEqual([
+      { id: "conf-a" },
+      { id: "conf-b" },
+    ]);
+    expect(gates.map((gate) => gate.result)).toEqual([undefined, undefined]);
+    expect(assistant.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+  });
+
   it("settles a confirmation reply carried beside user text without an orphan message", () => {
     const accumulator = new AdkEventAccumulator();
     accumulator.processEvent({

--- a/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
@@ -1,0 +1,272 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  RespondToToolApprovalOptions,
+  ThreadMessage,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import type { AdkMessage } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  adapters: [] as unknown[],
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  messages: [] as AdkMessage[],
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: () => ({}),
+  useExternalStoreRuntime: (adapter: unknown) => {
+    mocks.adapters.push(adapter);
+    return {};
+  },
+  useRemoteThreadListRuntime: (options: { runtimeHook: () => unknown }) =>
+    options.runtimeHook(),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({
+    threadListItem: {
+      source: null,
+      getState: () => ({ externalId: undefined }),
+      initialize: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("./useAdkMessages", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useAdkMessages")>()),
+  useAdkMessages: () => ({
+    messages: mocks.messages,
+    stateDelta: {},
+    agentInfo: {},
+    longRunningToolIds: [],
+    artifactDelta: {},
+    // Deliberately empty: the projection must come from the transcript, not
+    // from derived confirmation state that a mid-run accumulator swap drops.
+    toolConfirmations: [],
+    authRequests: [],
+    escalated: false,
+    messageMetadata: new Map(),
+    sendMessage: mocks.sendMessage,
+    cancel: vi.fn(),
+    setMessages: vi.fn(),
+    replaceMessages: vi.fn(),
+    applySnapshot: vi.fn(),
+  }),
+}));
+
+import { AdkEventAccumulator } from "./AdkEventAccumulator";
+import { useAdkRuntime } from "./useAdkRuntime";
+
+type ApprovalAdapter = {
+  messages: readonly ThreadMessage[];
+  onRespondToToolApproval?: (
+    options: RespondToToolApprovalOptions,
+  ) => Promise<void> | void;
+};
+
+const CONFIRMATION_CALL = "adk-confirmation-1";
+
+const latestAdapter = () => mocks.adapters.at(-1) as ApprovalAdapter;
+
+const makeConfirmationRequest = (): AdkMessage => ({
+  id: "ai-1",
+  type: "ai",
+  content: [],
+  tool_calls: [
+    {
+      id: CONFIRMATION_CALL,
+      name: "adk_request_confirmation",
+      args: {
+        originalFunctionCall: { id: "adk-original-1", name: "delete_file" },
+        toolConfirmation: { hint: "Delete /tmp/a?" },
+      },
+    },
+  ],
+});
+
+const approvalPart = () =>
+  latestAdapter()
+    .messages.at(-1)!
+    .content.find(
+      (part) => part.type === "tool-call" && part.approval !== undefined,
+    );
+
+afterEach(() => {
+  mocks.adapters.length = 0;
+  mocks.messages = [];
+  vi.clearAllMocks();
+});
+
+describe("useAdkRuntime tool approvals", () => {
+  it("exposes, answers, and settles the default approval seam across a rerender", async () => {
+    // Retained across the rerender: core caches converted messages by input
+    // object, so only a rebuilt converter can surface the settled decision.
+    const confirmationRequest = makeConfirmationRequest();
+    mocks.messages = [
+      { id: "u-1", type: "human", content: "delete the file" },
+      confirmationRequest,
+    ];
+
+    const { rerender } = renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+
+    expect(latestAdapter().messages.at(-1)!.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(approvalPart()).toMatchObject({
+      toolCallId: CONFIRMATION_CALL,
+      approval: { id: CONFIRMATION_CALL },
+    });
+
+    await act(async () => {
+      await latestAdapter().onRespondToToolApproval!({
+        approvalId: CONFIRMATION_CALL,
+        approved: false,
+      });
+    });
+
+    expect(mocks.sendMessage.mock.calls.at(-1)![0]).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content: JSON.stringify({ confirmed: false }),
+      }),
+    ]);
+
+    mocks.messages = [
+      ...mocks.messages,
+      {
+        id: "tool-1",
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content: JSON.stringify({ confirmed: false }),
+        status: "success",
+      },
+    ];
+    rerender();
+
+    expect(approvalPart()).toMatchObject({
+      approval: { id: CONFIRMATION_CALL, approved: false },
+    });
+    expect(latestAdapter().messages.at(-1)!.status).not.toMatchObject({
+      type: "requires-action",
+    });
+
+    await expect(
+      latestAdapter().onRespondToToolApproval!({
+        approvalId: CONFIRMATION_CALL,
+        approved: true,
+      }),
+    ).rejects.toThrow("No pending ADK tool confirmation");
+  });
+
+  it("keeps a gate answered by an unreadable reply retryable at the runtime seam", async () => {
+    mocks.messages = [
+      { id: "u-1", type: "human", content: "delete the file" },
+      makeConfirmationRequest(),
+      {
+        id: "tool-1",
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content: "not-json",
+        status: "success",
+      },
+    ];
+
+    renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+
+    expect(latestAdapter().messages.at(-1)!.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    const part = approvalPart() as { result?: unknown; approval: unknown };
+    expect(part.result).toBeUndefined();
+    expect(part.approval).toEqual({ id: CONFIRMATION_CALL });
+
+    await act(async () => {
+      await latestAdapter().onRespondToToolApproval!({
+        approvalId: CONFIRMATION_CALL,
+        approved: true,
+      });
+    });
+
+    expect(mocks.sendMessage.mock.calls.at(-1)![0]).toEqual([
+      expect.objectContaining({
+        tool_call_id: CONFIRMATION_CALL,
+        content: JSON.stringify({ confirmed: true }),
+      }),
+    ]);
+  });
+
+  it("settles a confirmation reply carried beside user text without an orphan message", () => {
+    const accumulator = new AdkEventAccumulator();
+    accumulator.processEvent({
+      id: "evt-request",
+      author: "agent",
+      longRunningToolIds: [CONFIRMATION_CALL],
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionCall: {
+              id: CONFIRMATION_CALL,
+              name: "adk_request_confirmation",
+              args: {
+                originalFunctionCall: {
+                  id: "adk-original-1",
+                  name: "delete_file",
+                },
+                toolConfirmation: { hint: "Delete /tmp/a?" },
+              },
+            },
+          },
+        ],
+      },
+    });
+    mocks.messages = accumulator.processEvent({
+      id: "evt-reply",
+      author: "user",
+      content: {
+        role: "user",
+        parts: [
+          { text: "go ahead" },
+          {
+            functionResponse: {
+              id: CONFIRMATION_CALL,
+              name: "adk_request_confirmation",
+              response: { confirmed: true },
+            },
+          },
+        ],
+      },
+    });
+
+    renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+
+    const messages = latestAdapter().messages;
+    const assistant = messages.find(
+      (message): message is Extract<ThreadMessage, { role: "assistant" }> =>
+        message.role === "assistant",
+    );
+    const gate = assistant?.content.find(
+      (part) => part.type === "tool-call" && part.approval !== undefined,
+    ) as ToolCallMessagePart | undefined;
+    expect(gate?.approval).toEqual({
+      id: CONFIRMATION_CALL,
+      approved: true,
+    });
+    expect(
+      messages.some(
+        (message) =>
+          message.role === "assistant" && message.content.length === 0,
+      ),
+    ).toBe(false);
+    expect(messages.at(-1)!.role).toBe("user");
+  });
+});

--- a/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
@@ -174,7 +174,9 @@ describe("useAdkRuntime tool approvals", () => {
         type: "tool",
         tool_call_id: CONFIRMATION_CALL,
         name: "adk_request_confirmation",
-        content: "not-json",
+        // ADK parses the wrapped text without a `try`, so this reply raises
+        // rather than denying, and the gate stays answerable.
+        content: JSON.stringify({ response: "not-json" }),
         status: "success",
       },
     ];


### PR DESCRIPTION
> **Supersedes #5816** (same branch, same work). #5816 was closed while the branch finished converging locally. It cannot be reopened: GitHub answers the reopen with a 422 because the review-cycle force-pushes replaced the head it recorded (`dfbe046`), and the branch now sits at `a8d7bcd`. This refiles it at the finished state, after 8 rounds of adversarial review whose outcomes are in the branch history.

Pressing **Allow** on a tool call that Google ADK gated behind a confirmation does not approve anything. It writes the literal string `"Approved by user"` into the tool call as its result, ADK is never told a decision was made, the gated tool never runs, and the turn ends looking answered. The user sees an approval UI that works and a result that is a lie.

I reproduced this against `upstream/main` with a deterministic ADK stream: clicking Allow yields `Result: "Approved by user"` and nothing else happens. With this branch, the same click yields `{"confirmed":true}` on the wire, the gated `delete_file` runs, and the agent replies.

### Reproduction

Exact versions: `@google/adk@1.6.0` (the peer this package targets — adk-js, not adk-python), `@assistant-ui/react-google-adk` at this branch, Node 24.11.1.

The gate is produced by any `FunctionTool` with `require_confirmation`, and the wire shape it puts on the stream is these two events, in this order:

```jsonc
// 1. the gated call, yielded before any confirmation is requested
{"id": "evt-1", "author": "agent", "content": {"role": "model", "parts": [
  {"functionCall": {"id": "call-delete", "name": "delete_file", "args": {"path": "/tmp/a"}}}]}}

// 2. the synthetic confirmation, quoting the call it gates
{"id": "evt-2", "author": "agent", "longRunningToolIds": ["call-confirm"],
 "actions": {"requestedToolConfirmations": {"call-delete": {"hint": "Delete /tmp/a?"}}},
 "content": {"role": "model", "parts": [
  {"functionCall": {"id": "call-confirm", "name": "adk_request_confirmation", "args": {
    "originalFunctionCall": {"id": "call-delete", "name": "delete_file", "args": {"path": "/tmp/a"}},
    "toolConfirmation": {"hint": "Delete /tmp/a?"}}}}]}}
```

Feed those two events to `useAdkRuntime` and press Allow in the default kit. Before this branch the click writes `Result: "Approved by user"` and the stream goes quiet; after it, the reply on the wire is a user-authored function response `{"id": "call-confirm", "name": "adk_request_confirmation", "response": {"confirmed": true}}`, which is what ADK's confirmation processor resumes on.

`useAdkRuntimeApproval.test.tsx` drives exactly this through a mounted runtime and the real external converter, so the pre-fix failure and the post-fix reply are both reproducible in-repo without an ADK server: reverting the runtime wiring fails all 4 of its seam tests.

### Where each ADK claim comes from

Every assertion below is read off the installed `@google/adk@1.6.0`, not inferred from docs:

| Claim | Source |
| --- | --- |
| The gated call is streamed before the confirmation is requested | `dist/esm/agents/llm_agent.js:510` yields the merged LLM event; `:523-543` only then runs the tools, builds the confirmation event, yields it and sets `endInvocation` |
| The confirmation is built around the original call | `dist/esm/agents/functions.js:87-105` looks the call up in the function-call event and copies it into `args.originalFunctionCall` |
| Both `{confirmed}` and `{response: "<json>"}` are accepted | `dist/esm/agents/processors/request_confirmation_llm_request_processor.js` — the wrapper branch requires exactly one key named `response` and `JSON.parse`s it; the else-branch reads `confirmed` off the response directly |
| An unreadable *wrapped* reply raises rather than denying | same file — that `JSON.parse` has no `try` around it, so it throws out of `runAsync` |
| Every response in an event is parsed before any tool runs | same file — the parse loop over the event's responses completes, and only afterwards is `handleFunctionCallList` called once |

The one place this nuance bites: most replies that *look* unreadable are denials on ADK's side. Any truthy response it cannot take a `confirmed` off — raw text, a scalar, an array — builds a `ToolConfirmation` with `confirmed: undefined` and resumes the tool unconfirmed. Only a falsy response records nothing (leaving the gate genuinely open), and only two readings raise: the client wrapper around text that is not JSON, and a one-character response, on which ADK's own `"response" in response` test throws. `readConfirmation` mirrors all three outcomes, so a gate is never left clickable for a decision ADK has already consumed.

## Why it happens

`react-google-adk` receives ADK's confirmation requests but never maps them onto core's tool-approval gate. A pending confirmation still leaves the tool call in `requires-action`, so the default `ToolFallback` kit *does* render Allow/Deny — but with no `approval` on the part, `respond()` falls through to its `addResult` branch and writes that string. The only correct answer path today is the bespoke `useAdkConfirmTool`, which the default kit does not know about.

The parity rule in AGENTS.md is the other half of the reason: `onRespondToToolApproval` is wired in `react-ai-sdk`, `eve`, `react-opencode` and `react-pi`. On `react-google-adk` it is absent, so `aui.part.respondToToolApproval` throws "Runtime does not support tool approvals". `react-opencode`'s conversion (#5325) is the template this follows.

## How

The gate is projected from the transcript, not from ADK's `toolConfirmations` bookkeeping — that distinction is the load-bearing decision in this PR.

When ADK asks for a confirmation it emits a *synthetic* `adk_request_confirmation` tool call with a fresh id, and it resumes only when a reply quotes that id. The gated tool's own id also appears, in `actions.requestedToolConfirmations`, but it is metadata: a reply quoting it matches neither of ADK's resume paths, and building a reply around it also breaks core's own invariant that a tool result's name matches its call (`packages/core/src/react/runtimes/external-message-converter.ts:154`). So every approval carries the **synthetic** id.

ADK yields the gated call to the client first, in its own event, before it requests the confirmation. Both calls therefore sit result-less in the same joined message, and a result-less tool-call part inherits the message's `requires-action` status verbatim (`packages/core/src/utils/normalizePartStatus.ts:66-68`), so the default kit renders an approval control for each. Leaving the gated one bare is what produces the bug in the title: with no `approval` on the part, `respond()` falls to `addResult` and writes `"Approved by user"`. `projectAdkToolApprovals` therefore maps the gated call id — read from the confirmation's `args.originalFunctionCall.id` — to the *same approval object*. Answering from either control sends the reply ADK resumes on, and both fall away together once it is answered.

The rest follows from what ADK actually does with a reply:

- **Reading a reply.** ADK accepts both `{confirmed}` and its client wrapper (`{response: "{\"confirmed\":true}"}`), and rejects any tool whose confirmation is not explicitly truthy, so a readable non-`true` reply is a denial — including a bare string, number or array, which it resumes unconfirmed rather than rejecting as malformed. A falsy response records no confirmation at all, so the gate stays open. A reply it cannot parse raises inside its processor, which projects as undecided and stays answerable rather than settling as a "no" ADK never made.
- **Batch atomicity.** ADK's processor parses every function response in an event before running any tool, so one reply that *raises* aborts the whole event and none of its siblings execute — while a reply ADK merely records nothing for leaves its siblings resumed as usual. Replies are therefore bucketed by source event (the accumulator's `<eventId>:<partIndex>` id), and an unreadable reply leaves its whole batch undecided. A response carrying no id is skipped where it is minted, since it answers no call and would otherwise be grouped into a batch it can unsettle. The optimistic path had to be moved onto the same boundary: `messagesToEvents` packs one `send()` call into a single synthetic event exactly as the transport packs it into a single `Content`, including dropping interleaved `ai` messages and emitting the empty user content the transport sends for an AI-only batch, so the optimistic view equals what a reload replays. An *empty* batch projects nothing: the transport still sends empty user content for it, but mirroring that optimistically would put an empty user bubble above every regenerated turn.
- **Reload.** ADK records client-supplied tool results as *user-authored* function responses. The accumulator dropped those on `load()`, so a refetch reopened settled gates. It now collects them, ahead of any human content in the same event, so a reply is not orphaned from its call. This is keyed on the function response, not on `adk_request_confirmation`, so it is deliberately wider than confirmations: `useAdkSubmitInput` answers, `useAdkSubmitAuth` credentials and `onAddToolResult` results were dropped on reload the same way and came back as result-less calls re-rendering as `requires-action`. Narrowing it to confirmations would leave that bug in place for every other client-side tool, so the changeset names the wider behavior.
- **Answering.** `onRespondToToolApproval` maps approve → `{confirmed: true}` and deny → `{confirmed: false}` through `toAdkConfirmationReply` — the same builder `useAdkConfirmTool` now shares — over the existing `handleSendMessage` path. ADK confirmations are a plain confirm/reject pair with no option list and no reason field, so no `optionId` is declared and core's `reason` is not fabricated onto the wire. An approval id with no open gate throws rather than sending a reply ADK would ignore.
- **Rendering.** An unreadable reply is dropped at the conversion seam, because any result settles a tool call in core and would hide the controls on a gate that is still open.

The converter is parameterized (`createAdkMessageConverter`) and `convertAdkMessage` is that factory applied to an empty map, so its signature and behavior are unchanged. The runtime rebuilds the closure only when a gate opens or settles, so an ordinary streaming turn does not re-convert the thread.

`useAdkToolConfirmations`, `useAdkConfirmTool`, `useAdkSubmitAuth` and `useAdkSubmitInput` are untouched and keep working. `adk_request_credential` is deliberately left alone — auth is not an approval.

## Size and surface

6 production files (+403/-66), 5 test files (+1149), 1 changeset. No new public exports; the whole feature is reachable through the existing core API, so there is no api-surface change.

## Tests

Colocated, and every claim above is pinned by one: the projection (pending, approve/deny settle, wrapper-form reply, unreadable reply stays answerable, sibling atomicity within one event, malformed input does not throw), the reply builder in both directions, the optimistic batching against the captured transport body, accumulator and session replay of user-authored confirmation replies, and the consumer seam driven end-to-end through a mounted runtime and the real external converter.

Revert-proof: reverting only the runtime wiring fails all 4 seam tests in `useAdkRuntimeApproval.test.tsx`; reverting each individual fix reproduces the exact failure it was written for. Package suite is 282 passing, with lint, formatting and a dependency-closure build clean.

This branch went through 8 rounds of adversarial review, and most of what is described above exists because a round found the simpler version wrong against ADK's real processor rather than against my reading of it — the double gate, the wrapper reply form, event-level atomicity, the reload path, and the optimistic/transport divergence were all found that way.

Sibling PR #5902 closes the same seam on `react-ag-ui`. The shape differs where the adapter does: ADK converts provider messages through `useExternalMessageConverter`, so its projection lives in the converter; AG-UI owns core `ThreadMessage`s, so its projection lives in the run aggregator.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.3lW2jFx0r3SIwFOSbRUH40jRBjNBXlAAQWpGdSPB-a58px6g1TF_kUGBO5E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


