### PR TITLE
fix(core): handle local history append failures

### DIFF
--- a/.changeset/bright-histories-wait.md
+++ b/.changeset/bright-histories-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: handle failed LocalRuntime user-message history writes without abandoning the run

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -143,6 +143,37 @@ describe("LocalThreadRuntimeCore events", () => {
   });
 });
 
+describe("LocalThreadRuntimeCore history persistence", () => {
+  it("surfaces failed user persistence without abandoning the run", async () => {
+    const persistenceError = new Error("history unavailable");
+    const run = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "done" }],
+    }));
+    const append = vi
+      .fn()
+      .mockRejectedValueOnce(persistenceError)
+      .mockResolvedValueOnce(undefined);
+    const thread = createThread(
+      { run },
+      {
+        history: {
+          async load() {
+            return { messages: [] };
+          },
+          append,
+        },
+      },
+    );
+
+    await expect(thread.append(userMessage("hello"))).rejects.toBe(
+      persistenceError,
+    );
+
+    expect(append).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledOnce();
+  });
+});
+
 describe("LocalThreadRuntimeCore - detach", () => {
   it("drops a pending append when detached", async () => {
     let resolveInitialization!: () => void;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -149,10 +149,9 @@ describe("LocalThreadRuntimeCore history persistence", () => {
     const run = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "done" }],
     }));
-    const append = vi
-      .fn()
-      .mockRejectedValueOnce(persistenceError)
-      .mockResolvedValueOnce(undefined);
+    const append = vi.fn(async (item: ExportedMessageRepositoryItem) => {
+      if (item.message.role === "user") throw persistenceError;
+    });
     const thread = createThread(
       { run },
       {
@@ -171,6 +170,56 @@ describe("LocalThreadRuntimeCore history persistence", () => {
 
     expect(append).toHaveBeenCalledTimes(2);
     expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces failed persistence for messages that do not start a run", async () => {
+    const persistenceError = new Error("history unavailable");
+    const run = vi.fn();
+    const thread = createThread(
+      { run },
+      {
+        history: {
+          async load() {
+            return { messages: [] };
+          },
+          async append() {
+            throw persistenceError;
+          },
+        },
+      },
+    );
+
+    await expect(
+      thread.append({ ...userMessage("hello"), startRun: false }),
+    ).rejects.toBe(persistenceError);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("handles failed persistence before notifying no-run subscribers", async () => {
+    const persistenceError = new Error("history unavailable");
+    const listenerError = new Error("listener unavailable");
+    const thread = createThread(
+      { run: vi.fn() },
+      {
+        history: {
+          async load() {
+            return { messages: [] };
+          },
+          async append() {
+            throw persistenceError;
+          },
+        },
+      },
+    );
+    thread.subscribe(() => {
+      throw listenerError;
+    });
+
+    await expect(
+      thread.append({ ...userMessage("hello"), startRun: false }),
+    ).rejects.toBe(listenerError);
+    await flush();
   });
 });
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -335,7 +335,7 @@ export class LocalThreadRuntimeCore
       reason: "unknown",
     });
     this.repository.addOrUpdateMessage(message.parentId, newMessage);
-    this._options.adapters.history?.append({
+    const historyWrite = this._options.adapters.history?.append({
       parentId: message.parentId,
       message: newMessage,
       ...(message.runConfig !== undefined && { runConfig: message.runConfig }),
@@ -343,14 +343,20 @@ export class LocalThreadRuntimeCore
 
     const startRun = message.startRun ?? message.role === "user";
     if (startRun) {
-      await this.startRun({
-        parentId: newMessage.id,
-        sourceId: message.sourceId,
-        runConfig: message.runConfig ?? {},
-      });
+      const [runResult, historyResult] = await Promise.allSettled([
+        this.startRun({
+          parentId: newMessage.id,
+          sourceId: message.sourceId,
+          runConfig: message.runConfig ?? {},
+        }),
+        historyWrite,
+      ]);
+      if (runResult.status === "rejected") throw runResult.reason;
+      if (historyResult.status === "rejected") throw historyResult.reason;
     } else {
       this.repository.resetHead(newMessage.id);
       this._notifySubscribers();
+      await historyWrite;
     }
   }
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -340,6 +340,7 @@ export class LocalThreadRuntimeCore
       message: newMessage,
       ...(message.runConfig !== undefined && { runConfig: message.runConfig }),
     });
+    void historyWrite?.catch(() => {});
 
     const startRun = message.startRun ?? message.role === "user";
     if (startRun) {


### PR DESCRIPTION
## Summary

- keep each user-message history write concurrent with LocalRuntime run startup
- settle the run and history operations together so the history promise no longer floats independently
- preserve run failures as the primary error when both operations fail
- handle the history rejection immediately, including no-run paths where subscriber notification can throw

## Why

`ThreadHistoryAdapter.append()` returns a promise, but the user-message write in `LocalThreadRuntimeCore` was started without being attached to the append task. A rejecting network, IndexedDB, or custom history adapter could therefore reject independently while the model run continued.

The write remains concurrent so persistence latency does not delay generation. The internal append task now settles it and propagates a persistence-only failure through that task. Existing host-facing error policy is unchanged: composer sends consume their send task, while the imperative `ThreadRuntime.append()` wrapper continues to surface non-`MessageNotSentError` failures according to its existing contract.

Regression coverage verifies user-message persistence failure without abandoning the run, no-run persistence failure, and the subscriber-throw edge case.

## Testing

- `@assistant-ui/core`: 111 test files, 1122 tests passed
- `pnpm --filter @assistant-ui/core... build`
- targeted oxlint and oxfmt checks