### PR TITLE
feat(svelte): action bar and branch picker builders

### DIFF
--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -68,8 +68,8 @@
         </div>
       {/if}
       <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-        {#each messages.items as message (message.id)}
-          <Message {message} />
+        {#each messages.items as message, index (message.id)}
+          <Message {message} item={messages.item(index)} />
         {/each}
         {#if isRunning.current}
           <li class="text-foreground px-2 leading-relaxed">

--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -68,7 +68,7 @@
         </div>
       {/if}
       <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-        {#each messages.items as message, index (message.id)}
+        {#each messages.items as message, index (index)}
           <Message {message} item={messages.item(index)} />
         {/each}
         {#if isRunning.current}

--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -68,7 +68,7 @@
         </div>
       {/if}
       <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-        {#each messages.items as message, index (index)}
+        {#each messages.items as message, index}
           <Message {message} item={messages.item(index)} />
         {/each}
         {#if isRunning.current}

--- a/examples/with-svelte/src/Message.svelte
+++ b/examples/with-svelte/src/Message.svelte
@@ -88,7 +88,7 @@
     </div>
   {/if}
   <div
-    class="text-muted-foreground flex items-center gap-1 px-2 transition-opacity focus-within:opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
+    class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100"
   >
     {#if message.role === "user"}
       <button

--- a/examples/with-svelte/src/Message.svelte
+++ b/examples/with-svelte/src/Message.svelte
@@ -57,6 +57,7 @@
       <textarea
         {...editInput.props}
         class="w-full resize-none bg-transparent px-1 py-0.5 outline-none"
+        aria-label="Edit message"
         rows="2"
       ></textarea>
       <div class="flex justify-end gap-2 text-sm">
@@ -87,7 +88,7 @@
     </div>
   {/if}
   <div
-    class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+    class="text-muted-foreground flex items-center gap-1 px-2 transition-opacity focus-within:opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
   >
     {#if message.role === "user"}
       <button

--- a/examples/with-svelte/src/Message.svelte
+++ b/examples/with-svelte/src/Message.svelte
@@ -1,13 +1,46 @@
 <script lang="ts">
-  import type { ThreadMessage } from "@assistant-ui/core";
+  import type { MessageState } from "@assistant-ui/core/store";
+  import {
+    actionBarCopy,
+    actionBarEdit,
+    actionBarReload,
+    branchPickerNext,
+    branchPickerPrevious,
+    composerCancel,
+    composerInput,
+    composerSend,
+    useAuiState,
+    type MessageItem,
+  } from "@assistant-ui/svelte";
+  import {
+    CheckIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    CopyIcon,
+    PencilIcon,
+    RefreshCwIcon,
+  } from "@lucide/svelte";
 
-  let { message }: { message: ThreadMessage } = $props();
+  let { message, item }: { message: MessageState; item: MessageItem } =
+    $props();
 
   const text = $derived(
     message.content
       .map((part) => (part.type === "text" ? part.text : ""))
       .join(""),
   );
+
+  const isEditing = useAuiState((s) => s.composer.isEditing, { item });
+  const branchNumber = useAuiState((s) => s.message.branchNumber, { item });
+  const branchCount = useAuiState((s) => s.message.branchCount, { item });
+  const edit = actionBarEdit({ item });
+  const copy = actionBarCopy({ item });
+  const reload = actionBarReload({ item });
+  const previous = branchPickerPrevious({ item });
+  const next = branchPickerNext({ item });
+  const editInput = composerInput({ item });
+  const editSend = composerSend({ item });
+  const editCancel = composerCancel({ item });
 </script>
 
 <li
@@ -17,14 +50,92 @@
     message.role === "user" ? "items-end" : "items-start",
   ].join(" ")}
 >
+  {#if isEditing.current}
+    <div
+      class="border-border/60 flex w-full max-w-[80%] flex-col gap-2 rounded-xl border p-2"
+    >
+      <textarea
+        {...editInput.props}
+        class="w-full resize-none bg-transparent px-1 py-0.5 outline-none"
+        rows="2"
+      ></textarea>
+      <div class="flex justify-end gap-2 text-sm">
+        <button
+          {...editCancel.props}
+          class="text-muted-foreground rounded-lg px-2 py-1"
+        >
+          Discard
+        </button>
+        <button
+          {...editSend.props}
+          class="bg-primary text-primary-foreground rounded-lg px-2 py-1 disabled:opacity-50"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  {:else}
+    <div
+      class={[
+        "px-2 wrap-break-word",
+        message.role === "user"
+          ? "bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2"
+          : "text-foreground leading-relaxed",
+      ].join(" ")}
+    >
+      <p class="whitespace-pre-line">{text}</p>
+    </div>
+  {/if}
   <div
-    class={[
-      "px-2 wrap-break-word",
-      message.role === "user"
-        ? "bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2"
-        : "text-foreground leading-relaxed",
-    ].join(" ")}
+    class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
   >
-    <p class="whitespace-pre-line">{text}</p>
+    {#if message.role === "user"}
+      <button
+        {...edit.props}
+        class="hover:text-foreground rounded p-1"
+        aria-label="Edit"
+      >
+        <PencilIcon class="size-3.5" />
+      </button>
+    {/if}
+    <button
+      {...copy.props}
+      class="hover:text-foreground rounded p-1"
+      aria-label="Copy"
+    >
+      {#if copy.isCopied}
+        <CheckIcon class="size-3.5" />
+      {:else}
+        <CopyIcon class="size-3.5" />
+      {/if}
+    </button>
+    {#if message.role === "assistant"}
+      <button
+        {...reload.props}
+        class="hover:text-foreground rounded p-1"
+        aria-label="Regenerate"
+      >
+        <RefreshCwIcon class="size-3.5" />
+      </button>
+    {/if}
+    {#if branchCount.current > 1}
+      <span class="flex items-center gap-0.5 text-xs">
+        <button
+          {...previous.props}
+          class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+          aria-label="Previous branch"
+        >
+          <ChevronLeftIcon class="size-3.5" />
+        </button>
+        {branchNumber.current} / {branchCount.current}
+        <button
+          {...next.props}
+          class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+          aria-label="Next branch"
+        >
+          <ChevronRightIcon class="size-3.5" />
+        </button>
+      </span>
+    {/if}
   </div>
 </li>

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -57,7 +57,7 @@ export const createEchoRuntime = () => {
     const text = message.content
       .map((part: any) => (part.type === "text" ? part.text : ""))
       .join("");
-    messages = [...messages, { id: `u${nextId++}`, role: "user", text }];
+    messages = [...messages, { id: `gn${nextId++}`, role: "user", text }];
     sync();
   });
   const onEdit = vi.fn(async (message: any) => {
@@ -69,7 +69,7 @@ export const createEchoRuntime = () => {
       : 0;
     messages = [
       ...messages.slice(0, parentIndex),
-      { id: `u${nextId++}`, role: "user", text },
+      { id: `gn${nextId++}`, role: "user", text },
     ];
     sync();
   });
@@ -77,14 +77,28 @@ export const createEchoRuntime = () => {
     isRunning = false;
     queueMicrotask(sync);
   });
+  const convertMessage = (message: EchoMessage) => ({
+    id: message.id,
+    role: message.role,
+    content: [{ type: "text" as const, text: message.text }],
+  });
+  const onReload = vi.fn(async (parentId: string | null) => {
+    let parentIndex = 0;
+    if (parentId) {
+      const index = messages.findIndex((entry) => entry.id === parentId);
+      if (index === -1) return;
+      parentIndex = index + 1;
+    }
+    messages = [
+      ...messages.slice(0, parentIndex),
+      { id: `gr${nextId++}`, role: "assistant", text: "regenerated" },
+    ];
+    sync();
+  });
   const makeAdapter = () => ({
     messages,
     isRunning,
-    convertMessage: (message: EchoMessage) => ({
-      id: message.id,
-      role: message.role,
-      content: [{ type: "text" as const, text: message.text }],
-    }),
+    convertMessage,
     setMessages: (next: EchoMessage[]) => {
       messages = next;
       sync();
@@ -92,6 +106,7 @@ export const createEchoRuntime = () => {
     onNew,
     onEdit,
     onCancel,
+    onReload,
   });
   const core = new ExternalStoreRuntimeCore(makeAdapter() as never);
   const sync = () => core.setAdapter(makeAdapter() as never);
@@ -101,6 +116,7 @@ export const createEchoRuntime = () => {
     onNew,
     onEdit,
     onCancel,
+    onReload,
     setMessages: (next: EchoMessage[]) => {
       messages = next;
       sync();

--- a/packages/svelte/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/svelte/src/__tests__/primitives-actionbar.test.ts
@@ -11,7 +11,7 @@ import {
   actionBarReload,
 } from "../primitives/actionBar";
 import { composerInput, composerSend } from "../primitives/composer";
-import { threadMessages } from "../primitives/threadMessages";
+import { threadMessages, type MessageItem } from "../primitives/threadMessages";
 import Host from "./fixtures/Host.svelte";
 import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
 
@@ -122,6 +122,8 @@ describe("action bar builders", () => {
     const copy = actionBarCopy({ item, copyToClipboard });
 
     copy.props.onclick();
+    // The deferred writer needs a microtask before resolveWrite exists
+    await Promise.resolve();
     // The slot occupant changes before the clipboard write settles
     flushTapSync(() =>
       echo.setMessages([
@@ -158,6 +160,74 @@ describe("action bar builders", () => {
     );
 
     flushSync(() => void unmount(app));
+  });
+
+  it("destroy invalidates pending copies and clears the copied timer", async () => {
+    const echo = createEchoRuntime();
+    echo.setMessages([
+      { id: "u0", role: "user", text: "hi" },
+      { id: "a0", role: "assistant", text: "reply" },
+    ]);
+    let copy!: ReturnType<typeof actionBarCopy>;
+    let item!: MessageItem;
+    let resolveWrite!: () => void;
+    const copyToClipboard = vi.fn(
+      () => new Promise<void>((resolve) => (resolveWrite = resolve)),
+    );
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+          const messages = threadMessages();
+          item = messages.item(1);
+          item.source.subscribe(() => {});
+          copy = actionBarCopy({ item, copyToClipboard });
+        },
+      },
+    });
+
+    // A clipboard write pending across destroy must not mark the message
+    copy.props.onclick();
+    await Promise.resolve();
+    flushSync(() => void unmount(app));
+    resolveWrite();
+    await flushEvents();
+    await flushEvents();
+    expect((item.aui as AnyClient).message.getState().isCopied).toBe(false);
+  });
+
+  it("destroy during the copied window clears the timer and resets state", async () => {
+    const echo = createEchoRuntime();
+    echo.setMessages([
+      { id: "u0", role: "user", text: "hi" },
+      { id: "a0", role: "assistant", text: "reply" },
+    ]);
+    let copy!: ReturnType<typeof actionBarCopy>;
+    let item!: MessageItem;
+    const app = mount(Host, {
+      target: target(),
+      props: {
+        setup: () => {
+          provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+          const messages = threadMessages();
+          item = messages.item(1);
+          item.source.subscribe(() => {});
+          copy = actionBarCopy({
+            item,
+            copiedDuration: 60_000,
+            copyToClipboard: vi.fn(async () => {}),
+          });
+        },
+      },
+    });
+
+    copy.props.onclick();
+    await vi.waitFor(() =>
+      expect((item.aui as AnyClient).message.getState().isCopied).toBe(true),
+    );
+    flushSync(() => void unmount(app));
+    expect((item.aui as AnyClient).message.getState().isCopied).toBe(false);
   });
 });
 

--- a/packages/svelte/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/svelte/src/__tests__/primitives-actionbar.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import { useAuiState } from "../useAuiState";
+import {
+  actionBarCopy,
+  actionBarEdit,
+  actionBarReload,
+} from "../primitives/actionBar";
+import { composerInput, composerSend } from "../primitives/composer";
+import { threadMessages } from "../primitives/threadMessages";
+import Host from "./fixtures/Host.svelte";
+import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
+
+const target = () => document.createElement("div");
+
+const mountThread = (
+  seed: { id: string; role: "user" | "assistant"; text: string }[],
+) => {
+  const echo = createEchoRuntime();
+  echo.setMessages(seed);
+  let messages!: ReturnType<typeof threadMessages>;
+  const app = mount(Host, {
+    target: target(),
+    props: {
+      setup: () => {
+        provideAui(AuiConfig({ threads: RuntimeAdapter(echo.runtime) }));
+        messages = threadMessages();
+      },
+    },
+  });
+  return { app, echo, messages: () => messages };
+};
+
+describe("action bar builders", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("edit begins the item's edit composer and disables while editing", () => {
+    const { app, messages } = mountThread([
+      { id: "u0", role: "user", text: "original" },
+    ]);
+    const item = messages().item(0);
+    const edit = actionBarEdit({ item });
+    const input = composerInput({ item });
+
+    expect(edit.props.disabled).toBe(false);
+    flushTapSync(() => edit.props.onclick());
+    expect(edit.props.disabled).toBe(true);
+    expect(input.props.value).toBe("original");
+
+    flushTapSync(() => edit.props.onclick());
+    expect(input.props.value).toBe("original");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("reload regenerates an assistant message and stays disabled for user rows", async () => {
+    const { app, echo, messages } = mountThread([
+      { id: "u0", role: "user", text: "hi" },
+      { id: "a0", role: "assistant", text: "reply" },
+    ]);
+    const userReload = actionBarReload({ item: messages().item(0) });
+    const assistantItem = messages().item(1);
+    assistantItem.source.subscribe(() => {});
+    const assistantReload = actionBarReload({ item: assistantItem });
+
+    expect(userReload.props.disabled).toBe(true);
+    userReload.props.onclick();
+    expect(echo.onReload).not.toHaveBeenCalled();
+
+    expect(assistantReload.props.disabled).toBe(false);
+    assistantReload.props.onclick();
+    await flushEvents();
+    expect(echo.onReload).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(
+        useAuiState((s) => (s.message.content[0] as AnyClient).text, {
+          item: assistantItem,
+        }).current,
+      ).toBe("regenerated"),
+    );
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("copy writes the message text and opens a bounded isCopied window", async () => {
+    const { app, messages } = mountThread([
+      { id: "u0", role: "user", text: "hi" },
+      { id: "a0", role: "assistant", text: "reply" },
+    ]);
+    const item = messages().item(1);
+    const copyToClipboard = vi.fn(async () => {});
+    const copy = actionBarCopy({ item, copiedDuration: 300, copyToClipboard });
+
+    expect(copy.props.disabled).toBe(false);
+    copy.props.onclick();
+    await vi.waitFor(() => expect(copy.isCopied).toBe(true));
+    expect(copyToClipboard).toHaveBeenCalledWith("reply");
+
+    await vi.waitFor(() => expect(copy.isCopied).toBe(false), {
+      timeout: 2000,
+    });
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("a late clipboard completion does not mark a replaced slot occupant", async () => {
+    const { app, echo, messages } = mountThread([
+      { id: "u0", role: "user", text: "hi" },
+      { id: "a0", role: "assistant", text: "reply" },
+    ]);
+    const item = messages().item(1);
+    let resolveWrite!: () => void;
+    const copyToClipboard = vi.fn(
+      () => new Promise<void>((resolve) => (resolveWrite = resolve)),
+    );
+    const copy = actionBarCopy({ item, copyToClipboard });
+
+    copy.props.onclick();
+    // The slot occupant changes before the clipboard write settles
+    flushTapSync(() =>
+      echo.setMessages([
+        { id: "u0", role: "user", text: "hi" },
+        { id: "a9", role: "assistant", text: "different" },
+      ]),
+    );
+    resolveWrite();
+    await flushEvents();
+    await flushEvents();
+    expect(copy.isCopied).toBe(false);
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("copy while editing copies the edit composer draft", async () => {
+    const { app, messages } = mountThread([
+      { id: "u0", role: "user", text: "original" },
+    ]);
+    const item = messages().item(0);
+    const copyToClipboard = vi.fn(async () => {});
+    const copy = actionBarCopy({ item, copyToClipboard });
+
+    flushTapSync(() => item.aui.composer.beginEdit());
+    const textarea = document.createElement("textarea");
+    textarea.value = "draft edit";
+    composerInput({ item }).props.oninput({
+      target: textarea,
+    } as unknown as Event);
+
+    copy.props.onclick();
+    await vi.waitFor(() =>
+      expect(copyToClipboard).toHaveBeenCalledWith("draft edit"),
+    );
+
+    flushSync(() => void unmount(app));
+  });
+});
+
+describe("branch flow through the builders", () => {
+  it("editing a user message creates a sibling branch navigable by the pickers", async () => {
+    const { app, messages } = mountThread([
+      { id: "u0", role: "user", text: "first" },
+    ]);
+    const item = messages().item(0);
+    item.source.subscribe(() => {});
+    const edit = actionBarEdit({ item });
+    const input = composerInput({ item });
+    const send = composerSend({ item });
+    const branchNumber = useAuiState((s) => s.message.branchNumber, { item });
+    const branchCount = useAuiState((s) => s.message.branchCount, { item });
+
+    flushTapSync(() => edit.props.onclick());
+    const textarea = document.createElement("textarea");
+    textarea.value = "second";
+    input.props.oninput({ target: textarea } as unknown as Event);
+    flushTapSync(() => send.props.onclick());
+    await vi.waitFor(() => expect(branchCount.current).toBe(2));
+    expect(branchNumber.current).toBe(2);
+
+    const { branchPickerPrevious, branchPickerNext } =
+      await import("../primitives/branchPicker");
+    const previous = branchPickerPrevious({ item });
+    const next = branchPickerNext({ item });
+
+    expect(next.props.disabled).toBe(true);
+    expect(previous.props.disabled).toBe(false);
+
+    flushTapSync(() => previous.props.onclick());
+    await vi.waitFor(() => expect(branchNumber.current).toBe(1));
+    expect(
+      useAuiState((s) => (s.message.content[0] as AnyClient).text, { item })
+        .current,
+    ).toBe("first");
+    expect(previous.props.disabled).toBe(true);
+    expect(next.props.disabled).toBe(false);
+
+    flushTapSync(() => next.props.onclick());
+    await vi.waitFor(() => expect(branchNumber.current).toBe(2));
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/svelte/src/__tests__/primitives-actionbar.test.ts
@@ -122,8 +122,6 @@ describe("action bar builders", () => {
     const copy = actionBarCopy({ item, copyToClipboard });
 
     copy.props.onclick();
-    // The deferred writer needs a microtask before resolveWrite exists
-    await Promise.resolve();
     // The slot occupant changes before the clipboard write settles
     flushTapSync(() =>
       echo.setMessages([
@@ -189,7 +187,6 @@ describe("action bar builders", () => {
 
     // A clipboard write pending across destroy must not mark the message
     copy.props.onclick();
-    await Promise.resolve();
     flushSync(() => void unmount(app));
     resolveWrite();
     await flushEvents();

--- a/packages/svelte/src/__tests__/primitives-messages.test.ts
+++ b/packages/svelte/src/__tests__/primitives-messages.test.ts
@@ -67,6 +67,7 @@ describe("threadMessages", () => {
     });
 
     const item = messages.item(0);
+    item.source.subscribe(() => {});
     const input = composerInput({ item });
     const send = composerSend({ item });
 

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -9,6 +9,15 @@ export {
   composerInput,
   composerSend,
 } from "./primitives/composer";
+export {
+  actionBarCopy,
+  actionBarEdit,
+  actionBarReload,
+} from "./primitives/actionBar";
+export {
+  branchPickerNext,
+  branchPickerPrevious,
+} from "./primitives/branchPicker";
 export { threadMessages, type MessageItem } from "./primitives/threadMessages";
 
 export {

--- a/packages/svelte/src/primitives/actionBar.ts
+++ b/packages/svelte/src/primitives/actionBar.ts
@@ -1,3 +1,4 @@
+import { onDestroy } from "svelte";
 import { flushTapSync } from "@assistant-ui/tap";
 import {
   actionBarCopyDisabled,
@@ -91,6 +92,21 @@ export const actionBarCopy = (options?: {
   const composerText = useAuiState((s) => s.composer.text, { item });
 
   let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+  let destroyed = false;
+  // Best effort: created during component initialization the builder cleans
+  // up with the component, matching the react and vue implementations; with
+  // an explicit item outside init there is no lifecycle to bind.
+  try {
+    onDestroy(() => {
+      destroyed = true;
+      if (copiedTimer === undefined) return;
+      clearTimeout(copiedTimer);
+      copiedTimer = undefined;
+      flushTapSync(() => aui.message.setIsCopied(false));
+    });
+  } catch {
+    /* outside component init */
+  }
 
   const onclick = (event?: MouseEvent) => {
     if (event?.defaultPrevented || disabled.current) return;
@@ -103,24 +119,26 @@ export const actionBarCopy = (options?: {
     // state.
     const copiedMessageId = aui.message.getState().id;
     const stillCopiedMessage = () =>
-      aui.message.getState().id === copiedMessageId;
-    // The rejection handler swallows clipboard write failures (permission
-    // denied, API unavailable) so they don't surface as unhandled promise
-    // rejections.
-    Promise.resolve(copyToClipboard(value)).then(
-      () => {
-        if (!stillCopiedMessage()) return;
-        if (copiedTimer !== undefined) clearTimeout(copiedTimer);
-        flushTapSync(() => aui.message.setIsCopied(true));
-        copiedTimer = setTimeout(() => {
-          copiedTimer = undefined;
-          if (stillCopiedMessage()) {
-            flushTapSync(() => aui.message.setIsCopied(false));
-          }
-        }, copiedDuration);
-      },
-      () => {},
-    );
+      !destroyed && aui.message.getState().id === copiedMessageId;
+    // The deferred call keeps a synchronously throwing writer inside the
+    // rejection handler, which swallows clipboard failures (permission
+    // denied, API unavailable) so they don't surface as unhandled rejections.
+    Promise.resolve()
+      .then(() => copyToClipboard(value))
+      .then(
+        () => {
+          if (!stillCopiedMessage()) return;
+          if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+          flushTapSync(() => aui.message.setIsCopied(true));
+          copiedTimer = setTimeout(() => {
+            copiedTimer = undefined;
+            if (stillCopiedMessage()) {
+              flushTapSync(() => aui.message.setIsCopied(false));
+            }
+          }, copiedDuration);
+        },
+        () => {},
+      );
   };
 
   return {
@@ -131,6 +149,9 @@ export const actionBarCopy = (options?: {
       type: "button" as const,
       get disabled() {
         return disabled.current;
+      },
+      get "data-copied"() {
+        return isCopied.current ? "" : undefined;
       },
       onclick,
     },

--- a/packages/svelte/src/primitives/actionBar.ts
+++ b/packages/svelte/src/primitives/actionBar.ts
@@ -92,6 +92,7 @@ export const actionBarCopy = (options?: {
   const composerText = useAuiState((s) => s.composer.text, { item });
 
   let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+  let copiedMessageId: string | undefined;
   let destroyed = false;
   // Best effort: created during component initialization the builder cleans
   // up with the component, matching the react and vue implementations; with
@@ -102,7 +103,11 @@ export const actionBarCopy = (options?: {
       if (copiedTimer === undefined) return;
       clearTimeout(copiedTimer);
       copiedTimer = undefined;
-      flushTapSync(() => aui.message.setIsCopied(false));
+      // The index may have been retargeted since the copy; only the copied
+      // message's own flag is cleared
+      if (aui.message.getState().id === copiedMessageId) {
+        flushTapSync(() => aui.message.setIsCopied(false));
+      }
     });
   } catch {
     /* outside component init */
@@ -117,28 +122,35 @@ export const actionBarCopy = (options?: {
     // The item's slot follows whatever message occupies the index, so late
     // completions and timers re-check the copied message's id before touching
     // state.
-    const copiedMessageId = aui.message.getState().id;
+    copiedMessageId = aui.message.getState().id;
+    const anchorId = copiedMessageId;
     const stillCopiedMessage = () =>
-      !destroyed && aui.message.getState().id === copiedMessageId;
-    // The deferred call keeps a synchronously throwing writer inside the
-    // rejection handler, which swallows clipboard failures (permission
-    // denied, API unavailable) so they don't surface as unhandled rejections.
-    Promise.resolve()
-      .then(() => copyToClipboard(value))
-      .then(
-        () => {
-          if (!stillCopiedMessage()) return;
-          if (copiedTimer !== undefined) clearTimeout(copiedTimer);
-          flushTapSync(() => aui.message.setIsCopied(true));
-          copiedTimer = setTimeout(() => {
-            copiedTimer = undefined;
-            if (stillCopiedMessage()) {
-              flushTapSync(() => aui.message.setIsCopied(false));
-            }
-          }, copiedDuration);
-        },
-        () => {},
-      );
+      !destroyed && aui.message.getState().id === anchorId;
+    // The writer runs synchronously inside the click so the user-gesture
+    // gating of navigator.clipboard survives (WebKit scopes it to the stack);
+    // the try contains a synchronously throwing caller-supplied writer, and
+    // the rejection handler swallows clipboard failures (permission denied,
+    // API unavailable) so they don't surface as unhandled rejections.
+    let write: void | Promise<void>;
+    try {
+      write = copyToClipboard(value);
+    } catch {
+      return;
+    }
+    Promise.resolve(write).then(
+      () => {
+        if (!stillCopiedMessage()) return;
+        if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+        flushTapSync(() => aui.message.setIsCopied(true));
+        copiedTimer = setTimeout(() => {
+          copiedTimer = undefined;
+          if (stillCopiedMessage()) {
+            flushTapSync(() => aui.message.setIsCopied(false));
+          }
+        }, copiedDuration);
+      },
+      () => {},
+    );
   };
 
   return {

--- a/packages/svelte/src/primitives/actionBar.ts
+++ b/packages/svelte/src/primitives/actionBar.ts
@@ -1,0 +1,138 @@
+import { flushTapSync } from "@assistant-ui/tap";
+import {
+  actionBarCopyDisabled,
+  actionBarEditDisabled,
+  actionBarReloadDisabled,
+} from "@assistant-ui/core/store/internal";
+import { getAuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const resolveTarget = (item: ScopeTarget | undefined): ScopeTarget =>
+  item ?? getAuiContext();
+
+const defaultCopyToClipboard = (text: string) => {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    return Promise.reject(new Error("Clipboard API is not available."));
+  }
+  return navigator.clipboard.writeText(text);
+};
+
+/**
+ * Builder for the edit button. Spread `props` onto a `<button>`. Begins
+ * editing the scoped message; disabled while already editing. Caller handlers
+ * compose the same way as `composerSend`.
+ */
+export const actionBarEdit = (options?: { item?: ScopeTarget | undefined }) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const disabled = useAuiState(actionBarEditDisabled, { item });
+
+  return {
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented || disabled.current) return;
+        aui.composer.beginEdit();
+      },
+    },
+  };
+};
+
+/**
+ * Builder for the reload button. Spread `props` onto a `<button>`.
+ * Regenerates the scoped assistant message; disabled while a run is in
+ * flight, the thread is disabled, or the message is not an assistant
+ * message.
+ */
+export const actionBarReload = (options?: {
+  item?: ScopeTarget | undefined;
+}) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const disabled = useAuiState(actionBarReloadDisabled, { item });
+
+  return {
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented || disabled.current) return;
+        aui.message.reload();
+      },
+    },
+  };
+};
+
+/**
+ * Builder for the copy button. Spread `props` onto a `<button>`. Copies the
+ * scoped message's text (or, while editing, the edit composer text) and
+ * reflects the copied window through `isCopied` for `copiedDuration`
+ * milliseconds. Disabled while an assistant message is still running or the
+ * message has no text.
+ */
+export const actionBarCopy = (options?: {
+  item?: ScopeTarget | undefined;
+  copiedDuration?: number | undefined;
+  copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
+}) => {
+  const item = resolveTarget(options?.item);
+  const { aui } = item;
+  const copiedDuration = options?.copiedDuration ?? 3000;
+  const copyToClipboard = options?.copyToClipboard ?? defaultCopyToClipboard;
+
+  const disabled = useAuiState(actionBarCopyDisabled, { item });
+  const isCopied = useAuiState((s) => s.message.isCopied, { item });
+  const isEditing = useAuiState((s) => s.composer.isEditing, { item });
+  const composerText = useAuiState((s) => s.composer.text, { item });
+
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const onclick = (event?: MouseEvent) => {
+    if (event?.defaultPrevented || disabled.current) return;
+    const value = isEditing.current
+      ? composerText.current
+      : aui.message.getCopyText();
+    if (!value) return;
+    // The item's slot follows whatever message occupies the index, so late
+    // completions and timers re-check the copied message's id before touching
+    // state.
+    const copiedMessageId = aui.message.getState().id;
+    const stillCopiedMessage = () =>
+      aui.message.getState().id === copiedMessageId;
+    // The rejection handler swallows clipboard write failures (permission
+    // denied, API unavailable) so they don't surface as unhandled promise
+    // rejections.
+    Promise.resolve(copyToClipboard(value)).then(
+      () => {
+        if (!stillCopiedMessage()) return;
+        if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+        flushTapSync(() => aui.message.setIsCopied(true));
+        copiedTimer = setTimeout(() => {
+          copiedTimer = undefined;
+          if (stillCopiedMessage()) {
+            flushTapSync(() => aui.message.setIsCopied(false));
+          }
+        }, copiedDuration);
+      },
+      () => {},
+    );
+  };
+
+  return {
+    get isCopied() {
+      return isCopied.current;
+    },
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick,
+    },
+  };
+};

--- a/packages/svelte/src/primitives/actionBar.ts
+++ b/packages/svelte/src/primitives/actionBar.ts
@@ -75,6 +75,11 @@ export const actionBarReload = (options?: {
  * reflects the copied window through `isCopied` for `copiedDuration`
  * milliseconds. Disabled while an assistant message is still running or the
  * message has no text.
+ *
+ * Constructed during component initialization the builder clears its timer
+ * and copied state with the component; constructed elsewhere (with `item`)
+ * there is no lifecycle to bind, and late completions are contained by the
+ * copied message's id guard alone.
  */
 export const actionBarCopy = (options?: {
   item?: ScopeTarget | undefined;

--- a/packages/svelte/src/primitives/branchPicker.ts
+++ b/packages/svelte/src/primitives/branchPicker.ts
@@ -1,0 +1,50 @@
+import {
+  branchPickerNextDisabled,
+  branchPickerPreviousDisabled,
+} from "@assistant-ui/core/store/internal";
+import { getAuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const resolveTarget = (item: ScopeTarget | undefined): ScopeTarget =>
+  item ?? getAuiContext();
+
+const branchButton = (
+  predicate: typeof branchPickerPreviousDisabled,
+  position: "previous" | "next",
+) => {
+  return (options?: { item?: ScopeTarget | undefined }) => {
+    const item = resolveTarget(options?.item);
+    const { aui } = item;
+    const disabled = useAuiState(predicate, { item });
+
+    return {
+      props: {
+        type: "button" as const,
+        get disabled() {
+          return disabled.current;
+        },
+        onclick: (event?: MouseEvent) => {
+          if (event?.defaultPrevented || disabled.current) return;
+          aui.message.switchToBranch({ position });
+        },
+      },
+    };
+  };
+};
+
+/**
+ * Builder for the previous-branch button. Spread `props` onto a `<button>`.
+ * Read the position with `useAuiState((s) => s.message.branchNumber, { item })`
+ * and `s.message.branchCount`.
+ */
+export const branchPickerPrevious = branchButton(
+  branchPickerPreviousDisabled,
+  "previous",
+);
+
+/**
+ * Builder for the next-branch button. Spread `props` onto a `<button>`. Read
+ * the position with `useAuiState((s) => s.message.branchNumber, { item })`
+ * and `s.message.branchCount`.
+ */
+export const branchPickerNext = branchButton(branchPickerNextDisabled, "next");

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -105,9 +105,10 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
 /**
  * Builder for the thread's message list. Call during component
  * initialization; iterate `items` by index and scope per-row work through
- * `item(index)`. Do not key the iteration by message id: `item(index)` binds
- * by index, and an id-keyed row whose index shifts keeps its component
- * instance silently driving the old index.
+ * `item(index)`. Until items can be addressed by message id, keying the
+ * iteration by id would let a row whose index shifts keep its component
+ * instance silently driving the old index, so index iteration trades
+ * per-row transition identity for correctness.
  *
  * Items are cached per index for the builder's lifetime: a row that stops
  * being observed suspends its scopes and resumes with state intact when a

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -104,8 +104,10 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
 
 /**
  * Builder for the thread's message list. Call during component
- * initialization; iterate `items` keyed by message id and scope per-row work
- * through `item(index)`.
+ * initialization; iterate `items` by index and scope per-row work through
+ * `item(index)`. Do not key the iteration by message id: `item(index)` binds
+ * by index, and an id-keyed row whose index shifts keeps its component
+ * instance silently driving the old index.
  *
  * Items are cached per index for the builder's lifetime: a row that stops
  * being observed suspends its scopes and resumes with state intact when a
@@ -114,7 +116,7 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
  * @example
  * ```svelte
  * const messages = threadMessages();
- * // {#each messages.items as message, index (message.id)}
+ * // {#each messages.items as message, index}
  * //   {@const item = messages.item(index)}
  * // {/each}
  * ```


### PR DESCRIPTION
## summary

- second wave of the svelte builder primitives: `actionBarEdit`, `actionBarReload`, and `actionBarCopy` (the copy builder ports the vue semantics: copies the edit composer draft while editing, anchors late clipboard completions and the timed clear to the copied message's id so a replaced slot occupant is never marked, and exposes the bounded copied window as an `isCopied` getter), plus `branchPickerPrevious`/`branchPickerNext` through a shared branch-button factory. all follow the wave-one contract: optional `{ item }` retargeting, event vetoes via `defaultPrevented`, disabled state from the shared predicates.
- branch number and count deliberately ship no builders: they are plain reads (`useAuiState((s) => s.message.branchNumber, { item })`), per the standing division that builders expose behavior and `useAuiState` reads state.
- `examples/with-svelte` now carries the full per-item story: hover action bar, an inline edit card driven by the `{ item }` composer builders, and branch navigation.
- the test echo runtime gains `onReload`, a module-stable `convertMessage` (branch bookkeeping silently degrades to in-place replacement when the converter identity changes per sync), and generated ids disjoint from test seeds (a collision makes an edit an in-place replace and no branch is ever created, invisibly to text-only assertions).

## test plan

### already verified

- [x] `pnpm -C packages/svelte test` -> 31/31 (6 new: edit begins/disables, reload role matrix routing to the adapter, the bounded isCopied window, the late-clipboard id-anchor guard, copy-while-editing, and the full edit -> sibling branch -> previous/next navigation flow)
- [x] `pnpm -C packages/svelte exec tsc --noEmit` clean; oxlint clean; `pnpm -C examples/with-svelte build` green
- [x] browser E2E: edit-save creates a sibling with a live 2/2 picker, previous flips the whole conversation tail, regenerate branches the assistant row, console clean

### reviewer should verify

- [ ] `pnpm -C examples/with-svelte dev`: hover a message row for the action bar, edit and save a user message, then walk the branch picker; the edited and original conversations should switch wholesale

## notes

- imperative consumers (including these tests) must hold `item.source.subscribe(() => {})` before actions that swap an index's occupant: an unobserved item is frozen at its last render, so in-place same-id updates still show through while an id swap stays invisible. the tests pin this discipline; templates get it for free from their effects.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HpdTryqICTV_isSm7U0Hvf0Py0CHnrClZGcqQdD9eOknxcpKu44Iv89FITg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->