### PR TITLE
fix(cloud): validate run stream responses

### DIFF
--- a/.changeset/fuzzy-runs-stream.md
+++ b/.changeset/fuzzy-runs-stream.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: validate Cloud run stream response bodies and content types

--- a/packages/cloud/src/AssistantCloudRuns.ts
+++ b/packages/cloud/src/AssistantCloudRuns.ts
@@ -1,6 +1,7 @@
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
 import type { SamplingCallData } from "./instrumentMcpSampling";
 import { AssistantStream, PlainTextDecoder } from "assistant-stream";
+import { CloudResponseError } from "./cloudResponse";
 
 type AssistantCloudRunsStreamBody = {
   thread_id: string;
@@ -83,6 +84,25 @@ export class AssistantCloudRuns {
       },
       body,
     });
+
+    if (!response.body) {
+      throw new CloudResponseError(
+        'Invalid Assistant Cloud response for "run stream": expected a response body',
+      );
+    }
+
+    const contentType = response.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (contentType !== "text/plain") {
+      await response.body.cancel().catch(() => undefined);
+      throw new CloudResponseError(
+        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type',
+      );
+    }
+
     return AssistantStream.fromResponse(response, new PlainTextDecoder());
   }
 

--- a/packages/cloud/src/AssistantCloudRuns.ts
+++ b/packages/cloud/src/AssistantCloudRuns.ts
@@ -91,15 +91,19 @@ export class AssistantCloudRuns {
       );
     }
 
-    const contentType = response.headers
-      .get("content-type")
+    const receivedContentType = response.headers.get("content-type");
+    const contentType = receivedContentType
       ?.split(";", 1)[0]
       ?.trim()
       .toLowerCase();
     if (contentType !== "text/plain") {
       await response.body.cancel().catch(() => undefined);
       throw new CloudResponseError(
-        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type',
+        `Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type, received ${
+          receivedContentType
+            ? `"${receivedContentType}"`
+            : "no Content-Type header"
+        }`,
       );
     }
 

--- a/packages/cloud/src/tests/AssistantCloudRuns.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudRuns.test.ts
@@ -70,7 +70,20 @@ describe("AssistantCloudRuns", () => {
 
     await expect(createCloud().runs.stream(streamBody)).rejects.toThrow(
       new CloudResponseError(
-        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type',
+        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type, received "text/html; charset=utf-8"',
+      ),
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects and cancels run responses without a content type", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({ cancel });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(body)));
+
+    await expect(createCloud().runs.stream(streamBody)).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type, received no Content-Type header',
       ),
     );
     expect(cancel).toHaveBeenCalledOnce();

--- a/packages/cloud/src/tests/AssistantCloudRuns.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudRuns.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AssistantCloud } from "../AssistantCloud";
+import { CloudResponseError } from "../cloudResponse";
+
+const createCloud = () =>
+  new AssistantCloud({
+    apiKey: "test-key",
+    userId: "user-id",
+    workspaceId: "workspace-id",
+  });
+
+const streamBody = {
+  thread_id: "thread-id",
+  assistant_id: "system/thread_title" as const,
+  messages: [],
+};
+
+describe("AssistantCloudRuns", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("decodes text/plain run streams", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("Generated title", {
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }),
+      ),
+    );
+    const stream = await createCloud().runs.stream(streamBody);
+    let text = "";
+
+    await stream.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          if (chunk.type === "text-delta") text += chunk.textDelta;
+        },
+      }),
+    );
+
+    expect(text).toBe("Generated title");
+  });
+
+  it("rejects successful run responses without a body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    );
+
+    await expect(createCloud().runs.stream(streamBody)).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "run stream": expected a response body',
+      ),
+    );
+  });
+
+  it("rejects and cancels run responses with the wrong content type", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream({ cancel });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        }),
+      ),
+    );
+
+    await expect(createCloud().runs.stream(streamBody)).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "run stream": expected a "text/plain" content type',
+      ),
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- require Cloud run streams to include a response body
- validate the backend's documented `text/plain` media type before decoding
- cancel incorrect response bodies before throwing `CloudResponseError`

## Why

`AssistantCloudRuns.stream()` currently passes every successful HTTP response directly to `PlainTextDecoder`. A proxy or authentication layer returning `200 text/html` is therefore emitted as assistant text and can become a generated thread title. Successful responses without a body fail later with a low-context stream error.

The Cloud run endpoint explicitly returns `text/plain` for this request. Validating that contract at the API boundary gives consumers a typed, contextual error and prevents rejected responses from continuing upstream work.

## Testing

- `pnpm --filter assistant-stream build`
- `pnpm --filter assistant-cloud test` (63 passed)
- `pnpm exec oxlint packages/cloud/src/AssistantCloudRuns.ts packages/cloud/src/tests/AssistantCloudRuns.test.ts`
- `pnpm --filter assistant-cloud build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kfa4pAiZSmt4Uu7d-rz0or4HVWgqbdWuppQ1carFHY3g67xg-yVNNcF4SoY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->