### PR TITLE
fix(react-ink): isolate notification callbacks

### DIFF
--- a/.changeset/gentle-ink-notifications.md
+++ b/.changeset/gentle-ink-notifications.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: isolate custom notification callback failures from the terminal runtime

--- a/packages/react-ink/src/hooks/useNotification.ts
+++ b/packages/react-ink/src/hooks/useNotification.ts
@@ -65,6 +65,24 @@ const DEFAULTS = {
   onNeedsInput: NotificationHandler<"needs-input">;
 };
 
+const invokeCustomHandler = <T extends NotificationEvent["type"]>(
+  handler: NonNullable<NotificationHandler<T>["custom"]>,
+  event: Extract<NotificationEvent, { type: T }>,
+) => {
+  const reportError = (error: unknown) => {
+    console.error(
+      `[assistant-ui/react-ink] ${event.type} notification callback threw an error`,
+      error,
+    );
+  };
+
+  try {
+    void Promise.resolve(handler(event)).catch(reportError);
+  } catch (error) {
+    reportError(error);
+  }
+};
+
 const dispatch = <T extends NotificationEvent["type"]>(
   handler: NotificationHandler<T> | false | undefined,
   fallback: NotificationHandler<T>,
@@ -78,7 +96,7 @@ const dispatch = <T extends NotificationEvent["type"]>(
       typeof resolved.osc === "string" ? resolved.osc : "osc9";
     sendOSCNotification(event.title, undefined, variant);
   }
-  resolved.custom?.(event);
+  if (resolved.custom) invokeCustomHandler(resolved.custom, event);
 };
 
 type Snapshot = {

--- a/packages/react-ink/src/tests/useNotification.test.tsx
+++ b/packages/react-ink/src/tests/useNotification.test.tsx
@@ -94,6 +94,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 

--- a/packages/react-ink/src/tests/useNotification.test.tsx
+++ b/packages/react-ink/src/tests/useNotification.test.tsx
@@ -481,6 +481,50 @@ describe("useNotification", () => {
     w.mockRestore();
   });
 
+  it.each([
+    [
+      "synchronous",
+      (error: Error) => () => {
+        throw error;
+      },
+    ],
+    [
+      "asynchronous",
+      (error: Error) => async () => {
+        throw error;
+      },
+    ],
+  ])("isolates %s custom handler errors", async (_name, createCustom) => {
+    const callbackError = new Error("notification unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const custom = createCustom(callbackError);
+    snapshot = {
+      isRunning: true,
+      messages: [makeAssistantMessage("m1", { type: "running" })],
+    };
+    const instance = renderNotifier(
+      <Notifier config={{ onTaskComplete: { custom } }} />,
+    );
+    await flush();
+
+    snapshot = {
+      isRunning: false,
+      messages: [
+        makeAssistantMessage("m1", { type: "complete", reason: "stop" }),
+      ],
+    };
+    instance.rerender(<Notifier config={{ onTaskComplete: { custom } }} />);
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui/react-ink] task-complete notification callback threw an error",
+      callbackError,
+    );
+    consoleError.mockRestore();
+  });
+
   it("calls onTaskIncomplete.custom with the incomplete reason", async () => {
     snapshot = {
       isRunning: true,


### PR DESCRIPTION
## Summary

- isolate synchronous exceptions from custom React Ink notification handlers
- consume and report rejected async notification handlers
- cover both failure modes with a parameterized runtime regression test

## Why

Custom notification handlers are observational hooks, but they were invoked directly inside the notification effect. A synchronous throw could fail the Ink component tree, while an async handler rejection could become a global `unhandledRejection`. Neither failure should interfere with the chat runtime or terminal UI.

Failures are now reported with the notification event type and the existing callback behavior remains unchanged.

## Testing

- `@assistant-ui/react-ink`: 23 test files, 249 tests passed
- `pnpm --filter @assistant-ui/react-ink... build`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.64z7HMj0RBou_Tjs6cAtWktNX9xF1fhyk1IuW7j6eBoJfcyZCKEKm8eX99Y?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->