### PR TITLE
fix(cloud): validate file API responses

### DIFF
--- a/.changeset/calm-cloud-files.md
+++ b/.changeset/calm-cloud-files.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: validate file API responses before returning them to consumers

--- a/packages/cloud/src/AssistantCloudFiles.test.ts
+++ b/packages/cloud/src/AssistantCloudFiles.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloudAPI } from "./AssistantCloudAPI";
+import { AssistantCloudFiles } from "./AssistantCloudFiles";
+
+const createCloudFiles = () => {
+  const makeRequest = vi.fn();
+  const api = { makeRequest } as unknown as AssistantCloudAPI;
+  return { files: new AssistantCloudFiles(api), makeRequest };
+};
+
+describe("AssistantCloudFiles responses", () => {
+  it("decodes PDF conversion responses", async () => {
+    const { files, makeRequest } = createCloudFiles();
+    makeRequest.mockResolvedValue({
+      success: true,
+      urls: ["https://example.com/page-1.png"],
+      message: "converted",
+    });
+
+    await expect(
+      files.pdfToImages({ file_url: "https://example.com/file.pdf" }),
+    ).resolves.toEqual({
+      success: true,
+      urls: ["https://example.com/page-1.png"],
+      message: "converted",
+    });
+  });
+
+  it("rejects malformed PDF conversion responses", async () => {
+    const { files, makeRequest } = createCloudFiles();
+    makeRequest.mockResolvedValue({
+      success: true,
+      urls: [42],
+      message: "converted",
+    });
+
+    await expect(files.pdfToImages({ file_blob: "data" })).rejects.toThrow(
+      'Invalid Assistant Cloud response for "PDF conversion response.urls[0]": expected a string',
+    );
+  });
+
+  it("decodes presigned upload responses", async () => {
+    const { files, makeRequest } = createCloudFiles();
+    makeRequest.mockResolvedValue({
+      success: true,
+      signedUrl: "https://uploads.example.com/file",
+      expiresAt: "2026-08-16T12:00:00.000Z",
+      publicUrl: "https://cdn.example.com/file",
+    });
+
+    await expect(
+      files.generatePresignedUploadUrl({ filename: "notes.txt" }),
+    ).resolves.toEqual({
+      success: true,
+      signedUrl: "https://uploads.example.com/file",
+      expiresAt: "2026-08-16T12:00:00.000Z",
+      publicUrl: "https://cdn.example.com/file",
+    });
+  });
+
+  it("rejects malformed presigned upload responses", async () => {
+    const { files, makeRequest } = createCloudFiles();
+    makeRequest.mockResolvedValue({});
+
+    await expect(
+      files.generatePresignedUploadUrl({ filename: "notes.txt" }),
+    ).rejects.toThrow(
+      'Invalid Assistant Cloud response for "presigned upload response.success": expected a boolean',
+    );
+  });
+});

--- a/packages/cloud/src/AssistantCloudFiles.ts
+++ b/packages/cloud/src/AssistantCloudFiles.ts
@@ -1,4 +1,10 @@
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
+import {
+  readCloudArray,
+  readCloudBoolean,
+  readCloudRecord,
+  readCloudString,
+} from "./cloudResponse";
 
 type PdfToImagesRequestBody = {
   file_blob?: string | undefined;
@@ -32,21 +38,61 @@ export class AssistantCloudFiles {
   public async pdfToImages(
     body: PdfToImagesRequestBody,
   ): Promise<PdfToImagesResponse> {
-    return this.cloud.makeRequest("/files/pdf-to-images", {
-      method: "POST",
-      body,
-    });
+    const response = readCloudRecord(
+      await this.cloud.makeRequest("/files/pdf-to-images", {
+        method: "POST",
+        body,
+      }),
+      "PDF conversion response",
+    );
+
+    return {
+      success: readCloudBoolean(
+        response.success,
+        "PDF conversion response.success",
+      ),
+      urls: readCloudArray(response.urls, "PDF conversion response.urls").map(
+        (url, index) =>
+          readCloudString(url, `PDF conversion response.urls[${index}]`),
+      ),
+      message: readCloudString(
+        response.message,
+        "PDF conversion response.message",
+      ),
+    };
   }
 
   public async generatePresignedUploadUrl(
     body: GeneratePresignedUploadUrlRequestBody,
   ): Promise<GeneratePresignedUploadUrlResponse> {
-    return this.cloud.makeRequest(
-      "/files/attachments/generate-presigned-upload-url",
-      {
-        method: "POST",
-        body,
-      },
+    const response = readCloudRecord(
+      await this.cloud.makeRequest(
+        "/files/attachments/generate-presigned-upload-url",
+        {
+          method: "POST",
+          body,
+        },
+      ),
+      "presigned upload response",
     );
+
+    return {
+      success: readCloudBoolean(
+        response.success,
+        "presigned upload response.success",
+      ),
+      signedUrl: readCloudString(
+        response.signedUrl,
+        "presigned upload response.signedUrl",
+      ),
+      expiresAt: readCloudString(
+        response.expiresAt,
+        "presigned upload response.expiresAt",
+      ),
+      publicUrl: readCloudString(
+        response.publicUrl,
+        "presigned upload response.publicUrl",
+      ),
+    };
   }
 }


### PR DESCRIPTION
## Summary

- decode PDF conversion responses with the shared Assistant Cloud response validators
- validate presigned upload URLs and metadata before returning them to attachment consumers
- add valid-shape and malformed-response regression coverage for both file methods

## Why

`AssistantCloudFiles` previously cast successful JSON directly to its published response types. A malformed success such as `200 {}` could pass through the Cloud boundary and fail later as `fetch(undefined)` in the attachment adapter, obscuring the actual server contract violation. Array entries in PDF conversion responses were also accepted without validation.

The validated fields match the backend contracts: the presigned-upload endpoint returns `success`, `signedUrl`, `expiresAt`, and `publicUrl` on its 201 response; the historical PDF endpoint returned `success`, `urls`, and `message` on success and used non-2xx errors for failures. The methods now throw `CloudResponseError` with field-level context, matching the validation behavior used by the thread, message, run, and authentication clients.

## Testing

- `assistant-cloud`: 10 test files, 67 tests passed
- `pnpm --filter assistant-cloud... build`
- targeted oxlint and oxfmt checks