### PR TITLE
fix(core): notify all thread state subscribers

### DIFF
--- a/.changeset/calm-thread-subscribers.md
+++ b/.changeset/calm-thread-subscribers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify every thread state subscriber when one throws

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -112,6 +112,25 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("BaseThreadRuntimeCore state subscriptions", () => {
+  it("notifies later subscribers when one throws", () => {
+    const runtime = new TestRuntime(createVoiceAdapter());
+    runtime.connectVoice();
+
+    const listenerError = new Error("listener failed");
+    const laterListener = vi.fn();
+
+    runtime.subscribe(() => {
+      throw listenerError;
+    });
+    runtime.subscribe(laterListener);
+
+    expect(() => runtime.muteVoice()).toThrow(listenerError);
+    expect(runtime.voice?.isMuted).toBe(true);
+    expect(laterListener).toHaveBeenCalledOnce();
+  });
+});
+
 describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
   it("continues notifying subscribers when one throws", () => {
     const consoleError = vi

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -36,6 +36,7 @@ import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { ThreadMessageLike } from "../utils/thread-message-like";
 import { notifyEventListeners } from "../../utils/notify-event-listeners";
 import { gateInteractableComposerMetadata } from "../../model-context/interactable-composer-metadata";
+import { notifySubscribers } from "../../subscribable/subscribable";
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
@@ -214,7 +215,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   }
 
   protected _notifySubscribers() {
-    for (const callback of this._subscriptions) callback();
+    notifySubscribers(this._subscriptions);
   }
 
   public _notifyEventSubscribers<E extends ThreadRuntimeEventType>(


### PR DESCRIPTION
## Summary

- notify every `BaseThreadRuntimeCore` state subscriber even when an earlier subscriber throws
- preserve existing error propagation after subscriber fan-out completes
- add a regression test covering a real voice-state transition

## Why

Thread state is mutated before subscribers are notified. Previously, one throwing subscriber stopped iteration immediately, so later subscribers such as React could miss the update and remain stale even though the runtime state had changed.

The fix reuses core's existing `notifySubscribers` helper, which invokes the full subscriber set before rethrowing listener errors.

## Testing

- `pnpm --filter @assistant-ui/core exec vitest run src/runtime/base/base-thread-runtime-core.test.ts`
- `pnpm --filter @assistant-ui/core test` (124 files, 1,237 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.unvXdjjg5NBB_Bzf7UxUQCdJjCLWY6i3mFZ5MlK-04WKK4yXzLm-vgNnWew?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

