### PR TITLE
chore: use maintainers team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CI and repository policy changes require maintainer review.
-/.github/CODEOWNERS @Yonom @okisdev @AVGVSTVS96
+/.github/CODEOWNERS @assistant-ui/maintainers
 /.github/actions/ @assistant-ui/maintainers
 /.github/workflows/ @assistant-ui/maintainers
 
 # Public API surface snapshots require maintainer review.
-/api-surface/ @Yonom @okisdev @AVGVSTVS96
+/api-surface/ @assistant-ui/maintainers


### PR DESCRIPTION
Replaces the individual maintainer list for /.github/CODEOWNERS and /api-surface/ with the @assistant-ui/maintainers team, matching the other CODEOWNERS entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JxWPBU74fhKxpc59tGUFZ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

