### PR TITLE
feat(core): add unstable_notifySessionReset for adapter session resets

### DIFF
--- a/.changeset/session-reset-seam.md
+++ b/.changeset/session-reset-seam.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/eve": patch
+---
+
+feat: add `unstable_notifySessionReset` so adapters with a resettable backing session can clear session-scoped tool-invocation state without run-cancel side effects; the eve reset now uses it instead of composing `cancelRun` with a hand-rolled session filter

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -859,6 +859,7 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   abstract cancelRun(): void;
   abstract exportExternalState(): any;
   abstract importExternalState(state: any): void;
+  abstract unstable_notifySessionReset(): void;
   protected _voiceMessages: ThreadMessage[];
   protected _voiceGeneration: number;
   private _cachedMergedMessages;
@@ -1854,6 +1855,7 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   resumeRun(config: ResumeRunConfig): Promise<void>;
   exportExternalState(): any;
   importExternalState(state: any): void;
+  unstable_notifySessionReset(): void;
   cancelRun(): void;
   private dropEmptyOptimisticHead;
   addToolResult(options: AddToolResultOptions): void;
@@ -2384,6 +2386,7 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   resumeRun(_param4: ResumeRunConfig): Promise<void>;
   exportExternalState(): any;
   importExternalState(): void;
+  unstable_notifySessionReset(): void;
   startRun(_param5: StartRunConfig, runCallback?: ChatModelAdapter["run"]): Promise<void>;
   private _runLoop;
   private performRoundtrip;
@@ -3331,6 +3334,7 @@ declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements Thre
   getModelContext(): {};
   exportExternalState(): void;
   importExternalState(): void;
+  unstable_notifySessionReset(): void;
   composer: {
     attachments: never[];
     attachmentAccept: string;
@@ -3522,6 +3526,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     startRun: (config: StartRunConfig) => void;
     resumeRun: (config: ResumeRunConfig) => void;
     cancelRun: () => void;
+    unstable_notifySessionReset: () => void;
     addToolResult: (options: AddToolResultOptions) => void;
     resumeToolCall: (options: ResumeToolCallOptions) => void;
     respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3575,6 +3580,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     startRun: (config: StartRunConfig) => void;
     resumeRun: (config: ResumeRunConfig) => void;
     cancelRun: () => void;
+    unstable_notifySessionReset: () => void;
     addToolResult: (options: AddToolResultOptions) => void;
     resumeToolCall: (options: ResumeToolCallOptions) => void;
     respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3628,6 +3634,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     startRun: (config: StartRunConfig) => void;
     resumeRun: (config: ResumeRunConfig) => void;
     cancelRun: () => void;
+    unstable_notifySessionReset: () => void;
     addToolResult: (options: AddToolResultOptions) => void;
     resumeToolCall: (options: ResumeToolCallOptions) => void;
     respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3751,6 +3758,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
     startRun: (config: StartRunConfig) => void;
     resumeRun: (config: ResumeRunConfig) => void;
     cancelRun: () => void;
+    unstable_notifySessionReset: () => void;
     addToolResult: (options: AddToolResultOptions) => void;
     resumeToolCall: (options: ResumeToolCallOptions) => void;
     respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3804,6 +3812,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
     startRun: (config: StartRunConfig) => void;
     resumeRun: (config: ResumeRunConfig) => void;
     cancelRun: () => void;
+    unstable_notifySessionReset: () => void;
     addToolResult: (options: AddToolResultOptions) => void;
     resumeToolCall: (options: ResumeToolCallOptions) => void;
     respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -4898,6 +4907,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext$1;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
@@ -4927,6 +4937,7 @@ type ThreadRuntimeCore = Readonly<{
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
+  unstable_notifySessionReset: () => void;
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;
   respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -5000,6 +5011,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
       startRun: (config: StartRunConfig) => void;
       resumeRun: (config: ResumeRunConfig) => void;
       cancelRun: () => void;
+      unstable_notifySessionReset: () => void;
       addToolResult: (options: AddToolResultOptions) => void;
       resumeToolCall: (options: ResumeToolCallOptions) => void;
       respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -5089,6 +5101,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   exportExternalState(): any;
   importExternalState(state: any): void;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   stopSpeaking(): void;
   connectVoice(): void;
   disconnectVoice(): void;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1202,6 +1202,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1538,6 +1538,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1270,6 +1270,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1708,6 +1708,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1545,6 +1545,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2030,6 +2030,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3817,6 +3817,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext$1;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
@@ -3846,6 +3847,7 @@ type ThreadRuntimeCore = Readonly<{
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
+  unstable_notifySessionReset: () => void;
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;
   respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3919,6 +3921,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
       startRun: (config: StartRunConfig) => void;
       resumeRun: (config: ResumeRunConfig) => void;
       cancelRun: () => void;
+      unstable_notifySessionReset: () => void;
       addToolResult: (options: AddToolResultOptions) => void;
       resumeToolCall: (options: ResumeToolCallOptions) => void;
       respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -4008,6 +4011,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   exportExternalState(): any;
   importExternalState(state: any): void;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   stopSpeaking(): void;
   connectVoice(): void;
   disconnectVoice(): void;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1716,6 +1716,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1887,6 +1887,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3328,6 +3328,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext$1;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
@@ -3357,6 +3358,7 @@ type ThreadRuntimeCore = Readonly<{
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
+  unstable_notifySessionReset: () => void;
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;
   respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3430,6 +3432,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
       startRun: (config: StartRunConfig) => void;
       resumeRun: (config: ResumeRunConfig) => void;
       cancelRun: () => void;
+      unstable_notifySessionReset: () => void;
       addToolResult: (options: AddToolResultOptions) => void;
       resumeToolCall: (options: ResumeToolCallOptions) => void;
       respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -3519,6 +3522,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   exportExternalState(): any;
   importExternalState(state: any): void;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   stopSpeaking(): void;
   connectVoice(): void;
   disconnectVoice(): void;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1654,6 +1654,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -2083,6 +2083,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4838,6 +4838,7 @@ type ThreadRuntime = {
   importExternalState(state: any): void;
   subscribe(callback: () => void): Unsubscribe$1;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext$1;
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
@@ -4867,6 +4868,7 @@ type ThreadRuntimeCore = Readonly<{
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
+  unstable_notifySessionReset: () => void;
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;
   respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -4940,6 +4942,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
       startRun: (config: StartRunConfig) => void;
       resumeRun: (config: ResumeRunConfig) => void;
       cancelRun: () => void;
+      unstable_notifySessionReset: () => void;
       addToolResult: (options: AddToolResultOptions) => void;
       resumeToolCall: (options: ResumeToolCallOptions) => void;
       respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
@@ -5029,6 +5032,7 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   exportExternalState(): any;
   importExternalState(state: any): void;
   cancelRun(): void;
+  unstable_notifySessionReset(): void;
   stopSpeaking(): void;
   connectVoice(): void;
   disconnectVoice(): void;

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -294,6 +294,13 @@ export type ThreadRuntime = {
 
   subscribe(callback: () => void): Unsubscribe;
   cancelRun(): void;
+  /**
+   * Notifies the runtime that the adapter discarded its backing session.
+   * Clears session-scoped tool-invocation state without run-cancel side
+   * effects such as composer draft restoration. Internal API for
+   * external-store adapter authors.
+   */
+  unstable_notifySessionReset(): void;
   getModelContext(): ModelContext;
 
   export(): ExportedMessageRepository;
@@ -397,6 +404,8 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
     this.exportExternalState = this.exportExternalState.bind(this);
     this.startRun = this.startRun.bind(this);
     this.cancelRun = this.cancelRun.bind(this);
+    this.unstable_notifySessionReset =
+      this.unstable_notifySessionReset.bind(this);
     this.stopSpeaking = this.stopSpeaking.bind(this);
     this.connectVoice = this.connectVoice.bind(this);
     this.disconnectVoice = this.disconnectVoice.bind(this);
@@ -465,6 +474,10 @@ export class ThreadRuntimeImpl implements ThreadRuntime {
 
   public cancelRun() {
     this._threadBinding.getState().cancelRun();
+  }
+
+  public unstable_notifySessionReset() {
+    this._threadBinding.getState().unstable_notifySessionReset();
   }
 
   public stopSpeaking() {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -69,6 +69,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   public abstract cancelRun(): void;
   public abstract exportExternalState(): any;
   public abstract importExternalState(state: any): void;
+  public abstract unstable_notifySessionReset(): void;
 
   protected _voiceMessages: ThreadMessage[] = [];
   protected _voiceGeneration = 0;

--- a/packages/core/src/runtime/interfaces/thread-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-runtime-core.ts
@@ -156,6 +156,7 @@ export type ThreadRuntimeCore = Readonly<{
   startRun: (config: StartRunConfig) => void;
   resumeRun: (config: ResumeRunConfig) => void;
   cancelRun: () => void;
+  unstable_notifySessionReset: () => void;
 
   addToolResult: (options: AddToolResultOptions) => void;
   resumeToolCall: (options: ResumeToolCallOptions) => void;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -627,13 +627,10 @@ export class ExternalStoreThreadRuntimeCore
     // imported state) is treated as historical — no streamCall/execute
     // fires for the loaded tool calls. The adapter is expected to update
     // its messages in response to onLoadExternalState; that update flows
-    // back here via __internal_setAdapter. We only clear adapter-side
-    // tool statuses when the tracker is the source of truth — otherwise
-    // we'd wipe statuses the adapter is managing on its own.
-    if (this._toolInvocations) {
-      this._toolInvocations.reset();
-      this._store.setToolStatuses?.({});
-    }
+    // back here via __internal_setAdapter. The tracker publishes the
+    // cleared status map itself, so adapter-side statuses reset only when
+    // the tracker is the source of truth.
+    this._toolInvocations?.reset();
 
     this._store.onLoadExternalState(state);
   }
@@ -644,10 +641,7 @@ export class ExternalStoreThreadRuntimeCore
    * without run-cancel semantics (`onCancel`, composer draft restoration).
    */
   public unstable_notifySessionReset(): void {
-    if (this._toolInvocations) {
-      this._toolInvocations.reset();
-      this._store.setToolStatuses?.({});
-    }
+    this._toolInvocations?.reset();
     this._store.queue?.__internal_notifyCancelled?.();
   }
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -638,6 +638,19 @@ export class ExternalStoreThreadRuntimeCore
     this._store.onLoadExternalState(state);
   }
 
+  /**
+   * Adapter-facing notification that the backing session was discarded.
+   * Clears session-scoped tool-invocation state and parks queued work,
+   * without run-cancel semantics (`onCancel`, composer draft restoration).
+   */
+  public unstable_notifySessionReset(): void {
+    if (this._toolInvocations) {
+      this._toolInvocations.reset();
+      this._store.setToolStatuses?.({});
+    }
+    this._store.queue?.__internal_notifyCancelled?.();
+  }
+
   public cancelRun(): void {
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -387,6 +387,10 @@ export class LocalThreadRuntimeCore
     throw new Error("Runtime does not support importing external states.");
   }
 
+  public unstable_notifySessionReset(): void {
+    throw new Error("Runtime does not support resetting sessions.");
+  }
+
   public async startRun(
     { parentId, runConfig }: StartRunConfig,
     runCallback?: ChatModelAdapter["run"],

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -112,6 +112,10 @@ export class ReadonlyThreadRuntimeCore
     throw READONLY_THREAD_ERROR;
   }
 
+  unstable_notifySessionReset(): void {
+    throw READONLY_THREAD_ERROR;
+  }
+
   composer = {
     attachments: [] as never[],
     attachmentAccept: "*",

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -91,6 +91,10 @@ export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
     throw EMPTY_THREAD_ERROR;
   },
 
+  unstable_notifySessionReset() {
+    throw EMPTY_THREAD_ERROR;
+  },
+
   composer: {
     attachments: [],
     attachmentAccept: "*",

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -1172,3 +1172,112 @@ describe("ToolInvocationTracker", () => {
     }
   });
 });
+
+describe("ToolInvocationTracker reset", () => {
+  const trackerWith = (tools: Record<string, Tool>) => {
+    let statuses: Record<string, ToolExecutionStatus> = {};
+    const tracker = new ToolInvocationTracker(() => tools, {
+      onResult: vi.fn(),
+      onStatusesChange: (s: ReadonlyMap<string, ToolExecutionStatus>) => {
+        statuses = Object.fromEntries(s);
+      },
+    });
+    return { tracker, statuses: () => statuses };
+  };
+
+  it("clears statuses for discarded executions that never settle", async () => {
+    const { tracker, statuses } = trackerWith({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(() => new Promise(() => {})),
+      } satisfies Tool,
+    });
+    tracker.setState(createState([]));
+    tracker.setState(
+      createState([
+        createAssistantMessage('{"query":"London"}', { query: "London" }),
+      ]),
+    );
+    await waitFor(() => {
+      expect(statuses()["tool-1"]?.type).toBe("executing");
+    });
+
+    tracker.reset();
+
+    expect(statuses()).toEqual({});
+  });
+
+  it("does not republish sibling statuses when a discarded execution settles after reset", async () => {
+    const { tracker, statuses } = trackerWith({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(
+          (_args, { abortSignal }: { abortSignal: AbortSignal }) =>
+            new Promise((resolve) => {
+              abortSignal.addEventListener("abort", () =>
+                resolve({ ok: true }),
+              );
+            }),
+        ),
+      } satisfies Tool,
+      pressureSearch: {
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(() => new Promise(() => {})),
+      } satisfies Tool,
+    });
+    tracker.setState(createState([]));
+    tracker.setState(
+      createState([
+        createAssistantMessage('{"query":"London"}', { query: "London" }),
+        createAssistantMessage(
+          '{"query":"London"}',
+          { query: "London" },
+          {
+            toolCallId: "tool-2",
+            toolName: "pressureSearch",
+          },
+        ),
+      ]),
+    );
+    await waitFor(() => {
+      expect(statuses()["tool-1"]?.type).toBe("executing");
+      expect(statuses()["tool-2"]?.type).toBe("executing");
+    });
+
+    tracker.reset();
+    expect(statuses()).toEqual({});
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(statuses()).toEqual({});
+  });
+
+  it("rejects a human-input request from a discarded execution without resurrecting its status", async () => {
+    let humanFn: ((payload: unknown) => Promise<unknown>) | undefined;
+    const { tracker, statuses } = trackerWith({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(() => new Promise(() => {})),
+        streamCall: vi.fn((_reader, { human }) => {
+          humanFn = human;
+        }),
+      } satisfies Tool,
+    });
+    tracker.setState(createState([]));
+    tracker.setState(
+      createState([
+        createAssistantMessage('{"query":"London"}', { query: "London" }),
+      ]),
+    );
+    await waitFor(() => {
+      expect(statuses()["tool-1"]?.type).toBe("executing");
+      expect(humanFn).toBeDefined();
+    });
+
+    tracker.reset();
+
+    await expect(humanFn!({ request: "approve" })).rejects.toThrow(
+      "Tool execution aborted",
+    );
+    expect(statuses()).toEqual({});
+  });
+});

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -1205,18 +1205,39 @@ describe("ToolInvocationTracker reset", () => {
     tracker.reset();
 
     expect(statuses()).toEqual({});
+
+    // A new-session snapshot restoring tool activity must not drag the
+    // discarded id back in through the whole-map republication. The first
+    // post-reset snapshot is the fresh session's empty state, consuming the
+    // pending-restore mark.
+    tracker.setState(createState([]));
+    tracker.setState(
+      createState([
+        createAssistantMessage(
+          '{"query":"Paris"}',
+          { query: "Paris" },
+          { toolCallId: "tool-2" },
+        ),
+      ]),
+    );
+    await waitFor(() => {
+      expect(statuses()["tool-2"]?.type).toBe("executing");
+    });
+    expect(statuses()["tool-1"]).toBeUndefined();
   });
 
   it("does not republish sibling statuses when a discarded execution settles after reset", async () => {
+    const settled = Promise.withResolvers<void>();
     const { tracker, statuses } = trackerWith({
       weatherSearch: {
         parameters: { type: "object", properties: {} },
         execute: vi.fn(
           (_args, { abortSignal }: { abortSignal: AbortSignal }) =>
             new Promise((resolve) => {
-              abortSignal.addEventListener("abort", () =>
-                resolve({ ok: true }),
-              );
+              abortSignal.addEventListener("abort", () => {
+                resolve({ ok: true });
+                settled.resolve();
+              });
             }),
         ),
       } satisfies Tool,
@@ -1247,7 +1268,10 @@ describe("ToolInvocationTracker reset", () => {
     tracker.reset();
     expect(statuses()).toEqual({});
 
-    await new Promise((r) => setTimeout(r, 20));
+    // The settle-after-abort of tool-1 is what could republish tool-2;
+    // await it deterministically instead of sleeping.
+    await settled.promise;
+    await new Promise((r) => setTimeout(r, 0));
     expect(statuses()).toEqual({});
   });
 

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -285,6 +285,15 @@ export class ToolInvocationTracker {
       void this.abort().finally(() => {
         this._executing.clear();
       });
+      // Statuses are cleared synchronously: discarded executions may never
+      // settle (aborting hands the signal to the tool, it does not force
+      // settlement), and a late settlement of one sibling must not republish
+      // the others. `_deleteStatus` no-ops for cleared ids, so post-reset
+      // settlements stay silent.
+      if (this._statuses.size > 0) {
+        this._statuses = new Map();
+        this._invokeOnStatusesChange();
+      }
     } catch (err) {
       console.error("[ToolInvocationTracker] reset failed", err);
     }
@@ -388,6 +397,12 @@ export class ToolInvocationTracker {
     payload: unknown,
   ): Promise<unknown> {
     return new Promise<unknown>((resolve, reject) => {
+      // A discarded execution (reset or rolled back — its entry is gone) must
+      // not resurrect a status entry or park an unanswerable request.
+      if (!this._entries.has(toolCallId)) {
+        reject(new Error("Tool execution aborted"));
+        return;
+      }
       const previous = this._humanInput.get(toolCallId);
       if (previous) {
         try {

--- a/packages/core/src/tests/session-reset-notification.test.ts
+++ b/packages/core/src/tests/session-reset-notification.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExternalStoreRuntimeCore } from "../runtimes/external-store/external-store-runtime-core";
+import { LocalRuntimeCore } from "../runtimes/local/local-runtime-core";
+import type { ChatModelAdapter } from "../runtime/utils/chat-model-adapter";
+import type { ThreadMessage } from "../types/message";
+
+const trailingUserMessage = {
+  id: "u1",
+  role: "user",
+  createdAt: new Date(),
+  content: [{ type: "text", text: "draft in flight" }],
+  attachments: [],
+  metadata: { custom: {} },
+} as ThreadMessage;
+
+const externalThread = () => {
+  const setToolStatuses = vi.fn();
+  const setMessages = vi.fn();
+  const onCancel = vi.fn();
+  const notifyCancelled = vi.fn();
+  const core = new ExternalStoreRuntimeCore({
+    messages: [trailingUserMessage],
+    onNew: vi.fn(async () => {}),
+    onCancel,
+    setMessages,
+    unstable_enableToolInvocations: true,
+    setToolStatuses,
+    queue: {
+      __internal_notifyCancelled: notifyCancelled,
+    } as never,
+  });
+  return {
+    thread: core.threads.getMainThreadRuntimeCore(),
+    setToolStatuses,
+    setMessages,
+    onCancel,
+    notifyCancelled,
+  };
+};
+
+describe("unstable_notifySessionReset", () => {
+  it("clears session-scoped tool state and parks queued work", () => {
+    const { thread, setToolStatuses, notifyCancelled } = externalThread();
+
+    thread.unstable_notifySessionReset();
+
+    expect(setToolStatuses).toHaveBeenLastCalledWith({});
+    expect(notifyCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries no run-cancel semantics", () => {
+    const { thread, setMessages, onCancel } = externalThread();
+
+    thread.unstable_notifySessionReset();
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(thread.messages.at(-1)?.id).toBe("u1");
+  });
+
+  it("throws on runtimes without a backing session", () => {
+    const local = new LocalRuntimeCore(
+      { async *run() {} } satisfies ChatModelAdapter,
+      undefined,
+      {},
+    );
+
+    expect(() =>
+      local.threads.getMainThreadRuntimeCore().unstable_notifySessionReset(),
+    ).toThrow("Runtime does not support resetting sessions.");
+  });
+});

--- a/packages/core/src/tests/session-reset-notification.test.ts
+++ b/packages/core/src/tests/session-reset-notification.test.ts
@@ -4,6 +4,23 @@ import { LocalRuntimeCore } from "../runtimes/local/local-runtime-core";
 import type { ChatModelAdapter } from "../runtime/utils/chat-model-adapter";
 import type { ThreadMessage } from "../types/message";
 
+async function waitFor(
+  predicate: () => unknown,
+  timeoutMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await predicate();
+      return;
+    } catch {
+      // retry
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  await predicate();
+}
+
 const trailingUserMessage = {
   id: "u1",
   role: "user",
@@ -13,13 +30,36 @@ const trailingUserMessage = {
   metadata: { custom: {} },
 } as ThreadMessage;
 
+const toolCallMessage = {
+  id: "a1",
+  role: "assistant",
+  createdAt: new Date(),
+  status: { type: "requires-action", reason: "tool-calls" },
+  metadata: {
+    unstable_state: null,
+    unstable_annotations: [],
+    unstable_data: [],
+    steps: [],
+    custom: {},
+  },
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "send_email",
+      args: { to: "dev@example.com" },
+      argsText: '{"to":"dev@example.com"}',
+    },
+  ],
+} as unknown as ThreadMessage;
+
 const externalThread = () => {
   const setToolStatuses = vi.fn();
   const setMessages = vi.fn();
   const onCancel = vi.fn();
   const notifyCancelled = vi.fn();
-  const core = new ExternalStoreRuntimeCore({
-    messages: [trailingUserMessage],
+  const store = {
+    messages: [trailingUserMessage] as ThreadMessage[],
     onNew: vi.fn(async () => {}),
     onCancel,
     setMessages,
@@ -28,8 +68,21 @@ const externalThread = () => {
     queue: {
       __internal_notifyCancelled: notifyCancelled,
     } as never,
+  };
+  const core = new ExternalStoreRuntimeCore(store);
+  core.registerModelContextProvider({
+    getModelContext: () => ({
+      tools: {
+        send_email: {
+          parameters: { type: "object", properties: {} },
+          execute: vi.fn(() => new Promise(() => {})),
+        },
+      },
+    }),
   });
   return {
+    core,
+    store,
     thread: core.threads.getMainThreadRuntimeCore(),
     setToolStatuses,
     setMessages,
@@ -38,24 +91,43 @@ const externalThread = () => {
   };
 };
 
+const driveExecutingTool = async (
+  harness: ReturnType<typeof externalThread>,
+) => {
+  harness.core.setAdapter({
+    ...harness.store,
+    messages: [trailingUserMessage, toolCallMessage],
+  });
+  await waitFor(() => {
+    const statuses = harness.setToolStatuses.mock.lastCall?.[0] as
+      | Record<string, { type: string }>
+      | undefined;
+    expect(statuses?.["tool-1"]?.type).toBe("executing");
+  });
+};
+
 describe("unstable_notifySessionReset", () => {
-  it("clears session-scoped tool state and parks queued work", () => {
-    const { thread, setToolStatuses, notifyCancelled } = externalThread();
+  it("clears session-scoped tool state once and parks queued work", async () => {
+    const harness = externalThread();
+    await driveExecutingTool(harness);
 
-    thread.unstable_notifySessionReset();
+    harness.setToolStatuses.mockClear();
+    harness.thread.unstable_notifySessionReset();
 
-    expect(setToolStatuses).toHaveBeenLastCalledWith({});
-    expect(notifyCancelled).toHaveBeenCalledTimes(1);
+    expect(harness.setToolStatuses).toHaveBeenCalledTimes(1);
+    expect(harness.setToolStatuses).toHaveBeenLastCalledWith({});
+    expect(harness.notifyCancelled).toHaveBeenCalledTimes(1);
   });
 
-  it("carries no run-cancel semantics", () => {
-    const { thread, setMessages, onCancel } = externalThread();
+  it("carries no run-cancel semantics", async () => {
+    const harness = externalThread();
+    await driveExecutingTool(harness);
 
-    thread.unstable_notifySessionReset();
+    harness.thread.unstable_notifySessionReset();
 
-    expect(onCancel).not.toHaveBeenCalled();
-    expect(setMessages).not.toHaveBeenCalled();
-    expect(thread.messages.at(-1)?.id).toBe("u1");
+    expect(harness.onCancel).not.toHaveBeenCalled();
+    expect(harness.setMessages).not.toHaveBeenCalled();
+    expect(harness.thread.messages.at(-1)?.id).toBe("a1");
   });
 
   it("throws on runtimes without a backing session", () => {

--- a/packages/core/src/tests/session-reset-notification.test.ts
+++ b/packages/core/src/tests/session-reset-notification.test.ts
@@ -60,9 +60,10 @@ describe("unstable_notifySessionReset", () => {
 
   it("throws on runtimes without a backing session", () => {
     const local = new LocalRuntimeCore(
-      { async *run() {} } satisfies ChatModelAdapter,
+      {
+        adapters: { chatModel: { async *run() {} } satisfies ChatModelAdapter },
+      },
       undefined,
-      {},
     );
 
     expect(() =>

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -196,23 +196,8 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     >(),
   );
 
-  // The core tracker publishes its whole status map on every transition, and
-  // an execution discarded by a reset keeps its entry until it settles — so a
-  // status is only evidence of a live turn while its tool call is still in the
-  // session.
-  const sessionToolCallIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const message of agent.data.messages) {
-      for (const part of message.parts) {
-        if (part.type === "dynamic-tool") ids.add(part.toolCallId);
-      }
-    }
-    return ids;
-  }, [agent.data]);
-
-  const hasExecutingTools = Object.entries(toolStatuses).some(
-    ([toolCallId, status]) =>
-      status?.type === "executing" && sessionToolCallIds.has(toolCallId),
+  const hasExecutingTools = Object.values(toolStatuses).some(
+    (status) => status?.type === "executing",
   );
   const isRunning =
     agent.status === "submitted" ||
@@ -326,10 +311,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   };
 
   const reset = useCallback(() => {
-    // Client-side tool executions live in the core tracker, which an adapter
-    // can only reach through the cancel path; without it an execution keeps
-    // running against a session that is gone.
-    runtimeRef.current?.thread.cancelRun();
+    runtimeRef.current?.thread.unstable_notifySessionReset();
     // Sends parked behind an active turn captured the pre-reset epoch, so the
     // epoch has to advance before the session is torn down or they dispatch
     // into the new one; `lastFinishStatusRef` is run-scoped for the same


### PR DESCRIPTION
closes #5918

## summary

- adds `unstable_notifySessionReset(): void` along the runtime api chain (ThreadRuntimeCore interface, base abstract, external-store implementation, throwing stubs on local/readonly/empty, ThreadRuntime bind + delegate), following the `importExternalState` precedent for external-store-specific surface
- the external-store implementation is the composition core already trusted in `importExternalState`: `ToolInvocationTracker.reset()` (clears entries, rejects pending human input, aborts in-flight executions, re-arms the next snapshot as historical) plus `setToolStatuses({})` under the same source-of-truth guard, plus the queue park notification; deliberately WITHOUT run-cancel semantics (`store.onCancel`, optimistic-head drop, composer draft restoration)
- migrates the eve adapter's composed reset onto the verb and deletes its `sessionToolCallIds` filter outright: the filter existed because `cancelRun` reaches only `tracker.abort()`, whose entries survive until settle and pollute `isRunning`; `tracker.reset()` clears them at the source, so the eve runtime file nets out 21 lines lighter
- shapes considered and rejected in the #5918 discussion: a store callback (`onSessionReset`) inverts the actual direction (the adapter initiates, core is notified); exposing the tracker handle leaks internals without the composition; a core-level `thread.reset()` product verb conflates adapter session lifecycle with UI verbs eve already owns via extras; an epoch parameter re-implements what the tracker's `_pendingRestore` already does

## test plan

### already verified

- [x] new contract test `packages/core/src/tests/session-reset-notification.test.ts` -> 3/3: clears tool statuses and parks queued work; carries no run-cancel semantics (onCancel untouched, trailing user draft stays in the thread); unsupported runtimes throw
- [x] full workspace `turbo test` -> 82/82; the #5626 eve reset suite (queued-send drop, tool-execution abort, human-input rejection, composer untouched) now exercises this verb end to end
- [x] `pnpm api-surface` regenerated (14 surface files, append-only additions) and `pnpm api-surface:check` -> no drift; docs generator run -> no content change (ThreadRuntime methods are not per-method doc pages, same as cancelRun)
- [x] `pnpm lint` -> clean; `tsc --noEmit` in both elevenlabs examples -> clean; runtime ESM-link smoke of the rebuilt eve dist -> ok

### reviewer should verify

- [ ] code quality workflow green on this PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.q3_xGRd9MnSp7DItsqHdWyEKvZuJfTzE_OMGbNZyqTIAS_xK6CKINFwci0w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->