### PR TITLE
fix(assistant-stream): release tool argument stream readers

### DIFF
--- a/.changeset/calm-tool-readers-release.md
+++ b/.changeset/calm-tool-readers-release.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: release streamed tool argument readers after parsing

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { ToolCallReaderImpl } from "./ToolCallReader";
+import { describe, expect, it, vi } from "vitest";
+import { ToolCallArgsReaderImpl, ToolCallReaderImpl } from "./ToolCallReader";
 
 type Args = {
   required: string;
@@ -10,6 +10,19 @@ type Args = {
 const createReader = () => new ToolCallReaderImpl<Args, string>();
 
 describe("ToolCallArgsReader.get", () => {
+  it("releases the argument stream reader after completion", async () => {
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue('{"required":"hello"}');
+        controller.close();
+      },
+    });
+    const reader = new ToolCallArgsReaderImpl<Args>(stream);
+
+    expect(await reader.get("required")).toBe("hello");
+    await vi.waitFor(() => expect(stream.locked).toBe(false));
+  });
+
   it("resolves with the value once the field is complete", async () => {
     const reader = createReader();
     const promise = reader.args.get("required");

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -278,9 +278,10 @@ export class ToolCallArgsReaderImpl<
   }
 
   private async processStream(): Promise<void> {
+    let reader: ReadableStreamDefaultReader<string> | undefined;
     try {
       let accumulatedText = "";
-      const reader = this.argTextDeltas.getReader();
+      reader = this.argTextDeltas.getReader();
 
       while (true) {
         const { value, done } = await reader.read();
@@ -300,6 +301,7 @@ export class ToolCallArgsReaderImpl<
     } catch (error) {
       console.error("Error processing argument stream:", error);
     } finally {
+      reader?.releaseLock();
       this.finished = true;
       for (const handle of this.handles) {
         handle.end(this.args);


### PR DESCRIPTION
## Summary

- retain the reader acquired for streamed tool arguments
- release its lock when parsing finishes or fails
- verify a fully consumed argument stream is no longer locked

## Why

`ToolCallArgsReaderImpl` acquired a reader but never released it. Even after parsing reached EOF and waiting consumers settled, the source stream remained locked, preventing later consumers or cleanup from acquiring it.

The reader is now released in the existing settlement `finally` block, which covers both normal completion and read/parser failures.

## Test plan

- `pnpm --filter assistant-stream test`
- `pnpm --filter assistant-stream build`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Awb0WkMaZombt7ytmTKHVV7O2oR5IU-Uk_SymRlQV4IjbyesPeLPohWFUy8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->