### PR TITLE
feat(eve): adopt the eve 0.31+ session api and support eve through 0.37

### DIFF
--- a/.changeset/eve-widen-peer-floor.md
+++ b/.changeset/eve-widen-peer-floor.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+feat: adopt the eve 0.31+ session API (positional `send`, separate `respond` for HITL responses, `cancel` approval option) and raise the eve peer floor to >=0.32.0, validated against eve 0.37

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1,6 +1,6 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-import { InputResponse, SendTurnPayload } from "eve/client";
+import { InputResponse } from "eve/client";
 
 import { EveAuthorizationOutcome, EveAuthorizationPart, EveMessage, EveMessageData, UseEveAgentOptions } from "eve/react";
 
@@ -330,6 +330,16 @@ type EveAuthorizationData = {
   readonly outcome?: EveAuthorizationOutcome;
   readonly reason?: string;
 };
+
+type EveMessageContent = string | ({
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+})[];
 
 type ExportedMessageRepository = {
   headId?: string | null;
@@ -1501,7 +1511,7 @@ declare const convertEveMessage: (message: EveMessage, index: number, messages: 
 
 declare const convertEveMessages: (data: EveMessageData, options?: ConvertEveMessagesOptions) => ThreadMessage[];
 
-declare const getEveMessageContent: (message: AppendMessage) => NonNullable<SendTurnPayload["message"]>;
+declare const getEveMessageContent: (message: AppendMessage) => EveMessageContent;
 
 declare global {
   interface Window {

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1521,7 +1521,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { ConvertEveMessagesOptions, EveAuthorizationData, UseEveAgentRuntimeOptions, convertEveMessage, convertEveMessages, getEveMessageContent, toEveInputResponse, useEveAgentRuntime };
+  export { ConvertEveMessagesOptions, EveAuthorizationData, EveMessageContent, UseEveAgentRuntimeOptions, convertEveMessage, convertEveMessages, getEveMessageContent, toEveInputResponse, useEveAgentRuntime };
 }
 
 declare const toEveInputResponse: (response: RespondToToolApprovalOptions) => InputResponse;

--- a/api-surface/package.json
+++ b/api-surface/package.json
@@ -22,7 +22,7 @@
     "@standard-schema/spec": "^1.1.0",
     "ai": "^7.0.62",
     "denque": "^2.1.0",
-    "eve": "^0.27.6",
+    "eve": "^0.37.0",
     "ink": "^7.1.1",
     "ink-spinner": "^5.0.0",
     "lexical": "^0.49.0",

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/eve.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/eve.mdx
@@ -36,7 +36,7 @@ Converts an assistant-ui append message into the message payload accepted by
 Eve's `send` API.
 
 ```ts
-const getEveMessageContent: (message: AppendMessage) => NonNullable<SendTurnPayload["message"]>;
+const getEveMessageContent: (message: AppendMessage) => EveMessageContent;
 ```
 
 ### toEveInputResponse

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -15,7 +15,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.27.6",
+    "eve": "^0.37.0",
     "lucide-react": "^1.31.0",
     "next": "^16.3.0",
     "react": "^19.2.8",

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
-    "eve": "^0.27.6",
+    "eve": ">=0.32.0",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {
@@ -50,7 +50,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.18",
-    "eve": "^0.27.6",
+    "eve": "^0.37.0",
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -8,6 +8,11 @@ import {
 } from "./convertEveMessages";
 import type { AppendMessage } from "@assistant-ui/core";
 
+const eventMeta = (sequence: number) => ({
+  at: "2026-01-01T00:00:00.000Z",
+  id: `evt_${sequence}`,
+});
+
 describe("convertEveMessages", () => {
   it("converts text and reasoning parts", () => {
     const data = {
@@ -68,11 +73,12 @@ describe("convertEveMessages", () => {
                   name: "send_email",
                   inputRequest: {
                     requestId: "req_1",
+                    kind: "tool-approval",
                     prompt: "Send the email?",
                     display: "confirmation",
                     options: [
                       { id: "approve", label: "Approve" },
-                      { id: "deny", label: "Deny", style: "danger" },
+                      { id: "cancel", label: "Cancel", style: "danger" },
                       { id: "escalate", label: "Escalate" },
                     ],
                   },
@@ -98,7 +104,7 @@ describe("convertEveMessages", () => {
             id: "req_1",
             options: [
               { id: "approve", kind: "allow-once", label: "Approve" },
-              { id: "deny", kind: "reject-once", label: "Deny" },
+              { id: "cancel", kind: "reject-once", label: "Cancel" },
               { id: "escalate", kind: "_escalate", label: "Escalate" },
             ],
           },
@@ -846,6 +852,7 @@ describe("convertEveMessages", () => {
       const events: readonly EveAgentReducerEvent[] = [
         {
           type: "authorization.required",
+          meta: eventMeta(0),
           data: {
             turnId: "turn_1",
             stepIndex: 0,
@@ -856,6 +863,7 @@ describe("convertEveMessages", () => {
         },
         {
           type: "turn.cancelled",
+          meta: eventMeta(1),
           data: { turnId: "turn_1", sequence: 1 },
         },
       ];
@@ -1010,14 +1018,22 @@ describe("convertEveMessages", () => {
         },
         {
           type: "turn.started",
+          meta: eventMeta(0),
           data: { turnId: "turn_1", sequence: 0 },
         },
         {
           type: "step.started",
-          data: { turnId: "turn_1", stepIndex: 0, sequence: 1 },
+          meta: eventMeta(1),
+          data: {
+            turnId: "turn_1",
+            stepIndex: 0,
+            sequence: 1,
+            modelId: "test-model",
+          },
         },
         {
           type: "message.appended",
+          meta: eventMeta(2),
           data: {
             turnId: "turn_1",
             stepIndex: 0,
@@ -1033,6 +1049,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "authorization.required",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1073,6 +1090,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "authorization.required",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1083,6 +1101,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "authorization.completed",
+            meta: eventMeta(4),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1112,6 +1131,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "authorization.required",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1122,6 +1142,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "authorization.required",
+            meta: eventMeta(4),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1132,6 +1153,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "authorization.completed",
+            meta: eventMeta(5),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1165,6 +1187,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "session.failed",
+            meta: eventMeta(3),
             data: { sessionId: "session_1", code: "internal", message: "boom" },
           },
         ]);
@@ -1188,6 +1211,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "turn.failed",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               sequence: 3,
@@ -1209,6 +1233,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents,
           {
             type: "message.completed",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1219,6 +1244,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "turn.completed",
+            meta: eventMeta(4),
             data: { turnId: "turn_1", sequence: 4 },
           },
         ]);
@@ -1428,7 +1454,7 @@ describe("toEveInputResponse", () => {
       }),
     ).toEqual({
       requestId: "req_1",
-      optionId: "deny",
+      optionId: "cancel",
       text: "Not yet",
     });
   });

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -24,7 +24,7 @@ import type {
   EveMessageInputRequest,
   EveMessagePart,
 } from "eve/react";
-import type { InputResponse, SendTurnPayload } from "eve/client";
+import type { InputResponse } from "eve/client";
 
 const ASSISTANT_COMPLETE_STATUS = {
   type: "complete",
@@ -148,7 +148,7 @@ const toolApprovalOptionsFromInputRequest = (
     kind:
       option.id === "approve"
         ? "allow-once"
-        : option.id === "deny"
+        : option.id === "cancel"
           ? "reject-once"
           : `_${option.id}`,
     ...(option.label && { label: option.label }),
@@ -419,12 +419,29 @@ export const convertEveMessages = (
   );
 
 /**
+ * Structural subset of the `string | UserContent` message content Eve's `send`
+ * API accepts. The helpers declare the shapes they produce and leave
+ * assignability to the send call site, checked against the installed version.
+ */
+export type EveMessageContent =
+  | string
+  | (
+      | { readonly type: "text"; readonly text: string }
+      | {
+          readonly type: "file";
+          readonly data: string;
+          readonly mediaType: string;
+          readonly filename?: string;
+        }
+    )[];
+
+/**
  * Converts an assistant-ui append message into the message payload accepted by
  * Eve's `send` API.
  */
 export const getEveMessageContent = (
   message: AppendMessage,
-): NonNullable<SendTurnPayload["message"]> => {
+): EveMessageContent => {
   const content = [
     ...message.content,
     ...(message.attachments?.flatMap((attachment) => attachment.content) ?? []),
@@ -496,6 +513,6 @@ export const toEveInputResponse = (
   response: RespondToToolApprovalOptions,
 ): InputResponse => ({
   requestId: response.approvalId,
-  optionId: response.optionId ?? (response.approved ? "approve" : "deny"),
+  optionId: response.optionId ?? (response.approved ? "approve" : "cancel"),
   ...(response.reason && { text: response.reason }),
 });

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -9,6 +9,7 @@ export {
 export type {
   ConvertEveMessagesOptions,
   EveAuthorizationData,
+  EveMessageContent,
 } from "./convertEveMessages";
 export { useEveAgentRuntime } from "./useEveAgentRuntime";
 export type { UseEveAgentRuntimeOptions } from "./useEveAgentRuntime";

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -34,6 +34,7 @@ const createAgent = (overrides: Record<string, unknown>) => ({
   session: undefined,
   status: "ready",
   send: vi.fn(),
+  respond: vi.fn(),
   stop: vi.fn(),
   reset: vi.fn(),
   ...overrides,
@@ -160,8 +161,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({
-        message: "hello",
+      expect(agent.send).toHaveBeenCalledWith("hello", {
         clientContext: { page: "/pricing" },
       });
     });
@@ -183,7 +183,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({ message: "hello" });
+      expect(agent.send).toHaveBeenCalledWith("hello", undefined);
     });
   });
 
@@ -204,7 +204,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({ message: "hello" });
+      expect(agent.send).toHaveBeenCalledWith("hello", undefined);
     });
   });
 
@@ -238,8 +238,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({
-        message: "hello",
+      expect(agent.send).toHaveBeenCalledWith("hello", {
         clientContext: { page: "/reload" },
       });
     });
@@ -272,8 +271,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({
-        message: "hello",
+      expect(agent.send).toHaveBeenCalledWith("hello", {
         clientContext: { page: "/staged" },
       });
     });
@@ -310,8 +308,7 @@ describe("useEveAgentRuntime status forwarding", () => {
     });
 
     await waitFor(() => {
-      expect(agent.send).toHaveBeenCalledWith({
-        message: "hello",
+      expect(agent.send).toHaveBeenCalledWith("hello", {
         clientContext: { page: "/staged" },
       });
     });
@@ -394,9 +391,7 @@ describe("useEveAgentRuntime staged messages", () => {
         content: [{ type: "text", text: "hello" }],
       });
     });
-    expect(agent.send).toHaveBeenCalledWith({
-      message: "hello",
-    });
+    expect(agent.send).toHaveBeenCalledWith("hello", undefined);
 
     mockUseEveAgent.mockReturnValue(
       createAgent({
@@ -504,8 +499,8 @@ describe("useEveAgentRuntime staged messages", () => {
     });
 
     expect(send).toHaveBeenCalledTimes(3);
-    expect(send).toHaveBeenNthCalledWith(2, { message: "first staged" });
-    expect(send).toHaveBeenNthCalledWith(3, { message: "second staged" });
+    expect(send).toHaveBeenNthCalledWith(2, "first staged", undefined);
+    expect(send).toHaveBeenNthCalledWith(3, "second staged", undefined);
     await waitFor(() => {
       expect(getText(result.current)).toEqual(["earlier", "earlier answer"]);
     });
@@ -541,12 +536,10 @@ describe("useEveAgentRuntime staged messages", () => {
 
     // the earlier draft keeps the context it was staged with; only the
     // reloaded message takes the reload-time config
-    expect(agent.send).toHaveBeenNthCalledWith(1, {
-      message: "first staged",
+    expect(agent.send).toHaveBeenNthCalledWith(1, "first staged", {
       clientContext: { page: "/first" },
     });
-    expect(agent.send).toHaveBeenNthCalledWith(2, {
-      message: "second staged",
+    expect(agent.send).toHaveBeenNthCalledWith(2, "second staged", {
       clientContext: { page: "/reloaded" },
     });
   });
@@ -569,9 +562,7 @@ describe("useEveAgentRuntime staged messages", () => {
     });
 
     expect(agent.send).toHaveBeenCalledTimes(1);
-    expect(agent.send).toHaveBeenCalledWith({
-      message: "first staged",
-    });
+    expect(agent.send).toHaveBeenCalledWith("first staged", undefined);
     await waitFor(() => {
       expect(getText(result.current)).toEqual([
         "earlier",
@@ -609,17 +600,13 @@ describe("useEveAgentRuntime staged messages", () => {
     });
 
     await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
-    expect(send).toHaveBeenNthCalledWith(1, {
-      message: "first staged",
-    });
+    expect(send).toHaveBeenNthCalledWith(1, "first staged", undefined);
 
     await act(async () => {
       resolveFirstSend();
     });
     await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
-    expect(send).toHaveBeenNthCalledWith(2, {
-      message: "second staged",
-    });
+    expect(send).toHaveBeenNthCalledWith(2, "second staged", undefined);
 
     await waitFor(() => {
       expect(getText(result.current)).toEqual(["earlier", "earlier answer"]);
@@ -681,7 +668,7 @@ describe("useEveAgentRuntime staged messages", () => {
     });
 
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith({ message: "first staged" });
+    expect(send).toHaveBeenCalledWith("first staged", undefined);
     await waitFor(() => {
       expect(getText(result.current)).toEqual([
         "earlier",
@@ -776,11 +763,12 @@ const approvalData: EveMessageData = {
               name: "send_email",
               inputRequest: {
                 requestId: "req_1",
+                kind: "tool-approval",
                 prompt: "Send the email?",
                 display: "confirmation",
                 options: [
                   { id: "approve", label: "Approve" },
-                  { id: "deny", label: "Deny" },
+                  { id: "cancel", label: "Cancel" },
                 ],
               },
             },
@@ -794,16 +782,14 @@ const approvalData: EveMessageData = {
 describe("useEveAgentRuntime concurrent sends", () => {
   it("defers an approval clicked while a turn is in flight until the turn parks", async () => {
     let resolveFirstSend!: () => void;
-    const send = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveFirstSend = resolve;
-          }),
-      )
-      .mockResolvedValue(undefined);
-    const agent = createAgent({ data: approvalData, send });
+    const send = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstSend = resolve;
+        }),
+    );
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const agent = createAgent({ data: approvalData, send, respond });
     mockUseEveAgent.mockReturnValue(agent as never);
     const { result } = renderHook(() => useEveAgentRuntime());
 
@@ -821,15 +807,15 @@ describe("useEveAgentRuntime concurrent sends", () => {
         .getMessagePartByToolCallId("call_1")
         .respondToToolApproval({ optionId: "approve" });
     });
-    expect(send).toHaveBeenCalledTimes(1);
+    expect(respond).not.toHaveBeenCalled();
 
     await act(async () => {
       resolveFirstSend();
     });
-    await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
-    expect(send).toHaveBeenNthCalledWith(2, {
-      inputResponses: [{ requestId: "req_1", optionId: "approve" }],
-    });
+    await waitFor(() => expect(respond).toHaveBeenCalledTimes(1));
+    expect(respond).toHaveBeenCalledWith([
+      { requestId: "req_1", optionId: "approve" },
+    ]);
   });
 
   it("queues a send issued while a turn is in flight and preserves order", async () => {
@@ -867,8 +853,8 @@ describe("useEveAgentRuntime concurrent sends", () => {
       resolveFirstSend();
     });
     await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
-    expect(send).toHaveBeenNthCalledWith(1, { message: "first" });
-    expect(send).toHaveBeenNthCalledWith(2, { message: "second" });
+    expect(send).toHaveBeenNthCalledWith(1, "first", undefined);
+    expect(send).toHaveBeenNthCalledWith(2, "second", undefined);
   });
 
   it("drops a queued send when the run is cancelled before it dispatches", async () => {
@@ -1007,16 +993,14 @@ describe("useEveAgentRuntime concurrent sends", () => {
 
   it("keeps a cancelled tool approval discarded", async () => {
     let resolveFirstSend!: () => void;
-    const send = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveFirstSend = resolve;
-          }),
-      )
-      .mockResolvedValue(undefined);
-    const agent = createAgent({ data: approvalData, send });
+    const send = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstSend = resolve;
+        }),
+    );
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const agent = createAgent({ data: approvalData, send, respond });
     mockUseEveAgent.mockReturnValue(agent as never);
     const { result } = renderHook(() => useEveAgentRuntime());
     const before = getText(result.current);
@@ -1043,6 +1027,7 @@ describe("useEveAgentRuntime concurrent sends", () => {
     });
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(respond).not.toHaveBeenCalled();
     expect(result.current.thread.composer.getState().text).toBe("");
     expect(getText(result.current)).toEqual(before);
   });
@@ -1142,10 +1127,10 @@ describe("useEveAgentRuntime concurrent sends", () => {
     });
     await waitFor(() => expect(send).toHaveBeenCalledTimes(3));
 
-    expect(send.mock.calls.map(([payload]) => payload)).toEqual([
-      { message: "first staged" },
-      { message: "interleaved" },
-      { message: "second staged" },
+    expect(send.mock.calls.map(([message]) => message)).toEqual([
+      "first staged",
+      "interleaved",
+      "second staged",
     ]);
   });
 });

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -91,9 +91,11 @@ type EveJsonValue =
   | { readonly [key: string]: EveJsonValue };
 
 /**
- * Structural equivalent of eve's `JsonObject`. Eve's transport payload types
- * are internal, so the helpers declare the shapes they forward and leave
- * assignability to the call site, checked against the installed version.
+ * Structural equivalent of eve's `JsonObject`. Eve demoted its public send
+ * payload type once already (`SendTurnPayload`, public through 0.30, internal
+ * from 0.31), so the helpers declare the shapes they forward instead of
+ * re-exporting eve's option types, and assignability is checked at the send
+ * call sites against the installed version.
  */
 type EveClientContext = { readonly [key: string]: EveJsonValue };
 

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -26,7 +26,6 @@ import {
   type UseEveAgentOptions,
   type UseEveAgentStatus,
 } from "eve/react";
-import type { SendTurnPayload } from "eve/client";
 import {
   convertEveMessages,
   getEveMessageContent,
@@ -83,22 +82,33 @@ const hasRunConfig = (
 ): runConfig is NonNullable<AppendMessage["runConfig"]> =>
   runConfig?.custom !== undefined && Object.keys(runConfig.custom).length > 0;
 
+type EveJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly EveJsonValue[]
+  | { readonly [key: string]: EveJsonValue };
+
+/**
+ * Structural equivalent of eve's `JsonObject`. Eve's transport payload types
+ * are internal, so the helpers declare the shapes they forward and leave
+ * assignability to the call site, checked against the installed version.
+ */
+type EveClientContext = { readonly [key: string]: EveJsonValue };
+
 /**
  * Only the `custom` bag crosses the wire. Eve reads `clientContext` as its own
  * namespace and serializes it into a model-visible context message, so sending
  * the assistant-ui envelope would surface a literal `"custom"` key in the
  * prompt and to every eve-side handler.
  */
-const toEveClientContext = (
+const toEveSendOptions = (
   runConfig: AppendMessage["runConfig"],
-): Pick<SendTurnPayload, "clientContext"> =>
+): { readonly clientContext: EveClientContext } | undefined =>
   hasRunConfig(runConfig)
-    ? {
-        clientContext: runConfig.custom as NonNullable<
-          SendTurnPayload["clientContext"]
-        >,
-      }
-    : {};
+    ? { clientContext: runConfig.custom as EveClientContext }
+    : undefined;
 
 export type UseEveAgentRuntimeOptions = Omit<
   UseEveAgentOptions<EveMessageData>,
@@ -218,20 +228,20 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
 
-  // Upstream `EveAgentStore.send` rejects while a turn is in flight and only
-  // resolves once the turn's stream parks, so a pending chain link is exactly
-  // an active turn; chaining every send serializes them without watching
-  // status.
+  // Upstream `EveAgentStore` `send` and `respond` reject while a turn is in
+  // flight and only resolve once the turn's stream parks, so a pending chain
+  // link is exactly an active turn; chaining every dispatch serializes them
+  // without watching status.
   const sendChainRef = useRef<Promise<void>>(Promise.resolve());
   const sendEpochRef = useRef(0);
   const isMountedRef = useRef(true);
 
-  const enqueueSend = (payload: Parameters<typeof agent.send>[0]) => {
+  const enqueueSend = (dispatch: () => Promise<void>) => {
     const epoch = sendEpochRef.current;
     const next = sendChainRef.current.then(() => {
       if (epoch !== sendEpochRef.current)
         throw isMountedRef.current ? sendCancelledError : sendAbandonedError;
-      return agent.send(payload);
+      return dispatch();
     });
     sendChainRef.current = next.catch(() => {});
     return next;
@@ -309,10 +319,12 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
         return;
       }
       try {
-        await enqueueSend({
-          message: getEveMessageContent(message),
-          ...toEveClientContext(message.runConfig),
-        });
+        await enqueueSend(() =>
+          agent.send(
+            getEveMessageContent(message),
+            toEveSendOptions(message.runConfig),
+          ),
+        );
       } catch (error) {
         // A cancelled send never reached the session, so it rethrows for the
         // composer to take the draft back; an unmounted one has no composer
@@ -347,10 +359,12 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
                   ? config.runConfig
                   : input.runConfig;
               try {
-                await enqueueSend({
-                  message: getEveMessageContent(input.message),
-                  ...toEveClientContext(runConfig),
-                });
+                await enqueueSend(() =>
+                  agent.send(
+                    getEveMessageContent(input.message),
+                    toEveSendOptions(runConfig),
+                  ),
+                );
               } catch (error) {
                 stagedInputsRef.current.set(stagedMessage.id, input);
                 messagesRef.current = previousMessages;
@@ -370,7 +384,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     },
     onRespondToToolApproval: async (response) => {
       try {
-        await enqueueSend({ inputResponses: [toEveInputResponse(response)] });
+        await enqueueSend(() => agent.respond([toEveInputResponse(response)]));
       } catch (error) {
         if (!isDroppedSend(error)) throw error;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       eve:
-        specifier: ^0.27.6
-        version: 0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.37.0
+        version: 0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       ink:
         specifier: ^7.1.1
         version: 7.1.1(@types/react@19.2.18)(react-devtools-core@6.1.5)(react@19.2.8)
@@ -1544,8 +1544,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.27.6
-        version: 0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.37.0
+        version: 0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -3658,8 +3658,8 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
       eve:
-        specifier: ^0.27.6
-        version: 0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.37.0
+        version: 0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -5381,8 +5381,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.27.6
-        version: 0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.37.0
+        version: 0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -13403,13 +13403,13 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eve@0.27.13:
-    resolution: {integrity: sha512-RN5EDp+w3H9kTH/92DYmWlt1vZ1vKLgdfoXpL9zRodC1wEBS51w97odDKcreR5+XtC+q+mNTmmAMQUQvk0c8gg==}
+  eve@0.37.0:
+    resolution: {integrity: sha512-wPjFLucADqWYGmnOaUrg7cCaWaxMAs/GFsy0O5Jb/2LqJ9wyN0RT/n3UKT1L4YJSrZds+anwdtFAgD57/rY3Zw==}
     engines: {node: '>=24'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
-      ai: ^7.0.38
+      ai: ^7.0.58
       braintrust: ^3.0.0
       just-bash: ^3.0.0
       microsandbox: ^0.5.0
@@ -28714,7 +28714,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  eve@0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.62(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.2)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -28762,7 +28762,7 @@ snapshots:
       - xml2js
       - zephyr-agent
 
-  eve@0.27.13(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  eve@0.37.0(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.2)(ai@7.0.62(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.2.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.62(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.2)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.2.0))(rollup@4.62.4)(sqlite3@5.1.7)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))

--- a/templates/eve/package.json
+++ b/templates/eve/package.json
@@ -22,7 +22,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.27.6",
+    "eve": "^0.37.0",
     "lucide-react": "^1.31.0",
     "next": "^16.3.0",
     "react": "^19.2.8",


### PR DESCRIPTION
supersedes #5607

## summary

- migrates @assistant-ui/eve to the session API eve shipped in 0.31: positional `agent.send(message, options)` with `clientContext` in the options bag, and HITL approvals through the separate `agent.respond(inputResponses, options)` instead of `send({ inputResponses })`
- raises the eve peer to `>=0.32.0` (forward-open, no ceiling) with the devDependency test pin at ^0.37.0, and moves api-surface, examples/with-eve, and templates/eve to ^0.37.0 in lockstep
- the floor is 0.32, not 0.31, because of a value-level protocol change: eve 0.32 renamed the negative approval option from `deny` to `cancel`, and the adapter's approval fallback emits that literal option id, so one source cannot be correct on both sides of that rename (the 0.31 line was superseded within two days)
- keeps #5607's structural-type approach (`EveMessageContent`, `EveClientContext`) and its 0.28+ event fixtures; `SendTurnPayload` is internal from 0.31 so the helpers declare the shapes they produce, now aligned with the `string | UserContent` contract eve 0.37 actually accepts
- the send-chain serialization is unchanged on purpose: eve 0.37's `EveAgentStore` `send` and `respond` still reject while a turn is in flight (verified in the shipped types), and the 0.33 `turnPolicy: "steer"` default applies to channel sends, not the client hook
- fixtures gain the `modelId` that 0.37 requires on `step.started`, and approval option fixtures move to the approve/cancel pair

## test plan

### already verified

- [x] `vitest run` in packages/eve -> 87/87 against eve 0.37.0
- [x] `tsc --noEmit` in packages/eve -> clean
- [x] runtime ESM-link smoke on the built dist -> all five exports import cleanly (the eve-family failure mode a green build does not catch)
- [x] `tsc --noEmit` in examples/with-eve -> clean (it only uses `defineAgent` / `withEve`, untouched by the 0.31 break)
- [x] api-surface and the docs eve.mdx page regenerated via their generators; `pnpm api-surface:check` -> 39 files, no drift
- [x] `pnpm lint` -> clean

### reviewer should verify

- [ ] a live tool-approval round-trip against a real eve 0.37 server (approve and cancel both resolve the pending input request); unit coverage asserts the wire shapes but no live server ran in this validation

## notes

- builds on the structural-type and fixture work from #5607; that PR capped the peer at `<0.31.0` to avoid the session API break, and this one migrates through it instead so the range stays forward-open
- consumers staying on eve 0.27-0.31 pin the previous @assistant-ui/eve release; the peer floor raise rides the usual patch changeset per the repo's semver policy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Ipd97iMy_F3TKyPCBUUAYnJ1zy-U-EJ3T1hcX4Yp8H1f3UITD0KrYdTEZI4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->