### PR TITLE
refactor: adopt @assistant-ui/ai-sdk in workspace-internal consumers

### DIFF
--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -3,12 +3,12 @@ import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
 import {
   injectQuoteContext,
   unstable_injectInteractableContext as injectInteractableContext,
-} from "@assistant-ui/react-ai-sdk";
+} from "@assistant-ui/ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateGeneralChatInput } from "@/lib/validate-input";
 import { getModel } from "@/lib/ai/provider";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
-import { AISDKToolkit } from "@assistant-ui/react-ai-sdk";
+import { AISDKToolkit } from "@assistant-ui/ai-sdk";
 import docsToolkit from "@/lib/docs-toolkit";
 import {
   convertToModelMessages,

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -3,7 +3,7 @@ import { getDistinctId } from "@/lib/posthog-server";
 import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { injectQuoteContext } from "@assistant-ui/react-ai-sdk";
+import { injectQuoteContext } from "@assistant-ui/ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
 import {
@@ -14,7 +14,7 @@ import {
 } from "@/lib/source";
 import { getModel } from "@/lib/ai/provider";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
-import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import { frontendTools } from "@assistant-ui/ai-sdk";
 import { createBashTool } from "bash-tool";
 import {
   convertToModelMessages,

--- a/apps/docs/app/api/playground-chat/route.ts
+++ b/apps/docs/app/api/playground-chat/route.ts
@@ -2,7 +2,7 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { validateGeneralChatInput } from "@/lib/validate-input";
 import { getModel } from "@/lib/ai/provider";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
-import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import { frontendTools } from "@assistant-ui/ai-sdk";
 import { NextResponse } from "next/server";
 import {
   convertToModelMessages,

--- a/apps/docs/app/api/xulux/chat/agents.ts
+++ b/apps/docs/app/api/xulux/chat/agents.ts
@@ -1,4 +1,4 @@
-import type { FrontendTools } from "@assistant-ui/react-ai-sdk";
+import type { FrontendTools } from "@assistant-ui/ai-sdk";
 import type { ToolSet, UIMessage } from "ai";
 import { NextResponse } from "next/server";
 import { parseLearnContext } from "@/lib/xulux/learn/context";

--- a/apps/docs/app/api/xulux/chat/handler.ts
+++ b/apps/docs/app/api/xulux/chat/handler.ts
@@ -1,9 +1,6 @@
 import { getDistinctId } from "@/lib/posthog-server";
 import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
-import {
-  injectQuoteContext,
-  type FrontendTools,
-} from "@assistant-ui/react-ai-sdk";
+import { injectQuoteContext, type FrontendTools } from "@assistant-ui/ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
 import { getModel, openai } from "@/lib/ai/provider";

--- a/apps/docs/app/api/xulux/chat/tools.test.ts
+++ b/apps/docs/app/api/xulux/chat/tools.test.ts
@@ -1,4 +1,4 @@
-import type { FrontendTools } from "@assistant-ui/react-ai-sdk";
+import type { FrontendTools } from "@assistant-ui/ai-sdk";
 import { createAppBuilderTools, createLearnAgentTools } from "./tools";
 import { appBuilderAgent, learnAgent } from "./agents";
 

--- a/apps/docs/app/api/xulux/chat/tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools.ts
@@ -1,4 +1,4 @@
-import { frontendTools, type FrontendTools } from "@assistant-ui/react-ai-sdk";
+import { frontendTools, type FrontendTools } from "@assistant-ui/ai-sdk";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import { resolveNextCourseStep } from "@/lib/xulux/learn/next-step-result";

--- a/apps/docs/app/api/xulux/learn/preview-agent.test.ts
+++ b/apps/docs/app/api/xulux/learn/preview-agent.test.ts
@@ -1,4 +1,4 @@
-import type { FrontendTools } from "@assistant-ui/react-ai-sdk";
+import type { FrontendTools } from "@assistant-ui/ai-sdk";
 import {
   createLearnPreviewTools,
   getLearnPreviewStageId,

--- a/apps/docs/app/api/xulux/learn/preview-agent.ts
+++ b/apps/docs/app/api/xulux/learn/preview-agent.ts
@@ -2,7 +2,7 @@ import {
   frontendTools,
   unstable_injectInteractableContext as injectInteractableContext,
   type FrontendTools,
-} from "@assistant-ui/react-ai-sdk";
+} from "@assistant-ui/ai-sdk";
 import { NextResponse } from "next/server";
 import { tool, zodSchema, type ToolSet } from "ai";
 import { z } from "zod";

--- a/apps/docs/components/builder/builder-chat-sidebar.tsx
+++ b/apps/docs/components/builder/builder-chat-sidebar.tsx
@@ -20,10 +20,7 @@ import {
   Tools,
   Suggestions,
 } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/ai-sdk";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { SendHorizontal, SquareIcon } from "lucide-react";
 import {

--- a/apps/docs/components/docs/assistant/footer.tsx
+++ b/apps/docs/components/docs/assistant/footer.tsx
@@ -5,7 +5,7 @@ import { PlusIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { analytics } from "@/lib/analytics";
 import { useCurrentPage } from "@/components/docs/contexts/current-page";
-import { useThreadTokenUsage } from "@assistant-ui/react-ai-sdk";
+import { useThreadTokenUsage } from "@assistant-ui/ai-sdk";
 import { ContextDisplay } from "@assistant-ui/ui/components/assistant-ui/context-display";
 import { useSharedDocsModelSelection } from "./composer";
 import { getContextWindow } from "@/constants/model";

--- a/apps/docs/components/docs/assistant/thread.tsx
+++ b/apps/docs/components/docs/assistant/thread.tsx
@@ -22,7 +22,7 @@ import { useCurrentPage } from "@/components/docs/contexts/current-page";
 import {
   getThreadMessageTokenUsage,
   type ThreadTokenUsage,
-} from "@assistant-ui/react-ai-sdk";
+} from "@assistant-ui/ai-sdk";
 import { getContextWindow } from "@/constants/model";
 import { Button } from "@/components/ui/button";
 import {

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -13,10 +13,7 @@ import {
   AssistantRuntimeProvider,
   useRemoteThreadListRuntime,
 } from "@assistant-ui/react";
-import {
-  AssistantChatTransport,
-  useChatRuntime,
-} from "@assistant-ui/react-ai-sdk";
+import { AssistantChatTransport, useChatRuntime } from "@assistant-ui/ai-sdk";
 import { AssistantPanelProvider } from "@/components/docs/assistant/context";
 import { XuluxAnalyticsProvider } from "@/lib/xulux/analytics-context";
 import type { XuluxTemplate } from "./templates/types";

--- a/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
+++ b/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
@@ -9,7 +9,7 @@ import {
   Tools,
   type Toolkit,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/ai-sdk";
 import { DevToolsModal } from "@assistant-ui/react-devtools";
 import { ModelContextClient as ModelContext } from "@assistant-ui/react";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";

--- a/apps/docs/contexts/AssistantRuntimeProvider.tsx
+++ b/apps/docs/contexts/AssistantRuntimeProvider.tsx
@@ -12,7 +12,7 @@ import {
   useChatRuntime,
   AssistantChatTransport,
   getThreadMessageTokenUsage,
-} from "@assistant-ui/react-ai-sdk";
+} from "@assistant-ui/ai-sdk";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { useEffect, useRef, type ReactNode } from "react";
 import { useCurrentPage } from "@/components/docs/contexts/current-page";

--- a/apps/docs/contexts/DocsRuntimeProvider.tsx
+++ b/apps/docs/contexts/DocsRuntimeProvider.tsx
@@ -13,7 +13,7 @@ import {
   unstable_Interactables,
   type FeedbackAdapter,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/ai-sdk";
 import { DevToolsModal } from "@assistant-ui/react-devtools";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import docsToolkit from "@/lib/docs-toolkit";

--- a/apps/docs/contexts/PlaygroundRuntimeProvider.tsx
+++ b/apps/docs/contexts/PlaygroundRuntimeProvider.tsx
@@ -4,7 +4,7 @@ import {
   AssistantRuntimeProvider,
   WebSpeechSynthesisAdapter,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/ai-sdk";
 
 export function PlaygroundRuntimeProvider({
   children,

--- a/apps/docs/lib/assistant-metrics.test.ts
+++ b/apps/docs/lib/assistant-metrics.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { getThreadMessageTokenUsage } from "@assistant-ui/react-ai-sdk";
+import { getThreadMessageTokenUsage } from "@assistant-ui/ai-sdk";
 
 it("reads usage from legacy custom.usage metadata path", () => {
   const usage = getThreadMessageTokenUsage({

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,7 @@
     "@ai-sdk/openai": "^4.0.40",
     "@ai-sdk/otel": "^1.0.62",
     "@ai-sdk/react": "^4.0.65",
+    "@assistant-ui/ai-sdk": "workspace:*",
     "@assistant-ui/next": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-ai-sdk": "workspace:*",

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@ai-sdk/react": "^4.0.65",
     "@ai-sdk/react-v3": "npm:@ai-sdk/react@^3.0.211",
-    "@assistant-ui/react-ai-sdk": "workspace:*",
+    "@assistant-ui/ai-sdk": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^4.0.65
         version: 4.0.65(react@19.2.8)(zod@4.4.3)
+      '@assistant-ui/ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/ai-sdk
       '@assistant-ui/next':
         specifier: workspace:*
         version: link:../../packages/next
@@ -3589,9 +3592,9 @@ importers:
       '@ai-sdk/react-v3':
         specifier: npm:@ai-sdk/react@^3.0.211
         version: '@ai-sdk/react@3.0.252(react@19.2.8)(zod@4.4.3)'
-      '@assistant-ui/react-ai-sdk':
+      '@assistant-ui/ai-sdk':
         specifier: workspace:*
-        version: link:../react-ai-sdk
+        version: link:../ai-sdk
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils


### PR DESCRIPTION
part of #5920, following #5923.

## summary

- workspace-internal consumers now import from `@assistant-ui/ai-sdk` directly instead of going through the `@assistant-ui/react-ai-sdk` shell: 18 app-owned files in apps/docs (api routes, docs assistant components, runtime provider contexts, the metrics test) and the cloud-ai-sdk devDependency
- the apps/docs manifest gains `@assistant-ui/ai-sdk` additively and keeps the old dependency, because the embedded xulux course content still references the old name on purpose
- scope is deliberately limited to references the workspace resolves: everything a user might `npm install` or read as instructions (templates, examples, docs prose and install snippets, registry items, packages/ui copied components, CLI installers, package READMEs, JSDoc examples) stays on the old name until `@assistant-ui/ai-sdk` is published to npm, and moves in a follow-up
- notable exclusions found while sweeping: `xulux-suggestions.ts` looks like code but is canned teaching content (its imports live inside template literals), and apps/registry `app/**` files are registry item sources whose imports the registry build validates against item dependency arrays, so the registry moves wholesale in the follow-up

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/docs test` 138/138
- [x] `pnpm --filter @assistant-ui/cloud-ai-sdk test` 80/80 plus both peer typecheck projects
- [x] `pnpm --filter ./apps/registry build` and `test` green (registry deliberately untouched)
- [x] every changed line is an import specifier or a manifest dependency line (machine-audited diff)
- [x] oxlint and oxfmt clean

### reviewer should verify

- [ ] no file under `apps/docs/content`, `templates/`, `examples/`, or `apps/registry` appears in this diff

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hvyVfTBoYlPPPDEkU0OY1wufPoxcEW5URB2A0bMqOeVPdCNbBpUdaDfGNYo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->