### PR TITLE
fix(react-devtools): sanitize non-json runtime values

### DIFF
--- a/.changeset/calm-devtools-values.md
+++ b/.changeset/calm-devtools-values.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: sanitize circular collections and non-JSON primitives

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -33,6 +33,27 @@ describe("sanitizeForMessage", () => {
     const cyclicArray: unknown[] = [];
     cyclicArray.push(cyclicArray);
     expect(sanitizeForMessage(cyclicArray)).toEqual(["[Circular]"]);
+
+    const cyclicMap = new Map<string, unknown>();
+    cyclicMap.set("self", cyclicMap);
+    expect(sanitizeForMessage(cyclicMap)).toEqual({ self: "[Circular]" });
+
+    const cyclicSet = new Set<unknown>();
+    cyclicSet.add(cyclicSet);
+    expect(sanitizeForMessage(cyclicSet)).toEqual(["[Circular]"]);
+  });
+
+  it("converts non-JSON primitives to strings", () => {
+    const result = sanitizeForMessage({
+      bigint: 42n,
+      symbol: Symbol("status"),
+    });
+
+    expect(result).toEqual({
+      bigint: "42",
+      symbol: "Symbol(status)",
+    });
+    expect(() => JSON.stringify(result)).not.toThrow();
   });
 });
 

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -15,6 +15,9 @@ export const sanitizeForMessage = (
   ) {
     return value;
   }
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    return String(value);
+  }
   if (typeof value === "function") {
     return "[Function]";
   }
@@ -22,14 +25,23 @@ export const sanitizeForMessage = (
     return value.toISOString();
   }
   if (value instanceof Map) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
     const result: Record<string, unknown> = {};
     for (const [key, entry] of value.entries()) {
       result[String(key)] = sanitizeForMessage(entry, seen);
     }
+    seen.delete(value);
     return result;
   }
   if (value instanceof Set) {
-    return Array.from(value).map((entry) => sanitizeForMessage(entry, seen));
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    const result = Array.from(value).map((entry) =>
+      sanitizeForMessage(entry, seen),
+    );
+    seen.delete(value);
+    return result;
   }
   if (Array.isArray(value)) {
     if (seen.has(value as unknown as object)) return "[Circular]";


### PR DESCRIPTION
## Summary
- convert `bigint` and `symbol` runtime values to JSON-safe strings
- detect circular `Map` and `Set` values during DevTools serialization
- preserve shared non-cyclic references as serializable values
- add focused regression coverage for each unsupported value shape

## Why
DevTools serializes runtime state and log data before rendering it. A self-referencing `Map` or `Set` previously overflowed the stack, while `bigint` values reached `JSON.stringify` and threw. Either value could crash the DevTools panel.

The sanitizer now produces JSON-safe output for these values while retaining the existing path-scoped cycle behavior.

## Testing
- `vitest run` in `packages/react-devtools` (30 files, 108 tests)
- `aui-build` in `packages/react-devtools`
- focused oxlint and oxfmt checks
- direct post-build circular-`Map` and `bigint` serialization probe