### PR TITLE
fix(x-generative-compiler): refresh tsconfig aliases

### DIFF
--- a/.changeset/fresh-generative-aliases.md
+++ b/.changeset/fresh-generative-aliases.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+---
+
+fix: refresh TypeScript path aliases after config changes

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import * as nodePath from "node:path";
 import { describe, it, expect, vi } from "vitest";
@@ -1346,9 +1346,6 @@ export default defineToolkit({
     ).not.toThrow();
 
     writeAliasConfig(tsconfigPath, "./fallbacks/*");
-    const updatedAt = new Date(Date.now() + 1_000);
-    utimesSync(tsconfigPath, updatedAt, updatedAt);
-
     expect(() =>
       compileGenerative(aliasedToolkitSource, { target: "client", filename }),
     ).toThrow(/compiler-visible toolkit spread/);
@@ -1402,36 +1399,33 @@ export default defineToolkit({
     ).not.toThrow();
   });
 
-  it("refreshes cached aliases when a package extended config is installed", () => {
+  it("retries unresolved package configs on the next compile", () => {
     const appRoot = mkdtempSync(
       nodePath.join(tmpdir(), "aui-generative-package-config-"),
     );
-    const packageRoot = nodePath.join(appRoot, "package");
     writeAliasTarget(appRoot, "generated", generativeChild);
-    writeAliasTarget(packageRoot, "fallbacks", nonGenerativeChild);
-    mkdirSync(nodePath.join(packageRoot, "src"), { recursive: true });
-    writeAliasConfig(nodePath.join(appRoot, "tsconfig.json"), "./generated/*");
+    mkdirSync(nodePath.join(appRoot, "src"), { recursive: true });
     writeFileSync(
-      nodePath.join(packageRoot, "tsconfig.json"),
+      nodePath.join(appRoot, "tsconfig.json"),
       JSON.stringify({ extends: "config/base" }),
     );
-    const filename = nodePath.join(packageRoot, "src", "toolkit.tsx");
-
-    expect(() =>
-      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
-    ).not.toThrow();
-
-    const configPackage = nodePath.join(packageRoot, "node_modules", "config");
-    mkdirSync(configPackage, { recursive: true });
-    writeAliasConfig(
-      nodePath.join(configPackage, "base.json"),
-      "./fallbacks/*",
-      nodePath.relative(configPackage, packageRoot),
-    );
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
 
     expect(() =>
       compileGenerative(aliasedToolkitSource, { target: "client", filename }),
     ).toThrow(/compiler-visible toolkit spread/);
+
+    const configPackage = nodePath.join(appRoot, "node_modules", "config");
+    mkdirSync(configPackage, { recursive: true });
+    writeAliasConfig(
+      nodePath.join(configPackage, "base.json"),
+      "./generated/*",
+      nodePath.relative(configPackage, appRoot),
+    );
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
   });
 
   it("prefers the most specific tsconfig path alias", () => {

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1299,6 +1299,59 @@ export default defineToolkit({
     expect(client).toContain('from "@/tools/weather"');
   });
 
+  it("refreshes cached path aliases after tsconfig changes", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-alias-refresh-"),
+    );
+    mkdirSync(nodePath.join(appRoot, "src", "fallback-tools"), {
+      recursive: true,
+    });
+    mkdirSync(nodePath.join(appRoot, "generated"), { recursive: true });
+    writeFileSync(
+      nodePath.join(appRoot, "generated", "weather.tsx"),
+      generativeChild,
+    );
+    writeFileSync(
+      nodePath.join(appRoot, "src", "fallback-tools", "weather.tsx"),
+      `export default { get_weather: { execute: async () => 1 } };\n`,
+    );
+    const tsconfigPath = nodePath.join(appRoot, "tsconfig.json");
+    writeFileSync(
+      tsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "@/tools/*": ["./generated/*"] },
+        },
+      }),
+    );
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
+    const src = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "@/tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+    expect(() =>
+      compileGenerative(src, { target: "client", filename }),
+    ).not.toThrow();
+
+    writeFileSync(
+      tsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "@/tools/*": ["./src/fallback-tools/*"] },
+        },
+      }),
+    );
+
+    expect(() =>
+      compileGenerative(src, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
   it("prefers the most specific tsconfig path alias", () => {
     const appRoot = mkdtempSync(
       nodePath.join(tmpdir(), "aui-generative-alias-spec-"),

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import * as nodePath from "node:path";
 import { describe, it, expect, vi } from "vitest";
@@ -129,6 +129,38 @@ export default defineToolkit({
   },
 });
 `;
+
+const nonGenerativeChild =
+  "export default { get_weather: { execute: async () => 1 } };\n";
+
+const aliasedToolkitSource = `"use generative";
+import { defineToolkit } from "@assistant-ui/react";
+import weatherTools from "@/tools/weather";
+export default defineToolkit({
+  ...weatherTools,
+});`;
+
+function writeAliasTarget(
+  root: string,
+  directory: string,
+  childSource: string,
+): void {
+  const target = nodePath.join(root, directory);
+  mkdirSync(target, { recursive: true });
+  writeFileSync(nodePath.join(target, "weather.tsx"), childSource);
+}
+
+function writeAliasConfig(path: string, target: string, baseUrl = "."): void {
+  writeFileSync(
+    path,
+    JSON.stringify({
+      compilerOptions: {
+        baseUrl,
+        paths: { "@/tools/*": [target] },
+      },
+    }),
+  );
+}
 
 const source = `"use generative";
 import { z } from "zod";
@@ -1303,52 +1335,102 @@ export default defineToolkit({
     const appRoot = mkdtempSync(
       nodePath.join(tmpdir(), "aui-generative-alias-refresh-"),
     );
-    mkdirSync(nodePath.join(appRoot, "src", "fallback-tools"), {
-      recursive: true,
-    });
-    mkdirSync(nodePath.join(appRoot, "generated"), { recursive: true });
-    writeFileSync(
-      nodePath.join(appRoot, "generated", "weather.tsx"),
-      generativeChild,
-    );
-    writeFileSync(
-      nodePath.join(appRoot, "src", "fallback-tools", "weather.tsx"),
-      `export default { get_weather: { execute: async () => 1 } };\n`,
-    );
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    writeAliasTarget(appRoot, "fallbacks", nonGenerativeChild);
     const tsconfigPath = nodePath.join(appRoot, "tsconfig.json");
-    writeFileSync(
-      tsconfigPath,
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: { "@/tools/*": ["./generated/*"] },
-        },
-      }),
-    );
+    writeAliasConfig(tsconfigPath, "./generated/*");
     const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
-    const src = `"use generative";
-import { defineToolkit } from "@assistant-ui/react";
-import weatherTools from "@/tools/weather";
-export default defineToolkit({
-  ...weatherTools,
-});`;
 
     expect(() =>
-      compileGenerative(src, { target: "client", filename }),
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
     ).not.toThrow();
 
+    writeAliasConfig(tsconfigPath, "./fallbacks/*");
+    const updatedAt = new Date(Date.now() + 1_000);
+    utimesSync(tsconfigPath, updatedAt, updatedAt);
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("refreshes cached aliases when a missing extended config is created", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-extends-refresh-"),
+    );
+    const packageRoot = nodePath.join(appRoot, "package");
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    writeAliasTarget(packageRoot, "fallbacks", nonGenerativeChild);
+    mkdirSync(nodePath.join(packageRoot, "src"), { recursive: true });
+    writeAliasConfig(nodePath.join(appRoot, "tsconfig.json"), "./generated/*");
     writeFileSync(
-      tsconfigPath,
-      JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: { "@/tools/*": ["./src/fallback-tools/*"] },
-        },
-      }),
+      nodePath.join(packageRoot, "tsconfig.json"),
+      JSON.stringify({ extends: "./tsconfig.paths.json" }),
+    );
+    const filename = nodePath.join(packageRoot, "src", "toolkit.tsx");
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
+
+    writeAliasConfig(
+      nodePath.join(packageRoot, "tsconfig.paths.json"),
+      "./fallbacks/*",
     );
 
     expect(() =>
-      compileGenerative(src, { target: "client", filename }),
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("refreshes cached alias misses when a tsconfig is created", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-config-create-"),
+    );
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    mkdirSync(nodePath.join(appRoot, "src"), { recursive: true });
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+
+    writeAliasConfig(nodePath.join(appRoot, "tsconfig.json"), "./generated/*");
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
+  });
+
+  it("refreshes cached aliases when a package extended config is installed", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-package-config-"),
+    );
+    const packageRoot = nodePath.join(appRoot, "package");
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    writeAliasTarget(packageRoot, "fallbacks", nonGenerativeChild);
+    mkdirSync(nodePath.join(packageRoot, "src"), { recursive: true });
+    writeAliasConfig(nodePath.join(appRoot, "tsconfig.json"), "./generated/*");
+    writeFileSync(
+      nodePath.join(packageRoot, "tsconfig.json"),
+      JSON.stringify({ extends: "config/base" }),
+    );
+    const filename = nodePath.join(packageRoot, "src", "toolkit.tsx");
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
+
+    const configPackage = nodePath.join(packageRoot, "node_modules", "config");
+    mkdirSync(configPackage, { recursive: true });
+    writeAliasConfig(
+      nodePath.join(configPackage, "base.json"),
+      "./fallbacks/*",
+      nodePath.relative(configPackage, packageRoot),
+    );
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
     ).toThrow(/compiler-visible toolkit spread/);
   });
 

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import * as nodePath from "node:path";
 import { describe, it, expect, vi } from "vitest";
@@ -1426,6 +1432,54 @@ export default defineToolkit({
     expect(() =>
       compileGenerative(aliasedToolkitSource, { target: "client", filename }),
     ).not.toThrow();
+  });
+
+  it("refreshes cached aliases when a tsconfig is deleted", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-config-delete-"),
+    );
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    mkdirSync(nodePath.join(appRoot, "src"), { recursive: true });
+    const tsconfigPath = nodePath.join(appRoot, "tsconfig.json");
+    writeAliasConfig(tsconfigPath, "./generated/*");
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
+
+    rmSync(tsconfigPath);
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
+  });
+
+  it("refreshes cached aliases when an edit preserves size and mtime", () => {
+    const appRoot = mkdtempSync(
+      nodePath.join(tmpdir(), "aui-generative-same-mtime-"),
+    );
+    writeAliasTarget(appRoot, "generated", generativeChild);
+    writeAliasTarget(appRoot, "fallbacks", nonGenerativeChild);
+    const tsconfigPath = nodePath.join(appRoot, "tsconfig.json");
+    const filename = nodePath.join(appRoot, "src", "toolkit.tsx");
+
+    // Both writes are pinned to one timestamp, standing in for a filesystem
+    // whose mtime granularity cannot separate them.
+    const tick = 1700000000;
+    writeAliasConfig(tsconfigPath, "./generated/*");
+    utimesSync(tsconfigPath, tick, tick);
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).not.toThrow();
+
+    writeAliasConfig(tsconfigPath, "./fallbacks/*");
+    utimesSync(tsconfigPath, tick, tick);
+
+    expect(() =>
+      compileGenerative(aliasedToolkitSource, { target: "client", filename }),
+    ).toThrow(/compiler-visible toolkit spread/);
   });
 
   it("prefers the most specific tsconfig path alias", () => {

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as nodePath from "node:path";
 import { parse } from "@babel/parser";
@@ -1017,25 +1017,50 @@ function matchAliasPattern(pattern: string, source: string): string | null {
   return null;
 }
 
-/**
- * Memoizes resolved aliases per start directory. The compiler runs once per
- * file across a build, so without this every aliased spread re-walks and
- * re-parses the same `tsconfig.json`. Process-lifetime, like
- * `checkedCorePackageJsonPaths`.
- */
-const tsconfigAliasesByDir = new Map<string, TsconfigAliases | null>();
+interface TsconfigAliasesCacheEntry {
+  aliases: TsconfigAliases;
+  fileVersions: Map<string, string | null>;
+}
+
+const tsconfigAliasesByDir = new Map<string, TsconfigAliasesCacheEntry>();
+
+function tsconfigFileVersion(path: string): string | null {
+  try {
+    const stats = statSync(path, { bigint: true });
+    return `${stats.mtimeNs}:${stats.size}`;
+  } catch {
+    return null;
+  }
+}
+
+function trackTsconfigFile(
+  fileVersions: Map<string, string | null>,
+  path: string,
+): string | null {
+  const version = tsconfigFileVersion(path);
+  fileVersions.set(path, version);
+  return version;
+}
+
+function isTsconfigCacheCurrent(entry: TsconfigAliasesCacheEntry): boolean {
+  for (const [path, version] of entry.fileVersions) {
+    if (tsconfigFileVersion(path) !== version) return false;
+  }
+  return true;
+}
 
 /** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
 function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
   const cached = tsconfigAliasesByDir.get(fromDir);
-  if (cached !== undefined) return cached;
+  if (cached && isTsconfigCacheCurrent(cached)) return cached.aliases;
 
   let aliases: TsconfigAliases | null = null;
+  const fileVersions = new Map<string, string | null>();
   let dir = fromDir;
   for (;;) {
     const tsconfigPath = nodePath.join(dir, "tsconfig.json");
-    if (existsSync(tsconfigPath)) {
-      aliases = readTsconfigAliases(tsconfigPath, new Set());
+    if (trackTsconfigFile(fileVersions, tsconfigPath) !== null) {
+      aliases = readTsconfigAliases(tsconfigPath, new Set(), fileVersions);
       if (aliases) break;
     }
     const parent = nodePath.dirname(dir);
@@ -1043,7 +1068,11 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
     dir = parent;
   }
 
-  tsconfigAliasesByDir.set(fromDir, aliases);
+  if (aliases) {
+    tsconfigAliasesByDir.set(fromDir, { aliases, fileVersions });
+  } else {
+    tsconfigAliasesByDir.delete(fromDir);
+  }
   return aliases;
 }
 
@@ -1051,9 +1080,11 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
 function readTsconfigAliases(
   tsconfigPath: string,
   seen: Set<string>,
+  fileVersions: Map<string, string | null>,
 ): TsconfigAliases | null {
   if (seen.has(tsconfigPath)) return null;
   seen.add(tsconfigPath);
+  trackTsconfigFile(fileVersions, tsconfigPath);
 
   let config: {
     extends?: string | string[];
@@ -1089,7 +1120,7 @@ function readTsconfigAliases(
     if (typeof entry !== "string") continue;
     const extended = resolveExtendedTsconfig(entry, configDir);
     if (extended) {
-      const aliases = readTsconfigAliases(extended, seen);
+      const aliases = readTsconfigAliases(extended, seen, fileVersions);
       if (aliases) return aliases;
     }
   }

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1018,7 +1018,7 @@ function matchAliasPattern(pattern: string, source: string): string | null {
 }
 
 interface TsconfigAliasesCacheEntry {
-  aliases: TsconfigAliases;
+  aliases: TsconfigAliases | null;
   fileVersions: Map<string, string | null>;
 }
 
@@ -1068,11 +1068,8 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
     dir = parent;
   }
 
-  if (aliases) {
-    tsconfigAliasesByDir.set(fromDir, { aliases, fileVersions });
-  } else {
-    tsconfigAliasesByDir.delete(fromDir);
-  }
+  // Cache misses too; tracked absent paths invalidate when a config appears.
+  tsconfigAliasesByDir.set(fromDir, { aliases, fileVersions });
   return aliases;
 }
 
@@ -1118,7 +1115,7 @@ function readTsconfigAliases(
   for (let i = extendsList.length - 1; i >= 0; i--) {
     const entry = extendsList[i];
     if (typeof entry !== "string") continue;
-    const extended = resolveExtendedTsconfig(entry, configDir);
+    const extended = resolveExtendedTsconfig(entry, configDir, fileVersions);
     if (extended) {
       const aliases = readTsconfigAliases(extended, seen, fileVersions);
       if (aliases) return aliases;
@@ -1131,17 +1128,40 @@ function readTsconfigAliases(
 function resolveExtendedTsconfig(
   extendsValue: string,
   configDir: string,
+  fileVersions: Map<string, string | null>,
 ): string | null {
   if (extendsValue.startsWith(".")) {
     const base = nodePath.resolve(configDir, extendsValue);
     const candidates =
       nodePath.extname(base) === ".json" ? [base] : [`${base}.json`, base];
-    return candidates.find((candidate) => existsSync(candidate)) ?? null;
+    for (const candidate of candidates) {
+      if (trackTsconfigFile(fileVersions, candidate) !== null) return candidate;
+    }
+    return null;
   }
-  try {
-    return createRequire(nodePath.join(configDir, "package.json")).resolve(
-      extendsValue.endsWith(".json") ? extendsValue : `${extendsValue}.json`,
+
+  const request = extendsValue.endsWith(".json")
+    ? extendsValue
+    : `${extendsValue}.json`;
+  const requireFromConfig = createRequire(
+    nodePath.join(configDir, "package.json"),
+  );
+  const packageName = extendsValue.startsWith("@")
+    ? extendsValue.split("/").slice(0, 2).join("/")
+    : extendsValue.split("/")[0]!;
+  for (const searchPath of requireFromConfig.resolve.paths(request) ?? []) {
+    trackTsconfigFile(fileVersions, nodePath.join(searchPath, packageName));
+    trackTsconfigFile(
+      fileVersions,
+      nodePath.join(searchPath, packageName, "package.json"),
     );
+    trackTsconfigFile(fileVersions, nodePath.join(searchPath, request));
+  }
+
+  try {
+    const resolved = requireFromConfig.resolve(request);
+    trackTsconfigFile(fileVersions, resolved);
+    return resolved;
   } catch {
     return null;
   }

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -248,6 +248,7 @@ export function compileGenerative(
   code: string,
   options: CompileOptions,
 ): CompileResult {
+  currentCompilePass++;
   const { target, filename } = options;
 
   const ast = parse(code, {
@@ -1020,9 +1021,17 @@ function matchAliasPattern(pattern: string, source: string): string | null {
 interface TsconfigAliasesCacheEntry {
   aliases: TsconfigAliases | null;
   fileVersions: Map<string, string | null>;
+  validatedInPass: number;
+  reuseAcrossPasses: boolean;
 }
 
 const tsconfigAliasesByDir = new Map<string, TsconfigAliasesCacheEntry>();
+let currentCompilePass = 0;
+
+interface TsconfigResolutionState {
+  fileVersions: Map<string, string | null>;
+  cacheable: boolean;
+}
 
 function tsconfigFileVersion(path: string): string | null {
   try {
@@ -1052,15 +1061,26 @@ function isTsconfigCacheCurrent(entry: TsconfigAliasesCacheEntry): boolean {
 /** Walks up from a directory to the nearest `tsconfig.json` that declares `paths`. */
 function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
   const cached = tsconfigAliasesByDir.get(fromDir);
-  if (cached && isTsconfigCacheCurrent(cached)) return cached.aliases;
+  if (cached) {
+    if (
+      cached.validatedInPass === currentCompilePass ||
+      (cached.reuseAcrossPasses && isTsconfigCacheCurrent(cached))
+    ) {
+      cached.validatedInPass = currentCompilePass;
+      return cached.aliases;
+    }
+  }
 
   let aliases: TsconfigAliases | null = null;
-  const fileVersions = new Map<string, string | null>();
+  const state: TsconfigResolutionState = {
+    fileVersions: new Map(),
+    cacheable: true,
+  };
   let dir = fromDir;
   for (;;) {
     const tsconfigPath = nodePath.join(dir, "tsconfig.json");
-    if (trackTsconfigFile(fileVersions, tsconfigPath) !== null) {
-      aliases = readTsconfigAliases(tsconfigPath, new Set(), fileVersions);
+    if (trackTsconfigFile(state.fileVersions, tsconfigPath) !== null) {
+      aliases = readTsconfigAliases(tsconfigPath, new Set(), state);
       if (aliases) break;
     }
     const parent = nodePath.dirname(dir);
@@ -1069,7 +1089,13 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
   }
 
   // Cache misses too; tracked absent paths invalidate when a config appears.
-  tsconfigAliasesByDir.set(fromDir, { aliases, fileVersions });
+  // Unresolved package configs are reused only within the current compile.
+  tsconfigAliasesByDir.set(fromDir, {
+    aliases,
+    fileVersions: state.fileVersions,
+    validatedInPass: currentCompilePass,
+    reuseAcrossPasses: state.cacheable,
+  });
   return aliases;
 }
 
@@ -1077,11 +1103,11 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
 function readTsconfigAliases(
   tsconfigPath: string,
   seen: Set<string>,
-  fileVersions: Map<string, string | null>,
+  state: TsconfigResolutionState,
 ): TsconfigAliases | null {
   if (seen.has(tsconfigPath)) return null;
   seen.add(tsconfigPath);
-  trackTsconfigFile(fileVersions, tsconfigPath);
+  trackTsconfigFile(state.fileVersions, tsconfigPath);
 
   let config: {
     extends?: string | string[];
@@ -1115,9 +1141,9 @@ function readTsconfigAliases(
   for (let i = extendsList.length - 1; i >= 0; i--) {
     const entry = extendsList[i];
     if (typeof entry !== "string") continue;
-    const extended = resolveExtendedTsconfig(entry, configDir, fileVersions);
+    const extended = resolveExtendedTsconfig(entry, configDir, state);
     if (extended) {
-      const aliases = readTsconfigAliases(extended, seen, fileVersions);
+      const aliases = readTsconfigAliases(extended, seen, state);
       if (aliases) return aliases;
     }
   }
@@ -1128,14 +1154,16 @@ function readTsconfigAliases(
 function resolveExtendedTsconfig(
   extendsValue: string,
   configDir: string,
-  fileVersions: Map<string, string | null>,
+  state: TsconfigResolutionState,
 ): string | null {
   if (extendsValue.startsWith(".")) {
     const base = nodePath.resolve(configDir, extendsValue);
     const candidates =
       nodePath.extname(base) === ".json" ? [base] : [`${base}.json`, base];
     for (const candidate of candidates) {
-      if (trackTsconfigFile(fileVersions, candidate) !== null) return candidate;
+      if (trackTsconfigFile(state.fileVersions, candidate) !== null) {
+        return candidate;
+      }
     }
     return null;
   }
@@ -1146,23 +1174,13 @@ function resolveExtendedTsconfig(
   const requireFromConfig = createRequire(
     nodePath.join(configDir, "package.json"),
   );
-  const packageName = extendsValue.startsWith("@")
-    ? extendsValue.split("/").slice(0, 2).join("/")
-    : extendsValue.split("/")[0]!;
-  for (const searchPath of requireFromConfig.resolve.paths(request) ?? []) {
-    trackTsconfigFile(fileVersions, nodePath.join(searchPath, packageName));
-    trackTsconfigFile(
-      fileVersions,
-      nodePath.join(searchPath, packageName, "package.json"),
-    );
-    trackTsconfigFile(fileVersions, nodePath.join(searchPath, request));
-  }
 
   try {
     const resolved = requireFromConfig.resolve(request);
-    trackTsconfigFile(fileVersions, resolved);
+    trackTsconfigFile(state.fileVersions, resolved);
     return resolved;
   } catch {
+    state.cacheable = false;
     return null;
   }
 }

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import * as nodePath from "node:path";
 import { parse } from "@babel/parser";
@@ -1033,10 +1034,12 @@ interface TsconfigResolutionState {
   cacheable: boolean;
 }
 
+// Fingerprints content rather than mtime and size: filesystems with coarse
+// timestamp granularity report an unchanged mtime for a same-length rewrite,
+// which would serve the stale aliases this cache exists to invalidate.
 function tsconfigFileVersion(path: string): string | null {
   try {
-    const stats = statSync(path, { bigint: true });
-    return `${stats.mtimeNs}:${stats.size}`;
+    return createHash("sha1").update(readFileSync(path)).digest("hex");
   } catch {
     return null;
   }

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -1031,32 +1031,49 @@ let currentCompilePass = 0;
 
 interface TsconfigResolutionState {
   fileVersions: Map<string, string | null>;
+  fileContents: Map<string, string | null>;
   cacheable: boolean;
 }
 
 // Fingerprints content rather than mtime and size: filesystems with coarse
 // timestamp granularity report an unchanged mtime for a same-length rewrite,
 // which would serve the stale aliases this cache exists to invalidate.
-function tsconfigFileVersion(path: string): string | null {
+function tsconfigFileVersion(content: string): string {
+  return createHash("sha1").update(content).digest("hex");
+}
+
+function readTsconfigFile(
+  state: TsconfigResolutionState,
+  path: string,
+): string | null {
+  const cached = state.fileContents.get(path);
+  if (cached !== undefined) return cached;
+
+  let content: string | null;
   try {
-    return createHash("sha1").update(readFileSync(path)).digest("hex");
+    content = readFileSync(path, "utf8");
+  } catch {
+    content = null;
+  }
+  state.fileContents.set(path, content);
+  state.fileVersions.set(
+    path,
+    content === null ? null : tsconfigFileVersion(content),
+  );
+  return content;
+}
+
+function currentFileVersion(path: string): string | null {
+  try {
+    return tsconfigFileVersion(readFileSync(path, "utf8"));
   } catch {
     return null;
   }
 }
 
-function trackTsconfigFile(
-  fileVersions: Map<string, string | null>,
-  path: string,
-): string | null {
-  const version = tsconfigFileVersion(path);
-  fileVersions.set(path, version);
-  return version;
-}
-
 function isTsconfigCacheCurrent(entry: TsconfigAliasesCacheEntry): boolean {
   for (const [path, version] of entry.fileVersions) {
-    if (tsconfigFileVersion(path) !== version) return false;
+    if (currentFileVersion(path) !== version) return false;
   }
   return true;
 }
@@ -1077,12 +1094,13 @@ function loadTsconfigAliases(fromDir: string): TsconfigAliases | null {
   let aliases: TsconfigAliases | null = null;
   const state: TsconfigResolutionState = {
     fileVersions: new Map(),
+    fileContents: new Map(),
     cacheable: true,
   };
   let dir = fromDir;
   for (;;) {
     const tsconfigPath = nodePath.join(dir, "tsconfig.json");
-    if (trackTsconfigFile(state.fileVersions, tsconfigPath) !== null) {
+    if (readTsconfigFile(state, tsconfigPath) !== null) {
       aliases = readTsconfigAliases(tsconfigPath, new Set(), state);
       if (aliases) break;
     }
@@ -1110,14 +1128,16 @@ function readTsconfigAliases(
 ): TsconfigAliases | null {
   if (seen.has(tsconfigPath)) return null;
   seen.add(tsconfigPath);
-  trackTsconfigFile(state.fileVersions, tsconfigPath);
+
+  const raw = readTsconfigFile(state, tsconfigPath);
+  if (raw === null) return null;
 
   let config: {
     extends?: string | string[];
     compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
   } | null;
   try {
-    config = parseJsonc(readFileSync(tsconfigPath, "utf8"));
+    config = parseJsonc(raw);
   } catch {
     return null;
   }
@@ -1164,7 +1184,7 @@ function resolveExtendedTsconfig(
     const candidates =
       nodePath.extname(base) === ".json" ? [base] : [`${base}.json`, base];
     for (const candidate of candidates) {
-      if (trackTsconfigFile(state.fileVersions, candidate) !== null) {
+      if (readTsconfigFile(state, candidate) !== null) {
         return candidate;
       }
     }
@@ -1180,7 +1200,7 @@ function resolveExtendedTsconfig(
 
   try {
     const resolved = requireFromConfig.resolve(request);
-    trackTsconfigFile(state.fileVersions, resolved);
+    readTsconfigFile(state, resolved);
     return resolved;
   } catch {
     state.cacheable = false;


### PR DESCRIPTION
## Summary

- revalidate cached TypeScript path aliases when the searched config chain changes
- fingerprint each tracked config by content, so an edit is detected regardless of timestamp granularity
- track missing relative `extends` candidates so newly created configs invalidate the cache
- retry unresolved package configs on the next compiler invocation without polling `node_modules`
- keep successful and negative alias lookups memoized while their inputs are unchanged
- validate each cache entry at most once per compiler invocation

## Why

The compiler cached resolved aliases by source directory for the lifetime of the process. When a long-lived host invoked the compiler again after a source or transform-cache refresh, it could still resolve through an older `tsconfig.json` chain until the process restarted.

The cache now records a content fingerprint for every config path it inspected, including the ones that were absent. Changes, removals, and newly appearing relative configs invalidate the entry, while unresolved package configs are reused only for the current synchronous compile. A fingerprint over content rather than `mtime` and size matters because a filesystem with coarse timestamp granularity reports an unchanged `mtime` for a same-length rewrite, which would keep serving exactly the stale aliases this cache exists to invalidate. It also means a `touch`, or a rewrite that produces identical bytes, no longer forces a needless re-walk.

Validation reads the tracked configs once per compiler invocation rather than on every alias lookup, and it never walks the `node_modules` search path in the steady state.

Changing the `exports` mapping of an already resolved package still requires restarting the host because Node caches successful package resolution. This PR intentionally does not replace the platform package resolver.

## Testing

- `vitest run src/compile.test.ts` in `packages/x-generative-compiler` (97 tests)
- the four invalidation cases fail against the pre-fix `compile.ts` and pass after it; the same-`mtime` case fails against the earlier `mtime`-and-size fingerprint
- measured cost of the content fingerprint on a three-deep `extends` chain: 233 vs 212 us per compile, against ~200 us of Babel parsing in the same call
- `aui-build` in `packages/x-generative-compiler`
- focused oxlint and oxfmt checks
