### PR TITLE
feat: run the ai-sdk graph react-free on the standalone shim

### DIFF
--- a/.changeset/ai-sdk-reactless-graph.md
+++ b/.changeset/ai-sdk-reactless-graph.md
@@ -2,4 +2,4 @@
 "@assistant-ui/ai-sdk": patch
 ---
 
-feat: the whole package now loads and runs under the `react` to `@assistant-ui/tap/standalone-shim` alias with no real React installed, and `react` becomes an optional peer dependency. The react-less path is pinned by a standalone test project that streams an `AISDKChat` round trip through the aliased graph.
+feat: the whole package now loads and runs react-free under the documented bundler alias `react: "@assistant-ui/tap/standalone-shim"` (whose string-prefix form also routes the `react/*` subpaths, including the new `jsx-runtime` entries), and `react` becomes an optional peer dependency. The react-less path is pinned by a standalone test project that streams an `AISDKChat` round trip through the aliased graph.

--- a/.changeset/ai-sdk-reactless-graph.md
+++ b/.changeset/ai-sdk-reactless-graph.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+feat: the whole package now loads and runs under the `react` to `@assistant-ui/tap/standalone-shim` alias with no real React installed, and `react` becomes an optional peer dependency. The react-less path is pinned by a standalone test project that streams an `AISDKChat` round trip through the aliased graph.

--- a/.changeset/tap-standalone-shim-module-scope.md
+++ b/.changeset/tap-standalone-shim-module-scope.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: the standalone shim gains `jsx-runtime` and `jsx-dev-runtime` entries plus module-scope `forwardRef` and `memo`, so react-coupled module graphs stay loadable under the react-less alias; rendering their JSX without real React still throws.

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -49,6 +49,7 @@
     "build": "aui-build",
     "test": "vitest run",
     "test:react-compiler": "vitest run --config vitest.react-compiler.config.ts",
+    "test:standalone": "vitest run --project standalone",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -67,6 +68,9 @@
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "react": {
       "optional": true
     }
   },

--- a/packages/ai-sdk/src/__tests__/standalone.e2e.ts
+++ b/packages/ai-sdk/src/__tests__/standalone.e2e.ts
@@ -5,6 +5,11 @@ import * as aiSdk from "../index";
 import { createControlledTransport } from "../runtime/__tests__/controlled-transport";
 
 describe("react-less standalone graph", () => {
+  it("resolves react to the standalone shim", async () => {
+    const react = await import("react");
+    expect(() => react.useState(0)).toThrow(/standalone-shim/);
+  });
+
   it("loads the whole barrel under the standalone shim", () => {
     expect(typeof aiSdk.AISDKChat).toBe("function");
     expect(typeof aiSdk.useChatRuntime).toBe("function");

--- a/packages/ai-sdk/src/__tests__/standalone.e2e.ts
+++ b/packages/ai-sdk/src/__tests__/standalone.e2e.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig, createAssistantClient } from "@assistant-ui/store/client";
+import * as aiSdk from "../index";
+import { createControlledTransport } from "../runtime/__tests__/controlled-transport";
+
+describe("react-less standalone graph", () => {
+  it("loads the whole barrel under the standalone shim", () => {
+    expect(typeof aiSdk.AISDKChat).toBe("function");
+    expect(typeof aiSdk.useChatRuntime).toBe("function");
+    expect(typeof aiSdk.useAISDKRuntime).toBe("function");
+    expect(typeof aiSdk.frontendTools).toBe("function");
+    expect(typeof aiSdk.AssistantChatTransport).toBe("function");
+  });
+
+  it("streams a chat round trip with the shim as the only react", async () => {
+    const { transport, emit, close } = createControlledTransport();
+    const handle = createAssistantClient(
+      AuiConfig({ threads: aiSdk.AISDKChat({ transport }) }),
+    );
+    try {
+      handle.subscribe(() => {});
+      const aui = handle.getClient();
+
+      flushTapSync(() => aui.composer.setText("hi"));
+      flushTapSync(() => aui.composer.send());
+
+      await vi.waitFor(() => {
+        expect(aui.thread.getState().isRunning).toBe(true);
+      });
+
+      emit(
+        { type: "start" },
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: "hello " },
+        { type: "text-delta", id: "t1", delta: "world" },
+        { type: "text-end", id: "t1" },
+        { type: "finish" },
+      );
+      close();
+
+      await vi.waitFor(() => {
+        const state = aui.thread.getState();
+        expect(state.isRunning).toBe(false);
+        expect(state.messages).toHaveLength(2);
+        expect(state.messages.at(-1)?.content).toContainEqual(
+          expect.objectContaining({ type: "text", text: "hello world" }),
+        );
+      });
+    } finally {
+      handle.destroy();
+    }
+  });
+});

--- a/packages/ai-sdk/vitest.config.ts
+++ b/packages/ai-sdk/vitest.config.ts
@@ -4,10 +4,7 @@ import { defineConfig } from "vitest/config";
 
 const packageRoot = fileURLToPath(new URL(".", import.meta.url));
 const mcpStdioNode = resolve(packageRoot, "src/tools/mcp-stdio.node.ts");
-const standaloneShim = resolve(
-  packageRoot,
-  "../tap/dist/standalone-shim/index.js",
-);
+const standaloneShim = "@assistant-ui/tap/standalone-shim";
 
 export default defineConfig({
   test: {
@@ -32,24 +29,15 @@ export default defineConfig({
             { find: "#mcp-stdio", replacement: mcpStdioNode },
             {
               find: /^react\/compiler-runtime$/,
-              replacement: resolve(
-                packageRoot,
-                "../tap/dist/standalone-shim/compiler-runtime.js",
-              ),
+              replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
             },
             {
               find: /^react\/jsx-runtime$/,
-              replacement: resolve(
-                packageRoot,
-                "../tap/dist/standalone-shim/jsx-runtime.js",
-              ),
+              replacement: "@assistant-ui/tap/standalone-shim/jsx-runtime",
             },
             {
               find: /^react\/jsx-dev-runtime$/,
-              replacement: resolve(
-                packageRoot,
-                "../tap/dist/standalone-shim/jsx-dev-runtime.js",
-              ),
+              replacement: "@assistant-ui/tap/standalone-shim/jsx-dev-runtime",
             },
             { find: /^react$/, replacement: standaloneShim },
           ],

--- a/packages/ai-sdk/vitest.config.ts
+++ b/packages/ai-sdk/vitest.config.ts
@@ -44,6 +44,13 @@ export default defineConfig({
                 "../tap/dist/standalone-shim/jsx-runtime.js",
               ),
             },
+            {
+              find: /^react\/jsx-dev-runtime$/,
+              replacement: resolve(
+                packageRoot,
+                "../tap/dist/standalone-shim/jsx-dev-runtime.js",
+              ),
+            },
             { find: /^react$/, replacement: standaloneShim },
           ],
         },

--- a/packages/ai-sdk/vitest.config.ts
+++ b/packages/ai-sdk/vitest.config.ts
@@ -1,12 +1,66 @@
-import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const packageRoot = fileURLToPath(new URL(".", import.meta.url));
+const mcpStdioNode = resolve(packageRoot, "src/tools/mcp-stdio.node.ts");
+const standaloneShim = resolve(
+  packageRoot,
+  "../tap/dist/standalone-shim/index.js",
+);
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      "#mcp-stdio": fileURLToPath(
-        new URL("./src/tools/mcp-stdio.node.ts", import.meta.url),
-      ),
-    },
+  test: {
+    projects: [
+      {
+        resolve: {
+          alias: {
+            "#mcp-stdio": mcpStdioNode,
+          },
+        },
+        test: {
+          name: "default",
+          include: ["src/**/*.test.{ts,tsx}"],
+        },
+      },
+      {
+        // Proves the react-less path: `react` resolves to the standalone shim
+        // for the whole graph, including the react-shim rewrites inside the
+        // core and store dists.
+        resolve: {
+          alias: [
+            { find: "#mcp-stdio", replacement: mcpStdioNode },
+            {
+              find: /^react\/compiler-runtime$/,
+              replacement: resolve(
+                packageRoot,
+                "../tap/dist/standalone-shim/compiler-runtime.js",
+              ),
+            },
+            {
+              find: /^react\/jsx-runtime$/,
+              replacement: resolve(
+                packageRoot,
+                "../tap/dist/standalone-shim/jsx-runtime.js",
+              ),
+            },
+            { find: /^react$/, replacement: standaloneShim },
+          ],
+        },
+        test: {
+          name: "standalone",
+          environment: "node",
+          include: ["src/__tests__/**/*.e2e.ts"],
+          server: {
+            deps: {
+              // @ai-sdk/react resolves natively as an external dep by default,
+              // which would bypass the react alias; inline it so its hooks
+              // route to the shim like the rest of the graph.
+              inline: [/@ai-sdk\/react/],
+            },
+          },
+        },
+      },
+    ],
   },
 });

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -32,6 +32,14 @@
     "./standalone-shim/compiler-runtime": {
       "types": null,
       "default": "./dist/standalone-shim/compiler-runtime.js"
+    },
+    "./standalone-shim/jsx-runtime": {
+      "types": null,
+      "default": "./dist/standalone-shim/jsx-runtime.js"
+    },
+    "./standalone-shim/jsx-dev-runtime": {
+      "types": null,
+      "default": "./dist/standalone-shim/jsx-dev-runtime.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/tap/src/standalone-shim/index.ts
+++ b/packages/tap/src/standalone-shim/index.ts
@@ -78,6 +78,20 @@ export const use = (usable: any) =>
 export const useContext = (context: any) =>
   inTap() ? useTapContext(context) : throwOutsideTap("useContext");
 
+// Component factories evaluated at module scope in react-coupled barrels.
+// They return React's marker shapes so the modules load; rendering the
+// results without real React fails in the jsx-runtime shim instead.
+export const forwardRef = (render: any) => ({
+  $$typeof: Symbol.for("react.forward_ref"),
+  render,
+});
+
+export const memo = (type: any, compare?: any) => ({
+  $$typeof: Symbol.for("react.memo"),
+  type,
+  compare: compare ?? null,
+});
+
 const StandaloneRuntime = Object.freeze({
   useState,
   useReducer,
@@ -93,6 +107,8 @@ const StandaloneRuntime = Object.freeze({
   createContext,
   use,
   useContext,
+  forwardRef,
+  memo,
 });
 
 export default StandaloneRuntime;

--- a/packages/tap/src/standalone-shim/jsx-dev-runtime.ts
+++ b/packages/tap/src/standalone-shim/jsx-dev-runtime.ts
@@ -1,9 +1,4 @@
 export { Fragment } from "./jsx-runtime";
-
-const throwRender = (): never => {
-  throw new Error(
-    "JSX from @assistant-ui/tap/standalone-shim was rendered without React. The standalone shim only makes react-coupled modules loadable; rendering them requires real React.",
-  );
-};
+import { throwRender } from "./jsx-runtime";
 
 export const jsxDEV = throwRender;

--- a/packages/tap/src/standalone-shim/jsx-dev-runtime.ts
+++ b/packages/tap/src/standalone-shim/jsx-dev-runtime.ts
@@ -1,0 +1,9 @@
+export { Fragment } from "./jsx-runtime";
+
+const throwRender = (): never => {
+  throw new Error(
+    "JSX from @assistant-ui/tap/standalone-shim was rendered without React. The standalone shim only makes react-coupled modules loadable; rendering them requires real React.",
+  );
+};
+
+export const jsxDEV = throwRender;

--- a/packages/tap/src/standalone-shim/jsx-runtime.ts
+++ b/packages/tap/src/standalone-shim/jsx-runtime.ts
@@ -1,7 +1,7 @@
 // React-free stand-in for "react/jsx-runtime": react-coupled modules stay
 // loadable under the standalone alias, while actually rendering their JSX
 // still requires real React.
-const throwRender = (): never => {
+export const throwRender = (): never => {
   throw new Error(
     "JSX from @assistant-ui/tap/standalone-shim was rendered without React. The standalone shim only makes react-coupled modules loadable; rendering them requires real React.",
   );

--- a/packages/tap/src/standalone-shim/jsx-runtime.ts
+++ b/packages/tap/src/standalone-shim/jsx-runtime.ts
@@ -1,0 +1,12 @@
+// React-free stand-in for "react/jsx-runtime": react-coupled modules stay
+// loadable under the standalone alias, while actually rendering their JSX
+// still requires real React.
+const throwRender = (): never => {
+  throw new Error(
+    "JSX from @assistant-ui/tap/standalone-shim was rendered without React. The standalone shim only makes react-coupled modules loadable; rendering them requires real React.",
+  );
+};
+
+export const Fragment = Symbol.for("react.fragment");
+export const jsx = throwRender;
+export const jsxs = throwRender;

--- a/packages/tap/src/standalone-shim/standalone-shim.behavior.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.behavior.test.ts
@@ -6,6 +6,8 @@ import { resource } from "../core/resource";
 import { useResource } from "../hooks/useResource";
 import * as shim from "./index";
 import { c } from "./compiler-runtime";
+import * as jsxRuntime from "./jsx-runtime";
+import * as jsxDevRuntime from "./jsx-dev-runtime";
 
 describe("@assistant-ui/tap/standalone-shim behavior", () => {
   it("hosts stateful resource hooks under createTapRoot", () => {
@@ -110,5 +112,23 @@ describe("@assistant-ui/tap/standalone-shim behavior", () => {
     expect(() => c(1)).toThrow("standalone-shim");
 
     root.unmount();
+  });
+  it("keeps component factories loadable but their JSX unrenderable", () => {
+    const render = () => null;
+    expect(shim.forwardRef(render)).toEqual({
+      $$typeof: Symbol.for("react.forward_ref"),
+      render,
+    });
+    expect(shim.memo(render)).toEqual({
+      $$typeof: Symbol.for("react.memo"),
+      type: render,
+      compare: null,
+    });
+
+    expect(jsxRuntime.Fragment).toBe(Symbol.for("react.fragment"));
+    expect(jsxDevRuntime.Fragment).toBe(Symbol.for("react.fragment"));
+    expect(() => jsxRuntime.jsx()).toThrow("standalone-shim");
+    expect(() => jsxRuntime.jsxs()).toThrow("standalone-shim");
+    expect(() => jsxDevRuntime.jsxDEV()).toThrow("standalone-shim");
   });
 });

--- a/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
@@ -17,7 +17,7 @@ const DIST_ENTRY_FILES = [
   resolve(DIST_DIR, "standalone-shim/jsx-dev-runtime.js"),
 ];
 const REACT_SHIM_DIR = resolve(SRC_DIR, "react-shim");
-const ALLOWED_REACT_HOOK_NAMES = [
+const ALLOWED_SHIM_EXPORTS = [
   "default",
   "createContext",
   "use",
@@ -151,9 +151,7 @@ describe("@assistant-ui/tap/standalone-shim import graph", () => {
     ].map((match) => match[1]!);
     if (/export default \w+/.test(indexSource)) exportedSurface.push("default");
 
-    expect([...ALLOWED_REACT_HOOK_NAMES].sort()).toEqual(
-      exportedSurface.sort(),
-    );
+    expect([...ALLOWED_SHIM_EXPORTS].sort()).toEqual(exportedSurface.sort());
   });
 
   it("imports React nowhere in the entry files", () => {

--- a/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
@@ -7,10 +7,14 @@ const DIST_DIR = resolve(SRC_DIR, "../dist");
 const ENTRY_FILES = [
   resolve(__dirname, "index.ts"),
   resolve(__dirname, "compiler-runtime.ts"),
+  resolve(__dirname, "jsx-runtime.ts"),
+  resolve(__dirname, "jsx-dev-runtime.ts"),
 ];
 const DIST_ENTRY_FILES = [
   resolve(DIST_DIR, "standalone-shim/index.js"),
   resolve(DIST_DIR, "standalone-shim/compiler-runtime.js"),
+  resolve(DIST_DIR, "standalone-shim/jsx-runtime.js"),
+  resolve(DIST_DIR, "standalone-shim/jsx-dev-runtime.js"),
 ];
 const REACT_SHIM_DIR = resolve(SRC_DIR, "react-shim");
 const ALLOWED_REACT_HOOK_NAMES = [
@@ -29,6 +33,8 @@ const ALLOWED_REACT_HOOK_NAMES = [
   "useRef",
   "useState",
   "useSyncExternalStore",
+  "forwardRef",
+  "memo",
 ] as const;
 
 type ModuleReference = {

--- a/packages/tap/standalone-shim/jsx-dev-runtime/package.json
+++ b/packages/tap/standalone-shim/jsx-dev-runtime/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../../dist/standalone-shim/jsx-dev-runtime.js"
+}

--- a/packages/tap/standalone-shim/jsx-runtime/package.json
+++ b/packages/tap/standalone-shim/jsx-runtime/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../../dist/standalone-shim/jsx-runtime.js"
+}


### PR DESCRIPTION
part of #5920, completing the react-less leg deferred from #5932.

## summary

- the whole `@assistant-ui/ai-sdk` barrel now loads and `AISDKChat` streams a full chat round trip under the `react` to `@assistant-ui/tap/standalone-shim` alias with no real React in the module graph, and `react` becomes an optional peer dependency (the tap precedent's rationale: optional encodes the supported react-less alias configuration, the range still validates when react is present)
- the fix lives at the source, in the shim, not in per-import seam sweeps: `@assistant-ui/tap/standalone-shim` gains `jsx-runtime` and `jsx-dev-runtime` entries (importable, throw-on-render) plus module-scope `forwardRef` and `memo` returning React's marker shapes, so react-coupled module graphs survive module-scope evaluation; rendering their JSX without real React still fails loudly. exports map and the main-field proxy directories follow the existing subpath pattern, and the shim's surface-allowlist guard test is extended with the new members and entry files
- the react-less path is pinned by a new standalone vitest project in ai-sdk (`.e2e.ts` suffix separation, the tap pattern): one test proves the barrel import, one streams the round trip. the aliases point at the tap dist so the shim shares one tap instance with the core and store dists, and `@ai-sdk/react` is inlined so vitest's externalization cannot bypass the alias
- practical effect: an app using the documented `react: "@assistant-ui/tap/standalone-shim"` alias (with-nuxt, with-vue) can now import the ai-sdk barrel react-free; this is name-independent and applies equally if the package naming discussion lands elsewhere

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/tap test` 570/570, including the extended shim surface guard
- [x] `pnpm --filter @assistant-ui/ai-sdk test` 222/222 across both projects, including the new react-less e2e
- [x] `pnpm --filter @assistant-ui/ai-sdk test:react-compiler` 1/1
- [x] `pnpm check:resource-memo` 19/19
- [x] api-surface regenerated for tap, ai-sdk, react-ai-sdk: zero drift (types-null shim entries and peer metadata are invisible to the generator)
- [x] oxlint and oxfmt clean

### reviewer should verify

- [ ] the shim additions are load-time only: `jsx`/`jsxs`/`jsxDEV` throw on call, `forwardRef`/`memo` return inert marker objects, and no new member weakens the outside-tap hook guards

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-3V8rsQGbEmzn9PQ-utina-PNGuvjfQu1_j5CVuzfZKkAgio68iJ-ZE5bZk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->