### PR TITLE
fix(react-hook-form): report blocked form submissions

### DIFF
--- a/.changeset/react-hook-form-blocked-submit.md
+++ b/.changeset/react-hook-form-blocked-submit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-hook-form": patch
+---
+
+fix: report when validation blocks assistant-triggered form submissions

--- a/.changeset/react-hook-form-blocked-submit.md
+++ b/.changeset/react-hook-form-blocked-submit.md
@@ -4,4 +4,4 @@
 
 fix: validate assistant-triggered form submissions before reporting success
 
-Assistant-triggered submissions now respect React Hook Form rules and native constraints before dispatch, while preserving native `noValidate` behavior.
+Assistant-triggered submissions now respect native constraints and report React Hook Form validation results while preserving the form's normal valid and invalid submission lifecycle.

--- a/.changeset/react-hook-form-blocked-submit.md
+++ b/.changeset/react-hook-form-blocked-submit.md
@@ -2,4 +2,6 @@
 "@assistant-ui/react-hook-form": patch
 ---
 
-fix: report when validation blocks assistant-triggered form submissions
+fix: validate assistant-triggered form submissions before reporting success
+
+Assistant-triggered submissions now respect React Hook Form rules and native constraints before dispatch, while preserving native `noValidate` behavior.

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -143,15 +143,9 @@ describe("useAssistantForm", () => {
   });
 
   it("reports when react-hook-form validation blocks submission", async () => {
-    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-    });
+    const onValid = vi.fn();
 
-    render(
-      <form onSubmit={onSubmit}>
-        <ReactHookFormRequiredField />
-      </form>,
-    );
+    render(<ReactHookFormRequiredForm onValid={onValid} />);
 
     const submitTool = provider.getModelContext().tools?.submit_form;
     if (!submitTool?.execute) throw new Error("submit_form is not registered");
@@ -160,7 +154,7 @@ describe("useAssistantForm", () => {
       success: false,
       message: "The form contains invalid fields and was not submitted.",
     });
-    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onValid).not.toHaveBeenCalled();
   });
 });
 
@@ -169,7 +163,11 @@ const NativeRequiredField = () => {
   return <input required {...form.register("name")} />;
 };
 
-const ReactHookFormRequiredField = () => {
+const ReactHookFormRequiredForm = ({ onValid }: { onValid: () => void }) => {
   const form = useAssistantForm<{ name: string }>();
-  return <input {...form.register("name", { required: true })} />;
+  return (
+    <form onSubmit={form.handleSubmit(onValid)}>
+      <input {...form.register("name", { required: true })} />
+    </form>
+  );
 };

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -1,5 +1,11 @@
 /** @vitest-environment jsdom */
-import { act, render, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  waitFor,
+} from "@testing-library/react";
 import type { ModelContext } from "@assistant-ui/core";
 import type { FormEvent, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -145,11 +151,26 @@ describe("useAssistantForm", () => {
 
   it("reports when react-hook-form validation blocks submission", async () => {
     const onValid = vi.fn();
+    const onInvalid = vi.fn();
 
-    render(<ReactHookFormRequiredForm onValid={onValid} />);
+    const { getByTestId } = render(
+      <ReactHookFormRequiredForm onInvalid={onInvalid} onValid={onValid} />,
+    );
 
     await expectSubmitBlocked();
     expect(onValid).not.toHaveBeenCalled();
+    expect(onInvalid).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(getByTestId("submit-count").textContent).toBe("1");
+      expect(getByTestId("name-error").textContent).toBe("invalid");
+    });
+
+    fireEvent.change(getByTestId("name-input"), {
+      target: { value: "Ada" },
+    });
+    await waitFor(() => {
+      expect(getByTestId("name-error").textContent).toBe("valid");
+    });
   });
 
   it("reports react-hook-form errors when native validation is disabled", async () => {
@@ -178,10 +199,12 @@ const NativeRequiredField = () => {
 
 const ReactHookFormRequiredForm = ({
   defaultName = "",
+  onInvalid,
   onValid,
   noValidate,
 }: {
   defaultName?: string | undefined;
+  onInvalid?: (() => void) | undefined;
   onValid: () => void;
   noValidate?: boolean | undefined;
 }) => {
@@ -189,8 +212,18 @@ const ReactHookFormRequiredForm = ({
     defaultValues: { name: defaultName },
   });
   return (
-    <form noValidate={noValidate} onSubmit={form.handleSubmit(onValid)}>
-      <input {...form.register("name", { required: true })} />
+    <form
+      noValidate={noValidate}
+      onSubmit={form.handleSubmit(onValid, onInvalid)}
+    >
+      <input
+        data-testid="name-input"
+        {...form.register("name", { required: true })}
+      />
+      <output data-testid="submit-count">{form.formState.submitCount}</output>
+      <output data-testid="name-error">
+        {form.formState.errors.name ? "invalid" : "valid"}
+      </output>
     </form>
   );
 };

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -56,21 +56,6 @@ const expectSubmitBlocked = async () => {
   });
 };
 
-const captureUnhandledRejections = async (
-  callback: () => Promise<void>,
-): Promise<unknown[]> => {
-  const reasons: unknown[] = [];
-  const listener = (reason: unknown) => reasons.push(reason);
-  process.on("unhandledRejection", listener);
-  try {
-    await callback();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    return reasons;
-  } finally {
-    process.off("unhandledRejection", listener);
-  }
-};
-
 const expectRegisteredFieldsToSubmit = async (Fields: () => ReactNode) => {
   const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -286,7 +271,10 @@ describe("useAssistantForm", () => {
         </form>,
       );
 
-      await expectSubmitBlocked();
+      await expect(executeSubmitForm()).resolves.toEqual({
+        success: false,
+        message: "The form did not accept the submission.",
+      });
     } finally {
       requestSubmit.mockRestore();
     }
@@ -306,10 +294,8 @@ describe("useAssistantForm", () => {
         </form>,
       );
 
-      const unhandledRejections = await captureUnhandledRejections(async () => {
-        await expect(executeSubmitForm()).rejects.toBe(error);
-      });
-      expect(unhandledRejections).toEqual([]);
+      await expect(executeSubmitForm()).rejects.toBe(error);
+      await new Promise((resolve) => setTimeout(resolve, 0));
     } finally {
       requestSubmit.mockRestore();
     }

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -56,6 +56,21 @@ const expectSubmitBlocked = async () => {
   });
 };
 
+const captureUnhandledRejections = async (
+  callback: () => Promise<void>,
+): Promise<unknown[]> => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    await callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
+
 const expectRegisteredFieldsToSubmit = async (Fields: () => ReactNode) => {
   const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -249,6 +264,46 @@ describe("useAssistantForm", () => {
       success: false,
       message: "The form contains invalid fields and was not submitted.",
     });
+  });
+
+  it("reports when requestSubmit does not dispatch a submit event", async () => {
+    const requestSubmit = vi
+      .spyOn(HTMLFormElement.prototype, "requestSubmit")
+      .mockImplementation(() => {});
+    try {
+      render(
+        <form noValidate>
+          <NativeRequiredField />
+        </form>,
+      );
+
+      await expectSubmitBlocked();
+    } finally {
+      requestSubmit.mockRestore();
+    }
+  });
+
+  it("does not leak rejections when requestSubmit throws", async () => {
+    const error = new Error("requestSubmit unavailable");
+    const requestSubmit = vi
+      .spyOn(HTMLFormElement.prototype, "requestSubmit")
+      .mockImplementation(() => {
+        throw error;
+      });
+    try {
+      render(
+        <form noValidate>
+          <NativeRequiredField />
+        </form>,
+      );
+
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        await expect(executeSubmitForm()).rejects.toBe(error);
+      });
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      requestSubmit.mockRestore();
+    }
   });
 });
 

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -122,6 +122,26 @@ describe("useAssistantForm", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("submits when native form validation is disabled", async () => {
+    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <form noValidate onSubmit={onSubmit}>
+        <NativeRequiredField />
+      </form>,
+    );
+
+    const submitTool = provider.getModelContext().tools?.submit_form;
+    if (!submitTool?.execute) throw new Error("submit_form is not registered");
+
+    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
+      success: true,
+    });
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
   it("reports when react-hook-form validation blocks submission", async () => {
     const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -36,6 +36,19 @@ beforeEach(() => {
   });
 });
 
+const executeSubmitForm = () => {
+  const submitTool = provider.getModelContext().tools?.submit_form;
+  if (!submitTool?.execute) throw new Error("submit_form is not registered");
+  return submitTool.execute({}, {} as never);
+};
+
+const expectSubmitBlocked = async () => {
+  await expect(executeSubmitForm()).resolves.toEqual({
+    success: false,
+    message: "The form contains invalid fields and was not submitted.",
+  });
+};
+
 const expectRegisteredFieldsToSubmit = async (Fields: () => ReactNode) => {
   const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -47,10 +60,7 @@ const expectRegisteredFieldsToSubmit = async (Fields: () => ReactNode) => {
     </form>,
   );
 
-  const submitTool = provider.getModelContext().tools?.submit_form;
-  if (!submitTool?.execute) throw new Error("submit_form is not registered");
-
-  await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
+  await expect(executeSubmitForm()).resolves.toEqual({
     success: true,
   });
   expect(onSubmit).toHaveBeenCalledOnce();
@@ -112,13 +122,7 @@ describe("useAssistantForm", () => {
       </form>,
     );
 
-    const submitTool = provider.getModelContext().tools?.submit_form;
-    if (!submitTool?.execute) throw new Error("submit_form is not registered");
-
-    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
-      success: false,
-      message: "The form contains invalid fields and was not submitted.",
-    });
+    await expectSubmitBlocked();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -133,10 +137,7 @@ describe("useAssistantForm", () => {
       </form>,
     );
 
-    const submitTool = provider.getModelContext().tools?.submit_form;
-    if (!submitTool?.execute) throw new Error("submit_form is not registered");
-
-    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
+    await expect(executeSubmitForm()).resolves.toEqual({
       success: true,
     });
     expect(onSubmit).toHaveBeenCalledOnce();
@@ -147,13 +148,16 @@ describe("useAssistantForm", () => {
 
     render(<ReactHookFormRequiredForm onValid={onValid} />);
 
-    const submitTool = provider.getModelContext().tools?.submit_form;
-    if (!submitTool?.execute) throw new Error("submit_form is not registered");
+    await expectSubmitBlocked();
+    expect(onValid).not.toHaveBeenCalled();
+  });
 
-    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
-      success: false,
-      message: "The form contains invalid fields and was not submitted.",
-    });
+  it("reports react-hook-form errors when native validation is disabled", async () => {
+    const onValid = vi.fn();
+
+    render(<ReactHookFormRequiredForm noValidate onValid={onValid} />);
+
+    await expectSubmitBlocked();
     expect(onValid).not.toHaveBeenCalled();
   });
 });
@@ -163,10 +167,16 @@ const NativeRequiredField = () => {
   return <input required {...form.register("name")} />;
 };
 
-const ReactHookFormRequiredForm = ({ onValid }: { onValid: () => void }) => {
+const ReactHookFormRequiredForm = ({
+  onValid,
+  noValidate,
+}: {
+  onValid: () => void;
+  noValidate?: boolean | undefined;
+}) => {
   const form = useAssistantForm<{ name: string }>();
   return (
-    <form onSubmit={form.handleSubmit(onValid)}>
+    <form noValidate={noValidate} onSubmit={form.handleSubmit(onValid)}>
       <input {...form.register("name", { required: true })} />
     </form>
   );

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -150,6 +150,26 @@ describe("useAssistantForm", () => {
     expect(onSubmit).toHaveBeenCalledOnce();
   });
 
+  it("submits a form with react-hook-form rules and a plain onSubmit", async () => {
+    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    const Fields = () => {
+      const form = useAssistantForm<{ name: string }>();
+      return <input {...form.register("name", { required: true })} />;
+    };
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Fields />
+      </form>,
+    );
+
+    await expect(executeSubmitForm()).resolves.toEqual({ success: true });
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
   it("reports when react-hook-form validation blocks submission", async () => {
     const onValid = vi.fn();
     const onInvalid = vi.fn();

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, render, renderHook } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type { ModelContext } from "@assistant-ui/core";
 import type { FormEvent, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -160,6 +160,15 @@ describe("useAssistantForm", () => {
     await expectSubmitBlocked();
     expect(onValid).not.toHaveBeenCalled();
   });
+
+  it("submits forms that pass react-hook-form validation", async () => {
+    const onValid = vi.fn();
+
+    render(<ReactHookFormRequiredForm defaultName="Ada" onValid={onValid} />);
+
+    await expect(executeSubmitForm()).resolves.toEqual({ success: true });
+    await waitFor(() => expect(onValid).toHaveBeenCalledOnce());
+  });
 });
 
 const NativeRequiredField = () => {
@@ -168,13 +177,17 @@ const NativeRequiredField = () => {
 };
 
 const ReactHookFormRequiredForm = ({
+  defaultName = "",
   onValid,
   noValidate,
 }: {
+  defaultName?: string | undefined;
   onValid: () => void;
   noValidate?: boolean | undefined;
 }) => {
-  const form = useAssistantForm<{ name: string }>();
+  const form = useAssistantForm<{ name: string }>({
+    defaultValues: { name: defaultName },
+  });
   return (
     <form noValidate={noValidate} onSubmit={form.handleSubmit(onValid)}>
       <input {...form.register("name", { required: true })} />

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -280,7 +280,7 @@ describe("useAssistantForm", () => {
     }
   });
 
-  it("does not leak rejections when requestSubmit throws", async () => {
+  it("propagates errors when requestSubmit throws", async () => {
     const error = new Error("requestSubmit unavailable");
     const requestSubmit = vi
       .spyOn(HTMLFormElement.prototype, "requestSubmit")
@@ -295,7 +295,6 @@ describe("useAssistantForm", () => {
       );
 
       await expect(executeSubmitForm()).rejects.toBe(error);
-      await new Promise((resolve) => setTimeout(resolve, 0));
     } finally {
       requestSubmit.mockRestore();
     }

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -100,4 +100,56 @@ describe("useAssistantForm", () => {
       );
     });
   });
+
+  it("reports when native form validation blocks submission", async () => {
+    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <form onSubmit={onSubmit}>
+        <NativeRequiredField />
+      </form>,
+    );
+
+    const submitTool = provider.getModelContext().tools?.submit_form;
+    if (!submitTool?.execute) throw new Error("submit_form is not registered");
+
+    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
+      success: false,
+      message: "The form contains invalid fields and was not submitted.",
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("reports when react-hook-form validation blocks submission", async () => {
+    const onSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <form onSubmit={onSubmit}>
+        <ReactHookFormRequiredField />
+      </form>,
+    );
+
+    const submitTool = provider.getModelContext().tools?.submit_form;
+    if (!submitTool?.execute) throw new Error("submit_form is not registered");
+
+    await expect(submitTool.execute({}, {} as never)).resolves.toEqual({
+      success: false,
+      message: "The form contains invalid fields and was not submitted.",
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });
+
+const NativeRequiredField = () => {
+  const form = useAssistantForm<{ name: string }>();
+  return <input required {...form.register("name")} />;
+};
+
+const ReactHookFormRequiredField = () => {
+  const form = useAssistantForm<{ name: string }>();
+  return <input {...form.register("name", { required: true })} />;
+};

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import type { ModelContext } from "@assistant-ui/core";
 import type { FormEvent, ReactNode } from "react";
+import type { Resolver, ResolverResult } from "react-hook-form";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -189,6 +190,65 @@ describe("useAssistantForm", () => {
 
     await expect(executeSubmitForm()).resolves.toEqual({ success: true });
     await waitFor(() => expect(onValid).toHaveBeenCalledOnce());
+  });
+
+  it("ignores user submissions while an assistant submission is validating", async () => {
+    type FormValues = { name: string };
+    let validationCount = 0;
+    let resolveAssistantValidation: (
+      result: ResolverResult<FormValues>,
+    ) => void = () => {};
+    const resolver: Resolver<FormValues> = (values) => {
+      validationCount += 1;
+      if (validationCount === 1) {
+        return new Promise((resolve) => {
+          resolveAssistantValidation = resolve;
+        });
+      }
+      return Promise.resolve({ values, errors: {} });
+    };
+    const onValid = vi.fn();
+
+    const Form = () => {
+      const form = useAssistantForm<FormValues>({
+        defaultValues: { name: "" },
+        resolver,
+      });
+      return (
+        <form
+          data-testid="concurrent-form"
+          onSubmit={form.handleSubmit(onValid)}
+        >
+          <input data-testid="concurrent-name" {...form.register("name")} />
+        </form>
+      );
+    };
+    const { getByTestId } = render(<Form />);
+
+    let assistantSubmitSettled = false;
+    const assistantSubmit = executeSubmitForm().finally(() => {
+      assistantSubmitSettled = true;
+    });
+    await waitFor(() => expect(validationCount).toBe(1));
+
+    fireEvent.change(getByTestId("concurrent-name"), {
+      target: { value: "Ada" },
+    });
+    fireEvent.submit(getByTestId("concurrent-form"));
+    await waitFor(() => {
+      expect(validationCount).toBe(2);
+      expect(onValid).toHaveBeenCalledOnce();
+    });
+    expect(assistantSubmitSettled).toBe(false);
+
+    resolveAssistantValidation({
+      values: {},
+      errors: { name: { type: "required", message: "Name is required" } },
+    });
+    await expect(assistantSubmit).resolves.toEqual({
+      success: false,
+      message: "The form contains invalid fields and was not submitted.",
+    });
   });
 });
 

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -189,6 +189,15 @@ describe("useAssistantForm", () => {
     });
   });
 
+  it("reports validation blocked by a capture-phase handler", async () => {
+    const onValid = vi.fn();
+
+    render(<ReactHookFormRequiredForm capture onValid={onValid} />);
+
+    await expectSubmitBlocked();
+    expect(onValid).not.toHaveBeenCalled();
+  });
+
   it("reports react-hook-form errors when native validation is disabled", async () => {
     const onValid = vi.fn();
 
@@ -207,7 +216,7 @@ describe("useAssistantForm", () => {
     await waitFor(() => expect(onValid).toHaveBeenCalledOnce());
   });
 
-  it("ignores user submissions while an assistant submission is validating", async () => {
+  it("does not let user submissions settle a pending assistant submission", async () => {
     type FormValues = { name: string };
     let validationCount = 0;
     let resolveAssistantValidation: (
@@ -313,11 +322,13 @@ const NativeRequiredField = () => {
 };
 
 const ReactHookFormRequiredForm = ({
+  capture = false,
   defaultName = "",
   onInvalid,
   onValid,
   noValidate,
 }: {
+  capture?: boolean | undefined;
   defaultName?: string | undefined;
   onInvalid?: (() => void) | undefined;
   onValid: () => void;
@@ -326,10 +337,12 @@ const ReactHookFormRequiredForm = ({
   const form = useAssistantForm<{ name: string }>({
     defaultValues: { name: defaultName },
   });
+  const handleSubmit = form.handleSubmit(onValid, onInvalid);
   return (
     <form
       noValidate={noValidate}
-      onSubmit={form.handleSubmit(onValid, onInvalid)}
+      onSubmit={capture ? undefined : handleSubmit}
+      onSubmitCapture={capture ? handleSubmit : undefined}
     >
       <input
         data-testid="name-input"

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -241,10 +241,15 @@ export const useAssistantForm = <
               try {
                 formElement.requestSubmit();
               } catch (error) {
-                rejectAssistantSubmit(error);
+                settleAssistantSubmit(false);
                 throw error;
               } finally {
                 formElement.removeEventListener("submit", onSubmit);
+              }
+
+              const pending = pendingAssistantSubmitRef.current;
+              if (pending?.event === undefined) {
+                settleAssistantSubmit(false);
               }
 
               if (await submissionResult) return { success: true };

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -4,7 +4,7 @@ import { type ModelContext, tool } from "@assistant-ui/core";
 import type {} from "@assistant-ui/core/store";
 import { type ToolCallMessagePartComponent } from "@assistant-ui/core/react";
 import { useAui } from "@assistant-ui/store";
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   type Field,
   type FieldValues,
@@ -17,6 +17,13 @@ import {
 } from "react-hook-form";
 import type { z } from "zod";
 import { formTools } from "./formTools";
+
+type PendingAssistantSubmit = {
+  handlerInvoked: boolean;
+  outcome: boolean | undefined;
+  resolve: (outcome: boolean) => void;
+  reject: (error: unknown) => void;
+};
 
 export type UseAssistantFormProps<
   TFieldValues extends FieldValues,
@@ -78,9 +85,75 @@ export const useAssistantForm = <
     getValues,
     setValue,
     reset,
-    trigger,
+    handleSubmit: baseHandleSubmit,
     formState: { isSubmitting },
   } = form;
+
+  const pendingAssistantSubmitRef = useRef<PendingAssistantSubmit | null>(null);
+  const settleAssistantSubmit = useCallback((outcome: boolean) => {
+    const pending = pendingAssistantSubmitRef.current;
+    if (!pending) return;
+
+    pendingAssistantSubmitRef.current = null;
+    pending.resolve(outcome);
+  }, []);
+  const rejectAssistantSubmit = useCallback((error: unknown) => {
+    const pending = pendingAssistantSubmitRef.current;
+    if (!pending) return;
+
+    pendingAssistantSubmitRef.current = null;
+    pending.reject(error);
+  }, []);
+
+  const handleSubmit = useCallback<
+    UseFormReturn<TFieldValues, TContext, TTransformedValues>["handleSubmit"]
+  >(
+    (onValid, onInvalid) => {
+      const submit = baseHandleSubmit(
+        (...args) => {
+          const pending = pendingAssistantSubmitRef.current;
+          if (pending) pending.outcome = true;
+          return onValid(...args);
+        },
+        (...args) => {
+          const pending = pendingAssistantSubmitRef.current;
+          if (pending) pending.outcome = false;
+          return onInvalid?.(...args);
+        },
+      );
+
+      return async (event) => {
+        const pending = pendingAssistantSubmitRef.current;
+        if (pending) pending.handlerInvoked = true;
+
+        try {
+          const result = await submit(event);
+          if (pendingAssistantSubmitRef.current === pending && pending) {
+            settleAssistantSubmit(pending.outcome ?? true);
+          }
+          return result;
+        } catch (error) {
+          if (pendingAssistantSubmitRef.current === pending) {
+            rejectAssistantSubmit(error);
+          }
+          throw error;
+        }
+      };
+    },
+    [baseHandleSubmit, rejectAssistantSubmit, settleAssistantSubmit],
+  );
+  const assistantForm = useMemo<
+    UseFormReturn<TFieldValues, TContext, TTransformedValues>
+  >(
+    () => ({
+      ...form,
+      handleSubmit,
+      get formState() {
+        return form.formState;
+      },
+    }),
+    [form, handleSubmit],
+  );
 
   const aui = useAui();
   useEffect(() => {
@@ -101,7 +174,7 @@ export const useAssistantForm = <
         submit_form: tool({
           ...formTools.submit_form,
           execute: async () => {
-            if (isSubmitting) {
+            if (isSubmitting || pendingAssistantSubmitRef.current) {
               return {
                 success: false,
                 message: "The form is already submitting.",
@@ -124,12 +197,7 @@ export const useAssistantForm = <
             }
 
             if (formElement) {
-              const isValid = await trigger(undefined, { shouldFocus: true });
-              const isNativeValid =
-                !isValid ||
-                formElement.noValidate ||
-                formElement.reportValidity();
-              if (!isValid || !isNativeValid) {
+              if (!formElement.noValidate && !formElement.reportValidity()) {
                 return {
                   success: false,
                   message:
@@ -137,8 +205,41 @@ export const useAssistantForm = <
                 };
               }
 
-              formElement.requestSubmit();
-              return { success: true };
+              const submissionResult = new Promise<boolean>(
+                (resolve, reject) => {
+                  pendingAssistantSubmitRef.current = {
+                    handlerInvoked: false,
+                    outcome: undefined,
+                    resolve,
+                    reject,
+                  };
+                },
+              );
+              const onSubmit = () => {
+                queueMicrotask(() => {
+                  const pending = pendingAssistantSubmitRef.current;
+                  if (pending && !pending.handlerInvoked) {
+                    settleAssistantSubmit(true);
+                  }
+                });
+              };
+
+              formElement.addEventListener("submit", onSubmit, { once: true });
+              try {
+                formElement.requestSubmit();
+              } catch (error) {
+                rejectAssistantSubmit(error);
+                throw error;
+              } finally {
+                formElement.removeEventListener("submit", onSubmit);
+              }
+
+              if (await submissionResult) return { success: true };
+              return {
+                success: false,
+                message:
+                  "The form contains invalid fields and was not submitted.",
+              };
             }
 
             return {
@@ -164,7 +265,16 @@ export const useAssistantForm = <
         system: `Form State:\n${JSON.stringify(getValues())}`,
       }),
     });
-  }, [control, setValue, getValues, aui, reset, trigger, isSubmitting]);
+  }, [
+    control,
+    setValue,
+    getValues,
+    aui,
+    reset,
+    isSubmitting,
+    rejectAssistantSubmit,
+    settleAssistantSubmit,
+  ]);
 
   const renderFormFieldTool = props?.assistant?.tools?.set_form_field?.render;
   useEffect(() => {
@@ -184,5 +294,5 @@ export const useAssistantForm = <
     return aui.tools.setToolUI("reset_form", renderResetFormTool);
   }, [aui, renderResetFormTool]);
 
-  return form;
+  return assistantForm;
 };

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -78,6 +78,7 @@ export const useAssistantForm = <
     getValues,
     setValue,
     reset,
+    trigger,
     formState: { isSubmitting },
   } = form;
 
@@ -107,6 +108,7 @@ export const useAssistantForm = <
               };
             }
             const { _names, _fields } = control;
+            let formElement: HTMLFormElement | null = null;
             for (const name of _names.mount) {
               const field: Field | undefined = get(_fields, name);
               if (field?._f) {
@@ -115,14 +117,25 @@ export const useAssistantForm = <
                   : field._f.ref;
 
                 if (fieldReference instanceof HTMLElement) {
-                  const form = fieldReference.closest("form");
-                  if (form) {
-                    form.requestSubmit();
-
-                    return { success: true };
-                  }
+                  formElement = fieldReference.closest("form");
+                  if (formElement) break;
                 }
               }
+            }
+
+            if (formElement) {
+              const isValid = await trigger(undefined, { shouldFocus: true });
+              if (!isValid || !formElement.checkValidity()) {
+                formElement.reportValidity();
+                return {
+                  success: false,
+                  message:
+                    "The form contains invalid fields and was not submitted.",
+                };
+              }
+
+              formElement.requestSubmit();
+              return { success: true };
             }
 
             return {
@@ -148,7 +161,7 @@ export const useAssistantForm = <
         system: `Form State:\n${JSON.stringify(getValues())}`,
       }),
     });
-  }, [control, setValue, getValues, aui, reset, isSubmitting]);
+  }, [control, setValue, getValues, aui, reset, trigger, isSubmitting]);
 
   const renderFormFieldTool = props?.assistant?.tools?.set_form_field?.render;
   useEffect(() => {

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -126,7 +126,9 @@ export const useAssistantForm = <
             if (formElement) {
               const isValid = await trigger(undefined, { shouldFocus: true });
               const isNativeValid =
-                formElement.noValidate || formElement.reportValidity();
+                !isValid ||
+                formElement.noValidate ||
+                formElement.reportValidity();
               if (!isValid || !isNativeValid) {
                 return {
                   success: false,

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -19,6 +19,7 @@ import type { z } from "zod";
 import { formTools } from "./formTools";
 
 type PendingAssistantSubmit = {
+  dispatching: boolean;
   event: unknown;
   handlerInvoked: boolean;
   outcome: boolean | undefined;
@@ -128,8 +129,18 @@ export const useAssistantForm = <
       return async (event) => {
         const pending = pendingAssistantSubmitRef.current;
         const nativeEvent = event?.nativeEvent ?? event;
-        const assistantSubmit = pending?.event === nativeEvent ? pending : null;
-        if (assistantSubmit) assistantSubmit.handlerInvoked = true;
+        const assistantSubmit =
+          pending &&
+          (pending.event === nativeEvent ||
+            (pending.dispatching &&
+              pending.event === undefined &&
+              nativeEvent !== undefined))
+            ? pending
+            : null;
+        if (assistantSubmit) {
+          assistantSubmit.event = nativeEvent;
+          assistantSubmit.handlerInvoked = true;
+        }
 
         try {
           const result = await submit(event);
@@ -216,6 +227,7 @@ export const useAssistantForm = <
               const submissionResult = new Promise<boolean>(
                 (resolve, reject) => {
                   pendingAssistantSubmitRef.current = {
+                    dispatching: true,
                     event: undefined,
                     handlerInvoked: false,
                     outcome: undefined,
@@ -226,7 +238,7 @@ export const useAssistantForm = <
               );
               const onSubmit = (event: SubmitEvent) => {
                 const pending = pendingAssistantSubmitRef.current;
-                if (pending) pending.event = event;
+                if (pending?.event === undefined) pending.event = event;
                 queueMicrotask(() => {
                   if (
                     pendingAssistantSubmitRef.current === pending &&
@@ -244,6 +256,8 @@ export const useAssistantForm = <
                 settleAssistantSubmit(false);
                 throw error;
               } finally {
+                const pending = pendingAssistantSubmitRef.current;
+                if (pending) pending.dispatching = false;
                 formElement.removeEventListener("submit", onSubmit);
               }
 

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -115,18 +115,18 @@ export const useAssistantForm = <
         (...args) => {
           const pending = pendingAssistantSubmitRef.current;
           const event = args[1]?.nativeEvent ?? args[1];
-          if (pending?.event === event) pending.outcome = true;
+          if (pending && pending.event === event) pending.outcome = true;
           return onValid(...args);
         },
         (...args) => {
           const pending = pendingAssistantSubmitRef.current;
           const event = args[1]?.nativeEvent ?? args[1];
-          if (pending?.event === event) pending.outcome = false;
+          if (pending && pending.event === event) pending.outcome = false;
           return onInvalid?.(...args);
         },
       );
 
-      return async (event) => {
+      return (async (event) => {
         const pending = pendingAssistantSubmitRef.current;
         const nativeEvent = event?.nativeEvent ?? event;
         const assistantSubmit =
@@ -157,7 +157,7 @@ export const useAssistantForm = <
           }
           throw error;
         }
-      };
+      }) as typeof submit;
     },
     [baseHandleSubmit, rejectAssistantSubmit, settleAssistantSubmit],
   );
@@ -224,25 +224,34 @@ export const useAssistantForm = <
                 };
               }
 
+              let resolveSubmission: (outcome: boolean) => void = () => {};
+              let rejectSubmission: (error: unknown) => void = () => {};
               const submissionResult = new Promise<boolean>(
                 (resolve, reject) => {
-                  pendingAssistantSubmitRef.current = {
-                    dispatching: true,
-                    event: undefined,
-                    handlerInvoked: false,
-                    outcome: undefined,
-                    resolve,
-                    reject,
-                  };
+                  resolveSubmission = resolve;
+                  rejectSubmission = reject;
                 },
               );
+              const assistantSubmit: PendingAssistantSubmit = {
+                dispatching: true,
+                event: undefined,
+                handlerInvoked: false,
+                outcome: undefined,
+                resolve: resolveSubmission,
+                reject: rejectSubmission,
+              };
+              pendingAssistantSubmitRef.current = assistantSubmit;
               const onSubmit = (event: SubmitEvent) => {
-                const pending = pendingAssistantSubmitRef.current;
-                if (pending?.event === undefined) pending.event = event;
+                if (
+                  pendingAssistantSubmitRef.current === assistantSubmit &&
+                  assistantSubmit.event === undefined
+                ) {
+                  assistantSubmit.event = event;
+                }
                 queueMicrotask(() => {
                   if (
-                    pendingAssistantSubmitRef.current === pending &&
-                    !pending.handlerInvoked
+                    pendingAssistantSubmitRef.current === assistantSubmit &&
+                    !assistantSubmit.handlerInvoked
                   ) {
                     settleAssistantSubmit(true);
                   }
@@ -256,21 +265,21 @@ export const useAssistantForm = <
                 settleAssistantSubmit(false);
                 throw error;
               } finally {
-                const pending = pendingAssistantSubmitRef.current;
-                if (pending) pending.dispatching = false;
+                assistantSubmit.dispatching = false;
                 formElement.removeEventListener("submit", onSubmit);
               }
 
-              const pending = pendingAssistantSubmitRef.current;
-              if (pending?.event === undefined) {
+              const dispatched = assistantSubmit.event !== undefined;
+              if (!dispatched) {
                 settleAssistantSubmit(false);
               }
 
               if (await submissionResult) return { success: true };
               return {
                 success: false,
-                message:
-                  "The form contains invalid fields and was not submitted.",
+                message: dispatched
+                  ? "The form contains invalid fields and was not submitted."
+                  : "The form did not accept the submission.",
               };
             }
 

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -19,6 +19,7 @@ import type { z } from "zod";
 import { formTools } from "./formTools";
 
 type PendingAssistantSubmit = {
+  event: unknown;
   handlerInvoked: boolean;
   outcome: boolean | undefined;
   resolve: (outcome: boolean) => void;
@@ -112,28 +113,35 @@ export const useAssistantForm = <
       const submit = baseHandleSubmit(
         (...args) => {
           const pending = pendingAssistantSubmitRef.current;
-          if (pending) pending.outcome = true;
+          const event = args[1]?.nativeEvent ?? args[1];
+          if (pending?.event === event) pending.outcome = true;
           return onValid(...args);
         },
         (...args) => {
           const pending = pendingAssistantSubmitRef.current;
-          if (pending) pending.outcome = false;
+          const event = args[1]?.nativeEvent ?? args[1];
+          if (pending?.event === event) pending.outcome = false;
           return onInvalid?.(...args);
         },
       );
 
       return async (event) => {
         const pending = pendingAssistantSubmitRef.current;
-        if (pending) pending.handlerInvoked = true;
+        const nativeEvent = event?.nativeEvent ?? event;
+        const assistantSubmit = pending?.event === nativeEvent ? pending : null;
+        if (assistantSubmit) assistantSubmit.handlerInvoked = true;
 
         try {
           const result = await submit(event);
-          if (pendingAssistantSubmitRef.current === pending && pending) {
-            settleAssistantSubmit(pending.outcome ?? true);
+          if (
+            assistantSubmit &&
+            pendingAssistantSubmitRef.current === assistantSubmit
+          ) {
+            settleAssistantSubmit(assistantSubmit.outcome ?? true);
           }
           return result;
         } catch (error) {
-          if (pendingAssistantSubmitRef.current === pending) {
+          if (pendingAssistantSubmitRef.current === assistantSubmit) {
             rejectAssistantSubmit(error);
           }
           throw error;
@@ -208,6 +216,7 @@ export const useAssistantForm = <
               const submissionResult = new Promise<boolean>(
                 (resolve, reject) => {
                   pendingAssistantSubmitRef.current = {
+                    event: undefined,
                     handlerInvoked: false,
                     outcome: undefined,
                     resolve,
@@ -215,10 +224,14 @@ export const useAssistantForm = <
                   };
                 },
               );
-              const onSubmit = () => {
+              const onSubmit = (event: SubmitEvent) => {
+                const pending = pendingAssistantSubmitRef.current;
+                if (pending) pending.event = event;
                 queueMicrotask(() => {
-                  const pending = pendingAssistantSubmitRef.current;
-                  if (pending && !pending.handlerInvoked) {
+                  if (
+                    pendingAssistantSubmitRef.current === pending &&
+                    !pending.handlerInvoked
+                  ) {
                     settleAssistantSubmit(true);
                   }
                 });

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -125,8 +125,10 @@ export const useAssistantForm = <
 
             if (formElement) {
               const isValid = await trigger(undefined, { shouldFocus: true });
-              if (!isValid || !formElement.checkValidity()) {
-                formElement.reportValidity();
+              const isNativeValid =
+                formElement.noValidate || formElement.checkValidity();
+              if (!isValid || !isNativeValid) {
+                if (!formElement.noValidate) formElement.reportValidity();
                 return {
                   success: false,
                   message:

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -126,9 +126,8 @@ export const useAssistantForm = <
             if (formElement) {
               const isValid = await trigger(undefined, { shouldFocus: true });
               const isNativeValid =
-                formElement.noValidate || formElement.checkValidity();
+                formElement.noValidate || formElement.reportValidity();
               if (!isValid || !isNativeValid) {
-                if (!formElement.noValidate) formElement.reportValidity();
                 return {
                   success: false,
                   message:


### PR DESCRIPTION
## Summary
- report native and React Hook Form validation failures instead of unconditional success
- observe the real `handleSubmit` lifecycle rather than pre-validating separately
- preserve `onInvalid`, submit bookkeeping, revalidation, native feedback, and `noValidate`
- scope each assistant result to its own native submit event

## Why
The submit tool returned success immediately after calling `requestSubmit()`, even though browser constraint validation or React Hook Form validation could block submission. The model could therefore report a submission that never occurred.

The tool now waits for the form's normal submission lifecycle. Native validation failures are reported before dispatch; handled React Hook Form submissions report the result produced by the application's existing `handleSubmit` path. Concurrent user submissions are kept independent from a pending assistant-triggered submission.

## Testing
- added regressions for native required validation and React Hook Form required validation
- verified blocked React Hook Form submits call `onInvalid`, increment `submitCount`, and revalidate when corrected
- verified valid handled submissions and native `noValidate` submissions still succeed
- verified a concurrent user submit cannot settle a pending assistant submission
- `pnpm --filter @assistant-ui/react-hook-form test`
- `pnpm --filter @assistant-ui/react-hook-form build`
- `pnpm lint`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bIsHH3ARMFzWdcnU2P0gMp_nMvSDJq6peKL1viO5_OqMfGdphvYjZLHd7IA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->