### PR TITLE
docs(tap): document where a throwing snapshot surfaces

### DIFF
--- a/apps/docs/content/tap-docs/tap/differences-from-react.mdx
+++ b/apps/docs/content/tap-docs/tap/differences-from-react.mdx
@@ -58,10 +58,8 @@ tap has a single effect primitive. `useLayoutEffect` and `useInsertionEffect`
 are accepted (so React code ports cleanly) but behave like `useEffect` inside a
 resource.
 
-## A throwing snapshot keeps the committed value
+## Where a throwing snapshot surfaces depends on the host
 
-In React, when a store notifies `useSyncExternalStore` and `getSnapshot`
-throws, React re-renders and the error surfaces during that render. In tap, the
-resource keeps its last committed value and skips the re-render; the throw is
-swallowed for that notification only, and the next notification whose snapshot
-succeeds and differs re-renders as usual. This may change in a future release.
+`useSyncExternalStore` matches React: when a store notifies and `getSnapshot` throws, the snapshot counts as changed and the resource re-renders. The error comes from that render, not from the store's notify loop.
+
+Which render that is depends on the host at the root of the tree, not on the hook that reads the store. A tree owned by a React component ([`useResource`](/tap/docs/tap/api-reference#useresource) called from a component, or [`useTapRoot`](/tap/docs/tap/trees-and-rerenders#separate-scheduling-with-usetaproot), which escalates a throwing update into a host render) surfaces the error in a React render, where an error boundary can catch it. A bare [`createTapRoot`](/tap/docs/tap/api-reference#createtaproot) re-renders in the scheduler flush, so the error is uncaught, the same route every other resource render error takes there.


### PR DESCRIPTION
closes #6010

## summary

- `#5897` already treats a throwing `getSnapshot` as changed and force-renders
- the differences page still described the old swallow. that is now a lie
- the remaining difference is which host render the error comes from: a React-owned tree surfaces in a React render (boundary-catchable); a bare `createTapRoot` surfaces from the scheduler flush

no test plan, docs only

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GKGK6ad5KAeonhJ0r0pdMIoyKepXZEWK3oim6NgJq30s33OnSc75-j3JuoA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->