### PR TITLE
ci: autofix api-reference pages and drop private snapshot noise

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -38,4 +38,7 @@ jobs:
       - name: Update API surface snapshots
         run: pnpm api-surface
 
+      - name: Update API reference pages
+        run: pnpm -C apps/docs generate:api-reference
+
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -207,10 +207,15 @@ jobs:
       - name: Detect API reference inputs
         id: api_ref
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="origin/${{ github.base_ref }}"
           else
             BASE="HEAD^1"
+          fi
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "Unable to resolve API reference diff base: $BASE"
+            exit 1
           fi
           if git diff --name-only "$BASE" -- \
             "packages/react/" \
@@ -224,8 +229,10 @@ jobs:
             "packages/cloud-ai-sdk/" \
             "packages/eve/" \
             "apps/docs/scripts/" \
+            "apps/docs/content/types-to-generate/" \
             "apps/docs/content/docs/(reference)/api-reference/" \
             "apps/docs/package.json" \
+            "apps/docs/tsconfig.json" \
             ".github/workflows/code-quality.yaml" \
             | grep -q .; then
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -207,7 +207,7 @@ jobs:
       - name: Detect API reference inputs
         id: api_ref
         run: |
-          set -euo pipefail
+          set -eu
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="origin/${{ github.base_ref }}"
           else
@@ -217,11 +217,13 @@ jobs:
             echo "Unable to resolve API reference diff base: $BASE"
             exit 1
           fi
-          if git diff --name-only "$BASE" -- \
+          changed="$(git diff --name-only "$BASE" -- \
             "packages/react/" \
             "packages/core/" \
             "packages/store/" \
             "packages/tap/" \
+            "packages/cloud/" \
+            "packages/assistant-stream/" \
             "packages/react-generative-ui/" \
             "packages/ai-sdk/" \
             "packages/react-ai-sdk/" \
@@ -233,8 +235,8 @@ jobs:
             "apps/docs/content/docs/(reference)/api-reference/" \
             "apps/docs/package.json" \
             "apps/docs/tsconfig.json" \
-            ".github/workflows/code-quality.yaml" \
-            | grep -q .; then
+            ".github/workflows/code-quality.yaml")"
+          if [ -n "$changed" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -204,25 +204,61 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect API reference inputs
+        id: api_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD^1"
+          fi
+          if git diff --name-only "$BASE" -- \
+            "packages/react/" \
+            "packages/core/" \
+            "packages/store/" \
+            "packages/tap/" \
+            "packages/react-generative-ui/" \
+            "packages/ai-sdk/" \
+            "packages/react-ai-sdk/" \
+            "packages/react-data-stream/" \
+            "packages/cloud-ai-sdk/" \
+            "packages/eve/" \
+            "apps/docs/scripts/" \
+            "apps/docs/content/docs/(reference)/api-reference/" \
+            "apps/docs/package.json" \
+            ".github/workflows/code-quality.yaml" \
+            | grep -q .; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install pnpm
+        if: steps.api_ref.outputs.run == 'true'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6.0.10
 
       - name: Setup node.js
+        if: steps.api_ref.outputs.run == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
 
       - name: Install dependencies
+        if: steps.api_ref.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Generate API reference (strict)
+        if: steps.api_ref.outputs.run == 'true'
         run: pnpm -C apps/docs generate:api-reference -- --strict
 
       - name: Fail on API reference drift
+        if: steps.api_ref.outputs.run == 'true'
         run: |
           if git status --porcelain -- 'apps/docs/content/docs/(reference)/api-reference' | grep -q .; then
-            echo "API reference drift detected. Move durable prose into source JSDoc (or api-manual slots), then re-run pnpm -C apps/docs generate:api-reference."
+            echo "API reference pages are stale. JSDoc or export changes are not reflected in apps/docs/content/docs/(reference)/api-reference."
+            echo "Run \`pnpm -C apps/docs generate:api-reference\` and commit the result."
+            echo "Durable hand-written prose belongs in source JSDoc or api-manual slots."
             git status --porcelain -- 'apps/docs/content/docs/(reference)/api-reference'
             git diff -- 'apps/docs/content/docs/(reference)/api-reference'
             exit 1

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -28,7 +28,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -53,7 +52,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -74,14 +72,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -127,7 +123,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -176,7 +171,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -185,7 +179,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -314,8 +307,6 @@ type CloudMessage = {
 };
 
 declare class CloudMessagePersistence {
-  private idMapping;
-  private getCloud;
   constructor(cloud: AssistantCloud);
   constructor(getCloud: () => AssistantCloud);
   append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -28,6 +28,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -52,6 +53,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -72,11 +74,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -123,6 +127,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -171,6 +176,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -178,6 +184,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -307,6 +314,7 @@ type CloudMessage = {
 };
 
 declare class CloudMessagePersistence {
+  #private;
   constructor(cloud: AssistantCloud);
   constructor(getCloud: () => AssistantCloud);
   append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -13,6 +13,7 @@ import { Readable, ReadableOptions } from "stream";
 import { ConnectionOptions, TLSSocket } from "tls";
 
 declare abstract class AbstractConnector {
+  #private;
   firstError?: Error;
   protected connecting: boolean;
   protected stream: NetStream;
@@ -310,6 +311,7 @@ declare class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends 
   type: "default";
   mapping: ReplyMapping extends "resp3" ? "resp3" : "resp2";
 }> {
+  #private;
   options: ClusterOptions;
   slots: NodeKey[][];
   status: ClusterStatus;
@@ -391,6 +393,7 @@ type ClusterOptionsWithReplyMapping<Mapping extends ReplyMappingMode> = ClusterO
 type ClusterStatus = "close" | "connect" | "connecting" | "disconnecting" | "end" | "ready" | "reconnecting" | "wait";
 
 declare class Command implements Respondable {
+  #private;
   name: string;
   static FLAGS: {
     [key in keyof CommandNameFlags]: CommandNameFlags[key];
@@ -733,6 +736,7 @@ type GorpStreamChunk = {
 };
 
 declare class GorpStreamDeltaTracker {
+  #private;
   constructor(initialValue?: ReadonlyJSONValue);
   get state(): ReadonlyJSONValue;
   append(operations: readonly GorpStreamOperation[]): void;
@@ -1100,6 +1104,7 @@ declare class Redis<ReplyMapping extends ReplyMappingMode = "legacy"> extends Co
   type: "default";
   mapping: ReplyMapping extends "resp3" ? "resp3" : "resp2";
 }> implements DataHandledable {
+  #private;
   static Cluster: typeof Cluster;
   static Command: typeof Command;
   static createClient(...args: ConstructorParameters<typeof Redis>): Redis;
@@ -24283,6 +24288,7 @@ type SSEEvent = {
 };
 
 declare class SSEEventDecoder {
+  #private;
   constructor(options?: {
     trailing?: "dispatch" | "drop";
   });
@@ -24291,6 +24297,7 @@ declare class SSEEventDecoder {
 }
 
 declare class ScanStream extends Readable {
+  #private;
   constructor(opt: Options);
   _read(): void;
   close(): void;
@@ -24349,6 +24356,7 @@ type StandaloneConnectionOptions = Partial<TcpOptions & IpcOptions> & {
 };
 
 declare class SubscriptionSet {
+  #private;
   add(set: AddSet, channel: string): void;
   del(set: DelSet, channel: string): void;
   channels(set: AddSet | DelSet): string[];

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -16,7 +16,6 @@ declare abstract class AbstractConnector {
   firstError?: Error;
   protected connecting: boolean;
   protected stream: NetStream;
-  private disconnectTimeout;
   constructor(disconnectTimeout: number);
   check(info: any): boolean;
   disconnect(): void;
@@ -319,23 +318,6 @@ declare class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends 
   };
   _groupsBySlot: number[];
   isCluster: boolean;
-  private startupNodes;
-  private connectionPool;
-  private manuallyClosing;
-  private retryAttempts;
-  private delayQueue;
-  private offlineQueue;
-  private subscriber;
-  private shardedSubscribers;
-  private slotsTimer;
-  private reconnectTimeout;
-  private isRefreshing;
-  private _refreshSlotsCacheCallbacks;
-  private _autoPipelines;
-  private _runningAutoPipelines;
-  private _readyDelayedCallbacks;
-  private subscriberGroupEmitter;
-  private connectionEpoch;
   constructor(startupNodes: ClusterNode[], options?: ClusterOptionsWithReplyMapping<ReplyMapping>);
   connect(): Promise<void>;
   disconnect(reconnect?: boolean): void;
@@ -355,22 +337,6 @@ declare class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends 
   handleError(error: Error, ttl: {
     value?: any;
   }, handlers: any): void;
-  private resetOfflineQueue;
-  private clearNodesRefreshInterval;
-  private resetNodesRefreshInterval;
-  private setStatus;
-  private handleCloseEvent;
-  private flushQueue;
-  private executeOfflineCommands;
-  private natMapper;
-  private getInfoFromNode;
-  private invokeReadyDelayedCallbacks;
-  private readyCheck;
-  private resolveSrv;
-  private dnsLookup;
-  private resolveStartupNodeHostnames;
-  private createScanStream;
-  private createShardedSubscriberGroup;
 }
 
 interface Cluster<ReplyMapping extends "legacy" | "resp3" = "legacy"> extends EventEmitter {
@@ -429,12 +395,9 @@ declare class Command implements Respondable {
   static FLAGS: {
     [key in keyof CommandNameFlags]: CommandNameFlags[key];
   };
-  private static flagMap?;
-  private static _transformer;
   static checkFlag<T extends keyof CommandNameFlags>(flagName: T, commandName: string): commandName is CommandNameFlags[T][number];
   static setArgumentTransformer(name: string, func: ArgumentTransformer): void;
   static setReplyTransformer(name: string, func: ReplyTransformer): void;
-  private static getFlagMap;
   ignore?: boolean;
   isReadOnly?: boolean;
   args: CommandParameter[];
@@ -446,18 +409,6 @@ declare class Command implements Respondable {
   reject: (err: Error) => void;
   resolve: (result: any) => void;
   promise: Promise<any>;
-  private replyEncoding;
-  private protocol;
-  private replyMapping;
-  private errorStack;
-  private bufferMode;
-  private callback;
-  private transformed;
-  private _commandTimeoutTimer?;
-  private _blockingTimeoutTimer?;
-  private _blockingDeadline?;
-  private slot?;
-  private keys?;
   constructor(name: string, args?: Array<ArgumentType>, options?: CommandOptions, callback?: Callback);
   getSlot(): number;
   getKeys(): Array<string | Buffer>;
@@ -468,10 +419,6 @@ declare class Command implements Respondable {
   setTimeout(ms: number): void;
   setBlockingTimeout(ms: number): void;
   extractBlockingTimeout(): number | null | undefined;
-  private _clearTimers;
-  private initPromise;
-  private _iterateKeys;
-  private _convertValue;
 }
 
 interface CommandItem {
@@ -786,9 +733,6 @@ type GorpStreamChunk = {
 };
 
 declare class GorpStreamDeltaTracker {
-  private readonly accumulator;
-  private previousState;
-  private changes;
   constructor(initialValue?: ReadonlyJSONValue);
   get state(): ReadonlyJSONValue;
   append(operations: readonly GorpStreamOperation[]): void;
@@ -1158,7 +1102,6 @@ declare class Redis<ReplyMapping extends ReplyMappingMode = "legacy"> extends Co
 }> implements DataHandledable {
   static Cluster: typeof Cluster;
   static Command: typeof Command;
-  private static defaultOptions;
   static createClient(...args: ConstructorParameters<typeof Redis>): Redis;
   options: RedisOptions;
   status: RedisStatus;
@@ -1166,16 +1109,6 @@ declare class Redis<ReplyMapping extends ReplyMappingMode = "legacy"> extends Co
   isCluster: boolean;
   condition: Condition | null;
   commandQueue: Deque<CommandItem>;
-  private connector;
-  private reconnectTimeout;
-  private offlineQueue;
-  private connectionEpoch;
-  private retryAttempts;
-  private manuallyClosing;
-  private socketTimeoutTimer;
-  private [hasHimportCoordinator];
-  private _autoPipelines;
-  private _runningAutoPipelines;
   constructor(port: number, host: string, options: RedisOptions & {
     replyMapping?: ReplyMapping;
   });
@@ -1194,16 +1127,12 @@ declare class Redis<ReplyMapping extends ReplyMappingMode = "legacy"> extends Co
   constructor();
   get autoPipelineQueueSize(): number;
   connect(callback?: Callback<void>): Promise<void>;
-  private _connect;
   disconnect(reconnect?: boolean): void;
   end(): void;
   duplicate<Override extends Partial<RedisOptions> | undefined = undefined>(override?: Override): Redis<ReplyMappingFromOptions<ReplyMapping, Override>>;
   get mode(): "monitor" | "normal" | "subscriber";
   monitor(callback?: Callback<Redis>): Promise<Redis>;
   sendCommand(command: Command, stream?: WriteableStream): unknown;
-  private getBlockingTimeoutInMs;
-  private getConfiguredBlockingTimeout;
-  private setSocketTimeout;
   scanStream(options?: ScanStreamOptions): ScanStream;
   scanBufferStream(options?: ScanStreamOptions): ScanStream;
   sscanStream(key: string, options?: ScanStreamOptions): ScanStream;
@@ -1219,16 +1148,7 @@ declare class Redis<ReplyMapping extends ReplyMappingMode = "legacy"> extends Co
     address: string;
     port: number | undefined;
   };
-  private _buildCommandContext;
   _buildBatchContext(batchSize: number): BatchOperationContext;
-  private _getDescription;
-  private resetCommandQueue;
-  private resetOfflineQueue;
-  private parseOptions;
-  private setStatus;
-  private createScanStream;
-  private flushQueue;
-  private _readyCheck;
 }
 
 interface Redis<ReplyMapping extends "legacy" | "resp3" = "legacy"> extends EventEmitter {
@@ -24363,27 +24283,14 @@ type SSEEvent = {
 };
 
 declare class SSEEventDecoder {
-  private lineBuffer;
-  private dataLines;
-  private eventName;
-  private lastEventId;
-  private retry;
-  private pendingLF;
-  private readonly trailing;
   constructor(options?: {
     trailing?: "dispatch" | "drop";
   });
   push(text: string): SSEEvent[];
   flush(): SSEEvent | null;
-  private processLine;
-  private dispatchEvent;
-  private resetFrame;
 }
 
 declare class ScanStream extends Readable {
-  private opt;
-  private _redisCursor;
-  private _redisDrained;
   constructor(opt: Options);
   _read(): void;
   close(): void;
@@ -24442,7 +24349,6 @@ type StandaloneConnectionOptions = Partial<TcpOptions & IpcOptions> & {
 };
 
 declare class SubscriptionSet {
-  private set;
   add(set: AddSet, channel: string): void;
   del(set: DelSet, channel: string): void;
   channels(set: AddSet | DelSet): string[];

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -29,7 +29,6 @@ type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<Ch
 };
 
 declare class AISDKToolkit {
-  #private;
   constructor(options: AISDKToolkitOptions);
   tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
   close(): Promise<void>;
@@ -70,10 +69,6 @@ type AssistantChatResumableOptions = {
 };
 
 declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
-  private runtime;
-  private getThreadListItem;
-  private readonly resumable;
-  private readonly __internal_initOptions;
   __internal_clone(): AssistantChatTransport<UI_MESSAGE>;
   constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
   setRuntime(runtime: AssistantRuntime): void;
@@ -113,7 +108,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -138,7 +132,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -159,14 +152,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -212,7 +203,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -261,7 +251,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -270,7 +259,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -29,6 +29,7 @@ type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<Ch
 };
 
 declare class AISDKToolkit {
+  #private;
   constructor(options: AISDKToolkitOptions);
   tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
   close(): Promise<void>;
@@ -69,6 +70,7 @@ type AssistantChatResumableOptions = {
 };
 
 declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
+  #private;
   __internal_clone(): AssistantChatTransport<UI_MESSAGE>;
   constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
   setRuntime(runtime: AssistantRuntime): void;
@@ -108,6 +110,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -132,6 +135,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -152,11 +156,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -203,6 +209,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -251,6 +258,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -258,6 +266,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -32,6 +32,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -56,6 +57,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -76,11 +78,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -127,6 +131,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -175,6 +180,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -182,6 +188,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -32,7 +32,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -57,7 +56,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -78,14 +76,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -131,7 +127,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -180,7 +175,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -189,7 +183,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread$1>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -111,7 +111,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -136,7 +135,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -157,14 +155,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -210,7 +206,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -259,7 +254,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -268,7 +262,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -344,37 +337,14 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
 };
 
 declare class AssistantFrameHost implements ModelContextProvider {
-  private _context;
-  private _subscribers;
-  private _pendingRequests;
-  private _requestCounter;
-  private _iframeWindow;
-  private _targetOrigin;
-  private _disposed;
   constructor(iframeWindow: Window, targetOrigin?: string);
-  private handleMessage;
-  private updateContext;
-  private callTool;
-  private sendRequest;
-  private requestContext;
-  private notifySubscribers;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   dispose(): void;
 }
 
 declare class AssistantFrameProvider {
-  private static _instance;
-  private _providers;
-  private _providerUnsubscribes;
-  private _targetOrigin;
   private constructor();
-  private static getInstance;
-  private handleMessage;
-  private handleToolCall;
-  private sendMessage;
-  private getModelContext;
-  private broadcastUpdate;
   static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
   static dispose(): void;
 }
@@ -416,7 +386,6 @@ type AssistantRuntimeCore = {
 declare class AssistantRuntimeImpl implements AssistantRuntime {
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
-  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -609,7 +578,6 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
     attachmentSource: Source;
   };
   abstract get source(): Source;
-  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -714,33 +682,20 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     };
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
-  private _attachments;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;
   abstract get canSend(): boolean;
   get isEmpty(): boolean;
-  private _text;
   get text(): string;
-  private _role;
   get role(): "assistant" | "system" | "user";
-  private _runConfig;
   get runConfig(): RunConfig;
-  private _quote;
   get quote(): QuoteInfo | undefined;
   setQuote(quote: QuoteInfo | undefined): void;
   setText(value: string): void;
-  private _rebaseDictation;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
-  private _removedDuringSend;
-  private _sendGeneration;
-  private _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
   reset(): Promise<void>;
   clearAttachments(): Promise<void>;
   send(options?: SendOptions): Promise<void>;
@@ -754,7 +709,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): void;
-  private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];
   moveQueueItem(_queueItemId: string, _placement: QueuePlacement): void;
@@ -762,22 +716,10 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
   removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
   get dictation(): DictationState | undefined;
-  private _isActiveSession;
   startDictation(): void;
   stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
   protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
 }
@@ -798,17 +740,13 @@ type BaseComposerState = {
 };
 
 declare abstract class BaseSubject {
-  private _subscriptions;
-  private _connection;
   protected get isConnected(): boolean;
   protected abstract _connect(): Unsubscribe$1;
   protected notifySubscribers(payload?: unknown, errorContext?: string): void;
-  private _updateConnection;
   subscribe(callback: (payload?: unknown) => void): () => void;
 }
 
 declare class BaseSubscribable {
-  private _subscribers;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -839,8 +777,6 @@ type BaseThreadMessage = {
 };
 
 declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
-  private _subscriptions;
-  private _isInitialized;
   protected readonly repository: MessageRepository;
   abstract get adapters(): BaseThreadAdapters | undefined;
   abstract get isDisabled(): boolean;
@@ -862,19 +798,14 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   abstract unstable_notifySessionReset(): void;
   protected _voiceMessages: ThreadMessage[];
   protected _voiceGeneration: number;
-  private _cachedMergedMessages;
-  private _cachedVoiceGeneration;
-  private _cachedMergedBase;
   protected _markVoiceMessagesDirty(): void;
   protected _getBaseMessages(): readonly ThreadMessage[];
   get messages(): readonly ThreadMessage[];
   get state(): string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | null;
   readonly composer: DefaultThreadComposerRuntimeCore;
-  private readonly _contextProvider;
   constructor(_contextProvider: ModelContextProvider);
   getModelContext(): ModelContext$1;
   protected enrichAppendMetadata(message: AppendMessage, anchorId?: string | null): AppendMessage;
-  private _editComposers;
   getEditComposer(messageId: string): DefaultEditComposerRuntimeCore | undefined;
   beginEdit(messageId: string): void;
   getMessageById(messageId: string): {
@@ -888,21 +819,13 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   _notifyEventSubscribers<E extends ThreadRuntimeEventType>(event: E, payload: ThreadRuntimeEventPayload[E]): void;
   subscribe(callback: () => void): Unsubscribe$1;
   submitFeedback(_param1: SubmitFeedbackOptions): void;
-  private _stopSpeaking;
   speech: SpeechState | undefined;
   speak(messageId: string): void;
   stopSpeaking(): void;
-  private _voiceSession;
-  private _voiceUnsubs;
   voice: VoiceSessionState | undefined;
-  private _voiceVolume;
-  private _voiceVolumeSubscribers;
   getVoiceVolume: () => number;
   subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
   connectVoice(): void;
-  private _currentAssistantMsg;
-  private _handleVoiceTranscript;
-  private _finishVoiceAssistantMessage;
   disconnectVoice(): void;
   muteVoice(): void;
   unmuteVoice(): void;
@@ -910,7 +833,6 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   export(): ExportedMessageRepository;
   import(data: ExportedMessageRepository): void;
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  private _eventSubscribers;
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
@@ -1065,9 +987,7 @@ type ClientScopes = {
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
   accept: string;
-  private cloud;
   constructor(cloud: AssistantCloud);
-  private uploadedUrls;
   add(_param2: {
     file: File;
   }): AsyncGenerator<PendingAttachment, void>;
@@ -1118,7 +1038,6 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1334,7 +1253,6 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   stopDictation(): void;
   setQuote(quote: QuoteInfo | undefined): void;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
@@ -1368,7 +1286,6 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1379,10 +1296,8 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
   notifySubscribers(): void;
   subscribe(callback: () => void): () => void;
 }
@@ -1477,11 +1392,6 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   get canSend(): boolean;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private _nonTextPassthrough;
-  private _parentId;
-  private _sourceId;
-  private runtime;
-  private endEditCallback;
   constructor(runtime: ThreadRuntimeCore & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1498,16 +1408,13 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 }
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
-  private _queueCache;
   get queue(): readonly QueueItemState[];
   moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1591,8 +1498,6 @@ declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements Edi
     composerSource: "edit";
   };
   get type(): "edit";
-  private _getState;
-  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -1643,7 +1548,6 @@ type EventSubscribable<TEvent extends string> = {
 };
 
 declare class EventSubscriptionSubject<TEvent extends string> extends BaseSubject {
-  private config;
   constructor(config: EventSubscribable<TEvent>);
   getState(): {
     unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
@@ -1769,20 +1673,13 @@ type ExternalStoreThreadListAdapter = {
 };
 
 declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
-  private _mainThreadId;
-  private _threads;
-  private _archivedThreads;
-  private _threadData;
-  private adapter;
   get isLoading(): boolean;
   get newThreadId(): undefined;
   get threadIds(): readonly string[];
   get archivedThreadIds(): readonly string[];
   get threadItems(): Readonly<Record<string, ThreadListItemCoreState>>;
   getLoadThreadsPromise(): Promise<void>;
-  private _mainThread;
   get mainThreadId(): string;
-  private threadFactory;
   constructor(adapter: ExternalStoreThreadListAdapter | undefined, threadFactory: ExternalStoreThreadFactory);
   getMainThreadRuntimeCore(): ExternalStoreThreadRuntimeCore;
   getThreadRuntimeCore(): never;
@@ -1804,15 +1701,11 @@ declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCor
     externalId: string | undefined;
   }>;
   generateTitle(): never;
-  private _subscriptions;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _notifySubscribers;
 }
 
 declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
-  private _capabilities;
   get capabilities(): RuntimeCapabilities;
-  private _messages;
   isDisabled: boolean;
   isSendDisabled: boolean;
   get isLoading(): boolean;
@@ -1830,21 +1723,11 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   get unstable_refetchThread(): (() => Promise<void>) | undefined;
   suggestions: readonly ThreadSuggestion[];
   extras: unknown;
-  private _converter;
-  private _store;
-  private _getInitializePromise?;
   __internal_setGetInitializePromise(getPromise: () => Promise<unknown> | undefined): void;
-  private _transformedQueue;
-  private _toolInvocations;
   beginEdit(messageId: string): void;
   constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);
   __internal_setAdapter(store: ExternalStoreAdapter<any>): void;
-  private _driveToolInvocations;
-  private _toolCallToMessageId;
-  private _messagesForToolCallIndex;
-  private _findMessageIdForToolCall;
   switchToBranch(branchId: string): void;
-  private _notifyBranchChange;
   append(rawMessage: AppendMessage): Promise<void>;
   deleteMessage(messageId: string): Promise<void>;
   getQueueItems(): readonly QueueItemState[];
@@ -1857,13 +1740,11 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   importExternalState(state: any): void;
   unstable_notifySessionReset(): void;
   cancelRun(): void;
-  private dropEmptyOptimisticHead;
   addToolResult(options: AddToolResultOptions): void;
   resumeToolCall(options: ResumeToolCallOptions): void;
   respondToToolApproval(options: RespondToToolApprovalOptions): void;
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
   import(data: ExportedMessageRepository): void;
-  private updateMessages;
 }
 
 declare const ExternalThread: Resource<ClientOutput<"thread">, [
@@ -2245,10 +2126,7 @@ type LanguageModelV1CallSettings = {
 
 declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
   get path(): TPath;
-  private binding;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
-  private _previousStateDirty;
-  private _previousState;
   getState: () => TState;
   protected _connect(): Unsubscribe$1;
 }
@@ -2256,7 +2134,6 @@ declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubje
 declare class LocalRuntimeCore extends BaseAssistantRuntimeCore {
   readonly threads: LocalThreadListRuntimeCore;
   readonly Provider: undefined;
-  private _options;
   constructor(options: LocalRuntimeOptionsBase, initialMessages: readonly ThreadMessageLike[] | undefined);
 }
 
@@ -2293,7 +2170,6 @@ type LocalStorageAdapterOptions = {
 type LocalThreadFactory = () => LocalThreadRuntimeCore;
 
 declare class LocalThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
-  private _mainThread;
   constructor(_threadFactory: LocalThreadFactory);
   get isLoading(): boolean;
   getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
@@ -2351,20 +2227,9 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
     feedback: boolean;
     queue: boolean;
   };
-  private abortController;
-  private _queue;
-  private _queueRunInFlight;
-  private _activeRun;
-  private _runGeneration;
-  private _historyWrites;
-  private _chainHistoryWrite;
-  private _persistPausedMessage;
   readonly isDisabled = false;
   readonly isSendDisabled = false;
-  private _isLoading;
   get isLoading(): boolean;
-  private _suggestions;
-  private _suggestionsController;
   get suggestions(): readonly ThreadSuggestion[];
   get adapters(): {
     chatModel: ChatModelAdapter;
@@ -2377,30 +2242,22 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
     suggestion?: SuggestionAdapter | undefined;
   };
   constructor(contextProvider: ModelContextProvider, options: LocalRuntimeOptionsBase);
-  private _options;
-  private _lastRunConfig;
-  private _getThreadId?;
   __internal_setGetThreadId(getThreadId: () => string | undefined): void;
-  private _getInitializePromise?;
   __internal_setGetInitializePromise(getPromise: () => Promise<unknown> | undefined): void;
   get extras(): undefined;
   __internal_setOptions(options: LocalRuntimeOptionsBase): void;
-  private _loadPromise;
   __internal_load(): Promise<void>;
   append(message: AppendMessage): Promise<void>;
   getQueueItems(): readonly QueueItemState[];
   getSteerQueueItems(): readonly QueueItemState[];
   moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
   removeQueueItem(queueItemId: string): void;
-  private _runAppend;
   deleteMessage(messageId: string): Promise<void>;
   resumeRun(_param4: ResumeRunConfig): Promise<void>;
   exportExternalState(): any;
   importExternalState(): void;
   unstable_notifySessionReset(): void;
   startRun(_param5: StartRunConfig, runCallback?: ChatModelAdapter["run"]): Promise<void>;
-  private _runLoop;
-  private performRoundtrip;
   detach(): void;
   cancelRun(): void;
   addToolResult(_param6: AddToolResultOptions): void;
@@ -2607,9 +2464,6 @@ type MessagePartRuntime = {
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
   get path(): MessagePartRuntimePath;
-  private contentBinding;
-  private messageApi;
-  private threadApi;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
@@ -2817,12 +2671,6 @@ type MessageQuoteState = {
 };
 
 declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2834,7 +2682,6 @@ declare class MessageRepository {
   };
   deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
   getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
   switchToBranch(messageId: string): void;
   resetHead(messageId: string | null): void;
   clear(): void;
@@ -2870,12 +2717,9 @@ type MessageRuntime = {
 
 declare class MessageRuntimeImpl implements MessageRuntime {
   get path(): MessageRuntimePath;
-  private _core;
-  private _threadBinding;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
   getState(): ThreadMessage & {
     readonly parentId: string | null;
     readonly index: number;
@@ -3021,14 +2865,8 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
   addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
   addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
@@ -3057,7 +2895,6 @@ type NestedSubscribable<TState extends Subscribable | undefined, TPath> = Subscr
 
 declare class NestedSubscriptionSubject<TState extends Subscribable | undefined, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath>, NestedSubscribable<TState, TPath> {
   get path(): TPath;
-  private binding;
   constructor(binding: NestedSubscribable<TState, TPath>);
   getState(): TState;
   outerSubscribe(callback: () => void): Unsubscribe$1;
@@ -3075,13 +2912,7 @@ type ObjectKey<T> = keyof T & (string | number);
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 declare class OptimisticState<TState> extends BaseSubscribable {
-  private readonly _pendingTransforms;
-  private readonly _completedOptimistics;
-  private _nextTransformOrder;
-  private _baseValue;
-  private _cachedValue;
   constructor(initialState: TState);
-  private _updateState;
   get baseValue(): TState;
   get value(): TState;
   update(state: TState): void;
@@ -3315,7 +3146,6 @@ declare namespace ReadonlyThreadProvider {
 declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
 
 declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
-  private _messages;
   get messages(): readonly ThreadMessage[];
   setMessages(messages: readonly ThreadMessage[]): void;
   getMessageById(messageId: string): {
@@ -3517,13 +3347,7 @@ type RemoteThreadListAdapter = {
 type RemoteThreadListHook = () => AssistantRuntime;
 
 declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
-  private useRuntimeHook;
-  private instances;
-  private nextGeneration;
-  private useAliveThreadsKeysChanged;
-  private parent;
   constructor(runtimeHook: RemoteThreadListHook, parent: ThreadListRuntimeCore);
-  private _whenRuntimeAttached;
   startThreadRuntime(threadId: string): Promise<Readonly<{
     getMessageById: (messageId: string) => {
       parentId: string | null;
@@ -3687,15 +3511,9 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
   }> | undefined;
   __internal_isThreadRunning(threadId: string): boolean;
-  private runningSubscribers;
   __internal_subscribeRunningChanged(callback: () => void): Unsubscribe$1;
-  private _publishThreadRuntime;
-  private _trackRunning;
-  private _setRunning;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
-  private _RuntimeBinder;
-  private _OuterActiveThreadProvider;
   __internal_RenderThreadRuntimes: FC<{
     provider: ComponentType<PropsWithChildren>;
   }>;
@@ -3726,22 +3544,10 @@ type RemoteThreadListResponse = {
 };
 
 declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
-  private _options;
-  private readonly _hookManager;
-  private _loadThreadsPromise;
-  private _loadMorePromise;
-  private _loadGeneration;
-  private _switchGeneration;
-  private _switchTask;
-  private _mainThreadId;
-  private readonly _state;
   get threadItems(): Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
   getLoadThreadsPromise(): Promise<void>;
   loadMore(): Promise<void>;
-  private readonly contextProvider;
   constructor(options: RemoteThreadListOptions, contextProvider: ModelContextProvider);
-  private _initialThreadLoaded;
-  private useProvider;
   __internal_setOptions(options: RemoteThreadListOptions): void;
   __internal_load(): void;
   reloadMainThread(): Promise<void>;
@@ -3753,9 +3559,6 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   get archivedThreadIds(): readonly string[];
   get newThreadId(): string | undefined;
   get mainThreadId(): string;
-  private get _mainThreadRemoteId();
-  private _lastNotifiedThreadId;
-  private _notifyThreadIdChange;
   getMainThreadRuntimeCore(): Readonly<{
     getMessageById: (messageId: string) => {
       parentId: string | null;
@@ -3869,12 +3672,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   switchToThread(threadIdOrRemoteId: string, options?: {
     unarchive?: boolean;
   }): Promise<void>;
-  private _startSwitchToThread;
-  private _switchToThread;
   switchToNewThread(): Promise<void>;
-  private _switchToThreadFromProp;
-  private _startSwitchToNewThread;
-  private _switchToNewThread;
   initialize: (threadId: string) => Promise<{
     remoteId: string;
     externalId: string | undefined;
@@ -3882,12 +3680,10 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   generateTitle: (threadId: string) => Promise<void>;
   rename(threadIdOrRemoteId: string, newTitle: string): Promise<void>;
   updateCustom(threadIdOrRemoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  private _ensureThreadIsNotMain;
   archive(threadIdOrRemoteId: string): Promise<void>;
   unarchive(threadIdOrRemoteId: string): Promise<void>;
   delete(threadIdOrRemoteId: string): Promise<void>;
   detach(threadIdOrRemoteId: string): Promise<void>;
-  private useBoundIds;
   __internal_RenderComponent: FC;
 }
 
@@ -4060,11 +3856,8 @@ type SerializedTool = {
 
 declare class ShallowMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
   get path(): TPath;
-  private binding;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
-  private _previousState;
   getState: () => TState;
-  private _syncState;
   protected _connect(): Unsubscribe$1;
 }
 
@@ -4386,7 +4179,6 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
     composerSource: "thread";
   };
   get type(): "thread";
-  private _getState;
   constructor(core: ThreadComposerRuntimeCoreBinding);
   getState(): ThreadComposerState;
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
@@ -4548,8 +4340,6 @@ type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1,
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
   get path(): ThreadListItemRuntimePath;
-  private _core;
-  private _threadListBinding;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -4706,10 +4496,6 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _getState;
-  private _stateBinding;
-  private _core;
-  private _runtimeFactory;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -4722,7 +4508,6 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
   readonly main: ThreadRuntime;
   get mainItem(): ThreadListItemRuntimeImpl;
   getById(threadId: string): ThreadRuntime;
@@ -4757,7 +4542,6 @@ type ThreadMessageClientProps = {
 };
 
 declare class ThreadMessageConverter {
-  private readonly cache;
   convertMessages<TIn extends WeakKey>(messages: readonly TIn[], converter: ConverterCallback<TIn>): ThreadMessage[];
 }
 
@@ -5097,8 +4881,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   } & {
     getStateState(): ThreadState;
   };
-  private readonly _threadBinding;
-  private readonly _stateBinding;
   constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
   protected __internal_bindMethods(): void;
   readonly composer: ThreadComposerRuntimeImpl;
@@ -5125,8 +4907,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
   getMessageByIndex(idx: number): MessageRuntimeImpl;
   getMessageById(messageId: string): MessageRuntimeImpl;
-  private _getMessageRuntime;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
@@ -5420,43 +5200,12 @@ type ToolExecutionStatus = {
 };
 
 declare class ToolInvocationTracker {
-  private readonly _getTools;
-  private readonly _callbacks;
-  private readonly _entries;
-  private readonly _humanInput;
-  private readonly _executing;
-  private readonly _settledResolvers;
-  private _statuses;
-  private _ac;
-  private _pendingRestore;
-  private _lastSnapshot;
-  private _isRunning;
-  private _controller;
-  private _pipelineDead;
-  private _pipelineRestartUsed;
   constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTracker.Callbacks);
-  private _initPipeline;
   setState(snapshot: ToolInvocationTracker.Snapshot): void;
   reset(): void;
   abort(): Promise<void>;
   resume(toolCallId: string, payload: unknown): boolean;
   getStatuses(): ReadonlyMap<string, ToolExecutionStatus>;
-  private _getWrappedTools;
-  private _captureExecution;
-  private _onHumanInput;
-  private _onExecutionStart;
-  private _onExecutionEnd;
-  private _handleResultChunk;
-  private _invokeOnResult;
-  private _invokeOnStatusesChange;
-  private _setStatus;
-  private _deleteStatus;
-  private _hasExecutableTool;
-  private _shouldCloseArgsStream;
-  private _startActiveEntry;
-  private _demoteEntriesToRestored;
-  private _processArgsText;
-  private _processMessages;
 }
 
 declare namespace ToolInvocationTracker {
@@ -5810,9 +5559,6 @@ type VoiceSessionState = {
 };
 
 declare class WebSpeechDictationAdapter implements DictationAdapter {
-  private _language;
-  private _continuous;
-  private _interimResults;
   constructor(options?: {
     language?: string;
     continuous?: boolean;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -111,6 +111,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -135,6 +136,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -155,11 +157,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -206,6 +210,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -254,6 +259,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -261,6 +267,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -337,6 +344,7 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
 };
 
 declare class AssistantFrameHost implements ModelContextProvider {
+  #private;
   constructor(iframeWindow: Window, targetOrigin?: string);
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
@@ -344,6 +352,7 @@ declare class AssistantFrameHost implements ModelContextProvider {
 }
 
 declare class AssistantFrameProvider {
+  #private;
   private constructor();
   static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
   static dispose(): void;
@@ -384,6 +393,7 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
+  #private;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
   constructor(_core: AssistantRuntimeCore);
@@ -574,6 +584,7 @@ declare const AttachmentRuntimeClient: Resource<ClientOutput<"attachment">, [
 ]>;
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  #private;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
@@ -673,6 +684,7 @@ type BaseAttachment = {
 };
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  #private;
   readonly isEditing = true;
   protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected abstract getDictationAdapter(): DictationAdapter | undefined;
@@ -740,6 +752,7 @@ type BaseComposerState = {
 };
 
 declare abstract class BaseSubject {
+  #private;
   protected get isConnected(): boolean;
   protected abstract _connect(): Unsubscribe$1;
   protected notifySubscribers(payload?: unknown, errorContext?: string): void;
@@ -747,6 +760,7 @@ declare abstract class BaseSubject {
 }
 
 declare class BaseSubscribable {
+  #private;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -777,6 +791,7 @@ type BaseThreadMessage = {
 };
 
 declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
+  #private;
   protected readonly repository: MessageRepository;
   abstract get adapters(): BaseThreadAdapters | undefined;
   abstract get isDisabled(): boolean;
@@ -986,6 +1001,7 @@ type ClientScopes = {
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(cloud: AssistantCloud);
   add(_param2: {
@@ -1038,6 +1054,7 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  #private;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1232,6 +1249,7 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
   protected _core: ComposerRuntimeCoreBinding;
@@ -1286,6 +1304,7 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1296,6 +1315,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
   notifySubscribers(): void;
@@ -1388,6 +1408,7 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
+  #private;
   get canCancel(): boolean;
   get canSend(): boolean;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
@@ -1408,6 +1429,7 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 }
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  #private;
   get canCancel(): boolean;
   get canSend(): boolean;
   get queue(): readonly QueueItemState[];
@@ -1494,6 +1516,7 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1548,6 +1571,7 @@ type EventSubscribable<TEvent extends string> = {
 };
 
 declare class EventSubscriptionSubject<TEvent extends string> extends BaseSubject {
+  #private;
   constructor(config: EventSubscribable<TEvent>);
   getState(): {
     unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
@@ -1673,6 +1697,7 @@ type ExternalStoreThreadListAdapter = {
 };
 
 declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
+  #private;
   get isLoading(): boolean;
   get newThreadId(): undefined;
   get threadIds(): readonly string[];
@@ -1705,6 +1730,7 @@ declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCor
 }
 
 declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
+  #private;
   get capabilities(): RuntimeCapabilities;
   isDisabled: boolean;
   isSendDisabled: boolean;
@@ -2125,6 +2151,7 @@ type LanguageModelV1CallSettings = {
 };
 
 declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
+  #private;
   get path(): TPath;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
   getState: () => TState;
@@ -2132,6 +2159,7 @@ declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubje
 }
 
 declare class LocalRuntimeCore extends BaseAssistantRuntimeCore {
+  #private;
   readonly threads: LocalThreadListRuntimeCore;
   readonly Provider: undefined;
   constructor(options: LocalRuntimeOptionsBase, initialMessages: readonly ThreadMessageLike[] | undefined);
@@ -2170,6 +2198,7 @@ type LocalStorageAdapterOptions = {
 type LocalThreadFactory = () => LocalThreadRuntimeCore;
 
 declare class LocalThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
+  #private;
   constructor(_threadFactory: LocalThreadFactory);
   get isLoading(): boolean;
   getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
@@ -2211,6 +2240,7 @@ declare class LocalThreadListRuntimeCore extends BaseSubscribable implements Thr
 }
 
 declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
+  #private;
   readonly capabilities: {
     switchToBranch: boolean;
     switchBranchDuringRun: boolean;
@@ -2463,6 +2493,7 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  #private;
   get path(): MessagePartRuntimePath;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2671,6 +2702,7 @@ type MessageQuoteState = {
 };
 
 declare class MessageRepository {
+  #private;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2716,6 +2748,7 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  #private;
   get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2865,6 +2898,7 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
@@ -2894,6 +2928,7 @@ type ModelContextState = {
 type NestedSubscribable<TState extends Subscribable | undefined, TPath> = SubscribableWithState<TState, TPath>;
 
 declare class NestedSubscriptionSubject<TState extends Subscribable | undefined, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath>, NestedSubscribable<TState, TPath> {
+  #private;
   get path(): TPath;
   constructor(binding: NestedSubscribable<TState, TPath>);
   getState(): TState;
@@ -2912,6 +2947,7 @@ type ObjectKey<T> = keyof T & (string | number);
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 declare class OptimisticState<TState> extends BaseSubscribable {
+  #private;
   constructor(initialState: TState);
   get baseValue(): TState;
   get value(): TState;
@@ -3146,6 +3182,7 @@ declare namespace ReadonlyThreadProvider {
 declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
 
 declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
+  #private;
   get messages(): readonly ThreadMessage[];
   setMessages(messages: readonly ThreadMessage[]): void;
   getMessageById(messageId: string): {
@@ -3347,6 +3384,7 @@ type RemoteThreadListAdapter = {
 type RemoteThreadListHook = () => AssistantRuntime;
 
 declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
+  #private;
   constructor(runtimeHook: RemoteThreadListHook, parent: ThreadListRuntimeCore);
   startThreadRuntime(threadId: string): Promise<Readonly<{
     getMessageById: (messageId: string) => {
@@ -3544,6 +3582,7 @@ type RemoteThreadListResponse = {
 };
 
 declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
+  #private;
   get threadItems(): Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
   getLoadThreadsPromise(): Promise<void>;
   loadMore(): Promise<void>;
@@ -3855,6 +3894,7 @@ type SerializedTool = {
 };
 
 declare class ShallowMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
+  #private;
   get path(): TPath;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
   getState: () => TState;
@@ -4175,6 +4215,7 @@ type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRunt
 }>;
 
 declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -4339,6 +4380,7 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  #private;
   get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -4496,6 +4538,7 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  #private;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -4542,6 +4585,7 @@ type ThreadMessageClientProps = {
 };
 
 declare class ThreadMessageConverter {
+  #private;
   convertMessages<TIn extends WeakKey>(messages: readonly TIn[], converter: ConverterCallback<TIn>): ThreadMessage[];
 }
 
@@ -4790,6 +4834,7 @@ type ThreadRuntimeEventPayload = {
 type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
+  #private;
   get path(): ThreadRuntimePath;
   get __internal_threadBinding(): Subscribable & {
     path: ThreadRuntimePath;
@@ -5200,6 +5245,7 @@ type ToolExecutionStatus = {
 };
 
 declare class ToolInvocationTracker {
+  #private;
   constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTracker.Callbacks);
   setState(snapshot: ToolInvocationTracker.Snapshot): void;
   reset(): void;
@@ -5559,6 +5605,7 @@ type VoiceSessionState = {
 };
 
 declare class WebSpeechDictationAdapter implements DictationAdapter {
+  #private;
   constructor(options?: {
     language?: string;
     continuous?: boolean;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -85,6 +85,7 @@ type A2AAuthorizationCodeOAuthFlow = {
 };
 
 declare class A2AClient {
+  #private;
   constructor(options: A2AClientOptions);
   getAgentCard(signal?: AbortSignal): Promise<A2AAgentCard>;
   getExtendedAgentCard(signal?: AbortSignal): Promise<A2AAgentCard>;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -85,17 +85,7 @@ type A2AAuthorizationCodeOAuthFlow = {
 };
 
 declare class A2AClient {
-  private baseUrl;
-  private basePath;
-  private tenant;
-  private extensionUris;
-  private fetchOptions;
-  private headersFn;
   constructor(options: A2AClientOptions);
-  private getBasePath;
-  private getHeaders;
-  private throwResponseError;
-  private fetchJSON;
   getAgentCard(signal?: AbortSignal): Promise<A2AAgentCard>;
   getExtendedAgentCard(signal?: AbortSignal): Promise<A2AAgentCard>;
   sendMessage(message: A2AMessage, configuration?: A2ASendMessageConfiguration, metadata?: Record<string, unknown>, signal?: AbortSignal): Promise<A2ATask | A2AMessage>;
@@ -111,7 +101,6 @@ declare class A2AClient {
     pageToken?: string;
   }, signal?: AbortSignal): Promise<A2AListTaskPushNotificationConfigsResponse>;
   deleteTaskPushNotificationConfig(taskId: string, configId: string, signal?: AbortSignal): Promise<void>;
-  private parseSSE;
 }
 
 type A2AClientCredentialsOAuthFlow = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -29,7 +29,6 @@ type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<Ch
 };
 
 declare class AISDKToolkit {
-  #private;
   constructor(options: AISDKToolkitOptions);
   tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
   close(): Promise<void>;
@@ -70,10 +69,6 @@ type AssistantChatResumableOptions = {
 };
 
 declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
-  private runtime;
-  private getThreadListItem;
-  private readonly resumable;
-  private readonly __internal_initOptions;
   __internal_clone(): AssistantChatTransport<UI_MESSAGE>;
   constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
   setRuntime(runtime: AssistantRuntime): void;
@@ -113,7 +108,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -138,7 +132,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -159,14 +152,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -212,7 +203,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -261,7 +251,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -270,7 +259,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -29,6 +29,7 @@ type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<Ch
 };
 
 declare class AISDKToolkit {
+  #private;
   constructor(options: AISDKToolkitOptions);
   tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
   close(): Promise<void>;
@@ -69,6 +70,7 @@ type AssistantChatResumableOptions = {
 };
 
 declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
+  #private;
   __internal_clone(): AssistantChatTransport<UI_MESSAGE>;
   constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
   setRuntime(runtime: AssistantRuntime): void;
@@ -108,6 +110,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -132,6 +135,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -152,11 +156,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -203,6 +209,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -251,6 +258,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -258,6 +266,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -40,7 +40,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -65,7 +64,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -86,14 +84,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -139,7 +135,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -188,7 +183,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -197,7 +191,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -40,6 +40,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -64,6 +65,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -84,11 +86,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -135,6 +139,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -183,6 +188,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -190,6 +196,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -456,12 +456,14 @@ type ImageMessagePart = {
 type ImageSize = (typeof IMAGE_SIZE_TOKENS)[number] | number;
 
 declare class JSONGenerativeUI {
+  #private;
   constructor(options: JSONGenerativeUIOptions);
   present(options?: PresentToolOptions): PresentTool;
   promptUser(): PromptUserTool;
 }
 
 declare class JSONGenerativeUI$1 {
+  #private;
   constructor(options: JSONGenerativeUIOptions);
   present(options?: PresentToolOptions): PresentTool;
   promptUser(): PromptUserTool;

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -456,18 +456,13 @@ type ImageMessagePart = {
 type ImageSize = (typeof IMAGE_SIZE_TOKENS)[number] | number;
 
 declare class JSONGenerativeUI {
-  private readonly parameters;
   constructor(options: JSONGenerativeUIOptions);
   present(options?: PresentToolOptions): PresentTool;
   promptUser(): PromptUserTool;
 }
 
 declare class JSONGenerativeUI$1 {
-  private readonly library;
-  private readonly parameters;
-  private readonly actions;
   constructor(options: JSONGenerativeUIOptions);
-  private readonly render;
   present(options?: PresentToolOptions): PresentTool;
   promptUser(): PromptUserTool;
 }

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -78,30 +78,8 @@ type AdkEvent = {
 };
 
 declare class AdkEventAccumulator {
-  private messagesMap;
-  private currentMessageId;
-  private partialTextBuffer;
-  private partialReasoningBuffer;
-  private accumulatedStateDelta;
-  private accumulatedArtifactDelta;
-  private lastAgentInfo;
-  private lastTransferToAgent;
-  private pendingLongRunningToolIds;
-  private toolConfirmations;
-  private authRequests;
-  private escalated;
-  private messageMetadataMap;
-  private aiMessageOrdinals;
   constructor(initialMessages?: AdkMessage[]);
   processEvent(rawEvent: AdkEvent): AdkMessage[];
-  private processPart;
-  private trackMessageMetadata;
-  private getContentArray;
-  private getOrCreateAiMessage;
-  private appendContent;
-  private replaceLastTextContent;
-  private replaceLastReasoningContent;
-  private finalizeCurrentMessage;
   getMessages(): AdkMessage[];
   getStateDelta(): Record<string, unknown>;
   getArtifactDelta(): Record<string, number>;
@@ -430,7 +408,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -455,7 +432,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -476,14 +452,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -529,7 +503,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -578,7 +551,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -587,7 +559,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -78,6 +78,7 @@ type AdkEvent = {
 };
 
 declare class AdkEventAccumulator {
+  #private;
   constructor(initialMessages?: AdkMessage[]);
   processEvent(rawEvent: AdkEvent): AdkMessage[];
   getMessages(): AdkMessage[];
@@ -408,6 +409,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -432,6 +434,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -452,11 +455,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -503,6 +508,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -551,6 +557,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -558,6 +565,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -112,7 +112,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -137,7 +136,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -158,14 +156,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -211,7 +207,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -260,7 +255,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -269,7 +263,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -364,7 +357,6 @@ type AssistantRuntimeCore = {
 declare class AssistantRuntimeImpl implements AssistantRuntime {
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
-  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -539,7 +531,6 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
     attachmentSource: Source;
   };
   abstract get source(): Source;
-  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -685,33 +676,20 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     };
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
-  private _attachments;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;
   abstract get canSend(): boolean;
   get isEmpty(): boolean;
-  private _text;
   get text(): string;
-  private _role;
   get role(): "assistant" | "system" | "user";
-  private _runConfig;
   get runConfig(): RunConfig;
-  private _quote;
   get quote(): QuoteInfo | undefined;
   setQuote(quote: QuoteInfo | undefined): void;
   setText(value: string): void;
-  private _rebaseDictation;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
-  private _removedDuringSend;
-  private _sendGeneration;
-  private _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
   reset(): Promise<void>;
   clearAttachments(): Promise<void>;
   send(options?: SendOptions): Promise<void>;
@@ -725,7 +703,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): void;
-  private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];
   moveQueueItem(_queueItemId: string, _placement: QueuePlacement): void;
@@ -733,22 +710,10 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
   removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
   get dictation(): DictationState | undefined;
-  private _isActiveSession;
   startDictation(): void;
   stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
   protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
 }
@@ -769,7 +734,6 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
-  private _subscribers;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -1028,7 +992,6 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1220,7 +1183,6 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   stopDictation(): void;
   setQuote(quote: QuoteInfo | undefined): void;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
@@ -1256,7 +1218,6 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1267,10 +1228,8 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
   notifySubscribers(): void;
   subscribe(callback: () => void): () => void;
 }
@@ -1336,16 +1295,13 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
-  private _queueCache;
   get queue(): readonly QueueItemState[];
   moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1506,8 +1462,6 @@ declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements Edi
     composerSource: "edit";
   };
   get type(): "edit";
-  private _getState;
-  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -2195,9 +2149,6 @@ type MessagePartRuntime = {
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
   get path(): MessagePartRuntimePath;
-  private contentBinding;
-  private messageApi;
-  private threadApi;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
@@ -2342,12 +2293,6 @@ declare namespace MessagePrimitiveParts$1 {
 declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
 
 declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2359,7 +2304,6 @@ declare class MessageRepository {
   };
   deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
   getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
   switchToBranch(messageId: string): void;
   resetHead(messageId: string | null): void;
   clear(): void;
@@ -2401,12 +2345,9 @@ type MessageRuntime = {
 
 declare class MessageRuntimeImpl implements MessageRuntime {
   get path(): MessageRuntimePath;
-  private _core;
-  private _threadBinding;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
   getState(): ThreadMessage & {
     readonly parentId: string | null;
     readonly index: number;
@@ -2543,14 +2484,8 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
   addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
   addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
@@ -3371,7 +3306,6 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
     composerSource: "thread";
   };
   get type(): "thread";
-  private _getState;
   constructor(core: ThreadComposerRuntimeCoreBinding);
   getState(): ThreadComposerState;
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
@@ -3484,8 +3418,6 @@ type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1,
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
   get path(): ThreadListItemRuntimePath;
-  private _core;
-  private _threadListBinding;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -3645,10 +3577,6 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _getState;
-  private _stateBinding;
-  private _core;
-  private _runtimeFactory;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -3661,7 +3589,6 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
   readonly main: ThreadRuntime;
   get mainItem(): ThreadListItemRuntimeImpl;
   getById(threadId: string): ThreadRuntime;
@@ -3996,8 +3923,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   } & {
     getStateState(): ThreadState;
   };
-  private readonly _threadBinding;
-  private readonly _stateBinding;
   constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
   protected __internal_bindMethods(): void;
   readonly composer: ThreadComposerRuntimeImpl;
@@ -4024,8 +3949,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
   getMessageByIndex(idx: number): MessageRuntimeImpl;
   getMessageById(messageId: string): MessageRuntimeImpl;
-  private _getMessageRuntime;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -112,6 +112,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -136,6 +137,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -156,11 +158,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -207,6 +211,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -255,6 +260,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -262,6 +268,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -355,6 +362,7 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
+  #private;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
   constructor(_core: AssistantRuntimeCore);
@@ -527,6 +535,7 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  #private;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
@@ -667,6 +676,7 @@ type BaseAttachment = {
 };
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  #private;
   readonly isEditing = true;
   protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected abstract getDictationAdapter(): DictationAdapter | undefined;
@@ -734,6 +744,7 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
+  #private;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -992,6 +1003,7 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  #private;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1162,6 +1174,7 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
   protected _core: ComposerRuntimeCoreBinding;
@@ -1218,6 +1231,7 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1228,6 +1242,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
   notifySubscribers(): void;
@@ -1295,6 +1310,7 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  #private;
   get canCancel(): boolean;
   get canSend(): boolean;
   get queue(): readonly QueueItemState[];
@@ -1458,6 +1474,7 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2148,6 +2165,7 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  #private;
   get path(): MessagePartRuntimePath;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2293,6 +2311,7 @@ declare namespace MessagePrimitiveParts$1 {
 declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
 
 declare class MessageRepository {
+  #private;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2344,6 +2363,7 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  #private;
   get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2484,6 +2504,7 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
@@ -3302,6 +3323,7 @@ type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRunt
 }>;
 
 declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -3417,6 +3439,7 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  #private;
   get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -3577,6 +3600,7 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  #private;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -3832,6 +3856,7 @@ type ThreadRuntimeEventPayload = {
 type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
+  #private;
   get path(): ThreadRuntimePath;
   get __internal_threadBinding(): Subscribable & {
     path: ThreadRuntimePath;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -50,7 +50,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -75,7 +74,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -96,14 +94,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -149,7 +145,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -198,7 +193,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -207,7 +201,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -50,6 +50,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -74,6 +75,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -94,11 +96,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -145,6 +149,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -193,6 +198,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -200,6 +206,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -52,6 +52,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -76,6 +77,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -96,11 +98,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -147,6 +151,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -195,6 +200,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -202,6 +208,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -1013,6 +1020,7 @@ type LangGraphKnownEventTypes = (typeof LangGraphKnownEventTypes)[keyof typeof L
 declare class LangGraphMessageAccumulator<TMessage extends {
   id?: string;
 }> {
+  #private;
   constructor(_param0?: LangGraphStateAccumulatorConfig<TMessage>);
   addMessages(newMessages: TMessage[]): TMessage[];
   addMessageWithMetadata(message: TMessage, metadata: LangGraphTupleMetadata): TMessage[];

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -52,7 +52,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -77,7 +76,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -98,14 +96,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -151,7 +147,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -200,7 +195,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -209,7 +203,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -1020,14 +1013,7 @@ type LangGraphKnownEventTypes = (typeof LangGraphKnownEventTypes)[keyof typeof L
 declare class LangGraphMessageAccumulator<TMessage extends {
   id?: string;
 }> {
-  private messagesMap;
-  private metadataMap;
-  private uiMessages;
-  private appendMessage;
   constructor(_param0?: LangGraphStateAccumulatorConfig<TMessage>);
-  private ensureMessageId;
-  private upsertMessage;
-  private applyRemove;
   addMessages(newMessages: TMessage[]): TMessage[];
   addMessageWithMetadata(message: TMessage, metadata: LangGraphTupleMetadata): TMessage[];
   getMessages(): TMessage[];

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -110,7 +110,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -135,7 +134,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -156,14 +154,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -209,7 +205,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -258,7 +253,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -267,7 +261,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -362,7 +355,6 @@ type AssistantRuntimeCore = {
 declare class AssistantRuntimeImpl implements AssistantRuntime {
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
-  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -537,7 +529,6 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
     attachmentSource: Source;
   };
   abstract get source(): Source;
-  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -677,33 +668,20 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     };
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
-  private _attachments;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;
   abstract get canSend(): boolean;
   get isEmpty(): boolean;
-  private _text;
   get text(): string;
-  private _role;
   get role(): "assistant" | "system" | "user";
-  private _runConfig;
   get runConfig(): RunConfig;
-  private _quote;
   get quote(): QuoteInfo | undefined;
   setQuote(quote: QuoteInfo | undefined): void;
   setText(value: string): void;
-  private _rebaseDictation;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
-  private _removedDuringSend;
-  private _sendGeneration;
-  private _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
   reset(): Promise<void>;
   clearAttachments(): Promise<void>;
   send(options?: SendOptions): Promise<void>;
@@ -717,7 +695,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): void;
-  private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];
   moveQueueItem(_queueItemId: string, _placement: QueuePlacement): void;
@@ -725,22 +702,10 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
   removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
   get dictation(): DictationState | undefined;
-  private _isActiveSession;
   startDictation(): void;
   stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
   protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
 }
@@ -761,7 +726,6 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
-  private _subscribers;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -981,7 +945,6 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1137,7 +1100,6 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   stopDictation(): void;
   setQuote(quote: QuoteInfo | undefined): void;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
@@ -1173,7 +1135,6 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1184,10 +1145,8 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
   notifySubscribers(): void;
   subscribe(callback: () => void): () => void;
 }
@@ -1247,16 +1206,13 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
-  private _queueCache;
   get queue(): readonly QueueItemState[];
   moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1338,8 +1294,6 @@ declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements Edi
     composerSource: "edit";
   };
   get type(): "edit";
-  private _getState;
-  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -1868,9 +1822,6 @@ type MessagePartRuntime = {
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
   get path(): MessagePartRuntimePath;
-  private contentBinding;
-  private messageApi;
-  private threadApi;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
@@ -2041,12 +1992,6 @@ declare namespace MessagePrimitiveParts$1 {
 declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
 
 declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2058,7 +2003,6 @@ declare class MessageRepository {
   };
   deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
   getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
   switchToBranch(messageId: string): void;
   resetHead(messageId: string | null): void;
   clear(): void;
@@ -2100,12 +2044,9 @@ type MessageRuntime = {
 
 declare class MessageRuntimeImpl implements MessageRuntime {
   get path(): MessageRuntimePath;
-  private _core;
-  private _threadBinding;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
   getState(): ThreadMessage & {
     readonly parentId: string | null;
     readonly index: number;
@@ -2252,14 +2193,8 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
   addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
   addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
@@ -2895,7 +2830,6 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
     composerSource: "thread";
   };
   get type(): "thread";
-  private _getState;
   constructor(core: ThreadComposerRuntimeCoreBinding);
   getState(): ThreadComposerState;
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
@@ -3008,8 +2942,6 @@ type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1,
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
   get path(): ThreadListItemRuntimePath;
-  private _core;
-  private _threadListBinding;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -3169,10 +3101,6 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _getState;
-  private _stateBinding;
-  private _core;
-  private _runtimeFactory;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -3185,7 +3113,6 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
   readonly main: ThreadRuntime;
   get mainItem(): ThreadListItemRuntimeImpl;
   getById(threadId: string): ThreadRuntime;
@@ -3507,8 +3434,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   } & {
     getStateState(): ThreadState;
   };
-  private readonly _threadBinding;
-  private readonly _stateBinding;
   constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
   protected __internal_bindMethods(): void;
   readonly composer: ThreadComposerRuntimeImpl;
@@ -3535,8 +3460,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
   getMessageByIndex(idx: number): MessageRuntimeImpl;
   getMessageById(messageId: string): MessageRuntimeImpl;
-  private _getMessageRuntime;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -110,6 +110,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -134,6 +135,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -154,11 +156,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -205,6 +209,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -253,6 +258,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -260,6 +266,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -353,6 +360,7 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
+  #private;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
   constructor(_core: AssistantRuntimeCore);
@@ -525,6 +533,7 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  #private;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
@@ -659,6 +668,7 @@ type BaseAttachment = {
 };
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  #private;
   readonly isEditing = true;
   protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected abstract getDictationAdapter(): DictationAdapter | undefined;
@@ -726,6 +736,7 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
+  #private;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -945,6 +956,7 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  #private;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1079,6 +1091,7 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
   protected _core: ComposerRuntimeCoreBinding;
@@ -1135,6 +1148,7 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1145,6 +1159,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
   notifySubscribers(): void;
@@ -1206,6 +1221,7 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  #private;
   get canCancel(): boolean;
   get canSend(): boolean;
   get queue(): readonly QueueItemState[];
@@ -1290,6 +1306,7 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -1821,6 +1838,7 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  #private;
   get path(): MessagePartRuntimePath;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -1992,6 +2010,7 @@ declare namespace MessagePrimitiveParts$1 {
 declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
 
 declare class MessageRepository {
+  #private;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -2043,6 +2062,7 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  #private;
   get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2193,6 +2213,7 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
@@ -2826,6 +2847,7 @@ type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRunt
 }>;
 
 declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -2941,6 +2963,7 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  #private;
   get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -3101,6 +3124,7 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  #private;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -3343,6 +3367,7 @@ type ThreadRuntimeEventPayload = {
 type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
+  #private;
   get path(): ThreadRuntimePath;
   get __internal_threadBinding(): Subscribable & {
     path: ThreadRuntimePath;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -881,6 +881,7 @@ type OpenCodeAttachmentAdapterOptions = {
 };
 
 declare class OpenCodeEventSource {
+  #private;
   constructor(client: OpencodeClient);
   subscribe(listener: Listener): () => void;
   dispose(): void;
@@ -1075,6 +1076,7 @@ type OpenCodeStateEvent = {
 };
 
 declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
+  #private;
   constructor(client: OpencodeClient, getEventSource: OpenCodeEventSourceProvider, sessionId: string);
   dispose(): void;
   getState: () => OpenCodeThreadState;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -881,22 +881,9 @@ type OpenCodeAttachmentAdapterOptions = {
 };
 
 declare class OpenCodeEventSource {
-  private readonly listeners;
-  private readonly reconnectDelayMs;
-  private readonly maxReconnectDelayMs;
-  private abortController;
-  private connectionPromise;
-  private stopped;
-  private nextReconnectDelayMs;
-  private hadConnection;
-  private readonly client;
   constructor(client: OpencodeClient);
   subscribe(listener: Listener): () => void;
   dispose(): void;
-  private emit;
-  private connect;
-  private disconnect;
-  private run;
 }
 
 type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
@@ -1088,39 +1075,12 @@ type OpenCodeStateEvent = {
 };
 
 declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
-  private state;
-  private readonly listeners;
-  private readonly getEventSource;
-  private unsubscribeFromEvents;
-  private loadPromise;
-  private reconnectSyncToken;
-  private readonly childControllersById;
-  private readonly childSessionIdByPartId;
-  private ancestorSessionIds;
-  private isChildSession;
-  private readonly stagedMessages;
-  private readonly client;
-  private readonly sessionId;
   constructor(client: OpencodeClient, getEventSource: OpenCodeEventSourceProvider, sessionId: string);
-  private notifyListeners;
-  private updateChildSnapshot;
-  private attachChildController;
-  private detachChildControllers;
-  private discard;
-  private rebuildChildSessionIndex;
-  private updateChildSessionIndex;
-  private removeFromChildSessionIndex;
-  private syncChildControllers;
-  private syncChildSessionIndex;
-  private ensureEventSubscription;
-  private handleStreamReconnect;
   dispose(): void;
   getState: () => OpenCodeThreadState;
   subscribe: (listener: () => void) => () => void;
   load(force?: boolean): Promise<void>;
   refresh(): Promise<void>;
-  private createPendingMessage;
-  private promptMessage;
   sendMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
   stageMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
   sendStagedMessage(parentId: string, options?: OpenCodeUserMessageOptions): Promise<boolean>;
@@ -1131,9 +1091,6 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   replyToPermission(permissionId: string, response: OpenCodePermissionResponse): Promise<void>;
   replyToQuestion(questionId: string, answers: readonly QuestionAnswer$1[]): Promise<void>;
   rejectQuestion(questionId: string): Promise<void>;
-  private refreshInBackground;
-  private handleServerEvent;
-  private dispatch;
 }
 
 type OpenCodeThreadControllerLike = {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1376,6 +1376,7 @@ interface PiThinkingContent {
 type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
 
 declare class PiThreadController implements PiThreadControllerLike {
+  #private;
   constructor(client: PiClient, threadId: string, options?: {
     scheduleNotify?: PiNotificationScheduler;
   });
@@ -1493,6 +1494,7 @@ interface PiThreadState {
 type PiThreadStatus = "failed" | "idle" | "running";
 
 declare class PiThreadSupervisor {
+  #private;
   constructor(options?: PiThreadSupervisorOptions);
   listThreads(input?: {
     workspacePath?: string;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1376,23 +1376,6 @@ interface PiThinkingContent {
 type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
 
 declare class PiThreadController implements PiThreadControllerLike {
-  private state;
-  private projectedMessages;
-  private messageRepository;
-  private version;
-  private readonly allListeners;
-  private readonly metadataListeners;
-  private readonly messageListeners;
-  private connectionRetainers;
-  private readonly optimisticUserMessages;
-  private unsubscribeFromEvents;
-  private disconnectTimer;
-  private loadPromise;
-  private messageFlushScheduled;
-  private readonly localSnapshotSeq;
-  private readonly client;
-  private readonly threadId;
-  private readonly options;
   constructor(client: PiClient, threadId: string, options?: {
     scheduleNotify?: PiNotificationScheduler;
   });
@@ -1405,15 +1388,9 @@ declare class PiThreadController implements PiThreadControllerLike {
   subscribeMetadata(listener: () => void): () => void;
   subscribeMessages(listener: () => void): () => void;
   dispose(): void;
-  private ensureEventSubscription;
-  private hasConsumers;
-  private maybeDisconnectFromEvents;
-  private clearDisconnectTimer;
   load(force?: boolean): Promise<void>;
   refresh(): Promise<void>;
-  private refreshInBackground;
   sendMessage(message: AppendMessage, options?: PiSendOptions): Promise<void>;
-  private sendQueued;
   clearQueue(): Promise<{
     steering: string[];
     followUp: string[];
@@ -1427,18 +1404,6 @@ declare class PiThreadController implements PiThreadControllerLike {
   respondToToolApproval(approvalId: string, approved: boolean): Promise<void>;
   resumeToolCall(toolCallId: string, payload: unknown): Promise<void>;
   respondToHostUiRequest(response: PiHostUiResponse): Promise<void>;
-  private respond;
-  private applySnapshot;
-  private dispatch;
-  private setState;
-  private projectedInputMessages;
-  private reconcileOptimisticUserMessages;
-  private projectMessages;
-  private recomputeProjectedMessagesAndNotify;
-  private scheduleProjectedMessageFlush;
-  private bumpVersion;
-  private notifyMetadataListeners;
-  private notifyMessageListeners;
 }
 
 interface PiThreadControllerLike {
@@ -1528,16 +1493,6 @@ interface PiThreadState {
 type PiThreadStatus = "failed" | "idle" | "running";
 
 declare class PiThreadSupervisor {
-  private readonly records;
-  private readonly pendingOpens;
-  private readonly recordsBySessionFile;
-  private readonly workspacePath;
-  private readonly agentDir;
-  private readonly model;
-  private modelRuntimePromise;
-  private readonly archivedSessionFiles;
-  private readonly catalogCache;
-  private readonly catalogInfoByThreadId;
   constructor(options?: PiThreadSupervisorOptions);
   listThreads(input?: {
     workspacePath?: string;
@@ -1570,26 +1525,6 @@ declare class PiThreadSupervisor {
     includeSnapshot?: boolean;
   }): () => void;
   dispose(): Promise<void>;
-  private getModelRuntime;
-  private openSession;
-  private ensureOpen;
-  private openCold;
-  private listSessionInfos;
-  private invalidateCatalog;
-  private findSessionInfo;
-  private rememberSessionInfos;
-  private send;
-  private onSessionEvent;
-  private emitContextUsage;
-  private emit;
-  private notifyListener;
-  private liveStatusFor;
-  private runStatus;
-  private readinessOf;
-  private queuedMessagesOf;
-  private metadataOf;
-  private snapshotOf;
-  private snapshotFromSessionFile;
 }
 
 interface PiThreadSupervisorOptions {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -273,7 +273,6 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -298,7 +297,6 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -319,14 +317,12 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
   readonly messages: AssistantCloudProjectThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -372,7 +368,6 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -421,7 +416,6 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -430,7 +424,6 @@ declare class AssistantCloudThreadMessages {
 
 declare class AssistantCloudThreads {
   readonly messages: AssistantCloudThreadMessages;
-  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -497,37 +490,14 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
 };
 
 declare class AssistantFrameHost implements ModelContextProvider {
-  private _context;
-  private _subscribers;
-  private _pendingRequests;
-  private _requestCounter;
-  private _iframeWindow;
-  private _targetOrigin;
-  private _disposed;
   constructor(iframeWindow: Window, targetOrigin?: string);
-  private handleMessage;
-  private updateContext;
-  private callTool;
-  private sendRequest;
-  private requestContext;
-  private notifySubscribers;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   dispose(): void;
 }
 
 declare class AssistantFrameProvider {
-  private static _instance;
-  private _providers;
-  private _providerUnsubscribes;
-  private _targetOrigin;
   private constructor();
-  private static getInstance;
-  private handleMessage;
-  private handleToolCall;
-  private sendMessage;
-  private getModelContext;
-  private broadcastUpdate;
   static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
   static dispose(): void;
 }
@@ -607,7 +577,6 @@ type AssistantRuntimeCore = {
 declare class AssistantRuntimeImpl implements AssistantRuntime {
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
-  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -857,7 +826,6 @@ declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSou
     attachmentSource: Source;
   };
   abstract get source(): Source;
-  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState & {
@@ -993,33 +961,20 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     };
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
-  private _attachments;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;
   abstract get canSend(): boolean;
   get isEmpty(): boolean;
-  private _text;
   get text(): string;
-  private _role;
   get role(): "assistant" | "system" | "user";
-  private _runConfig;
   get runConfig(): RunConfig;
-  private _quote;
   get quote(): QuoteInfo | undefined;
   setQuote(quote: QuoteInfo | undefined): void;
   setText(value: string): void;
-  private _rebaseDictation;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
-  private _removedDuringSend;
-  private _sendGeneration;
-  private _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
   reset(): Promise<void>;
   clearAttachments(): Promise<void>;
   send(options?: SendOptions): Promise<void>;
@@ -1033,7 +988,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
     quote?: QuoteInfo | undefined;
     attachments?: readonly Attachment[] | undefined;
   }): void;
-  private _restoreUnsentDraft;
   cancel(): void;
   get queue(): readonly QueueItemState[];
   moveQueueItem(_queueItemId: string, _placement: QueuePlacement): void;
@@ -1041,22 +995,10 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
   removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
   get dictation(): DictationState | undefined;
-  private _isActiveSession;
   startDictation(): void;
   stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
   protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
 }
@@ -1077,7 +1019,6 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
-  private _subscribers;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -1292,9 +1233,7 @@ type ClientScopes = {
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
   accept: string;
-  private cloud;
   constructor(cloud: AssistantCloud);
-  private uploadedUrls;
   add(_param0: {
     file: File;
   }): AsyncGenerator<PendingAttachment, void>;
@@ -1352,7 +1291,6 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1792,7 +1730,6 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   stopDictation(): void;
   setQuote(quote: QuoteInfo | undefined): void;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
@@ -1826,7 +1763,6 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1837,10 +1773,8 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
   notifySubscribers(): void;
   subscribe(callback: () => void): () => void;
 }
@@ -1900,16 +1834,13 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
-  private _queueCache;
   get queue(): readonly QueueItemState[];
   moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1940,13 +1871,10 @@ declare class DevToolsHooks {
   static subscribe(listener: () => void): Unsubscribe$1;
   static clearEventLogs(apiId: number): void;
   static getApis(): Map<number, DevToolsApiEntry>;
-  private static notifyListeners;
 }
 
 declare class DevToolsProviderApi {
-  private static readonly MAX_EVENT_LOGS_PER_API;
   static register(aui: Partial<AssistantClient>): Unsubscribe$1;
-  private static notifyListeners;
 }
 
 declare namespace DictationAdapter {
@@ -2015,8 +1943,6 @@ declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements Edi
     composerSource: "edit";
   };
   get type(): "edit";
-  private _getState;
-  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -2810,9 +2736,6 @@ type MessagePartRuntime = {
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
   get path(): MessagePartRuntimePath;
-  private contentBinding;
-  private messageApi;
-  private threadApi;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
@@ -3074,12 +2997,6 @@ type MessageQueueDriver = {
 };
 
 declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -3091,7 +3008,6 @@ declare class MessageRepository {
   };
   deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
   getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
   switchToBranch(messageId: string): void;
   resetHead(messageId: string | null): void;
   clear(): void;
@@ -3127,12 +3043,9 @@ type MessageRuntime = {
 
 declare class MessageRuntimeImpl implements MessageRuntime {
   get path(): MessageRuntimePath;
-  private _core;
-  private _threadBinding;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
   getState(): ThreadMessage & {
     readonly parentId: string | null;
     readonly index: number;
@@ -3269,14 +3182,8 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
   addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
   addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
@@ -4193,7 +4100,6 @@ declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements T
     composerSource: "thread";
   };
   get type(): "thread";
-  private _getState;
   constructor(core: ThreadComposerRuntimeCoreBinding);
   getState(): ThreadComposerState;
   getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
@@ -4391,8 +4297,6 @@ type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1,
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
   get path(): ThreadListItemRuntimePath;
-  private _core;
-  private _threadListBinding;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -4582,10 +4486,6 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _getState;
-  private _stateBinding;
-  private _core;
-  private _runtimeFactory;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -4598,7 +4498,6 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
   readonly main: ThreadRuntime;
   get mainItem(): ThreadListItemRuntimeImpl;
   getById(threadId: string): ThreadRuntime;
@@ -5018,8 +4917,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   } & {
     getStateState(): ThreadState;
   };
-  private readonly _threadBinding;
-  private readonly _stateBinding;
   constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
   protected __internal_bindMethods(): void;
   readonly composer: ThreadComposerRuntimeImpl;
@@ -5046,8 +4943,6 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
   getMessageByIndex(idx: number): MessageRuntimeImpl;
   getMessageById(messageId: string): MessageRuntimeImpl;
-  private _getMessageRuntime;
-  private _eventSubscriptionSubjects;
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
@@ -5819,9 +5714,6 @@ type VoiceSessionState = {
 };
 
 declare class WebSpeechDictationAdapter implements DictationAdapter {
-  private _language;
-  private _continuous;
-  private _interimResults;
   constructor(options?: {
     language?: string;
     continuous?: boolean;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1887,14 +1887,12 @@ interface DevToolsHook {
 }
 
 declare class DevToolsHooks {
-  #private;
   static subscribe(listener: () => void): Unsubscribe$1;
   static clearEventLogs(apiId: number): void;
   static getApis(): Map<number, DevToolsApiEntry>;
 }
 
 declare class DevToolsProviderApi {
-  #private;
   static register(aui: Partial<AssistantClient>): Unsubscribe$1;
 }
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -273,6 +273,7 @@ type AssistantCloudAuthStrategy = {
 };
 
 declare class AssistantCloudAuthTokens {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   create(): Promise<AssistantCloudAuthTokensCreateResponse>;
 }
@@ -297,6 +298,7 @@ type AssistantCloudConfig = ({
 };
 
 declare class AssistantCloudFiles {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
   generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
@@ -317,11 +319,13 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 declare class AssistantCloudProjectThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudProjectThreadMessageListQuery): Promise<AssistantCloudProjectThreadMessageListResponse>;
 }
 
 declare class AssistantCloudProjectThreads {
+  #private;
   readonly messages: AssistantCloudProjectThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
@@ -368,6 +372,7 @@ type AssistantCloudRunReport = {
 };
 
 declare class AssistantCloudRuns {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   __internal_getAssistantOptions(assistantId: string): {
     api: string;
@@ -416,6 +421,7 @@ type AssistantCloudThreadMessageUpdateBody = {
 };
 
 declare class AssistantCloudThreadMessages {
+  #private;
   constructor(cloud: AssistantCloudAPI);
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
@@ -423,6 +429,7 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
+  #private;
   readonly messages: AssistantCloudThreadMessages;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
@@ -490,6 +497,7 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
 };
 
 declare class AssistantFrameHost implements ModelContextProvider {
+  #private;
   constructor(iframeWindow: Window, targetOrigin?: string);
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
@@ -497,6 +505,7 @@ declare class AssistantFrameHost implements ModelContextProvider {
 }
 
 declare class AssistantFrameProvider {
+  #private;
   private constructor();
   static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
   static dispose(): void;
@@ -575,6 +584,7 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
+  #private;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
   constructor(_core: AssistantRuntimeCore);
@@ -822,6 +832,7 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  #private;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
@@ -952,6 +963,7 @@ type BaseAttachment = {
 };
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  #private;
   readonly isEditing = true;
   protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected abstract getDictationAdapter(): DictationAdapter | undefined;
@@ -1019,6 +1031,7 @@ type BaseComposerState = {
 };
 
 declare class BaseSubscribable {
+  #private;
   subscribe(callback: () => void): Unsubscribe$1;
   waitForUpdate(): Promise<void>;
   protected _notifySubscribers(): void;
@@ -1232,6 +1245,7 @@ type ClientScopes = {
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(cloud: AssistantCloud);
   add(_param0: {
@@ -1291,6 +1305,7 @@ declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
 }>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  #private;
   constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
   remove(): Promise<void>;
 }
@@ -1709,6 +1724,7 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
   protected _core: ComposerRuntimeCoreBinding;
@@ -1763,6 +1779,7 @@ type ComposerState = {
 type ComposerState$1 = ThreadComposerState | EditComposerState;
 
 declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  #private;
   accept: string;
   constructor(adapters: AttachmentAdapter[]);
   add(state: {
@@ -1773,6 +1790,7 @@ declare class CompositeAttachmentAdapter implements AttachmentAdapter {
 }
 
 declare class CompositeContextProvider implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   registerModelContextProvider(provider: ModelContextProvider): () => void;
   notifySubscribers(): void;
@@ -1834,6 +1852,7 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  #private;
   get canCancel(): boolean;
   get canSend(): boolean;
   get queue(): readonly QueueItemState[];
@@ -1868,12 +1887,14 @@ interface DevToolsHook {
 }
 
 declare class DevToolsHooks {
+  #private;
   static subscribe(listener: () => void): Unsubscribe$1;
   static clearEventLogs(apiId: number): void;
   static getApis(): Map<number, DevToolsApiEntry>;
 }
 
 declare class DevToolsProviderApi {
+  #private;
   static register(aui: Partial<AssistantClient>): Unsubscribe$1;
 }
 
@@ -1939,6 +1960,7 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
@@ -2735,6 +2757,7 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  #private;
   get path(): MessagePartRuntimePath;
   constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -2997,6 +3020,7 @@ type MessageQueueDriver = {
 };
 
 declare class MessageRepository {
+  #private;
   get headId(): string | null;
   get canonicalHeadId(): string | null;
   getMessages(headId?: string): readonly ThreadMessage[];
@@ -3042,6 +3066,7 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  #private;
   get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -3182,6 +3207,7 @@ type ModelContextProvider = {
 };
 
 declare class ModelContextRegistry implements ModelContextProvider {
+  #private;
   getModelContext(): ModelContext$1;
   subscribe(callback: () => void): Unsubscribe$1;
   addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
@@ -4096,6 +4122,7 @@ type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRunt
 }>;
 
 declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  #private;
   get path(): ComposerRuntimePath & {
     composerSource: "thread";
   };
@@ -4296,6 +4323,7 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  #private;
   get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
@@ -4486,6 +4514,7 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  #private;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {
@@ -4826,6 +4855,7 @@ type ThreadRuntimeEventPayload = {
 type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
+  #private;
   get path(): ThreadRuntimePath;
   get __internal_threadBinding(): Subscribable & {
     path: ThreadRuntimePath;
@@ -5714,6 +5744,7 @@ type VoiceSessionState = {
 };
 
 declare class WebSpeechDictationAdapter implements DictationAdapter {
+  #private;
   constructor(options?: {
     language?: string;
     continuous?: boolean;

--- a/api-surface/safe-content-frame.ts
+++ b/api-surface/safe-content-frame.ts
@@ -7,16 +7,12 @@ interface RenderedFrame {
 }
 
 declare class SafeContentFrame {
-  private product;
-  private options;
   constructor(product: string, options?: SafeContentFrameOptions);
   renderHtml(html: string, container: HTMLElement, opts?: {
     unsafeDocumentWrite?: boolean;
   }): Promise<RenderedFrame>;
   renderRaw(content: Uint8Array | string, mimeType: string, container: HTMLElement): Promise<RenderedFrame>;
   renderPdf(content: Uint8Array, container: HTMLElement): Promise<RenderedFrame>;
-  private render;
-  private getSandbox;
 }
 
 interface SafeContentFrameOptions {

--- a/api-surface/safe-content-frame.ts
+++ b/api-surface/safe-content-frame.ts
@@ -7,6 +7,7 @@ interface RenderedFrame {
 }
 
 declare class SafeContentFrame {
+  #private;
   constructor(product: string, options?: SafeContentFrameOptions);
   renderHtml(html: string, container: HTMLElement, opts?: {
     unsafeDocumentWrite?: boolean;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ci:publish": "turbo build --filter=\"./packages/*\" && changeset publish",
     "build": "turbo build --concurrency=4",
     "api-surface": "pnpm api-surface:build && node scripts/generate-api-surface.mjs",
-    "api-surface:build": "pnpm exec turbo build --filter='./packages/*' --force",
+    "api-surface:build": "pnpm exec turbo build --filter='./packages/*'",
     "api-surface:check": "node scripts/check-api-surface.mjs",
     "api-surface:test": "node --test scripts/generate-api-surface.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -585,12 +585,24 @@ function publicizeConstructor(member, factory) {
     : member;
 }
 
+function privateIdentityMarker(factory) {
+  return factory.createPropertyDeclaration(
+    undefined,
+    factory.createPrivateIdentifier("#private"),
+    undefined,
+    undefined,
+    undefined,
+  );
+}
+
 function stripPrivateClassMembers(node, factory, visit, context) {
   const visited = ts.visitEachChild(node, visit, context);
   const members = [];
+  let strippedAny = false;
   let changed = visited !== node;
   for (const member of visited.members) {
     if (shouldStripClassMember(member)) {
+      strippedAny = true;
       changed = true;
       continue;
     }
@@ -599,6 +611,9 @@ function stripPrivateClassMembers(node, factory, visit, context) {
       : member;
     if (nextMember !== member) changed = true;
     members.push(nextMember);
+  }
+  if (strippedAny) {
+    members.unshift(privateIdentityMarker(factory));
   }
   if (!changed) return visited;
   if (ts.isClassDeclaration(visited)) {

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -602,7 +602,9 @@ function stripPrivateClassMembers(node, factory, visit, context) {
   let changed = visited !== node;
   for (const member of visited.members) {
     if (shouldStripClassMember(member)) {
-      strippedAny = true;
+      if (!hasModifier(member, ts.SyntaxKind.StaticKeyword)) {
+        strippedAny = true;
+      }
       changed = true;
       continue;
     }

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -537,6 +537,90 @@ function stringLiteralUnionMemberValue(type) {
   return undefined;
 }
 
+function hasModifier(node, kind) {
+  return Boolean(node.modifiers?.some((modifier) => modifier.kind === kind));
+}
+
+function isPrivateIdentifierMember(node) {
+  return Boolean(node.name && ts.isPrivateIdentifier(node.name));
+}
+
+function shouldStripClassMember(member) {
+  if (ts.isConstructorDeclaration(member)) return false;
+  return (
+    hasModifier(member, ts.SyntaxKind.PrivateKeyword) ||
+    isPrivateIdentifierMember(member)
+  );
+}
+
+function publicizeConstructor(member, factory) {
+  let changed = false;
+  const parameters = member.parameters.map((parameter) => {
+    if (!hasModifier(parameter, ts.SyntaxKind.PrivateKeyword)) {
+      return parameter;
+    }
+    changed = true;
+    const modifiers = parameter.modifiers?.filter(
+      (modifier) =>
+        modifier.kind !== ts.SyntaxKind.PrivateKeyword &&
+        modifier.kind !== ts.SyntaxKind.ReadonlyKeyword,
+    );
+    return factory.updateParameterDeclaration(
+      parameter,
+      modifiers && modifiers.length > 0 ? modifiers : undefined,
+      parameter.dotDotDotToken,
+      parameter.name,
+      parameter.questionToken,
+      parameter.type,
+      parameter.initializer,
+    );
+  });
+  return changed
+    ? factory.updateConstructorDeclaration(
+        member,
+        member.modifiers,
+        parameters,
+        member.body,
+      )
+    : member;
+}
+
+function stripPrivateClassMembers(node, factory, visit, context) {
+  const visited = ts.visitEachChild(node, visit, context);
+  const members = [];
+  let changed = visited !== node;
+  for (const member of visited.members) {
+    if (shouldStripClassMember(member)) {
+      changed = true;
+      continue;
+    }
+    const nextMember = ts.isConstructorDeclaration(member)
+      ? publicizeConstructor(member, factory)
+      : member;
+    if (nextMember !== member) changed = true;
+    members.push(nextMember);
+  }
+  if (!changed) return visited;
+  if (ts.isClassDeclaration(visited)) {
+    return factory.updateClassDeclaration(
+      visited,
+      visited.modifiers,
+      visited.name,
+      visited.typeParameters,
+      visited.heritageClauses,
+      members,
+    );
+  }
+  return factory.updateClassExpression(
+    visited,
+    visited.modifiers,
+    visited.name,
+    visited.typeParameters,
+    visited.heritageClauses,
+    members,
+  );
+}
+
 function normalizeStringLiteralUnionType(node, factory) {
   const memberValues = node.types.map(stringLiteralUnionMemberValue);
   if (memberValues.some((value) => value === undefined)) return node;
@@ -575,6 +659,14 @@ export function normalizeBundledDeclaration(content) {
     (context) => {
       let bindingParameterIndex = 0;
       const visit = (node) => {
+        if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+          return stripPrivateClassMembers(
+            node,
+            context.factory,
+            visit,
+            context,
+          );
+        }
         if (ts.isUnionTypeNode(node)) {
           const attachmentNormalized = normalizeAttachmentUnionType(
             ts.visitEachChild(node, visit, context),

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -119,11 +119,20 @@ test("an unrecognized composer attachment union shape throws", () => {
   assert.throws(() => normalizeBundledDeclaration(bad), /unsupported shape/);
 });
 
-test("private instance members and #private placeholders are stripped", () => {
-  const output = normalizeBundledDeclaration(
+test("private instance members collapse to a single #private identity marker", () => {
+  const disposed = normalizeBundledDeclaration(
     [
       "declare class Foo {",
       "  private disposed;",
+      "  constructor(options?: Options);",
+      "  listThreads(): void;",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
+  const generation = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
       "  #private;",
       "  private generation;",
       "  constructor(options?: Options);",
@@ -133,11 +142,25 @@ test("private instance members and #private placeholders are stripped", () => {
     ].join("\n"),
   );
 
-  assert.equal(output.includes("disposed"), false);
+  assert.equal(disposed, generation);
+  assert.match(disposed, /#private;/);
+  assert.equal(disposed.includes("disposed"), false);
+  assert.equal(disposed.includes("generation"), false);
+  assert.match(disposed, /constructor\(options\?: Options\)/);
+  assert.match(disposed, /listThreads\(\): void/);
+});
+
+test("a class with no private members does not gain a #private marker", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
+      "  constructor();",
+      "  listThreads(): void;",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
   assert.equal(output.includes("#private"), false);
-  assert.equal(output.includes("generation"), false);
-  assert.match(output, /constructor\(options\?: Options\)/);
-  assert.match(output, /listThreads\(\): void/);
 });
 
 test("private constructors stay in the surface", () => {
@@ -171,5 +194,6 @@ test("protected members stay in the surface", () => {
     ].join("\n"),
   );
   assert.match(output, /protected render\(\): void/);
+  assert.match(output, /#private;/);
   assert.equal(output.includes("hide"), false);
 });

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -183,6 +183,21 @@ test("private constructor parameter fields become ordinary parameters", () => {
   assert.equal(output.includes("private name"), false);
 });
 
+test("private static members do not add an instance #private brand", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
+      "  private static notifyListeners(): void;",
+      "  static get(): Foo;",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
+  assert.equal(output.includes("#private"), false);
+  assert.equal(output.includes("notifyListeners"), false);
+  assert.match(output, /static get\(\): Foo/);
+});
+
 test("protected members stay in the surface", () => {
   const output = normalizeBundledDeclaration(
     [

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -118,3 +118,58 @@ test("an unrecognized composer attachment union shape throws", () => {
   );
   assert.throws(() => normalizeBundledDeclaration(bad), /unsupported shape/);
 });
+
+test("private instance members and #private placeholders are stripped", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
+      "  private disposed;",
+      "  #private;",
+      "  private generation;",
+      "  constructor(options?: Options);",
+      "  listThreads(): void;",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
+
+  assert.equal(output.includes("disposed"), false);
+  assert.equal(output.includes("#private"), false);
+  assert.equal(output.includes("generation"), false);
+  assert.match(output, /constructor\(options\?: Options\)/);
+  assert.match(output, /listThreads\(\): void/);
+});
+
+test("private constructors stay in the surface", () => {
+  const output = normalizeBundledDeclaration(
+    "declare class Foo {\n  private constructor();\n}\nexport { Foo };\n",
+  );
+  assert.match(output, /private constructor\(\)/);
+});
+
+test("private constructor parameter fields become ordinary parameters", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
+      "  constructor(private readonly name: string);",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
+  assert.match(output, /constructor\(name: string\)/);
+  assert.equal(output.includes("private name"), false);
+});
+
+test("protected members stay in the surface", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      "declare class Foo {",
+      "  protected render(): void;",
+      "  private hide(): void;",
+      "}",
+      "export { Foo };",
+    ].join("\n"),
+  );
+  assert.match(output, /protected render\(\): void/);
+  assert.equal(output.includes("hide"), false);
+});


### PR DESCRIPTION
## summary

- autofix now regenerates committed api-reference MDX, so a JSDoc-only change no longer sits red until someone remembers `pnpm -C apps/docs generate:api-reference`.
- api-surface snapshots no longer include `private` members or `#private` placeholders. renaming an internal field (the recent react-pi `disposed` to `generation` failures) is no longer a public-contract miss. private constructors and protected members stay.
- `pnpm api-surface` no longer `--force` rebuilds every package. the drift job skips its install and generate when the generator inputs did not change, and the failure text now says the pages are stale.

## test plan

### already verified

- [x] `pnpm api-surface:test` -> 12/12, including the new private-member cases
- [x] `pnpm api-surface` then `pnpm api-surface:check -- --skip-build` -> 40 files checked, `tsc --noEmit` green
- [x] leftover `private` / `#private` lines are only the two intentional `private constructor()` entries on `AssistantFrameProvider`
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` -> no tree drift

### reviewer should verify

- [ ] a JSDoc-only edit on an exported hook should get an autofix commit that updates the matching api-reference page
- [ ] a PR that only touches `examples/` or an unrelated package should show API Reference Drift as a skipped/fast path, not a full install

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yjomkBucKSx9AJpG0tgurNo4exuXHdFNUWsVWOutqh0awQM5zLNqQxLukAk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->