### PR TITLE
fix(core): handle automatic title generation failures

### DIFF
--- a/.changeset/bright-wolves-report.md
+++ b/.changeset/bright-wolves-report.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: report automatic thread title generation failures

--- a/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AssistantRuntimeImpl } from "../../runtime/api/assistant-runtime";
 import type { ThreadListItemRuntime } from "../../runtime/api/thread-list-item-runtime";
 import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
 import type { AppendMessage } from "../../types/message";
 import { subscribeToTitleGeneration } from "./RemoteThreadResource";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("subscribeToTitleGeneration", () => {
   it("reports title generation failures through the runtime event boundary", async () => {

--- a/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
@@ -1,39 +1,57 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import { AssistantRuntimeImpl } from "../../runtime/api/assistant-runtime";
 import type { ThreadListItemRuntime } from "../../runtime/api/thread-list-item-runtime";
-import { notifyEventListeners } from "../../utils/notify-event-listeners";
+import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
+import type { AppendMessage } from "../../types/message";
 import { subscribeToTitleGeneration } from "./RemoteThreadResource";
 
 describe("subscribeToTitleGeneration", () => {
   it("reports title generation failures through the runtime event boundary", async () => {
     const error = new Error("title unavailable");
-    const titleTask = Promise.reject(error);
-    void titleTask.catch(() => undefined);
-
-    let runEndListener: (() => unknown) | undefined;
-    const unsubscribe = vi.fn();
-    const threadRuntime = {
-      unstable_on: vi.fn((_event, listener) => {
-        runEndListener = listener;
-        return unsubscribe;
-      }),
-    } as unknown as AssistantRuntime["thread"];
+    const runtime = new AssistantRuntimeImpl(
+      new LocalRuntimeCore(
+        {
+          adapters: {
+            chatModel: {
+              async run() {
+                return { content: [{ type: "text", text: "done" }] };
+              },
+            },
+          },
+          unstable_humanToolNames: [],
+        },
+        undefined,
+      ),
+    );
     const itemRuntime = {
-      generateTitle: vi.fn(() => titleTask),
+      generateTitle: vi.fn(async () => {
+        throw error;
+      }),
     } as unknown as ThreadListItemRuntime;
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    subscribeToTitleGeneration(threadRuntime, itemRuntime);
-    notifyEventListeners([runEndListener!], {}, 'Runtime event "runEnd"');
-    await titleTask.catch(() => undefined);
-    await Promise.resolve();
+    subscribeToTitleGeneration(runtime.thread, itemRuntime);
+    const message: AppendMessage = {
+      parentId: null,
+      sourceId: null,
+      runConfig: {},
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      attachments: [],
+      metadata: { custom: {} },
+      createdAt: new Date(),
+    };
 
-    expect(unsubscribe).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith(
-      '[assistant-ui] Runtime event "runEnd" listener threw an error',
-      error,
-    );
+    runtime.thread.append(message);
+
+    await vi.waitFor(() => {
+      expect(itemRuntime.generateTitle).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith(
+        '[assistant-ui] Runtime event "runEnd" listener threw an error',
+        error,
+      );
+    });
   });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
@@ -12,21 +12,20 @@ afterEach(() => {
 describe("subscribeToTitleGeneration", () => {
   it("reports title generation failures through the runtime event boundary", async () => {
     const error = new Error("title unavailable");
-    const runtime = new AssistantRuntimeImpl(
-      new LocalRuntimeCore(
-        {
-          adapters: {
-            chatModel: {
-              async run() {
-                return { content: [{ type: "text", text: "done" }] };
-              },
+    const core = new LocalRuntimeCore(
+      {
+        adapters: {
+          chatModel: {
+            async run() {
+              return { content: [{ type: "text", text: "done" }] };
             },
           },
-          unstable_humanToolNames: [],
         },
-        undefined,
-      ),
+        unstable_humanToolNames: [],
+      },
+      undefined,
     );
+    const runtime = new AssistantRuntimeImpl(core);
     const itemRuntime = {
       generateTitle: vi.fn(async () => {
         throw error;
@@ -48,7 +47,9 @@ describe("subscribeToTitleGeneration", () => {
       createdAt: new Date(),
     };
 
-    runtime.thread.append(message);
+    await expect(
+      core.threads.getMainThreadRuntimeCore().append(message),
+    ).resolves.toBeUndefined();
 
     await vi.waitFor(() => {
       expect(itemRuntime.generateTitle).toHaveBeenCalledOnce();

--- a/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import type { ThreadListItemRuntime } from "../../runtime/api/thread-list-item-runtime";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
+import { subscribeToTitleGeneration } from "./RemoteThreadResource";
+
+describe("subscribeToTitleGeneration", () => {
+  it("reports title generation failures through the runtime event boundary", async () => {
+    const error = new Error("title unavailable");
+    const titleTask = Promise.reject(error);
+    void titleTask.catch(() => undefined);
+
+    let runEndListener: (() => unknown) | undefined;
+    const unsubscribe = vi.fn();
+    const threadRuntime = {
+      unstable_on: vi.fn((_event, listener) => {
+        runEndListener = listener;
+        return unsubscribe;
+      }),
+    } as unknown as AssistantRuntime["thread"];
+    const itemRuntime = {
+      generateTitle: vi.fn(() => titleTask),
+    } as unknown as ThreadListItemRuntime;
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    subscribeToTitleGeneration(threadRuntime, itemRuntime);
+    notifyEventListeners([runEndListener!], {}, 'Runtime event "runEnd"');
+    await titleTask.catch(() => undefined);
+    await Promise.resolve();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      '[assistant-ui] Runtime event "runEnd" listener threw an error',
+      error,
+    );
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -38,6 +38,17 @@ export type RemoteThreadResourceProps = {
   ) => void;
 };
 
+export const subscribeToTitleGeneration = (
+  threadRuntime: AssistantRuntime["thread"],
+  itemRuntime: ThreadListItemRuntime,
+) => {
+  const dispose = threadRuntime.unstable_on("runEnd", () => {
+    dispose();
+    return itemRuntime.generateTitle();
+  });
+  return dispose;
+};
+
 const useRemoteThreadBinder = ({
   threadId,
   generation,
@@ -85,10 +96,7 @@ const useRemoteThreadBinder = ({
     const initPromise = itemRuntime.initialize();
     initPromiseRef.current = initPromise;
 
-    const dispose = runtime.thread.unstable_on("runEnd", () => {
-      dispose();
-      void itemRuntime.generateTitle();
-    });
+    const dispose = subscribeToTitleGeneration(runtime.thread, itemRuntime);
 
     void initPromise.catch(() => {
       dispose();


### PR DESCRIPTION
## Summary

- return automatic title-generation promises from the `runEnd` listener
- let the existing runtime-event boundary catch and report rejected title adapters or streams
- add a focused regression for a rejected automatic title task

## Why

The first remote-thread `runEnd` detached `itemRuntime.generateTitle()` with `void`. If title generation rejected because an adapter or response stream failed, no handler observed that promise and the application could receive a global `unhandledRejection` after an otherwise successful run.

Runtime event delivery already isolates both synchronous and asynchronous listener failures. Returning the title promise reconnects this internal listener to that established reporting path without changing successful title generation or the public runtime API.

## Testing

- `pnpm --filter @assistant-ui/core... build`
- `pnpm --filter @assistant-ui/core build`
- `pnpm --filter @assistant-ui/core exec vitest run src/react/runtimes/RemoteThreadResource.test.ts`
- `pnpm exec oxlint packages/core/src/react/runtimes/RemoteThreadResource.ts packages/core/src/react/runtimes/RemoteThreadResource.test.ts`
- `pnpm exec oxfmt --check packages/core/src/react/runtimes/RemoteThreadResource.ts packages/core/src/react/runtimes/RemoteThreadResource.test.ts`


<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lQ9GX7aXtwrzCwWZSb5TpS7R-m6bY38L-jmq1K_zctHtnr5abXa6Szh67Ds?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->