### PR TITLE
fix(core): resync thread snapshots and load late history

### DIFF
--- a/.changeset/thread-snapshot-late-history.md
+++ b/.changeset/thread-snapshot-late-history.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: resync a memoized thread snapshot when a subscriber connects, and load local history if the adapter arrives after the first load

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
 import { act, render, waitFor } from "@testing-library/react";
-import { StrictMode } from "react";
+import { type FC, StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AssistantCloud } from "assistant-cloud";
+import { useAui, useAuiState } from "@assistant-ui/store";
 import type { ChatModelAdapter } from "../../runtime/utils/chat-model-adapter";
 import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
 import { useLocalRuntime } from "./useLocalRuntime";
@@ -31,6 +32,35 @@ afterEach(() => {
 });
 
 describe("useLocalRuntime", () => {
+  it("surfaces the live thread after mount without user input", async () => {
+    const auiRef: { current: ReturnType<typeof useAui> | null } = {
+      current: null,
+    };
+    const loadingRef = { current: true };
+    const Capture: FC = () => {
+      auiRef.current = useAui();
+      loadingRef.current = useAuiState((s) => s.thread.isLoading);
+      return null;
+    };
+
+    const App = () => {
+      const runtime = useLocalRuntime(chatModel, {
+        unstable_enableMessageQueue: true,
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <Capture />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => {
+      expect(loadingRef.current).toBe(false);
+      expect(auiRef.current!.thread.getState().capabilities.queue).toBe(true);
+    });
+  });
+
   it("keeps the Cloud thread list loaded across unrelated rerenders", async () => {
     const firstCloud = makeCloud();
     const secondCloud = makeCloud();

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -1465,4 +1465,41 @@ describe("LocalThreadRuntimeCore runs", () => {
     expect(thread.capabilities.attachments).toBe(false);
     expect(thread.capabilities.feedback).toBe(false);
   });
+
+  it("loads history when the adapter arrives after the first load", async () => {
+    const adapter: ChatModelAdapter = {
+      run: async () => ({ content: [] }),
+    };
+    const thread = createPlainThread(adapter);
+    const load = vi.fn(async () => ({
+      headId: "restored",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "restored",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "hello" }],
+            createdAt: new Date(0),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+    }));
+
+    thread.__internal_load();
+    expect(load).not.toHaveBeenCalled();
+    expect(thread.messages).toHaveLength(0);
+
+    thread.__internal_setOptions({
+      adapters: {
+        chatModel: adapter,
+        history: { load, append: async () => {} },
+      },
+    });
+    await flush();
+
+    expect(load).toHaveBeenCalledOnce();
+    expect(thread.messages.map((message) => message.id)).toEqual(["restored"]);
+  });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -1502,4 +1502,73 @@ describe("LocalThreadRuntimeCore runs", () => {
     expect(load).toHaveBeenCalledOnce();
     expect(thread.messages.map((message) => message.id)).toEqual(["restored"]);
   });
+
+  it("does not load late history over a thread that already has messages", async () => {
+    const adapter: ChatModelAdapter = {
+      run: async () => ({ content: [] }),
+    };
+    const thread = createPlainThread(adapter);
+    const load = vi.fn(async () => ({
+      headId: "restored",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "restored",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "hello" }],
+            createdAt: new Date(0),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+    }));
+
+    thread.__internal_load();
+    await thread.append({ ...userMessage("typed"), startRun: false });
+    expect(thread.messages).toHaveLength(1);
+
+    thread.__internal_setOptions({
+      adapters: {
+        chatModel: adapter,
+        history: { load, append: async () => {} },
+      },
+    });
+    await flush();
+
+    expect(load).not.toHaveBeenCalled();
+    expect(thread.messages.map((message) => message.content)).toEqual([
+      [{ type: "text", text: "typed" }],
+    ]);
+  });
+
+  it("logs a rejected late history load", async () => {
+    const adapter: ChatModelAdapter = {
+      run: async () => ({ content: [] }),
+    };
+    const thread = createPlainThread(adapter);
+    const error = new Error("history unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    thread.__internal_load();
+    thread.__internal_setOptions({
+      adapters: {
+        chatModel: adapter,
+        history: {
+          load: async () => {
+            throw error;
+          },
+          append: async () => {},
+        },
+      },
+    });
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] local thread history load failed:",
+      error,
+    );
+  });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -167,6 +167,7 @@ export class LocalThreadRuntimeCore
   public __internal_setOptions(options: LocalRuntimeOptionsBase) {
     if (this._options === options) return;
 
+    const previousHistory = this._options?.adapters.history;
     this._options = options;
 
     let hasUpdates = false;
@@ -239,13 +240,25 @@ export class LocalThreadRuntimeCore
     }
 
     if (hasUpdates) this._notifySubscribers();
+
+    if (
+      this._loadRequested &&
+      !this._loadPromise &&
+      !previousHistory &&
+      options.adapters.history
+    ) {
+      void this.__internal_load();
+    }
   }
 
   private _loadPromise: Promise<void> | undefined;
+  private _loadRequested = false;
   public __internal_load() {
+    this._loadRequested = true;
     if (this._loadPromise) return this._loadPromise;
+    if (!this.adapters.history) return Promise.resolve();
 
-    const promise = this.adapters.history?.load() ?? Promise.resolve(null);
+    const promise = this.adapters.history.load();
 
     this._isLoading = true;
     this._notifySubscribers();

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -245,9 +245,15 @@ export class LocalThreadRuntimeCore
       this._loadRequested &&
       !this._loadPromise &&
       !previousHistory &&
-      options.adapters.history
+      options.adapters.history &&
+      this.messages.length === 0
     ) {
-      void this.__internal_load();
+      void this.__internal_load().catch((error: unknown) => {
+        console.error(
+          "[assistant-ui] local thread history load failed:",
+          error,
+        );
+      });
     }
   }
 

--- a/packages/core/src/subscribable/subscribable.test.ts
+++ b/packages/core/src/subscribable/subscribable.test.ts
@@ -55,4 +55,17 @@ describe("ShallowMemoizeSubject", () => {
 
     expect(subscriber).not.toHaveBeenCalled();
   });
+
+  it("reads a value that landed while nobody was subscribed", () => {
+    const source = createBinding({ status: "empty" });
+    const subject = new ShallowMemoizeSubject(source.binding);
+    expect(subject.getState()).toEqual({ status: "empty" });
+
+    source.update({ status: "ready" });
+    const subscriber = vi.fn();
+    subject.subscribe(subscriber);
+
+    expect(subject.getState()).toEqual({ status: "ready" });
+    expect(subscriber).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -177,7 +177,9 @@ export class ShallowMemoizeSubject<TState extends object, TPath>
       }
     };
 
-    return this.binding.subscribe(callback);
+    const unsubscribe = this.binding.subscribe(callback);
+    this._syncState();
+    return unsubscribe;
   }
 }
 

--- a/packages/react/src/tests/local-runtime-queue.test.tsx
+++ b/packages/react/src/tests/local-runtime-queue.test.tsx
@@ -482,12 +482,12 @@ describe("local runtime message queue", () => {
     await act(async () => {
       await flush();
     });
-    expect(captured.aui!.thread().getState().capabilities.queue).toBe(true);
+    expect(captured.aui!.thread.getState().capabilities.queue).toBe(true);
 
     await act(async () => {
       rerender(<App enabled={false} />);
       await flush();
     });
-    expect(captured.aui!.thread().getState().capabilities.queue).toBe(false);
+    expect(captured.aui!.thread.getState().capabilities.queue).toBe(false);
   });
 });

--- a/packages/react/src/tests/local-runtime-queue.test.tsx
+++ b/packages/react/src/tests/local-runtime-queue.test.tsx
@@ -482,12 +482,12 @@ describe("local runtime message queue", () => {
     await act(async () => {
       await flush();
     });
-    expect(captured.aui!.thread.getState().capabilities.queue).toBe(true);
+    expect(captured.aui!.thread().getState().capabilities.queue).toBe(true);
 
     await act(async () => {
       rerender(<App enabled={false} />);
       await flush();
     });
-    expect(captured.aui!.thread.getState().capabilities.queue).toBe(false);
+    expect(captured.aui!.thread().getState().capabilities.queue).toBe(false);
   });
 });


### PR DESCRIPTION
## summary

- a `ShallowMemoizeSubject` that received a value while nobody was subscribed kept serving the cached empty state after `subscribe`. connect now resyncs without notifying, so the first connected `getState()` is the live thread rather than the empty placeholder.
- `LocalThreadRuntimeCore.__internal_load` no longer caches a no-history result. if history arrives later via `setOptions` on an empty thread, the requested load actually runs. a rejecting late load is logged. a thread that already has messages (including one constructed with `initialMessages`) is left alone.

## test plan

### already verified

- [x] `vitest run` on `subscribable.test.ts`, `local-thread-runtime-core.test.ts`, and `useLocalRuntime.test.tsx`
- [x] first-paint `isLoading` stays `true` on main without the `_connect` resync, and goes `false` with it
- [x] late history loads on an empty thread, does not overwrite an already-typed thread, and logs a rejecting late load

### reviewer should verify

- [ ] mount a `useLocalRuntime` with `unstable_enableMessageQueue` and confirm the thread is not stuck on `isLoading` or missing the queue capability before any send