### PR TITLE
feat(ui): show a history skeleton while a switched thread loads

### DIFF
--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -24,6 +24,7 @@ import {
   ReasoningTrigger,
 } from "@/components/assistant-ui/reasoning";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import icon from "@/public/favicon/icon.svg";
 import {
@@ -177,27 +178,28 @@ const isNewChatView = (s: AssistantState) =>
 
 // A switched thread that is still fetching its history: skeleton, not welcome.
 const isHistoryLoadingView = (s: AssistantState) =>
-  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+  s.thread.messages.length === 0 &&
+  s.thread.isLoading &&
+  !s.thread.isDisabled &&
+  !s.threads.isLoading;
 
 const ThreadHistorySkeleton: FC = () => (
   <div
     data-slot="aui_thread-history-skeleton"
     role="status"
-    aria-label="Loading conversation"
-    className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
+    className="animate-in fade-in fill-mode-both mx-auto flex w-full max-w-(--thread-max-width) flex-col gap-y-6 [animation-delay:150ms] [animation-duration:200ms]"
   >
-    <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
-      <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
-      <div className="flex flex-col gap-y-2">
-        <div className="bg-muted h-4 w-11/12 rounded-md" />
-        <div className="bg-muted h-4 w-4/5 rounded-md" />
-        <div className="bg-muted h-4 w-3/5 rounded-md" />
-      </div>
-      <div className="bg-muted ml-auto h-9 w-1/3 rounded-xl" />
-      <div className="flex flex-col gap-y-2">
-        <div className="bg-muted h-4 w-10/12 rounded-md" />
-        <div className="bg-muted h-4 w-2/3 rounded-md" />
-      </div>
+    <span className="sr-only">Loading conversation</span>
+    <Skeleton className="ml-auto h-9 w-2/5 rounded-xl motion-reduce:animate-none" />
+    <div className="flex flex-col gap-y-2">
+      <Skeleton className="h-4 w-11/12 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-4/5 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-3/5 motion-reduce:animate-none" />
+    </div>
+    <Skeleton className="ml-auto h-9 w-1/3 rounded-xl motion-reduce:animate-none" />
+    <div className="flex flex-col gap-y-2">
+      <Skeleton className="h-4 w-10/12 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-2/3 motion-reduce:animate-none" />
     </div>
   </div>
 );

--- a/apps/docs/components/examples/base.tsx
+++ b/apps/docs/components/examples/base.tsx
@@ -175,6 +175,33 @@ const isNewChatView = (s: AssistantState) =>
   s.thread.messages.length === 0 &&
   (!s.thread.isLoading || s.threads.isLoading);
 
+// A switched thread that is still fetching its history: skeleton, not welcome.
+const isHistoryLoadingView = (s: AssistantState) =>
+  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+
+const ThreadHistorySkeleton: FC = () => (
+  <div
+    data-slot="aui_thread-history-skeleton"
+    role="status"
+    aria-label="Loading conversation"
+    className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
+  >
+    <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
+      <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-11/12 rounded-md" />
+        <div className="bg-muted h-4 w-4/5 rounded-md" />
+        <div className="bg-muted h-4 w-3/5 rounded-md" />
+      </div>
+      <div className="bg-muted ml-auto h-9 w-1/3 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-10/12 rounded-md" />
+        <div className="bg-muted h-4 w-2/3 rounded-md" />
+      </div>
+    </div>
+  </div>
+);
+
 const Thread: FC = () => {
   const isEmpty = useAuiState(isNewChatView);
 
@@ -198,6 +225,9 @@ const Thread: FC = () => {
       >
         <AuiIf condition={isNewChatView}>
           <ThreadWelcome />
+        </AuiIf>
+        <AuiIf condition={isHistoryLoadingView}>
+          <ThreadHistorySkeleton />
         </AuiIf>
 
         <div

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1006,6 +1006,7 @@ export const registry: RegistryItem[] = [
     dependencies: ["@assistant-ui/react", "lucide-react"],
     registryDependencies: [
       "button",
+      "skeleton",
       "https://r.assistant-ui.com/attachment.json",
       "https://r.assistant-ui.com/file.json",
       "https://r.assistant-ui.com/follow-up-suggestions.json",

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/assistant-ui/tool-group";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
   ActionBarMorePrimitive,
@@ -102,27 +103,28 @@ const isNewChatView = (s: AssistantState) =>
 
 // A switched thread that is still fetching its history: skeleton, not welcome.
 const isHistoryLoadingView = (s: AssistantState) =>
-  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+  s.thread.messages.length === 0 &&
+  s.thread.isLoading &&
+  !s.thread.isDisabled &&
+  !s.threads.isLoading;
 
 const ThreadHistorySkeleton: FC = () => (
   <div
     data-slot="aui_thread-history-skeleton"
     role="status"
-    aria-label="Loading conversation"
-    className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
+    className="animate-in fade-in fill-mode-both flex flex-col gap-y-6 [animation-delay:150ms] [animation-duration:200ms]"
   >
-    <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
-      <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
-      <div className="flex flex-col gap-y-2">
-        <div className="bg-muted h-4 w-11/12 rounded-md" />
-        <div className="bg-muted h-4 w-4/5 rounded-md" />
-        <div className="bg-muted h-4 w-3/5 rounded-md" />
-      </div>
-      <div className="bg-muted ml-auto h-9 w-1/3 rounded-xl" />
-      <div className="flex flex-col gap-y-2">
-        <div className="bg-muted h-4 w-10/12 rounded-md" />
-        <div className="bg-muted h-4 w-2/3 rounded-md" />
-      </div>
+    <span className="sr-only">Loading conversation</span>
+    <Skeleton className="ml-auto h-9 w-2/5 rounded-xl motion-reduce:animate-none" />
+    <div className="flex flex-col gap-y-2">
+      <Skeleton className="h-4 w-11/12 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-4/5 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-3/5 motion-reduce:animate-none" />
+    </div>
+    <Skeleton className="ml-auto h-9 w-1/3 rounded-xl motion-reduce:animate-none" />
+    <div className="flex flex-col gap-y-2">
+      <Skeleton className="h-4 w-10/12 motion-reduce:animate-none" />
+      <Skeleton className="h-4 w-2/3 motion-reduce:animate-none" />
     </div>
   </div>
 );

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -100,6 +100,33 @@ const isNewChatView = (s: AssistantState) =>
   s.thread.messages.length === 0 &&
   (!s.thread.isLoading || s.threads.isLoading);
 
+// A switched thread that is still fetching its history: skeleton, not welcome.
+const isHistoryLoadingView = (s: AssistantState) =>
+  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+
+const ThreadHistorySkeleton: FC = () => (
+  <div
+    data-slot="aui_thread-history-skeleton"
+    role="status"
+    aria-label="Loading conversation"
+    className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
+  >
+    <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
+      <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-11/12 rounded-md" />
+        <div className="bg-muted h-4 w-4/5 rounded-md" />
+        <div className="bg-muted h-4 w-3/5 rounded-md" />
+      </div>
+      <div className="bg-muted ml-auto h-9 w-1/3 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-10/12 rounded-md" />
+        <div className="bg-muted h-4 w-2/3 rounded-md" />
+      </div>
+    </div>
+  </div>
+);
+
 export const Thread: FC<ThreadProps> = ({ components = EMPTY_COMPONENTS }) => {
   const isEmpty = useAuiState(isNewChatView);
 
@@ -136,6 +163,9 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
         >
           <AuiIf condition={isNewChatView}>
             <Welcome />
+          </AuiIf>
+          <AuiIf condition={isHistoryLoadingView}>
+            <ThreadHistorySkeleton />
           </AuiIf>
 
           <div

--- a/templates/minimal/components/assistant-ui/thread.tsx
+++ b/templates/minimal/components/assistant-ui/thread.tsx
@@ -43,6 +43,33 @@ const isNewChatView = (s: AssistantState) =>
   s.thread.messages.length === 0 &&
   (!s.thread.isLoading || s.threads.isLoading);
 
+// A switched thread that is still fetching its history: skeleton, not welcome.
+const isHistoryLoadingView = (s: AssistantState) =>
+  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+
+const ThreadHistorySkeleton: FC = () => (
+  <div
+    data-slot="aui_thread-history-skeleton"
+    role="status"
+    aria-label="Loading conversation"
+    className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
+  >
+    <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
+      <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-11/12 rounded-md" />
+        <div className="bg-muted h-4 w-4/5 rounded-md" />
+        <div className="bg-muted h-4 w-3/5 rounded-md" />
+      </div>
+      <div className="bg-muted ml-auto h-9 w-1/3 rounded-xl" />
+      <div className="flex flex-col gap-y-2">
+        <div className="bg-muted h-4 w-10/12 rounded-md" />
+        <div className="bg-muted h-4 w-2/3 rounded-md" />
+      </div>
+    </div>
+  </div>
+);
+
 export const Thread: FC = () => {
   const isEmpty = useAuiState(isNewChatView);
 
@@ -69,6 +96,9 @@ export const Thread: FC = () => {
         >
           <AuiIf condition={isNewChatView}>
             <ThreadWelcome />
+          </AuiIf>
+          <AuiIf condition={isHistoryLoadingView}>
+            <ThreadHistorySkeleton />
           </AuiIf>
 
           <div

--- a/templates/minimal/components/assistant-ui/thread.tsx
+++ b/templates/minimal/components/assistant-ui/thread.tsx
@@ -45,15 +45,18 @@ const isNewChatView = (s: AssistantState) =>
 
 // A switched thread that is still fetching its history: skeleton, not welcome.
 const isHistoryLoadingView = (s: AssistantState) =>
-  s.thread.messages.length === 0 && s.thread.isLoading && !s.threads.isLoading;
+  s.thread.messages.length === 0 &&
+  s.thread.isLoading &&
+  !s.thread.isDisabled &&
+  !s.threads.isLoading;
 
 const ThreadHistorySkeleton: FC = () => (
   <div
     data-slot="aui_thread-history-skeleton"
     role="status"
-    aria-label="Loading conversation"
     className="animate-in fade-in fill-mode-both flex flex-col [animation-delay:150ms] [animation-duration:200ms]"
   >
+    <span className="sr-only">Loading conversation</span>
     <div className="flex animate-pulse flex-col gap-y-6 motion-reduce:animate-none">
       <div className="bg-muted ml-auto h-9 w-2/5 rounded-xl" />
       <div className="flex flex-col gap-y-2">


### PR DESCRIPTION
## summary

- switching to a thread whose history is still loading used to render a bare empty viewport for the whole fetch (~2s measured on the deployed base demo: old thread clears at +9ms, messages pop at +1965ms, nothing in between). the kit already distinguishes this state; `isNewChatView` suppresses the welcome when `thread.isLoading` is set, but nothing rendered in its place.
- a new `isHistoryLoadingView` selector (`messages empty && thread.isLoading && !threads.isLoading`, the exact complement of the welcome carve-out) renders `ThreadHistorySkeleton`: muted pulse blocks shaped like a short conversation, `role="status"`, `motion-reduce:animate-none`, and a 150ms appearance delay so a warm switch never flashes it.
- applied to the canonical kit (`packages/ui`), the minimal template's slim fork (an `OVERRIDES` entry, synced by hand), and the docs base example. plain divs and existing tokens only, so no registry dependency changes.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/ui test` -> 338 passed, 15 skipped
- [x] `pnpm lint` -> oxlint and oxfmt clean
- [x] `bash scripts/sync-templates.sh` -> templates in sync, no redundant copies

### reviewer should verify

- [ ] on the preview deployment's /demos/base, create two threads and switch between them: the skeleton appears during the history fetch and never flashes on a warm switch

## notes

- no changeset: `@assistant-ui/ui` is private and the other two surfaces are unpublished, matching #6015

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IusBDXdzf9xFidOK1FLSdU4-rHl01LjFRUze7t_nVVUyu6ehBnANUrhJLV8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->