### PR TITLE
fix(core): handle attachment removal failures

### DIFF
--- a/.changeset/calm-attachment-removals.md
+++ b/.changeset/calm-attachment-removals.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: report attachment removal failures without leaking unhandled rejections

--- a/packages/core/src/store/runtime-clients/attachment-runtime-client.test.ts
+++ b/packages/core/src/store/runtime-clients/attachment-runtime-client.test.ts
@@ -1,69 +1,41 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { handleAttachmentRemove } from "./attachment-runtime-client";
+import type { AttachmentRuntime } from "../../runtime/api/attachment-runtime";
+import { AttachmentRuntimeClient } from "./attachment-runtime-client";
 
-describe("handleAttachmentRemove", () => {
+describe("AttachmentRuntimeClient", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("reports a rejected removal", async () => {
+  it("reports attachment removal failures", async () => {
     const error = new Error("storage unavailable");
-    const task = Promise.reject(error);
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-
-    const result = handleAttachmentRemove(() => task);
-
-    expect(result).toBe(task);
-    await expect(result).rejects.toBe(error);
-    expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] attachment remove failed:",
-      error,
-    );
-  });
-
-  it("preserves synchronous failures", () => {
-    const error = new Error("attachment unavailable");
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-
-    expect(() =>
-      handleAttachmentRemove(() => {
-        throw error;
-      }),
-    ).toThrow(error);
-    expect(consoleError).not.toHaveBeenCalled();
-  });
-
-  it("does not leak an ignored removal as an unhandled rejection", async () => {
-    const error = new Error("remove failed");
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const rejections: unknown[] = [];
-    const onUnhandledRejection = (reason: unknown) => {
-      rejections.push(reason);
+    const state = {
+      id: "attachment-1",
+      type: "file",
+      name: "notes.txt",
+      status: { type: "complete" },
+      content: [],
+      source: "thread-composer",
     };
-    const priorListeners = process.listeners("unhandledRejection");
-    process.removeAllListeners("unhandledRejection");
-    process.on("unhandledRejection", onUnhandledRejection);
+    const runtime = {
+      getState: () => state,
+      subscribe: () => () => {},
+      remove: () => Promise.reject(error),
+    } as unknown as AttachmentRuntime;
+    const root = createTapRoot(function AttachmentClientRoot() {
+      return useResource(AttachmentRuntimeClient({ runtime }));
+    });
 
-    try {
-      handleAttachmentRemove(() => Promise.reject(error));
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    } finally {
-      process.removeListener("unhandledRejection", onUnhandledRejection);
-      for (const listener of priorListeners) {
-        process.on("unhandledRejection", listener);
-      }
-    }
+    await expect(root.getValue().remove()).rejects.toBe(error);
 
-    expect(rejections).toEqual([]);
     expect(consoleError).toHaveBeenCalledWith(
       "[assistant-ui] attachment remove failed:",
       error,
     );
+    root.unmount();
   });
 });

--- a/packages/core/src/store/runtime-clients/attachment-runtime-client.test.ts
+++ b/packages/core/src/store/runtime-clients/attachment-runtime-client.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleAttachmentRemove } from "./attachment-runtime-client";
+
+describe("handleAttachmentRemove", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a rejected removal", async () => {
+    const error = new Error("storage unavailable");
+    const task = Promise.reject(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = handleAttachmentRemove(() => task);
+
+    expect(result).toBe(task);
+    await expect(result).rejects.toBe(error);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] attachment remove failed:",
+      error,
+    );
+  });
+
+  it("preserves synchronous failures", () => {
+    const error = new Error("attachment unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(() =>
+      handleAttachmentRemove(() => {
+        throw error;
+      }),
+    ).toThrow(error);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("does not leak an ignored removal as an unhandled rejection", async () => {
+    const error = new Error("remove failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const rejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      handleAttachmentRemove(() => Promise.reject(error));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandledRejection);
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+    }
+
+    expect(rejections).toEqual([]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] attachment remove failed:",
+      error,
+    );
+  });
+});

--- a/packages/core/src/store/runtime-clients/attachment-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/attachment-runtime-client.ts
@@ -1,18 +1,8 @@
 import { resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import type { AttachmentRuntime } from "../../runtime/api/attachment-runtime";
+import { handleRuntimeAction } from "./handle-runtime-action";
 import { useSubscribable } from "./useSubscribable";
-
-export const handleAttachmentRemove = (
-  remove: () => Promise<void>,
-): Promise<void> => {
-  const task = remove();
-
-  void task.catch((error: unknown) => {
-    console.error("[assistant-ui] attachment remove failed:", error);
-  });
-  return task;
-};
 
 const useAttachmentRuntimeClient = ({
   runtime,
@@ -23,7 +13,7 @@ const useAttachmentRuntimeClient = ({
 
   return {
     getState: () => state,
-    remove: () => handleAttachmentRemove(runtime.remove),
+    remove: () => handleRuntimeAction("attachment remove", runtime.remove),
     __internal_getRuntime: () => runtime,
   };
 };

--- a/packages/core/src/store/runtime-clients/attachment-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/attachment-runtime-client.ts
@@ -3,6 +3,17 @@ import type { ClientOutput } from "@assistant-ui/store";
 import type { AttachmentRuntime } from "../../runtime/api/attachment-runtime";
 import { useSubscribable } from "./useSubscribable";
 
+export const handleAttachmentRemove = (
+  remove: () => Promise<void>,
+): Promise<void> => {
+  const task = remove();
+
+  void task.catch((error: unknown) => {
+    console.error("[assistant-ui] attachment remove failed:", error);
+  });
+  return task;
+};
+
 const useAttachmentRuntimeClient = ({
   runtime,
 }: {
@@ -12,7 +23,7 @@ const useAttachmentRuntimeClient = ({
 
   return {
     getState: () => state,
-    remove: runtime.remove,
+    remove: () => handleAttachmentRemove(runtime.remove),
     __internal_getRuntime: () => runtime,
   };
 };

--- a/packages/core/src/store/runtime-clients/handle-runtime-action.ts
+++ b/packages/core/src/store/runtime-clients/handle-runtime-action.ts
@@ -1,0 +1,11 @@
+export const handleRuntimeAction = (
+  label: string,
+  execute: () => Promise<void>,
+): Promise<void> => {
+  const task = execute();
+
+  void task.catch((error: unknown) => {
+    console.error(`[assistant-ui] ${label} failed:`, error);
+  });
+  return task;
+};

--- a/packages/core/src/store/runtime-clients/handle-thread-list-action.ts
+++ b/packages/core/src/store/runtime-clients/handle-thread-list-action.ts
@@ -1,11 +1,6 @@
+import { handleRuntimeAction } from "./handle-runtime-action";
+
 export const handleThreadListAction = (
   action: string,
   execute: () => Promise<void>,
-): Promise<void> => {
-  const task = execute();
-
-  void task.catch((error: unknown) => {
-    console.error(`[assistant-ui] thread list ${action} failed:`, error);
-  });
-  return task;
-};
+): Promise<void> => handleRuntimeAction(`thread list ${action}`, execute);


### PR DESCRIPTION
## Summary

- report rejected attachment removals from the shared attachment runtime client
- prevent fire-and-forget remove buttons from leaking global unhandled rejections
- preserve the original rejecting promise for consumers that await `remove()`

## Problem

The web, React Native, and Ink remove primitives all invoke the shared `aui.attachment.remove()` action without awaiting it. A custom attachment adapter can reject while removing remote or persisted data, which previously surfaced as a global `unhandledRejection`.

The fix generalizes the existing thread-list action handler into a shared runtime-action helper. The attachment client uses that helper to attach rejection reporting while returning the original task unchanged. All three distributions receive the behavior without duplicated platform code, and callers that await `remove()` still receive the original rejection.

## Testing

- `pnpm --filter @assistant-ui/core test` (1,238 tests)
- `pnpm lint`
- `pnpm --filter @assistant-ui/core build`