### PR TITLE
chore: replace stale example model ids with gpt-5.6-luna

### DIFF
--- a/.changeset/example-model-sweep.md
+++ b/.changeset/example-model-sweep.md
@@ -1,0 +1,10 @@
+---
+"assistant-ui": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+chore: replace stale example model ids with gpt-5.6-luna

--- a/apps/docs/app/api/xulux/chat/handler.ts
+++ b/apps/docs/app/api/xulux/chat/handler.ts
@@ -60,15 +60,15 @@ function resolveXuluxModel(config: unknown) {
     ? requestConfig.reasoningEffort
     : undefined;
 
-  if (modelName === "gpt-5.4" && reasoningEffort) {
+  if (modelName === "gpt-5.6-luna" && reasoningEffort) {
     return {
-      model: openai.responses("gpt-5.4"),
+      model: openai.responses("gpt-5.6-luna"),
       providerOptions: { openai: { reasoningEffort } },
     };
   }
 
   return {
-    model: modelName ? getModel(modelName) : getModel("gpt-5.4-mini"),
+    model: modelName ? getModel(modelName) : getModel("gpt-5.6-luna"),
     providerOptions: undefined,
   };
 }

--- a/apps/docs/app/api/xulux/chat/handler.ts
+++ b/apps/docs/app/api/xulux/chat/handler.ts
@@ -3,7 +3,6 @@ import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
 import { injectQuoteContext, type FrontendTools } from "@assistant-ui/ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
-import { getModel, openai } from "@/lib/ai/provider";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { NextResponse } from "next/server";
@@ -22,56 +21,7 @@ import {
   getLatestUserMessageId,
 } from "@/lib/xulux/turn-outcome";
 import type { XuluxAgentDefinition } from "./agents";
-
-type XuluxReasoningEffort =
-  | "none"
-  | "minimal"
-  | "low"
-  | "medium"
-  | "high"
-  | "xhigh";
-
-type XuluxRequestConfig = {
-  modelName?: unknown;
-  reasoningEffort?: unknown;
-};
-
-function isReasoningEffort(value: unknown): value is XuluxReasoningEffort {
-  return (
-    value === "none" ||
-    value === "minimal" ||
-    value === "low" ||
-    value === "medium" ||
-    value === "high" ||
-    value === "xhigh"
-  );
-}
-
-function resolveXuluxModel(config: unknown) {
-  const requestConfig =
-    config && typeof config === "object" && !Array.isArray(config)
-      ? (config as XuluxRequestConfig)
-      : undefined;
-  const modelName =
-    typeof requestConfig?.modelName === "string"
-      ? requestConfig.modelName.trim()
-      : "";
-  const reasoningEffort = isReasoningEffort(requestConfig?.reasoningEffort)
-    ? requestConfig.reasoningEffort
-    : undefined;
-
-  if (modelName === "gpt-5.6-luna" && reasoningEffort) {
-    return {
-      model: openai.responses("gpt-5.6-luna"),
-      providerOptions: { openai: { reasoningEffort } },
-    };
-  }
-
-  return {
-    model: modelName ? getModel(modelName) : getModel("gpt-5.6-luna"),
-    providerOptions: undefined,
-  };
-}
+import { resolveXuluxModel } from "./resolve-model";
 
 const PRUNE_OPTIONS = {
   toolCalls: "before-last-2-messages",

--- a/apps/docs/app/api/xulux/chat/resolve-model.test.ts
+++ b/apps/docs/app/api/xulux/chat/resolve-model.test.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_MODEL_ID } from "@/constants/model";
+import { resolveXuluxModel } from "./resolve-model";
+
+describe("resolveXuluxModel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the default model without warning when no config is sent", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { model, providerOptions } = resolveXuluxModel(undefined);
+
+    expect(model.modelId).toBe(DEFAULT_MODEL_ID);
+    expect(providerOptions).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns and falls back to the default for an unknown model id", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { model } = resolveXuluxModel({ modelName: "gpt-4.1-mini" });
+
+    expect(model.modelId).toBe(DEFAULT_MODEL_ID);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("routes gpt-5.6-luna with a reasoning effort through the responses API", () => {
+    const { model, providerOptions } = resolveXuluxModel({
+      modelName: "gpt-5.6-luna",
+      reasoningEffort: "high",
+    });
+
+    expect(model.modelId).toBe("gpt-5.6-luna");
+    expect(providerOptions).toEqual({ openai: { reasoningEffort: "high" } });
+  });
+
+  it("ignores an invalid reasoning effort", () => {
+    const { providerOptions } = resolveXuluxModel({
+      modelName: "gpt-5.6-luna",
+      reasoningEffort: "ultra",
+    });
+
+    expect(providerOptions).toBeUndefined();
+  });
+});

--- a/apps/docs/app/api/xulux/chat/resolve-model.ts
+++ b/apps/docs/app/api/xulux/chat/resolve-model.ts
@@ -1,0 +1,51 @@
+import { getModel, openai } from "@/lib/ai/provider";
+
+type XuluxReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+
+type XuluxRequestConfig = {
+  modelName?: unknown;
+  reasoningEffort?: unknown;
+};
+
+function isReasoningEffort(value: unknown): value is XuluxReasoningEffort {
+  return (
+    value === "none" ||
+    value === "minimal" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh"
+  );
+}
+
+export function resolveXuluxModel(config: unknown) {
+  const requestConfig =
+    config && typeof config === "object" && !Array.isArray(config)
+      ? (config as XuluxRequestConfig)
+      : undefined;
+  const modelName =
+    typeof requestConfig?.modelName === "string"
+      ? requestConfig.modelName.trim()
+      : "";
+  const reasoningEffort = isReasoningEffort(requestConfig?.reasoningEffort)
+    ? requestConfig.reasoningEffort
+    : undefined;
+
+  if (modelName === "gpt-5.6-luna" && reasoningEffort) {
+    return {
+      model: openai.responses("gpt-5.6-luna"),
+      providerOptions: { openai: { reasoningEffort } },
+    };
+  }
+
+  return {
+    model: getModel(modelName),
+    providerOptions: undefined,
+  };
+}

--- a/apps/docs/app/api/xulux/learn/preview-agent.ts
+++ b/apps/docs/app/api/xulux/learn/preview-agent.ts
@@ -191,7 +191,7 @@ export const learnPreviewAgent: XuluxAgentDefinition = {
     "You are a concise, helpful assistant. Use only the tools available in this course stage.",
   maxSteps: 5,
   maxOutputTokens: 4_096,
-  modelName: "gpt-5.4-mini",
+  modelName: "gpt-5.6-luna",
   traceName: "xulux_learn_preview",
   getTraceMetadata: ({ routeUrl }) => ({
     course_id: "build-generative-ui-assistant",

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -378,7 +378,7 @@ The `useCloudChat` hook automatically reports run telemetry to Assistant Cloud a
 **Requires route configuration:**
 - `model_id` — The model used for the response
 - `input_tokens` / `output_tokens` — Token usage statistics
-- `reasoning_tokens` — Tokens used for chain-of-thought reasoning (e.g. GPT-5.4 Mini or GPT-5.5 models)
+- `reasoning_tokens` — Tokens used for chain-of-thought reasoning (e.g. GPT-5.6 Luna or other reasoning models)
 - `cached_input_tokens` — Input tokens served from the provider's prompt cache
 
 To capture model and usage data, configure the `messageMetadata` callback in your AI SDK route:

--- a/apps/docs/content/docs/guides/attachments.mdx
+++ b/apps/docs/content/docs/guides/attachments.mdx
@@ -118,7 +118,7 @@ Build your own adapters for specialized file handling. Below are complete exampl
 
 ### Vision-Capable Image Adapter
 
-Send images to vision-capable LLMs like GPT-5.4, Claude Sonnet 4.6, or Gemini Pro Vision:
+Send images to vision-capable LLMs like GPT-5.6, Claude Sonnet 4.6, or Gemini Pro Vision:
 
 ```tsx
 import {
@@ -276,7 +276,7 @@ const MyModelAdapter: ChatModelAdapter = {
         msg.role === "user" &&
         msg.content.some((part) => part.type === "image")
       ) {
-        // Format for GPT-5.4 or similar vision models
+        // Format for GPT-5.6 or similar vision models
         return {
           role: "user",
           content: msg.content.map((part) => {

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -1217,7 +1217,7 @@ Container `Box` for the status bar. Forwards all `Box` props; pass `gap` to spac
 ```tsx
 <StatusBarPrimitive.Root gap={1}>
   <StatusBarPrimitive.Status />
-  <StatusBarPrimitive.ModelName name="gpt-5" />
+  <StatusBarPrimitive.ModelName name="gpt-5.6-luna" />
   <StatusBarPrimitive.MessageCount />
   <StatusBarPrimitive.TokenCount />
   <StatusBarPrimitive.Latency />

--- a/apps/docs/content/docs/tools/generative-ui.mdx
+++ b/apps/docs/content/docs/tools/generative-ui.mdx
@@ -145,7 +145,7 @@ export async function POST(req: Request) {
   const { messages, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: await aiToolkit.tools({ frontend: tools }),

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S1/project/app/api/chat/route.ts
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S1/project/app/api/chat/route.ts
@@ -6,7 +6,7 @@ export const maxDuration = 30;
 export async function POST(request: Request) {
   const { messages }: { messages: UIMessage[] } = await request.json();
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-5.6-luna"),
     system: "You are a concise, helpful assistant.",
     messages: await convertToModelMessages(messages),
   });

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S3/project/app/api/chat/route.ts
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S3/project/app/api/chat/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request) {
   const { messages, tools }: { messages: UIMessage[]; tools?: FrontendTools } =
     await request.json();
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-5.6-luna"),
     system:
       "You are a concise, helpful assistant. Use the weather tools for weather questions.",
     messages: await convertToModelMessages(messages),

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S5/project/app/api/chat/route.ts
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S5/project/app/api/chat/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
   const { messages, tools }: { messages: UIMessage[]; tools?: FrontendTools } =
     await request.json();
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-5.6-luna"),
     system:
       "You are a concise, helpful assistant. Use the weather tools for weather questions.",
     messages: await convertToModelMessages(injectInteractableContext(messages)),

--- a/apps/registry/app/api/chat/route.ts
+++ b/apps/registry/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       ...frontendTools(tools ?? {}),

--- a/apps/registry/templates/ai-sdk-backend-resumable/app/api/chat/route.ts
+++ b/apps/registry/templates/ai-sdk-backend-resumable/app/api/chat/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
   const streamId = crypto.randomUUID();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       ...frontendTools(tools ?? {}),

--- a/examples/with-ag-ui/README.md
+++ b/examples/with-ag-ui/README.md
@@ -53,7 +53,7 @@ pnpm dev
 The included `server/agent.py` provides:
 
 - **Echo mode** (default): Echoes back user messages for testing
-- **OpenAI mode**: Uses GPT-5.4 Nano when `OPENAI_API_KEY` is set
+- **OpenAI mode**: Uses GPT-5.6 Luna when `OPENAI_API_KEY` is set
 
 ### Endpoints
 

--- a/examples/with-ag-ui/server/agent.py
+++ b/examples/with-ag-ui/server/agent.py
@@ -103,7 +103,7 @@ async def openai_agent(messages: list, run_id: str, thread_id: str) -> AsyncGene
 
     try:
         stream = await client.chat.completions.create(
-            model="gpt-5.4-nano",
+            model="gpt-5.6-luna",
             messages=openai_messages,
             stream=True,
         )

--- a/examples/with-ai-sdk-v7/app/api/chat/route.ts
+++ b/examples/with-ai-sdk-v7/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     ...(system ? { system } : {}),
     stopWhen: stepCountIs(10),

--- a/examples/with-artifacts/app/api/chat/route.ts
+++ b/examples/with-artifacts/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     system:
       "You create functional HTML artifacts. When the user requests a webpage, interface, visualization, or other visual content, call the artifact tool with a short title and a complete HTML document. When an artifact already exists and the user requests a change, call update_artifact with its id and only the fields that changed. Do not put artifact HTML in a code block.",
     messages: await convertToModelMessages(

--- a/examples/with-chain-of-thought/app/api/chat/route.ts
+++ b/examples/with-chain-of-thought/app/api/chat/route.ts
@@ -114,7 +114,7 @@ async function streamModel(
 
   const result = streamText({
     // Reasoning model so the chain-of-thought group has real content.
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {

--- a/examples/with-cloud-standalone/app/api/chat/route.ts
+++ b/examples/with-cloud-standalone/app/api/chat/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
 

--- a/examples/with-cloud/app/api/chat/route.ts
+++ b/examples/with-cloud/app/api/chat/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     // forward system prompt and tools from the frontend
     system,

--- a/examples/with-custom-thread-list/app/api/chat/route.ts
+++ b/examples/with-custom-thread-list/app/api/chat/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {

--- a/examples/with-elevenlabs-conversational/app/api/chat/route.ts
+++ b/examples/with-elevenlabs-conversational/app/api/chat/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
   });

--- a/examples/with-elevenlabs-scribe/app/api/chat/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/chat/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     tools: {

--- a/examples/with-expo/app/api/chat+api.ts
+++ b/examples/with-expo/app/api/chat+api.ts
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   const body = await req.json();
   const { messages, tools } = body;
 
-  const model = openai("gpt-5.4-nano");
+  const model = openai("gpt-5.6-luna");
 
   const prunedMessages = pruneMessages({
     messages: await convertToModelMessages(messages),

--- a/examples/with-ffmpeg/app/api/chat/route.ts
+++ b/examples/with-ffmpeg/app/api/chat/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/examples/with-generative-ui/app/api/chat/route.ts
+++ b/examples/with-generative-ui/app/api/chat/route.ts
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     ...(system ? { system } : {}),

--- a/examples/with-generative-ui/app/api/present/route.ts
+++ b/examples/with-generative-ui/app/api/present/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
     ...(system ? { system } : {}),

--- a/examples/with-interactables/app/api/chat/route.ts
+++ b/examples/with-interactables/app/api/chat/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
   );
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: modelMessages,
     stopWhen: stepCountIs(10),
     ...(system ? { system } : {}),

--- a/examples/with-livekit/app/api/chat/route.ts
+++ b/examples/with-livekit/app/api/chat/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(10),
   });

--- a/examples/with-mcp/app/app/api/chat/route.ts
+++ b/examples/with-mcp/app/app/api/chat/route.ts
@@ -7,7 +7,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: { ...frontendTools(tools) },

--- a/examples/with-nuxt/server/api/chat.post.ts
+++ b/examples/with-nuxt/server/api/chat.post.ts
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event) => {
   }>(event);
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages,
     system,
   });

--- a/examples/with-react-hook-form/app/api/chat/route.ts
+++ b/examples/with-react-hook-form/app/api/chat/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/examples/with-react-router/app/routes/api.chat.ts
+++ b/examples/with-react-router/app/routes/api.chat.ts
@@ -68,7 +68,7 @@ export async function action({ request }: Route.ActionArgs) {
 
       while (continueLoop) {
         const response = await openai.chat.completions.create({
-          model: "gpt-5.4-nano",
+          model: "gpt-5.6-luna",
           messages: openaiMessages,
           tools,
           stream: true,

--- a/examples/with-resumable-stream/app/api/chat/route.ts
+++ b/examples/with-resumable-stream/app/api/chat/route.ts
@@ -81,7 +81,7 @@ async function buildOpenAIBody({
     }),
   });
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     ...(system ? { system } : {}),
     stopWhen: stepCountIs(10),

--- a/examples/with-tanstack/src/server/chat.ts
+++ b/examples/with-tanstack/src/server/chat.ts
@@ -18,7 +18,7 @@ export const chatStream = createServerFn({ method: "POST" })
     });
 
     const stream = await openai.chat.completions.create({
-      model: "gpt-5.4-nano",
+      model: "gpt-5.6-luna",
       messages: data.messages,
       stream: true,
     });

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -93,13 +93,13 @@ describe("useAISDKRuntime", () => {
       result.current.thread.append({
         role: "user",
         content: [{ type: "text", text: "hello" }],
-        runConfig: { custom: { model: "gpt-5.4-nano" } },
+        runConfig: { custom: { model: "gpt-5.6-luna" } },
       });
     });
 
     await waitFor(() => {
       expect(chat.sendMessage).toHaveBeenCalledWith(expect.anything(), {
-        metadata: { custom: { model: "gpt-5.4-nano" } },
+        metadata: { custom: { model: "gpt-5.6-luna" } },
       });
     });
   });

--- a/packages/cli/plugin/skills/assistant-ui/SKILL.md
+++ b/packages/cli/plugin/skills/assistant-ui/SKILL.md
@@ -83,7 +83,7 @@ export async function POST(req: Request) {
   const { messages, config } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages,
     ...config,
   });
@@ -125,7 +125,7 @@ import { streamText, tool } from "ai";
 import { z } from "zod";
 
 const result = streamText({
-  model: openai("gpt-5.4-nano"),
+  model: openai("gpt-5.6-luna"),
   messages,
   tools: {
     get_weather: tool({

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.test.ts
@@ -72,7 +72,7 @@ describe("CloudTelemetryReporter", () => {
 
     await reporter.reportFromMessages("thread-1", [
       assistantMsg("m-1", "hello", {
-        modelId: "gpt-5.4-nano",
+        modelId: "gpt-5.6-luna",
         usage: {
           promptTokens: 100,
           completionTokens: 50,
@@ -86,7 +86,7 @@ describe("CloudTelemetryReporter", () => {
     expect(reportMock).toHaveBeenCalledWith({
       thread_id: "thread-1",
       status: "completed",
-      model_id: "gpt-5.4-nano",
+      model_id: "gpt-5.6-luna",
       input_tokens: 100,
       output_tokens: 50,
       reasoning_tokens: 20,

--- a/packages/core/src/store/clients/model-context-client.test.ts
+++ b/packages/core/src/store/clients/model-context-client.test.ts
@@ -39,10 +39,12 @@ describe("ModelContext", () => {
   it("reflects modelName from a registered provider", async () => {
     const { sub, unmount } = render();
     try {
-      sub.getValue().register(provider({ config: { modelName: "gpt-4" } }));
+      sub
+        .getValue()
+        .register(provider({ config: { modelName: "gpt-5.6-luna" } }));
       await tick();
 
-      expect(sub.getValue().getState().modelName).toBe("gpt-4");
+      expect(sub.getValue().getState().modelName).toBe("gpt-5.6-luna");
     } finally {
       unmount();
     }
@@ -67,11 +69,15 @@ describe("ModelContext", () => {
   it("keeps the same state reference when an extra provider does not change the merged values", async () => {
     const { sub, unmount } = render();
     try {
-      sub.getValue().register(provider({ config: { modelName: "gpt-4" } }));
+      sub
+        .getValue()
+        .register(provider({ config: { modelName: "gpt-5.6-luna" } }));
       await tick();
       const before = sub.getValue().getState();
 
-      sub.getValue().register(provider({ config: { modelName: "gpt-4" } }));
+      sub
+        .getValue()
+        .register(provider({ config: { modelName: "gpt-5.6-luna" } }));
       await tick();
       const after = sub.getValue().getState();
 
@@ -86,9 +92,9 @@ describe("ModelContext", () => {
     try {
       const unsubscribe = sub
         .getValue()
-        .register(provider({ config: { modelName: "gpt-4" } }));
+        .register(provider({ config: { modelName: "gpt-5.6-luna" } }));
       await tick();
-      expect(sub.getValue().getState().modelName).toBe("gpt-4");
+      expect(sub.getValue().getState().modelName).toBe("gpt-5.6-luna");
 
       unsubscribe();
       await tick();
@@ -102,9 +108,11 @@ describe("ModelContext", () => {
   it("reflects modelName synchronously after register without awaiting", () => {
     const { sub, unmount } = render();
     try {
-      sub.getValue().register(provider({ config: { modelName: "gpt-4" } }));
+      sub
+        .getValue()
+        .register(provider({ config: { modelName: "gpt-5.6-luna" } }));
 
-      expect(sub.getValue().getState().modelName).toBe("gpt-4");
+      expect(sub.getValue().getState().modelName).toBe("gpt-5.6-luna");
     } finally {
       unmount();
     }

--- a/packages/react-ink/src/tests/StatusBarPrimitive.test.tsx
+++ b/packages/react-ink/src/tests/StatusBarPrimitive.test.tsx
@@ -47,8 +47,10 @@ describe("StatusBarPrimitive.Root", () => {
 
 describe("StatusBarPrimitive.ModelName", () => {
   it("renders the provided name", () => {
-    const { lastFrame } = render(<StatusBarPrimitiveModelName name="gpt-5" />);
-    expect(lastFrame()).toContain("gpt-5");
+    const { lastFrame } = render(
+      <StatusBarPrimitiveModelName name="gpt-5.6-luna" />,
+    );
+    expect(lastFrame()).toContain("gpt-5.6-luna");
   });
 
   it("falls back to 'unknown'", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -66,14 +66,14 @@ describe("convertLangChainMessages metadata", () => {
       id: "ai-1",
       content: "Hi there!",
       additional_kwargs: {
-        metadata: { model: "gpt-5.4-nano", speaker_name: "Assistant" },
+        metadata: { model: "gpt-5.6-luna", speaker_name: "Assistant" },
       },
     });
 
     expect(result).toMatchObject({
       role: "assistant",
       metadata: {
-        custom: { model: "gpt-5.4-nano", speaker_name: "Assistant" },
+        custom: { model: "gpt-5.6-luna", speaker_name: "Assistant" },
       },
     });
   });

--- a/packages/react-langgraph/src/createLangGraphStream.test.ts
+++ b/packages/react-langgraph/src/createLangGraphStream.test.ts
@@ -191,7 +191,7 @@ describe("unstable_createLangGraphStream", () => {
       client,
       assistantId: "graph-1",
     });
-    const runConfig = { configurable: { model_name: "gpt-5.4-nano" } };
+    const runConfig = { configurable: { model_name: "gpt-5.6-luna" } };
 
     await callback([humanMessage], {
       abortSignal: new AbortController().signal,

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -1119,7 +1119,7 @@ describe("useLangGraphMessages", {}, () => {
       result.current.sendMessage([{ type: "human", content: "test" }], {
         checkpointId: "cp-456",
         command: { resume: "yes" },
-        runConfig: { model: "gpt-5.4-nano" },
+        runConfig: { model: "gpt-5.6-luna" },
       });
     });
 
@@ -1128,7 +1128,7 @@ describe("useLangGraphMessages", {}, () => {
       const config = streamSpy.mock.calls[0]![1];
       expect(config.checkpointId).toBe("cp-456");
       expect(config.command).toEqual({ resume: "yes" });
-      expect(config.runConfig).toEqual({ model: "gpt-5.4-nano" });
+      expect(config.runConfig).toEqual({ model: "gpt-5.6-luna" });
       expect(config.abortSignal).toBeInstanceOf(AbortSignal);
       expect(typeof config.initialize).toBe("function");
     });

--- a/python/assistant-transport-backend-langgraph/README.md
+++ b/python/assistant-transport-backend-langgraph/README.md
@@ -163,7 +163,7 @@ const runtime = useExternalStoreRuntime({
 
 ## Customizing the LangGraph
 
-You can customize the graph in the `create_graph()` function. Currently, it implements a simple chat node using OpenAI's GPT-5.4 Nano model. You can:
+You can customize the graph in the `create_graph()` function. Currently, it implements a simple chat node using OpenAI's GPT-5.6 Luna model. You can:
 
 - Add more nodes for different functionalities
 - Implement tool calling

--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -229,7 +229,7 @@ async def subagent_node(state: SubagentState) -> dict[str, Any]:
     if os.getenv("OPENAI_API_KEY"):
         # Initialize a simpler LLM for the subagent
         llm = ChatOpenAI(
-            model="gpt-5.4-nano",
+            model="gpt-5.6-luna",
             temperature=0.7,
             streaming=True
         )
@@ -267,7 +267,7 @@ async def agent_node(state: GraphState) -> dict[str, Any]:
     if os.getenv("OPENAI_API_KEY"):
         # Initialize the LLM with tool binding
         llm = ChatOpenAI(
-            model="gpt-5.4-nano",
+            model="gpt-5.6-luna",
             temperature=0.7,
             streaming=True,
         )

--- a/python/assistant-ui-sync-server-api/tests/test_client.py
+++ b/python/assistant-ui-sync-server-api/tests/test_client.py
@@ -312,7 +312,7 @@ async def test_all_parameters():
             tools=tools,
             system="You are an analyzer",
             unstable_assistantMessageId="asst-456",
-            runConfig={"model": "gpt-5.4-nano"},
+            runConfig={"model": "gpt-5.6-luna"},
             state={"session": "abc"},
             custom_field="custom_value"
         )
@@ -326,7 +326,7 @@ async def test_all_parameters():
         assert payload["messages"] == messages
         assert payload["tools"] == tools
         assert payload["unstable_assistantMessageId"] == "asst-456"
-        assert payload["runConfig"] == {"model": "gpt-5.4-nano"}
+        assert payload["runConfig"] == {"model": "gpt-5.6-luna"}
         assert payload["state"] == {"session": "abc"}
         assert payload["custom_field"] == "custom_value"
 

--- a/templates/cloud-clerk/app/api/chat/route.ts
+++ b/templates/cloud-clerk/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai.responses("gpt-5.4-nano"),
+    model: openai.responses("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/templates/cloud/app/api/chat/route.ts
+++ b/templates/cloud/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai.responses("gpt-5.4-nano"),
+    model: openai.responses("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/templates/default/app/api/chat/route.ts
+++ b/templates/default/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai.responses("gpt-5.4-nano"),
+    model: openai.responses("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/templates/mcp/app/api/chat/route.ts
+++ b/templates/mcp/app/api/chat/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
   const mcpTools = await getMCPTools();
 
   const result = streamText({
-    model: openai.responses("gpt-5.4-nano"),
+    model: openai.responses("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/templates/minimal/app/api/chat/route.ts
+++ b/templates/minimal/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {


### PR DESCRIPTION
## summary

- replaces every stale example model id (`gpt-5.4-nano`, `gpt-5.4-mini`, `gpt-4.1-mini`, bare `gpt-4`/`gpt-5` test fixtures) with `gpt-5.6-luna` across examples, templates, the registry, the python backends, docs pages, the cli plugin skill, and colocated test fixtures
- fixes real drift in the docs xulux chat handler: the `getModel("gpt-5.4-mini")` fallback logged an invalid-model warning and fell back to luna on every request, and the reasoning effort branch still compared against `gpt-5.4`, which the frontend no longer sends; both now target `gpt-5.6-luna`
- updates prose mentions ("GPT-5.4 Nano", "GPT-5.4" vision references, the `reasoning_tokens` example) to the GPT-5.6 family
- consciously skipped: `chatgpt-subscription.mdx` (`gpt-5.3-codex` and `gpt-5.4` there are facts about ChatGPT plan models, not placeholders) and the decorative model labels in the perplexity clone demo and the data-table element demo

## test plan

### already verified

- [x] `vitest run` on the touched suites in react-langgraph, ai-sdk, cloud-ai-sdk, core, and react-ink -> 226/226 green
- [x] `uv run pytest tests/test_client.py` in python/assistant-ui-sync-server-api -> 14/14 green
- [x] repo-wide `rg` sweep confirms no `gpt-5.4*`, `gpt-4*`, or bare `gpt-5` example ids remain outside the consciously skipped files

### reviewer should verify

- [ ] docs xulux chat still answers with the default model and the server log no longer prints the `[ai/provider] invalid model` warning

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yy7Wk1Emu7bx0t0IwE5DkIWCzcyR3Aw9yC7lVoC15xl7SsFppk4mhXQ5Ugk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->