### PR TITLE
fix(react-ag-ui): cancel active runs on runtime teardown

### DIFF
--- a/.changeset/calm-cats-cancel.md
+++ b/.changeset/calm-cats-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): cancel active runs on runtime teardown

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -16,7 +16,7 @@ Reference for the runtime's API surface. Start with [quickstart](/docs/runtimes/
 | `showThinking` | `boolean` | Whether to render `THINKING_*` and `REASONING_*` events as visible reasoning. Defaults to `true`. |
 | `autoCancelPendingToolCalls` | `boolean` | Cancel unresolved client-side tool calls automatically when the user sends, edits, or reloads a message. Defaults to `true`. See [below](#auto-cancelling-pending-tool-calls). |
 | `onError` | `(e: Error) => void` | Error callback fired on `RUN_ERROR` events and protocol errors. |
-| `onCancel` | `() => void` | Cancellation callback fired when the user cancels a run. |
+| `onCancel` | `() => void` | Cancellation callback fired when a run is cancelled, including user cancel and runtime teardown. |
 | `adapters` | `UseAgUiRuntimeAdapters` | Standard adapter slots (see below). |
 
 ## Adapter slots

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -200,6 +200,9 @@ export class AgUiThreadRuntimeCore {
 
   detachRuntime() {
     this.runtime = undefined;
+    void this.cancel().catch((error) => {
+      this.logger.error("[agui] failed to cancel run during teardown", error);
+    });
   }
 
   getMessages(): readonly ThreadMessage[] {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -610,6 +610,38 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(agent.abortRun).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels an active run when the runtime detaches", async () => {
+    let runSignal: AbortSignal | undefined;
+    const agent = {
+      runAgent: vi.fn((_input, _subscriber, { signal }) => {
+        runSignal = signal;
+        return new Promise((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const appendPromise = core.append(createAppendMessage());
+
+    await vi.waitFor(() => expect(runSignal).toBeDefined());
+    core.detachRuntime();
+
+    expect(agent.abortRun).toHaveBeenCalledTimes(1);
+    expect(runSignal?.aborted).toBe(true);
+    await expect(appendPromise).resolves.toBeUndefined();
+    expect(core.isRunning()).toBe(false);
+  });
+
   it.each(["throws", "rejects"] as const)(
     "keeps cancellation settled when onCancel %s",
     async (failureMode) => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -630,7 +630,8 @@ describe("AGUIThreadRuntimeCore", () => {
       abortRun: vi.fn(),
     } as unknown as HttpAgent;
 
-    const core = createCore(agent);
+    const onCancel = vi.fn();
+    const core = createCore(agent, { onCancel });
     const appendPromise = core.append(createAppendMessage());
 
     await vi.waitFor(() => expect(runSignal).toBeDefined());
@@ -638,6 +639,7 @@ describe("AGUIThreadRuntimeCore", () => {
 
     expect(agent.abortRun).toHaveBeenCalledTimes(1);
     expect(runSignal?.aborted).toBe(true);
+    expect(onCancel).toHaveBeenCalledTimes(1);
     await expect(appendPromise).resolves.toBeUndefined();
     expect(core.isRunning()).toBe(false);
   });


### PR DESCRIPTION
## Summary

- cancel the active AG-UI run when its runtime detaches
- route teardown through the existing cancellation path so both `agent.abortRun()` and the local request signal are triggered
- consume and log teardown-only cancellation failures

## Why

Unmounting `useAgUiRuntime()` called `detachRuntime()`, but that method only cleared the runtime reference. An active request therefore kept running, its signal remained un-aborted, and the agent's `abortRun()` hook was never called.

A focused regression test starts a pending run, detaches the runtime, and verifies that the agent cancellation hook runs, the request signal aborts, and the runtime settles.

## Testing

- `pnpm --filter @assistant-ui/react-ag-ui test` (11 files, 374 tests)
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `pnpm lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.S8DWyxNVXwfKWzfEHeHtdSpIlliyXzao4S9ww_kcuZ03fCIEYqcqy35CryY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->