### PR TITLE
fix(react-pi): isolate event stream callbacks

### DIFF
--- a/.changeset/calm-pi-event-callbacks.md
+++ b/.changeset/calm-pi-event-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: isolate event stream callbacks from transport reconnection

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -435,6 +435,55 @@ describe("openPiEventStream", () => {
     },
   );
 
+  it.each(["throws", "rejects"] as const)(
+    "continues without reconnecting when the event callback %s",
+    async (failureMode) => {
+      const callbackError = new Error("consumer failed");
+      const fetchImpl = vi.fn(async () =>
+        sseResponse([
+          sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+          sseFrame({ type: "agent_end", threadId: "t1", seq: 2 }),
+        ]),
+      ) as unknown as typeof fetch;
+      const onError = vi.fn();
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      let events = 0;
+
+      try {
+        await new Promise<void>((resolve) => {
+          const close = openPiEventStream({
+            url: "/events",
+            fetchImpl,
+            reconnectDelay: () => Promise.resolve(),
+            onError,
+            onEvent: () => {
+              events += 1;
+              if (events === 1) {
+                if (failureMode === "throws") throw callbackError;
+                return Promise.reject(callbackError);
+              }
+              close();
+              resolve();
+            },
+          });
+        });
+        await Promise.resolve();
+
+        expect(events).toBe(2);
+        expect(fetchImpl).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-pi] onEvent callback threw an error",
+          callbackError,
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    },
+  );
+
   it("reconnects when the reconnect delay rejects", async () => {
     vi.useFakeTimers();
     let calls = 0;

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -172,12 +172,22 @@ export const openPiEventStream = (
   const reportCallbackError = (callbackError: unknown) => {
     console.error("[react-pi] onError callback threw an error", callbackError);
   };
+  const reportEventCallbackError = (callbackError: unknown) => {
+    console.error("[react-pi] onEvent callback threw an error", callbackError);
+  };
   const reportError = (error: unknown) => {
     if (!onError) return;
     try {
       void Promise.resolve(onError(error)).catch(reportCallbackError);
     } catch (callbackError) {
       reportCallbackError(callbackError);
+    }
+  };
+  const emitEvent = (event: PiAnyClientEvent) => {
+    try {
+      void Promise.resolve(onEvent(event)).catch(reportEventCallbackError);
+    } catch (callbackError) {
+      reportEventCallbackError(callbackError);
     }
   };
 
@@ -235,7 +245,7 @@ export const openPiEventStream = (
                 reportError(error);
                 continue;
               }
-              if (!closed) onEvent(parsed);
+              if (!closed) emitEvent(parsed);
             }
           }
         } finally {


### PR DESCRIPTION
## Summary

- isolate synchronous throws and rejected promises from public `openPiEventStream()` event callbacks
- keep consumer callback failures from reaching `onError` or reconnecting a healthy SSE transport
- add regression coverage for both failure modes

## Why

`onEvent` runs inside the transport loop today, so a consumer callback that throws is mistaken for a network failure. That reports the callback error through `onError` and reconnects an otherwise healthy stream. #5040 isolated the higher-level shared-client fan-out, but direct `openPiEventStream()` consumers remain exposed.

## Testing

- `pnpm --filter @assistant-ui/react-pi test` (180 tests)
- `pnpm --filter @assistant-ui/react-pi build`
- `pnpm exec oxlint packages/react-pi/src/client/eventSource.ts packages/react-pi/src/client/eventSource.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kZWPGCgUwewwtkLMY55IvMl0WcUzwcxsBMqiDJLJQUsHVx0lJLTa6xcCbe0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->