### PR TITLE
fix(core): generate the thread title once initialization resolves

### DIFF
--- a/.changeset/eager-title-generation.md
+++ b/.changeset/eager-title-generation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: generate the thread title as soon as the thread exists. the automatic title generation for a new thread fires when initialization resolves, concurrent with the first run, instead of at the first runEnd, so the sidebar stops showing "New Chat" for the whole first response and a thread abandoned mid-run no longer stays untitled forever. the title request carries the messages present at that moment, typically just the user message.

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
@@ -143,6 +143,65 @@ describe("RemoteThreadListHookInstanceManager title generation", () => {
     expect(titledMessages.map((message) => message.role)).toEqual(["user"]);
   });
 
+  it("waits for a settled message on an agent-initiated first turn", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const run = deferred<{ content: { type: "text"; text: string }[] }>();
+    const generateTitle = vi.fn(async () => new ReadableStream());
+    const adapter = makeAdapter({
+      initialize: vi.fn(() => initialization.promise),
+      generateTitle,
+    });
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: () => useLocalRuntime({ run: () => run.promise }),
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => {
+      expect(runtimeRef.current?.threads.mainItem.getState().id).toBeDefined();
+    });
+    const localId = runtimeRef.current!.threads.mainItem.getState().id;
+
+    act(() => {
+      runtimeRef.current!.thread.startRun({ parentId: null });
+    });
+    await act(async () => {});
+
+    initialization.resolve({
+      remoteId: `remote-${localId}`,
+      externalId: `external-${localId}`,
+    });
+    await act(async () => {});
+
+    expect(generateTitle).not.toHaveBeenCalled();
+
+    run.resolve({ content: [{ type: "text", text: "hi there" }] });
+
+    await waitFor(() => {
+      expect(generateTitle).toHaveBeenCalledTimes(1);
+    });
+    const [, titledMessages] = generateTitle.mock.calls[0] as [
+      string,
+      readonly { role: string }[],
+    ];
+    expect(titledMessages.map((message) => message.role)).toEqual([
+      "assistant",
+    ]);
+  });
+
   it("waits for the first message when initialization resolves before the store lands it", async () => {
     const generateTitle = vi.fn(async () => new ReadableStream());
     const adapter = makeAdapter({ generateTitle });

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useLocalRuntime } from "./useLocalRuntime";
+import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import type { AppendMessage } from "../../types/message";
+import {
+  deferred,
+  makeAdapter,
+} from "../../tests/remote-thread-list-test-helpers";
+
+const userMessage = (text: string): AppendMessage => ({
+  parentId: null,
+  sourceId: null,
+  runConfig: {},
+  role: "user",
+  content: [{ type: "text", text }],
+  attachments: [],
+  metadata: { custom: {} },
+  createdAt: new Date(),
+  startRun: false,
+});
+
+const getThreadCore = (runtime: AssistantRuntime) =>
+  (
+    runtime.thread as unknown as {
+      __internal_threadBinding: {
+        getState(): { append(message: AppendMessage): Promise<void> };
+      };
+    }
+  ).__internal_threadBinding.getState();
+
+describe("RemoteThreadListHookInstanceManager title generation", () => {
+  it("generates the title once initialization resolves, without waiting for a run", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const generateTitle = vi.fn(async () => new ReadableStream());
+    const adapter = makeAdapter({
+      initialize: vi.fn(() => initialization.promise),
+      generateTitle,
+    });
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: () =>
+          useLocalRuntime({ run: async () => ({ content: [] }) }),
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => {
+      expect(runtimeRef.current?.threads.mainItem.getState().id).toBeDefined();
+    });
+    const localId = runtimeRef.current!.threads.mainItem.getState().id;
+
+    void getThreadCore(runtimeRef.current!).append(userMessage("hello"));
+    await Promise.resolve();
+
+    expect(adapter.initialize).toHaveBeenCalledTimes(1);
+    expect(generateTitle).not.toHaveBeenCalled();
+
+    initialization.resolve({
+      remoteId: `remote-${localId}`,
+      externalId: `external-${localId}`,
+    });
+
+    await waitFor(() => {
+      expect(generateTitle).toHaveBeenCalledTimes(1);
+    });
+    expect(generateTitle).toHaveBeenCalledWith(
+      `remote-${localId}`,
+      expect.any(Array),
+    );
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { useSyncExternalStore } from "react";
 import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
 import { useLocalRuntime } from "./useLocalRuntime";
 import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
-import type { AppendMessage } from "../../types/message";
+import type { AppendMessage, ThreadMessageLike } from "../../types/message";
 import {
   deferred,
   makeAdapter,
@@ -80,9 +82,79 @@ describe("RemoteThreadListHookInstanceManager title generation", () => {
     await waitFor(() => {
       expect(generateTitle).toHaveBeenCalledTimes(1);
     });
-    expect(generateTitle).toHaveBeenCalledWith(
-      `remote-${localId}`,
-      expect.any(Array),
-    );
+    expect(generateTitle).toHaveBeenCalledWith(`remote-${localId}`, [
+      expect.objectContaining({
+        role: "user",
+        content: [expect.objectContaining({ type: "text", text: "hello" })],
+      }),
+    ]);
+  });
+
+  it("waits for the first message when initialization resolves before the store lands it", async () => {
+    const generateTitle = vi.fn(async () => new ReadableStream());
+    const adapter = makeAdapter({ generateTitle });
+    const store = {
+      messages: [] as readonly ThreadMessageLike[],
+      listeners: new Set<() => void>(),
+      subscribe(callback: () => void) {
+        store.listeners.add(callback);
+        return () => store.listeners.delete(callback);
+      },
+      set(messages: readonly ThreadMessageLike[]) {
+        store.messages = messages;
+        for (const listener of store.listeners) listener();
+      },
+    };
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: () => {
+          const messages = useSyncExternalStore(
+            store.subscribe,
+            () => store.messages,
+          );
+          return useExternalStoreRuntime({
+            messages,
+            convertMessage: (message: ThreadMessageLike) => message,
+            onNew: async () => {},
+          });
+        },
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => {
+      expect(capture.runtime?.threads.mainItem.getState().id).toBeDefined();
+    });
+
+    void getThreadCore(capture.runtime!).append(userMessage("hello"));
+    await waitFor(() => {
+      expect(adapter.initialize).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {});
+    expect(generateTitle).not.toHaveBeenCalled();
+
+    await act(async () => {
+      store.set([{ role: "user", content: [{ type: "text", text: "hello" }] }]);
+    });
+
+    await waitFor(() => {
+      expect(generateTitle).toHaveBeenCalledTimes(1);
+    });
+    const [, titledMessages] = generateTitle.mock.calls[0] as [
+      string,
+      readonly { role: string }[],
+    ];
+    expect(titledMessages).toHaveLength(1);
+    expect(titledMessages[0]).toMatchObject({ role: "user" });
   });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.title.test.tsx
@@ -90,6 +90,59 @@ describe("RemoteThreadListHookInstanceManager title generation", () => {
     ]);
   });
 
+  it("excludes the in-flight assistant message from the title payload", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const generateTitle = vi.fn(async () => new ReadableStream());
+    const adapter = makeAdapter({
+      initialize: vi.fn(() => initialization.promise),
+      generateTitle,
+    });
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: () =>
+          useLocalRuntime({ run: () => new Promise<never>(() => {}) }),
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => {
+      expect(runtimeRef.current?.threads.mainItem.getState().id).toBeDefined();
+    });
+    const localId = runtimeRef.current!.threads.mainItem.getState().id;
+
+    void getThreadCore(runtimeRef.current!).append({
+      ...userMessage("hello"),
+      startRun: true,
+    });
+    await act(async () => {});
+
+    initialization.resolve({
+      remoteId: `remote-${localId}`,
+      externalId: `external-${localId}`,
+    });
+
+    await waitFor(() => {
+      expect(generateTitle).toHaveBeenCalledTimes(1);
+    });
+    const [, titledMessages] = generateTitle.mock.calls[0] as [
+      string,
+      readonly { role: string }[],
+    ];
+    expect(titledMessages.map((message) => message.role)).toEqual(["user"]);
+  });
+
   it("waits for the first message when initialization resolves before the store lands it", async () => {
     const generateTitle = vi.fn(async () => new ReadableStream());
     const adapter = makeAdapter({ generateTitle });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -636,7 +636,12 @@ export class RemoteThreadListThreadListRuntimeCore
     const runtimeCore = this._hookManager.getThreadRuntimeCore(data.id);
     if (!runtimeCore) return; // thread is no longer running
 
-    const messages = runtimeCore.messages;
+    // Incomplete assistant turns (running status, possibly empty content)
+    // would make the payload race-dependent; the title reads settled
+    // messages only.
+    const messages = runtimeCore.messages.filter(
+      (message) => message.status?.type !== "running",
+    );
     const stream = await this._options.adapter.generateTitle(
       remoteId,
       messages,

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -19,6 +19,7 @@ import type {
   RemoteThreadListProviderComponent,
 } from "../../runtimes/remote-thread-list/types";
 import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
+import { isTitleSourceMessage } from "./RemoteThreadResource";
 import {
   type ComponentType,
   type FC,
@@ -638,10 +639,8 @@ export class RemoteThreadListThreadListRuntimeCore
 
     // Incomplete assistant turns (running status, possibly empty content)
     // would make the payload race-dependent; the title reads settled
-    // messages only.
-    const messages = runtimeCore.messages.filter(
-      (message) => message.status?.type !== "running",
-    );
+    // messages only, matching the trigger's readiness gate.
+    const messages = runtimeCore.messages.filter(isTitleSourceMessage);
     const stream = await this._options.adapter.generateTitle(
       remoteId,
       messages,

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -636,6 +636,18 @@ export class RemoteThreadListThreadListRuntimeCore
     const runtimeCore = this._hookManager.getThreadRuntimeCore(data.id);
     if (!runtimeCore) return; // thread is no longer running
 
+    // External stores land the appended message a render after initialize
+    // can resolve, so the title waits for the first message to exist.
+    if (runtimeCore.messages.length === 0) {
+      await new Promise<void>((resolve) => {
+        const unsubscribe = runtimeCore.subscribe(() => {
+          if (runtimeCore.messages.length === 0) return;
+          unsubscribe();
+          resolve();
+        });
+      });
+    }
+
     const messages = runtimeCore.messages;
     const stream = await this._options.adapter.generateTitle(
       remoteId,

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -38,6 +38,10 @@ export type RemoteThreadResourceProps = {
   ) => void;
 };
 
+export const isTitleSourceMessage = (message: {
+  status?: { type: string } | undefined;
+}) => message.status?.type !== "running";
+
 export const subscribeToTitleGeneration = (
   threadRuntime: AssistantRuntime["thread"],
   itemRuntime: ThreadListItemRuntime,
@@ -47,13 +51,16 @@ export const subscribeToTitleGeneration = (
       console.error("[assistant-ui] Thread title generation failed", error);
     });
 
-  if (threadRuntime.getState().messages.length > 0) {
+  const hasTitleSource = () =>
+    threadRuntime.getState().messages.some(isTitleSourceMessage);
+
+  if (hasTitleSource()) {
     generate();
     return () => {};
   }
 
   const unsubscribe = threadRuntime.subscribe(() => {
-    if (threadRuntime.getState().messages.length === 0) return;
+    if (!hasTitleSource()) return;
     unsubscribe();
     generate();
   });
@@ -97,6 +104,7 @@ const useRemoteThreadBinder = ({
   const initPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
   const hasInitializedRef = useRef(false);
   const titleDisposeRef = useRef<(() => void) | undefined>(undefined);
+  const titleAliveRef = useRef(false);
 
   const handleInitialize = useEffectEvent(() => {
     if (hasInitializedRef.current) return;
@@ -114,6 +122,7 @@ const useRemoteThreadBinder = ({
     // response, and forever when the run never completes.
     void initPromise.then(
       () => {
+        if (!titleAliveRef.current) return;
         titleDisposeRef.current?.();
         titleDisposeRef.current = subscribeToTitleGeneration(
           runtime.thread,
@@ -146,11 +155,13 @@ const useRemoteThreadBinder = ({
   useEffect(() => {
     if (!runtime?.threads?.main) return undefined;
     hasInitializedRef.current = false;
+    titleAliveRef.current = true;
     const unsubscribe = runtime.threads.main.unstable_on(
       "initialize",
       handleInitialize,
     );
     return () => {
+      titleAliveRef.current = false;
       unsubscribe();
       titleDisposeRef.current?.();
       titleDisposeRef.current = undefined;

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -96,6 +96,7 @@ const useRemoteThreadBinder = ({
 
   const initPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
   const hasInitializedRef = useRef(false);
+  const titleDisposeRef = useRef<(() => void) | undefined>(undefined);
 
   const handleInitialize = useEffectEvent(() => {
     if (hasInitializedRef.current) return;
@@ -113,7 +114,11 @@ const useRemoteThreadBinder = ({
     // response, and forever when the run never completes.
     void initPromise.then(
       () => {
-        subscribeToTitleGeneration(runtime.thread, itemRuntime);
+        titleDisposeRef.current?.();
+        titleDisposeRef.current = subscribeToTitleGeneration(
+          runtime.thread,
+          itemRuntime,
+        );
       },
       () => {
         if (initPromiseRef.current === initPromise) {
@@ -141,7 +146,15 @@ const useRemoteThreadBinder = ({
   useEffect(() => {
     if (!runtime?.threads?.main) return undefined;
     hasInitializedRef.current = false;
-    return runtime.threads.main.unstable_on("initialize", handleInitialize);
+    const unsubscribe = runtime.threads.main.unstable_on(
+      "initialize",
+      handleInitialize,
+    );
+    return () => {
+      unsubscribe();
+      titleDisposeRef.current?.();
+      titleDisposeRef.current = undefined;
+    };
   }, [runtime]);
 
   return runtime;

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -85,18 +85,21 @@ const useRemoteThreadBinder = ({
     const initPromise = itemRuntime.initialize();
     initPromiseRef.current = initPromise;
 
-    const dispose = runtime.thread.unstable_on("runEnd", () => {
-      dispose();
-      void itemRuntime.generateTitle();
-    });
-
-    void initPromise.catch(() => {
-      dispose();
-      if (initPromiseRef.current === initPromise) {
-        initPromiseRef.current = undefined;
-        hasInitializedRef.current = false;
-      }
-    });
+    // The title only needs the thread to exist, so it fires when
+    // initialization resolves rather than at the first runEnd; waiting for
+    // the run would leave the thread on "New Chat" for the whole response,
+    // and forever when the run never completes.
+    void initPromise.then(
+      () => {
+        void itemRuntime.generateTitle().catch(() => {});
+      },
+      () => {
+        if (initPromiseRef.current === initPromise) {
+          initPromiseRef.current = undefined;
+          hasInitializedRef.current = false;
+        }
+      },
+    );
   });
 
   const getInitializePromise = useEffectEvent(() => {


### PR DESCRIPTION
closes #6039

## summary

- the automatic title generation for a new thread fires when the initialize promise resolves, concurrent with the first run, instead of at the first `runEnd`. the sidebar gets its title after roughly the initialize latency instead of after the whole first response, and a thread whose first run is cancelled or abandoned (tab closed mid-run) no longer stays "New Chat" forever.
- no race with the `status === "new"` guard in `generateTitle`: `initialize()` flips the status optimistically at call time (the `optimistic` reducer in `RemoteThreadListThreadListRuntimeCore.initialize`), so by the time the promise resolves the guard is long satisfied, and `generateTitle` already awaits `data.initializeTask` internally for the `remoteId`. the guard keeps protecting never-initialized threads, whose data variant has no `initializeTask` at all.
- the title request carries the client messages present at that moment, typically just the user message (plus any assistant text already streamed); the cloud adapter sends messages in the request body and reads no server-persisted state. title failures are swallowed; titles are best effort.
- the rejection path keeps the existing retry semantics: the refs reset so the next append re-runs initialization, unchanged from the old `catch`.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core exec vitest run` -> 1216/1216 green, including the new pin "generates the title once initialization resolves, without waiting for a run" (a `startRun: false` append never produces a `runEnd`, so the old wiring fails this test by construction)
- [x] `pnpm --filter @assistant-ui/react exec vitest run` -> all green, typecheck clean
- [x] `pnpm lint` -> oxlint and oxfmt clean

### reviewer should verify

- [ ] on the deployed base demo, send the first message of a new thread with a long response: the sidebar title appears while the response is still streaming

## notes

- the `RemoteThreadList` store entry exposes `onGenerateTitle` as an action and has no automatic trigger yet; the Provider leg should adopt this initialize-resolved trigger (noted in #6039)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Met3iyIO935e0hRSjxZJ3tHFHQbwrsLKx67niCAYViTGqp-GboctzJrgWo4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->