### PR TITLE
fix(tap): notify every root subscriber

### DIFF
--- a/.changeset/bright-tap-subscribers.md
+++ b/.changeset/bright-tap-subscribers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: notify every Tap root subscriber when one throws

--- a/packages/tap/src/__tests__/react/useTapRoot.host-render.test.tsx
+++ b/packages/tap/src/__tests__/react/useTapRoot.host-render.test.tsx
@@ -102,6 +102,32 @@ describe("useTapRoot host renders", () => {
     );
   });
 
+  it("notifies later root subscribers when one throws", () => {
+    let root!: useTapRoot.Root<number>;
+    let setCount!: (value: number) => void;
+
+    function Host() {
+      root = useTapRoot(function Counter() {
+        const [count, setState] = useResourceState(0);
+        setCount = setState;
+        return count;
+      });
+      return null;
+    }
+
+    render(<Host />);
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+    root.subscribe(() => {
+      throw error;
+    });
+    root.subscribe(laterSubscriber);
+
+    expect(() => flushTapSync(() => setCount(1))).toThrow(error);
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+    expect(root.getValue()).toBe(1);
+  });
+
   it("a host render consumes pending updates and the scheduled flush no-ops", async () => {
     let renders = 0;
     let bump!: (value: number) => void;

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -13,6 +13,7 @@ import {
 } from "../core/helpers/root";
 import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
 import { isThenable } from "../core/helpers/thenable";
+import { throwAggregated } from "../core/helpers/throwAggregated";
 import type { ResourceContext, ResourceFiber } from "../core/types";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
@@ -34,6 +35,21 @@ export namespace useTapRoot {
 }
 
 const useHostRoot = <R>(render: () => R): R => render();
+
+const notifySubscribers = (subscribers: Iterable<() => void>): void => {
+  const errors: unknown[] = [];
+  for (const listener of subscribers) {
+    try {
+      listener();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  throwAggregated(
+    errors,
+    "Errors occurred while notifying Tap root subscribers",
+  );
+};
 
 type Instance<R> = {
   readonly scheduler: UpdateScheduler;
@@ -103,7 +119,7 @@ const createInstance = <R>(
       )
         return;
       inst.value = output;
-      scheduleNotify(() => inst.subscribers.forEach((listener) => listener()));
+      scheduleNotify(() => notifySubscribers(inst.subscribers));
     },
 
     finishFlush: (output, version, drained) => {


### PR DESCRIPTION
## Summary

- isolate `useTapRoot` subscriber failures so every listener observes committed updates
- rethrow collected listener errors through Tap's existing `scheduleNotify` path
- add a React-hosted regression test and a patch changeset

## Why

`useTapRoot` currently invokes all subscribers inside one `Set.forEach` callback. If one listener throws, iteration stops after the root value has already committed, leaving later React consumers stale. A focused test on current `main` reproduced the update reaching `getValue()` while the second subscriber was called zero times.

The fix uses Tap's existing `throwAggregated` helper inside the scheduled notification. A single error is still rethrown unchanged, and the scheduler remains responsible for its final routing. This is adjacent to #5903 but does not change the async error-handling policy discussed there.

## Testing

- `vitest run --config vitest.config.ts --project dev` (442 passed, 1 skipped)
- focused `oxlint`
- focused `oxfmt --check`
- strict TypeScript check for `useTapRoot.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iUMBeWrtwOPeUcWcHr9YkTn4lETlUG08mT2TaGsXyyAIBNWHYnSKLkPqPp8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->