### PR TITLE
fix(react-google-adk): cancel streams on runtime teardown

### DIFF
--- a/.changeset/warm-ants-abort.md
+++ b/.changeset/warm-ants-abort.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix(react-google-adk): cancel active streams on runtime teardown

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -130,6 +130,41 @@ describe("ADK runtime callbacks", () => {
   });
 });
 
+describe("ADK stream lifecycle", () => {
+  it("aborts the active stream when the hook unmounts", async () => {
+    let runSignal: AbortSignal | undefined;
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const stream: AdkStreamCallback = async function* (
+      _messages,
+      { abortSignal },
+    ) {
+      runSignal = abortSignal;
+      resolveStarted();
+      await new Promise<void>((resolve) => {
+        abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    };
+    const { result, unmount } = renderHook(() => useAdkMessages({ stream }));
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendMessage(
+        [{ id: "user", type: "human", content: "hello" }],
+        {},
+      );
+    });
+    await started;
+
+    unmount();
+
+    expect(runSignal?.aborted).toBe(true);
+    await expect(sendPromise).resolves.toBeUndefined();
+  });
+});
+
 describe("optimistic confirmation replies", () => {
   const confirmationCall = (id: string): AdkMessage => ({
     id: `ai-${id}`,

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useAui } from "@assistant-ui/store";
 import { AdkEventAccumulator } from "./AdkEventAccumulator";
@@ -244,6 +244,8 @@ export const useAdkMessages = ({
       abortControllerRef.current.abort();
     }
   }, []);
+
+  useEffect(() => cancel, [cancel]);
 
   return {
     messages,


### PR DESCRIPTION
## Summary

- abort the active Google ADK stream when `useAdkMessages()` unmounts
- reuse the hook's existing `cancel()` callback for teardown
- add a regression test covering a pending stream during unmount

## Why

`useAdkMessages()` stored the active stream's `AbortController` for explicit cancellation, but registered no unmount cleanup. Removing the runtime therefore left the request signal active and allowed server or model work to continue after the consumer disappeared.

The regression test starts a pending stream, unmounts the hook, and verifies that the same signal passed to the stream is aborted and the send settles cleanly.

## Testing

- `pnpm --filter @assistant-ui/react-google-adk test` (11 files, 317 tests)
- `pnpm --filter @assistant-ui/react-google-adk build`
- `pnpm lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-B6UpqCq41FmxCu0FXyTDfixO8QNAIIXlnHlvYW3I2v00rYma8y_ckzx3TY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->