### PR TITLE
fix(cloud-ai-sdk): stop chats after cloud scope changes

### DIFF
--- a/.changeset/brave-clouds-stop.md
+++ b/.changeset/brave-clouds-stop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: stop abandoned chats when the Cloud scope changes

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -65,14 +65,12 @@ export class ChatRegistry {
     return this.keyByThreadId.get(threadId);
   }
 
+  // The maps stay populated: stopping emits onFinish(isAbort) whose
+  // persistence path resolves this registry's meta, so the aborted partial
+  // run still saves through the scope it belongs to.
   async stopAll(): Promise<void> {
-    const chats = [...this.chatByKey.values()];
-    this.chatByKey.clear();
-    this.metaByKey.clear();
-    this.keyByThreadId.clear();
-
     await Promise.allSettled(
-      chats.map(async (chat) => {
+      [...this.chatByKey.values()].map(async (chat) => {
         await chat.stop();
       }),
     );

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -64,4 +64,17 @@ export class ChatRegistry {
   getChatKeyForThread(threadId: string): string | undefined {
     return this.keyByThreadId.get(threadId);
   }
+
+  async stopAll(): Promise<void> {
+    const chats = [...this.chatByKey.values()];
+    this.chatByKey.clear();
+    this.metaByKey.clear();
+    this.keyByThreadId.clear();
+
+    await Promise.allSettled(
+      chats.map(async (chat) => {
+        await chat.stop();
+      }),
+    );
+  }
 }

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -118,7 +118,7 @@ describe("useChatRegistry", () => {
     expect(result.current.activeChat).not.toBe(chatA);
     expect(createChat).toHaveBeenCalledTimes(2);
     expect(stop).toHaveBeenCalledOnce();
-    expect(registryA.get("thread-1")).toBeUndefined();
+    expect(registryA.get("thread-1")).toBe(chatA);
   });
 
   it("does not stop chats during ordinary rerenders", () => {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -91,9 +91,12 @@ describe("useChatRegistry", () => {
   });
 
   it("creates a new registry and chat when the scope changes", () => {
-    const createChat = vi
-      .fn()
-      .mockImplementation((chatKey: string) => ({ id: chatKey, messages: [] }));
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
     const scopeA = {};
     const scopeB = {};
 
@@ -114,5 +117,29 @@ describe("useChatRegistry", () => {
     expect(result.current.registry).not.toBe(registryA);
     expect(result.current.activeChat).not.toBe(chatA);
     expect(createChat).toHaveBeenCalledTimes(2);
+    expect(stop).toHaveBeenCalledOnce();
+    expect(registryA.get("thread-1")).toBeUndefined();
+  });
+
+  it("does not stop chats during ordinary rerenders", () => {
+    const scope = {};
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
+
+    const { rerender } = renderHook(() =>
+      useChatRegistry({
+        scope,
+        threadId: "thread-1",
+        createChat: createChat as never,
+      }),
+    );
+
+    rerender();
+
+    expect(stop).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { Chat } from "@ai-sdk/react";
 import type { UIMessage } from "@ai-sdk/react";
 import { ChatRegistry } from "./ChatRegistry";
@@ -68,6 +68,15 @@ export function useChatRegistry({
     : freshSessionKey.current!;
 
   const activeChat = registry.getOrCreate(activeChatKey, threadId);
+
+  const committedRegistryRef = useRef(registry);
+  useEffect(() => {
+    const previousRegistry = committedRegistryRef.current;
+    committedRegistryRef.current = registry;
+    if (previousRegistry !== registry) {
+      void previousRegistry.stopAll();
+    }
+  }, [registry]);
 
   return { registry, activeChat };
 }


### PR DESCRIPTION
## Summary

- stop every chat owned by a registry after a committed Cloud scope change
- keep the retired registry readable while stopping so abort finish callbacks persist through the original Cloud client
- isolate individual stop failures and leave ordinary rerenders untouched

## Why

Switching from Cloud/account/workspace A to B replaced the registry reference without stopping A’s active chats. Their requests could continue generating after the switch and late lifecycle work could still use A’s client.

The cleanup is tied to committed registry identity changes rather than effect cleanup, so React Strict Mode effect rehearsal does not stop the active registry.

## Testing

- `pnpm test` in `packages/cloud-ai-sdk` (81 tests on current and peer AI SDK versions)
- `pnpm run test:types:peer-v6` in `packages/cloud-ai-sdk`
- `pnpm build` in `packages/cloud-ai-sdk`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.3NWmgD_IlZr8GpDBmV0GFmJEatSk-9U2WRrHiJhSiPuBloacCk-wapL022E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->