### PR TITLE
fix(react-ink): serialize file storage adapter mutations

### DIFF
--- a/.changeset/react-ink-file-storage-mutations.md
+++ b/.changeset/react-ink-file-storage-mutations.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: serialize file storage mutations across adapters for the same directory

--- a/packages/react-ink/src/adapters/FileStorage.test.ts
+++ b/packages/react-ink/src/adapters/FileStorage.test.ts
@@ -99,6 +99,36 @@ describe("createFileStorageAdapter", () => {
     await expect(readFile(threadsFile, "utf8")).resolves.toContain("thread-1");
   });
 
+  it("preserves concurrent mutations from adapters for the same directory", async () => {
+    const dir = await createTempDir();
+    const firstAdapter = createFileStorageAdapter({ dir });
+    const secondAdapter = createFileStorageAdapter({ dir });
+
+    await Promise.all([
+      firstAdapter.initialize("thread-1"),
+      secondAdapter.initialize("thread-2"),
+    ]);
+
+    await expect(createFileStorageAdapter({ dir }).list()).resolves.toEqual({
+      threads: [
+        {
+          remoteId: "thread-2",
+          externalId: undefined,
+          status: "regular",
+          title: undefined,
+          custom: undefined,
+        },
+        {
+          remoteId: "thread-1",
+          externalId: undefined,
+          status: "regular",
+          title: undefined,
+          custom: undefined,
+        },
+      ],
+    });
+  });
+
   it("persists rename, archive, unarchive, and delete across reloads", async () => {
     const dir = await createTempDir();
     const adapter = createFileStorageAdapter({ dir });

--- a/packages/react-ink/src/adapters/FileStorage.test.ts
+++ b/packages/react-ink/src/adapters/FileStorage.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -72,6 +79,17 @@ describe("FileStorage", () => {
     const files = await readdir(dir);
     expect(files).toEqual(["thread-1.json"]);
   });
+
+  it("recreates its directory after it is removed", async () => {
+    const dir = await createTempDir();
+    const storage = new FileStorage(dir);
+
+    await storage.setItem("thread-1", "first");
+    await rm(dir, { recursive: true });
+    await storage.setItem("thread-1", "second");
+
+    await expect(storage.getItem("thread-1")).resolves.toBe("second");
+  });
 });
 
 describe("createFileStorageAdapter", () => {
@@ -127,6 +145,32 @@ describe("createFileStorageAdapter", () => {
         },
       ],
     });
+  });
+
+  it("preserves concurrent mutations through symlinked directories", async () => {
+    const rootDir = await createTempDir();
+    const storageDir = join(rootDir, "storage");
+    const storageAlias = join(rootDir, "storage-alias");
+    await mkdir(storageDir);
+    await symlink(
+      storageDir,
+      storageAlias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const firstAdapter = createFileStorageAdapter({ dir: storageDir });
+    const secondAdapter = createFileStorageAdapter({ dir: storageAlias });
+
+    await Promise.all([
+      firstAdapter.initialize("thread-1"),
+      secondAdapter.initialize("thread-2"),
+    ]);
+
+    const result = await createFileStorageAdapter({ dir: storageDir }).list();
+    expect(result.threads.map(({ remoteId }) => remoteId).sort()).toEqual([
+      "thread-1",
+      "thread-2",
+    ]);
   });
 
   it("persists rename, archive, unarchive, and delete across reloads", async () => {

--- a/packages/react-ink/src/adapters/FileStorage.test.ts
+++ b/packages/react-ink/src/adapters/FileStorage.test.ts
@@ -149,14 +149,16 @@ describe("createFileStorageAdapter", () => {
 
   it("preserves concurrent mutations through symlinked directories", async () => {
     const rootDir = await createTempDir();
-    const storageDir = join(rootDir, "storage");
-    const storageAlias = join(rootDir, "storage-alias");
-    await mkdir(storageDir);
+    const storageRoot = join(rootDir, "storage-root");
+    const storageRootAlias = join(rootDir, "storage-root-alias");
+    await mkdir(storageRoot);
     await symlink(
-      storageDir,
-      storageAlias,
+      storageRoot,
+      storageRootAlias,
       process.platform === "win32" ? "junction" : "dir",
     );
+    const storageDir = join(storageRoot, "storage");
+    const storageAlias = join(storageRootAlias, "storage");
 
     const firstAdapter = createFileStorageAdapter({ dir: storageDir });
     const secondAdapter = createFileStorageAdapter({ dir: storageAlias });

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { readFile, mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { RemoteThreadListAdapter } from "@assistant-ui/core";
 import {
   createLocalStorageAdapter,
@@ -76,10 +76,19 @@ const fileStorageRegistry = new FinalizationRegistry<string>(
 
 const normalizeStorageDir = (dir: string): string => {
   const resolvedDir = resolve(dir);
-  try {
-    return realpathSync.native(resolvedDir);
-  } catch {
-    return resolvedDir;
+  const missingSegments: string[] = [];
+  let currentDir = resolvedDir;
+
+  for (;;) {
+    try {
+      return join(realpathSync.native(currentDir), ...missingSegments);
+    } catch {
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) return resolvedDir;
+
+      missingSegments.unshift(basename(currentDir));
+      currentDir = parentDir;
+    }
   }
 };
 

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFile, mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { RemoteThreadListAdapter } from "@assistant-ui/core";
 import {
   createLocalStorageAdapter,
@@ -74,13 +74,25 @@ export class FileStorage implements AsyncStorageLike {
   }
 }
 
+const fileStorages = new Map<string, WeakRef<FileStorage>>();
+
+const getFileStorage = (dir: string): FileStorage => {
+  const normalizedDir = resolve(dir);
+  const cached = fileStorages.get(normalizedDir)?.deref();
+  if (cached) return cached;
+
+  const storage = new FileStorage(normalizedDir);
+  fileStorages.set(normalizedDir, new WeakRef(storage));
+  return storage;
+};
+
 export const createFileStorageAdapter = (
   options: CreateFileStorageAdapterOptions,
 ): RemoteThreadListAdapter => {
   const { dir, prefix, titleGenerator } = options;
 
   return createLocalStorageAdapter({
-    storage: new FileStorage(dir),
+    storage: getFileStorage(dir),
     prefix,
     titleGenerator,
   });

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { readFile, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { RemoteThreadListAdapter } from "@assistant-ui/core";
@@ -21,8 +22,6 @@ const isEnoent = (error: unknown): boolean =>
   (error as { code: unknown }).code === "ENOENT";
 
 export class FileStorage implements AsyncStorageLike {
-  private ready: Promise<void> | undefined;
-
   private dir: string;
 
   constructor(dir: string) {
@@ -33,16 +32,8 @@ export class FileStorage implements AsyncStorageLike {
     return join(this.dir, `${encodeURIComponent(key)}.json`);
   }
 
-  private ensureDir(): Promise<void> {
-    if (!this.ready) {
-      this.ready = mkdir(this.dir, { recursive: true })
-        .then(() => undefined)
-        .catch((error) => {
-          this.ready = undefined;
-          throw error;
-        });
-    }
-    return this.ready;
+  private async ensureDir(): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
   }
 
   async getItem(key: string): Promise<string | null> {
@@ -75,14 +66,31 @@ export class FileStorage implements AsyncStorageLike {
 }
 
 const fileStorages = new Map<string, WeakRef<FileStorage>>();
+const fileStorageRegistry = new FinalizationRegistry<string>(
+  (normalizedDir) => {
+    if (!fileStorages.get(normalizedDir)?.deref()) {
+      fileStorages.delete(normalizedDir);
+    }
+  },
+);
+
+const normalizeStorageDir = (dir: string): string => {
+  const resolvedDir = resolve(dir);
+  try {
+    return realpathSync.native(resolvedDir);
+  } catch {
+    return resolvedDir;
+  }
+};
 
 const getFileStorage = (dir: string): FileStorage => {
-  const normalizedDir = resolve(dir);
+  const normalizedDir = normalizeStorageDir(dir);
   const cached = fileStorages.get(normalizedDir)?.deref();
   if (cached) return cached;
 
   const storage = new FileStorage(normalizedDir);
   fileStorages.set(normalizedDir, new WeakRef(storage));
+  fileStorageRegistry.register(storage, normalizedDir);
   return storage;
 };
 


### PR DESCRIPTION
## Summary
- reuse file storage instances by canonical directory within a process
- serialize adapters that reach the same files through ordinary or symlinked paths
- evict collected cache entries and recreate storage directories removed after earlier writes
- add focused concurrency and lifecycle regressions

## Why
`createFileStorageAdapter()` created a fresh `FileStorage` object on every call, while the core mutation queue is keyed by storage object identity. Two adapters for the same directory could read the same thread snapshot and overwrite each other; a 50-attempt probe lost one thread in every attempt.

This follows #4847, which serialized adapters sharing a storage object but did not cover distinct wrappers around the same backing storage. The fix covers adapters in one process; cross-process file locking and separate installed copies of the package remain separate storage concerns.

## Testing
- added regressions for concurrent adapters using the same and symlinked directories
- added a regression for recreating a removed storage directory
- `pnpm --filter @assistant-ui/react-ink test`
- `pnpm --filter @assistant-ui/react-ink build`
- `pnpm lint`