### PR TITLE
fix(react): isolate assistant transport callbacks

### DIFF
--- a/.changeset/quiet-transports-settle.md
+++ b/.changeset/quiet-transports-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: isolate assistant transport lifecycle callback failures

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
@@ -12,12 +12,10 @@ const disposeReason = Symbol("assistant-transport-dispose");
 type LifecycleCallbackName = "onCancel" | "onError" | "onFinish";
 
 const reportCallbackError = (name: LifecycleCallbackName, error: unknown) => {
-  try {
-    console.error(
-      `[assistant-ui] Assistant transport ${name} callback threw an error`,
-      error,
-    );
-  } catch {}
+  console.error(
+    `[assistant-ui] Assistant transport ${name} callback threw an error`,
+    error,
+  );
 };
 
 const invokeCallback = (

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
@@ -12,10 +12,12 @@ const disposeReason = Symbol("assistant-transport-dispose");
 type LifecycleCallbackName = "onCancel" | "onError" | "onFinish";
 
 const reportCallbackError = (name: LifecycleCallbackName, error: unknown) => {
-  console.error(
-    `[assistant-ui] Assistant transport ${name} callback threw an error`,
-    error,
-  );
+  try {
+    console.error(
+      `[assistant-ui] Assistant transport ${name} callback threw an error`,
+      error,
+    );
+  } catch {}
 };
 
 const invokeCallback = (

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
@@ -18,18 +18,16 @@ const reportCallbackError = (name: LifecycleCallbackName, error: unknown) => {
   );
 };
 
-const invokeCallback = (
+const invokeCallback = async (
   name: LifecycleCallbackName,
   callback: (() => unknown) | undefined,
 ): Promise<void> => {
   try {
-    return Promise.resolve(callback?.()).then(
-      () => {},
-      (error) => reportCallbackError(name, error),
-    );
+    await callback?.();
   } catch (error) {
-    reportCallbackError(name, error);
-    return Promise.resolve();
+    try {
+      reportCallbackError(name, error);
+    } catch {}
   }
 };
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
@@ -9,11 +9,28 @@ export type RunManager = Readonly<{
 
 const disposeReason = Symbol("assistant-transport-dispose");
 
-const reportFinishError = (error: unknown) => {
+type LifecycleCallbackName = "onCancel" | "onError" | "onFinish";
+
+const reportCallbackError = (name: LifecycleCallbackName, error: unknown) => {
   console.error(
-    "[assistant-ui] Assistant transport onFinish callback threw an error",
+    `[assistant-ui] Assistant transport ${name} callback threw an error`,
     error,
   );
+};
+
+const invokeCallback = (
+  name: LifecycleCallbackName,
+  callback: (() => unknown) | undefined,
+): Promise<void> => {
+  try {
+    return Promise.resolve(callback?.()).then(
+      () => {},
+      (error) => reportCallbackError(name, error),
+    );
+  } catch (error) {
+    reportCallbackError(name, error);
+    return Promise.resolve();
+  }
 };
 
 export function useRunManager(config: {
@@ -52,20 +69,16 @@ export function useRunManager(config: {
         if (!disposeAborted() && !stateRef.current.disposed) {
           stateRef.current.pending = false;
           if (ac.signal.aborted) {
-            onCancelRef.current?.();
+            void invokeCallback("onCancel", onCancelRef.current);
           } else {
-            await onErrorRef.current?.(error as Error);
+            await invokeCallback("onError", () =>
+              onErrorRef.current?.(error as Error),
+            );
           }
         }
       } finally {
         if (!disposeAborted() && !stateRef.current.disposed) {
-          try {
-            void Promise.resolve(onFinishRef.current?.()).catch(
-              reportFinishError,
-            );
-          } catch (error) {
-            reportFinishError(error);
-          }
+          void invokeCallback("onFinish", onFinishRef.current);
         }
         if (!stateRef.current.disposed && stateRef.current.pending) {
           startRun();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -25,11 +25,26 @@ const createDeferred = () => {
   return { promise, resolve };
 };
 
+const captureUnhandledRejections = async (
+  callback: () => Promise<void>,
+): Promise<unknown[]> => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    await callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
+
 const useTransportSchedulingHarness = (
   opts: {
     onRun?: (signal: AbortSignal) => Promise<void> | void;
     onCancel?: (commands: AssistantTransportCommand[]) => void;
-    onError?: (commands: AssistantTransportCommand[]) => void;
+    onError?: (commands: AssistantTransportCommand[]) => void | Promise<void>;
     onFinish?: () => void;
   } = {},
 ) => {
@@ -52,7 +67,7 @@ const useTransportSchedulingHarness = (
     },
     onError: async () => {
       const queue = commandQueueRef.current!;
-      opts.onError?.([...queue.state.inTransit]);
+      await opts.onError?.([...queue.state.inTransit]);
     },
     onFinish: () => opts.onFinish?.(),
   });
@@ -179,6 +194,91 @@ describe("assistant transport scheduling contracts", () => {
         "[assistant-ui] Assistant transport onFinish callback threw an error",
         error,
       );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("contains rejected onError callbacks", async () => {
+    const callbackError = new Error("error telemetry failed");
+    const onError = vi.fn().mockRejectedValue(callbackError);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        const { result } = renderHook(() =>
+          useTransportSchedulingHarness({
+            onRun: () => Promise.reject(new Error("network failed")),
+            onError,
+          }),
+        );
+
+        act(() => {
+          result.current.commandQueue.enqueue(createMessageCommand("m1"));
+        });
+
+        await waitFor(() => {
+          expect(result.current.runManager.isRunning).toBe(false);
+        });
+      });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Assistant transport onError callback threw an error",
+        callbackError,
+      );
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("contains throwing onCancel callbacks", async () => {
+    const callbackError = new Error("cancel telemetry failed");
+    const onCancel = vi.fn().mockImplementation(() => {
+      throw callbackError;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        const { result } = renderHook(() =>
+          useTransportSchedulingHarness({
+            onRun: (signal) =>
+              new Promise<void>((_resolve, reject) => {
+                signal.addEventListener(
+                  "abort",
+                  () => reject(new Error("aborted")),
+                  { once: true },
+                );
+              }),
+            onCancel,
+          }),
+        );
+
+        act(() => {
+          result.current.commandQueue.enqueue(createMessageCommand("m1"));
+        });
+        await waitFor(() => {
+          expect(result.current.runBatchesRef.current).toHaveLength(1);
+        });
+
+        act(() => result.current.runManager.cancel());
+        await waitFor(() => {
+          expect(result.current.runManager.isRunning).toBe(false);
+        });
+      });
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Assistant transport onCancel callback threw an error",
+        callbackError,
+      );
+      expect(unhandledRejections).toEqual([]);
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -202,9 +202,9 @@ describe("assistant transport scheduling contracts", () => {
   it("contains rejected onError callbacks", async () => {
     const callbackError = new Error("error telemetry failed");
     const onError = vi.fn().mockRejectedValue(callbackError);
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
-      throw new Error("console unavailable");
-    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     try {
       const unhandledRejections = await captureUnhandledRejections(async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -202,9 +202,9 @@ describe("assistant transport scheduling contracts", () => {
   it("contains rejected onError callbacks", async () => {
     const callbackError = new Error("error telemetry failed");
     const onError = vi.fn().mockRejectedValue(callbackError);
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+      throw new Error("console unavailable");
+    });
 
     try {
       const unhandledRejections = await captureUnhandledRejections(async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -204,7 +204,14 @@ describe("assistant transport scheduling contracts", () => {
     const onError = vi.fn().mockRejectedValue(callbackError);
     const consoleError = vi
       .spyOn(console, "error")
-      .mockImplementation(() => {});
+      .mockImplementation((message) => {
+        if (
+          message ===
+          "[assistant-ui] Assistant transport onError callback threw an error"
+        ) {
+          throw new Error("console unavailable");
+        }
+      });
 
     try {
       const unhandledRejections = await captureUnhandledRejections(async () => {


### PR DESCRIPTION
## Summary

- contain synchronous and asynchronous `onError`, `onCancel`, and `onFinish` callback failures inside the assistant transport run manager
- preserve the existing awaited `onError` lifecycle and run cleanup behavior
- add regressions proving rejected error callbacks and throwing cancellation callbacks do not produce global `unhandledRejection` events

## Why

These callbacks are application lifecycle hooks, commonly used for telemetry or cleanup. A callback failure should not escape the queued run microtask, replace the original transport failure, or leave a global unhandled rejection. `onFinish` already had this protection; this applies the same behavior consistently to the other lifecycle callbacks.

## Testing

- `pnpm exec vitest run src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts --typecheck.enabled=false`
- `pnpm --filter @assistant-ui/react build`
- focused oxfmt and oxlint checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Ai5ePnZJfZaz8w7w93v925CdaHVS-DJ2savn-s61aTpfn0L9GRd11ntLAf4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->