### PR TITLE
Feat/react acp

### DIFF
--- a/.changeset/react-acp-initial-release.md
+++ b/.changeset/react-acp-initial-release.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-acp": minor
+---
+
+feat: add `@assistant-ui/react-acp`, an adapter that runs Agent Client Protocol (ACP v1) agents inside assistant-ui. Ships `AcpClient` (JSON-RPC over WebSocket or stdio), `AcpThreadRuntimeCore` (maps `session/update` notification streams onto the thread runtime), `useAcpRuntime` (external-store adapter for `AssistantRuntimeProvider`), and `useAcpConnectionState`. Client subscription is StrictMode-safe (effect-driven attach/detach); validated against a live ACP agent server, 46 unit tests.

--- a/api-surface/assistant-ui__react-acp.ts
+++ b/api-surface/assistant-ui__react-acp.ts
@@ -1,0 +1,2025 @@
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
+declare const ACP_PROTOCOL_VERSION = 1;
+
+type AcpAgentCapabilities = {
+  readonly loadSession?: boolean;
+  readonly promptCapabilities?: AcpPromptCapabilities;
+  readonly mcpCapabilities?: ReadonlyJSONObject;
+};
+
+type AcpAnnotations = {
+  readonly audience?: readonly ("assistant" | "user")[];
+  readonly priority?: number;
+};
+
+type AcpAudioContentBlock = {
+  readonly type: "audio";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+type AcpAvailableCommand = {
+  readonly name: string;
+  readonly description: string;
+  readonly input?: {
+    readonly hint: string;
+  };
+};
+
+declare class AcpClient {
+  #private;
+  onSessionUpdate: ((sessionId: string, update: AcpSessionUpdate) => void) | undefined;
+  permissionHandler: AcpPermissionHandler;
+  onConnectionChange: ((state: AcpConnectionState) => void) | undefined;
+  constructor(options: AcpClientOptions);
+  get connectionState(): AcpConnectionState;
+  get sessionId(): string | undefined;
+  get agentInfo(): AcpImplementation | undefined;
+  get agentCapabilities(): AcpAgentCapabilities | undefined;
+  connect(): Promise<AcpInitializeResponse>;
+  ensureSession(): Promise<string>;
+  prompt(content: readonly AcpContentBlock[]): Promise<AcpStopReason>;
+  cancel(): Promise<void>;
+  respondPermission(requestId: JsonRpcId, outcome: AcpPermissionOutcome): void;
+  dispose(): void;
+}
+
+type AcpClientCapabilities = {
+  readonly fs?: {
+    readonly readTextFile?: boolean;
+    readonly writeTextFile?: boolean;
+  };
+  readonly terminal?: boolean;
+};
+
+type AcpClientOptions = {
+  url: string;
+  cwd?: string;
+  mcpServers?: readonly AcpMcpServer[];
+  clientInfo?: AcpImplementation;
+  webSocketFactory?: AcpWebSocketFactory;
+};
+
+type AcpConnectionState = "connected" | "connecting" | "disconnected";
+
+declare class AcpContentAccumulator {
+  #private;
+  get content(): ThreadAssistantMessage["content"];
+  consume(update: {
+    sessionUpdate: string;
+    content?: AcpContentBlock;
+  } & Partial<AcpToolCallUpdate>): boolean;
+  attachApproval(toolCall: AcpToolCallUpdate, approval: ToolCallMessagePart["approval"]): boolean;
+  resolveApproval(approvalId: string, resolution: {
+    approved: boolean;
+    optionId?: string;
+  }): boolean;
+}
+
+type AcpContentBlock = AcpTextContentBlock | AcpImageContentBlock | AcpAudioContentBlock | AcpResourceContentBlock;
+
+declare class AcpError extends Error {
+  readonly code: number;
+  readonly data?: unknown | undefined;
+  constructor(message: string, code: number, data?: unknown | undefined);
+}
+
+type AcpExtras = {
+  readonly connectionState: AcpConnectionState;
+  readonly sessionId: string | undefined;
+  readonly agentInfo: AcpImplementation | undefined;
+  readonly agentCapabilities: AcpAgentCapabilities | undefined;
+  readonly plan: readonly AcpPlanEntry[] | undefined;
+  readonly sessionTitle: string | undefined;
+  readonly currentModeId: string | undefined;
+  readonly availableCommands: readonly AcpAvailableCommand[] | undefined;
+};
+
+type AcpImageContentBlock = {
+  readonly type: "image";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly uri?: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+type AcpImplementation = {
+  readonly name: string;
+  readonly title?: string;
+  readonly version: string;
+};
+
+type AcpInitializeResponse = {
+  readonly protocolVersion: number;
+  readonly agentCapabilities?: AcpAgentCapabilities;
+  readonly agentInfo?: AcpImplementation;
+};
+
+type AcpMcpServer = {
+  readonly name: string;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly url?: string;
+};
+
+type AcpPermissionHandler = (request: AcpPermissionRequest) => AcpPermissionOutcome | Promise<AcpPermissionOutcome>;
+
+type AcpPermissionOption = {
+  readonly optionId: string;
+  readonly name: string;
+  readonly kind: AcpPermissionOptionKind;
+  readonly description?: string;
+};
+
+type AcpPermissionOptionKind = "allow_always" | "allow_once" | "reject_always" | "reject_once";
+
+type AcpPermissionOutcome = {
+  readonly outcome: "selected";
+  readonly optionId: string;
+} | {
+  readonly outcome: "cancelled";
+};
+
+type AcpPermissionRequest = {
+  readonly sessionId: string;
+  readonly toolCall: AcpToolCallUpdate;
+  readonly options: readonly AcpPermissionOption[];
+};
+
+type AcpPermissionsMode = "ask" | "auto-allow";
+
+type AcpPlanEntry = {
+  readonly content: string;
+  readonly priority: "high" | "low" | "medium";
+  readonly status: "completed" | "in_progress" | "pending";
+};
+
+type AcpPromptCapabilities = {
+  readonly image?: boolean;
+  readonly audio?: boolean;
+  readonly embeddedContext?: boolean;
+};
+
+type AcpResourceContentBlock = {
+  readonly type: "resource";
+  readonly resource: AcpResourceLink;
+  readonly annotations?: AcpAnnotations;
+};
+
+type AcpResourceLink = {
+  readonly uri: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly mimeType?: string;
+  readonly text?: string;
+  readonly blob?: string;
+};
+
+type AcpSessionUpdate = {
+  readonly sessionUpdate: "agent_message_chunk";
+  readonly content: AcpContentBlock;
+  readonly stopReason?: AcpStopReason;
+} | {
+  readonly sessionUpdate: "agent_thought_chunk";
+  readonly content: AcpContentBlock;
+} | ({
+  readonly sessionUpdate: "tool_call";
+} & AcpToolCall) | ({
+  readonly sessionUpdate: "tool_call_update";
+} & AcpToolCallUpdate) | {
+  readonly sessionUpdate: "plan";
+  readonly entries: readonly AcpPlanEntry[];
+} | {
+  readonly sessionUpdate: "available_commands_update";
+  readonly availableCommands: readonly AcpAvailableCommand[];
+} | {
+  readonly sessionUpdate: "current_mode_update";
+  readonly currentModeId: string;
+} | {
+  readonly sessionUpdate: "session_info_update";
+  readonly title?: string;
+  readonly updatedAt?: string;
+} | {
+  readonly sessionUpdate: "user_message_chunk";
+  readonly content: AcpContentBlock;
+};
+
+type AcpStopReason = "cancelled" | "end_turn" | "max_tokens" | "max_turn_requests" | "refusal";
+
+type AcpTextContentBlock = {
+  readonly type: "text";
+  readonly text: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+declare class AcpThreadRuntimeCore {
+  #private;
+  constructor(options: AcpThreadRuntimeCoreOptions);
+  attachClient(): void;
+  detachClient(): void;
+  updateOptions(options: Omit<AcpThreadRuntimeCoreOptions, "notifyUpdate">): void;
+  attachRuntime(runtime: AssistantRuntime): void;
+  detachRuntime(): void;
+  getRuntime(): AssistantRuntime | undefined;
+  getMessages(): readonly ThreadMessage[];
+  getMessageRepository(): ExportedMessageRepository;
+  isRunning(): boolean;
+  get isLoading(): boolean;
+  getExtras(): AcpExtras;
+  __internal_load(): Promise<void>;
+  append(message: AppendMessage): Promise<void>;
+  edit(message: AppendMessage): Promise<void>;
+  reload(parentId: string | null): Promise<void>;
+  cancel(): Promise<void>;
+  respondToApproval(options: RespondToToolApprovalOptions): void;
+  applyExternalMessages(messages: readonly ThreadMessage[]): void;
+}
+
+type AcpThreadRuntimeCoreOptions = {
+  client: AcpClient;
+  permissions?: AcpPermissionsMode;
+  autoConnect?: boolean;
+  onError?: ((error: Error) => void) | undefined;
+  onCancel?: (() => void) | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  notifyUpdate: () => void;
+};
+
+type AcpToolCall = {
+  readonly toolCallId: string;
+  readonly title?: string;
+  readonly kind?: AcpToolKind;
+  readonly status?: AcpToolCallStatus;
+  readonly content?: readonly AcpToolCallContent[];
+  readonly locations?: readonly AcpToolCallLocation[];
+  readonly rawInput?: ReadonlyJSONValue;
+  readonly rawOutput?: ReadonlyJSONValue;
+};
+
+type AcpToolCallContent = {
+  readonly type: "content";
+  readonly content: readonly AcpContentBlock[];
+} | {
+  readonly type: "diff";
+  readonly path: string;
+  readonly oldText?: string;
+  readonly newText: string;
+};
+
+type AcpToolCallLocation = {
+  readonly path: string;
+  readonly line?: number;
+};
+
+type AcpToolCallStatus = "completed" | "failed" | "in_progress" | "pending";
+
+type AcpToolCallUpdate = {
+  readonly toolCallId: string;
+  readonly title?: string;
+  readonly kind?: AcpToolKind;
+  readonly status?: AcpToolCallStatus;
+  readonly content?: readonly AcpToolCallContent[];
+  readonly locations?: readonly AcpToolCallLocation[];
+  readonly rawInput?: ReadonlyJSONValue;
+  readonly rawOutput?: ReadonlyJSONValue;
+};
+
+type AcpToolKind = "delete" | "edit" | "execute" | "fetch" | "move" | "other" | "read" | "search" | "switch_mode" | "think";
+
+type AcpWebSocketFactory = (url: string) => AcpWebSocketLike;
+
+type AcpWebSocketLike = {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((event?: unknown) => void) | null;
+  onmessage: ((event: {
+    data: unknown;
+  }) => void) | null;
+  onclose: ((event?: {
+    code?: number;
+    reason?: string;
+  }) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+};
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantClient = ClientScopes & {
+  readonly optional: {
+    readonly [K in keyof ClientScopes]: ClientScopes[K] | undefined;
+  };
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"] & {
+  (): ClientSchemas[K]["methods"];
+} & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BaseAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K & string> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends string> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends (infer U) ? U : never;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
+};
+
+type ClientScopes = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+};
+
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
+
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  moveQueueItem(queueItemId: string, placement: QueuePlacement): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
+
+type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};
+
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe$1;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
+  };
+}
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onRefetchThread?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  steerItems: readonly QueueItemState[];
+  enqueue: (message: AppendMessage) => void;
+  steer: (message: AppendMessage) => void;
+  move: (queueItemId: string, placement: QueuePlacement) => void;
+  edit: (queueItemId: string, message: AppendMessage) => void;
+  remove: (queueItemId: string) => void;
+  __internal_setDispatchTransform?: ((transform: (message: AppendMessage) => AppendMessage) => void) | undefined;
+  __internal_notifyCancelled?: (() => void) | undefined;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
+  readonly providerMetadata?: PartProviderMetadata;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+  readonly providerMetadata?: PartProviderMetadata;
+};
+
+interface JSONSchema7 {
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  $schema?: JSONSchema7Version | undefined;
+  $comment?: string | undefined;
+  $defs?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
+  enum?: JSONSchema7Type[] | undefined;
+  const?: JSONSchema7Type | undefined;
+  multipleOf?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  minimum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  maxLength?: number | undefined;
+  minLength?: number | undefined;
+  pattern?: string | undefined;
+  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
+  additionalItems?: JSONSchema7Definition | undefined;
+  maxItems?: number | undefined;
+  minItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
+  contains?: JSONSchema7Definition | undefined;
+  maxProperties?: number | undefined;
+  minProperties?: number | undefined;
+  required?: string[] | undefined;
+  properties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  patternProperties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  additionalProperties?: JSONSchema7Definition | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7Definition | string[];
+  } | undefined;
+  propertyNames?: JSONSchema7Definition | undefined;
+  if?: JSONSchema7Definition | undefined;
+  then?: JSONSchema7Definition | undefined;
+  else?: JSONSchema7Definition | undefined;
+  allOf?: JSONSchema7Definition[] | undefined;
+  anyOf?: JSONSchema7Definition[] | undefined;
+  oneOf?: JSONSchema7Definition[] | undefined;
+  not?: JSONSchema7Definition | undefined;
+  format?: string | undefined;
+  contentMediaType?: string | undefined;
+  contentEncoding?: string | undefined;
+  definitions?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  default?: JSONSchema7Type | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchema7Type | undefined;
+}
+
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type JsonRpcId = number | string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
+};
+
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
+};
+
+type McpServerConfig = {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
+} | {
+  type: "stdio";
+  command: string;
+  args?: readonly string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  connectionTimeout?: number | undefined;
+};
+
+type McpTool = ToolBase<Record<string, unknown>, unknown> & {
+  type: "mcp";
+  server: McpServerConfig;
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessagePartStreamStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe$1;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type PartProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+  message?: string;
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+  readonly parts: readonly (FileMessagePart | TextMessagePart)[];
+};
+
+type QueuePlacement = {
+  readonly lane?: "queue" | "steer";
+  readonly insertAfter?: string | null;
+  readonly insertBefore?: string | null;
+};
+
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+declare namespace RealtimeVoiceAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Mode = "listening" | "speaking";
+  type TranscriptItem = {
+    role: "assistant" | "user";
+    text: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    isMuted: boolean;
+    disconnect: () => void;
+    mute: () => void;
+    unmute: () => void;
+    onStatusChange: (callback: (status: Status) => void) => Unsubscribe$1;
+    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe$1;
+    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe$1;
+    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe$1;
+  };
+}
+
+type RealtimeVoiceAdapter = {
+  connect: (options: {
+    abortSignal?: AbortSignal;
+  }) => RealtimeVoiceAdapter.Session;
+};
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly status?: MessagePartStreamStatus;
+  readonly unstable_summary?: string;
+  readonly providerMetadata?: PartProviderMetadata;
+  readonly parentId?: string;
+};
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
+};
+
+type ReservedAccessorProps = "name" | "query" | "source";
+
+type ReservedScopeNames = "on" | "optional" | "subscribe";
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly refetchThread: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type RuntimeExtras<T extends object> = {
+  provide: (value: T) => T;
+  is: (extras: unknown) => extras is T;
+  tryGet: (extras: unknown) => T | undefined;
+  get: (client: AssistantClient) => T;
+  use: {
+    (): T;
+    <S>(select: (extras: T) => S): S;
+    <S>(select: (extras: T) => S, fallback: S): S;
+  };
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = PartProviderMetadata;
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe$1;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly status?: MessagePartStreamStatus;
+  readonly providerMetadata?: PartProviderMetadata;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
+};
+
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
+};
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly isRunning: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+type ThreadMessageLike = {
+  readonly role: "assistant" | "system" | "user";
+  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
+    readonly type: "tool-call";
+    readonly toolCallId?: string;
+    readonly toolName: string;
+    readonly args?: ReadonlyJSONObject;
+    readonly argsText?: string;
+    readonly artifact?: any;
+    readonly result?: any | undefined;
+    readonly isError?: boolean | undefined;
+    readonly parentId?: string | undefined;
+    readonly messages?: readonly ThreadMessage[] | undefined;
+    readonly interrupt?: {
+      type: "human";
+      payload: unknown;
+    };
+    readonly timing?: ToolCallTiming;
+    readonly providerMetadata?: PartProviderMetadata;
+    readonly approval?: {
+      readonly id: string;
+      readonly approved?: boolean;
+      readonly reason?: string;
+      readonly isAutomatic?: boolean;
+      readonly options?: readonly ToolApprovalOption[];
+      readonly optionId?: string;
+      readonly resolution?: "cancelled" | "expired";
+    };
+  })[];
+  readonly id?: string | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
+    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
+  })[] | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly isOptimistic?: boolean | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  } | undefined;
+};
+
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  cancelRun(): void;
+  unstable_notifySessionReset(): void;
+  getModelContext(): ModelContext;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+};
+
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+};
+
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
+};
+
+type ThreadSuggestion = {
+  title?: string;
+  label?: string;
+  prompt: string;
+};
+
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+  overwrite?: boolean;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly providerMetadata?: PartProviderMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
+
+type UseAcpRuntimeOptions = ExternalStoreSharedOptions & {
+  client?: AcpClient;
+  url?: string;
+  cwd?: string;
+  mcpServers?: readonly AcpMcpServer[];
+  clientInfo?: AcpImplementation;
+  webSocketFactory?: AcpWebSocketFactory;
+  permissions?: AcpPermissionsMode;
+  autoConnect?: boolean;
+  onError?: (error: Error) => void;
+  onCancel?: () => void;
+  adapters?: {
+    attachments?: AttachmentAdapter;
+    speech?: SpeechSynthesisAdapter;
+    dictation?: DictationAdapter;
+    voice?: RealtimeVoiceAdapter;
+    feedback?: FeedbackAdapter;
+    history?: ThreadHistoryAdapter;
+  };
+};
+
+type ValidateClient<K extends string, TClient> = K extends ReservedScopeNames ? ClientError<`ERROR: ${K} is a reserved scope name`> : unknown extends ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient> ? TClient : ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient> & ClientError<never>;
+
+type ValidateEvents<K extends string, TClient> = "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? unknown : ClientError<`ERROR: ${K} has invalid events type`> : unknown;
+
+type ValidateMeta<K extends string, TClient> = "meta" extends keyof TClient ? TClient["meta"] extends ClientMetaType ? unknown : ClientError<`ERROR: ${K} has invalid meta type`> : unknown;
+
+type ValidateMethods<K extends string, TClient> = TClient extends {
+  methods: ClientMethods;
+} ? keyof TClient["methods"] & ReservedAccessorProps extends never ? unknown : ClientError<`ERROR: ${K} methods declare a reserved accessor property (source/query/name)`> : ClientError<`ERROR: ${K} has invalid methods type`>;
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+declare const acpExtras: RuntimeExtras<AcpExtras>;
+
+declare function acpToolStatusToPartStatus(status: AcpToolCallStatus): MessagePartStatus;
+
+declare const autoAllowPermissionHandler: AcpPermissionHandler;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { ACP_PROTOCOL_VERSION, AcpAgentCapabilities, AcpAnnotations, AcpAudioContentBlock, AcpAvailableCommand, AcpClient, AcpClientCapabilities, AcpClientOptions, AcpConnectionState, AcpContentAccumulator, AcpContentBlock, AcpError, AcpExtras, AcpImageContentBlock, AcpImplementation, AcpInitializeResponse, AcpMcpServer, AcpPermissionHandler, AcpPermissionOption, AcpPermissionOptionKind, AcpPermissionOutcome, AcpPermissionRequest, AcpPermissionsMode, AcpPlanEntry, AcpPromptCapabilities, AcpResourceContentBlock, AcpResourceLink, AcpSessionUpdate, AcpStopReason, AcpTextContentBlock, AcpThreadRuntimeCore, AcpThreadRuntimeCoreOptions, AcpToolCall, AcpToolCallContent, AcpToolCallLocation, AcpToolCallStatus, AcpToolCallUpdate, AcpToolKind, AcpWebSocketFactory, AcpWebSocketLike, UseAcpRuntimeOptions, acpExtras, acpToolStatusToPartStatus, autoAllowPermissionHandler, isAllowKind, permissionOptionToApprovalOption, stopReasonToMessageStatus, threadContentToAcpBlocks, toolCallContentToText, useAcpAgentInfo, useAcpAvailableCommands, useAcpConnectionState, useAcpCurrentModeId, useAcpPlan, useAcpRuntime, useAcpSessionId, useAcpSessionTitle };
+}
+
+declare function isAllowKind(kind: AcpPermissionOption["kind"]): boolean;
+
+declare function permissionOptionToApprovalOption(option: AcpPermissionOption): {
+  id: string;
+  kind: string;
+  label: string;
+  description?: string;
+};
+
+declare function stopReasonToMessageStatus(stopReason: AcpStopReason): MessageStatus;
+
+declare function threadContentToAcpBlocks(content: ThreadUserMessage["content"]): AcpContentBlock[];
+
+declare function toolCallContentToText(content: readonly AcpToolCallContent[] | undefined): string | undefined;
+
+declare const useAcpAgentInfo: () => AcpImplementation | undefined;
+
+declare const useAcpAvailableCommands: () => readonly AcpAvailableCommand[] | undefined;
+
+declare const useAcpConnectionState: () => AcpConnectionState;
+
+declare const useAcpCurrentModeId: () => string | undefined;
+
+declare const useAcpPlan: () => readonly AcpPlanEntry[] | undefined;
+
+declare function useAcpRuntime(options: UseAcpRuntimeOptions): AssistantRuntime;
+
+declare const useAcpSessionId: () => string | undefined;
+
+declare const useAcpSessionTitle: () => string | undefined;
+
+export { entry_root_exports as entry_root };

--- a/packages/react-acp/README.md
+++ b/packages/react-acp/README.md
@@ -1,0 +1,83 @@
+# `@assistant-ui/react-acp`
+
+[ACP (Agent Client Protocol)](https://agentclientprotocol.com/) adapter for
+[assistant-ui](https://www.assistant-ui.com/). The sequel to
+[`@assistant-ui/react-a2a`](../react-a2a/README.md): where react-a2a speaks
+Google's A2A protocol over fetch + SSE, this package speaks ACP v1 over a
+single WebSocket carrying JSON-RPC in both directions — the transport used by
+agents like [crow](https://crow-ai.dev) (`crow acp --http`).
+
+- ACP session ↔ assistant-ui thread
+- `session/update` notifications ↔ streamed assistant message parts
+  (text chunks, thought chunks, tool calls, plans)
+- `session/request_permission` server requests ↔ tool-call **approvals**
+  (ACP's `allow_once`/`allow_always`/`reject_once`/`reject_always` map 1:1 to
+  assistant-ui's approval option kinds)
+
+## Installation
+
+```sh
+npm install @assistant-ui/react-acp @assistant-ui/react
+```
+
+## Usage
+
+```tsx
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useAcpRuntime } from "@assistant-ui/react-acp";
+
+export function App() {
+  const runtime = useAcpRuntime({
+    url: "ws://127.0.0.1:2770/",
+    // permissions: "auto-allow",  // default "ask" shows approval UI
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {/* your thread UI, e.g. the shadcn kit's <Thread /> */}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+### Options
+
+| Option             | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| `url`              | WebSocket endpoint of the ACP agent (`ws://` / `wss://`).                    |
+| `client`           | Pre-built `AcpClient` (alternative to `url`).                                |
+| `cwd`              | Working directory for `session/new` (default `"."`).                         |
+| `mcpServers`       | MCP servers to pass to `session/new`.                                        |
+| `permissions`      | `"ask"` (default) or `"auto-allow"`.                                         |
+| `autoConnect`      | Connect + `initialize` on mount (default `true`).                            |
+| `webSocketFactory` | Inject a custom WebSocket implementation (tests, proxies).                   |
+| `onError`          | Error callback (connection failures, prompt errors).                         |
+| `adapters.history` | Persist/restore the transcript (ACP v1 has no server-side history fetch).    |
+
+### Extras hooks
+
+```tsx
+import {
+  useAcpConnectionState,
+  useAcpPlan,
+  useAcpSessionTitle,
+} from "@assistant-ui/react-acp";
+```
+
+## How it maps ACP → assistant-ui
+
+| ACP                                        | assistant-ui                                             |
+| ------------------------------------------ | -------------------------------------------------------- |
+| WebSocket connection + `initialize`        | runtime connection state (`useAcpConnectionState`)       |
+| `session/new` → `sessionId`                | thread (`useAcpSessionId`)                               |
+| `session/prompt`                           | append / run                                             |
+| `agent_message_chunk`                      | text content part (streamed)                             |
+| `agent_thought_chunk`                      | reasoning content part (streamed)                        |
+| `tool_call` / `tool_call_update`           | tool-call content part (title, args, result, status)     |
+| `session/request_permission`               | tool-call approval (`requires-action` until answered)    |
+| `session/cancel`                           | cancel                                                   |
+| `plan` / `session_info_update` / modes     | extras hooks                                             |
+
+Browser clients advertise **no** filesystem or terminal capabilities, so a
+conforming ACP agent will never send `fs/*` or `terminal/*` requests; any such
+request is answered with JSON-RPC `-32601`.

--- a/packages/react-acp/package.json
+++ b/packages/react-acp/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@assistant-ui/react-acp",
+  "version": "0.1.0",
+  "description": "ACP (Agent Client Protocol) adapter for assistant-ui",
+  "keywords": [
+    "acp",
+    "agent-client-protocol",
+    "assistant-ui",
+    "react",
+    "ai",
+    "chat",
+    "protocol"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@assistant-ui/core": "^0.3.13",
+    "@assistant-ui/store": "^0.3.9",
+    "assistant-stream": "^0.3.37"
+  },
+  "peerDependencies": {
+    "@types/react": "*",
+    "react": "^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.18",
+    "jsdom": "^30.0.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "vitest": "^4.1.10"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/react-acp"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/react-acp/src/AcpClient.test.ts
+++ b/packages/react-acp/src/AcpClient.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { AcpClient, AcpError } from "./AcpClient";
+import type { AcpSessionUpdate } from "./types";
+
+type JsonRpcFrame = {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+};
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  onopen: ((event?: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((event?: unknown) => void) | null = null;
+
+  sent: JsonRpcFrame[] = [];
+  closed = false;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(JSON.parse(data) as JsonRpcFrame);
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.onclose?.({});
+  }
+
+  open() {
+    this.onopen?.({});
+  }
+
+  receive(frame: JsonRpcFrame) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+async function until<T>(fn: () => T | undefined, ms = 2000): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = fn();
+    if (value !== undefined) return value;
+    if (Date.now() - start > ms) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const lastWs = () => MockWebSocket.instances.at(-1)!;
+
+async function connectClient(client: AcpClient): Promise<void> {
+  const pending = client.connect();
+  const ws = await until(() =>
+    MockWebSocket.instances.at(-1)?.onopen ? lastWs() : undefined,
+  );
+  ws.open();
+  const init = await until(() =>
+    ws.sent.find((f) => f.method === "initialize"),
+  );
+  ws.receive({
+    jsonrpc: "2.0",
+    id: init.id!,
+    result: {
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: true },
+      agentInfo: { name: "menu-agent", version: "0.1.0" },
+    },
+  });
+  await pending;
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+});
+
+describe("AcpClient", () => {
+  it("runs the initialize handshake over the WebSocket", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+
+    const pending = client.connect();
+    expect(client.connectionState).toBe("connecting");
+
+    const ws = lastWs();
+    expect(ws.url).toBe("ws://agent.test/");
+    ws.open();
+
+    const init = await until(() =>
+      ws.sent.find((f) => f.method === "initialize"),
+    );
+    expect(init.params).toMatchObject({
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "react-acp" },
+    });
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: init.id!,
+      result: { protocolVersion: 1, agentInfo: { name: "crow", version: "1" } },
+    });
+
+    const result = await pending;
+    expect(result.agentInfo?.name).toBe("crow");
+    expect(client.connectionState).toBe("connected");
+    expect(client.agentInfo?.name).toBe("crow");
+    expect(ws.sent.some((f) => f.method === "notifications/initialized")).toBe(
+      true,
+    );
+  });
+
+  it("rejects connect when the socket errors before handshake", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    const pending = client.connect();
+    lastWs().onerror?.({});
+    await expect(pending).rejects.toThrow(
+      "connection to ws://agent.test/ failed",
+    );
+    expect(client.connectionState).toBe("disconnected");
+  });
+
+  it("creates one session and reuses it", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      cwd: "/home/thomas/src/crow-team/menu",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+
+    const first = client.ensureSession();
+    const second = client.ensureSession();
+
+    await connectClient(client);
+    const ws = lastWs();
+    const newSession = await until(() =>
+      ws.sent.find((f) => f.method === "session/new"),
+    );
+    expect(newSession.params).toEqual({
+      cwd: "/home/thomas/src/crow-team/menu",
+      mcpServers: [],
+    });
+    ws.receive({
+      jsonrpc: "2.0",
+      id: newSession.id!,
+      result: { sessionId: "session-1" },
+    });
+
+    expect(await first).toBe("session-1");
+    expect(await second).toBe("session-1");
+    expect(ws.sent.filter((f) => f.method === "session/new")).toHaveLength(1);
+  });
+
+  it("sends prompts and dispatches session/update notifications", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    const promptPromise = client.prompt([{ type: "text", text: "hi" }]);
+    await connectClient(client);
+    const ws = lastWs();
+
+    const newSession = await until(() =>
+      ws.sent.find((f) => f.method === "session/new"),
+    );
+    ws.receive({
+      jsonrpc: "2.0",
+      id: newSession.id!,
+      result: { sessionId: "s1" },
+    });
+
+    const prompt = await until(() =>
+      ws.sent.find((f) => f.method === "session/prompt"),
+    );
+    expect(prompt.params).toEqual({
+      sessionId: "s1",
+      content: [{ type: "text", text: "hi" }],
+    });
+
+    const updates: Array<{ sessionId: string; update: AcpSessionUpdate }> = [];
+    client.onSessionUpdate = (sessionId, update) =>
+      updates.push({ sessionId, update });
+    ws.receive({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Hello!" },
+        },
+      },
+    });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.sessionId).toBe("s1");
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    expect(await promptPromise).toBe("end_turn");
+  });
+
+  it("surfaces JSON-RPC errors as AcpError", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    const promptPromise = client.prompt([{ type: "text", text: "hi" }]);
+    await connectClient(client);
+    const ws = lastWs();
+    const newSession = await until(() =>
+      ws.sent.find((f) => f.method === "session/new"),
+    );
+    ws.receive({
+      jsonrpc: "2.0",
+      id: newSession.id!,
+      result: { sessionId: "s1" },
+    });
+    const prompt = await until(() =>
+      ws.sent.find((f) => f.method === "session/prompt"),
+    );
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      error: { code: -32000, message: "model exploded" },
+    });
+    await expect(promptPromise).rejects.toBeInstanceOf(AcpError);
+    await expect(promptPromise).rejects.toThrow("model exploded");
+  });
+
+  it("answers permission requests with the auto-allow policy by default", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    await connectClient(client);
+    const ws = lastWs();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 77,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t1", title: "write_file" },
+        options: [
+          { optionId: "reject-1", name: "Reject", kind: "reject_once" },
+          { optionId: "allow-1", name: "Allow", kind: "allow_once" },
+        ],
+      },
+    });
+
+    const response = await until(() => ws.sent.find((f) => f.id === 77));
+    expect(response.result).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-1" },
+    });
+  });
+
+  it("routes permission requests through a custom handler", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    client.permissionHandler = () => ({ outcome: "cancelled" });
+    await connectClient(client);
+    const ws = lastWs();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 78,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t1" },
+        options: [{ optionId: "allow-1", name: "Allow", kind: "allow_once" }],
+      },
+    });
+
+    const response = await until(() => ws.sent.find((f) => f.id === 78));
+    expect(response.result).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  it("rejects unsupported server requests", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    await connectClient(client);
+    const ws = lastWs();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 79,
+      method: "terminal/create",
+      params: {},
+    });
+
+    const response = await until(() => ws.sent.find((f) => f.id === 79));
+    expect(response.error?.code).toBe(-32601);
+  });
+
+  it("sends session/cancel and clears the session on close", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    const sessionPromise = client.ensureSession();
+    await connectClient(client);
+    const ws = lastWs();
+    const newSession = await until(() =>
+      ws.sent.find((f) => f.method === "session/new"),
+    );
+    ws.receive({
+      jsonrpc: "2.0",
+      id: newSession.id!,
+      result: { sessionId: "s1" },
+    });
+    await sessionPromise;
+
+    void client.cancel();
+    const cancel = await until(() =>
+      ws.sent.find((f) => f.method === "session/cancel"),
+    );
+    expect(cancel.params).toEqual({ sessionId: "s1" });
+    ws.receive({ jsonrpc: "2.0", id: cancel.id!, result: null });
+
+    const states: string[] = [];
+    client.onConnectionChange = (state) => states.push(state);
+    ws.onclose?.({});
+    expect(client.connectionState).toBe("disconnected");
+    expect(client.sessionId).toBeUndefined();
+    expect(states).toEqual(["disconnected"]);
+  });
+
+  it("rejects in-flight requests when the connection closes", async () => {
+    const client = new AcpClient({
+      url: "ws://agent.test/",
+      webSocketFactory: (url) => new MockWebSocket(url),
+    });
+    const promptPromise = client.prompt([{ type: "text", text: "hi" }]);
+    await connectClient(client);
+    const ws = lastWs();
+    const newSession = await until(() =>
+      ws.sent.find((f) => f.method === "session/new"),
+    );
+    ws.receive({
+      jsonrpc: "2.0",
+      id: newSession.id!,
+      result: { sessionId: "s1" },
+    });
+    await until(() => ws.sent.find((f) => f.method === "session/prompt"));
+
+    ws.onclose?.({});
+    await expect(promptPromise).rejects.toThrow("connection closed");
+  });
+});

--- a/packages/react-acp/src/AcpClient.test.ts
+++ b/packages/react-acp/src/AcpClient.test.ts
@@ -116,7 +116,7 @@ describe("AcpClient", () => {
     expect(client.connectionState).toBe("connected");
     expect(client.agentInfo?.name).toBe("crow");
     expect(ws.sent.some((f) => f.method === "notifications/initialized")).toBe(
-      true,
+      false,
     );
   });
 
@@ -186,7 +186,7 @@ describe("AcpClient", () => {
     );
     expect(prompt.params).toEqual({
       sessionId: "s1",
-      content: [{ type: "text", text: "hi" }],
+      prompt: [{ type: "text", text: "hi" }],
     });
 
     const updates: Array<{ sessionId: string; update: AcpSessionUpdate }> = [];
@@ -336,7 +336,7 @@ describe("AcpClient", () => {
       ws.sent.find((f) => f.method === "session/cancel"),
     );
     expect(cancel.params).toEqual({ sessionId: "s1" });
-    ws.receive({ jsonrpc: "2.0", id: cancel.id!, result: null });
+    expect(cancel.id).toBeUndefined(); // notification — no response expected
 
     const states: string[] = [];
     client.onConnectionChange = (state) => states.push(state);

--- a/packages/react-acp/src/AcpClient.ts
+++ b/packages/react-acp/src/AcpClient.ts
@@ -1,0 +1,350 @@
+import {
+  ACP_PROTOCOL_VERSION,
+  type AcpAgentCapabilities,
+  type AcpConnectionState,
+  type AcpContentBlock,
+  type AcpImplementation,
+  type AcpInitializeResponse,
+  type AcpMcpServer,
+  type AcpPermissionOutcome,
+  type AcpPermissionRequest,
+  type AcpSessionUpdate,
+  type AcpStopReason,
+} from "./types";
+import { isAllowKind } from "./conversions";
+
+/** Minimal WebSocket surface (browser WebSocket and Node >= 22 both satisfy it). */
+export type AcpWebSocketLike = {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((event?: unknown) => void) | null;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null;
+  onerror: ((event?: unknown) => void) | null;
+};
+
+export type AcpWebSocketFactory = (url: string) => AcpWebSocketLike;
+
+export type AcpPermissionHandler = (
+  request: AcpPermissionRequest,
+) => AcpPermissionOutcome | Promise<AcpPermissionOutcome>;
+
+export type AcpClientOptions = {
+  /** WebSocket endpoint of the ACP agent, e.g. `ws://127.0.0.1:2770/`. */
+  url: string;
+  /** Working directory passed to `session/new`. */
+  cwd?: string;
+  /** MCP servers passed to `session/new`. */
+  mcpServers?: readonly AcpMcpServer[];
+  /** Client identity for the `initialize` handshake. */
+  clientInfo?: AcpImplementation;
+  /** Inject a WebSocket implementation (tests / custom transports). */
+  webSocketFactory?: AcpWebSocketFactory;
+};
+
+type JsonRpcId = number | string;
+
+type PendingRequest = {
+  resolve: (result: any) => void;
+  reject: (error: Error) => void;
+};
+
+export class AcpError extends Error {
+  constructor(
+    message: string,
+    readonly code: number,
+    readonly data?: unknown,
+  ) {
+    super(message);
+    this.name = "AcpError";
+  }
+}
+
+/**
+ * Default permission policy: pick the first allow-family option, else the
+ * first option, else cancel. Keeps headless clients from hanging.
+ */
+export const autoAllowPermissionHandler: AcpPermissionHandler = (request) => {
+  const option =
+    request.options.find((o) => isAllowKind(o.kind)) ?? request.options[0];
+  return option
+    ? { outcome: "selected", optionId: option.optionId }
+    : { outcome: "cancelled" };
+};
+
+const defaultWebSocketFactory: AcpWebSocketFactory = (url) =>
+  new WebSocket(url) as unknown as AcpWebSocketLike;
+
+export class AcpClient {
+  private readonly options: AcpClientOptions;
+  private ws: AcpWebSocketLike | undefined;
+  private nextId = 1;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private connectPromise: Promise<AcpInitializeResponse> | undefined;
+  private sessionPromise: Promise<string> | undefined;
+  private initializeResult: AcpInitializeResponse | undefined;
+  private _sessionId: string | undefined;
+  private _connectionState: AcpConnectionState = "disconnected";
+
+  /** Invoked for every `session/update` notification. */
+  onSessionUpdate:
+    | ((sessionId: string, update: AcpSessionUpdate) => void)
+    | undefined;
+  /** Invoked for `session/request_permission` server requests. */
+  permissionHandler: AcpPermissionHandler = autoAllowPermissionHandler;
+  /** Invoked whenever the connection state changes. */
+  onConnectionChange: ((state: AcpConnectionState) => void) | undefined;
+
+  constructor(options: AcpClientOptions) {
+    this.options = options;
+  }
+
+  get connectionState(): AcpConnectionState {
+    return this._connectionState;
+  }
+
+  get sessionId(): string | undefined {
+    return this._sessionId;
+  }
+
+  get agentInfo(): AcpImplementation | undefined {
+    return this.initializeResult?.agentInfo;
+  }
+
+  get agentCapabilities(): AcpAgentCapabilities | undefined {
+    return this.initializeResult?.agentCapabilities;
+  }
+
+  /** Open the WebSocket and run the `initialize` handshake (idempotent). */
+  connect(): Promise<AcpInitializeResponse> {
+    if (this._connectionState === "connected" && this.initializeResult) {
+      return Promise.resolve(this.initializeResult);
+    }
+    this.connectPromise ??= this.doConnect().finally(() => {
+      this.connectPromise = undefined;
+    });
+    return this.connectPromise;
+  }
+
+  /** Get (or create) the ACP session for this connection. */
+  ensureSession(): Promise<string> {
+    if (this._sessionId) return Promise.resolve(this._sessionId);
+    this.sessionPromise ??= this.doNewSession().finally(() => {
+      this.sessionPromise = undefined;
+    });
+    return this.sessionPromise;
+  }
+
+  /** Send a prompt and resolve when the turn completes. */
+  async prompt(content: readonly AcpContentBlock[]): Promise<AcpStopReason> {
+    const sessionId = await this.ensureSession();
+    const result = await this.request<{ stopReason?: AcpStopReason }>(
+      "session/prompt",
+      { sessionId, content },
+    );
+    return result.stopReason ?? "end_turn";
+  }
+
+  /** Ask the agent to cancel the current turn. */
+  async cancel(): Promise<void> {
+    if (!this._sessionId || this._connectionState !== "connected") return;
+    try {
+      await this.request("session/cancel", { sessionId: this._sessionId });
+    } catch {
+      // best effort — the caller already aborted locally
+    }
+  }
+
+  /** Answer a pending `session/request_permission` server request. */
+  respondPermission(requestId: JsonRpcId, outcome: AcpPermissionOutcome): void {
+    this.sendRaw({ jsonrpc: "2.0", id: requestId, result: { outcome } });
+  }
+
+  /** Close the connection and reject everything in flight. */
+  dispose(): void {
+    const ws = this.ws;
+    this.ws = undefined;
+    ws?.close();
+    this.failPending(new Error("AcpClient disposed"));
+    this.setConnectionState("disconnected");
+  }
+
+  // --- internals ---
+
+  private setConnectionState(state: AcpConnectionState) {
+    if (this._connectionState === state) return;
+    this._connectionState = state;
+    this.onConnectionChange?.(state);
+  }
+
+  private doConnect(): Promise<AcpInitializeResponse> {
+    return new Promise<AcpInitializeResponse>((resolve, reject) => {
+      this.setConnectionState("connecting");
+      let settled = false;
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        this.setConnectionState("disconnected");
+        reject(error);
+      };
+
+      let ws: AcpWebSocketLike;
+      try {
+        ws = (this.options.webSocketFactory ?? defaultWebSocketFactory)(
+          this.options.url,
+        );
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      this.ws = ws;
+
+      ws.onopen = () => {
+        void (async () => {
+          try {
+            const result = await this.request<AcpInitializeResponse>(
+              "initialize",
+              {
+                protocolVersion: ACP_PROTOCOL_VERSION,
+                clientCapabilities: {},
+                clientInfo: this.options.clientInfo ?? {
+                  name: "react-acp",
+                  version: "0.1.0",
+                },
+              },
+            );
+            this.initializeResult = result;
+            this.sendNotification("notifications/initialized", {});
+            if (settled) return;
+            settled = true;
+            this.setConnectionState("connected");
+            resolve(result);
+          } catch (error) {
+            fail(error instanceof Error ? error : new Error(String(error)));
+            ws.close();
+          }
+        })();
+      };
+      ws.onmessage = (event) => {
+        this.handleMessage(typeof event.data === "string" ? event.data : "");
+      };
+      ws.onclose = () => {
+        this.handleClose();
+        fail(new Error("ACP WebSocket closed before handshake completed"));
+      };
+      ws.onerror = () => {
+        fail(
+          new Error(`ACP WebSocket connection to ${this.options.url} failed`),
+        );
+      };
+    });
+  }
+
+  private async doNewSession(): Promise<string> {
+    await this.connect();
+    const result = await this.request<{ sessionId: string }>("session/new", {
+      cwd: this.options.cwd ?? ".",
+      mcpServers: this.options.mcpServers ?? [],
+    });
+    this._sessionId = result.sessionId;
+    return result.sessionId;
+  }
+
+  private handleClose(): void {
+    this.failPending(new Error("ACP WebSocket connection closed"));
+    this.ws = undefined;
+    this._sessionId = undefined;
+    this.setConnectionState("disconnected");
+  }
+
+  private failPending(error: Error): void {
+    for (const [, pending] of this.pending) pending.reject(error);
+    this.pending.clear();
+  }
+
+  private handleMessage(raw: string): void {
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+
+    if (typeof msg.method === "string") {
+      if (msg.id !== undefined) this.handleServerRequest(msg);
+      else this.handleNotification(msg);
+      return;
+    }
+
+    if (msg.id !== undefined) {
+      const pending = this.pending.get(msg.id);
+      if (!pending) return;
+      this.pending.delete(msg.id);
+      if (msg.error) {
+        pending.reject(
+          new AcpError(
+            msg.error.message ?? "ACP request failed",
+            msg.error.code ?? -1,
+            msg.error.data,
+          ),
+        );
+      } else {
+        pending.resolve(msg.result);
+      }
+    }
+  }
+
+  private handleServerRequest(msg: any): void {
+    if (msg.method === "session/request_permission") {
+      const params = msg.params as AcpPermissionRequest;
+      void Promise.resolve(this.permissionHandler(params)).then(
+        (outcome) => this.respondPermission(msg.id, outcome),
+        () => this.respondPermission(msg.id, { outcome: "cancelled" }),
+      );
+      return;
+    }
+    // Browser clients advertise no fs/terminal capabilities; anything else
+    // arriving here is unsupported.
+    this.sendRaw({
+      jsonrpc: "2.0",
+      id: msg.id,
+      error: { code: -32601, message: `Method not supported: ${msg.method}` },
+    });
+  }
+
+  private handleNotification(msg: any): void {
+    if (msg.method !== "session/update") return;
+    const params = msg.params as
+      | { sessionId: string; update: AcpSessionUpdate }
+      | undefined;
+    if (!params?.update) return;
+    this.onSessionUpdate?.(params.sessionId, params.update);
+  }
+
+  private request<TResult>(method: string, params: unknown): Promise<TResult> {
+    if (this._connectionState !== "connected" && method !== "initialize") {
+      return Promise.reject(
+        new Error(`Cannot send ${method}: ACP client is not connected`),
+      );
+    }
+    const id = this.nextId++;
+    return new Promise<TResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.sendRaw({ jsonrpc: "2.0", id, method, params });
+      } catch (error) {
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    this.sendRaw({ jsonrpc: "2.0", method, params });
+  }
+
+  private sendRaw(frame: unknown): void {
+    this.ws?.send(JSON.stringify(frame));
+  }
+}

--- a/packages/react-acp/src/AcpClient.ts
+++ b/packages/react-acp/src/AcpClient.ts
@@ -140,7 +140,7 @@ export class AcpClient {
     const sessionId = await this.ensureSession();
     const result = await this.request<{ stopReason?: AcpStopReason }>(
       "session/prompt",
-      { sessionId, content },
+      { sessionId, prompt: content },
     );
     return result.stopReason ?? "end_turn";
   }
@@ -148,11 +148,8 @@ export class AcpClient {
   /** Ask the agent to cancel the current turn. */
   async cancel(): Promise<void> {
     if (!this._sessionId || this._connectionState !== "connected") return;
-    try {
-      await this.request("session/cancel", { sessionId: this._sessionId });
-    } catch {
-      // best effort — the caller already aborted locally
-    }
+    // session/cancel is a notification in ACP v1 — no response expected.
+    this.sendNotification("session/cancel", { sessionId: this._sessionId });
   }
 
   /** Answer a pending `session/request_permission` server request. */
@@ -214,7 +211,6 @@ export class AcpClient {
               },
             );
             this.initializeResult = result;
-            this.sendNotification("notifications/initialized", {});
             if (settled) return;
             settled = true;
             this.setConnectionState("connected");

--- a/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
+++ b/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
@@ -1,0 +1,466 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AppendMessage,
+  ThreadAssistantMessage,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import { AcpClient } from "./AcpClient";
+import { AcpThreadRuntimeCore } from "./AcpThreadRuntimeCore";
+
+type JsonRpcFrame = {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+};
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  onopen: ((event?: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((event?: unknown) => void) | null = null;
+
+  sent: JsonRpcFrame[] = [];
+  closed = false;
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(JSON.parse(data) as JsonRpcFrame);
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.onclose?.({});
+  }
+
+  open() {
+    this.onopen?.({});
+  }
+
+  receive(frame: JsonRpcFrame) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+async function until<T>(fn: () => T | undefined, ms = 2000): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const value = fn();
+    if (value !== undefined) return value;
+    if (Date.now() - start > ms) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const lastWs = () => MockWebSocket.instances.at(-1)!;
+
+function createUserAppendMessage(text: string): AppendMessage {
+  return {
+    parentId: null,
+    role: "user",
+    content: [{ type: "text", text }],
+  } as unknown as AppendMessage;
+}
+
+function setup() {
+  const client = new AcpClient({
+    url: "ws://agent.test/",
+    webSocketFactory: (url) => new MockWebSocket(url),
+  });
+  const notifyUpdate = vi.fn();
+  const core = new AcpThreadRuntimeCore({ client, notifyUpdate });
+  return { client, core, notifyUpdate };
+}
+
+/** Open the socket and drive initialize -> session/new -> session/prompt. */
+async function driveHandshake() {
+  const ws = lastWs();
+  ws.open();
+  const init = await until(() =>
+    ws.sent.find((f) => f.method === "initialize"),
+  );
+  ws.receive({
+    jsonrpc: "2.0",
+    id: init.id!,
+    result: {
+      protocolVersion: 1,
+      agentInfo: { name: "menu-agent", version: "0.1.0" },
+    },
+  });
+  const newSession = await until(() =>
+    ws.sent.find((f) => f.method === "session/new"),
+  );
+  ws.receive({
+    jsonrpc: "2.0",
+    id: newSession.id!,
+    result: { sessionId: "s1" },
+  });
+  const prompt = await until(() =>
+    ws.sent.find((f) => f.method === "session/prompt"),
+  );
+  return { ws, prompt };
+}
+
+const lastAssistant = (core: AcpThreadRuntimeCore) =>
+  core.getMessages().at(-1) as ThreadAssistantMessage;
+
+const sessionUpdate = (update: unknown): JsonRpcFrame => ({
+  jsonrpc: "2.0",
+  method: "session/update",
+  params: { sessionId: "s1", update },
+});
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+});
+
+describe("AcpThreadRuntimeCore", () => {
+  it("streams text chunks into the assistant message and completes", async () => {
+    const { core } = setup();
+    const runPromise = core.append(createUserAppendMessage("plan dinner"));
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[1]!.role).toBe("assistant");
+    expect(messages[1]!.status).toEqual({ type: "running" });
+    expect(core.isRunning()).toBe(true);
+
+    const { ws, prompt } = await driveHandshake();
+    expect(prompt.params).toEqual({
+      sessionId: "s1",
+      content: [{ type: "text", text: "plan dinner" }],
+    });
+
+    ws.receive(
+      sessionUpdate({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "How about " },
+      }),
+    );
+    ws.receive(
+      sessionUpdate({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "chana masala?" },
+      }),
+    );
+    expect(lastAssistant(core).content).toEqual([
+      { type: "text", text: "How about chana masala?" },
+    ]);
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+
+    expect(lastAssistant(core).status).toEqual({
+      type: "complete",
+      reason: "stop",
+    });
+    expect(core.isRunning()).toBe(false);
+    expect(core.getExtras().sessionId).toBe("s1");
+    expect(core.getExtras().agentInfo?.name).toBe("menu-agent");
+  });
+
+  it("renders tool calls and their updates as tool-call parts", async () => {
+    const { core } = setup();
+    const runPromise = core.append(
+      createUserAppendMessage("find queso recipes"),
+    );
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive(
+      sessionUpdate({
+        sessionUpdate: "tool_call",
+        toolCallId: "t1",
+        title: "web_search",
+        status: "in_progress",
+        rawInput: { query: "queso recipe" },
+      }),
+    );
+    let part = lastAssistant(core).content[0] as ToolCallMessagePart;
+    expect(part.type).toBe("tool-call");
+    expect(part.toolName).toBe("web_search");
+    expect(part.args).toEqual({ query: "queso recipe" });
+    expect(part.status).toEqual({ type: "running" });
+
+    ws.receive(
+      sessionUpdate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "t1",
+        status: "completed",
+        rawOutput: { hits: 5 },
+      }),
+    );
+    part = lastAssistant(core).content[0] as ToolCallMessagePart;
+    expect(part.result).toEqual({ hits: 5 });
+    expect(part.status).toEqual({ type: "complete" });
+    expect(lastAssistant(core).content).toHaveLength(1);
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("surfaces permission requests as approvals and answers them", async () => {
+    const { core } = setup();
+    const runPromise = core.append(createUserAppendMessage("save the recipe"));
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 500,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t9", title: "write_file", status: "pending" },
+        options: [
+          { optionId: "allow-1", name: "Allow once", kind: "allow_once" },
+          { optionId: "reject-1", name: "Reject", kind: "reject_once" },
+        ],
+      },
+    });
+
+    await until(() =>
+      lastAssistant(core).status.type === "requires-action" ? true : undefined,
+    );
+    const awaiting = lastAssistant(core);
+    expect(awaiting.status).toEqual({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+    const toolPart = awaiting.content.find(
+      (p) => p.type === "tool-call",
+    ) as ToolCallMessagePart;
+    expect(toolPart.toolName).toBe("write_file");
+    expect(toolPart.approval?.id).toBe("acp-permission-1");
+    expect(toolPart.approval?.options).toEqual([
+      { id: "allow-1", kind: "allow-once", label: "Allow once" },
+      { id: "reject-1", kind: "reject-once", label: "Reject" },
+    ]);
+
+    core.respondToApproval({
+      approvalId: "acp-permission-1",
+      approved: true,
+      optionId: "allow-1",
+    });
+    const response = await until(() => ws.sent.find((f) => f.id === 500));
+    expect(response.result).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-1" },
+    });
+    expect(lastAssistant(core).status).toEqual({ type: "running" });
+    const resolvedPart = lastAssistant(core).content.find(
+      (p) => p.type === "tool-call",
+    ) as ToolCallMessagePart;
+    expect(resolvedPart.approval?.approved).toBe(true);
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("picks an allow option by default when approved without optionId", async () => {
+    const { core } = setup();
+    const runPromise = core.append(createUserAppendMessage("save the recipe"));
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 501,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t9" },
+        options: [
+          { optionId: "reject-1", name: "Reject", kind: "reject_once" },
+          { optionId: "allow-1", name: "Allow once", kind: "allow_once" },
+        ],
+      },
+    });
+    await until(() =>
+      lastAssistant(core).status.type === "requires-action" ? true : undefined,
+    );
+
+    core.respondToApproval({ approvalId: "acp-permission-1", approved: true });
+    const response = await until(() => ws.sent.find((f) => f.id === 501));
+    expect(response.result).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-1" },
+    });
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("auto-allows permissions in auto-allow mode", async () => {
+    const { core, client } = setup();
+    core.updateOptions({ client, permissions: "auto-allow" });
+    const runPromise = core.append(createUserAppendMessage("save the recipe"));
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 502,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t9" },
+        options: [
+          { optionId: "reject-1", name: "Reject", kind: "reject_once" },
+          { optionId: "allow-1", name: "Allow once", kind: "allow_once" },
+        ],
+      },
+    });
+
+    const response = await until(() => ws.sent.find((f) => f.id === 502));
+    expect(response.result).toEqual({
+      outcome: { outcome: "selected", optionId: "allow-1" },
+    });
+    expect(lastAssistant(core).status).toEqual({ type: "running" });
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("cancels runs locally and on the server", async () => {
+    const { core, client } = setup();
+    const onCancel = vi.fn();
+    core.updateOptions({ client, onCancel });
+    const runPromise = core.append(createUserAppendMessage("long task"));
+    const { ws, prompt } = await driveHandshake();
+
+    await core.cancel();
+    expect(lastAssistant(core).status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    const cancelFrame = await until(() =>
+      ws.sent.find((f) => f.method === "session/cancel"),
+    );
+    expect(cancelFrame.params).toEqual({ sessionId: "s1" });
+    ws.receive({ jsonrpc: "2.0", id: cancelFrame.id!, result: null });
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "cancelled" },
+    });
+    await runPromise;
+    expect(core.isRunning()).toBe(false);
+    expect(lastAssistant(core).status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("cancels pending permissions when the run is cancelled", async () => {
+    const { core } = setup();
+    const runPromise = core.append(createUserAppendMessage("save the recipe"));
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: 503,
+      method: "session/request_permission",
+      params: {
+        sessionId: "s1",
+        toolCall: { toolCallId: "t9" },
+        options: [
+          { optionId: "allow-1", name: "Allow once", kind: "allow_once" },
+        ],
+      },
+    });
+    await until(() =>
+      lastAssistant(core).status.type === "requires-action" ? true : undefined,
+    );
+
+    await core.cancel();
+    const response = await until(() => ws.sent.find((f) => f.id === 503));
+    expect(response.result).toEqual({ outcome: { outcome: "cancelled" } });
+
+    const cancelFrame = await until(() =>
+      ws.sent.find((f) => f.method === "session/cancel"),
+    );
+    ws.receive({ jsonrpc: "2.0", id: cancelFrame.id!, result: null });
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "cancelled" },
+    });
+    await runPromise;
+  });
+
+  it("tracks plan and session info updates in extras", async () => {
+    const { core } = setup();
+    const runPromise = core.append(createUserAppendMessage("plan the week"));
+    const { ws, prompt } = await driveHandshake();
+
+    const entries = [
+      { content: "pick recipes", priority: "high", status: "in_progress" },
+      { content: "build grocery list", priority: "medium", status: "pending" },
+    ];
+    ws.receive(sessionUpdate({ sessionUpdate: "plan", entries }));
+    expect(core.getExtras().plan).toEqual(entries);
+
+    ws.receive(
+      sessionUpdate({ sessionUpdate: "session_info_update", title: "Week 33" }),
+    );
+    expect(core.getExtras().sessionTitle).toBe("Week 33");
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("marks the assistant message as errored when the prompt fails", async () => {
+    const { core, client } = setup();
+    const onError = vi.fn();
+    core.updateOptions({ client, onError });
+    const runPromise = core.append(createUserAppendMessage("hello"));
+    const { ws, prompt } = await driveHandshake();
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      error: { code: -32000, message: "LLM provider down" },
+    });
+    await runPromise;
+
+    expect(lastAssistant(core).status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "LLM provider down",
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0].message).toBe("LLM provider down");
+    expect(core.isRunning()).toBe(false);
+  });
+});

--- a/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
+++ b/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
@@ -137,7 +137,7 @@ describe("AcpThreadRuntimeCore", () => {
     const { ws, prompt } = await driveHandshake();
     expect(prompt.params).toEqual({
       sessionId: "s1",
-      content: [{ type: "text", text: "plan dinner" }],
+      prompt: [{ type: "text", text: "plan dinner" }],
     });
 
     ws.receive(
@@ -363,7 +363,7 @@ describe("AcpThreadRuntimeCore", () => {
       ws.sent.find((f) => f.method === "session/cancel"),
     );
     expect(cancelFrame.params).toEqual({ sessionId: "s1" });
-    ws.receive({ jsonrpc: "2.0", id: cancelFrame.id!, result: null });
+    expect(cancelFrame.id).toBeUndefined();
 
     ws.receive({
       jsonrpc: "2.0",
@@ -406,7 +406,7 @@ describe("AcpThreadRuntimeCore", () => {
     const cancelFrame = await until(() =>
       ws.sent.find((f) => f.method === "session/cancel"),
     );
-    ws.receive({ jsonrpc: "2.0", id: cancelFrame.id!, result: null });
+    expect(cancelFrame.id).toBeUndefined();
     ws.receive({
       jsonrpc: "2.0",
       id: prompt.id!,

--- a/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
+++ b/packages/react-acp/src/AcpThreadRuntimeCore.test.ts
@@ -4,7 +4,7 @@ import type {
   ThreadAssistantMessage,
   ToolCallMessagePart,
 } from "@assistant-ui/core";
-import { AcpClient } from "./AcpClient";
+import { AcpClient, autoAllowPermissionHandler } from "./AcpClient";
 import { AcpThreadRuntimeCore } from "./AcpThreadRuntimeCore";
 
 type JsonRpcFrame = {
@@ -77,6 +77,7 @@ function setup() {
   });
   const notifyUpdate = vi.fn();
   const core = new AcpThreadRuntimeCore({ client, notifyUpdate });
+  core.attachClient();
   return { client, core, notifyUpdate };
 }
 
@@ -170,6 +171,58 @@ describe("AcpThreadRuntimeCore", () => {
     expect(core.isRunning()).toBe(false);
     expect(core.getExtras().sessionId).toBe("s1");
     expect(core.getExtras().agentInfo?.name).toBe("menu-agent");
+  });
+
+  it("does not let a later-constructed core steal the client's callbacks (discarded React render regression)", async () => {
+    const { client, core } = setup();
+    // React may construct cores in render passes it later discards
+    // (StrictMode double-invocation, interrupted concurrent renders). A
+    // discarded twin sharing the same client must not steal the committed
+    // core's subscriptions — that dropped every session/update notification
+    // and assistant messages completed with empty content.
+    const ghost = new AcpThreadRuntimeCore({
+      client,
+      notifyUpdate: vi.fn(),
+    });
+    void ghost;
+    expect(client.onSessionUpdate).toBeDefined();
+
+    const runPromise = core.append(createUserAppendMessage("hello"));
+    const { ws, prompt } = await driveHandshake();
+    ws.receive(
+      sessionUpdate({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "still here" },
+      }),
+    );
+    expect(lastAssistant(core).content).toEqual([
+      { type: "text", text: "still here" },
+    ]);
+
+    ws.receive({
+      jsonrpc: "2.0",
+      id: prompt.id!,
+      result: { stopReason: "end_turn" },
+    });
+    await runPromise;
+  });
+
+  it("detachClient only clears callbacks owned by the detaching core", () => {
+    const { client, core } = setup();
+    const other = new AcpThreadRuntimeCore({
+      client,
+      notifyUpdate: vi.fn(),
+    });
+    other.attachClient();
+    // detaching the superseded core must not clobber the current one
+    core.detachClient();
+    expect(client.onSessionUpdate).toBeDefined();
+    expect(client.permissionHandler).toBeDefined();
+    other.detachClient();
+    expect(client.onSessionUpdate).toBeUndefined();
+    expect(client.onConnectionChange).toBeUndefined();
+    // permission handling falls back to the client's auto-allow default
+    expect(client.permissionHandler).toBe(autoAllowPermissionHandler);
   });
 
   it("renders tool calls and their updates as tool-call parts", async () => {

--- a/packages/react-acp/src/AcpThreadRuntimeCore.ts
+++ b/packages/react-acp/src/AcpThreadRuntimeCore.ts
@@ -117,6 +117,14 @@ export class AcpThreadRuntimeCore {
   private readonly assistantHistoryParents = new Map<string, string | null>();
   private readonly recordedHistoryIds = new Set<string>();
 
+  private readonly boundOnSessionUpdate = (
+    _sessionId: string,
+    update: AcpSessionUpdate,
+  ) => this.handleSessionUpdate(update);
+  private readonly boundOnConnectionChange = () => this.notifyUpdate();
+  private readonly boundPermissionHandler = (request: AcpPermissionRequest) =>
+    this.handlePermissionRequest(request);
+
   constructor(options: AcpThreadRuntimeCoreOptions) {
     this.client = options.client;
     this.permissions = options.permissions ?? "ask";
@@ -125,23 +133,33 @@ export class AcpThreadRuntimeCore {
     this.onCancel = options.onCancel;
     this.history = options.history;
     this.notifyUpdate = options.notifyUpdate;
+    // NOTE: deliberately does NOT touch client callbacks here. Cores are
+    // constructed inside useMemo factories, which React may run for render
+    // passes it later discards (StrictMode double-invocation, interrupted
+    // concurrent renders) — a discarded core must not be able to steal the
+    // client's event handlers from the committed one. attachClient() is the
+    // single subscription point; call it from an effect.
+  }
 
-    this.client.onSessionUpdate = (_sessionId, update) =>
-      this.handleSessionUpdate(update);
-    this.client.onConnectionChange = () => this.notifyUpdate();
-    this.client.permissionHandler = (request) =>
-      this.handlePermissionRequest(request);
+  /** Subscribe this core to its client's event streams. Idempotent. */
+  attachClient(): void {
+    this.client.onSessionUpdate = this.boundOnSessionUpdate;
+    this.client.onConnectionChange = this.boundOnConnectionChange;
+    this.client.permissionHandler = this.boundPermissionHandler;
+  }
+
+  /** Inverse of attachClient; only clears callbacks this core still owns. */
+  detachClient(): void {
+    if (this.client.onSessionUpdate === this.boundOnSessionUpdate)
+      this.client.onSessionUpdate = undefined;
+    if (this.client.onConnectionChange === this.boundOnConnectionChange)
+      this.client.onConnectionChange = undefined;
+    if (this.client.permissionHandler === this.boundPermissionHandler)
+      this.client.permissionHandler = autoAllowPermissionHandler;
   }
 
   updateOptions(options: Omit<AcpThreadRuntimeCoreOptions, "notifyUpdate">) {
-    if (this.client !== options.client) {
-      this.client = options.client;
-      this.client.onSessionUpdate = (_sessionId, update) =>
-        this.handleSessionUpdate(update);
-      this.client.onConnectionChange = () => this.notifyUpdate();
-      this.client.permissionHandler = (request) =>
-        this.handlePermissionRequest(request);
-    }
+    this.client = options.client;
     this.permissions = options.permissions ?? "ask";
     this.autoConnect = options.autoConnect ?? true;
     this.onError = options.onError;

--- a/packages/react-acp/src/AcpThreadRuntimeCore.ts
+++ b/packages/react-acp/src/AcpThreadRuntimeCore.ts
@@ -1,0 +1,629 @@
+"use client";
+
+import { fromThreadMessageLike, generateId } from "@assistant-ui/core";
+import type {
+  AppendMessage,
+  AssistantRuntime,
+  ExportedMessageRepository,
+  MessageStatus,
+  RespondToToolApprovalOptions,
+  ThreadAssistantMessage,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+import { MessageRepository } from "@assistant-ui/core/internal";
+import type { AcpClient } from "./AcpClient";
+import { autoAllowPermissionHandler } from "./AcpClient";
+import {
+  AcpContentAccumulator,
+  permissionOptionToApprovalOption,
+  stopReasonToMessageStatus,
+  threadContentToAcpBlocks,
+} from "./conversions";
+import type {
+  AcpAvailableCommand,
+  AcpExtras,
+  AcpPermissionOutcome,
+  AcpPermissionRequest,
+  AcpPlanEntry,
+  AcpSessionUpdate,
+} from "./types";
+
+export type AcpPermissionsMode = "ask" | "auto-allow";
+
+export type AcpThreadRuntimeCoreOptions = {
+  client: AcpClient;
+  permissions?: AcpPermissionsMode;
+  autoConnect?: boolean;
+  onError?: ((error: Error) => void) | undefined;
+  onCancel?: (() => void) | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  notifyUpdate: () => void;
+};
+
+const FALLBACK_USER_STATUS = {
+  type: "complete",
+  reason: "unknown",
+} as const;
+
+type AcpRuntimeCallbackName = "onError" | "onCancel";
+
+const reportCallbackError = (name: AcpRuntimeCallbackName, error: unknown) => {
+  console.error(`[react-acp] ${name} callback threw an error`, error);
+};
+
+const invokeRuntimeCallback = <TArgs extends unknown[]>(
+  name: AcpRuntimeCallbackName,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
+type ActiveRun = {
+  assistantId: string;
+  accumulator: AcpContentAccumulator;
+  abortController: AbortController;
+};
+
+type PendingPermission = {
+  request: AcpPermissionRequest;
+  resolve: (outcome: AcpPermissionOutcome) => void;
+};
+
+export class AcpThreadRuntimeCore {
+  private client: AcpClient;
+  private permissions: AcpPermissionsMode;
+  private autoConnect: boolean;
+  private onError: ((error: Error) => void) | undefined;
+  private onCancel: (() => void) | undefined;
+  private history: ThreadHistoryAdapter | undefined;
+  private readonly notifyUpdate: () => void;
+
+  private runtime: AssistantRuntime | undefined;
+  private readonly repository = new MessageRepository();
+  private exportedRepository: ExportedMessageRepository | undefined;
+  private isRunningFlag = false;
+  private abortController: AbortController | null = null;
+  private activeRun: ActiveRun | undefined;
+  private _isLoading = false;
+  private _loadPromise: Promise<void> | undefined;
+
+  // ACP-specific state
+  private plan: readonly AcpPlanEntry[] | undefined;
+  private sessionTitle: string | undefined;
+  private currentModeId: string | undefined;
+  private availableCommands: readonly AcpAvailableCommand[] | undefined;
+  private permissionCounter = 0;
+  private readonly pendingPermissions = new Map<string, PendingPermission>();
+
+  // History tracking
+  private readonly assistantHistoryParents = new Map<string, string | null>();
+  private readonly recordedHistoryIds = new Set<string>();
+
+  constructor(options: AcpThreadRuntimeCoreOptions) {
+    this.client = options.client;
+    this.permissions = options.permissions ?? "ask";
+    this.autoConnect = options.autoConnect ?? true;
+    this.onError = options.onError;
+    this.onCancel = options.onCancel;
+    this.history = options.history;
+    this.notifyUpdate = options.notifyUpdate;
+
+    this.client.onSessionUpdate = (_sessionId, update) =>
+      this.handleSessionUpdate(update);
+    this.client.onConnectionChange = () => this.notifyUpdate();
+    this.client.permissionHandler = (request) =>
+      this.handlePermissionRequest(request);
+  }
+
+  updateOptions(options: Omit<AcpThreadRuntimeCoreOptions, "notifyUpdate">) {
+    if (this.client !== options.client) {
+      this.client = options.client;
+      this.client.onSessionUpdate = (_sessionId, update) =>
+        this.handleSessionUpdate(update);
+      this.client.onConnectionChange = () => this.notifyUpdate();
+      this.client.permissionHandler = (request) =>
+        this.handlePermissionRequest(request);
+    }
+    this.permissions = options.permissions ?? "ask";
+    this.autoConnect = options.autoConnect ?? true;
+    this.onError = options.onError;
+    this.onCancel = options.onCancel;
+    this.history = options.history;
+  }
+
+  attachRuntime(runtime: AssistantRuntime) {
+    this.runtime = runtime;
+  }
+
+  detachRuntime() {
+    this.runtime = undefined;
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  getRuntime(): AssistantRuntime | undefined {
+    return this.runtime;
+  }
+
+  getMessages(): readonly ThreadMessage[] {
+    return this.repository.getMessages();
+  }
+
+  getMessageRepository(): ExportedMessageRepository {
+    this.exportedRepository ??= this.repository.export();
+    return this.exportedRepository;
+  }
+
+  isRunning(): boolean {
+    return this.isRunningFlag;
+  }
+
+  get isLoading(): boolean {
+    return this._isLoading;
+  }
+
+  getExtras(): AcpExtras {
+    return {
+      connectionState: this.client.connectionState,
+      sessionId: this.client.sessionId,
+      agentInfo: this.client.agentInfo,
+      agentCapabilities: this.client.agentCapabilities,
+      plan: this.plan,
+      sessionTitle: this.sessionTitle,
+      currentModeId: this.currentModeId,
+      availableCommands: this.availableCommands,
+    };
+  }
+
+  __internal_load(): Promise<void> {
+    if (this._loadPromise) return this._loadPromise;
+
+    this._isLoading = true;
+
+    const historyPromise = this.history?.load() ?? Promise.resolve(null);
+    const connectPromise = this.autoConnect
+      ? this.client.connect().catch((error) => {
+          invokeRuntimeCallback(
+            "onError",
+            this.onError,
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        })
+      : Promise.resolve(undefined);
+
+    this._loadPromise = Promise.all([historyPromise, connectPromise])
+      .then(([repo]) => {
+        if (repo) {
+          this.applyExternalMessages(repo.messages.map((m) => m.message));
+        }
+      })
+      .finally(() => {
+        this._isLoading = false;
+        this.notifyUpdate();
+      });
+
+    this.notifyUpdate();
+    return this._loadPromise;
+  }
+
+  async append(message: AppendMessage): Promise<void> {
+    const startRun = message.startRun ?? message.role === "user";
+
+    const threadMessage = fromThreadMessageLike(
+      message as any,
+      generateId(),
+      FALLBACK_USER_STATUS,
+    );
+    const parentId =
+      message.parentId === null
+        ? null
+        : message.parentId && this.hasMessage(message.parentId)
+          ? message.parentId
+          : this.repository.headId;
+    this.addOrUpdateMessage(parentId, threadMessage);
+    this.switchToBranch(threadMessage.id);
+    this.notifyUpdate();
+    this.recordHistoryEntry(parentId, threadMessage);
+
+    if (!startRun) return;
+    await this.startRun(threadMessage);
+  }
+
+  async edit(message: AppendMessage): Promise<void> {
+    await this.append(message);
+  }
+
+  async reload(parentId: string | null): Promise<void> {
+    const messages =
+      parentId === null
+        ? []
+        : (this.tryGetMessages(parentId) ?? this.getMessages());
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === "user") {
+        await this.startRun(messages[i]!);
+        return;
+      }
+    }
+  }
+
+  async cancel(): Promise<void> {
+    if (!this.abortController) return;
+
+    for (const [, pending] of this.pendingPermissions) {
+      pending.resolve({ outcome: "cancelled" });
+    }
+    this.pendingPermissions.clear();
+
+    this.abortController.abort();
+    void this.client.cancel();
+  }
+
+  respondToApproval(options: RespondToToolApprovalOptions): void {
+    const pending = this.pendingPermissions.get(options.approvalId);
+    if (!pending) return;
+    this.pendingPermissions.delete(options.approvalId);
+
+    let optionId = options.optionId;
+    if (!optionId) {
+      const kindPrefix = options.approved ? "allow" : "reject";
+      optionId =
+        pending.request.options.find((o) => o.kind.startsWith(kindPrefix))
+          ?.optionId ?? pending.request.options[0]?.optionId;
+    }
+
+    pending.resolve(
+      optionId ? { outcome: "selected", optionId } : { outcome: "cancelled" },
+    );
+
+    const run = this.activeRun;
+    if (run) {
+      run.accumulator.resolveApproval(options.approvalId, {
+        approved: options.approved,
+        ...(options.optionId != null && { optionId: options.optionId }),
+      });
+      this.updateAssistantContent(run.assistantId, run.accumulator.content);
+      this.updateAssistantStatus(run.assistantId, { type: "running" });
+      this.notifyUpdate();
+    }
+  }
+
+  applyExternalMessages(messages: readonly ThreadMessage[]): void {
+    if (messages.length === 0) {
+      this.clearRepository();
+    } else {
+      let expectedParentId: string | null = null;
+      let lastAppliedId: string | null = null;
+      let hardReplace = false;
+      const seen = new Set<string>();
+
+      for (const message of messages) {
+        if (seen.has(message.id)) continue;
+        seen.add(message.id);
+        const existing = this.tryGetMessage(message.id);
+        if (existing && existing.parentId !== expectedParentId) {
+          hardReplace = true;
+          break;
+        }
+        this.addOrUpdateMessage(expectedParentId, message);
+        expectedParentId = message.id;
+        lastAppliedId = message.id;
+      }
+
+      if (hardReplace) {
+        this.clearRepository();
+        let parentId: string | null = null;
+        lastAppliedId = null;
+        const chainSeen = new Set<string>();
+        for (const message of messages) {
+          if (chainSeen.has(message.id)) continue;
+          chainSeen.add(message.id);
+          this.addOrUpdateMessage(parentId, message);
+          parentId = message.id;
+          lastAppliedId = message.id;
+        }
+      }
+
+      this.resetRepositoryHead(lastAppliedId);
+    }
+
+    this.assistantHistoryParents.clear();
+    this.recordedHistoryIds.clear();
+    for (const { message } of this.getMessageRepository().messages) {
+      this.recordedHistoryIds.add(message.id);
+    }
+    this.notifyUpdate();
+  }
+
+  // --- Session update dispatch ---
+
+  private handleSessionUpdate(update: AcpSessionUpdate): void {
+    switch (update.sessionUpdate) {
+      case "plan":
+        this.plan = update.entries;
+        this.notifyUpdate();
+        return;
+      case "session_info_update":
+        if (update.title != null) this.sessionTitle = update.title;
+        this.notifyUpdate();
+        return;
+      case "current_mode_update":
+        this.currentModeId = update.currentModeId;
+        this.notifyUpdate();
+        return;
+      case "available_commands_update":
+        this.availableCommands = update.availableCommands;
+        this.notifyUpdate();
+        return;
+      case "user_message_chunk":
+        return;
+    }
+
+    const run = this.activeRun;
+    if (!run) return;
+    if (run.accumulator.consume(update as any)) {
+      this.updateAssistantContent(run.assistantId, run.accumulator.content);
+      this.notifyUpdate();
+    }
+  }
+
+  private handlePermissionRequest(
+    request: AcpPermissionRequest,
+  ): Promise<AcpPermissionOutcome> {
+    const run = this.activeRun;
+    if (this.permissions === "auto-allow" || !run) {
+      return Promise.resolve(autoAllowPermissionHandler(request));
+    }
+
+    const approvalId = `acp-permission-${++this.permissionCounter}`;
+    run.accumulator.attachApproval(request.toolCall, {
+      id: approvalId,
+      options: request.options.map(permissionOptionToApprovalOption),
+    });
+    this.updateAssistantContent(run.assistantId, run.accumulator.content);
+    this.updateAssistantStatus(run.assistantId, {
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+    this.notifyUpdate();
+
+    return new Promise<AcpPermissionOutcome>((resolve) => {
+      this.pendingPermissions.set(approvalId, { request, resolve });
+    });
+  }
+
+  // --- Run logic ---
+
+  private async startRun(userThreadMessage: ThreadMessage): Promise<void> {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+
+    const blocks = threadContentToAcpBlocks(
+      userThreadMessage.role === "user" ? userThreadMessage.content : [],
+    );
+
+    const assistantParentId = userThreadMessage.id;
+    const assistantId = this.insertAssistantPlaceholder(assistantParentId);
+    this.markPendingAssistantHistory(assistantId, assistantParentId);
+
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    const accumulator = new AcpContentAccumulator();
+    this.activeRun = { assistantId, accumulator, abortController };
+
+    abortController.signal.addEventListener(
+      "abort",
+      () => {
+        this.updateAssistantStatus(assistantId, {
+          type: "incomplete",
+          reason: "cancelled",
+        });
+        this.finishRun(abortController);
+        invokeRuntimeCallback("onCancel", this.onCancel);
+      },
+      { once: true },
+    );
+
+    this.setRunning(true);
+
+    try {
+      const stopReason = await this.client.prompt(blocks);
+      if (!abortController.signal.aborted) {
+        this.updateAssistantStatus(
+          assistantId,
+          stopReasonToMessageStatus(stopReason),
+        );
+      }
+    } catch (error) {
+      if (!abortController.signal.aborted) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.updateAssistantStatus(assistantId, {
+          type: "incomplete",
+          reason: "error",
+          error: err.message,
+        });
+        invokeRuntimeCallback("onError", this.onError, err);
+      }
+    } finally {
+      this.finishRun(abortController);
+      if (this.activeRun?.assistantId === assistantId) {
+        this.activeRun = undefined;
+      }
+    }
+  }
+
+  // --- Message helpers ---
+
+  private tryGetMessage(messageId: string) {
+    try {
+      return this.repository.getMessage(messageId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private tryGetMessages(
+    messageId: string,
+  ): readonly ThreadMessage[] | undefined {
+    try {
+      return this.repository.getMessages(messageId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private hasMessage(messageId: string): boolean {
+    return this.tryGetMessage(messageId) !== undefined;
+  }
+
+  private addOrUpdateMessage(
+    parentId: string | null,
+    message: ThreadMessage,
+  ): void {
+    this.repository.addOrUpdateMessage(parentId, message);
+    this.exportedRepository = undefined;
+  }
+
+  private switchToBranch(messageId: string): void {
+    this.repository.switchToBranch(messageId);
+    this.exportedRepository = undefined;
+  }
+
+  private resetRepositoryHead(messageId: string | null): void {
+    this.repository.resetHead(messageId);
+    this.exportedRepository = undefined;
+  }
+
+  private clearRepository(): void {
+    this.repository.clear();
+    this.exportedRepository = undefined;
+  }
+
+  private updateMessage(
+    messageId: string,
+    updater: (message: ThreadMessage) => ThreadMessage,
+  ): boolean {
+    const item = this.tryGetMessage(messageId);
+    if (!item) return false;
+    const message = updater(item.message);
+    if (message === item.message) return false;
+    this.addOrUpdateMessage(item.parentId, message);
+    return true;
+  }
+
+  private insertAssistantPlaceholder(parentId: string): string {
+    const id = generateId();
+    const assistant: ThreadAssistantMessage = {
+      id,
+      role: "assistant",
+      createdAt: new Date(),
+      status: { type: "running" },
+      content: [],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    this.addOrUpdateMessage(parentId, assistant);
+    this.switchToBranch(id);
+    this.notifyUpdate();
+    return id;
+  }
+
+  private updateAssistantContent(
+    messageId: string,
+    content: ThreadAssistantMessage["content"],
+  ) {
+    this.updateMessage(messageId, (message) => {
+      if (message.role !== "assistant") return message;
+      return { ...message, content };
+    });
+  }
+
+  private updateAssistantStatus(messageId: string, status: MessageStatus) {
+    const touched = this.updateMessage(messageId, (message) => {
+      if (message.role !== "assistant") return message;
+      return { ...message, status };
+    });
+    if (touched) {
+      this.notifyUpdate();
+      if (status.type === "complete" || status.type === "incomplete") {
+        this.persistAssistantHistory(messageId);
+      }
+    }
+  }
+
+  // --- Lifecycle helpers ---
+
+  private setRunning(running: boolean) {
+    this.isRunningFlag = running;
+    this.notifyUpdate();
+  }
+
+  private finishRun(controller: AbortController | null) {
+    if (this.abortController !== controller) return;
+    this.abortController = null;
+    this.setRunning(false);
+  }
+
+  // --- History persistence ---
+
+  private recordHistoryEntry(parentId: string | null, message: ThreadMessage) {
+    this.appendHistoryItem(parentId, message);
+  }
+
+  private markPendingAssistantHistory(
+    messageId: string,
+    parentId: string | null,
+  ) {
+    if (!this.history) return;
+    this.assistantHistoryParents.set(messageId, parentId);
+  }
+
+  private persistAssistantHistory(messageId: string) {
+    if (!this.history) return;
+    const parentId = this.assistantHistoryParents.get(messageId);
+    if (parentId === undefined) return;
+    const message = this.tryGetMessage(messageId)?.message;
+    if (!message || message.role !== "assistant") return;
+    if (
+      message.status?.type !== "complete" &&
+      message.status?.type !== "incomplete"
+    )
+      return;
+    this.assistantHistoryParents.delete(messageId);
+    this.appendHistoryItem(parentId, message);
+  }
+
+  private appendHistoryItem(parentId: string | null, message: ThreadMessage) {
+    if (!this.history || this.recordedHistoryIds.has(message.id)) return;
+    this.recordedHistoryIds.add(message.id);
+    void this.history.append({ parentId, message }).catch(() => {
+      this.recordedHistoryIds.delete(message.id);
+    });
+  }
+}

--- a/packages/react-acp/src/acpExtras.ts
+++ b/packages/react-acp/src/acpExtras.ts
@@ -1,0 +1,4 @@
+import { createRuntimeExtras } from "@assistant-ui/core/react";
+import type { AcpExtras } from "./types";
+
+export const acpExtras = createRuntimeExtras<AcpExtras>("useAcpRuntime");

--- a/packages/react-acp/src/conversions.test.ts
+++ b/packages/react-acp/src/conversions.test.ts
@@ -155,6 +155,18 @@ describe("toolCallContentToText", () => {
     ).toBe("line 1\nline 2");
   });
 
+  it("accepts a single content block object where the spec says array", () => {
+    // crow-cli sends {type:"content", content: <one block>} — must not throw
+    expect(
+      toolCallContentToText([
+        {
+          type: "content",
+          content: { type: "text", text: "solo block" } as any,
+        },
+      ]),
+    ).toBe("solo block");
+  });
+
   it("renders diffs", () => {
     expect(
       toolCallContentToText([{ type: "diff", path: "a.md", newText: "new" }]),

--- a/packages/react-acp/src/conversions.test.ts
+++ b/packages/react-acp/src/conversions.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCallMessagePart } from "@assistant-ui/core";
+import {
+  AcpContentAccumulator,
+  acpToolStatusToPartStatus,
+  isAllowKind,
+  permissionOptionToApprovalOption,
+  stopReasonToMessageStatus,
+  threadContentToAcpBlocks,
+  toolCallContentToText,
+} from "./conversions";
+
+describe("stopReasonToMessageStatus", () => {
+  it("maps end_turn to complete", () => {
+    expect(stopReasonToMessageStatus("end_turn")).toEqual({
+      type: "complete",
+      reason: "stop",
+    });
+  });
+
+  it("maps cancelled to incomplete/cancelled", () => {
+    expect(stopReasonToMessageStatus("cancelled")).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("maps max_tokens to incomplete/length", () => {
+    expect(stopReasonToMessageStatus("max_tokens")).toEqual({
+      type: "incomplete",
+      reason: "length",
+    });
+  });
+
+  it("maps refusal to incomplete/other", () => {
+    expect(stopReasonToMessageStatus("refusal")).toEqual({
+      type: "incomplete",
+      reason: "other",
+    });
+  });
+});
+
+describe("acpToolStatusToPartStatus", () => {
+  it("maps pending and in_progress to running", () => {
+    expect(acpToolStatusToPartStatus("pending")).toEqual({ type: "running" });
+    expect(acpToolStatusToPartStatus("in_progress")).toEqual({
+      type: "running",
+    });
+  });
+
+  it("maps completed to complete", () => {
+    expect(acpToolStatusToPartStatus("completed")).toEqual({
+      type: "complete",
+    });
+  });
+
+  it("maps failed to incomplete/error", () => {
+    expect(acpToolStatusToPartStatus("failed")).toEqual({
+      type: "incomplete",
+      reason: "error",
+    });
+  });
+});
+
+describe("permissionOptionToApprovalOption", () => {
+  it("maps ACP underscore kinds to assistant-ui dash kinds", () => {
+    expect(
+      permissionOptionToApprovalOption({
+        optionId: "o1",
+        name: "Allow once",
+        kind: "allow_once",
+      }),
+    ).toEqual({ id: "o1", kind: "allow-once", label: "Allow once" });
+    expect(
+      permissionOptionToApprovalOption({
+        optionId: "o2",
+        name: "Reject always",
+        kind: "reject_always",
+        description: "never again",
+      }),
+    ).toEqual({
+      id: "o2",
+      kind: "reject-always",
+      label: "Reject always",
+      description: "never again",
+    });
+  });
+
+  it("classifies allow kinds", () => {
+    expect(isAllowKind("allow_once")).toBe(true);
+    expect(isAllowKind("allow_always")).toBe(true);
+    expect(isAllowKind("reject_once")).toBe(false);
+  });
+});
+
+describe("threadContentToAcpBlocks", () => {
+  it("converts text parts", () => {
+    expect(threadContentToAcpBlocks([{ type: "text", text: "hello" }])).toEqual(
+      [{ type: "text", text: "hello" }],
+    );
+  });
+
+  it("converts data-url images to image blocks", () => {
+    const blocks = threadContentToAcpBlocks([
+      { type: "image", image: "data:image/png;base64,QUJD" },
+    ]);
+    expect(blocks).toEqual([
+      { type: "image", data: "QUJD", mimeType: "image/png" },
+    ]);
+  });
+
+  it("converts url images to resource links", () => {
+    const blocks = threadContentToAcpBlocks([
+      { type: "image", image: "https://example.com/x.png" },
+    ]);
+    expect(blocks).toEqual([
+      { type: "resource", resource: { uri: "https://example.com/x.png" } },
+    ]);
+  });
+
+  it("converts url files to resource links and skips empty text", () => {
+    const blocks = threadContentToAcpBlocks([
+      { type: "text", text: "" },
+      {
+        type: "file",
+        data: "https://example.com/notes.pdf",
+        mimeType: "application/pdf",
+        sourceType: "url",
+      },
+    ]);
+    expect(blocks).toEqual([
+      {
+        type: "resource",
+        resource: {
+          uri: "https://example.com/notes.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    ]);
+  });
+});
+
+describe("toolCallContentToText", () => {
+  it("joins text content blocks", () => {
+    expect(
+      toolCallContentToText([
+        {
+          type: "content",
+          content: [
+            { type: "text", text: "line 1" },
+            { type: "text", text: "line 2" },
+          ],
+        },
+      ]),
+    ).toBe("line 1\nline 2");
+  });
+
+  it("renders diffs", () => {
+    expect(
+      toolCallContentToText([{ type: "diff", path: "a.md", newText: "new" }]),
+    ).toContain("a.md");
+  });
+
+  it("returns undefined for empty content", () => {
+    expect(toolCallContentToText(undefined)).toBeUndefined();
+    expect(toolCallContentToText([])).toBeUndefined();
+  });
+});
+
+describe("AcpContentAccumulator", () => {
+  it("merges consecutive text chunks into one part", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Hello " },
+    } as any);
+    acc.consume({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "world" },
+    } as any);
+    expect(acc.content).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("accumulates thought chunks separately from message chunks", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: "thinking..." },
+    } as any);
+    acc.consume({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "answer" },
+    } as any);
+    expect(acc.content).toEqual([
+      { type: "reasoning", text: "thinking..." },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("starts a new text part after a tool call", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "before" },
+    } as any);
+    acc.consume({
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "web_search",
+      status: "in_progress",
+    } as any);
+    acc.consume({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "after" },
+    } as any);
+    expect(acc.content.map((p) => p.type)).toEqual([
+      "text",
+      "tool-call",
+      "text",
+    ]);
+  });
+
+  it("creates and merges tool calls by id", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "Searching recipes",
+      status: "in_progress",
+      rawInput: { query: "queso" },
+    } as any);
+    acc.consume({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+      rawOutput: { hits: 3 },
+    } as any);
+
+    expect(acc.content).toHaveLength(1);
+    const part = acc.content[0] as ToolCallMessagePart;
+    expect(part.type).toBe("tool-call");
+    expect(part.toolCallId).toBe("t1");
+    expect(part.toolName).toBe("Searching recipes");
+    expect(part.args).toEqual({ query: "queso" });
+    expect(part.argsText).toBe(JSON.stringify({ query: "queso" }));
+    expect(part.result).toEqual({ hits: 3 });
+    expect(part.status).toEqual({ type: "complete" });
+  });
+
+  it("derives result from content text when rawOutput is absent", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      title: "fetch",
+      status: "in_progress",
+    } as any);
+    acc.consume({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "t1",
+      status: "completed",
+      content: [
+        { type: "content", content: [{ type: "text", text: "page body" }] },
+      ],
+    } as any);
+    const part = acc.content[0] as ToolCallMessagePart;
+    expect(part.result).toBe("page body");
+  });
+
+  it("marks failed tool calls with isError", () => {
+    const acc = new AcpContentAccumulator();
+    acc.consume({
+      sessionUpdate: "tool_call",
+      toolCallId: "t1",
+      status: "failed",
+    } as any);
+    const part = acc.content[0] as ToolCallMessagePart;
+    expect(part.isError).toBe(true);
+    expect(part.status).toEqual({ type: "incomplete", reason: "error" });
+  });
+
+  it("attaches and resolves approvals on tool-call parts", () => {
+    const acc = new AcpContentAccumulator();
+    acc.attachApproval(
+      { toolCallId: "t1", title: "write_file", status: "pending" },
+      { id: "acp-permission-1", options: [{ id: "a", kind: "allow-once" }] },
+    );
+    let part = acc.content[0] as ToolCallMessagePart;
+    expect(part.approval?.id).toBe("acp-permission-1");
+    expect(part.approved).toBeUndefined();
+
+    acc.resolveApproval("acp-permission-1", { approved: true, optionId: "a" });
+    part = acc.content[0] as ToolCallMessagePart;
+    expect(part.approval?.approved).toBe(true);
+    expect(part.approval?.optionId).toBe("a");
+  });
+
+  it("ignores unknown update kinds", () => {
+    const acc = new AcpContentAccumulator();
+    expect(acc.consume({ sessionUpdate: "plan", entries: [] } as any)).toBe(
+      false,
+    );
+    expect(acc.content).toEqual([]);
+  });
+});

--- a/packages/react-acp/src/conversions.ts
+++ b/packages/react-acp/src/conversions.ts
@@ -82,7 +82,15 @@ export function toolCallContentToText(
   const pieces: string[] = [];
   for (const item of content) {
     if (item.type === "content") {
-      for (const block of item.content) {
+      // The spec says ContentBlock[], but some agents (e.g. crow-cli) send a
+      // single block object instead — accept both rather than throwing.
+      const raw = item.content as unknown;
+      const blocks: readonly AcpContentBlock[] = Array.isArray(raw)
+        ? (raw as readonly AcpContentBlock[])
+        : raw
+          ? [raw as AcpContentBlock]
+          : [];
+      for (const block of blocks) {
         if (block.type === "text") pieces.push(block.text);
         else if (block.type === "resource" && block.resource.text != null)
           pieces.push(block.resource.text);

--- a/packages/react-acp/src/conversions.ts
+++ b/packages/react-acp/src/conversions.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type {
+  MessagePartStatus,
   MessageStatus,
   ThreadAssistantMessage,
   ThreadUserMessage,
@@ -114,7 +115,7 @@ export function stopReasonToMessageStatus(
 
 export function acpToolStatusToPartStatus(
   status: AcpToolCallStatus,
-): ToolCallMessagePart["status"] {
+): MessagePartStatus {
   switch (status) {
     case "completed":
       return { type: "complete" };

--- a/packages/react-acp/src/conversions.ts
+++ b/packages/react-acp/src/conversions.ts
@@ -1,0 +1,370 @@
+"use client";
+
+import type {
+  MessageStatus,
+  ThreadAssistantMessage,
+  ThreadUserMessage,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import { isRecord, parseDataUrl } from "@assistant-ui/core/internal";
+import type {
+  AcpContentBlock,
+  AcpPermissionOption,
+  AcpStopReason,
+  AcpToolCallContent,
+  AcpToolCallStatus,
+  AcpToolCallUpdate,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// User content -> ACP content blocks
+// ---------------------------------------------------------------------------
+
+export function threadContentToAcpBlocks(
+  content: ThreadUserMessage["content"],
+): AcpContentBlock[] {
+  const blocks: AcpContentBlock[] = [];
+  for (const part of content) {
+    switch (part.type) {
+      case "text": {
+        if (part.text) blocks.push({ type: "text", text: part.text });
+        break;
+      }
+      case "image": {
+        if (!part.image) break;
+        const parsed = parseDataUrl(part.image);
+        if (parsed) {
+          blocks.push({
+            type: "image",
+            data: parsed.data,
+            mimeType: parsed.mimeType,
+          });
+        } else {
+          blocks.push({ type: "resource", resource: { uri: part.image } });
+        }
+        break;
+      }
+      case "file": {
+        if (part.sourceType === "url") {
+          blocks.push({
+            type: "resource",
+            resource: { uri: part.data, mimeType: part.mimeType },
+          });
+          break;
+        }
+        const parsed = parseDataUrl(part.data);
+        if (parsed) {
+          blocks.push({
+            type: "resource",
+            resource: {
+              uri: `file:///${part.filename ?? "attachment"}`,
+              mimeType: parsed.mimeType,
+              blob: parsed.data,
+            },
+          });
+        }
+        break;
+      }
+    }
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// ACP tool call content -> display text
+// ---------------------------------------------------------------------------
+
+export function toolCallContentToText(
+  content: readonly AcpToolCallContent[] | undefined,
+): string | undefined {
+  if (!content || content.length === 0) return undefined;
+  const pieces: string[] = [];
+  for (const item of content) {
+    if (item.type === "content") {
+      for (const block of item.content) {
+        if (block.type === "text") pieces.push(block.text);
+        else if (block.type === "resource" && block.resource.text != null)
+          pieces.push(block.resource.text);
+      }
+    } else if (item.type === "diff") {
+      pieces.push(`--- ${item.path}\n+++ ${item.path}\n${item.newText}`);
+    }
+  }
+  return pieces.length > 0 ? pieces.join("\n") : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Status mappings
+// ---------------------------------------------------------------------------
+
+export function stopReasonToMessageStatus(
+  stopReason: AcpStopReason,
+): MessageStatus {
+  switch (stopReason) {
+    case "cancelled":
+      return { type: "incomplete", reason: "cancelled" };
+    case "refusal":
+      return { type: "incomplete", reason: "other" };
+    case "max_tokens":
+      return { type: "incomplete", reason: "length" };
+    default:
+      return { type: "complete", reason: "stop" };
+  }
+}
+
+export function acpToolStatusToPartStatus(
+  status: AcpToolCallStatus,
+): ToolCallMessagePart["status"] {
+  switch (status) {
+    case "completed":
+      return { type: "complete" };
+    case "failed":
+      return { type: "incomplete", reason: "error" };
+    default:
+      return { type: "running" };
+  }
+}
+
+const PERMISSION_KIND_TO_APPROVAL_KIND: Record<
+  AcpPermissionOption["kind"],
+  string
+> = {
+  allow_once: "allow-once",
+  allow_always: "allow-always",
+  reject_once: "reject-once",
+  reject_always: "reject-always",
+};
+
+export function permissionOptionToApprovalOption(option: AcpPermissionOption): {
+  id: string;
+  kind: string;
+  label: string;
+  description?: string;
+} {
+  return {
+    id: option.optionId,
+    kind: PERMISSION_KIND_TO_APPROVAL_KIND[option.kind] ?? option.kind,
+    label: option.name,
+    ...(option.description != null && { description: option.description }),
+  };
+}
+
+export function isAllowKind(kind: AcpPermissionOption["kind"]): boolean {
+  return kind === "allow_once" || kind === "allow_always";
+}
+
+// ---------------------------------------------------------------------------
+// Run accumulator: ACP session updates -> assistant message content
+// ---------------------------------------------------------------------------
+
+export class AcpContentAccumulator {
+  private _content: ThreadAssistantMessage["content"] = [];
+  private readonly toolCallIndexes = new Map<string, number>();
+
+  get content(): ThreadAssistantMessage["content"] {
+    return this._content;
+  }
+
+  /** Consume one session update. Returns true when content changed. */
+  consume(
+    update: {
+      sessionUpdate: string;
+      content?: AcpContentBlock;
+    } & Partial<AcpToolCallUpdate>,
+  ): boolean {
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk":
+        return update.content
+          ? this.appendChunk(update.content, "text")
+          : false;
+      case "agent_thought_chunk":
+        return update.content
+          ? this.appendChunk(update.content, "reasoning")
+          : false;
+      case "tool_call":
+      case "tool_call_update":
+        return this.upsertToolCall(update as AcpToolCallUpdate);
+      default:
+        return false;
+    }
+  }
+
+  /** Attach an approval request to a tool-call part (creates it if needed). */
+  attachApproval(
+    toolCall: AcpToolCallUpdate,
+    approval: ToolCallMessagePart["approval"],
+  ): boolean {
+    const idx = this.toolCallIndexes.get(toolCall.toolCallId);
+    if (idx === undefined) {
+      this.upsertToolCall(toolCall);
+      return this.attachApproval(toolCall, approval);
+    }
+    const existing = this._content[idx] as ToolCallMessagePart;
+    const merged: ToolCallMessagePart = { ...existing, approval };
+    this.replaceAt(idx, merged);
+    return true;
+  }
+
+  /** Record an approval resolution on a tool-call part. */
+  resolveApproval(
+    approvalId: string,
+    resolution: { approved: boolean; optionId?: string },
+  ): boolean {
+    const idx = this._content.findIndex(
+      (part) => part.type === "tool-call" && part.approval?.id === approvalId,
+    );
+    if (idx < 0) return false;
+    const existing = this._content[idx] as ToolCallMessagePart;
+    if (!existing.approval) return false;
+    const merged: ToolCallMessagePart = {
+      ...existing,
+      approval: { ...existing.approval, ...resolution },
+    };
+    this.replaceAt(idx, merged);
+    return true;
+  }
+
+  private replaceAt(
+    index: number,
+    part: ThreadAssistantMessage["content"][number],
+  ) {
+    this._content = [
+      ...this._content.slice(0, index),
+      part,
+      ...this._content.slice(index + 1),
+    ];
+  }
+
+  private appendChunk(
+    block: AcpContentBlock,
+    kind: "text" | "reasoning",
+  ): boolean {
+    if (block.type === "text") {
+      const last = this._content[this._content.length - 1];
+      if (last && last.type === kind) {
+        this.replaceAt(this._content.length - 1, {
+          ...last,
+          text: last.text + block.text,
+        });
+      } else {
+        this._content = [...this._content, { type: kind, text: block.text }];
+      }
+      return true;
+    }
+    if (block.type === "image") {
+      this._content = [
+        ...this._content,
+        {
+          type: "image",
+          image: `data:${block.mimeType};base64,${block.data}`,
+        },
+      ];
+      return true;
+    }
+    if (block.type === "resource" && block.resource.text != null) {
+      return this.appendChunk(
+        { type: "text", text: block.resource.text },
+        kind,
+      );
+    }
+    return false;
+  }
+
+  private upsertToolCall(update: AcpToolCallUpdate): boolean {
+    const existingIdx = this.toolCallIndexes.get(update.toolCallId);
+    if (existingIdx === undefined) {
+      const part = this.buildToolCallPart(update);
+      this.toolCallIndexes.set(update.toolCallId, this._content.length);
+      this._content = [...this._content, part];
+      return true;
+    }
+
+    const existing = this._content[existingIdx] as ToolCallMessagePart;
+    const merged = this.mergeToolCallPart(existing, update);
+    if (merged === existing) return false;
+    this.replaceAt(existingIdx, merged);
+    return true;
+  }
+
+  private buildToolCallPart(update: AcpToolCallUpdate): ToolCallMessagePart {
+    const args = isRecord(update.rawInput) ? update.rawInput : {};
+    const status = update.status ?? "pending";
+    const result =
+      update.rawOutput ??
+      (status === "completed" || status === "failed"
+        ? toolCallContentToText(update.content)
+        : undefined);
+    return {
+      type: "tool-call",
+      toolCallId: update.toolCallId,
+      toolName: update.title || update.kind || "tool_call",
+      args,
+      argsText: update.rawInput != null ? safeStringify(update.rawInput) : "",
+      ...(result !== undefined && { result }),
+      ...(status === "failed" && { isError: true }),
+      status: acpToolStatusToPartStatus(status),
+    };
+  }
+
+  private mergeToolCallPart(
+    existing: ToolCallMessagePart,
+    update: AcpToolCallUpdate,
+  ): ToolCallMessagePart {
+    let next = existing;
+    let changed = false;
+    const set = (patch: Partial<ToolCallMessagePart>) => {
+      next = { ...next, ...patch };
+      changed = true;
+    };
+
+    if (update.title != null && update.title !== existing.toolName) {
+      set({ toolName: update.title });
+    }
+    if (update.rawInput !== undefined) {
+      set({
+        args: isRecord(update.rawInput) ? update.rawInput : {},
+        argsText: safeStringify(update.rawInput),
+      });
+    }
+    if (
+      update.rawOutput !== undefined &&
+      update.rawOutput !== existing.result
+    ) {
+      set({ result: update.rawOutput });
+    }
+    if (update.status != null) {
+      const partStatus = acpToolStatusToPartStatus(update.status);
+      if (
+        partStatus.type !== existing.status?.type ||
+        (partStatus.type === "incomplete" &&
+          existing.status?.type === "incomplete" &&
+          partStatus.reason !== existing.status.reason)
+      ) {
+        set({
+          status: partStatus,
+          ...(update.status === "failed" && { isError: true }),
+        });
+      }
+      if (
+        (update.status === "completed" || update.status === "failed") &&
+        next.result === undefined
+      ) {
+        const text = toolCallContentToText(update.content);
+        if (text !== undefined) set({ result: text });
+      }
+    } else if (update.content != null && next.result === undefined) {
+      const text = toolCallContentToText(update.content);
+      if (text !== undefined) set({ result: text });
+    }
+
+    return changed ? next : existing;
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/react-acp/src/hooks.ts
+++ b/packages/react-acp/src/hooks.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { acpExtras } from "./acpExtras";
+
+/** Current ACP connection state. */
+export const useAcpConnectionState = () =>
+  acpExtras.use((e) => e.connectionState);
+
+/** The ACP session id for the current connection, once created. */
+export const useAcpSessionId = () => acpExtras.use((e) => e.sessionId);
+
+/** Agent identity returned by the `initialize` handshake. */
+export const useAcpAgentInfo = () => acpExtras.use((e) => e.agentInfo);
+
+/** The agent's plan for the current turn, when it emits one. */
+export const useAcpPlan = () => acpExtras.use((e) => e.plan);
+
+/** Session title, when the agent provides one. */
+export const useAcpSessionTitle = () => acpExtras.use((e) => e.sessionTitle);
+
+/** The agent's current mode id, when it reports modes. */
+export const useAcpCurrentModeId = () => acpExtras.use((e) => e.currentModeId);
+
+/** Slash-style commands the agent makes available, when it reports them. */
+export const useAcpAvailableCommands = () =>
+  acpExtras.use((e) => e.availableCommands);

--- a/packages/react-acp/src/index.ts
+++ b/packages/react-acp/src/index.ts
@@ -1,0 +1,74 @@
+// Main hook
+export { useAcpRuntime } from "./useAcpRuntime";
+export type { UseAcpRuntimeOptions } from "./useAcpRuntime";
+export {
+  useAcpConnectionState,
+  useAcpSessionId,
+  useAcpAgentInfo,
+  useAcpPlan,
+  useAcpSessionTitle,
+  useAcpCurrentModeId,
+  useAcpAvailableCommands,
+} from "./hooks";
+
+// Client
+export { AcpClient, AcpError, autoAllowPermissionHandler } from "./AcpClient";
+export type {
+  AcpClientOptions,
+  AcpPermissionHandler,
+  AcpWebSocketFactory,
+  AcpWebSocketLike,
+} from "./AcpClient";
+
+// Runtime core (advanced usage)
+export { AcpThreadRuntimeCore } from "./AcpThreadRuntimeCore";
+export type {
+  AcpThreadRuntimeCoreOptions,
+  AcpPermissionsMode,
+} from "./AcpThreadRuntimeCore";
+export { acpExtras } from "./acpExtras";
+
+// Protocol types
+export type {
+  AcpAnnotations,
+  AcpTextContentBlock,
+  AcpImageContentBlock,
+  AcpAudioContentBlock,
+  AcpResourceLink,
+  AcpResourceContentBlock,
+  AcpContentBlock,
+  AcpToolKind,
+  AcpToolCallStatus,
+  AcpToolCallContent,
+  AcpToolCallLocation,
+  AcpToolCall,
+  AcpToolCallUpdate,
+  AcpPlanEntry,
+  AcpAvailableCommand,
+  AcpSessionUpdate,
+  AcpPermissionOptionKind,
+  AcpPermissionOption,
+  AcpPermissionRequest,
+  AcpPermissionOutcome,
+  AcpStopReason,
+  AcpPromptCapabilities,
+  AcpAgentCapabilities,
+  AcpImplementation,
+  AcpInitializeResponse,
+  AcpClientCapabilities,
+  AcpMcpServer,
+  AcpConnectionState,
+  AcpExtras,
+} from "./types";
+export { ACP_PROTOCOL_VERSION } from "./types";
+
+// Conversion utilities (for advanced usage)
+export {
+  threadContentToAcpBlocks,
+  toolCallContentToText,
+  stopReasonToMessageStatus,
+  acpToolStatusToPartStatus,
+  permissionOptionToApprovalOption,
+  isAllowKind,
+  AcpContentAccumulator,
+} from "./conversions";

--- a/packages/react-acp/src/types.ts
+++ b/packages/react-acp/src/types.ts
@@ -1,0 +1,261 @@
+import type { ReadonlyJSONObject, ReadonlyJSONValue } from "@assistant-ui/core";
+
+/** ACP v1 protocol version. */
+export const ACP_PROTOCOL_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Content blocks
+// ---------------------------------------------------------------------------
+
+export type AcpAnnotations = {
+  readonly audience?: readonly ("user" | "assistant")[];
+  readonly priority?: number;
+};
+
+export type AcpTextContentBlock = {
+  readonly type: "text";
+  readonly text: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+export type AcpImageContentBlock = {
+  readonly type: "image";
+  /** Base64-encoded image data. */
+  readonly data: string;
+  readonly mimeType: string;
+  readonly uri?: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+export type AcpAudioContentBlock = {
+  readonly type: "audio";
+  /** Base64-encoded audio data. */
+  readonly data: string;
+  readonly mimeType: string;
+  readonly annotations?: AcpAnnotations;
+};
+
+export type AcpResourceLink = {
+  readonly uri: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly mimeType?: string;
+  readonly text?: string;
+  /** Base64-encoded blob, when binary. */
+  readonly blob?: string;
+};
+
+export type AcpResourceContentBlock = {
+  readonly type: "resource";
+  readonly resource: AcpResourceLink;
+  readonly annotations?: AcpAnnotations;
+};
+
+export type AcpContentBlock =
+  | AcpTextContentBlock
+  | AcpImageContentBlock
+  | AcpAudioContentBlock
+  | AcpResourceContentBlock;
+
+// ---------------------------------------------------------------------------
+// Tool calls
+// ---------------------------------------------------------------------------
+
+export type AcpToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
+
+export type AcpToolCallStatus =
+  | "pending"
+  | "in_progress"
+  | "completed"
+  | "failed";
+
+export type AcpToolCallContent =
+  | { readonly type: "content"; readonly content: readonly AcpContentBlock[] }
+  | {
+      readonly type: "diff";
+      readonly path: string;
+      readonly oldText?: string;
+      readonly newText: string;
+    };
+
+export type AcpToolCallLocation = {
+  readonly path: string;
+  readonly line?: number;
+};
+
+export type AcpToolCall = {
+  readonly toolCallId: string;
+  readonly title?: string;
+  readonly kind?: AcpToolKind;
+  readonly status?: AcpToolCallStatus;
+  readonly content?: readonly AcpToolCallContent[];
+  readonly locations?: readonly AcpToolCallLocation[];
+  readonly rawInput?: ReadonlyJSONValue;
+  readonly rawOutput?: ReadonlyJSONValue;
+};
+
+/** All fields except toolCallId are optional in an update. */
+export type AcpToolCallUpdate = {
+  readonly toolCallId: string;
+  readonly title?: string;
+  readonly kind?: AcpToolKind;
+  readonly status?: AcpToolCallStatus;
+  readonly content?: readonly AcpToolCallContent[];
+  readonly locations?: readonly AcpToolCallLocation[];
+  readonly rawInput?: ReadonlyJSONValue;
+  readonly rawOutput?: ReadonlyJSONValue;
+};
+
+// ---------------------------------------------------------------------------
+// Session updates (server -> client notifications)
+// ---------------------------------------------------------------------------
+
+export type AcpPlanEntry = {
+  readonly content: string;
+  readonly priority: "high" | "medium" | "low";
+  readonly status: "pending" | "in_progress" | "completed";
+};
+
+export type AcpAvailableCommand = {
+  readonly name: string;
+  readonly description: string;
+  readonly input?: { readonly hint: string };
+};
+
+export type AcpSessionUpdate =
+  | {
+      readonly sessionUpdate: "agent_message_chunk";
+      readonly content: AcpContentBlock;
+      readonly stopReason?: AcpStopReason;
+    }
+  | {
+      readonly sessionUpdate: "agent_thought_chunk";
+      readonly content: AcpContentBlock;
+    }
+  | ({ readonly sessionUpdate: "tool_call" } & AcpToolCall)
+  | ({ readonly sessionUpdate: "tool_call_update" } & AcpToolCallUpdate)
+  | {
+      readonly sessionUpdate: "plan";
+      readonly entries: readonly AcpPlanEntry[];
+    }
+  | {
+      readonly sessionUpdate: "available_commands_update";
+      readonly availableCommands: readonly AcpAvailableCommand[];
+    }
+  | {
+      readonly sessionUpdate: "current_mode_update";
+      readonly currentModeId: string;
+    }
+  | {
+      readonly sessionUpdate: "session_info_update";
+      readonly title?: string;
+      readonly updatedAt?: string;
+    }
+  | {
+      readonly sessionUpdate: "user_message_chunk";
+      readonly content: AcpContentBlock;
+    };
+
+// ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+export type AcpPermissionOptionKind =
+  | "allow_once"
+  | "allow_always"
+  | "reject_once"
+  | "reject_always";
+
+export type AcpPermissionOption = {
+  readonly optionId: string;
+  readonly name: string;
+  readonly kind: AcpPermissionOptionKind;
+  readonly description?: string;
+};
+
+export type AcpPermissionRequest = {
+  readonly sessionId: string;
+  readonly toolCall: AcpToolCallUpdate;
+  readonly options: readonly AcpPermissionOption[];
+};
+
+export type AcpPermissionOutcome =
+  | { readonly outcome: "selected"; readonly optionId: string }
+  | { readonly outcome: "cancelled" };
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export type AcpStopReason =
+  | "end_turn"
+  | "max_tokens"
+  | "max_turn_requests"
+  | "refusal"
+  | "cancelled";
+
+export type AcpPromptCapabilities = {
+  readonly image?: boolean;
+  readonly audio?: boolean;
+  readonly embeddedContext?: boolean;
+};
+
+export type AcpAgentCapabilities = {
+  readonly loadSession?: boolean;
+  readonly promptCapabilities?: AcpPromptCapabilities;
+  readonly mcpCapabilities?: ReadonlyJSONObject;
+};
+
+export type AcpImplementation = {
+  readonly name: string;
+  readonly title?: string;
+  readonly version: string;
+};
+
+export type AcpInitializeResponse = {
+  readonly protocolVersion: number;
+  readonly agentCapabilities?: AcpAgentCapabilities;
+  readonly agentInfo?: AcpImplementation;
+};
+
+export type AcpClientCapabilities = {
+  readonly fs?: {
+    readonly readTextFile?: boolean;
+    readonly writeTextFile?: boolean;
+  };
+  readonly terminal?: boolean;
+};
+
+export type AcpMcpServer = {
+  readonly name: string;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly url?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Client options / extras
+// ---------------------------------------------------------------------------
+
+export type AcpConnectionState = "disconnected" | "connecting" | "connected";
+
+export type AcpExtras = {
+  readonly connectionState: AcpConnectionState;
+  readonly sessionId: string | undefined;
+  readonly agentInfo: AcpImplementation | undefined;
+  readonly agentCapabilities: AcpAgentCapabilities | undefined;
+  readonly plan: readonly AcpPlanEntry[] | undefined;
+  readonly sessionTitle: string | undefined;
+  readonly currentModeId: string | undefined;
+  readonly availableCommands: readonly AcpAvailableCommand[] | undefined;
+};

--- a/packages/react-acp/src/types.ts
+++ b/packages/react-acp/src/types.ts
@@ -1,4 +1,7 @@
-import type { ReadonlyJSONObject, ReadonlyJSONValue } from "@assistant-ui/core";
+import type {
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
+} from "assistant-stream/utils";
 
 /** ACP v1 protocol version. */
 export const ACP_PROTOCOL_VERSION = 1;

--- a/packages/react-acp/src/useAcpRuntime.ts
+++ b/packages/react-acp/src/useAcpRuntime.ts
@@ -168,6 +168,19 @@ export function useAcpRuntime(options: UseAcpRuntimeOptions): AssistantRuntime {
 
   const runtime = useExternalStoreRuntime(store);
 
+  // Subscribe the committed core to the client. This must run in an effect
+  // (not in the core's constructor): React runs useMemo factories for render
+  // passes it may later discard (StrictMode double-invocation, interrupted
+  // renders), and a discarded core must never steal the client's callbacks
+  // from the committed one — that silently drops every session/update
+  // notification (assistant messages complete with empty content).
+  useEffect(() => {
+    core.attachClient();
+    return () => {
+      core.detachClient();
+    };
+  }, [core]);
+
   useEffect(() => {
     core.attachRuntime(runtime);
     return () => {

--- a/packages/react-acp/src/useAcpRuntime.ts
+++ b/packages/react-acp/src/useAcpRuntime.ts
@@ -1,0 +1,183 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useExternalStoreRuntime,
+  useExternalStoreSharedOptions,
+  useRuntimeAdapters,
+} from "@assistant-ui/core/react";
+import type {
+  AppendMessage,
+  AssistantRuntime,
+  AttachmentAdapter,
+  DictationAdapter,
+  ExternalStoreAdapter,
+  ExternalStoreSharedOptions,
+  FeedbackAdapter,
+  RealtimeVoiceAdapter,
+  RespondToToolApprovalOptions,
+  SpeechSynthesisAdapter,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+import {
+  AcpClient,
+  type AcpClientOptions,
+  type AcpWebSocketFactory,
+} from "./AcpClient";
+import {
+  AcpThreadRuntimeCore,
+  type AcpPermissionsMode,
+} from "./AcpThreadRuntimeCore";
+import { acpExtras } from "./acpExtras";
+import type { AcpImplementation, AcpMcpServer } from "./types";
+
+export type UseAcpRuntimeOptions = ExternalStoreSharedOptions & {
+  /** Pre-built ACP client instance. Provide this OR `url`. */
+  client?: AcpClient;
+  /** WebSocket endpoint of the ACP agent, e.g. `ws://127.0.0.1:2770/`. */
+  url?: string;
+  /** Working directory passed to `session/new`. */
+  cwd?: string;
+  /** MCP servers passed to `session/new`. */
+  mcpServers?: readonly AcpMcpServer[];
+  /** Client identity for the `initialize` handshake. */
+  clientInfo?: AcpImplementation;
+  /** Inject a WebSocket implementation (tests / custom transports). */
+  webSocketFactory?: AcpWebSocketFactory;
+  /**
+   * Permission policy. `"ask"` (default) surfaces ACP permission requests as
+   * tool-call approvals in the UI; `"auto-allow"` answers them automatically.
+   */
+  permissions?: AcpPermissionsMode;
+  /** Connect on mount. Defaults to true. */
+  autoConnect?: boolean;
+
+  /** Called when an error occurs. */
+  onError?: (error: Error) => void;
+  /** Called when a run is cancelled. */
+  onCancel?: () => void;
+
+  adapters?: {
+    attachments?: AttachmentAdapter;
+    speech?: SpeechSynthesisAdapter;
+    dictation?: DictationAdapter;
+    voice?: RealtimeVoiceAdapter;
+    feedback?: FeedbackAdapter;
+    history?: ThreadHistoryAdapter;
+  };
+};
+
+type ManagedAcpClientOptions = Pick<
+  AcpClientOptions,
+  "url" | "cwd" | "mcpServers" | "clientInfo" | "webSocketFactory"
+>;
+
+const serializeManagedClientOptions = (
+  options: Omit<ManagedAcpClientOptions, "webSocketFactory">,
+): string => JSON.stringify(options);
+
+export function useAcpRuntime(options: UseAcpRuntimeOptions): AssistantRuntime {
+  const [_version, setVersion] = useState(0);
+  const notifyUpdate = useCallback(() => setVersion((v) => v + 1), []);
+  const runtimeAdapters = useRuntimeAdapters();
+  const historyAdapter = options.adapters?.history ?? runtimeAdapters?.history;
+
+  const managedClientOptionsKey = options.client
+    ? null
+    : options.url
+      ? serializeManagedClientOptions({
+          url: options.url,
+          cwd: options.cwd,
+          mcpServers: options.mcpServers,
+          clientInfo: options.clientInfo,
+        })
+      : null;
+
+  const webSocketFactory = options.webSocketFactory;
+  const client = useMemo(() => {
+    if (options.client) return options.client;
+    if (!managedClientOptionsKey) {
+      throw new Error("useAcpRuntime requires either `client` or `url`");
+    }
+
+    return new AcpClient({
+      ...(JSON.parse(managedClientOptionsKey) as Omit<
+        ManagedAcpClientOptions,
+        "webSocketFactory"
+      >),
+      ...(webSocketFactory && { webSocketFactory }),
+    });
+  }, [managedClientOptionsKey, options.client, webSocketFactory]);
+
+  const core = useMemo(
+    () =>
+      new AcpThreadRuntimeCore({
+        client,
+        notifyUpdate,
+      }),
+    [client, notifyUpdate],
+  );
+
+  core.updateOptions({
+    client,
+    permissions: options.permissions,
+    autoConnect: options.autoConnect,
+    ...(options.onError && { onError: options.onError }),
+    ...(options.onCancel && { onCancel: options.onCancel }),
+    ...(historyAdapter && { history: historyAdapter }),
+  });
+
+  // Adapters
+  const adapters = options.adapters;
+  const adapterAdapters = useMemo(
+    () => ({
+      attachments: adapters?.attachments ?? runtimeAdapters?.attachments,
+      speech: adapters?.speech,
+      dictation: adapters?.dictation,
+      voice: adapters?.voice,
+      feedback: adapters?.feedback,
+    }),
+    [adapters, runtimeAdapters],
+  );
+
+  // Build store adapter
+  const shared = useExternalStoreSharedOptions(options);
+  const store = useMemo(() => {
+    void _version;
+
+    return {
+      ...shared,
+      isLoading: core.isLoading,
+      messageRepository: core.getMessageRepository(),
+      isRunning: core.isRunning(),
+      extras: acpExtras.provide(core.getExtras()),
+      onNew: (message: AppendMessage) => core.append(message),
+      onEdit: (message: AppendMessage) => core.edit(message),
+      onReload: (parentId: string | null) => core.reload(parentId),
+      onCancel: () => core.cancel(),
+      onRespondToToolApproval: (approval: RespondToToolApprovalOptions) =>
+        core.respondToApproval(approval),
+      setMessages: (messages: readonly ThreadMessage[]) =>
+        core.applyExternalMessages(messages),
+      onImport: (messages: readonly ThreadMessage[]) =>
+        core.applyExternalMessages(messages),
+      adapters: adapterAdapters,
+    } satisfies ExternalStoreAdapter<ThreadMessage>;
+  }, [adapterAdapters, core, _version, shared]);
+
+  const runtime = useExternalStoreRuntime(store);
+
+  useEffect(() => {
+    core.attachRuntime(runtime);
+    return () => {
+      core.detachRuntime();
+    };
+  }, [core, runtime]);
+
+  useEffect(() => {
+    core.__internal_load();
+  }, [core]);
+
+  return runtime;
+}

--- a/packages/react-acp/tsconfig.json
+++ b/packages/react-acp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/react-acp/vitest.config.ts
+++ b/packages/react-acp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4120,6 +4120,43 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/react-acp:
+    dependencies:
+      '@assistant-ui/core':
+        specifier: ^0.3.13
+        version: link:../core
+      '@assistant-ui/store':
+        specifier: ^0.3.9
+        version: link:../store
+      assistant-stream:
+        specifier: ^0.3.37
+        version: link:../assistant-stream
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+
   packages/react-ag-ui:
     dependencies:
       '@ag-ui/client':


### PR DESCRIPTION
Agent Client Protocol has HTTP transport now, and I have written assistant-ui/react-acp to interact with my ACP agent running over HTTP.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Yr3zGf0m3_Es8W5jypqa6h2O70If-g9Zh_na0iINxWJLPsTu0k41dUXKlIU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->