### PR TITLE
fix(react-devtools): sanitize invalid date values

### DIFF
--- a/.changeset/slow-lions-smile.md
+++ b/.changeset/slow-lions-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: sanitize invalid dates in inspected runtime values

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -55,6 +55,10 @@ describe("sanitizeForMessage", () => {
     });
     expect(() => JSON.stringify(result)).not.toThrow();
   });
+
+  it("sanitizes invalid dates without throwing", () => {
+    expect(sanitizeForMessage(new Date(Number.NaN))).toBe("Invalid Date");
+  });
 });
 
 describe("redactSensitive", () => {

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -22,7 +22,7 @@ export const sanitizeForMessage = (
     return "[Function]";
   }
   if (value instanceof Date) {
-    return value.toISOString();
+    return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
   }
   if (value instanceof Map) {
     if (seen.has(value)) return "[Circular]";


### PR DESCRIPTION
## Summary

- preserve ISO serialization for valid `Date` values
- serialize invalid dates as `"Invalid Date"` instead of throwing
- cover the invalid-date path with a focused regression test

## Why

React DevTools sanitizes runtime state, tool data, logs, and scope values before rendering or sending them. `sanitizeForMessage(new Date(Number.NaN))` currently calls `toISOString()`, which throws `RangeError: Invalid time value`. One malformed or application-created date can therefore interrupt DevTools inspection rather than being represented as data.

The fix keeps valid dates unchanged and makes the invalid value visible without crashing serialization.

## Testing

- `pnpm --filter @assistant-ui/react-devtools build`
- `pnpm --filter @assistant-ui/react-devtools exec vitest run src/utils/serialization.test.ts`
- `pnpm exec oxlint packages/react-devtools/src/utils/serialization.ts packages/react-devtools/src/utils/serialization.test.ts`
- `pnpm exec oxfmt --check packages/react-devtools/src/utils/serialization.ts packages/react-devtools/src/utils/serialization.test.ts`


<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-auCpO1VtrsAvfaeWI75EQPkoc8RRAfcORqpKnaKeW3Xvk2bdzwm1a9ifvA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->