### PR TITLE
fix(assistant-stream): release merged stream readers

### DIFF
--- a/.changeset/calm-streams-release.md
+++ b/.changeset/calm-streams-release.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: release merged stream child readers after completion and cancellation

--- a/packages/assistant-stream/src/core/utils/stream/merge.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 import { createMergeStream } from "./merge";
 
 describe("createMergeStream", () => {
+  it("releases child readers after successful completion", async () => {
+    const child = new ReadableStream<never>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const merger = createMergeStream();
+
+    merger.addStream(child);
+    merger.seal();
+
+    await merger.readable.pipeTo(new WritableStream());
+
+    expect(child.locked).toBe(false);
+  });
+
   it("waits for every child reader to finish cancellation", async () => {
     let finishCleanup = () => {};
     const cleanup = new Promise<void>((resolve) => {
@@ -11,8 +27,10 @@ describe("createMergeStream", () => {
     const rejectedCancel = vi.fn(() => Promise.reject(new Error("failed")));
     const merger = createMergeStream();
 
-    merger.addStream(new ReadableStream({ cancel: delayedCancel }));
-    merger.addStream(new ReadableStream({ cancel: rejectedCancel }));
+    const delayedStream = new ReadableStream({ cancel: delayedCancel });
+    const rejectedStream = new ReadableStream({ cancel: rejectedCancel });
+    merger.addStream(delayedStream);
+    merger.addStream(rejectedStream);
 
     let cancelSettled = false;
     const cancel = merger.readable
@@ -31,6 +49,8 @@ describe("createMergeStream", () => {
     finishCleanup();
     await expect(cancel).resolves.toBeUndefined();
     expect(cancelSettled).toBe(true);
+    expect(delayedStream.locked).toBe(false);
+    expect(rejectedStream.locked).toBe(false);
   });
 
   it("cancels streams rejected after sealing", async () => {

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -20,8 +20,12 @@ export const createMergeStream = () => {
     // Repeated cancellation must wait for cleanup already in progress.
     cleanupPromise ??= Promise.all(
       list.splice(0).map(async (item) => {
-        await item.reader.cancel().catch(() => undefined);
-        await item.pipeTask;
+        try {
+          await item.reader.cancel().catch(() => undefined);
+          await item.pipeTask;
+        } finally {
+          item.reader.releaseLock();
+        }
       }),
     ).then(() => undefined);
     return cleanupPromise;
@@ -42,6 +46,7 @@ export const createMergeStream = () => {
 
           if (done) {
             list.splice(list.indexOf(item), 1);
+            item.reader.releaseLock();
             if (sealed && list.length === 0) {
               controller.close();
             }


### PR DESCRIPTION
## Summary

- release each child reader when it reaches EOF
- release readers after awaited cancellation cleanup, including rejected cancellation
- cover successful completion and cancellation with lock-state regression assertions

## Why

`createMergeStream()` removed completed children from its internal list without releasing their reader locks. A fully consumed merged stream therefore left the child stream locked, which can retain stream resources and prevents another reader from being acquired.

## Testing

- `pnpm test` in `packages/assistant-stream` (current and peer suites, 440 passed per suite)
- `pnpm build` in `packages/assistant-stream`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6HaPQ7AmqgP7_CUJeUEA3acstXVdkv6cy3JNCufaqoSgckstfiNI63mNMgQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->