### PR TITLE
fix(core): derive composer canCancel from the in-flight run

### DIFF
--- a/.changeset/composer-can-cancel-while-running.md
+++ b/.changeset/composer-can-cancel-while-running.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: derive thread composer canCancel from an in-flight run

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -177,4 +177,49 @@ describe("useLocalRuntime", () => {
     expect(history.load).toHaveBeenCalledTimes(loadsAfterMount);
     expect(consoleError).toHaveBeenCalledTimes(errorsAfterMount);
   });
+
+  it("exposes composer.canCancel while a run started after initial messages is in flight", async () => {
+    const hangingModel: ChatModelAdapter = {
+      async *run({ abortSignal }) {
+        await new Promise<void>((resolve) => {
+          if (abortSignal.aborted) {
+            resolve();
+            return;
+          }
+          abortSignal.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+      },
+    };
+    let runtime: ReturnType<typeof useLocalRuntime> | null = null;
+    const App = () => {
+      runtime = useLocalRuntime(hangingModel, {
+        initialMessages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Hello" }],
+            status: { type: "complete", reason: "stop" },
+          },
+        ],
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <div />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    act(() => {
+      runtime!.thread.append("Run");
+    });
+    await waitFor(() => {
+      expect(runtime!.thread.getState().isRunning).toBe(true);
+      expect(runtime!.thread.composer.getState().canCancel).toBe(true);
+    });
+    act(() => {
+      runtime!.thread.cancelRun();
+    });
+  });
 });

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -42,6 +42,11 @@ export type {
 };
 
 type BaseComposerState = {
+  /**
+   * Whether the composer can cancel the current run. `true` when the runtime
+   * supports cancel and a run is in flight, not merely when cancel is a
+   * capability.
+   */
   readonly canCancel: boolean;
   readonly canSend: boolean;
   readonly isEditing: boolean;

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -199,7 +199,7 @@ export type ThreadState = {
  * reports it directly; the rest fall back to the trailing assistant message.
  */
 export const getThreadRuntimeCoreIsRunning = (
-  runtime: ThreadRuntimeCore,
+  runtime: Pick<ThreadRuntimeCore, "isRunning" | "messages">,
 ): boolean => {
   if (runtime.isRunning !== undefined) return runtime.isRunning;
   const lastMessage = runtime.messages.at(-1);

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -100,7 +100,7 @@ export class DefaultThreadComposerRuntimeCore
   }
 
   public connect() {
-    let lastCanCancel = this.canCancel;
+    let lastCanCancel = false;
     let lastIsSendDisabled = this.runtime.isSendDisabled;
     let lastQueue = this.queue;
     return this.runtime.subscribe(() => {

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -6,6 +6,7 @@ import type {
   ThreadComposerRuntimeCore,
 } from "../interfaces/composer-runtime-core";
 import type { ThreadRuntimeCore } from "../interfaces/thread-runtime-core";
+import { getThreadRuntimeCoreIsRunning } from "../api/thread-runtime";
 import type { QueuePlacement } from "../queue/external-thread-queue-adapter";
 import {
   EMPTY_QUEUE_ITEMS,
@@ -14,12 +15,9 @@ import {
 import { BaseComposerRuntimeCore } from "./base-composer-runtime-core";
 
 const isCancelable = (runtime: Omit<ThreadRuntimeCore, "composer">) => {
+  // capabilities is a subclass field assigned after this composer is constructed
   if (!runtime.capabilities?.cancel) return false;
-  if (runtime.isRunning !== undefined) return runtime.isRunning;
-  const lastMessage = runtime.messages?.at(-1);
-  return (
-    lastMessage?.role === "assistant" && lastMessage.status.type === "running"
-  );
+  return getThreadRuntimeCoreIsRunning(runtime);
 };
 
 export class DefaultThreadComposerRuntimeCore

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -13,13 +13,21 @@ import {
 } from "../../store/scopes/queue-item";
 import { BaseComposerRuntimeCore } from "./base-composer-runtime-core";
 
+const isCancelable = (runtime: Omit<ThreadRuntimeCore, "composer">) => {
+  if (!runtime.capabilities?.cancel) return false;
+  if (runtime.isRunning !== undefined) return runtime.isRunning;
+  const lastMessage = runtime.messages?.at(-1);
+  return (
+    lastMessage?.role === "assistant" && lastMessage.status.type === "running"
+  );
+};
+
 export class DefaultThreadComposerRuntimeCore
   extends BaseComposerRuntimeCore
   implements ThreadComposerRuntimeCore
 {
-  private _canCancel = false;
   public get canCancel() {
-    return this._canCancel;
+    return isCancelable(this.runtime);
   }
 
   public get canSend() {
@@ -94,12 +102,14 @@ export class DefaultThreadComposerRuntimeCore
   }
 
   public connect() {
+    let lastCanCancel = this.canCancel;
     let lastIsSendDisabled = this.runtime.isSendDisabled;
     let lastQueue = this.queue;
     return this.runtime.subscribe(() => {
       let changed = false;
-      if (this.canCancel !== this.runtime.capabilities.cancel) {
-        this._canCancel = this.runtime.capabilities.cancel;
+      const nextCanCancel = this.canCancel;
+      if (lastCanCancel !== nextCanCancel) {
+        lastCanCancel = nextCanCancel;
         changed = true;
       }
       if (lastIsSendDisabled !== this.runtime.isSendDisabled) {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -1572,3 +1572,42 @@ describe("LocalThreadRuntimeCore runs", () => {
     );
   });
 });
+
+describe("LocalRuntimeCore composer.canCancel", () => {
+  it("is true after append when the thread was created with initial messages", async () => {
+    const core = new LocalRuntimeCore(
+      {
+        adapters: {
+          chatModel: {
+            async *run({ abortSignal }) {
+              await new Promise<void>((resolve) => {
+                if (abortSignal.aborted) {
+                  resolve();
+                  return;
+                }
+                abortSignal.addEventListener("abort", () => resolve(), {
+                  once: true,
+                });
+              });
+            },
+          },
+        },
+      },
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+          status: { type: "complete", reason: "stop" },
+        },
+      ],
+    );
+    const thread = core.threads.getMainThreadRuntimeCore();
+    expect(thread.composer.canCancel).toBe(false);
+
+    void thread.append(userMessage("Run"));
+    await flush();
+
+    expect(thread.composer.canCancel).toBe(true);
+    thread.cancelRun();
+  });
+});

--- a/packages/core/src/store/scopes/composer.ts
+++ b/packages/core/src/store/scopes/composer.ts
@@ -27,6 +27,11 @@ export type ComposerState = {
   readonly attachments: readonly Attachment[];
   readonly runConfig: RunConfig;
   readonly isEditing: boolean;
+  /**
+   * Whether the composer can cancel the current run. `true` when the runtime
+   * supports cancel and a run is in flight, not merely when cancel is a
+   * capability.
+   */
   readonly canCancel: boolean;
   /**
    * Whether the composer is currently willing to send. `true` when the

--- a/packages/core/src/tests/composer-can-cancel.test.ts
+++ b/packages/core/src/tests/composer-can-cancel.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
+import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
+import type { ThreadMessage } from "../types/message";
+
+type ThreadRuntimeStub = Omit<ThreadRuntimeCore, "composer"> & {
+  notify: () => void;
+};
+
+const makeRuntimeStub = (
+  overrides: Partial<ThreadRuntimeCore> = {},
+): ThreadRuntimeStub => {
+  const subscribers = new Set<() => void>();
+  return {
+    append: vi.fn(),
+    cancelRun: vi.fn(),
+    getModelContext: () => ({}),
+    subscribe: (cb: () => void) => {
+      subscribers.add(cb);
+      return () => subscribers.delete(cb);
+    },
+    capabilities: { cancel: true },
+    messages: [],
+    isDisabled: false,
+    isSendDisabled: false,
+    isLoading: false,
+    composer: { runConfig: {} },
+    notify: () => {
+      for (const cb of subscribers) cb();
+    },
+    ...overrides,
+  } as unknown as ThreadRuntimeStub;
+};
+
+const runningAssistant = {
+  id: "a1",
+  role: "assistant",
+  status: { type: "running" },
+} as ThreadMessage;
+
+describe("DefaultThreadComposerRuntimeCore.canCancel", () => {
+  it("is false when the runtime is idle even if cancel is supported", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(makeRuntimeStub());
+    expect(composer.canCancel).toBe(false);
+  });
+
+  it("is false when cancel is not a capability", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(
+      makeRuntimeStub({
+        capabilities: { cancel: false },
+        isRunning: true,
+      }),
+    );
+    expect(composer.canCancel).toBe(false);
+  });
+
+  it("is true while the runtime reports isRunning", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(
+      makeRuntimeStub({ isRunning: true }),
+    );
+    expect(composer.canCancel).toBe(true);
+  });
+
+  it("is true while the trailing assistant message is running", () => {
+    const composer = new DefaultThreadComposerRuntimeCore(
+      makeRuntimeStub({ messages: [runningAssistant] }),
+    );
+    expect(composer.canCancel).toBe(true);
+  });
+
+  it("stays false after a runtime notify while idle", () => {
+    const stub = makeRuntimeStub();
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    stub.notify();
+    expect(composer.canCancel).toBe(false);
+  });
+
+  it("notifies subscribers when a run starts", () => {
+    const stub = makeRuntimeStub();
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    const onChange = vi.fn();
+    composer.subscribe(onChange);
+
+    (stub as { isRunning?: boolean }).isRunning = true;
+    stub.notify();
+
+    expect(onChange).toHaveBeenCalled();
+    expect(composer.canCancel).toBe(true);
+  });
+
+  it("returns to false when the run ends", () => {
+    const stub = makeRuntimeStub({ isRunning: true });
+    const composer = new DefaultThreadComposerRuntimeCore(stub);
+    expect(composer.canCancel).toBe(true);
+
+    (stub as { isRunning?: boolean }).isRunning = false;
+    stub.notify();
+
+    expect(composer.canCancel).toBe(false);
+  });
+});

--- a/packages/react/src/primitives/thread/ThreadRoot.test.tsx
+++ b/packages/react/src/primitives/thread/ThreadRoot.test.tsx
@@ -226,4 +226,26 @@ describe("ThreadPrimitiveRoot", () => {
     expect(speech.cancel).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(true);
   });
+
+  it("lets an idle composer fall through so Escape still stops speech", async () => {
+    const speech = createSpeechAdapter();
+    const runtimeRef: RuntimeRef = { current: null };
+    render(
+      <RuntimeProvider runtimeRef={runtimeRef} speech={speech.adapter}>
+        <ThreadPrimitiveRoot>
+          <ComposerPrimitiveInput data-testid="composer" />
+        </ThreadPrimitiveRoot>
+      </RuntimeProvider>,
+    );
+    startSpeaking(runtimeRef);
+    await waitFor(() => {
+      expect(runtimeRef.current!.thread.getState().speech).toBeDefined();
+    });
+
+    const event = dispatchEscape(screen.getByTestId("composer"));
+
+    expect(speech.cancel).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+    expect(runtimeRef.current!.thread.getState().isRunning).toBe(false);
+  });
 });


### PR DESCRIPTION
closes #6021

## summary

- thread composer `canCancel` now tracks an in-flight run (`capabilities.cancel` plus the canonical `isRunning` derivation), matching ExternalThread
- the core field used to latch `capabilities.cancel` on the first runtime notify. `getState()` is a LazyMemoize that can keep the empty-thread `false`, and a run start is not a `canCancel` transition under that latch, so Escape on a late-mounted composer never called `cancel()`
- that is why `ThreadRoot` "lets a composer mounted after the root consume Escape first" failed on main after #5499. idle Escape now falls through to stop-speaking instead of calling `cancelRun()`

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core exec vitest run src/tests/composer-can-cancel.test.ts src/runtimes/local/local-thread-runtime-core.test.ts src/react/runtimes/useLocalRuntime.test.tsx` -> 68/68 green
- [x] `pnpm --filter @assistant-ui/react exec vitest run src/primitives/thread/ThreadRoot.test.tsx` -> 6/6 green, including the running-composer cancel case and the idle-composer stop-speaking case
- [x] `pnpm lint` -> 0 errors

### reviewer should verify

- [ ] start a local runtime with an initial assistant message, send a hanging run, mount the composer, press Escape: the run cancels and speech (if any) is left alone
- [ ] with speech active and no run, press Escape in the composer: speech stops