### PR TITLE
fix: docs Markdown menu wrapping

### DIFF
--- a/apps/docs/components/docs/layout/docs-pager.tsx
+++ b/apps/docs/components/docs/layout/docs-pager.tsx
@@ -60,7 +60,7 @@ export function DocsPager({ previous, next, markdownUrl }: DocsPagerProps) {
           <DropdownMenuTrigger className={buttonClass}>
             <MoreHorizontal className="size-4" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent>
+          <DropdownMenuContent className="w-max">
             <DropdownMenuItem onClick={copy} disabled={isLoading}>
               <Copy className="size-4" />
               {isLoading ? "Loading..." : "Copy page"}


### PR DESCRIPTION
## Summary

- size the docs page actions menu to its longest item
- keep “View as Markdown” on a single line

## Why

The dropdown inherited the width of its compact trigger and only expanded to the shared minimum width, causing the longer Markdown action to wrap. Setting the popup to `w-max` lets it use the intrinsic width of its contents.

## Testing

- `oxlint apps/docs/components/docs/layout/docs-pager.tsx`
- `oxfmt --check apps/docs/components/docs/layout/docs-pager.tsx`
- repository pre-commit hooks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NnEtEGb5CFQa-ieNqQHHX4EtZlil7i9PasbynMphTU0_4TgSUcXe--fhZa4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->