### PR TITLE
feat(examples): with-sveltekit with AI SDK streaming

### DIFF
--- a/examples/with-svelte/src/Message.svelte
+++ b/examples/with-svelte/src/Message.svelte
@@ -30,17 +30,23 @@
       .join(""),
   );
 
-  const isEditing = useAuiState((s) => s.composer.isEditing, { item });
-  const branchNumber = useAuiState((s) => s.message.branchNumber, { item });
-  const branchCount = useAuiState((s) => s.message.branchCount, { item });
-  const edit = actionBarEdit({ item });
-  const copy = actionBarCopy({ item });
-  const reload = actionBarReload({ item });
-  const previous = branchPickerPrevious({ item });
-  const next = branchPickerNext({ item });
-  const editInput = composerInput({ item });
-  const editSend = composerSend({ item });
-  const editCancel = composerCancel({ item });
+  // The item handle is index-bound and referentially stable for this
+  // position's lifetime under unkeyed iteration, so a one-time capture is
+  // correct.
+  // svelte-ignore state_referenced_locally
+  const target = { item };
+
+  const isEditing = useAuiState((s) => s.composer.isEditing, target);
+  const branchNumber = useAuiState((s) => s.message.branchNumber, target);
+  const branchCount = useAuiState((s) => s.message.branchCount, target);
+  const edit = actionBarEdit(target);
+  const copy = actionBarCopy(target);
+  const reload = actionBarReload(target);
+  const previous = branchPickerPrevious(target);
+  const next = branchPickerNext(target);
+  const editInput = composerInput(target);
+  const editSend = composerSend(target);
+  const editCancel = composerCancel(target);
 </script>
 
 <li

--- a/examples/with-svelte/src/Suggestion.svelte
+++ b/examples/with-svelte/src/Suggestion.svelte
@@ -5,6 +5,9 @@
   let { suggestion, index }: { suggestion: Suggestion; index: number } =
     $props();
 
+  // The index is position-bound under unkeyed iteration, so a one-time
+  // capture is correct.
+  // svelte-ignore state_referenced_locally
   const trigger = suggestionTrigger({ index, send: true });
 </script>
 

--- a/examples/with-svelte/src/ThreadItem.svelte
+++ b/examples/with-svelte/src/ThreadItem.svelte
@@ -7,8 +7,14 @@
 
   let { item }: { item: ThreadListItem } = $props();
 
-  const trigger = threadListItemTrigger({ item });
-  const title = useAuiState((s) => s.threadListItem.title, { item });
+  // The item handle is index-bound and referentially stable for this
+  // position's lifetime under unkeyed iteration, so a one-time capture is
+  // correct.
+  // svelte-ignore state_referenced_locally
+  const target = { item };
+
+  const trigger = threadListItemTrigger(target);
+  const title = useAuiState((s) => s.threadListItem.title, target);
 </script>
 
 <button

--- a/examples/with-svelte/svelte.config.js
+++ b/examples/with-svelte/svelte.config.js
@@ -2,4 +2,12 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 export default {
   preprocess: vitePreprocess(),
+  // Builders capture their index or item at construction by design: in an
+  // unkeyed {#each}, component instances are position-stable and
+  // messages.item(index) is referentially stable per index, so the
+  // captured value never changes for the instance's lifetime.
+  onwarn: (warning, handler) => {
+    if (warning.code === "state_referenced_locally") return;
+    handler(warning);
+  },
 };

--- a/examples/with-svelte/svelte.config.js
+++ b/examples/with-svelte/svelte.config.js
@@ -2,12 +2,4 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 export default {
   preprocess: vitePreprocess(),
-  // Builders capture their index or item at construction by design: in an
-  // unkeyed {#each}, component instances are position-stable and
-  // messages.item(index) is referentially stable per index, so the
-  // captured value never changes for the instance's lifetime.
-  onwarn: (warning, handler) => {
-    if (warning.code === "state_referenced_locally") return;
-    handler(warning);
-  },
 };

--- a/examples/with-sveltekit/.env.example
+++ b/examples/with-sveltekit/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/examples/with-sveltekit/.gitignore
+++ b/examples/with-sveltekit/.gitignore
@@ -1,0 +1,5 @@
+.svelte-kit/
+build/
+.env
+.env.*
+!.env.example

--- a/examples/with-sveltekit/README.md
+++ b/examples/with-sveltekit/README.md
@@ -1,0 +1,21 @@
+# SvelteKit Example
+
+assistant-ui in a SvelteKit app: `@assistant-ui/svelte` builders on the client, streaming from a SvelteKit server route via the AI SDK.
+
+## How it works
+
+- `src/routes/api/chat/+server.ts` runs `streamText` and returns the AI SDK UI message stream, like the Next.js templates. The request body differs: this client posts a plain `ModelMessage` array built with `getThreadMessageText`, not the `UIMessage` array the templates post.
+- `src/lib/runtime.ts` is a `ChatModelAdapter` that posts the conversation to the route and pipes the response through `UIMessageStreamDecoder` and `AssistantMessageAccumulator` from `assistant-stream` into a `LocalRuntimeCore`. Edit, reload, and branch switching come with it.
+- `src/routes/+layout.ts` disables SSR. `provideAui` creates the runtime client in component init, so rendering on the server would build a throwaway runtime per request for a page that is entirely client-driven.
+- `vite.config.ts` aliases `react` to `@assistant-ui/tap/standalone-shim`, so the app runs without React installed.
+- Messages render as plain text. `@assistant-ui/svelte` has no markdown renderer yet.
+
+## Run
+
+```sh
+cp .env.example .env   # set OPENAI_API_KEY
+pnpm install
+pnpm dev
+```
+
+`pnpm install` runs `svelte-kit sync`, which generates the `.svelte-kit/` directory that `tsconfig.json` extends.

--- a/examples/with-sveltekit/package.json
+++ b/examples/with-sveltekit/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "with-sveltekit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prepare": "svelte-kit sync",
+    "dev": "vite dev --port 3000",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^4.0.40",
+    "@assistant-ui/core": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/svelte": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@lucide/svelte": "^1.31.0",
+    "ai": "^7.0.62",
+    "assistant-stream": "workspace:*",
+    "svelte": "^5.56.8"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^7.0.1",
+    "@sveltejs/kit": "^2.70.2",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/react": "^19.2.18",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^7.0.2",
+    "vite": "^8.2.1"
+  }
+}

--- a/examples/with-sveltekit/src/app.css
+++ b/examples/with-sveltekit/src/app.css
@@ -1,0 +1,124 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
+html,
+body {
+  height: 100%;
+}

--- a/examples/with-sveltekit/src/app.html
+++ b/examples/with-sveltekit/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>assistant-ui × SvelteKit</title>
+    %sveltekit.head%
+  </head>
+  <body>
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/examples/with-sveltekit/src/lib/App.svelte
+++ b/examples/with-sveltekit/src/lib/App.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import {
+    composerCancel,
+    composerInput,
+    composerSend,
+    threadMessages,
+    threadScrollToBottom,
+    threadViewport,
+    useAuiState,
+  } from "@assistant-ui/svelte";
+  import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/svelte";
+  import Message from "./Message.svelte";
+  import Suggestion from "./Suggestion.svelte";
+
+  const messages = threadMessages();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const suggestions = useAuiState((s) => s.suggestions.suggestions);
+  const input = composerInput();
+  const send = composerSend();
+  const cancel = composerCancel();
+  const viewport = threadViewport();
+  const scrollDown = threadScrollToBottom({ viewport });
+</script>
+
+<div class="bg-background flex h-full flex-col">
+  <div
+    {@attach viewport.attach}
+    class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+  >
+    <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+      {#if messages.items.length === 0}
+        <div class="flex flex-1 flex-col items-center justify-center gap-6 pb-24">
+          <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+          <div class="flex flex-wrap items-center justify-center gap-2 px-4">
+            {#each suggestions.current as suggestion, index}
+              <Suggestion {suggestion} {index} />
+            {/each}
+          </div>
+        </div>
+      {/if}
+      <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
+        {#each messages.items as message, index}
+          <Message {message} item={messages.item(index)} />
+        {/each}
+      </ol>
+      <button
+        {...scrollDown.props}
+        class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
+        aria-label="Scroll to bottom"
+      >
+        <ArrowDownIcon class="size-4" />
+      </button>
+    </div>
+  </div>
+  <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+    <div
+      class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+    >
+      <textarea
+        {...input.props}
+        class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+        placeholder="Send a message..."
+        name="message"
+        rows="1"
+      ></textarea>
+      <div class="flex items-center justify-end">
+        {#if !isRunning.current}
+          <button
+            {...send.props}
+            class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+            aria-label="Send"
+          >
+            <ArrowUpIcon class="size-4.5" />
+          </button>
+        {:else}
+          <button
+            {...cancel.props}
+            class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+            aria-label="Stop"
+          >
+            <SquareIcon class="size-3.5 fill-current" />
+          </button>
+        {/if}
+      </div>
+    </div>
+  </div>
+</div>

--- a/examples/with-sveltekit/src/lib/Message.svelte
+++ b/examples/with-sveltekit/src/lib/Message.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import type { MessageState } from "@assistant-ui/core/store";
+  import {
+    actionBarCopy,
+    actionBarEdit,
+    actionBarReload,
+    branchPickerNext,
+    branchPickerPrevious,
+    composerCancel,
+    composerInput,
+    composerSend,
+    useAuiState,
+    type MessageItem,
+  } from "@assistant-ui/svelte";
+  import {
+    CheckIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    CopyIcon,
+    PencilIcon,
+    RefreshCwIcon,
+  } from "@lucide/svelte";
+
+  let { message, item }: { message: MessageState; item: MessageItem } =
+    $props();
+
+  const text = $derived(
+    message.content
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join(""),
+  );
+
+  const isEditing = useAuiState((s) => s.composer.isEditing, { item });
+  const branchNumber = useAuiState((s) => s.message.branchNumber, { item });
+  const branchCount = useAuiState((s) => s.message.branchCount, { item });
+  const edit = actionBarEdit({ item });
+  const copy = actionBarCopy({ item });
+  const reload = actionBarReload({ item });
+  const previous = branchPickerPrevious({ item });
+  const next = branchPickerNext({ item });
+  const editInput = composerInput({ item });
+  const editSend = composerSend({ item });
+  const editCancel = composerCancel({ item });
+</script>
+
+<li
+  data-role={message.role}
+  class={[
+    "group flex flex-col gap-1",
+    message.role === "user" ? "items-end" : "items-start",
+  ].join(" ")}
+>
+  {#if isEditing.current}
+    <div
+      class="border-border/60 flex w-full max-w-[80%] flex-col gap-2 rounded-xl border p-2"
+    >
+      <textarea
+        {...editInput.props}
+        class="w-full resize-none bg-transparent px-1 py-0.5 outline-none"
+        aria-label="Edit message"
+        rows="2"
+      ></textarea>
+      <div class="flex justify-end gap-2 text-sm">
+        <button
+          {...editCancel.props}
+          class="text-muted-foreground rounded-lg px-2 py-1"
+        >
+          Discard
+        </button>
+        <button
+          {...editSend.props}
+          class="bg-primary text-primary-foreground rounded-lg px-2 py-1 disabled:opacity-50"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  {:else}
+    <div
+      class={[
+        "px-2 wrap-break-word",
+        message.role === "user"
+          ? "bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2"
+          : "text-foreground leading-relaxed",
+      ].join(" ")}
+    >
+      <p class="whitespace-pre-line">{text}</p>
+    </div>
+  {/if}
+  <div
+    class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100"
+  >
+    {#if message.role === "user"}
+      <button
+        {...edit.props}
+        class="hover:text-foreground rounded p-1"
+        aria-label="Edit"
+      >
+        <PencilIcon class="size-3.5" />
+      </button>
+    {/if}
+    <button
+      {...copy.props}
+      class="hover:text-foreground rounded p-1"
+      aria-label="Copy"
+    >
+      {#if copy.isCopied}
+        <CheckIcon class="size-3.5" />
+      {:else}
+        <CopyIcon class="size-3.5" />
+      {/if}
+    </button>
+    {#if message.role === "assistant"}
+      <button
+        {...reload.props}
+        class="hover:text-foreground rounded p-1"
+        aria-label="Regenerate"
+      >
+        <RefreshCwIcon class="size-3.5" />
+      </button>
+    {/if}
+    {#if branchCount.current > 1}
+      <span class="flex items-center gap-0.5 text-xs">
+        <button
+          {...previous.props}
+          class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+          aria-label="Previous branch"
+        >
+          <ChevronLeftIcon class="size-3.5" />
+        </button>
+        {branchNumber.current} / {branchCount.current}
+        <button
+          {...next.props}
+          class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+          aria-label="Next branch"
+        >
+          <ChevronRightIcon class="size-3.5" />
+        </button>
+      </span>
+    {/if}
+  </div>
+</li>

--- a/examples/with-sveltekit/src/lib/Message.svelte
+++ b/examples/with-sveltekit/src/lib/Message.svelte
@@ -30,17 +30,43 @@
       .join(""),
   );
 
-  const isEditing = useAuiState((s) => s.composer.isEditing, { item });
-  const branchNumber = useAuiState((s) => s.message.branchNumber, { item });
-  const branchCount = useAuiState((s) => s.message.branchCount, { item });
-  const edit = actionBarEdit({ item });
-  const copy = actionBarCopy({ item });
-  const reload = actionBarReload({ item });
-  const previous = branchPickerPrevious({ item });
-  const next = branchPickerNext({ item });
-  const editInput = composerInput({ item });
-  const editSend = composerSend({ item });
-  const editCancel = composerCancel({ item });
+  // The item handle is index-bound and referentially stable for this
+  // position's lifetime under unkeyed iteration, so a one-time capture is
+  // correct.
+  // svelte-ignore state_referenced_locally
+  const target = { item };
+
+  const isEditing = useAuiState((s) => s.composer.isEditing, target);
+  const branchNumber = useAuiState((s) => s.message.branchNumber, target);
+  const branchCount = useAuiState((s) => s.message.branchCount, target);
+  const pulsing = useAuiState(
+    (s) => s.message.content.length === 0 && s.thread.isRunning,
+    target,
+  );
+  const error = useAuiState((s) => {
+    const current = s.message;
+    if (
+      current.role !== "assistant" ||
+      current.status.type !== "incomplete" ||
+      current.status.reason !== "error"
+    ) {
+      return null;
+    }
+    const value = current.status.error;
+    if (typeof value === "string") return value;
+    if (value && typeof value === "object" && "message" in value) {
+      return String(value.message);
+    }
+    return "An error occurred.";
+  }, target);
+  const edit = actionBarEdit(target);
+  const copy = actionBarCopy(target);
+  const reload = actionBarReload(target);
+  const previous = branchPickerPrevious(target);
+  const next = branchPickerNext(target);
+  const editInput = composerInput(target);
+  const editSend = composerSend(target);
+  const editCancel = composerCancel(target);
 </script>
 
 <li
@@ -84,7 +110,12 @@
           : "text-foreground leading-relaxed",
       ].join(" ")}
     >
-      <p class="whitespace-pre-line">{text}</p>
+      <p class="whitespace-pre-line">
+        {text}{#if pulsing.current}<span class="animate-pulse">…</span>{/if}
+        {#if error.current}<span class="text-destructive text-sm"
+          >{error.current}</span
+        >{/if}
+      </p>
     </div>
   {/if}
   <div

--- a/examples/with-sveltekit/src/lib/Suggestion.svelte
+++ b/examples/with-sveltekit/src/lib/Suggestion.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Suggestion } from "@assistant-ui/core/store";
+  import { suggestionTrigger } from "@assistant-ui/svelte";
+
+  let { suggestion, index }: { suggestion: Suggestion; index: number } =
+    $props();
+
+  const trigger = suggestionTrigger({ index, send: true });
+</script>
+
+<button
+  {...trigger.props}
+  class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+>
+  <span class="font-medium">{suggestion.title}</span>
+  <span class="text-muted-foreground text-xs">{suggestion.label}</span>
+</button>

--- a/examples/with-sveltekit/src/lib/Suggestion.svelte
+++ b/examples/with-sveltekit/src/lib/Suggestion.svelte
@@ -5,6 +5,9 @@
   let { suggestion, index }: { suggestion: Suggestion; index: number } =
     $props();
 
+  // The index is position-bound under unkeyed iteration, so a one-time
+  // capture is correct.
+  // svelte-ignore state_referenced_locally
   const trigger = suggestionTrigger({ index, send: true });
 </script>
 

--- a/examples/with-sveltekit/src/lib/runtime.ts
+++ b/examples/with-sveltekit/src/lib/runtime.ts
@@ -1,0 +1,46 @@
+import type { ChatModelAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  getThreadMessageText,
+  LocalRuntimeCore,
+} from "@assistant-ui/core/internal";
+import {
+  AssistantMessageAccumulator,
+  UIMessageStreamDecoder,
+} from "assistant-stream";
+import { asAsyncIterableStream } from "assistant-stream/utils";
+
+const chatModel: ChatModelAdapter = {
+  async *run({ messages, abortSignal, context }) {
+    const response = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        system: context.system,
+        messages: messages.map((message) => ({
+          role: message.role,
+          content: getThreadMessageText(message),
+        })),
+      }),
+      signal: abortSignal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Status ${response.status}: ${await response.text()}`);
+    }
+    if (!response.body) {
+      throw new Error("Response body is null");
+    }
+
+    const stream = response.body
+      .pipeThrough(new UIMessageStreamDecoder())
+      .pipeThrough(new AssistantMessageAccumulator());
+
+    yield* asAsyncIterableStream(stream);
+  },
+};
+
+export const createChatRuntime = () =>
+  new AssistantRuntimeImpl(
+    new LocalRuntimeCore({ adapters: { chatModel } }, undefined),
+  );

--- a/examples/with-sveltekit/src/routes/+layout.svelte
+++ b/examples/with-sveltekit/src/routes/+layout.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import "../app.css";
+
+  let { children } = $props();
+</script>
+
+{@render children()}

--- a/examples/with-sveltekit/src/routes/+layout.ts
+++ b/examples/with-sveltekit/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/examples/with-sveltekit/src/routes/+page.svelte
+++ b/examples/with-sveltekit/src/routes/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { AuiConfig, provideAui } from "@assistant-ui/svelte";
+  import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
+  import App from "$lib/App.svelte";
+  import { createChatRuntime } from "$lib/runtime";
+
+  provideAui(
+    AuiConfig({
+      threads: RuntimeAdapter(createChatRuntime()),
+      suggestions: Suggestions([
+        {
+          title: "Plan a weekend trip",
+          label: "three stops, one day each",
+          prompt: "Plan a weekend trip with three stops, one day each.",
+        },
+        {
+          title: "Explain streaming",
+          label: "how token streaming works",
+          prompt: "Explain how token streaming works in chat UIs.",
+        },
+        {
+          title: "Write a haiku",
+          label: "about the terminal",
+          prompt: "Write a haiku about the terminal.",
+        },
+      ]),
+    }),
+  );
+</script>
+
+<App />

--- a/examples/with-sveltekit/src/routes/api/chat/+server.ts
+++ b/examples/with-sveltekit/src/routes/api/chat/+server.ts
@@ -1,0 +1,23 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText, type ModelMessage } from "ai";
+import { env } from "$env/dynamic/private";
+import type { RequestHandler } from "./$types";
+
+export const POST: RequestHandler = async ({ request }) => {
+  const { messages, system } = (await request.json()) as {
+    messages: ModelMessage[];
+    system?: string;
+  };
+
+  const openai = createOpenAI({ apiKey: env.OPENAI_API_KEY });
+  const result = streamText({
+    model: openai("gpt-5.6-luna"),
+    messages,
+    system,
+  });
+
+  return result.toUIMessageStreamResponse({
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
+  });
+};

--- a/examples/with-sveltekit/svelte.config.js
+++ b/examples/with-sveltekit/svelte.config.js
@@ -6,12 +6,4 @@ export default {
   kit: {
     adapter: adapter(),
   },
-  // Builders capture their index or item at construction by design: in an
-  // unkeyed {#each}, component instances are position-stable and
-  // messages.item(index) is referentially stable per index, so the
-  // captured value never changes for the instance's lifetime.
-  onwarn: (warning, handler) => {
-    if (warning.code === "state_referenced_locally") return;
-    handler(warning);
-  },
 };

--- a/examples/with-sveltekit/svelte.config.js
+++ b/examples/with-sveltekit/svelte.config.js
@@ -1,0 +1,17 @@
+import adapter from "@sveltejs/adapter-auto";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter(),
+  },
+  // Builders capture their index or item at construction by design: in an
+  // unkeyed {#each}, component instances are position-stable and
+  // messages.item(index) is referentially stable per index, so the
+  // captured value never changes for the instance's lifetime.
+  onwarn: (warning, handler) => {
+    if (warning.code === "state_referenced_locally") return;
+    handler(warning);
+  },
+};

--- a/examples/with-sveltekit/tsconfig.json
+++ b/examples/with-sveltekit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/examples/with-sveltekit/vite.config.ts
+++ b/examples/with-sveltekit/vite.config.ts
@@ -1,0 +1,19 @@
+import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+// The assistant-ui runtime is written against react hook imports but runs on
+// @assistant-ui/tap; aliasing react to the standalone shim resolves it with
+// no React installed.
+export default defineConfig({
+  plugins: [sveltekit(), tailwindcss()],
+  resolve: {
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,13 +242,13 @@ importers:
         version: 1.38.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(518a1ffed8401bdeb366fd9ee9565d93)
+        version: 2.0.1(ecef3a0b45887eac25748caa92e89e17)
       '@vercel/otel':
         specifier: ^2.1.3
         version: 2.1.3(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.205.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(518a1ffed8401bdeb366fd9ee9565d93)
+        version: 2.0.0(ecef3a0b45887eac25748caa92e89e17)
       ai:
         specifier: ^7.0.62
         version: 7.0.62(zod@4.4.3)
@@ -3135,6 +3135,61 @@ importers:
         specifier: ^5.56.8
         version: 5.56.8
     devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  examples/with-sveltekit:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.40
+        version: 4.0.40(zod@4.4.3)
+      '@assistant-ui/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/svelte':
+        specifier: workspace:*
+        version: link:../../packages/svelte
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@lucide/svelte':
+        specifier: ^1.31.0
+        version: 1.31.0(svelte@5.56.8)
+      ai:
+        specifier: ^7.0.62
+        version: 7.0.62(zod@4.4.3)
+      assistant-stream:
+        specifier: workspace:*
+        version: link:../../packages/assistant-stream
+      svelte:
+        specifier: ^5.56.8
+        version: 5.56.8
+    devDependencies:
+      '@sveltejs/adapter-auto':
+        specifier: ^7.0.1
+        version: 7.0.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+      '@sveltejs/kit':
+        specifier: ^2.70.2
+        version: 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.3.0
         version: 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -10485,6 +10540,27 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
+  '@sveltejs/adapter-auto@7.0.1':
+    resolution: {integrity: sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.70.2':
+    resolution: {integrity: sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
+
   '@sveltejs/vite-plugin-svelte@7.3.0':
     resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
     engines: {node: ^20.19 || ^22.12 || >=24}
@@ -10856,6 +10932,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -12649,6 +12728,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -17968,6 +18051,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-value@2.0.1:
     resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
@@ -25795,6 +25881,31 @@ snapshots:
     dependencies:
       acorn: 8.18.0
 
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
+    dependencies:
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+
+  '@sveltejs/kit@2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.18.0)
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/cookie': 0.6.0
+      acorn: 8.18.0
+      cookie: 0.6.0
+      devalue: 5.9.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.2
+      sirv: 3.0.2
+      svelte: 5.56.8
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      typescript: 7.0.2
+
   '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
@@ -26247,6 +26358,8 @@ snapshots:
     dependencies:
       '@types/node': 26.2.0
 
+  '@types/cookie@0.6.0': {}
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 26.2.0
@@ -26675,8 +26788,9 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.8
 
-  '@vercel/analytics@2.0.1(518a1ffed8401bdeb366fd9ee9565d93)':
+  '@vercel/analytics@2.0.1(ecef3a0b45887eac25748caa92e89e17)':
     optionalDependencies:
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuxt: 4.5.2(@azure/identity@4.13.1)(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.144.0)(@types/node@26.2.0)(@upstash/redis@1.38.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@26.2.0))(sqlite3@5.1.7))(encoding@0.1.13)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(mysql2@3.20.0(@types/node@26.2.0))(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(sqlite3@5.1.7)(srvx@0.11.22)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.8
@@ -26714,8 +26828,9 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@vercel/speed-insights@2.0.0(518a1ffed8401bdeb366fd9ee9565d93)':
+  '@vercel/speed-insights@2.0.0(ecef3a0b45887eac25748caa92e89e17)':
     optionalDependencies:
+      '@sveltejs/kit': 2.70.2(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuxt: 4.5.2(@azure/identity@4.13.1)(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.144.0)(@types/node@26.2.0)(@upstash/redis@1.38.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@26.2.0))(sqlite3@5.1.7))(encoding@0.1.13)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(mysql2@3.20.0(@types/node@26.2.0))(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(sqlite3@5.1.7)(srvx@0.11.22)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.8
@@ -27998,6 +28113,8 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.6.0: {}
 
   cookie@0.7.2: {}
 
@@ -34821,6 +34938,8 @@ snapshots:
 
   set-blocking@2.0.0:
     optional: true
+
+  set-cookie-parser@3.1.2: {}
 
   set-value@2.0.1:
     dependencies:


### PR DESCRIPTION
## summary

- adds `examples/with-sveltekit`, the SvelteKit counterpart of with-nuxt: `@assistant-ui/svelte` builders on the client, streaming from a SvelteKit server route via the AI SDK
- `src/lib/runtime.ts` is a `ChatModelAdapter` that posts the conversation to `/api/chat` and pipes the response through `UIMessageStreamDecoder` and `AssistantMessageAccumulator` from `assistant-stream` into a `LocalRuntimeCore`, so edit, reload, and branch switching come for free; the server route runs `streamText` with `createOpenAI({apiKey: env.OPENAI_API_KEY})` from `$env/dynamic/private`, so the app builds without a key
- the message row mirrors the with-nuxt reference: a pulse while the assistant message has no content yet and the run is in flight, and the `status.error` text in destructive color when a stream error arrives
- `+layout.ts` disables SSR: `provideAui` creates the runtime client in component init, and rendering on the server would build a throwaway runtime per request for a page that is entirely client-driven
- the deliberate init-time captures use the repo's per-site `// svelte-ignore state_referenced_locally` idiom, collapsed to one site per component through a single `const target = { item }` capture; with-svelte's components get the same treatment (they were silently emitting 14 warnings per build)

## test plan

### already verified

- [x] `pnpm -C examples/with-sveltekit exec vite build` and `pnpm -C examples/with-svelte exec vite build` -> both green with zero compiler warnings; `tsc --noEmit` clean (the kit template tsconfig options are required: the generated `$types.d.ts` errors under TS7 without `skipLibCheck`)
- [x] `pnpm install --frozen-lockfile` -> lockfile consistent after the merge with main
- [x] live smoke against a real gateway key: the reply streams token by token into the thread
- [x] browser smoke against a local /responses-protocol mock: pulse shows before the first chunk and clears after, viewport stays pinned during the stream, stop cancels mid-stream, editing a user message reruns, regenerate creates branch 2/2 with working back-navigation, zero console errors
- [x] error path: pointing the provider at a dead port renders the provider error text in destructive color in the assistant row once the AI SDK's retries settle, and the pulse clears

### reviewer should verify

- [ ] `cp .env.example .env` with a valid OPENAI_API_KEY, `pnpm -C examples/with-sveltekit dev`, send a message and confirm the reply streams token by token

## notes

- the AI SDK OpenAI provider defaults to the responses API and honors `OPENAI_BASE_URL` from the environment, so the example works against gateways unchanged
- no changeset: examples are private packages

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-WeGLeysoY5AOVZTSO3GP_XMdll0zDNy6z70e-as4-l_axIF3pJ_CAaqX64?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->