### PR TITLE
fix(core): isolate interactable model context subscribers

### DIFF
--- a/.changeset/tidy-interactable-subscribers.md
+++ b/.changeset/tidy-interactable-subscribers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify every interactable model-context subscriber when one throws

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -9,6 +9,9 @@ import type { ThreadMessage } from "../../types/message";
 
 const clientHolder: { client: unknown } = { client: null };
 const clientListeners = new Set<() => void>();
+let registeredModelContextProvider:
+  | { subscribe?: (callback: () => void) => () => void }
+  | undefined;
 
 const replaceClient = (client: unknown) => {
   clientHolder.client = client;
@@ -75,9 +78,19 @@ const makeClient = (
   setToolUI?: (...args: unknown[]) => () => void,
   threadId?: string,
 ) => ({
-  modelContext: Object.assign(() => ({ register: () => () => {} }), {
-    source: "root",
-  }),
+  modelContext: Object.assign(
+    () => ({
+      register: (
+        provider: NonNullable<typeof registeredModelContextProvider>,
+      ) => {
+        registeredModelContextProvider = provider;
+        return () => {
+          registeredModelContextProvider = undefined;
+        };
+      },
+    }),
+    { source: "root" },
+  ),
   thread: threadMessages
     ? Object.assign(
         () => ({ getState: () => ({ messages: threadMessages }) }),
@@ -161,6 +174,7 @@ let root: ReturnType<typeof mount> | undefined;
 
 beforeEach(() => {
   vi.useFakeTimers();
+  registeredModelContextProvider = undefined;
 });
 
 afterEach(() => {
@@ -171,6 +185,31 @@ afterEach(() => {
 });
 
 describe("Interactables registration", () => {
+  it("notifies every model-context subscriber when one throws", async () => {
+    root = mount();
+    await flushMicrotasks();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const listenerError = new Error("listener failed");
+    const laterListener = vi.fn();
+
+    const provider = registeredModelContextProvider;
+    expect(provider).toBeDefined();
+    provider?.subscribe?.(() => {
+      throw listenerError;
+    });
+    provider?.subscribe?.(laterListener);
+
+    root.getValue().register(reg("n1"));
+    await flushMicrotasks();
+    expect(laterListener).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Interactables model context listener threw an error",
+      listenerError,
+    );
+  });
+
   it("seeds a new registration with initialState", () => {
     root = mount();
     root.getValue().register(reg("n1", { initialState: { v: 7 } }));

--- a/packages/core/src/react/client/Interactables.test.ts
+++ b/packages/core/src/react/client/Interactables.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, flushTapSync, useResource } from "@assistant-ui/tap";
 import type {
   Unstable_InteractablePersistedState,
   Unstable_InteractablePersistenceAdapter,
@@ -188,9 +188,6 @@ describe("Interactables registration", () => {
   it("notifies every model-context subscriber when one throws", async () => {
     root = mount();
     await flushMicrotasks();
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     const listenerError = new Error("listener failed");
     const laterListener = vi.fn();
 
@@ -201,13 +198,10 @@ describe("Interactables registration", () => {
     });
     provider?.subscribe?.(laterListener);
 
-    root.getValue().register(reg("n1"));
-    await flushMicrotasks();
+    expect(() =>
+      flushTapSync(() => root?.getValue().register(reg("n1"))),
+    ).toThrow(listenerError);
     expect(laterListener).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] Interactables model context listener threw an error",
-      listenerError,
-    );
   });
 
   it("seeds a new registration with initialState", () => {

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -23,7 +23,7 @@ import {
   findModelKnownState,
   interactableToolName,
 } from "../../model-context/interactable-composer-metadata";
-import { notifyEventListeners } from "../../utils/notify-event-listeners";
+import { notifySubscribers as notifyStateSubscribers } from "../../subscribable/subscribable";
 
 const PERSISTENCE_DEBOUNCE_MS = 500;
 
@@ -456,11 +456,7 @@ const useInteractablesResource = ({
   );
 
   useEffect(() => {
-    notifyEventListeners(
-      subscribersRef.current,
-      undefined,
-      "Interactables model context",
-    );
+    notifyStateSubscribers(subscribersRef.current);
   }, [state]);
 
   useAssistantScopeEffect(

--- a/packages/core/src/react/client/Interactables.ts
+++ b/packages/core/src/react/client/Interactables.ts
@@ -23,6 +23,7 @@ import {
   findModelKnownState,
   interactableToolName,
 } from "../../model-context/interactable-composer-metadata";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 
 const PERSISTENCE_DEBOUNCE_MS = 500;
 
@@ -455,7 +456,11 @@ const useInteractablesResource = ({
   );
 
   useEffect(() => {
-    for (const cb of subscribersRef.current) cb();
+    notifyEventListeners(
+      subscribersRef.current,
+      undefined,
+      "Interactables model context",
+    );
   }, [state]);
 
   useAssistantScopeEffect(

--- a/packages/core/src/react/interactables-legacy/Interactables.test.ts
+++ b/packages/core/src/react/interactables-legacy/Interactables.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, flushTapSync, useResource } from "@assistant-ui/tap";
 import type {
   InteractablePersistenceAdapter,
   InteractableRegistration,
@@ -114,9 +114,6 @@ describe("legacy Interactables persistence", () => {
   it("notifies every model-context subscriber when one throws", async () => {
     root = mount();
     await flushMicrotasks();
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     const listenerError = new Error("listener failed");
     const laterListener = vi.fn();
 
@@ -127,13 +124,10 @@ describe("legacy Interactables persistence", () => {
     });
     provider?.subscribe?.(laterListener);
 
-    root.getValue().register(reg("n1"));
-    await flushMicrotasks();
+    expect(() =>
+      flushTapSync(() => root?.getValue().register(reg("n1"))),
+    ).toThrow(listenerError);
     expect(laterListener).toHaveBeenCalledOnce();
-    expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] Interactables model context listener threw an error",
-      listenerError,
-    );
   });
 
   it("saves queued changes with the adapter that observed them", async () => {

--- a/packages/core/src/react/interactables-legacy/Interactables.test.ts
+++ b/packages/core/src/react/interactables-legacy/Interactables.test.ts
@@ -7,6 +7,9 @@ import type {
 
 const clientHolder: { client: unknown } = { client: null };
 const clientListeners = new Set<() => void>();
+let registeredModelContextProvider:
+  | { subscribe?: (callback: () => void) => () => void }
+  | undefined;
 
 vi.mock("@assistant-ui/store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@assistant-ui/store")>();
@@ -60,9 +63,19 @@ vi.mock("@assistant-ui/store/client", async (importOriginal) => {
 const { Interactables } = await import("./Interactables");
 
 const makeClient = () => ({
-  modelContext: Object.assign(() => ({ register: () => () => {} }), {
-    source: "root",
-  }),
+  modelContext: Object.assign(
+    () => ({
+      register: (
+        provider: NonNullable<typeof registeredModelContextProvider>,
+      ) => {
+        registeredModelContextProvider = provider;
+        return () => {
+          registeredModelContextProvider = undefined;
+        };
+      },
+    }),
+    { source: "root" },
+  ),
 });
 
 const mount = () => {
@@ -86,6 +99,7 @@ let root: ReturnType<typeof mount> | undefined;
 
 beforeEach(() => {
   vi.useFakeTimers();
+  registeredModelContextProvider = undefined;
 });
 
 afterEach(() => {
@@ -97,6 +111,31 @@ afterEach(() => {
 });
 
 describe("legacy Interactables persistence", () => {
+  it("notifies every model-context subscriber when one throws", async () => {
+    root = mount();
+    await flushMicrotasks();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const listenerError = new Error("listener failed");
+    const laterListener = vi.fn();
+
+    const provider = registeredModelContextProvider;
+    expect(provider).toBeDefined();
+    provider?.subscribe?.(() => {
+      throw listenerError;
+    });
+    provider?.subscribe?.(laterListener);
+
+    root.getValue().register(reg("n1"));
+    await flushMicrotasks();
+    expect(laterListener).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Interactables model context listener threw an error",
+      listenerError,
+    );
+  });
+
   it("saves queued changes with the adapter that observed them", async () => {
     const firstSave = vi.fn();
     const secondSave = vi.fn();

--- a/packages/core/src/react/interactables-legacy/Interactables.ts
+++ b/packages/core/src/react/interactables-legacy/Interactables.ts
@@ -16,6 +16,7 @@ import type {
 import { toJSONSchema, toPartialJSONSchema } from "assistant-stream";
 import { ModelContext } from "../../store";
 import { buildInteractableModelContext } from "./interactable-model-context";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 
 const PERSISTENCE_DEBOUNCE_MS = 500;
 
@@ -321,7 +322,11 @@ const useInteractables = (): ClientOutput<"interactables"> => {
   );
 
   useEffect(() => {
-    for (const cb of subscribersRef.current) cb();
+    notifyEventListeners(
+      subscribersRef.current,
+      undefined,
+      "Interactables model context",
+    );
   }, [state]);
 
   useAssistantScopeEffect(

--- a/packages/core/src/react/interactables-legacy/Interactables.ts
+++ b/packages/core/src/react/interactables-legacy/Interactables.ts
@@ -16,7 +16,7 @@ import type {
 import { toJSONSchema, toPartialJSONSchema } from "assistant-stream";
 import { ModelContext } from "../../store";
 import { buildInteractableModelContext } from "./interactable-model-context";
-import { notifyEventListeners } from "../../utils/notify-event-listeners";
+import { notifySubscribers as notifyStateSubscribers } from "../../subscribable/subscribable";
 
 const PERSISTENCE_DEBOUNCE_MS = 500;
 
@@ -322,11 +322,7 @@ const useInteractables = (): ClientOutput<"interactables"> => {
   );
 
   useEffect(() => {
-    notifyEventListeners(
-      subscribersRef.current,
-      undefined,
-      "Interactables model context",
-    );
+    notifyStateSubscribers(subscribersRef.current);
   }, [state]);
 
   useAssistantScopeEffect(


### PR DESCRIPTION
## Summary

- isolate model-context subscriber failures in the current and legacy Interactables resources
- continue notifying later subscribers when an earlier callback throws
- preserve model-context error visibility by rethrowing after all subscribers run

## Problem

Interactables notified model-context subscribers with a direct loop. If one subscriber threw, the loop stopped immediately, so later consumers missed an already-committed state update.

The fix uses the same state-subscriber helper as `ModelContextRegistry`, `CompositeContextProvider`, and the external thread-list runtime. It attempts every callback, then rethrows the original error or an `AggregateError`, preserving the existing state-subscriber contract.

The regression tests register two subscribers, make the first throw, and verify that the second still receives the update before the error is rethrown in both implementations.

## Testing

- `pnpm --filter @assistant-ui/core test` (1,239 tests)
- `pnpm lint`
- `pnpm --filter @assistant-ui/core build`