### PR TITLE
fix(react-google-adk): validate session history events

### DIFF
--- a/.changeset/fuzzy-hounds-check.md
+++ b/.changeset/fuzzy-hounds-check.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: validate events loaded from Google ADK session history

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -568,9 +568,9 @@ describe("createAdkStream - SSE parsing", () => {
     });
   });
 
-  it.each([true, null])("rejects unsupported event id values", async (id) => {
+  it("rejects unsupported event id types", async () => {
     mockFetch.mockResolvedValueOnce(
-      sseResponse(sseBody(`data: ${JSON.stringify({ id })}\n\n`)),
+      sseResponse(sseBody('data: {"id":true}\n\n')),
     );
 
     const stream = createAdkStream({ api: "/api/adk" });

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -568,9 +568,9 @@ describe("createAdkStream - SSE parsing", () => {
     });
   });
 
-  it("rejects unsupported event id types", async () => {
+  it.each([true, null])("rejects unsupported event id values", async (id) => {
     mockFetch.mockResolvedValueOnce(
-      sseResponse(sseBody('data: {"id":true}\n\n')),
+      sseResponse(sseBody(`data: ${JSON.stringify({ id })}\n\n`)),
     );
 
     const stream = createAdkStream({ api: "/api/adk" });

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -1,5 +1,6 @@
 import { SSEEventDecoder } from "assistant-stream/utils";
 import { contentToParts } from "./contentToParts";
+import { parseAdkEventValue } from "./parseAdkEvent";
 import { trimTrailingSlashes } from "./trimTrailingSlashes";
 import type {
   AdkEvent,
@@ -139,39 +140,7 @@ function parseAdkEvent(data: string): AdkEvent {
     throw new Error("Invalid ADK stream event: expected valid JSON.");
   }
 
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value) ||
-    Object.keys(value).length === 0
-  ) {
-    throw new Error("Invalid ADK stream event: expected a non-empty object.");
-  }
-
-  const { id: rawId, ...event } = value as Record<string, unknown>;
-  if (
-    rawId != null &&
-    typeof rawId !== "string" &&
-    (typeof rawId !== "number" || !Number.isFinite(rawId))
-  ) {
-    throw new Error(
-      'Invalid ADK stream event: expected "id" to be a string or finite number when present.',
-    );
-  }
-
-  const errorMessage =
-    "error" in event && typeof event.error === "string"
-      ? event.error
-      : undefined;
-  return {
-    ...event,
-    ...(rawId != null && { id: String(rawId) }),
-    ...(errorMessage !== undefined &&
-      !("errorMessage" in event) &&
-      !("error_message" in event) && {
-        errorMessage,
-      }),
-  } as AdkEvent;
+  return parseAdkEventValue(value, "Invalid ADK stream event");
 }
 
 async function resolveHeaders(

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAdkSessionAdapter } from "./AdkSessionAdapter";
 import { projectAdkToolApprovals } from "./adkToolApproval";
 
@@ -10,10 +10,6 @@ const mockFetch =
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
   mockFetch.mockReset();
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
 });
 
 const baseOptions = {
@@ -429,37 +425,28 @@ describe("createAdkSessionAdapter - load", () => {
     );
   });
 
-  it("skips malformed events when valid history remains", async () => {
+  it("rejects partial replay when a history event is malformed", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           id: "s1",
           events: [
-            {},
             {
               id: "e1",
               author: "user",
               content: { role: "user", parts: [{ text: "Hello" }] },
             },
+            {},
           ],
         }),
         { status: 200 },
       ),
     );
-    const consoleWarn = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
 
     const { load } = createAdkSessionAdapter(baseOptions);
-    const result = await load("s1");
 
-    expect(result.messages).toHaveLength(1);
-    expect(consoleWarn).toHaveBeenCalledWith(
-      "[assistant-ui] Skipping malformed ADK session event:",
-      expect.objectContaining({
-        message:
-          "Invalid ADK session event at index 0: expected a non-empty object.",
-      }),
+    await expect(load("s1")).rejects.toThrow(
+      "Invalid ADK session event at index 1: expected a non-empty object.",
     );
   });
 

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -421,7 +421,7 @@ describe("createAdkSessionAdapter - load", () => {
     const { load } = createAdkSessionAdapter(baseOptions);
 
     await expect(load("s1")).rejects.toThrow(
-      "Invalid ADK session event: expected a non-empty object.",
+      "Invalid ADK session event at index 0: expected a non-empty object.",
     );
   });
 

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -411,6 +411,20 @@ describe("createAdkSessionAdapter - load", () => {
     );
   });
 
+  it("rejects malformed events inside a session history", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "s1", events: [{}] }), {
+        status: 200,
+      }),
+    );
+
+    const { load } = createAdkSessionAdapter(baseOptions);
+
+    await expect(load("s1")).rejects.toThrow(
+      "Invalid ADK session event: expected a non-empty object.",
+    );
+  });
+
   it("throws when session fetch fails", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response("Server error", { status: 500 }),

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAdkSessionAdapter } from "./AdkSessionAdapter";
 import { projectAdkToolApprovals } from "./adkToolApproval";
 
@@ -10,6 +10,10 @@ const mockFetch =
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 const baseOptions = {
@@ -422,6 +426,40 @@ describe("createAdkSessionAdapter - load", () => {
 
     await expect(load("s1")).rejects.toThrow(
       "Invalid ADK session event at index 0: expected a non-empty object.",
+    );
+  });
+
+  it("skips malformed events when valid history remains", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "s1",
+          events: [
+            {},
+            {
+              id: "e1",
+              author: "user",
+              content: { role: "user", parts: [{ text: "Hello" }] },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    const { load } = createAdkSessionAdapter(baseOptions);
+    const result = await load("s1");
+
+    expect(result.messages).toHaveLength(1);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "[assistant-ui] Skipping malformed ADK session event:",
+      expect.objectContaining({
+        message:
+          "Invalid ADK session event at index 0: expected a non-empty object.",
+      }),
     );
   });
 

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -324,8 +324,8 @@ export function createAdkSessionAdapter(
       );
     }
 
-    const events = session.events?.map((event) =>
-      parseAdkEventValue(event, "Invalid ADK session event"),
+    const events = session.events?.map((event, index) =>
+      parseAdkEventValue(event, `Invalid ADK session event at index ${index}`),
     );
 
     if (!events?.length) {

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -6,7 +6,8 @@ import type {
   RemoteThreadMetadata,
 } from "@assistant-ui/core";
 import { AdkEventAccumulator } from "./AdkEventAccumulator";
-import type { AdkEvent, AdkMessage, AdkThreadSnapshot } from "./types";
+import { parseAdkEventValue } from "./parseAdkEvent";
+import type { AdkMessage, AdkThreadSnapshot } from "./types";
 import { trimTrailingSlashes } from "./trimTrailingSlashes";
 
 export type AdkSessionAdapterOptions = {
@@ -323,7 +324,9 @@ export function createAdkSessionAdapter(
       );
     }
 
-    const events = session.events as AdkEvent[] | undefined;
+    const events = session.events?.map((event) =>
+      parseAdkEventValue(event, "Invalid ADK session event"),
+    );
 
     if (!events?.length) {
       return { messages: [] };

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -7,7 +7,7 @@ import type {
 } from "@assistant-ui/core";
 import { AdkEventAccumulator } from "./AdkEventAccumulator";
 import { parseAdkEventValue } from "./parseAdkEvent";
-import type { AdkMessage, AdkThreadSnapshot } from "./types";
+import type { AdkEvent, AdkMessage, AdkThreadSnapshot } from "./types";
 import { trimTrailingSlashes } from "./trimTrailingSlashes";
 
 export type AdkSessionAdapterOptions = {
@@ -86,6 +86,34 @@ const parseAdkSessionResponse = (
     );
   }
   return value;
+};
+
+const parseAdkHistoryEvents = (events: unknown[]): AdkEvent[] => {
+  const parsed: AdkEvent[] = [];
+  const invalid: unknown[] = [];
+
+  for (const [index, event] of events.entries()) {
+    try {
+      parsed.push(
+        parseAdkEventValue(
+          event,
+          `Invalid ADK session event at index ${index}`,
+        ),
+      );
+    } catch (error) {
+      invalid.push(error);
+    }
+  }
+
+  if (parsed.length === 0 && invalid.length > 0) {
+    throw invalid[0];
+  }
+
+  for (const error of invalid) {
+    console.warn("[assistant-ui] Skipping malformed ADK session event:", error);
+  }
+
+  return parsed;
 };
 
 const parseAdkSessionListResponse = (value: unknown): AdkSessionResponse[] => {
@@ -324,9 +352,9 @@ export function createAdkSessionAdapter(
       );
     }
 
-    const events = session.events?.map((event, index) =>
-      parseAdkEventValue(event, `Invalid ADK session event at index ${index}`),
-    );
+    const events = session.events
+      ? parseAdkHistoryEvents(session.events)
+      : undefined;
 
     if (!events?.length) {
       return { messages: [] };

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -7,7 +7,7 @@ import type {
 } from "@assistant-ui/core";
 import { AdkEventAccumulator } from "./AdkEventAccumulator";
 import { parseAdkEventValue } from "./parseAdkEvent";
-import type { AdkEvent, AdkMessage, AdkThreadSnapshot } from "./types";
+import type { AdkMessage, AdkThreadSnapshot } from "./types";
 import { trimTrailingSlashes } from "./trimTrailingSlashes";
 
 export type AdkSessionAdapterOptions = {
@@ -86,34 +86,6 @@ const parseAdkSessionResponse = (
     );
   }
   return value;
-};
-
-const parseAdkHistoryEvents = (events: unknown[]): AdkEvent[] => {
-  const parsed: AdkEvent[] = [];
-  const invalid: unknown[] = [];
-
-  for (const [index, event] of events.entries()) {
-    try {
-      parsed.push(
-        parseAdkEventValue(
-          event,
-          `Invalid ADK session event at index ${index}`,
-        ),
-      );
-    } catch (error) {
-      invalid.push(error);
-    }
-  }
-
-  if (parsed.length === 0 && invalid.length > 0) {
-    throw invalid[0];
-  }
-
-  for (const error of invalid) {
-    console.warn("[assistant-ui] Skipping malformed ADK session event:", error);
-  }
-
-  return parsed;
 };
 
 const parseAdkSessionListResponse = (value: unknown): AdkSessionResponse[] => {
@@ -352,9 +324,11 @@ export function createAdkSessionAdapter(
       );
     }
 
-    const events = session.events
-      ? parseAdkHistoryEvents(session.events)
-      : undefined;
+    // Events carry ordered state and tool transitions, so partial replay can
+    // produce a plausible but incorrect thread.
+    const events = session.events?.map((event, index) =>
+      parseAdkEventValue(event, `Invalid ADK session event at index ${index}`),
+    );
 
     if (!events?.length) {
       return { messages: [] };

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -1,0 +1,40 @@
+import type { AdkEvent } from "./types";
+
+export function parseAdkEventValue(
+  value: unknown,
+  errorPrefix: string,
+): AdkEvent {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.keys(value).length === 0
+  ) {
+    throw new Error(`${errorPrefix}: expected a non-empty object.`);
+  }
+
+  const { id: rawId, ...event } = value as Record<string, unknown>;
+  if (
+    rawId != null &&
+    typeof rawId !== "string" &&
+    (typeof rawId !== "number" || !Number.isFinite(rawId))
+  ) {
+    throw new Error(
+      `${errorPrefix}: expected "id" to be a string or finite number when present.`,
+    );
+  }
+
+  const errorMessage =
+    "error" in event && typeof event.error === "string"
+      ? event.error
+      : undefined;
+  return {
+    ...event,
+    ...(rawId != null && { id: String(rawId) }),
+    ...(errorMessage !== undefined &&
+      !("errorMessage" in event) &&
+      !("error_message" in event) && {
+        errorMessage,
+      }),
+  } as AdkEvent;
+}

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -15,7 +15,7 @@ export function parseAdkEventValue(
 
   const { id: rawId, ...event } = value as Record<string, unknown>;
   if (
-    rawId != null &&
+    rawId !== undefined &&
     typeof rawId !== "string" &&
     (typeof rawId !== "number" || !Number.isFinite(rawId))
   ) {
@@ -30,7 +30,7 @@ export function parseAdkEventValue(
       : undefined;
   return {
     ...event,
-    ...(rawId != null && { id: String(rawId) }),
+    ...(rawId !== undefined && { id: String(rawId) }),
     ...(errorMessage !== undefined &&
       !("errorMessage" in event) &&
       !("error_message" in event) && {

--- a/packages/react-google-adk/src/parseAdkEvent.ts
+++ b/packages/react-google-adk/src/parseAdkEvent.ts
@@ -15,7 +15,7 @@ export function parseAdkEventValue(
 
   const { id: rawId, ...event } = value as Record<string, unknown>;
   if (
-    rawId !== undefined &&
+    rawId != null &&
     typeof rawId !== "string" &&
     (typeof rawId !== "number" || !Number.isFinite(rawId))
   ) {
@@ -30,7 +30,7 @@ export function parseAdkEventValue(
       : undefined;
   return {
     ...event,
-    ...(rawId !== undefined && { id: String(rawId) }),
+    ...(rawId != null && { id: String(rawId) }),
     ...(errorMessage !== undefined &&
       !("errorMessage" in event) &&
       !("error_message" in event) && {


### PR DESCRIPTION
## Summary

- validate every event loaded from Google ADK session history
- reuse the live-stream event parser so persisted and streamed events follow the same shape rules
- reject malformed history at the adapter boundary instead of treating it as a successful load

## Why

A successful session response such as `{ "id": "s1", "events": [{}] }` passed the session wrapper checks because only the `events` array itself was validated. The individual values were cast to `AdkEvent` and sent to the accumulator, where an empty object produced no messages and no useful error. Live ADK streams already reject this payload.

This change shares that event validation with the history loader while preserving the existing live-stream errors and normalization behavior.

## Testing

- `pnpm --filter @assistant-ui/react-google-adk... build`
- `pnpm --filter @assistant-ui/react-google-adk exec vitest run src/AdkClient.test.ts src/AdkSessionAdapter.test.ts`
- `pnpm lint`


<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.szzODUT6yXvhiyhysggV416wc6HQLtQqgA93yu8Vxx1y9grB8jBycz43jyg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->