### PR TITLE
docs(cloud-ai-sdk): fix assistant-cloud reference

### DIFF
--- a/packages/cloud-ai-sdk/AGENTS.md
+++ b/packages/cloud-ai-sdk/AGENTS.md
@@ -2,7 +2,7 @@
 
 > Part of assistant-ui monorepo. See root [AGENTS.md](../../AGENTS.md) for build commands.
 
-React hooks bridging Vercel AI SDK (`useChat`) with [`assistant-cloud`](../cloud/AGENTS.md) persistence. Works without the full `@assistant-ui/react` runtime.
+React hooks bridging Vercel AI SDK (`useChat`) with [`assistant-cloud`](../cloud/README.md) persistence. Works without the full `@assistant-ui/react` runtime.
 
 ## Structure
 


### PR DESCRIPTION
## Summary

Update the `cloud-ai-sdk` package guide to link to the existing
`assistant-cloud` README instead of the missing `cloud/AGENTS.md` file.

## Why

The current relative link leads to a file that does not exist, preventing
contributors from reaching the referenced package documentation.

## Validation

- `npx --yes markdown-link-check packages/cloud-ai-sdk/AGENTS.md -q`
- `git diff --check`

No issue is linked because this is a small documentation fix.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.riYef_84AlMo6BdHcMNXctms6sLccE1ZVIfsZTjD_OPrfOlJDikl9iKyxSc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

