### PR TITLE
test(cloud-ai-sdk): cover stop failure isolation

### DIFF
--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChatRegistry } from "./ChatRegistry";
+
+describe("ChatRegistry", () => {
+  it("attempts to stop every chat when one stop rejects", async () => {
+    const firstStop = vi.fn().mockRejectedValue(new Error("stop failed"));
+    const secondStop = vi.fn().mockResolvedValue(undefined);
+    const stopByKey = new Map([
+      ["first", firstStop],
+      ["second", secondStop],
+    ]);
+    const registry = new ChatRegistry(
+      (chatKey) =>
+        ({
+          id: chatKey,
+          messages: [],
+          stop: stopByKey.get(chatKey),
+        }) as never,
+    );
+    registry.getOrCreate("first");
+    registry.getOrCreate("second");
+
+    await expect(registry.stopAll()).resolves.toBeUndefined();
+
+    expect(firstStop).toHaveBeenCalledOnce();
+    expect(secondStop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import { ChatRegistry } from "./ChatRegistry";
 
 describe("ChatRegistry", () => {
-  it("attempts to stop every chat when one stop rejects", async () => {
+  it("waits for every stop when one stop rejects", async () => {
     const firstStop = vi.fn().mockRejectedValue(new Error("stop failed"));
-    const secondStop = vi.fn().mockResolvedValue(undefined);
+    let resolveSecond!: () => void;
+    const secondPending = new Promise<void>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const secondStop = vi.fn().mockReturnValue(secondPending);
     const stopByKey = new Map([
       ["first", firstStop],
       ["second", secondStop],
@@ -20,9 +24,19 @@ describe("ChatRegistry", () => {
     registry.getOrCreate("first");
     registry.getOrCreate("second");
 
-    await expect(registry.stopAll()).resolves.toBeUndefined();
+    let stopAllSettled = false;
+    const stopAll = registry.stopAll().then(() => {
+      stopAllSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(firstStop).toHaveBeenCalledOnce();
     expect(secondStop).toHaveBeenCalledOnce();
+    expect(stopAllSettled).toBe(false);
+
+    resolveSecond();
+    await expect(stopAll).resolves.toBeUndefined();
+    expect(stopAllSettled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- add focused coverage for `ChatRegistry.stopAll()` failure isolation
- verify one rejected `chat.stop()` does not prevent another chat from being stopped
- verify `stopAll()` resolves after all stop attempts settle

## Why

Follow-up to the remaining review on #5976. The production implementation already uses `Promise.allSettled`; this test locks in that behavior so a future change cannot accidentally short-circuit the remaining chats.

## Testing

- `pnpm exec vitest run src/chat/ChatRegistry.test.ts`
- `pnpm exec vitest run --config vitest.peer-v6.config.ts src/chat/ChatRegistry.test.ts`
- cloud-ai-sdk full suite: 84/84 on both current and peer AI SDK versions
- `pnpm --filter @assistant-ui/cloud-ai-sdk test:types:peer-v6`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`

No changeset: test-only change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.imvLZ2vThEw_yh0mVhJMpTxO0lhBakSqVCH_HzUHCVbtAZ8EKmACqljVfwQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->