### PR TITLE
feat(svelte): suggestion and thread list builders

### DIFF
--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -43,7 +43,7 @@
       <PlusIcon class="size-4" /> New chat
     </button>
     <div class="flex flex-col gap-1 overflow-y-auto">
-      {#each threads.ids as id, index}
+      {#each threads.ids as _, index}
         <ThreadItem item={threads.item(index)} />
       {/each}
     </div>

--- a/examples/with-svelte/src/App.svelte
+++ b/examples/with-svelte/src/App.svelte
@@ -3,10 +3,11 @@
     composerCancel,
     composerInput,
     composerSend,
+    threadList,
+    threadListNew,
     threadMessages,
     threadScrollToBottom,
     threadViewport,
-    useAui,
     useAuiState,
   } from "@assistant-ui/svelte";
   import {
@@ -16,8 +17,9 @@
     SquareIcon,
   } from "@lucide/svelte";
   import Message from "./Message.svelte";
+  import Suggestion from "./Suggestion.svelte";
+  import ThreadItem from "./ThreadItem.svelte";
 
-  const aui = useAui();
   const messages = threadMessages();
   const isRunning = useAuiState((s) => s.thread.isRunning);
   const suggestions = useAuiState((s) => s.suggestions.suggestions);
@@ -26,25 +28,27 @@
   const cancel = composerCancel();
   const viewport = threadViewport();
   const scrollDown = threadScrollToBottom({ viewport });
-
-  const sendSuggestion = (prompt: string) => {
-    aui.composer.setText(prompt);
-    aui.composer.send();
-  };
+  const threads = threadList();
+  const newThread = threadListNew();
 </script>
 
-<div class="bg-background flex h-full flex-col">
-  <header
-    class="border-border/60 flex items-center justify-between border-b px-4 py-2"
+<div class="bg-background flex h-full">
+  <aside
+    class="border-border/60 flex w-64 shrink-0 flex-col gap-2 border-r p-3"
   >
-    <span class="text-sm font-medium">assistant-ui × Svelte</span>
     <button
-      class="border-border/60 hover:bg-muted flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm transition-colors"
-      onclick={() => aui.threads.switchToNewThread()}
+      {...newThread.props}
+      class="border-border/60 hover:bg-muted flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors"
     >
       <PlusIcon class="size-4" /> New chat
     </button>
-  </header>
+    <div class="flex flex-col gap-1 overflow-y-auto">
+      {#each threads.ids as id, index}
+        <ThreadItem item={threads.item(index)} />
+      {/each}
+    </div>
+  </aside>
+  <div class="flex min-w-0 flex-1 flex-col">
   <div
     {@attach viewport.attach}
     class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
@@ -54,16 +58,8 @@
         <div class="flex flex-1 flex-col items-center justify-center gap-6 pb-24">
           <h1 class="text-2xl font-semibold">How can I help you today?</h1>
           <div class="flex flex-wrap items-center justify-center gap-2 px-4">
-            {#each suggestions.current as suggestion (suggestion.prompt)}
-              <button
-                class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
-                onclick={() => sendSuggestion(suggestion.prompt)}
-              >
-                <span class="font-medium">{suggestion.title}</span>
-                <span class="text-muted-foreground text-xs">
-                  {suggestion.label}
-                </span>
-              </button>
+            {#each suggestions.current as suggestion, index}
+              <Suggestion {suggestion} {index} />
             {/each}
           </div>
         </div>
@@ -118,5 +114,6 @@
         {/if}
       </div>
     </div>
+  </div>
   </div>
 </div>

--- a/examples/with-svelte/src/Suggestion.svelte
+++ b/examples/with-svelte/src/Suggestion.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Suggestion } from "@assistant-ui/core/store";
+  import { suggestionTrigger } from "@assistant-ui/svelte";
+
+  let { suggestion, index }: { suggestion: Suggestion; index: number } =
+    $props();
+
+  const trigger = suggestionTrigger({ index, send: true });
+</script>
+
+<button
+  {...trigger.props}
+  class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+>
+  <span class="font-medium">{suggestion.title}</span>
+  <span class="text-muted-foreground text-xs">{suggestion.label}</span>
+</button>

--- a/examples/with-svelte/src/ThreadItem.svelte
+++ b/examples/with-svelte/src/ThreadItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import {
+    threadListItemTrigger,
+    useAuiState,
+    type ThreadListItem,
+  } from "@assistant-ui/svelte";
+
+  let { item }: { item: ThreadListItem } = $props();
+
+  const trigger = threadListItemTrigger({ item });
+  const title = useAuiState((s) => s.threadListItem.title, { item });
+</script>
+
+<button
+  {...trigger.props}
+  class="hover:bg-muted text-muted-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground w-full truncate rounded-lg px-3 py-2 text-left text-sm transition-colors"
+>
+  {title.current || "New Chat"}
+</button>

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -98,6 +98,17 @@ export const createEchoRuntime = () => {
   let threads: { id: string; title: string }[] = [{ id: "t0", title: "" }];
   let currentThreadId = "t0";
   let nextThreadId = 1;
+  const onSwitchToThread = vi.fn((threadId: string) => {
+    currentThreadId = threadId;
+    sync();
+  });
+  const onSwitchToNewThread = vi.fn(() => {
+    const id = `t${nextThreadId++}`;
+    threads = [...threads, { id, title: id }];
+    currentThreadId = id;
+    messages = [];
+    sync();
+  });
   const makeAdapter = () => ({
     messages,
     isRunning,
@@ -110,17 +121,8 @@ export const createEchoRuntime = () => {
           id: thread.id,
           title: thread.title,
         })),
-        onSwitchToThread: (threadId: string) => {
-          currentThreadId = threadId;
-          sync();
-        },
-        onSwitchToNewThread: () => {
-          const id = `t${nextThreadId++}`;
-          threads = [...threads, { id, title: "" }];
-          currentThreadId = id;
-          messages = [];
-          sync();
-        },
+        onSwitchToThread,
+        onSwitchToNewThread,
       },
     },
     setMessages: (next: EchoMessage[]) => {
@@ -141,6 +143,8 @@ export const createEchoRuntime = () => {
     onEdit,
     onCancel,
     onReload,
+    onSwitchToThread,
+    onSwitchToNewThread,
     setMessages: (next: EchoMessage[]) => {
       messages = next;
       sync();

--- a/packages/svelte/src/__tests__/primitives-suggestions.test.ts
+++ b/packages/svelte/src/__tests__/primitives-suggestions.test.ts
@@ -159,11 +159,16 @@ describe("suggestionTrigger", () => {
   it("passes an empty prompt through instead of treating it as missing", () => {
     const { app, aui, triggers } = mountSuggestions(() => ({
       empty: suggestionTrigger({ index: 2 }),
+      append: suggestionTrigger({ index: 2, clearComposer: false }),
     }));
 
     flushTapSync(() => aui.composer.setText("draft"));
     triggers.empty!.props.onclick();
     expect(aui.composer.getState().text).toBe("");
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    triggers.append!.props.onclick();
+    expect(aui.composer.getState().text).toBe("draft");
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/__tests__/primitives-suggestions.test.ts
+++ b/packages/svelte/src/__tests__/primitives-suggestions.test.ts
@@ -3,6 +3,10 @@ import { flushSync, mount, unmount } from "svelte";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
 import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
 import { provideAui } from "../provideAui";
 import { suggestionTrigger } from "../primitives/suggestions";
 import Host from "./fixtures/Host.svelte";
@@ -24,6 +28,7 @@ const mountSuggestions = (
             suggestions: Suggestions([
               { title: "One", label: "first", prompt: "Prompt one" },
               { title: "Two", label: "second", prompt: "Prompt two" },
+              { title: "Empty", label: "third", prompt: "" },
             ]),
           }),
         ) as AnyClient;
@@ -92,6 +97,73 @@ describe("suggestionTrigger", () => {
     expect(triggers.insert!.props.disabled).toBe(false);
     triggers.send!.props.onclick();
     expect(echo.onNew).not.toHaveBeenCalled();
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("queues a send during a run without clearing the draft", async () => {
+    let isRunning = false;
+    const steer = vi.fn();
+    const makeAdapter = () => ({
+      messages: [],
+      isRunning,
+      convertMessage: (message: never) => message,
+      onNew: async () => {},
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue: () => {},
+        steer,
+        move: () => {},
+        edit: () => {},
+        remove: () => {},
+      },
+    });
+    const core = new ExternalStoreRuntimeCore(makeAdapter() as never);
+    const runtime = new AssistantRuntimeImpl(core as never);
+    let aui!: AnyClient;
+    let trigger!: ReturnType<typeof suggestionTrigger>;
+    const app = mount(Host, {
+      target: document.createElement("div"),
+      props: {
+        setup: () => {
+          aui = provideAui(
+            AuiConfig({
+              threads: RuntimeAdapter(runtime),
+              suggestions: Suggestions([
+                { title: "One", label: "first", prompt: "Prompt one" },
+              ]),
+            }),
+          ) as AnyClient;
+          trigger = suggestionTrigger({ index: 0, send: true });
+        },
+      },
+    });
+
+    flushTapSync(() => {
+      aui.composer.setText("half-typed draft");
+      isRunning = true;
+      core.setAdapter(makeAdapter() as never);
+    });
+    expect(trigger.props.disabled).toBe(false);
+    trigger.props.onclick();
+    await vi.waitFor(() => expect(steer).toHaveBeenCalledTimes(1));
+    expect(steer.mock.calls[0]![0]).toMatchObject({
+      content: [{ type: "text", text: "Prompt one" }],
+    });
+    expect(aui.composer.getState().text).toBe("half-typed draft");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("passes an empty prompt through instead of treating it as missing", () => {
+    const { app, aui, triggers } = mountSuggestions(() => ({
+      empty: suggestionTrigger({ index: 2 }),
+    }));
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    triggers.empty!.props.onclick();
+    expect(aui.composer.getState().text).toBe("");
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/__tests__/primitives-suggestions.test.ts
+++ b/packages/svelte/src/__tests__/primitives-suggestions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import { suggestionTrigger } from "../primitives/suggestions";
+import Host from "./fixtures/Host.svelte";
+import { createEchoRuntime, type AnyClient } from "./clients";
+
+const mountSuggestions = (
+  build: () => Record<string, ReturnType<typeof suggestionTrigger>>,
+) => {
+  const echo = createEchoRuntime();
+  let aui!: AnyClient;
+  let triggers!: Record<string, ReturnType<typeof suggestionTrigger>>;
+  const app = mount(Host, {
+    target: document.createElement("div"),
+    props: {
+      setup: () => {
+        aui = provideAui(
+          AuiConfig({
+            threads: RuntimeAdapter(echo.runtime),
+            suggestions: Suggestions([
+              { title: "One", label: "first", prompt: "Prompt one" },
+              { title: "Two", label: "second", prompt: "Prompt two" },
+            ]),
+          }),
+        ) as AnyClient;
+        triggers = build();
+      },
+    },
+  });
+  return { app, echo, aui, triggers };
+};
+
+describe("suggestionTrigger", () => {
+  it("replaces the composer text by default", () => {
+    const { app, aui, triggers } = mountSuggestions(() => ({
+      trigger: suggestionTrigger({ index: 0 }),
+    }));
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    triggers.trigger!.props.onclick();
+    expect(aui.composer.getState().text).toBe("Prompt one");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("appends to a non-empty draft when clearComposer is false", () => {
+    const { app, aui, triggers } = mountSuggestions(() => ({
+      trigger: suggestionTrigger({ index: 1, clearComposer: false }),
+    }));
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    triggers.trigger!.props.onclick();
+    expect(aui.composer.getState().text).toBe("draft Prompt two");
+
+    flushTapSync(() => aui.composer.setText(""));
+    triggers.trigger!.props.onclick();
+    expect(aui.composer.getState().text).toBe("Prompt two");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("send appends the prompt as a message and clears the draft", async () => {
+    const { app, echo, aui, triggers } = mountSuggestions(() => ({
+      trigger: suggestionTrigger({ index: 0, send: true }),
+    }));
+
+    flushTapSync(() => aui.composer.setText("draft"));
+    triggers.trigger!.props.onclick();
+    await vi.waitFor(() => expect(echo.onNew).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(aui.thread.getState().messages.at(-1)?.content).toEqual([
+        { type: "text", text: "Prompt one" },
+      ]),
+    );
+    expect(aui.composer.getState().text).toBe("");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("send is disabled while running without queue support", () => {
+    const { app, echo, triggers } = mountSuggestions(() => ({
+      send: suggestionTrigger({ index: 0, send: true }),
+      insert: suggestionTrigger({ index: 0 }),
+    }));
+
+    flushTapSync(() => echo.setRunning(true));
+    expect(triggers.send!.props.disabled).toBe(true);
+    expect(triggers.insert!.props.disabled).toBe(false);
+    triggers.send!.props.onclick();
+    expect(echo.onNew).not.toHaveBeenCalled();
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("honors caller vetoes and out-of-range indexes", () => {
+    const { app, aui, triggers } = mountSuggestions(() => ({
+      trigger: suggestionTrigger({ index: 0 }),
+      missing: suggestionTrigger({ index: 9 }),
+    }));
+
+    const vetoed = new MouseEvent("click", { cancelable: true });
+    vetoed.preventDefault();
+    triggers.trigger!.props.onclick(vetoed);
+    expect(aui.composer.getState().text).toBe("");
+
+    triggers.missing!.props.onclick();
+    expect(aui.composer.getState().text).toBe("");
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/svelte/src/__tests__/primitives-threadlist.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import { useAuiState } from "../useAuiState";
+import {
+  threadList,
+  threadListItemTrigger,
+  threadListNew,
+} from "../primitives/threadList";
+import Host from "./fixtures/Host.svelte";
+import { createEchoRuntime, flushEvents, type AnyClient } from "./clients";
+
+const mountThreadList = () => {
+  const echo = createEchoRuntime();
+  let aui!: AnyClient;
+  let list!: ReturnType<typeof threadList>;
+  let newButton!: ReturnType<typeof threadListNew>;
+  const app = mount(Host, {
+    target: document.createElement("div"),
+    props: {
+      setup: () => {
+        aui = provideAui(
+          AuiConfig({ threads: RuntimeAdapter(echo.runtime) }),
+        ) as AnyClient;
+        list = threadList();
+        newButton = threadListNew();
+      },
+    },
+  });
+  return { app, echo, aui, list: () => list, newButton: () => newButton };
+};
+
+describe("threadList", () => {
+  it("exposes the ids and per-item titles", async () => {
+    const { app, aui, list } = mountThreadList();
+    expect(list().ids).toEqual(["t0"]);
+
+    flushTapSync(() => aui.threads.switchToNewThread());
+    await flushEvents();
+    expect(list().ids).toEqual(["t0", "t1"]);
+
+    const item = list().item(1);
+    item.source.subscribe(() => {});
+    const title = useAuiState((s) => s.threadListItem.title, { item });
+    expect(title.current).toBe("t1");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("item triggers switch threads and mark the main one active", async () => {
+    const { app, echo, aui, list } = mountThreadList();
+    flushTapSync(() => aui.threads.switchToNewThread());
+    await flushEvents();
+
+    const first = list().item(0);
+    const second = list().item(1);
+    first.source.subscribe(() => {});
+    second.source.subscribe(() => {});
+    const firstTrigger = threadListItemTrigger({ item: first });
+    const secondTrigger = threadListItemTrigger({ item: second });
+
+    expect(firstTrigger.props["data-active"]).toBeUndefined();
+    expect(secondTrigger.props["data-active"]).toBe("true");
+    expect(secondTrigger.props["aria-current"]).toBe("true");
+
+    flushTapSync(() => firstTrigger.props.onclick());
+    expect(echo.onSwitchToThread).toHaveBeenCalledWith("t0");
+    expect(firstTrigger.props["data-active"]).toBe("true");
+    expect(secondTrigger.props["data-active"]).toBeUndefined();
+
+    const vetoed = new MouseEvent("click", { cancelable: true });
+    vetoed.preventDefault();
+    secondTrigger.props.onclick(vetoed);
+    expect(firstTrigger.props["data-active"]).toBe("true");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("the new-thread button switches and reports the active state", async () => {
+    const { app, echo, list, newButton } = mountThreadList();
+    const button = newButton();
+
+    flushTapSync(() => button.props.onclick());
+    await flushEvents();
+    expect(echo.onSwitchToNewThread).toHaveBeenCalledTimes(1);
+    expect(list().ids).toEqual(["t0", "t1"]);
+
+    const vetoed = new MouseEvent("click", { cancelable: true });
+    vetoed.preventDefault();
+    button.props.onclick(vetoed);
+    expect(echo.onSwitchToNewThread).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -23,6 +23,13 @@ export {
   threadViewport,
 } from "./primitives/threadViewport";
 export { threadMessages, type MessageItem } from "./primitives/threadMessages";
+export { suggestionTrigger } from "./primitives/suggestions";
+export {
+  threadList,
+  threadListItemTrigger,
+  threadListNew,
+  type ThreadListItem,
+} from "./primitives/threadList";
 
 export {
   AuiConfig,

--- a/packages/svelte/src/primitives/suggestions.ts
+++ b/packages/svelte/src/primitives/suggestions.ts
@@ -1,0 +1,56 @@
+import { flushTapSync } from "@assistant-ui/tap";
+import { suggestionTriggerDisabled } from "@assistant-ui/core/store/internal";
+import { getAuiContext } from "../context";
+import { useAuiState } from "../useAuiState";
+
+/**
+ * Builder for a suggestion button. Spread `props` onto a `<button>`. Iterate
+ * `s.suggestions.suggestions` and address the suggestion by `index`. With
+ * `send`, the prompt is appended as a message (queued sends never clear a
+ * draft the user is still composing); without it, the prompt replaces the
+ * composer text, or is appended to it when `clearComposer` is false. Caller
+ * handlers compose the same way as `composerSend`.
+ */
+export const suggestionTrigger = (options: {
+  index: number;
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+}) => {
+  const { index, send = false, clearComposer = true } = options;
+  const { aui } = getAuiContext();
+  const disabled = useAuiState((s) => suggestionTriggerDisabled(s, send));
+
+  return {
+    props: {
+      type: "button" as const,
+      get disabled() {
+        return disabled.current;
+      },
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented || disabled.current) return;
+        const prompt = aui.suggestions.getState().suggestions[index]?.prompt;
+        if (!prompt) return;
+        flushTapSync(() => {
+          if (send) {
+            const { isRunning, capabilities } = aui.thread.getState();
+            if (isRunning && !capabilities.queue) return;
+            aui.thread.append({
+              content: [{ type: "text", text: prompt }],
+              runConfig: aui.composer.getState().runConfig,
+            });
+            if (clearComposer && !isRunning) {
+              aui.composer.setText("");
+            }
+          } else if (clearComposer) {
+            aui.composer.setText(prompt);
+          } else {
+            const currentText = aui.composer.getState().text;
+            aui.composer.setText(
+              currentText.trim() ? `${currentText} ${prompt}` : prompt,
+            );
+          }
+        });
+      },
+    },
+  };
+};

--- a/packages/svelte/src/primitives/suggestions.ts
+++ b/packages/svelte/src/primitives/suggestions.ts
@@ -9,7 +9,9 @@ import { useAuiState } from "../useAuiState";
  * `send`, the prompt is appended as a message (queued sends never clear a
  * draft the user is still composing); without it, the prompt replaces the
  * composer text, or is appended to it when `clearComposer` is false. Caller
- * handlers compose the same way as `composerSend`.
+ * handlers compose the same way as `composerSend`. Call during component
+ * initialization. `index` is captured at construction, so iterate with an
+ * unkeyed `{#each}` the way `threadMessages` documents.
  */
 export const suggestionTrigger = (options: {
   index: number;
@@ -29,7 +31,7 @@ export const suggestionTrigger = (options: {
       onclick: (event?: MouseEvent) => {
         if (event?.defaultPrevented || disabled.current) return;
         const prompt = aui.suggestions.getState().suggestions[index]?.prompt;
-        if (!prompt) return;
+        if (prompt === undefined) return;
         flushTapSync(() => {
           if (send) {
             const { isRunning, capabilities } = aui.thread.getState();

--- a/packages/svelte/src/primitives/suggestions.ts
+++ b/packages/svelte/src/primitives/suggestions.ts
@@ -48,7 +48,7 @@ export const suggestionTrigger = (options: {
           } else {
             const currentText = aui.composer.getState().text;
             aui.composer.setText(
-              currentText.trim() ? `${currentText} ${prompt}` : prompt,
+              [currentText, prompt].filter((part) => part.trim()).join(" "),
             );
           }
         });

--- a/packages/svelte/src/primitives/threadList.ts
+++ b/packages/svelte/src/primitives/threadList.ts
@@ -1,0 +1,172 @@
+import { tick } from "svelte";
+import type {
+  ThreadListItemMethods,
+  ThreadsState,
+} from "@assistant-ui/core/store";
+import {
+  AuiConfig,
+  createAssistantClient,
+  createClientFacade,
+  createLastValidCache,
+  createStaleReporter,
+  Derived,
+} from "@assistant-ui/store/client";
+import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+
+/**
+ * A per-index handle over one thread-list item: through it, `useAuiState` and
+ * the builders resolve `s.threadListItem` to the thread at the index,
+ * extending the surrounding provider. The handle's scope mounts when the
+ * first reader is observed and suspends once none remain, like
+ * `MessageItem`.
+ */
+export type ThreadListItem = ScopeTarget;
+
+const createThreadListItem = (
+  context: AuiContext,
+  index: number,
+  archived: boolean,
+): ThreadListItem => {
+  const idsOf = (state: ThreadsState) =>
+    archived ? state.archivedThreadIds : state.threadIds;
+  let observers = 0;
+  const cache = createLastValidCache<ThreadListItemMethods>(
+    createStaleReporter({
+      name: "threadList.item",
+      index,
+      isCurrent: () => observers > 0,
+      isValid: () =>
+        index < idsOf(context.source.getClient().threads.getState()).length,
+    }),
+    scheduleExpiry,
+  );
+
+  const handle = createAssistantClient(
+    AuiConfig({
+      threadListItem: Derived({
+        source: "threads",
+        query: { type: "index", index, archived },
+        get: (aui) =>
+          cache.resolve(index < idsOf(aui.threads.getState()).length, () =>
+            aui.threads.item({ index, archived }),
+          ),
+      }),
+    }),
+    { parent: context.source },
+  );
+
+  const source = {
+    getClient: handle.getClient,
+    subscribe: (listener: () => void) => {
+      const release = handle.subscribe(listener);
+      observers++;
+      let subscribed = true;
+      return () => {
+        if (!subscribed) return;
+        subscribed = false;
+        observers--;
+        release();
+      };
+    },
+  };
+  return {
+    source,
+    aui: createClientFacade(source),
+  };
+};
+
+/**
+ * Builder for the thread list. Call during component initialization; iterate
+ * `ids` by index and scope per-row work through `item(index)`. With
+ * `archived`, both cover the archived list instead. Items are cached per
+ * index for the builder's lifetime, suspending and resuming with observation
+ * like `threadMessages`.
+ */
+export const threadList = (options?: { archived?: boolean | undefined }) => {
+  const archived = options?.archived ?? false;
+  const context = getAuiContext();
+  const ids = useAuiState(
+    (s) => (archived ? s.threads.archivedThreadIds : s.threads.threadIds),
+    { item: context },
+  );
+  const cache = new Map<number, ThreadListItem>();
+
+  return {
+    get ids(): readonly string[] {
+      return ids.current;
+    },
+    item: (index: number): ThreadListItem => {
+      let item = cache.get(index);
+      if (!item) {
+        item = createThreadListItem(context, index, archived);
+        cache.set(index, item);
+      }
+      return item;
+    },
+  };
+};
+
+/**
+ * Builder for the new-thread button. Spread `props` onto a `<button>`.
+ * Switches to a new thread; carries `data-active` and `aria-current` while
+ * the new thread is the main one. Caller handlers compose the same way as
+ * `composerSend`.
+ */
+export const threadListNew = () => {
+  const { aui } = getAuiContext();
+  const active = useAuiState(
+    (s) => s.threads.newThreadId === s.threads.mainThreadId,
+  );
+
+  return {
+    props: {
+      type: "button" as const,
+      get "data-active"() {
+        return active.current ? "true" : undefined;
+      },
+      get "aria-current"() {
+        return active.current ? ("true" as const) : undefined;
+      },
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented) return;
+        aui.threads.switchToNewThread();
+      },
+    },
+  };
+};
+
+/**
+ * Builder for a thread-list row button. Spread `props` onto a `<button>`.
+ * Switches to the scoped item's thread; carries `data-active` and
+ * `aria-current` while that thread is the main one. Caller handlers compose
+ * the same way as `composerSend`.
+ */
+export const threadListItemTrigger = (options?: {
+  item?: ScopeTarget | undefined;
+}) => {
+  const item = options?.item ?? getAuiContext();
+  const { aui } = item;
+  const active = useAuiState(
+    (s) => s.threads.mainThreadId === s.threadListItem.id,
+    { item },
+  );
+
+  return {
+    props: {
+      type: "button" as const,
+      get "data-active"() {
+        return active.current ? "true" : undefined;
+      },
+      get "aria-current"() {
+        return active.current ? ("true" as const) : undefined;
+      },
+      onclick: (event?: MouseEvent) => {
+        if (event?.defaultPrevented) return;
+        aui.threadListItem.switchTo();
+      },
+    },
+  };
+};

--- a/packages/svelte/src/primitives/threadList.ts
+++ b/packages/svelte/src/primitives/threadList.ts
@@ -83,7 +83,10 @@ const createThreadListItem = (
  * `ids` by index and scope per-row work through `item(index)`. With
  * `archived`, both cover the archived list instead. Items are cached per
  * index for the builder's lifetime, suspending and resuming with observation
- * like `threadMessages`.
+ * like `threadMessages`. Iterate unkeyed: keying the `{#each}` by thread id
+ * would let a row whose index shifts keep its component instance silently
+ * driving the old index, with no stale report while the index stays in
+ * range.
  */
 export const threadList = (options?: { archived?: boolean | undefined }) => {
   const archived = options?.archived ?? false;

--- a/packages/svelte/src/primitives/threadList.ts
+++ b/packages/svelte/src/primitives/threadList.ts
@@ -113,7 +113,7 @@ export const threadList = (options?: { archived?: boolean | undefined }) => {
  * Builder for the new-thread button. Spread `props` onto a `<button>`.
  * Switches to a new thread; carries `data-active` and `aria-current` while
  * the new thread is the main one. Caller handlers compose the same way as
- * `composerSend`.
+ * `composerSend`. Call during component initialization.
  */
 export const threadListNew = () => {
   const { aui } = getAuiContext();
@@ -142,7 +142,8 @@ export const threadListNew = () => {
  * Builder for a thread-list row button. Spread `props` onto a `<button>`.
  * Switches to the scoped item's thread; carries `data-active` and
  * `aria-current` while that thread is the main one. Caller handlers compose
- * the same way as `composerSend`.
+ * the same way as `composerSend`. Without `item`, call during component
+ * initialization.
  */
 export const threadListItemTrigger = (options?: {
   item?: ScopeTarget | undefined;


### PR DESCRIPTION
## summary

- adds `suggestionTrigger({index, send?, clearComposer?})`: with `send` the prompt is appended as a message (gated on the queue capability while a run is in flight, and queued sends never clear a draft the user is still composing); without it the prompt replaces the composer text, or is appended when `clearComposer` is false. no per-suggestion child client: the shared disabled predicate reads only thread state and the suggestion fields are already in the caller's hands from iterating `s.suggestions.suggestions`, so the trigger addresses the suggestion by index and reads the prompt at click time
- adds `threadList({archived?})` returning `{ids, item(index)}` with per-index cached item handles (same observation-riding pattern as `threadMessages`), plus `threadListNew()` and `threadListItemTrigger({item})` button builders carrying `data-active`/`aria-current` while their thread is the main one
- the active check is `s.threads.mainThreadId === s.threadListItem.id`; the store-level `ThreadListItemState` has no `isMain` (the Vue primitive reads it and that is one of its known pre-existing type errors, so this port does not copy it)
- rewires the with-svelte example to the Vue example's sidebar layout: a thread list with switch-and-highlight rows and a new-chat button, and suggestion cards driven by the send-mode trigger instead of hand-rolled `setText` + `send`

## test plan

### already verified

- [x] `pnpm -C packages/svelte exec vitest run` -> 50/50 green across four consecutive runs (8 new tests: composer replace/append semantics, send append + draft clear, running-without-queue disable, veto and out-of-range no-ops, ids and per-item titles, switch triggers with active flips, new-thread button)
- [x] `tsc --noEmit` clean for the svelte package, oxlint clean, package and example builds pass
- [x] browser smoke on the example: suggestion click sends and receives the echo reply, row titles update from the first message, active highlight follows switches, new chat returns to the empty state, switching back restores the thread history

### reviewer should verify

- [ ] run `pnpm -C examples/with-svelte dev`, send a message, click new chat, then click the previous thread row and confirm its history returns with the row highlighted

## notes

- builders without an `{item}` option (`suggestionTrigger`, `threadList`, `threadListNew`) resolve the ambient context via `getContext` and must be constructed during component initialization; the JSDoc states this
- no changeset: `@assistant-ui/svelte` and the example are private packages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.m1TyyyK2chiQxi5-JWPxeRkbUMDFNl0gYsjOdC0rrh7OOap6aYTgFXK60Ik?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->