### PR TITLE
docs(react-generative-ui): name the slack, teams, and a2ui subpaths

### DIFF
--- a/.changeset/genui-readme-subpaths.md
+++ b/.changeset/genui-readme-subpaths.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+docs: name the slack, teams, and a2ui converter subpaths in the README

--- a/packages/react-generative-ui/README.md
+++ b/packages/react-generative-ui/README.md
@@ -137,7 +137,7 @@ surface instead of inline. See the
 
 ## Slack, Teams, and A2UI
 
-The same tree is plain JSON, so it is not tied to the browser. Three React-free subpaths convert it for Slack Block Kit, Microsoft Teams Adaptive Cards, and inbound [A2UI](https://a2ui.org/) surfaces. They run in server actions, queue workers, and webhook handlers. What each target does with a component, and how unsupported content degrades, is documented on [Generative UI on Slack](https://www.assistant-ui.com/docs/tools/generative-ui-slack), [Generative UI on Microsoft Teams](https://www.assistant-ui.com/docs/tools/generative-ui-teams), and [A2UI over AG-UI](https://www.assistant-ui.com/docs/tools/a2ui).
+The same tree is plain JSON, so it is not tied to the browser. Three React-free subpaths convert it for Slack Block Kit, Microsoft Teams Adaptive Cards, and inbound [A2UI](https://a2ui.org/) surfaces. They run in server actions, queue workers, and webhook handlers. Conversion is over the built-in vocabulary; a `$type` outside it is dropped with a warning. What each target does with a component, and how unsupported content degrades, is documented on [Generative UI on Slack](https://www.assistant-ui.com/docs/tools/generative-ui-slack), [Generative UI on Microsoft Teams](https://www.assistant-ui.com/docs/tools/generative-ui-teams), and [A2UI over AG-UI](https://www.assistant-ui.com/docs/tools/a2ui).
 
 ### `@assistant-ui/react-generative-ui/slack`
 
@@ -172,9 +172,14 @@ const { card, warnings } = toAdaptiveCard({
 The inbound direction: applies A2UI surface operations (`applyA2uiOperations`) and converts a surface into a vocabulary tree (`convertSurfaceToUISpec`) that renders through the same `present` path.
 
 ```ts
-import { convertSurfaceToUISpec } from "@assistant-ui/react-generative-ui/a2ui";
+import {
+  applyA2uiOperations,
+  convertSurfaceToUISpec,
+} from "@assistant-ui/react-generative-ui/a2ui";
 
-const { spec, warnings } = convertSurfaceToUISpec(surface);
+const { state } = applyA2uiOperations(new Map(), operations);
+const surface = state.get("s1");
+const { spec, warnings } = convertSurfaceToUISpec(surface!);
 ```
 
 ## License

--- a/packages/react-generative-ui/README.md
+++ b/packages/react-generative-ui/README.md
@@ -178,8 +178,9 @@ import {
 } from "@assistant-ui/react-generative-ui/a2ui";
 
 const { state } = applyA2uiOperations(new Map(), operations);
-const surface = state.get("s1");
-const { spec, warnings } = convertSurfaceToUISpec(surface!);
+for (const surface of state.values()) {
+  const { spec, warnings } = convertSurfaceToUISpec(surface);
+}
 ```
 
 ## License

--- a/packages/react-generative-ui/README.md
+++ b/packages/react-generative-ui/README.md
@@ -135,6 +135,48 @@ Pass `present({ display: "standalone" })` to render the component on its own
 surface instead of inline. See the
 [`"use generative"` docs](https://www.assistant-ui.com/docs) for the build setup.
 
+## Slack, Teams, and A2UI
+
+The same tree is plain JSON, so it is not tied to the browser. Three React-free subpaths convert it for Slack Block Kit, Microsoft Teams Adaptive Cards, and inbound [A2UI](https://a2ui.org/) surfaces. They run in server actions, queue workers, and webhook handlers. What each target does with a component, and how unsupported content degrades, is documented on [Generative UI on Slack](https://www.assistant-ui.com/docs/tools/generative-ui-slack), [Generative UI on Microsoft Teams](https://www.assistant-ui.com/docs/tools/generative-ui-teams), and [A2UI over AG-UI](https://www.assistant-ui.com/docs/tools/a2ui).
+
+### `@assistant-ui/react-generative-ui/slack`
+
+Converts a tree to Slack Block Kit JSON (`toSlackBlocks`), decodes `block_actions` webhooks back into `$action` payloads (`decodeBlockAction`), and maps Block Kit back into vocabulary nodes (`fromSlackBlocks`).
+
+```ts
+import { toSlackBlocks } from "@assistant-ui/react-generative-ui/slack";
+
+const { blocks, warnings } = toSlackBlocks({
+  $type: "Card",
+  title: "Order #48213",
+  children: [{ $type: "Text", value: "Shipped, arriving Thursday." }],
+});
+```
+
+### `@assistant-ui/react-generative-ui/teams`
+
+Converts a tree to a Microsoft Teams Adaptive Card (`toAdaptiveCard`) or bot-framework attachments with root-carousel support (`toTeamsAttachments`), and decodes an incoming `activity.value` (`decodeSubmitData`).
+
+```ts
+import { toAdaptiveCard } from "@assistant-ui/react-generative-ui/teams";
+
+const { card, warnings } = toAdaptiveCard({
+  $type: "Card",
+  title: "Order #48213",
+  children: [{ $type: "Text", value: "Shipped, arriving Thursday." }],
+});
+```
+
+### `@assistant-ui/react-generative-ui/a2ui`
+
+The inbound direction: applies A2UI surface operations (`applyA2uiOperations`) and converts a surface into a vocabulary tree (`convertSurfaceToUISpec`) that renders through the same `present` path.
+
+```ts
+import { convertSurfaceToUISpec } from "@assistant-ui/react-generative-ui/a2ui";
+
+const { spec, warnings } = convertSurfaceToUISpec(surface);
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## summary

- the published README never mentioned `./slack`, `./teams`, or `./a2ui`, so the converters were invisible on npm
- this adds the three subpaths with a short example each, and links the existing Slack, Teams, and A2UI guides for fidelity and degradation
- no new docs page. a 27-row warns/silent matrix would drift from those guides (see #5632)

no test plan, docs only

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.cOXZ5iKinBdKKtaqKYACxXK2rNU2e1SEX5es8Zy9H-RLGCnqTG_LnYkKRko?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->