### PR TITLE
fix(docs): deduplicate type declarations in extractor

### DIFF
--- a/apps/docs/scripts/generated-docs/extract.mts
+++ b/apps/docs/scripts/generated-docs/extract.mts
@@ -626,10 +626,19 @@ function getLocalTypeDeclarations(
 
   const declarationsByName = new Map<string, TsNode[]>();
   const addDeclarations = (name: string, declarations: TsNode[]) => {
-    declarationsByName.set(name, [
-      ...(declarationsByName.get(name) ?? []),
-      ...declarations,
-    ]);
+    const existing = declarationsByName.get(name) ?? [];
+    // #6043: a file that both imports a type and re-exports it hits this
+    // path twice (once from getExportedDeclarations, once from the named
+    // import), which inlined the same declaration in the emitted signature.
+    // Deduplicate by node identity so import-plus-re-export emits once.
+    const seen = new Set(existing);
+    for (const decl of declarations) {
+      if (!seen.has(decl)) {
+        seen.add(decl);
+        existing.push(decl);
+      }
+    }
+    declarationsByName.set(name, existing);
   };
 
   for (const [name, declarations] of sourceFile.getExportedDeclarations()) {


### PR DESCRIPTION
Fixes #6043. A file that imports a `*Adapters` type and also re-exports it hit `addDeclarations` twice — once from `getExportedDeclarations()` and once from the named import — inlining the same `type` block twice in the generated hook reference. The fix deduplicates by node identity using a `Set`, so import-plus-re-export emits once.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2q0xSohx0pm100HiYTZvIQHiwZdzyZr0fyBMEwkmAg68IQbGoYb1EGIRvl8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->