### PR TITLE
feat(cli): register the with-openui example

### DIFF
--- a/.changeset/cli-register-with-openui.md
+++ b/.changeset/cli-register-with-openui.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+feat: register the with-openui example in `npx assistant-ui create` now that `@openuidev/react-headless` widened its `ai` peer to `^6 || ^7`

--- a/api-surface/assistant-ui.ts
+++ b/api-surface/assistant-ui.ts
@@ -79,7 +79,7 @@ export const cliSurface: CliSurfaceSnapshot = {
         },
         {
           "flags": "-e, --example <example>",
-          "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v7, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream)",
+          "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v7, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream, with-openui)",
           "required": true
         },
         {

--- a/api-surface/create-assistant-ui.ts
+++ b/api-surface/create-assistant-ui.ts
@@ -19,7 +19,7 @@ export const cliSurface: CliSurfaceSnapshot = {
     },
     {
       "flags": "-e, --example <example>",
-      "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v7, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream)",
+      "description": "create from an example (with-ag-ui, with-google-adk, with-ai-sdk-v7, with-eve, with-artifacts, with-assistant-transport, with-chain-of-thought, with-cloud, with-custom-thread-list, with-elevenlabs-conversational, with-elevenlabs-scribe, with-livekit, with-expo, with-interactables, with-external-store, with-ffmpeg, with-langgraph, with-react-hook-form, with-react-ink, with-react-router, with-tanstack, with-resumable-stream, with-openui)",
       "required": true
     },
     {

--- a/apps/docs/content/docs/(docs)/cli.mdx
+++ b/apps/docs/content/docs/(docs)/cli.mdx
@@ -78,6 +78,7 @@ Use `--example` to create a project from one of the monorepo examples with full 
 | `with-chain-of-thought` | Chain-of-thought reasoning, tool calls, and source citations | `npx assistant-ui create my-app -e with-chain-of-thought` |
 | `with-external-store` | External message store | `npx assistant-ui create my-app -e with-external-store` |
 | `with-interactables` | AI-driven interactive UI components | `npx assistant-ui create my-app -e with-interactables` |
+| `with-openui` | [OpenUI](/docs/tools/openui) generative UI integration | `npx assistant-ui create my-app -e with-openui` |
 | `with-custom-thread-list` | Custom thread list UI | `npx assistant-ui create my-app -e with-custom-thread-list` |
 | `with-react-hook-form` | React Hook Form integration | `npx assistant-ui create my-app -e with-react-hook-form` |
 | `with-ffmpeg` | FFmpeg video processing tool | `npx assistant-ui create my-app -e with-ffmpeg` |

--- a/apps/docs/content/docs/tools/openui.mdx
+++ b/apps/docs/content/docs/tools/openui.mdx
@@ -21,7 +21,7 @@ assistant-ui's first-party [Generative UI](/docs/tools/generative-ui) follows th
 
 ## Quick start
 
-The complete setup below runs in [`examples/with-openui`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-openui).
+The complete setup below runs in [`examples/with-openui`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-openui). To scaffold a standalone copy, run `npx assistant-ui create my-app --example with-openui`.
 
 <Steps>
 

--- a/examples/with-openui/README.md
+++ b/examples/with-openui/README.md
@@ -6,19 +6,16 @@ assistant-ui owns the chat shell, runtime, messages, streaming, and tool lifecyc
 
 ## Quick Start
 
-### Clone the example
+### Using CLI (Recommended)
 
 ```bash
-git clone https://github.com/assistant-ui/assistant-ui.git
-cd assistant-ui
-pnpm install
+npx assistant-ui@latest create my-app --example with-openui
+cd my-app
 ```
-
-The example runs inside the monorepo with pnpm.
 
 ### Environment Variables
 
-Create `examples/with-openui/.env.local`:
+Create `.env.local`:
 
 ```sh
 OPENAI_API_KEY=your-api-key-here
@@ -26,14 +23,24 @@ OPENAI_API_KEY=your-api-key-here
 
 ### Run
 
-Build the workspace packages the example imports, then start the dev server:
-
 ```bash
-pnpm exec turbo build --filter='with-openui^...'
-pnpm -C examples/with-openui dev
+pnpm install
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to see the result.
+
+### Run inside the monorepo
+
+To develop against the workspace packages directly, clone the repository and build the packages the example imports before starting the dev server. Create `examples/with-openui/.env.local` with your `OPENAI_API_KEY` first.
+
+```bash
+git clone https://github.com/assistant-ui/assistant-ui.git
+cd assistant-ui
+pnpm install
+pnpm exec turbo build --filter='with-openui^...'
+pnpm -C examples/with-openui dev
+```
 
 ## Key Features
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -264,6 +264,14 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     path: "examples/with-resumable-stream",
     hasLocalComponents: false,
   },
+  {
+    name: "with-openui",
+    label: "OpenUI",
+    description: "OpenUI generative UI integration",
+    category: "example",
+    path: "examples/with-openui",
+    hasLocalComponents: false,
+  },
 ];
 
 // Examples that exist in the monorepo but are intentionally excluded from the CLI:
@@ -274,9 +282,6 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
 // - with-store: In development, not ready for public use of the tap store.
 // - with-tap-runtime: In development, not ready for public use of the tap
 //     store.
-// - with-openui: Scaffolded npm installs fail because
-//     @openuidev/react-headless pins an optional peer on ai@^6 against the
-//     example's ai@^7; register once the upstream range widens.
 
 const templateNames = PROJECT_METADATA.filter(
   (m) => m.category === "template",


### PR DESCRIPTION
## summary

- register `with-openui` in `npx assistant-ui create`, unblocked by #5962: `@openuidev/react-headless@0.9.8` widened its `ai` peer to `^6 || ^7`, so CLI-scaffolded npm installs now resolve cleanly against `ai@^7` (the exact failure that reverted the registration in #5930)
- add the `with-openui` row to the CLI docs page and point the example README's quick start back at the CLI, keeping the monorepo path as a secondary section
- mention the scaffold command in the openui guide's quick start
- changeset: patch for the `assistant-ui` CLI package

## test plan

### already verified

- [x] scaffold-shape resolve repro: rewrote the example manifest the way the CLI does (`workspace:*` to `latest`, `@assistant-ui/ui` dropped) and `npm install --package-lock-only` exits 0, pulling `@openuidev/assistant-ui@0.0.3` + `react-headless@0.9.8` + `ai@7.x`
- [x] `pnpm -C apps/docs exec vitest run lib/cli-docs-sync.test.ts` -> 2/2 green (cli.mdx mirrors the registry)
- [x] `pnpm -C packages/cli test` -> 256/256 green
- [x] oxlint + oxfmt clean on the touched files
- [x] live smoke of the example on the bumped deps (display and prompt flows stream end to end)

### reviewer should verify

- [ ] `npx assistant-ui@latest create my-app --example with-openui` scaffolds and `npm install` completes without `--legacy-peer-deps` once the next CLI release ships

## notes

- the api-surface check will push an autofix commit for the CLI registry snapshot; that is expected
- both `@openuidev` entries in `minimumReleaseAgeExclude` become droppable after 2026-08-16T08:02Z; separate cleanup chore
- the upstream renderer crash tracked in thesysdev/openui#990 is unrelated to scaffolding and reproduces identically in the monorepo example

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.H--4dkS_YwJNgbCRe1XzvHYWQOFw_M5wC760Gb1bWEw6g466g30CgnjdI04?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->