### PR TITLE
feat(svelte): melt-style builders for the composer and message list

### DIFF
--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -1,38 +1,30 @@
 <script lang="ts">
-  import { useAui, useAuiState } from "@assistant-ui/svelte";
   import {
-    composerInputDisabled,
-    composerSendDisabled,
-  } from "@assistant-ui/core/store/internal";
+    composerCancel,
+    composerInput,
+    composerSend,
+    threadMessages,
+    useAui,
+    useAuiState,
+  } from "@assistant-ui/svelte";
   import { ArrowUpIcon, PlusIcon, SquareIcon } from "@lucide/svelte";
   import Message from "./Message.svelte";
 
   const aui = useAui();
-  const messages = useAuiState((s) => s.thread.messages);
+  const messages = threadMessages();
   const isRunning = useAuiState((s) => s.thread.isRunning);
   const suggestions = useAuiState((s) => s.suggestions.suggestions);
-  const text = useAuiState((s) => s.composer.text);
-  const sendDisabled = useAuiState(composerSendDisabled);
-  const inputDisabled = useAuiState(composerInputDisabled);
+  const input = composerInput();
+  const send = composerSend();
+  const cancel = composerCancel();
 
   let viewport = $state<HTMLElement>();
 
   $effect(() => {
-    void messages.current.length;
+    void messages.items.length;
     void isRunning.current;
     viewport?.scrollTo({ top: viewport.scrollHeight });
   });
-
-  const onInput = (event: Event) => {
-    aui.composer.setText((event.currentTarget as HTMLTextAreaElement).value);
-  };
-
-  const onKeydown = (event: KeyboardEvent) => {
-    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
-    if (sendDisabled.current || inputDisabled.current) return;
-    event.preventDefault();
-    aui.composer.send();
-  };
 
   const sendSuggestion = (prompt: string) => {
     aui.composer.setText(prompt);
@@ -57,7 +49,7 @@
     class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
   >
     <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
-      {#if messages.current.length === 0}
+      {#if messages.items.length === 0}
         <div class="flex flex-1 flex-col items-center justify-center gap-6 pb-24">
           <h1 class="text-2xl font-semibold">How can I help you today?</h1>
           <div class="flex flex-wrap items-center justify-center gap-2 px-4">
@@ -76,7 +68,7 @@
         </div>
       {/if}
       <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-        {#each messages.current as message (message.id)}
+        {#each messages.items as message (message.id)}
           <Message {message} />
         {/each}
         {#if isRunning.current}
@@ -92,30 +84,26 @@
       class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
     >
       <textarea
+        {...input.props}
         class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
         placeholder="Send a message..."
         name="message"
         rows="1"
-        value={text.current}
-        disabled={inputDisabled.current}
-        oninput={onInput}
-        onkeydown={onKeydown}
       ></textarea>
       <div class="flex items-center justify-end">
         {#if !isRunning.current}
           <button
+            {...send.props}
             class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
             aria-label="Send"
-            disabled={sendDisabled.current}
-            onclick={() => aui.composer.send()}
           >
             <ArrowUpIcon class="size-4.5" />
           </button>
         {:else}
           <button
+            {...cancel.props}
             class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
             aria-label="Stop"
-            onclick={() => aui.composer.cancel()}
           >
             <SquareIcon class="size-3.5 fill-current" />
           </button>

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -1,4 +1,9 @@
 import { useEffect, useState } from "react";
+import { vi } from "vitest";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
 import { resource } from "@assistant-ui/tap";
 import { useAssistantEmit } from "@assistant-ui/store/client";
 
@@ -40,4 +45,69 @@ export const createTrackedThread = () => {
     return { getState: () => ({ selected }), setSelected };
   };
   return { TrackedThread: resource(useTracked), counters };
+};
+
+type EchoMessage = { id: string; role: "user" | "assistant"; text: string };
+
+export const createEchoRuntime = () => {
+  let nextId = 0;
+  let messages: EchoMessage[] = [];
+  let isRunning = false;
+  const onNew = vi.fn(async (message: any) => {
+    const text = message.content
+      .map((part: any) => (part.type === "text" ? part.text : ""))
+      .join("");
+    messages = [...messages, { id: `u${nextId++}`, role: "user", text }];
+    sync();
+  });
+  const onEdit = vi.fn(async (message: any) => {
+    const text = message.content
+      .map((part: any) => (part.type === "text" ? part.text : ""))
+      .join("");
+    const parentIndex = message.parentId
+      ? messages.findIndex((entry) => entry.id === message.parentId) + 1
+      : 0;
+    messages = [
+      ...messages.slice(0, parentIndex),
+      { id: `u${nextId++}`, role: "user", text },
+    ];
+    sync();
+  });
+  const onCancel = vi.fn(async () => {
+    isRunning = false;
+    queueMicrotask(sync);
+  });
+  const makeAdapter = () => ({
+    messages,
+    isRunning,
+    convertMessage: (message: EchoMessage) => ({
+      id: message.id,
+      role: message.role,
+      content: [{ type: "text" as const, text: message.text }],
+    }),
+    setMessages: (next: EchoMessage[]) => {
+      messages = next;
+      sync();
+    },
+    onNew,
+    onEdit,
+    onCancel,
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter() as never);
+  const sync = () => core.setAdapter(makeAdapter() as never);
+  const runtime = new AssistantRuntimeImpl(core as never);
+  return {
+    runtime,
+    onNew,
+    onEdit,
+    onCancel,
+    setMessages: (next: EchoMessage[]) => {
+      messages = next;
+      sync();
+    },
+    setRunning: (value: boolean) => {
+      isRunning = value;
+      sync();
+    },
+  };
 };

--- a/packages/svelte/src/__tests__/fixtures/SpreadProbe.svelte
+++ b/packages/svelte/src/__tests__/fixtures/SpreadProbe.svelte
@@ -1,0 +1,8 @@
+<script>
+  let { setup } = $props();
+  // svelte-ignore state_referenced_locally
+  const built = setup();
+</script>
+
+<textarea {...built.input.props}></textarea>
+<button {...built.send.props}></button>

--- a/packages/svelte/src/__tests__/primitives-composer.test.ts
+++ b/packages/svelte/src/__tests__/primitives-composer.test.ts
@@ -10,6 +10,7 @@ import {
   composerSend,
 } from "../primitives/composer";
 import Host from "./fixtures/Host.svelte";
+import SpreadProbe from "./fixtures/SpreadProbe.svelte";
 import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
 
 const target = () => document.createElement("div");
@@ -92,6 +93,7 @@ describe("composer builders", () => {
     };
 
     expect(enter({ shiftKey: true }).defaultPrevented).toBe(false);
+    expect(enter({ isComposing: true }).defaultPrevented).toBe(false);
     expect(echo.onNew).not.toHaveBeenCalled();
 
     expect(enter({}).defaultPrevented).toBe(true);
@@ -117,6 +119,64 @@ describe("composer builders", () => {
     cancel.props.onclick();
     await flushEvents();
     expect(echo.onCancel).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+  it("submitOnEnter false never submits and a prevented click vetoes", async () => {
+    let aui!: AnyClient;
+    let input!: ReturnType<typeof composerInput>;
+    let send!: ReturnType<typeof composerSend>;
+    const { app, echo } = mountEcho((tools) => {
+      aui = tools.aui;
+      input = composerInput({ submitOnEnter: false });
+      send = composerSend();
+    });
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    const enter = new KeyboardEvent("keydown", {
+      key: "Enter",
+      cancelable: true,
+    });
+    input.props.onkeydown(enter);
+    expect(enter.defaultPrevented).toBe(false);
+    expect(echo.onNew).not.toHaveBeenCalled();
+
+    const vetoed = new MouseEvent("click", { cancelable: true });
+    vetoed.preventDefault();
+    send.props.onclick(vetoed);
+    expect(echo.onNew).not.toHaveBeenCalled();
+
+    send.props.onclick();
+    await flushEvents();
+    expect(echo.onNew).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("spread props bind reactively on real elements", async () => {
+    let aui!: AnyClient;
+    const echo = createEchoRuntime();
+    const host = target();
+    const app = mount(SpreadProbe, {
+      target: host,
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({ threads: RuntimeAdapter(echo.runtime) }),
+          ) as AnyClient;
+          return { input: composerInput(), send: composerSend() };
+        },
+      },
+    });
+
+    const textarea = host.querySelector("textarea")!;
+    const button = host.querySelector("button")!;
+    expect(button.disabled).toBe(true);
+    expect(textarea.value).toBe("");
+
+    flushTapSync(() => aui.composer.setText("typed"));
+    await vi.waitFor(() => expect(textarea.value).toBe("typed"));
+    expect(button.disabled).toBe(false);
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/__tests__/primitives-composer.test.ts
+++ b/packages/svelte/src/__tests__/primitives-composer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import {
+  composerCancel,
+  composerInput,
+  composerSend,
+} from "../primitives/composer";
+import Host from "./fixtures/Host.svelte";
+import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
+
+const target = () => document.createElement("div");
+
+const mountEcho = (
+  setup: (tools: { aui: AnyClient }) => void,
+  echo = createEchoRuntime(),
+) => {
+  const app = mount(Host, {
+    target: target(),
+    props: {
+      setup: () => {
+        const aui = provideAui(
+          AuiConfig({ threads: RuntimeAdapter(echo.runtime) }),
+        ) as AnyClient;
+        setup({ aui });
+      },
+    },
+  });
+  return { app, echo };
+};
+
+describe("composer builders", () => {
+  it("send flips disabled with the draft and routes clicks to the adapter", async () => {
+    let aui!: AnyClient;
+    let send!: ReturnType<typeof composerSend>;
+    const { app, echo } = mountEcho((tools) => {
+      aui = tools.aui;
+      send = composerSend();
+    });
+
+    expect(send.props.type).toBe("button");
+    expect(send.props.disabled).toBe(true);
+
+    flushTapSync(() => aui.composer.setText("hello"));
+    expect(send.props.disabled).toBe(false);
+
+    send.props.onclick();
+    await flushEvents();
+    expect(echo.onNew).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(aui.composer.getState().text).toBe(""));
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("send onclick is inert while disabled", () => {
+    let send!: ReturnType<typeof composerSend>;
+    const { app, echo } = mountEcho(() => {
+      send = composerSend();
+    });
+
+    send.props.onclick();
+    expect(echo.onNew).not.toHaveBeenCalled();
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("input binds the draft and submits on Enter with newline fallthrough", async () => {
+    let aui!: AnyClient;
+    let input!: ReturnType<typeof composerInput>;
+    const { app, echo } = mountEcho((tools) => {
+      aui = tools.aui;
+      input = composerInput();
+    });
+
+    const textarea = document.createElement("textarea");
+    textarea.value = "draft";
+    input.props.oninput({ target: textarea } as unknown as Event);
+    expect(input.props.value).toBe("draft");
+    expect(aui.composer.getState().text).toBe("draft");
+
+    const enter = (init: KeyboardEventInit) => {
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        cancelable: true,
+        ...init,
+      });
+      input.props.onkeydown(event);
+      return event;
+    };
+
+    expect(enter({ shiftKey: true }).defaultPrevented).toBe(false);
+    expect(echo.onNew).not.toHaveBeenCalled();
+
+    expect(enter({}).defaultPrevented).toBe(true);
+    await flushEvents();
+    expect(echo.onNew).toHaveBeenCalledTimes(1);
+
+    // The draft is now empty, so Enter cannot send and falls through
+    expect(enter({}).defaultPrevented).toBe(false);
+    expect(echo.onNew).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("cancel routes to the adapter during a run", async () => {
+    let cancel!: ReturnType<typeof composerCancel>;
+    const { app, echo } = mountEcho(() => {
+      cancel = composerCancel();
+    });
+
+    flushTapSync(() => echo.setRunning(true));
+    await vi.waitFor(() => expect(cancel.props.disabled).toBe(false));
+
+    cancel.props.onclick();
+    await flushEvents();
+    expect(echo.onCancel).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/primitives-messages.test.ts
+++ b/packages/svelte/src/__tests__/primitives-messages.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import { useAuiState } from "../useAuiState";
+import { composerInput, composerSend } from "../primitives/composer";
+import { threadMessages } from "../primitives/threadMessages";
+import Host from "./fixtures/Host.svelte";
+import StateProbe from "./fixtures/StateProbe.svelte";
+import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
+
+const target = () => document.createElement("div");
+
+describe("threadMessages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the live message list and cached per-index items", async () => {
+    let aui!: AnyClient;
+    let messages!: ReturnType<typeof threadMessages>;
+    const echo = createEchoRuntime();
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({ threads: RuntimeAdapter(echo.runtime) }),
+          ) as AnyClient;
+          messages = threadMessages();
+        },
+      },
+    });
+
+    expect(messages.items).toHaveLength(0);
+
+    flushTapSync(() => aui.composer.setText("hello"));
+    flushTapSync(() => aui.composer.send());
+    await vi.waitFor(() => expect(messages.items).toHaveLength(1));
+    expect(messages.items[0]!.role).toBe("user");
+
+    const item = messages.item(0);
+    expect(messages.item(0)).toBe(item);
+    expect(useAuiState((s) => s.message.role, { item }).current).toBe("user");
+    expect(
+      useAuiState((s) => (s.message.content[0] as AnyClient).text, { item })
+        .current,
+    ).toBe("hello");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("edits a message through the item's edit composer builders", async () => {
+    let messages!: ReturnType<typeof threadMessages>;
+    const echo = createEchoRuntime();
+    echo.setMessages([{ id: "u0", role: "user", text: "original" }]);
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+          messages = threadMessages();
+        },
+      },
+    });
+
+    const item = messages.item(0);
+    const input = composerInput({ item });
+    const send = composerSend({ item });
+
+    // Before beginEdit the edit composer rejects typing and stays empty
+    const textarea = document.createElement("textarea");
+    textarea.value = "typed";
+    input.props.oninput({ target: textarea } as unknown as Event);
+    expect(textarea.value).toBe("");
+    expect(input.props.value).toBe("");
+
+    flushTapSync(() => item.aui.composer.beginEdit());
+    expect(input.props.value).toBe("original");
+
+    textarea.value = "edited";
+    input.props.oninput({ target: textarea } as unknown as Event);
+    expect(input.props.value).toBe("edited");
+
+    send.props.onclick();
+    await flushEvents();
+    expect(echo.onEdit).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(
+        useAuiState((s) => (s.message.content[0] as AnyClient).text, { item })
+          .current,
+      ).toBe("edited"),
+    );
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("serves the last valid item through a shrink and reports once settled", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let messages!: ReturnType<typeof threadMessages>;
+    const echo = createEchoRuntime();
+    echo.setMessages([
+      { id: "u0", role: "user", text: "first" },
+      { id: "u1", role: "user", text: "second" },
+    ]);
+    const onValue = vi.fn();
+    const app = mount(StateProbe, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+          messages = threadMessages();
+          const text = useAuiState(
+            (s) => (s.message.content[0] as AnyClient).text,
+            { item: messages.item(1) },
+          );
+          return () => text.current;
+        },
+        onValue,
+      },
+    });
+
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledWith("second"));
+
+    flushTapSync(() =>
+      echo.setMessages([{ id: "u0", role: "user", text: "first" }]),
+    );
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(String(errorSpy.mock.calls[0]![0])).toContain("index 1");
+
+    // A never-valid index resolves at first read and throws immediately
+    expect(
+      () =>
+        useAuiState((s) => s.message.role, { item: messages.item(5) }).current,
+    ).toThrow();
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/primitives-messages.test.ts
+++ b/packages/svelte/src/__tests__/primitives-messages.test.ts
@@ -138,4 +138,40 @@ describe("threadMessages", () => {
 
     flushSync(() => void unmount(app));
   });
+  it("stays quiet on a shrink with no remaining observers", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let messages!: ReturnType<typeof threadMessages>;
+    const echo = createEchoRuntime();
+    echo.setMessages([
+      { id: "u0", role: "user", text: "first" },
+      { id: "u1", role: "user", text: "second" },
+    ]);
+    const onValue = vi.fn();
+    const app = mount(StateProbe, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+          messages = threadMessages();
+          const text = useAuiState(
+            (s) => (s.message.content[0] as AnyClient).text,
+            { item: messages.item(1) },
+          );
+          return () => text.current;
+        },
+        onValue,
+      },
+    });
+    await vi.waitFor(() => expect(onValue).toHaveBeenCalledWith("second"));
+
+    // Release every observer before the shrink; the suspended item must not
+    // report a stale scope for a row nobody reads
+    flushSync(() => void unmount(app));
+    flushTapSync(() =>
+      echo.setMessages([{ id: "u0", role: "user", text: "first" }]),
+    );
+    await flushEvents();
+    await flushEvents();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/svelte/src/context.ts
+++ b/packages/svelte/src/context.ts
@@ -11,6 +11,12 @@ export type AuiContext = {
   aui: AssistantClient;
 };
 
+/**
+ * The scope a builder or `useAuiState` binds to: the surrounding provider by
+ * default, or a per-item handle such as a `MessageItem`.
+ */
+export type ScopeTarget = AuiContext;
+
 export const auiContextKey: symbol = Symbol("assistant-ui.svelte.aui");
 
 const NO_OP_SUBSCRIBE = () => () => {};

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -3,6 +3,14 @@ export { useAui } from "./useAui";
 export { useAuiState } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
 
+export type { ScopeTarget } from "./context";
+export {
+  composerCancel,
+  composerInput,
+  composerSend,
+} from "./primitives/composer";
+export { threadMessages, type MessageItem } from "./primitives/threadMessages";
+
 export {
   AuiConfig,
   Derived,

--- a/packages/svelte/src/primitives/composer.ts
+++ b/packages/svelte/src/primitives/composer.ts
@@ -68,6 +68,10 @@ export const composerInput = (options?: {
  * Builder for the send button. Spread `props` onto a `<button>`. Disabled
  * while the composer cannot send or a queueless run is in flight. Without
  * `item`, call during component initialization.
+ *
+ * A caller's own `onclick` next to the spread replaces the builder's; compose
+ * by forwarding the event (`onclick={(e) => { mine(e); send.props.onclick(e);
+ * }}`), and a forwarded event that was `preventDefault`ed vetoes the send.
  */
 export const composerSend = (options?: { item?: ScopeTarget | undefined }) => {
   const item = resolveTarget(options?.item);
@@ -80,8 +84,8 @@ export const composerSend = (options?: { item?: ScopeTarget | undefined }) => {
       get disabled() {
         return disabled.current;
       },
-      onclick: () => {
-        if (disabled.current) return;
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented || disabled.current) return;
         aui.composer.send();
       },
     },
@@ -91,7 +95,7 @@ export const composerSend = (options?: { item?: ScopeTarget | undefined }) => {
 /**
  * Builder for the cancel button. Spread `props` onto a `<button>`. Disabled
  * while nothing is cancelable. Without `item`, call during component
- * initialization.
+ * initialization. Caller handlers compose the same way as `composerSend`.
  */
 export const composerCancel = (options?: {
   item?: ScopeTarget | undefined;
@@ -106,8 +110,8 @@ export const composerCancel = (options?: {
       get disabled() {
         return disabled.current;
       },
-      onclick: () => {
-        if (disabled.current) return;
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented || disabled.current) return;
         aui.composer.cancel();
       },
     },

--- a/packages/svelte/src/primitives/composer.ts
+++ b/packages/svelte/src/primitives/composer.ts
@@ -1,0 +1,115 @@
+import { flushTapSync } from "@assistant-ui/tap";
+import {
+  composerCancelDisabled,
+  composerInputDisabled,
+  composerSendDisabled,
+} from "@assistant-ui/core/store/internal";
+import { getAuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const resolveTarget = (item: ScopeTarget | undefined): ScopeTarget =>
+  item ?? getAuiContext();
+
+/**
+ * Builder for the composer textarea. Spread `props` onto a `<textarea>`.
+ *
+ * Enter submits (Shift+Enter inserts a newline, IME composition is ignored)
+ * unless `submitOnEnter` is false; an Enter that cannot send falls through to
+ * a newline. While the composer is not editing (an edit composer before
+ * `beginEdit`), the value stays controlled to the empty composer text.
+ * Without `item`, call during component initialization.
+ */
+export const composerInput = (options?: {
+  submitOnEnter?: boolean | undefined;
+  item?: ScopeTarget | undefined;
+}) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const submitOnEnter = options?.submitOnEnter ?? true;
+
+  const text = useAuiState(
+    (s) => (s.composer.isEditing ? s.composer.text : ""),
+    { item },
+  );
+  const inputDisabled = useAuiState(composerInputDisabled, { item });
+  const sendDisabled = useAuiState(composerSendDisabled, { item });
+
+  const oninput = (event: Event) => {
+    const target = event.target as HTMLTextAreaElement;
+    if (!aui.composer.getState().isEditing) {
+      target.value = text.current;
+      return;
+    }
+    flushTapSync(() => aui.composer.setText(target.value));
+  };
+  const onkeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented || !submitOnEnter) return;
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+    if (sendDisabled.current || inputDisabled.current) return;
+    event.preventDefault();
+    aui.composer.send();
+  };
+
+  return {
+    props: {
+      get value() {
+        return text.current;
+      },
+      get disabled() {
+        return inputDisabled.current;
+      },
+      oninput,
+      onkeydown,
+    },
+  };
+};
+
+/**
+ * Builder for the send button. Spread `props` onto a `<button>`. Disabled
+ * while the composer cannot send or a queueless run is in flight. Without
+ * `item`, call during component initialization.
+ */
+export const composerSend = (options?: { item?: ScopeTarget | undefined }) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const disabled = useAuiState(composerSendDisabled, { item });
+
+  return {
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick: () => {
+        if (disabled.current) return;
+        aui.composer.send();
+      },
+    },
+  };
+};
+
+/**
+ * Builder for the cancel button. Spread `props` onto a `<button>`. Disabled
+ * while nothing is cancelable. Without `item`, call during component
+ * initialization.
+ */
+export const composerCancel = (options?: {
+  item?: ScopeTarget | undefined;
+}) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const disabled = useAuiState(composerCancelDisabled, { item });
+
+  return {
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick: () => {
+        if (disabled.current) return;
+        aui.composer.cancel();
+      },
+    },
+  };
+};

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -27,7 +27,9 @@ export type MessageItem = ScopeTarget;
 // live observation: an ordinary shrink whose rows tear down in the same flush
 // settles with no observers and stays quiet, while a row still reading an out
 // of bounds index reports, matching the vue provider whose isCurrent dies
-// with the row.
+// with the row. Known limit: an out-transitioned row is paused, not
+// destroyed, so its observer outlives the expiry and a shrink may report;
+// revisited with the transitions-aware list chunk.
 const createMessageItem = (context: AuiContext, index: number): MessageItem => {
   let observers = 0;
   const messageCache = createLastValidCache<MessageMethods>(

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -1,6 +1,9 @@
 import { tick } from "svelte";
-import type { ThreadMessage } from "@assistant-ui/core";
-import type { ComposerMethods, MessageMethods } from "@assistant-ui/core/store";
+import type {
+  ComposerMethods,
+  MessageMethods,
+  MessageState,
+} from "@assistant-ui/core/store";
 import {
   AuiConfig,
   createAssistantClient,
@@ -116,14 +119,11 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
  */
 export const threadMessages = () => {
   const context = getAuiContext();
-  const items = useAuiState(
-    (s) => s.thread.messages as readonly ThreadMessage[],
-    { item: context },
-  );
+  const items = useAuiState((s) => s.thread.messages, { item: context });
   const cache = new Map<number, MessageItem>();
 
   return {
-    get items(): readonly ThreadMessage[] {
+    get items(): readonly MessageState[] {
       return items.current;
     },
     item: (index: number): MessageItem => {

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -75,8 +75,11 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
   const source = {
     getClient: handle.getClient,
     subscribe: (listener: () => void) => {
-      observers++;
+      // Increment only after a successful subscribe: the first one commits the
+      // mount, which throws for a never-valid index and must not latch the
+      // observer count
       const release = handle.subscribe(listener);
+      observers++;
       let subscribed = true;
       return () => {
         if (!subscribed) return;

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -23,12 +23,18 @@ const scheduleExpiry = (callback: () => void) => void tick().then(callback);
  */
 export type MessageItem = ScopeTarget;
 
+// The item is cached beyond any row's life, so the stale reporter binds to
+// live observation: an ordinary shrink whose rows tear down in the same flush
+// settles with no observers and stays quiet, while a row still reading an out
+// of bounds index reports, matching the vue provider whose isCurrent dies
+// with the row.
 const createMessageItem = (context: AuiContext, index: number): MessageItem => {
+  let observers = 0;
   const messageCache = createLastValidCache<MessageMethods>(
     createStaleReporter({
       name: "threadMessages.item",
       index,
-      isCurrent: () => true,
+      isCurrent: () => observers > 0,
       isValid: () =>
         index < context.source.getClient().thread.getState().messages.length,
     }),
@@ -63,9 +69,22 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
     { parent: context.source },
   );
 
+  // No destroy pairing (unlike provideAui's lifetime subscription): the item
+  // deliberately rides observation alone, suspending when its readers release
+  // and resuming with state intact.
   const source = {
     getClient: handle.getClient,
-    subscribe: handle.subscribe,
+    subscribe: (listener: () => void) => {
+      observers++;
+      const release = handle.subscribe(listener);
+      let subscribed = true;
+      return () => {
+        if (!subscribed) return;
+        subscribed = false;
+        observers--;
+        release();
+      };
+    },
   };
   return {
     source,

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -22,7 +22,9 @@ const scheduleExpiry = (callback: () => void) => void tick().then(callback);
  * the builders resolve `s.message` to the message at the index and
  * `s.composer` to its edit composer, extending the surrounding provider. The
  * handle's scopes mount when the first reader is observed and suspend once
- * none remain, so a row should read state before invoking actions.
+ * none remain. While unobserved the item's client is frozen at its last
+ * render: reads return stale state and actions can throw before the first
+ * observer, so a row must read state before invoking actions.
  */
 export type MessageItem = ScopeTarget;
 

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -1,0 +1,114 @@
+import { tick } from "svelte";
+import type { ThreadMessage } from "@assistant-ui/core";
+import type { ComposerMethods, MessageMethods } from "@assistant-ui/core/store";
+import {
+  AuiConfig,
+  createAssistantClient,
+  createClientFacade,
+  createLastValidCache,
+  createStaleReporter,
+  Derived,
+} from "@assistant-ui/store/client";
+import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+
+/**
+ * A per-index handle over one thread message: through it, `useAuiState` and
+ * the builders resolve `s.message` to the message at the index and
+ * `s.composer` to its edit composer, extending the surrounding provider. The
+ * handle's scopes mount when the first reader is observed and suspend once
+ * none remain, so a row should read state before invoking actions.
+ */
+export type MessageItem = ScopeTarget;
+
+const createMessageItem = (context: AuiContext, index: number): MessageItem => {
+  const messageCache = createLastValidCache<MessageMethods>(
+    createStaleReporter({
+      name: "threadMessages.item",
+      index,
+      isCurrent: () => true,
+      isValid: () =>
+        index < context.source.getClient().thread.getState().messages.length,
+    }),
+    scheduleExpiry,
+  );
+  const composerCache = createLastValidCache<ComposerMethods>(
+    null,
+    scheduleExpiry,
+  );
+
+  const handle = createAssistantClient(
+    AuiConfig({
+      message: Derived({
+        source: "thread",
+        query: { type: "index", index },
+        get: (aui) =>
+          messageCache.resolve(
+            index < aui.thread.getState().messages.length,
+            () => aui.thread.message({ index }),
+          ),
+      }),
+      composer: Derived({
+        source: "message",
+        query: {},
+        get: (aui) =>
+          composerCache.resolve(
+            index < aui.thread.getState().messages.length,
+            () => aui.thread.message({ index }).composer(),
+          ),
+      }),
+    }),
+    { parent: context.source },
+  );
+
+  const source = {
+    getClient: handle.getClient,
+    subscribe: handle.subscribe,
+  };
+  return {
+    source,
+    aui: createClientFacade(source),
+  };
+};
+
+/**
+ * Builder for the thread's message list. Call during component
+ * initialization; iterate `items` keyed by message id and scope per-row work
+ * through `item(index)`.
+ *
+ * Items are cached per index for the builder's lifetime: a row that stops
+ * being observed suspends its scopes and resumes with state intact when a
+ * later render reads it again.
+ *
+ * @example
+ * ```svelte
+ * const messages = threadMessages();
+ * // {#each messages.items as message, index (message.id)}
+ * //   {@const item = messages.item(index)}
+ * // {/each}
+ * ```
+ */
+export const threadMessages = () => {
+  const context = getAuiContext();
+  const items = useAuiState(
+    (s) => s.thread.messages as readonly ThreadMessage[],
+    { item: context },
+  );
+  const cache = new Map<number, MessageItem>();
+
+  return {
+    get items(): readonly ThreadMessage[] {
+      return items.current;
+    },
+    item: (index: number): MessageItem => {
+      let item = cache.get(index);
+      if (!item) {
+        item = createMessageItem(context, index);
+        cache.set(index, item);
+      }
+      return item;
+    },
+  };
+};

--- a/packages/svelte/src/useAuiState.ts
+++ b/packages/svelte/src/useAuiState.ts
@@ -3,11 +3,15 @@ import {
   getProxiedAssistantState,
   type AssistantState,
 } from "@assistant-ui/store/client";
-import { getAuiContext } from "./context";
+import { getAuiContext, type ScopeTarget } from "./context";
 
 /**
  * Subscribes to a slice of `AssistantState` and returns it behind a reactive
- * `current` getter. Call during component initialization.
+ * `current` getter.
+ *
+ * Reads the surrounding provider's scopes by default (call during component
+ * initialization); pass `item` (a per-item handle such as a `MessageItem`
+ * from `threadMessages`) to read that item's scopes instead, from anywhere.
  *
  * Reading `current` inside an effect or template tracks the store: the read
  * re-runs when the selected slice changes by `Object.is`, so a store update
@@ -28,8 +32,9 @@ import { getAuiContext } from "./context";
  */
 export const useAuiState = <T>(
   selector: (state: AssistantState) => T,
+  options?: { item?: ScopeTarget | undefined },
 ): { readonly current: T } => {
-  const { source } = getAuiContext();
+  const source = (options?.item ?? getAuiContext()).source;
 
   // Wake dependents only when the selected slice changes by Object.is, matching
   // the react (useSyncExternalStore) and vue (computed) bridges: a store tick


### PR DESCRIPTION
## summary

- first wave of the svelte primitives layer, shipped as melt-style builder functions rather than components, so the package stays plain TypeScript with no compiled Svelte: `composerInput`, `composerSend`, and `composerCancel` return spreadable `props` bags with reactive getters, consuming the shared disabled predicates from `@assistant-ui/core/store/internal` and matching the vue primitives' keyboard and veto semantics point for point (Enter submits, Shift+Enter and IME composition fall through, an Enter that cannot send falls through to a newline, prevented events veto, edit composers reject typing before `beginEdit`). attr-intent inertness (vue's `isAttrDisabled`) is inherent to rendering components and deliberately outside the builder contract: a builder never sees the attributes merged next to its props.
- `threadMessages()` exposes the live message list plus `item(index)`: an explicit per-index handle backed by a child `createAssistantClient` extending the provider (the vue `MessageByIndexProvider` Derived recipe verbatim, guarded by the shared last-valid cache). items are cached per index; a row that stops being observed suspends its scopes under the #5889 lifecycle and resumes with state intact.
- `useAuiState` gains an optional `{ item }` target and stays the single state-reading function: builders consume it internally, and per-item reads in userland use the same call with the same selector contract and dedup semantics. the standing division is builders expose behavior, `useAuiState` reads state.
- `examples/with-svelte` now drives its composer and message list through the builders; the hand-rolled input handlers and disabled wiring are deleted.

## test plan

### already verified

- [x] `pnpm -C packages/svelte test` -> 22/22 (7 new: send disabled flip and adapter routing, disabled clicks inert, the Enter matrix incl. newline fallthrough, cancel during a run, item cache identity, the edit flow through `{ item }` builders incl. the pre-beginEdit revert, and the shrink race pinning the observable contract: one stale report after settle plus a never-valid index throwing at first read)
- [x] `pnpm -C packages/svelte exec tsc --noEmit` clean; oxlint clean; `pnpm -C examples/with-svelte build` green
- [x] browser E2E on the example: suggestion send, typed Enter send, echo replies, send button disabled states, console free of errors (favicon 404 noise only)

### reviewer should verify

- [ ] `pnpm -C examples/with-svelte dev`: the composer should feel identical to the pre-builder version (typing, Enter, disabled states, stop button), since the builders are a refactor of the same semantics behind spreadable props

## notes

- builder handlers are unit-called in tests because svelte 5 event delegation ignores synthetic dispatch; real-browser flows are covered by the example smoke.
- the settled-stale shrink deliberately does not assert a throw on the next read: the derived re-resolution happens inside the child render on the next parent notification and tap discards the throwing work-in-progress render, so the pinned observables are the single console report and the never-valid first-read throw.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TWpFgdq75ovep5YoHCkCq7U93OX93X77H8iiibaq4RCR7ypFJ0qr51PVbMo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
