### PR TITLE
fix(core): isolate external thread list subscribers

### DIFF
--- a/.changeset/quiet-external-list-subscribers.md
+++ b/.changeset/quiet-external-list-subscribers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify every external thread-list subscriber when one listener throws

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../runtime/interfaces/thread-list-runtime-core";
 import type { ExternalStoreThreadListAdapter } from "./external-store-adapter";
 import { invalidateThreadRuntime } from "../../runtime/utils/thread-runtime-lifecycle";
+import { notifySubscribers } from "../../subscribable/subscribable";
 
 export type ExternalStoreThreadFactory = () => ExternalStoreThreadRuntimeCore;
 
@@ -270,6 +271,6 @@ export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore
   }
 
   private _notifySubscribers() {
-    for (const callback of this._subscriptions) callback();
+    notifySubscribers(this._subscriptions);
   }
 }

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -167,6 +167,26 @@ describe("ExternalStoreThreadListRuntimeCore - __internal_setAdapter", () => {
     expect(callback).toHaveBeenCalled();
   });
 
+  it("notifies later subscribers when an earlier subscriber throws", () => {
+    const core = new ExternalStoreThreadListRuntimeCore(
+      makeAdapter({ threadId: "thread-alpha" }),
+      makeFactory(),
+    );
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+
+    core.subscribe(() => {
+      throw error;
+    });
+    core.subscribe(laterSubscriber);
+
+    expect(() =>
+      core.__internal_setAdapter(makeAdapter({ threadId: "thread-beta" })),
+    ).toThrow(error);
+    expect(core.mainThreadId).toBe("thread-beta");
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+  });
+
   it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list", () => {
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha" }),


### PR DESCRIPTION
## Summary

- notify every external thread-list subscriber even when an earlier listener throws
- preserve error visibility by rethrowing after all listeners have run
- use the existing shared `notifySubscribers` primitive
- add a focused regression test and patch changeset

## Why

The external thread-list runtime mutates its selected thread and list state before notifying subscribers. Its raw listener loop stops at the first exception, so React or another later subscriber can remain stale even though the runtime has already changed.

On current `main`, the focused reproduction changes the selected thread, throws from the first subscriber, and calls the second subscriber zero times. The shared notifier keeps the existing thrown-error behavior while ensuring every subscriber observes the update.

## Verification

- regression test fails before the fix and passes after it
- `pnpm --filter @assistant-ui/core test` (124 files, 1,237 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rFRNAOLveOuudkcr6rXe1Gw6TarV2-PvnfpRoNEAXR7itQdEqWjRsRiTyTY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->