### PR TITLE
fix(assistant-stream): release failed producer readers

### DIFF
--- a/.changeset/warm-readers-release.md
+++ b/.changeset/warm-readers-release.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: release resumable producer readers after stream failures

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -247,9 +247,11 @@ describe("createResumableStreamContext", () => {
     });
   });
 
-  it("propagates producer errors to consumers", async () => {
+  it("propagates producer errors and releases the source reader", async () => {
+    const tasks: Promise<unknown>[] = [];
     const ctx = createResumableStreamContext({
       store: createInMemoryResumableStreamStore(),
+      waitUntil: (task) => tasks.push(task),
     });
     const failing = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -259,7 +261,9 @@ describe("createResumableStreamContext", () => {
     });
     const stream = await ctx.run("a", () => failing);
     await expect(collect(stream)).rejects.toThrow("oops");
+    await Promise.all(tasks);
     expect(await ctx.status("a")).toBe("error");
+    expect(failing.locked).toBe(false);
   });
 
   it("waitUntil receives the producer task promise", async () => {

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
@@ -128,7 +128,6 @@ function startProducerTask(
   const { waitUntil, onAppend, onFinalize, onError } = hooks;
   const task = (async () => {
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
-    let cancelled = false;
     try {
       reader = makeStream().getReader();
       while (true) {
@@ -145,7 +144,6 @@ function startProducerTask(
       await store.finalize(streamId, "done");
       invokeObservabilityHook("onFinalize", onFinalize, streamId, "done");
     } catch (err) {
-      cancelled = true;
       invokeObservabilityHook("onError", onError, streamId, err);
       const message = err instanceof Error ? err.message : String(err);
       try {
@@ -166,7 +164,7 @@ function startProducerTask(
         console.error("resumable stream finalize failed:", finalizeErr);
       }
     } finally {
-      if (!cancelled) reader?.releaseLock();
+      reader?.releaseLock();
     }
   })();
 


### PR DESCRIPTION
## Summary

- release resumable producer readers in the existing `finally` path after both success and failure
- retain cancellation-before-finalization behavior for failed producers
- assert the failed source is unlocked after the background producer task settles

## Why

The producer error path awaited `reader.cancel()` but intentionally skipped `releaseLock()`. A failed source therefore remained locked even after error finalization completed, retaining its reader and associated resources.

## Testing

- `pnpm test` in `packages/assistant-stream` (current and peer suites, 439 passed per suite)
- `pnpm build` in `packages/assistant-stream`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SGPWWJDY62C5Qxw_sY6j1Uy-_bgOzje0LSMXe2lxanvMCMQIQ6BSJRCEfWU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->