### PR TITLE
fix(core): isolate memoized subject subscribers

### DIFF
--- a/.changeset/tidy-subject-notifications.md
+++ b/.changeset/tidy-subject-notifications.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify every memoized subject subscriber when one throws

--- a/packages/core/src/subscribable/subscribable.test.ts
+++ b/packages/core/src/subscribable/subscribable.test.ts
@@ -59,6 +59,21 @@ describe("ShallowMemoizeSubject", () => {
     expect(subscriber).not.toHaveBeenCalled();
   });
 
+  it("notifies later subscribers when one throws", () => {
+    const source = createBinding({ status: "empty" });
+    const subject = new ShallowMemoizeSubject(source.binding);
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+    subject.subscribe(() => {
+      throw error;
+    });
+    subject.subscribe(laterSubscriber);
+
+    expect(() => source.update({ status: "ready" })).toThrow(error);
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+    expect(subject.getState()).toEqual({ status: "ready" });
+  });
+
   it("reads a value that landed while nobody was subscribed", () => {
     const source = createBinding({ status: "empty" });
     const subject = new ShallowMemoizeSubject(source.binding);
@@ -74,6 +89,21 @@ describe("ShallowMemoizeSubject", () => {
 });
 
 describe("LazyMemoizeSubject", () => {
+  it("notifies later subscribers when one throws", () => {
+    const source = createBinding({ status: "empty" });
+    const subject = new LazyMemoizeSubject(source.binding);
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+    subject.subscribe(() => {
+      throw error;
+    });
+    subject.subscribe(laterSubscriber);
+
+    expect(() => source.update({ status: "ready" })).toThrow(error);
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+    expect(subject.getState()).toEqual({ status: "ready" });
+  });
+
   it("reads a value replaced before connecting", () => {
     const source = createBinding({ status: "empty" });
     const subject = new LazyMemoizeSubject(source.binding);

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -32,11 +32,14 @@ export type EventSubscribable<TEvent extends string> = {
   >;
 };
 
-export const notifySubscribers = (subscribers: Iterable<() => void>): void => {
+export const notifySubscribers = <TArgs extends unknown[]>(
+  subscribers: Iterable<(...args: TArgs) => void>,
+  ...args: TArgs
+): void => {
   const errors: unknown[] = [];
   for (const callback of subscribers) {
     try {
-      callback();
+      callback(...args);
     } catch (error) {
       errors.push(error);
     }
@@ -113,7 +116,7 @@ export abstract class BaseSubject {
       return;
     }
 
-    for (const callback of this._subscriptions) callback(payload);
+    notifySubscribers(this._subscriptions, payload);
   }
 
   private _updateConnection() {


### PR DESCRIPTION
## Summary

- route memoized subject updates through the shared error-aggregating subscriber notifier
- preserve callback payloads and rethrow subscriber errors after every listener has run
- cover both shallow and lazy memoized subjects with regression tests

## Why

A throwing subscriber currently stops `BaseSubject` notification immediately. The subject state has already changed at that point, so later subscribers can remain stale even though `getState()` returns the new value. On current `main`, a focused reproduction updated the state but called the second subscriber zero times.

## Testing

- `vitest run src/subscribable/subscribable.test.ts src/tests/BaseSubscribable.test.ts` (11 tests)
- focused `oxlint`
- focused `oxfmt --check`
- strict TypeScript check for `subscribable.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.gxNQVKMDWQ_IWna3WuLYR22hWPYhQZDKihz4YkyNvMA73FcTYPCfJie-klc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->