### PR TITLE
fix(react): keep bottom follow through a content-growth undershoot

### DIFF
--- a/.changeset/fix-5970-growth-follow.md
+++ b/.changeset/fix-5970-growth-follow.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep bottom follow through a content-growth undershoot

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect, useState, type FC, type PropsWithChildren } from "react";
 import { useAuiState } from "@assistant-ui/store";
 import { AssistantRuntimeProvider } from "../../context";
+import { useThreadViewport } from "../../context/react/ThreadViewportContext";
 import * as MessagePrimitive from "../message";
 import { ThreadPrimitiveMessages } from "./ThreadMessages";
 import { ThreadPrimitiveRoot } from "./ThreadRoot";
@@ -152,6 +153,11 @@ const Message: FC = () => (
   </MessagePrimitive.Root>
 );
 
+const AtBottom: FC = () => {
+  const isAtBottom = useThreadViewport((s) => s.isAtBottom);
+  return <output data-testid="is-at-bottom">{String(isAtBottom)}</output>;
+};
+
 const Thread = ({
   autoScroll,
   scrollToBottomOnInitialize,
@@ -167,6 +173,7 @@ const Thread = ({
       scrollToBottomOnInitialize={scrollToBottomOnInitialize}
     >
       <ThreadPrimitiveMessages components={{ Message }} />
+      <AtBottom />
     </ThreadPrimitiveViewport>
   </ThreadPrimitiveRoot>
 );
@@ -175,6 +182,7 @@ const BottomAnchorThread = () => (
   <ThreadPrimitiveRoot>
     <ThreadPrimitiveViewport data-testid="viewport">
       <ThreadPrimitiveMessages components={{ Message }} />
+      <AtBottom />
     </ThreadPrimitiveViewport>
   </ThreadPrimitiveRoot>
 );
@@ -340,6 +348,7 @@ describe("useThreadViewportAutoScroll", () => {
     act(notifyResizeObservers);
 
     expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
+    expect(screen.getByTestId("is-at-bottom").textContent).toBe("true");
   });
 
   it("does not resume bottom follow after a stable-height user scroll-up", async () => {
@@ -365,6 +374,7 @@ describe("useThreadViewportAutoScroll", () => {
 
     expect(viewport.scrollTop).toBe(scrollTopAfterLeave);
     expect(viewport.scrollTop).toBeLessThan(getMaxScrollTop(viewport));
+    expect(screen.getByTestId("is-at-bottom").textContent).toBe("false");
   });
 
   it("defers auto-scroll to an active top anchor only while the run is active", async () => {
@@ -456,5 +466,8 @@ describe("useThreadViewportAutoScroll", () => {
     });
 
     expect(getViewport().scrollTop).toBe(0);
+    viewportMeasurementOffset += 200;
+    act(notifyResizeObservers);
+    expect(screen.getByTestId("is-at-bottom").textContent).toBe("false");
   });
 });

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
@@ -312,6 +312,61 @@ describe("useThreadViewportAutoScroll", () => {
     scrollToSpy.mockRestore();
   });
 
+  it("keeps following after a content-growth burst undershoots the bottom", async () => {
+    render(
+      <SyncRuntimeProvider>
+        <BottomAnchorThread />
+      </SyncRuntimeProvider>,
+    );
+
+    const viewport = getViewport();
+    await waitFor(() => {
+      expect(screen.getAllByTestId("thread-message")).toHaveLength(
+        messages.length,
+      );
+      expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
+    });
+
+    const scrollTopBeforeBurst = viewport.scrollTop;
+    viewportMeasurementOffset += 164;
+    act(() => {
+      viewport.scrollTop = scrollTopBeforeBurst + 106;
+      viewport.dispatchEvent(new Event("scroll"));
+      viewport.dispatchEvent(new Event("scroll"));
+    });
+    expect(viewport.scrollTop).toBeLessThan(getMaxScrollTop(viewport));
+
+    viewportMeasurementOffset += 200;
+    act(notifyResizeObservers);
+
+    expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
+  });
+
+  it("does not resume bottom follow after a stable-height user scroll-up", async () => {
+    render(
+      <SyncRuntimeProvider>
+        <BottomAnchorThread />
+      </SyncRuntimeProvider>,
+    );
+
+    const viewport = getViewport();
+    await waitFor(() => {
+      expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
+    });
+
+    act(() => {
+      viewport.scrollTop = viewport.scrollTop - 80;
+      viewport.dispatchEvent(new Event("scroll"));
+    });
+
+    const scrollTopAfterLeave = viewport.scrollTop;
+    viewportMeasurementOffset += 200;
+    act(notifyResizeObservers);
+
+    expect(viewport.scrollTop).toBe(scrollTopAfterLeave);
+    expect(viewport.scrollTop).toBeLessThan(getMaxScrollTop(viewport));
+  });
+
   it("defers auto-scroll to an active top anchor only while the run is active", async () => {
     let releaseRun!: () => void;
     const runGate = new Promise<void>((resolve) => {

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -124,6 +124,10 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
       // no-op: a smooth scroll-to-bottom fires many midpoint scroll events
       // before landing, don't flicker isAtBottom or clear intent mid-animation
     } else {
+      const isUserScrollUp =
+        lastScrollTop.current > div.scrollTop &&
+        lastScrollHeight.current === div.scrollHeight;
+
       if (newIsAtBottom) {
         // newIsAtBottom is ambiguous when the viewport doesn't overflow —
         // keep intent alive until content can actually scroll
@@ -131,16 +135,12 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
         if (viewportOverflows) {
           scrollingToBottomBehaviorRef.current = null;
         }
-      } else if (
-        lastScrollTop.current > div.scrollTop &&
-        lastScrollHeight.current === div.scrollHeight
-      ) {
+      } else if (isUserScrollUp) {
         // scrollHeight equality rules out content-driven shifts being misread as user scroll-up
         scrollingToBottomBehaviorRef.current = null;
       }
 
-      const shouldUpdate =
-        newIsAtBottom || scrollingToBottomBehaviorRef.current === null;
+      const shouldUpdate = newIsAtBottom || isUserScrollUp;
 
       if (shouldUpdate && newIsAtBottom !== isAtBottom) {
         writableStore(threadViewportStore).setState({

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.ts
@@ -3,6 +3,7 @@
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { useCallback, useLayoutEffect, useRef, type RefCallback } from "react";
 import { useAuiEvent, useAuiState } from "@assistant-ui/store";
+import { isUserScrollUp } from "@assistant-ui/store/client";
 import { useOnResizeContent } from "../../utils/hooks/useOnResizeContent";
 import { useOnScrollToBottom } from "../../utils/hooks/useOnScrollToBottom";
 import { useManagedRef } from "../../utils/hooks/useManagedRef";
@@ -68,11 +69,13 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
   // triggers, cleared when handleScroll confirms we reached bottom, or when the
   // user actively scrolls up while content size is stable.
   const scrollingToBottomBehaviorRef = useRef<ScrollBehavior | null>(null);
+  const followBottomRef = useRef(autoScroll);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
     const div = divRef.current;
     if (!div) return;
 
+    followBottomRef.current = true;
     scrollingToBottomBehaviorRef.current = behavior;
     div.scrollTo({ top: div.scrollHeight, behavior });
   }, []);
@@ -124,9 +127,13 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
       // no-op: a smooth scroll-to-bottom fires many midpoint scroll events
       // before landing, don't flicker isAtBottom or clear intent mid-animation
     } else {
-      const isUserScrollUp =
-        lastScrollTop.current > div.scrollTop &&
-        lastScrollHeight.current === div.scrollHeight;
+      const userScrolledUp = isUserScrollUp(
+        {
+          scrollTop: lastScrollTop.current,
+          scrollHeight: lastScrollHeight.current,
+        },
+        div,
+      );
 
       if (newIsAtBottom) {
         // newIsAtBottom is ambiguous when the viewport doesn't overflow —
@@ -135,12 +142,14 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
         if (viewportOverflows) {
           scrollingToBottomBehaviorRef.current = null;
         }
-      } else if (isUserScrollUp) {
-        // scrollHeight equality rules out content-driven shifts being misread as user scroll-up
+        if (autoScroll) followBottomRef.current = true;
+      } else if (userScrolledUp) {
         scrollingToBottomBehaviorRef.current = null;
+        followBottomRef.current = false;
       }
 
-      const shouldUpdate = newIsAtBottom || isUserScrollUp;
+      const shouldUpdate =
+        newIsAtBottom || scrollingToBottomBehaviorRef.current === null;
 
       if (shouldUpdate && newIsAtBottom !== isAtBottom) {
         writableStore(threadViewportStore).setState({
@@ -176,7 +185,7 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     } else if (
       autoScroll &&
       !(isRunning && hasActiveTopAnchor()) &&
-      threadViewportStore.getState().isAtBottom
+      followBottomRef.current
     ) {
       scrollToBottom("instant");
     }
@@ -190,6 +199,7 @@ export const useThreadViewportAutoScroll = <TElement extends HTMLElement>({
     // the next content growth, e.g. expanding a collapsible tool call.
     const cancelPendingScrollToBottom = () => {
       scrollingToBottomBehaviorRef.current = null;
+      followBottomRef.current = false;
     };
     el.addEventListener("scroll", handleScroll);
     el.addEventListener("pointerdown", cancelPendingScrollToBottom);


### PR DESCRIPTION
closes #5970

## summary

- `turnAnchor="bottom"` no longer latches `isAtBottom` false on a content-growth undershoot, so later resize ticks keep following
- `handleScroll` now publishes `isAtBottom` only when the viewport is at the bottom or the user scrolls up at a stable height (the #4141 leave signal)
- #5972 tried to keep a live intent through a 2px upward event. that is a different race and does not match the measured burst

## test plan

### already verified

- [x] `pnpm exec vitest run src/primitives/thread/useThreadViewportAutoScroll.test.tsx` in `@assistant-ui/react` -> 7/7, including the new undershoot case (`646` vs `904` on current `main`) and the stable-height scroll-up guard
- [x] chrome harness (`turnAnchor="bottom"`, `scroll-smooth`, 12ms chunks, 390px viewport): the fixed hook followed a ~23k px burst to gap 0 and never published `isAtBottom` false. the same harness on current `main` also followed, so chrome did not reproduce the reporter's permanent freeze on this primitives-only stream

### reviewer should verify

- [ ] a real markdown/ai-sdk thread with `turnAnchor="bottom"` and a fast answer-body burst still stays pinned, and a deliberate wheel/trackpad scroll-up still stops follow

## notes

- #5972 should be closed as the wrong mechanism once this lands

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Gn12-7xmh5iYRz9gs04bCidU-94URhfd5odPwTcDDwXZI-7XpsDz2nmpl3k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->