### PR TITLE
feat(svelte): message parts builder

### DIFF
--- a/examples/with-sveltekit/src/lib/Message.svelte
+++ b/examples/with-sveltekit/src/lib/Message.svelte
@@ -21,6 +21,7 @@
     PencilIcon,
     RefreshCwIcon,
   } from "@lucide/svelte";
+  import ToolPart from "./ToolPart.svelte";
 
   let { message, item }: { message: MessageState; item: MessageItem } =
     $props();
@@ -117,16 +118,9 @@
             </p>
           </details>
         {:else if part.type === "tool-call"}
-          <div
-            class="border-border/60 my-1 rounded-lg border px-3 py-2 font-mono text-xs"
-          >
-            <span class="font-semibold">{part.toolName}</span>({part.argsText})
-            {#if part.result !== undefined}
-              <pre class="text-muted-foreground mt-1 whitespace-pre-wrap">{JSON.stringify(
-                  part.result,
-                )}</pre>
-            {/if}
-          </div>
+          <ToolPart item={parts.item(index)} />
+        {:else}
+          <p class="text-muted-foreground text-xs">[{part.type}]</p>
         {/if}
       {/each}
       {#if pulsing.current}<span class="animate-pulse">…</span>{/if}

--- a/examples/with-sveltekit/src/lib/Message.svelte
+++ b/examples/with-sveltekit/src/lib/Message.svelte
@@ -109,7 +109,11 @@
     >
       {#each parts.items as part, index}
         {#if part.type === "text"}
-          <p class="whitespace-pre-line">{part.text}</p>
+          <p class="whitespace-pre-line">
+            {part.text}{#if pulsing.current && index === parts.items.length - 1}<span
+                class="animate-pulse">…</span
+              >{/if}
+          </p>
         {:else if part.type === "reasoning"}
           <details class="text-muted-foreground my-1 text-sm">
             <summary class="cursor-pointer select-none">Reasoning</summary>
@@ -123,7 +127,9 @@
           <p class="text-muted-foreground text-xs">[{part.type}]</p>
         {/if}
       {/each}
-      {#if pulsing.current}<span class="animate-pulse">…</span>{/if}
+      {#if pulsing.current && parts.items.at(-1)?.type !== "text"}<span
+          class="animate-pulse">…</span
+        >{/if}
       {#if error.current}<span class="text-destructive text-sm"
         >{error.current}</span
       >{/if}

--- a/examples/with-sveltekit/src/lib/Message.svelte
+++ b/examples/with-sveltekit/src/lib/Message.svelte
@@ -9,6 +9,7 @@
     composerCancel,
     composerInput,
     composerSend,
+    messageParts,
     useAuiState,
     type MessageItem,
   } from "@assistant-ui/svelte";
@@ -24,18 +25,13 @@
   let { message, item }: { message: MessageState; item: MessageItem } =
     $props();
 
-  const text = $derived(
-    message.content
-      .map((part) => (part.type === "text" ? part.text : ""))
-      .join(""),
-  );
-
   // The item handle is index-bound and referentially stable for this
   // position's lifetime under unkeyed iteration, so a one-time capture is
   // correct.
   // svelte-ignore state_referenced_locally
   const target = { item };
 
+  const parts = messageParts(target);
   const isEditing = useAuiState((s) => s.composer.isEditing, target);
   const branchNumber = useAuiState((s) => s.message.branchNumber, target);
   const branchCount = useAuiState((s) => s.message.branchCount, target);
@@ -110,12 +106,33 @@
           : "text-foreground leading-relaxed",
       ].join(" ")}
     >
-      <p class="whitespace-pre-line">
-        {text}{#if pulsing.current}<span class="animate-pulse">…</span>{/if}
-        {#if error.current}<span class="text-destructive text-sm"
-          >{error.current}</span
-        >{/if}
-      </p>
+      {#each parts.items as part, index}
+        {#if part.type === "text"}
+          <p class="whitespace-pre-line">{part.text}</p>
+        {:else if part.type === "reasoning"}
+          <details class="text-muted-foreground my-1 text-sm">
+            <summary class="cursor-pointer select-none">Reasoning</summary>
+            <p class="whitespace-pre-line border-border/60 mt-1 border-l-2 pl-3">
+              {part.text}
+            </p>
+          </details>
+        {:else if part.type === "tool-call"}
+          <div
+            class="border-border/60 my-1 rounded-lg border px-3 py-2 font-mono text-xs"
+          >
+            <span class="font-semibold">{part.toolName}</span>({part.argsText})
+            {#if part.result !== undefined}
+              <pre class="text-muted-foreground mt-1 whitespace-pre-wrap">{JSON.stringify(
+                  part.result,
+                )}</pre>
+            {/if}
+          </div>
+        {/if}
+      {/each}
+      {#if pulsing.current}<span class="animate-pulse">…</span>{/if}
+      {#if error.current}<span class="text-destructive text-sm"
+        >{error.current}</span
+      >{/if}
     </div>
   {/if}
   <div

--- a/examples/with-sveltekit/src/lib/ToolPart.svelte
+++ b/examples/with-sveltekit/src/lib/ToolPart.svelte
@@ -9,31 +9,34 @@
   // svelte-ignore state_referenced_locally
   const target = { item };
 
-  const tool = useAuiState(
-    (s) =>
-      s.part.type === "tool-call"
-        ? {
-            name: s.part.toolName,
-            argsText: s.part.argsText,
-            result: s.part.result,
-            running: s.part.status.type === "running",
-          }
-        : null,
+  const name = useAuiState(
+    (s) => (s.part.type === "tool-call" ? s.part.toolName : null),
+    target,
+  );
+  const argsText = useAuiState(
+    (s) => (s.part.type === "tool-call" ? s.part.argsText : ""),
+    target,
+  );
+  const result = useAuiState(
+    (s) => (s.part.type === "tool-call" ? s.part.result : undefined),
+    target,
+  );
+  const running = useAuiState(
+    (s) => s.part.status.type === "running",
     target,
   );
 </script>
 
-{#if tool.current}
+{#if name.current !== null}
   <div
     class="border-border/60 my-1 rounded-lg border px-3 py-2 font-mono text-xs"
   >
-    <span class="font-semibold">{tool.current.name}</span>({tool.current
-      .argsText})
-    {#if tool.current.running}
+    <span class="font-semibold">{name.current}</span>({argsText.current})
+    {#if running.current}
       <span class="animate-pulse">…</span>
-    {:else if tool.current.result !== undefined}
+    {:else if result.current !== undefined}
       <pre class="text-muted-foreground mt-1 whitespace-pre-wrap">{JSON.stringify(
-          tool.current.result,
+          result.current,
         )}</pre>
     {/if}
   </div>

--- a/examples/with-sveltekit/src/lib/ToolPart.svelte
+++ b/examples/with-sveltekit/src/lib/ToolPart.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { useAuiState, type PartItem } from "@assistant-ui/svelte";
+
+  let { item }: { item: PartItem } = $props();
+
+  // The part handle is index-bound and referentially stable for this
+  // position's lifetime under unkeyed iteration, so a one-time capture is
+  // correct.
+  // svelte-ignore state_referenced_locally
+  const target = { item };
+
+  const tool = useAuiState(
+    (s) =>
+      s.part.type === "tool-call"
+        ? {
+            name: s.part.toolName,
+            argsText: s.part.argsText,
+            result: s.part.result,
+            running: s.part.status.type === "running",
+          }
+        : null,
+    target,
+  );
+</script>
+
+{#if tool.current}
+  <div
+    class="border-border/60 my-1 rounded-lg border px-3 py-2 font-mono text-xs"
+  >
+    <span class="font-semibold">{tool.current.name}</span>({tool.current
+      .argsText})
+    {#if tool.current.running}
+      <span class="animate-pulse">…</span>
+    {:else if tool.current.result !== undefined}
+      <pre class="text-muted-foreground mt-1 whitespace-pre-wrap">{JSON.stringify(
+          tool.current.result,
+        )}</pre>
+    {/if}
+  </div>
+{/if}

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -88,6 +88,8 @@ export const createEchoRuntime = () => {
     content: message.parts ?? [{ type: "text" as const, text: message.text }],
   });
   const onAddToolResult = vi.fn();
+  const onResumeToolCall = vi.fn();
+  const onRespondToToolApproval = vi.fn();
   const onReload = vi.fn(async (parentId: string | null) => {
     let parentIndex = 0;
     if (parentId) {
@@ -140,6 +142,8 @@ export const createEchoRuntime = () => {
     onCancel,
     onReload,
     onAddToolResult,
+    onResumeToolCall,
+    onRespondToToolApproval,
   });
   const core = new ExternalStoreRuntimeCore(makeAdapter() as never);
   const sync = () => core.setAdapter(makeAdapter() as never);
@@ -151,6 +155,8 @@ export const createEchoRuntime = () => {
     onCancel,
     onReload,
     onAddToolResult,
+    onResumeToolCall,
+    onRespondToToolApproval,
     onSwitchToThread,
     onSwitchToNewThread,
     setMessages: (next: EchoMessage[]) => {

--- a/packages/svelte/src/__tests__/clients.ts
+++ b/packages/svelte/src/__tests__/clients.ts
@@ -47,7 +47,12 @@ export const createTrackedThread = () => {
   return { TrackedThread: resource(useTracked), counters };
 };
 
-type EchoMessage = { id: string; role: "user" | "assistant"; text: string };
+type EchoMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  parts?: readonly Record<string, unknown>[];
+};
 
 export const createEchoRuntime = () => {
   let nextId = 0;
@@ -80,8 +85,9 @@ export const createEchoRuntime = () => {
   const convertMessage = (message: EchoMessage) => ({
     id: message.id,
     role: message.role,
-    content: [{ type: "text" as const, text: message.text }],
+    content: message.parts ?? [{ type: "text" as const, text: message.text }],
   });
+  const onAddToolResult = vi.fn();
   const onReload = vi.fn(async (parentId: string | null) => {
     let parentIndex = 0;
     if (parentId) {
@@ -133,6 +139,7 @@ export const createEchoRuntime = () => {
     onEdit,
     onCancel,
     onReload,
+    onAddToolResult,
   });
   const core = new ExternalStoreRuntimeCore(makeAdapter() as never);
   const sync = () => core.setAdapter(makeAdapter() as never);
@@ -143,6 +150,7 @@ export const createEchoRuntime = () => {
     onEdit,
     onCancel,
     onReload,
+    onAddToolResult,
     onSwitchToThread,
     onSwitchToNewThread,
     setMessages: (next: EchoMessage[]) => {

--- a/packages/svelte/src/__tests__/primitives-parts.test.ts
+++ b/packages/svelte/src/__tests__/primitives-parts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { tick } from "svelte";
 import { flushSync, mount, unmount } from "svelte";
 import { flushTapSync } from "@assistant-ui/tap";
@@ -42,6 +42,10 @@ const mountParts = (
 };
 
 describe("messageParts", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("exposes the status-bearing part states of the scoped message", () => {
     const { app, messages } = mountParts([
       {
@@ -199,7 +203,6 @@ describe("messageParts", () => {
     expect(report).toHaveBeenCalledWith(
       expect.stringContaining("messageParts.item: index 1"),
     );
-    report.mockRestore();
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/__tests__/primitives-parts.test.ts
+++ b/packages/svelte/src/__tests__/primitives-parts.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { flushSync, mount, unmount } from "svelte";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { provideAui } from "../provideAui";
+import { useAuiState } from "../useAuiState";
+import { messageParts } from "../primitives/messageParts";
+import { threadMessages } from "../primitives/threadMessages";
+import Host from "./fixtures/Host.svelte";
+import { createEchoRuntime, type AnyClient } from "./clients";
+
+const toolCall = (overrides?: Record<string, unknown>) => ({
+  type: "tool-call",
+  toolCallId: "call-1",
+  toolName: "get_weather",
+  args: { city: "Berlin" },
+  argsText: '{"city":"Berlin"}',
+  ...overrides,
+});
+
+const mountParts = (
+  seed: Parameters<ReturnType<typeof createEchoRuntime>["setMessages"]>[0],
+) => {
+  const echo = createEchoRuntime();
+  echo.setMessages(seed);
+  let aui!: AnyClient;
+  let messages!: ReturnType<typeof threadMessages>;
+  const app = mount(Host, {
+    target: document.createElement("div"),
+    props: {
+      setup: () => {
+        aui = provideAui(
+          AuiConfig({ threads: RuntimeAdapter(echo.runtime) }),
+        ) as AnyClient;
+        messages = threadMessages();
+      },
+    },
+  });
+  return { app, echo, aui, messages: () => messages };
+};
+
+describe("messageParts", () => {
+  it("exposes the status-bearing part states of the scoped message", () => {
+    const { app, messages } = mountParts([
+      {
+        id: "a0",
+        role: "assistant",
+        text: "",
+        parts: [
+          { type: "reasoning", text: "thinking it through" },
+          { type: "text", text: "The weather is sunny." },
+          toolCall(),
+        ],
+      },
+    ]);
+    const item = messages().item(0);
+    item.source.subscribe(() => {});
+    const parts = messageParts({ item });
+
+    expect(parts.items.map((part) => part.type)).toEqual([
+      "reasoning",
+      "text",
+      "tool-call",
+    ]);
+    expect(parts.items[1]).toMatchObject({ text: "The weather is sunny." });
+    expect(parts.items[2]).toMatchObject({ toolName: "get_weather" });
+    expect(parts.items[0]!.status).toBeDefined();
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("scopes s.part reads and updates through the item handle", () => {
+    const { app, echo, messages } = mountParts([
+      {
+        id: "a0",
+        role: "assistant",
+        text: "",
+        parts: [{ type: "text", text: "first" }],
+      },
+    ]);
+    const message = messages().item(0);
+    message.source.subscribe(() => {});
+    const parts = messageParts({ item: message });
+    const part = parts.item(0);
+    part.source.subscribe(() => {});
+    const text = useAuiState(
+      (s) => (s.part.type === "text" ? s.part.text : ""),
+      { item: part },
+    );
+
+    expect(text.current).toBe("first");
+
+    flushTapSync(() =>
+      echo.setMessages([
+        {
+          id: "a0",
+          role: "assistant",
+          text: "",
+          parts: [{ type: "text", text: "second" }],
+        },
+      ]),
+    );
+    expect(text.current).toBe("second");
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("routes addToolResult through the part scope", () => {
+    const { app, echo, messages } = mountParts([
+      {
+        id: "a0",
+        role: "assistant",
+        text: "",
+        parts: [toolCall()],
+      },
+    ]);
+    const message = messages().item(0);
+    message.source.subscribe(() => {});
+    const parts = messageParts({ item: message });
+    const tool = parts.item(0);
+    tool.source.subscribe(() => {});
+
+    flushTapSync(() => tool.aui.part.addToolResult({ temperature: 21 }));
+    expect(echo.onAddToolResult).toHaveBeenCalledTimes(1);
+    expect(echo.onAddToolResult.mock.calls[0]![0]).toMatchObject({
+      toolCallId: "call-1",
+    });
+
+    flushSync(() => void unmount(app));
+  });
+
+  it("keeps the last valid part while observed after a shrink", () => {
+    const { app, echo, messages } = mountParts([
+      {
+        id: "a0",
+        role: "assistant",
+        text: "",
+        parts: [
+          { type: "text", text: "one" },
+          { type: "text", text: "two" },
+        ],
+      },
+    ]);
+    const message = messages().item(0);
+    message.source.subscribe(() => {});
+    const parts = messageParts({ item: message });
+    const second = parts.item(1);
+    second.source.subscribe(() => {});
+    const text = useAuiState(
+      (s) => (s.part.type === "text" ? s.part.text : ""),
+      { item: second },
+    );
+    expect(text.current).toBe("two");
+
+    flushTapSync(() =>
+      echo.setMessages([
+        {
+          id: "a0",
+          role: "assistant",
+          text: "",
+          parts: [{ type: "text", text: "one" }],
+        },
+      ]),
+    );
+    expect(text.current).toBe("two");
+
+    flushSync(() => void unmount(app));
+  });
+});

--- a/packages/svelte/src/__tests__/primitives-parts.test.ts
+++ b/packages/svelte/src/__tests__/primitives-parts.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
 import { flushSync, mount, unmount } from "svelte";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
@@ -106,6 +107,33 @@ describe("messageParts", () => {
     flushSync(() => void unmount(app));
   });
 
+  it("routes resumeToolCall and respondToToolApproval through the part scope", () => {
+    const { app, echo, messages } = mountParts([
+      {
+        id: "a0",
+        role: "assistant",
+        text: "",
+        parts: [toolCall({ approval: { id: "appr-1" } })],
+      },
+    ]);
+    const message = messages().item(0);
+    message.source.subscribe(() => {});
+    const parts = messageParts({ item: message });
+    const tool = parts.item(0);
+    tool.source.subscribe(() => {});
+
+    flushTapSync(() => tool.aui.part.resumeToolCall({ answer: "yes" }));
+    expect(echo.onResumeToolCall).toHaveBeenCalledTimes(1);
+    expect(echo.onResumeToolCall.mock.calls[0]![0]).toMatchObject({
+      toolCallId: "call-1",
+    });
+
+    flushTapSync(() => tool.aui.part.respondToToolApproval({ approved: true }));
+    expect(echo.onRespondToToolApproval).toHaveBeenCalledTimes(1);
+
+    flushSync(() => void unmount(app));
+  });
+
   it("routes addToolResult through the part scope", () => {
     const { app, echo, messages } = mountParts([
       {
@@ -130,7 +158,7 @@ describe("messageParts", () => {
     flushSync(() => void unmount(app));
   });
 
-  it("keeps the last valid part while observed after a shrink", () => {
+  it("keeps the last valid part while observed after a shrink", async () => {
     const { app, echo, messages } = mountParts([
       {
         id: "a0",
@@ -153,6 +181,7 @@ describe("messageParts", () => {
     );
     expect(text.current).toBe("two");
 
+    const report = vi.spyOn(console, "error").mockImplementation(() => {});
     flushTapSync(() =>
       echo.setMessages([
         {
@@ -164,6 +193,13 @@ describe("messageParts", () => {
       ]),
     );
     expect(text.current).toBe("two");
+
+    // The expiry is tick-scheduled; a still-observed out-of-range item reports
+    await tick();
+    expect(report).toHaveBeenCalledWith(
+      expect.stringContaining("messageParts.item: index 1"),
+    );
+    report.mockRestore();
 
     flushSync(() => void unmount(app));
   });

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -23,6 +23,7 @@ export {
   threadViewport,
 } from "./primitives/threadViewport";
 export { threadMessages, type MessageItem } from "./primitives/threadMessages";
+export { messageParts, type PartItem } from "./primitives/messageParts";
 export { suggestionTrigger } from "./primitives/suggestions";
 export {
   threadList,

--- a/packages/svelte/src/primitives/messageParts.ts
+++ b/packages/svelte/src/primitives/messageParts.ts
@@ -1,17 +1,12 @@
-import { tick } from "svelte";
 import type { PartMethods, PartState } from "@assistant-ui/core/store";
 import {
-  AuiConfig,
-  createAssistantClient,
-  createClientFacade,
   createLastValidCache,
   createStaleReporter,
   Derived,
 } from "@assistant-ui/store/client";
 import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
 import { useAuiState } from "../useAuiState";
-
-const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+import { createObservedItem, scheduleExpiry } from "./observedItem";
 
 /**
  * A per-index handle over one message content part: through it, `useAuiState`
@@ -22,21 +17,19 @@ const scheduleExpiry = (callback: () => void) => void tick().then(callback);
  */
 export type PartItem = ScopeTarget;
 
-const createPartItem = (context: AuiContext, index: number): PartItem => {
-  let observers = 0;
-  const cache = createLastValidCache<PartMethods>(
-    createStaleReporter({
-      name: "messageParts.item",
-      index,
-      isCurrent: () => observers > 0,
-      isValid: () =>
-        index < context.source.getClient().message.getState().parts.length,
-    }),
-    scheduleExpiry,
-  );
-
-  const handle = createAssistantClient(
-    AuiConfig({
+const createPartItem = (context: AuiContext, index: number): PartItem =>
+  createObservedItem(context, (isObserved) => {
+    const cache = createLastValidCache<PartMethods>(
+      createStaleReporter({
+        name: "messageParts.item",
+        index,
+        isCurrent: isObserved,
+        isValid: () =>
+          index < context.source.getClient().message.getState().parts.length,
+      }),
+      scheduleExpiry,
+    );
+    return {
       part: Derived({
         source: "message",
         query: { type: "index", index },
@@ -45,29 +38,8 @@ const createPartItem = (context: AuiContext, index: number): PartItem => {
             aui.message.part({ index }),
           ),
       }),
-    }),
-    { parent: context.source },
-  );
-
-  const source = {
-    getClient: handle.getClient,
-    subscribe: (listener: () => void) => {
-      const release = handle.subscribe(listener);
-      observers++;
-      let subscribed = true;
-      return () => {
-        if (!subscribed) return;
-        subscribed = false;
-        observers--;
-        release();
-      };
-    },
-  };
-  return {
-    source,
-    aui: createClientFacade(source),
-  };
-};
+    };
+  });
 
 /**
  * Builder for a message's content parts. Call during component

--- a/packages/svelte/src/primitives/messageParts.ts
+++ b/packages/svelte/src/primitives/messageParts.ts
@@ -1,0 +1,99 @@
+import { tick } from "svelte";
+import type { PartMethods, PartState } from "@assistant-ui/core/store";
+import {
+  AuiConfig,
+  createAssistantClient,
+  createClientFacade,
+  createLastValidCache,
+  createStaleReporter,
+  Derived,
+} from "@assistant-ui/store/client";
+import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
+import { useAuiState } from "../useAuiState";
+
+const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+
+/**
+ * A per-index handle over one message content part: through it, `useAuiState`
+ * resolves `s.part` to the part at the index and the part methods
+ * (`addToolResult`, `resumeToolCall`, `respondToToolApproval`) address it,
+ * extending the surrounding message scope. The handle's scope mounts when the
+ * first reader is observed and suspends once none remain, like `MessageItem`.
+ */
+export type PartItem = ScopeTarget;
+
+const createPartItem = (context: AuiContext, index: number): PartItem => {
+  let observers = 0;
+  const cache = createLastValidCache<PartMethods>(
+    createStaleReporter({
+      name: "messageParts.item",
+      index,
+      isCurrent: () => observers > 0,
+      isValid: () =>
+        index < context.source.getClient().message.getState().parts.length,
+    }),
+    scheduleExpiry,
+  );
+
+  const handle = createAssistantClient(
+    AuiConfig({
+      part: Derived({
+        source: "message",
+        query: { type: "index", index },
+        get: (aui) =>
+          cache.resolve(index < aui.message.getState().parts.length, () =>
+            aui.message.part({ index }),
+          ),
+      }),
+    }),
+    { parent: context.source },
+  );
+
+  const source = {
+    getClient: handle.getClient,
+    subscribe: (listener: () => void) => {
+      const release = handle.subscribe(listener);
+      observers++;
+      let subscribed = true;
+      return () => {
+        if (!subscribed) return;
+        subscribed = false;
+        observers--;
+        release();
+      };
+    },
+  };
+  return {
+    source,
+    aui: createClientFacade(source),
+  };
+};
+
+/**
+ * Builder for a message's content parts. Call during component
+ * initialization inside a message scope (pass the row's `item`); iterate
+ * `items` by index and scope per-part work through `item(index)`. The item
+ * states carry the per-part status the raw `message.content` lacks. Items
+ * are cached per index for the builder's lifetime, suspending and resuming
+ * with observation like `threadMessages`. Iterate unkeyed: `item(index)` is
+ * bound to its position.
+ */
+export const messageParts = (options?: { item?: ScopeTarget | undefined }) => {
+  const context = options?.item ?? getAuiContext();
+  const items = useAuiState((s) => s.message.parts, { item: context });
+  const cache = new Map<number, PartItem>();
+
+  return {
+    get items(): readonly PartState[] {
+      return items.current;
+    },
+    item: (index: number): PartItem => {
+      let item = cache.get(index);
+      if (!item) {
+        item = createPartItem(context, index);
+        cache.set(index, item);
+      }
+      return item;
+    },
+  };
+};

--- a/packages/svelte/src/primitives/observedItem.ts
+++ b/packages/svelte/src/primitives/observedItem.ts
@@ -1,0 +1,49 @@
+import { tick } from "svelte";
+import {
+  AuiConfig,
+  createAssistantClient,
+  createClientFacade,
+} from "@assistant-ui/store/client";
+import type { AuiContext, ScopeTarget } from "../context";
+
+export const scheduleExpiry = (callback: () => void) =>
+  void tick().then(callback);
+
+/**
+ * Shared machinery for per-index item handles: hosts the built config as a
+ * child client of the context and rides observation alone — the scope mounts
+ * on the first subscriber, suspends once none remain, and resumes with state
+ * intact. There is no destroy pairing (unlike `provideAui`'s lifetime
+ * subscription). `build` receives an observation probe for stale reporters.
+ */
+export const createObservedItem = (
+  context: AuiContext,
+  build: (isObserved: () => boolean) => AuiConfig.Input,
+): ScopeTarget => {
+  let observers = 0;
+  const handle = createAssistantClient(AuiConfig(build(() => observers > 0)), {
+    parent: context.source,
+  });
+
+  const source = {
+    getClient: handle.getClient,
+    subscribe: (listener: () => void) => {
+      // Increment only after a successful subscribe: the first one commits the
+      // mount, which throws for a never-valid index and must not latch the
+      // observer count
+      const release = handle.subscribe(listener);
+      observers++;
+      let subscribed = true;
+      return () => {
+        if (!subscribed) return;
+        subscribed = false;
+        observers--;
+        release();
+      };
+    },
+  };
+  return {
+    source,
+    aui: createClientFacade(source),
+  };
+};

--- a/packages/svelte/src/primitives/threadList.ts
+++ b/packages/svelte/src/primitives/threadList.ts
@@ -1,20 +1,15 @@
-import { tick } from "svelte";
 import type {
   ThreadListItemMethods,
   ThreadsState,
 } from "@assistant-ui/core/store";
 import {
-  AuiConfig,
-  createAssistantClient,
-  createClientFacade,
   createLastValidCache,
   createStaleReporter,
   Derived,
 } from "@assistant-ui/store/client";
 import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
 import { useAuiState } from "../useAuiState";
-
-const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+import { createObservedItem, scheduleExpiry } from "./observedItem";
 
 /**
  * A per-index handle over one thread-list item: through it, `useAuiState` and
@@ -29,23 +24,21 @@ const createThreadListItem = (
   context: AuiContext,
   index: number,
   archived: boolean,
-): ThreadListItem => {
-  const idsOf = (state: ThreadsState) =>
-    archived ? state.archivedThreadIds : state.threadIds;
-  let observers = 0;
-  const cache = createLastValidCache<ThreadListItemMethods>(
-    createStaleReporter({
-      name: "threadList.item",
-      index,
-      isCurrent: () => observers > 0,
-      isValid: () =>
-        index < idsOf(context.source.getClient().threads.getState()).length,
-    }),
-    scheduleExpiry,
-  );
-
-  const handle = createAssistantClient(
-    AuiConfig({
+): ThreadListItem =>
+  createObservedItem(context, (isObserved) => {
+    const idsOf = (state: ThreadsState) =>
+      archived ? state.archivedThreadIds : state.threadIds;
+    const cache = createLastValidCache<ThreadListItemMethods>(
+      createStaleReporter({
+        name: "threadList.item",
+        index,
+        isCurrent: isObserved,
+        isValid: () =>
+          index < idsOf(context.source.getClient().threads.getState()).length,
+      }),
+      scheduleExpiry,
+    );
+    return {
       threadListItem: Derived({
         source: "threads",
         query: { type: "index", index, archived },
@@ -54,29 +47,8 @@ const createThreadListItem = (
             aui.threads.item({ index, archived }),
           ),
       }),
-    }),
-    { parent: context.source },
-  );
-
-  const source = {
-    getClient: handle.getClient,
-    subscribe: (listener: () => void) => {
-      const release = handle.subscribe(listener);
-      observers++;
-      let subscribed = true;
-      return () => {
-        if (!subscribed) return;
-        subscribed = false;
-        observers--;
-        release();
-      };
-    },
-  };
-  return {
-    source,
-    aui: createClientFacade(source),
-  };
-};
+    };
+  });
 
 /**
  * Builder for the thread list. Call during component initialization; iterate

--- a/packages/svelte/src/primitives/threadMessages.ts
+++ b/packages/svelte/src/primitives/threadMessages.ts
@@ -1,21 +1,16 @@
-import { tick } from "svelte";
 import type {
   ComposerMethods,
   MessageMethods,
   MessageState,
 } from "@assistant-ui/core/store";
 import {
-  AuiConfig,
-  createAssistantClient,
-  createClientFacade,
   createLastValidCache,
   createStaleReporter,
   Derived,
 } from "@assistant-ui/store/client";
 import { getAuiContext, type AuiContext, type ScopeTarget } from "../context";
 import { useAuiState } from "../useAuiState";
-
-const scheduleExpiry = (callback: () => void) => void tick().then(callback);
+import { createObservedItem, scheduleExpiry } from "./observedItem";
 
 /**
  * A per-index handle over one thread message: through it, `useAuiState` and
@@ -35,25 +30,23 @@ export type MessageItem = ScopeTarget;
 // with the row. Known limit: an out-transitioned row is paused, not
 // destroyed, so its observer outlives the expiry and a shrink may report;
 // revisited with the transitions-aware list chunk.
-const createMessageItem = (context: AuiContext, index: number): MessageItem => {
-  let observers = 0;
-  const messageCache = createLastValidCache<MessageMethods>(
-    createStaleReporter({
-      name: "threadMessages.item",
-      index,
-      isCurrent: () => observers > 0,
-      isValid: () =>
-        index < context.source.getClient().thread.getState().messages.length,
-    }),
-    scheduleExpiry,
-  );
-  const composerCache = createLastValidCache<ComposerMethods>(
-    null,
-    scheduleExpiry,
-  );
-
-  const handle = createAssistantClient(
-    AuiConfig({
+const createMessageItem = (context: AuiContext, index: number): MessageItem =>
+  createObservedItem(context, (isObserved) => {
+    const messageCache = createLastValidCache<MessageMethods>(
+      createStaleReporter({
+        name: "threadMessages.item",
+        index,
+        isCurrent: isObserved,
+        isValid: () =>
+          index < context.source.getClient().thread.getState().messages.length,
+      }),
+      scheduleExpiry,
+    );
+    const composerCache = createLastValidCache<ComposerMethods>(
+      null,
+      scheduleExpiry,
+    );
+    return {
       message: Derived({
         source: "thread",
         query: { type: "index", index },
@@ -72,35 +65,8 @@ const createMessageItem = (context: AuiContext, index: number): MessageItem => {
             () => aui.thread.message({ index }).composer(),
           ),
       }),
-    }),
-    { parent: context.source },
-  );
-
-  // No destroy pairing (unlike provideAui's lifetime subscription): the item
-  // deliberately rides observation alone, suspending when its readers release
-  // and resuming with state intact.
-  const source = {
-    getClient: handle.getClient,
-    subscribe: (listener: () => void) => {
-      // Increment only after a successful subscribe: the first one commits the
-      // mount, which throws for a never-valid index and must not latch the
-      // observer count
-      const release = handle.subscribe(listener);
-      observers++;
-      let subscribed = true;
-      return () => {
-        if (!subscribed) return;
-        subscribed = false;
-        observers--;
-        release();
-      };
-    },
-  };
-  return {
-    source,
-    aui: createClientFacade(source),
-  };
-};
+    };
+  });
 
 /**
  * Builder for the thread's message list. Call during component


### PR DESCRIPTION
## summary

- adds `messageParts({item})`, the per-part sibling of `threadMessages`: `items` exposes the scoped message's status-bearing `PartState` array (per-part streaming and tool status that raw `message.content` lacks), and `item(index)` returns a cached per-index handle whose `s.part` scope carries the HITL methods (`addToolResult`, `resumeToolCall`, `respondToToolApproval`)
- the handles ride observation exactly like `MessageItem`: mount on first subscriber, suspend with none, last-valid cache with a stale reporter on out-of-range reads
- the with-sveltekit example renders parts instead of joining text: text paragraphs, reasoning as a collapsed block, tool calls as a card with the tool name, arguments, and the JSON result when present; until now reasoning and tool parts from real models were silently invisible
- the test harness gains an optional `parts` field on echo messages and an `onAddToolResult` spy

## test plan

### already verified

- [x] `pnpm -C packages/svelte exec vitest run` -> 56/56 (4 new tests: status-bearing part states, scoped `s.part` reads updating through the handle, `addToolResult` routed with the part's `toolCallId`, shrink keeps the last valid part while observed)
- [x] `tsc --noEmit` clean, oxlint zero findings beyond the known builder naming noise, package and example builds green
- [x] Chrome against a local /responses-protocol mock extended with a `function_call` output item: the text streams token by token and the tool card renders with the tool name and result block, zero console errors

### reviewer should verify

- [ ] run the with-sveltekit example against a model that emits tool calls or reasoning and confirm the parts render instead of an empty bubble

## notes

- the part scope already supports `{type: "toolCallId"}` addressing at the client layer; id-keyed iteration is a separate follow-up

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8RqCv9oNAtyOo9dsP-OuK9czGY9as9sUoqA0zveeLwrCkMC3eWHBydHqNSM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->