### PR TITLE
fix(cloud-ai-sdk): stop chats on registry teardown

### DIFF
--- a/.changeset/calm-cloud-registry-teardown.md
+++ b/.changeset/calm-cloud-registry-teardown.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: stop active Cloud chats when their registry owner unmounts

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -142,4 +142,32 @@ describe("useChatRegistry", () => {
 
     expect(stop).not.toHaveBeenCalled();
   });
+
+  it("stops chats on unmount without stopping during Strict Mode replay", async () => {
+    const scope = {};
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      stop,
+    }));
+
+    const { unmount } = renderHook(
+      () =>
+        useChatRegistry({
+          scope,
+          threadId: "thread-1",
+          createChat: createChat as never,
+        }),
+      { reactStrictMode: true },
+    );
+    await Promise.resolve();
+
+    expect(stop).not.toHaveBeenCalled();
+
+    unmount();
+    await Promise.resolve();
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -70,12 +70,23 @@ export function useChatRegistry({
   const activeChat = registry.getOrCreate(activeChatKey, threadId);
 
   const committedRegistryRef = useRef(registry);
+  const lifecycleRef = useRef({ version: 0 });
   useEffect(() => {
+    const lifecycle = lifecycleRef.current;
+    const lifecycleVersion = ++lifecycle.version;
     const previousRegistry = committedRegistryRef.current;
     committedRegistryRef.current = registry;
     if (previousRegistry !== registry) {
       void previousRegistry.stopAll();
     }
+
+    return () => {
+      queueMicrotask(() => {
+        if (lifecycle.version === lifecycleVersion) {
+          void registry.stopAll();
+        }
+      });
+    };
   }, [registry]);
 
   return { registry, activeChat };


### PR DESCRIPTION
## Summary

- stop registry-owned chats when `useChatRegistry()` unmounts
- defer teardown through one microtask so React Strict Mode effect replay keeps the live registry intact
- add a focused regression test and patch changeset

## Why

The existing lifecycle only stops a registry after the Cloud scope changes. On current `main`, unmounting the hook while a chat is active calls `chat.stop()` zero times, allowing model generation, network work, callbacks, and persistence through the abandoned scope to continue.

The cleanup uses a lifecycle version so a real unmount stops the registry, while Strict Mode's immediate cleanup/setup replay invalidates the deferred teardown.

## Verification

The regression test fails before the fix with `stop` called 0 times and passes after it.

- `pnpm --filter @assistant-ui/cloud-ai-sdk test` (85 tests on AI SDK v7, 85 tests on v6, and v6 type-check)
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MAgxktGrolG-guJuWHhv_Szo1gTPExe9UTanGkDXfGMX3jSNB6ND0TMhxfw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->