### PR TITLE
fix(react-langgraph): separate pending tool resumes by run

### DIFF
--- a/.changeset/6033-langgraph-pending-groups.md
+++ b/.changeset/6033-langgraph-pending-groups.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: keep frontend tool resumes separated by LangGraph run

--- a/packages/react-langgraph/src/messageHelpers.test.ts
+++ b/packages/react-langgraph/src/messageHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getPendingToolCallGroups,
   getPendingToolCalls,
+  pendingToolCallGroupKey,
 } from "./messageHelpers";
 import type { LangChainMessage } from "./types";
 
@@ -76,6 +77,29 @@ describe("getPendingToolCallGroups", () => {
       {
         key: "message:ai-2",
         toolCalls: [{ id: "tc-2", name: "b", args: {} }],
+      },
+    ]);
+  });
+
+  it("uses a custom group key resolver when provided", () => {
+    expect(
+      getPendingToolCallGroups(
+        [
+          ai("ai-1", [{ id: "tc-1", name: "a" }]),
+          ai("ai-2", [{ id: "tc-2", name: "b" }]),
+        ],
+        (message) =>
+          message.id === "ai-1" || message.id === "ai-2"
+            ? "run:shared"
+            : pendingToolCallGroupKey(message),
+      ),
+    ).toEqual([
+      {
+        key: "run:shared",
+        toolCalls: [
+          { id: "tc-1", name: "a", args: {} },
+          { id: "tc-2", name: "b", args: {} },
+        ],
       },
     ]);
   });

--- a/packages/react-langgraph/src/messageHelpers.test.ts
+++ b/packages/react-langgraph/src/messageHelpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPendingToolCallGroups,
+  getPendingToolCalls,
+} from "./messageHelpers";
+import type { LangChainMessage } from "./types";
+
+const ai = (
+  id: string | undefined,
+  toolCalls: { id: string; name: string }[],
+): LangChainMessage => ({
+  ...(id !== undefined && { id }),
+  type: "ai",
+  content: "",
+  tool_calls: toolCalls.map((toolCall) => ({
+    id: toolCall.id,
+    name: toolCall.name,
+    args: {},
+  })),
+});
+
+const tool = (toolCallId: string): LangChainMessage => ({
+  type: "tool",
+  content: "{}",
+  tool_call_id: toolCallId,
+  name: "my_tool",
+  status: "success",
+});
+
+describe("getPendingToolCallGroups", () => {
+  it("keeps parallel calls from one AI message in a single group", () => {
+    expect(
+      getPendingToolCallGroups([
+        ai("ai-1", [
+          { id: "tc-1", name: "a" },
+          { id: "tc-2", name: "b" },
+        ]),
+      ]),
+    ).toEqual([
+      {
+        key: "message:ai-1",
+        toolCalls: [
+          { id: "tc-1", name: "a", args: {} },
+          { id: "tc-2", name: "b", args: {} },
+        ],
+      },
+    ]);
+  });
+
+  it("splits pending calls from different AI messages", () => {
+    expect(
+      getPendingToolCallGroups([
+        ai("ai-1", [{ id: "tc-1", name: "a" }]),
+        ai("ai-2", [{ id: "tc-2", name: "b" }]),
+      ]),
+    ).toEqual([
+      {
+        key: "message:ai-1",
+        toolCalls: [{ id: "tc-1", name: "a", args: {} }],
+      },
+      {
+        key: "message:ai-2",
+        toolCalls: [{ id: "tc-2", name: "b", args: {} }],
+      },
+    ]);
+  });
+
+  it("drops a call once a tool result arrives", () => {
+    expect(
+      getPendingToolCallGroups([
+        ai("ai-1", [{ id: "tc-1", name: "a" }]),
+        ai("ai-2", [{ id: "tc-2", name: "b" }]),
+        tool("tc-1"),
+      ]),
+    ).toEqual([
+      {
+        key: "message:ai-2",
+        toolCalls: [{ id: "tc-2", name: "b", args: {} }],
+      },
+    ]);
+  });
+
+  it("falls back to the first tool id when the AI message has no id", () => {
+    expect(
+      getPendingToolCallGroups([
+        ai(undefined, [
+          { id: "tc-1", name: "a" },
+          { id: "tc-2", name: "b" },
+        ]),
+      ]),
+    ).toEqual([
+      {
+        key: "tool:tc-1",
+        toolCalls: [
+          { id: "tc-1", name: "a", args: {} },
+          { id: "tc-2", name: "b", args: {} },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("getPendingToolCalls", () => {
+  it("flattens groups in history order", () => {
+    expect(
+      getPendingToolCalls([
+        ai("ai-1", [{ id: "tc-1", name: "a" }]),
+        ai("ai-2", [{ id: "tc-2", name: "b" }]),
+      ]),
+    ).toEqual([
+      { id: "tc-1", name: "a", args: {} },
+      { id: "tc-2", name: "b", args: {} },
+    ]);
+  });
+});

--- a/packages/react-langgraph/src/messageHelpers.ts
+++ b/packages/react-langgraph/src/messageHelpers.ts
@@ -12,9 +12,10 @@ export type PendingToolCallGroup = {
 export const pendingToolCallGroupKey = (
   message: Extract<LangChainMessage, { type: "ai" }>,
 ): string | undefined => {
-  if (message.id) return `message:${message.id}`;
+  if (message.id !== undefined) return `message:${message.id}`;
   const firstToolCallId = message.tool_calls?.[0]?.id;
-  return firstToolCallId ? `tool:${firstToolCallId}` : undefined;
+  if (firstToolCallId !== undefined) return `tool:${firstToolCallId}`;
+  return undefined;
 };
 
 export const getPendingToolCallGroups = (

--- a/packages/react-langgraph/src/messageHelpers.ts
+++ b/packages/react-langgraph/src/messageHelpers.ts
@@ -9,8 +9,19 @@ export type PendingToolCallGroup = {
   toolCalls: LangChainToolCall[];
 };
 
+export const pendingToolCallGroupKey = (
+  message: Extract<LangChainMessage, { type: "ai" }>,
+): string | undefined => {
+  if (message.id) return `message:${message.id}`;
+  const firstToolCallId = message.tool_calls?.[0]?.id;
+  return firstToolCallId ? `tool:${firstToolCallId}` : undefined;
+};
+
 export const getPendingToolCallGroups = (
   messages: LangChainMessage[],
+  resolveGroupKey: (
+    message: Extract<LangChainMessage, { type: "ai" }>,
+  ) => string | undefined = pendingToolCallGroupKey,
 ): PendingToolCallGroup[] => {
   const pendingToolCalls = new Map<
     string,
@@ -18,12 +29,8 @@ export const getPendingToolCallGroups = (
   >();
   for (const message of messages) {
     if (message.type === "ai") {
-      const firstToolCallId = message.tool_calls?.[0]?.id;
-      const groupKey = message.id
-        ? `message:${message.id}`
-        : firstToolCallId
-          ? `tool:${firstToolCallId}`
-          : undefined;
+      const groupKey =
+        resolveGroupKey(message) ?? pendingToolCallGroupKey(message);
       if (!groupKey) continue;
       for (const toolCall of message.tool_calls ?? []) {
         pendingToolCalls.set(toolCall.id, { toolCall, groupKey });

--- a/packages/react-langgraph/src/messageHelpers.ts
+++ b/packages/react-langgraph/src/messageHelpers.ts
@@ -4,12 +4,29 @@ import {
 } from "@assistant-ui/core";
 import type { LangChainMessage, LangChainToolCall, UIMessage } from "./types";
 
-export const getPendingToolCalls = (messages: LangChainMessage[]) => {
-  const pendingToolCalls = new Map<string, LangChainToolCall>();
+export type PendingToolCallGroup = {
+  key: string;
+  toolCalls: LangChainToolCall[];
+};
+
+export const getPendingToolCallGroups = (
+  messages: LangChainMessage[],
+): PendingToolCallGroup[] => {
+  const pendingToolCalls = new Map<
+    string,
+    { toolCall: LangChainToolCall; groupKey: string }
+  >();
   for (const message of messages) {
     if (message.type === "ai") {
+      const firstToolCallId = message.tool_calls?.[0]?.id;
+      const groupKey = message.id
+        ? `message:${message.id}`
+        : firstToolCallId
+          ? `tool:${firstToolCallId}`
+          : undefined;
+      if (!groupKey) continue;
       for (const toolCall of message.tool_calls ?? []) {
-        pendingToolCalls.set(toolCall.id, toolCall);
+        pendingToolCalls.set(toolCall.id, { toolCall, groupKey });
       }
     }
     if (message.type === "tool") {
@@ -17,8 +34,17 @@ export const getPendingToolCalls = (messages: LangChainMessage[]) => {
     }
   }
 
-  return [...pendingToolCalls.values()];
+  const groups = new Map<string, LangChainToolCall[]>();
+  for (const { toolCall, groupKey } of pendingToolCalls.values()) {
+    const group = groups.get(groupKey);
+    if (group) group.push(toolCall);
+    else groups.set(groupKey, [toolCall]);
+  }
+  return [...groups].map(([key, toolCalls]) => ({ key, toolCalls }));
 };
+
+export const getPendingToolCalls = (messages: LangChainMessage[]) =>
+  getPendingToolCallGroups(messages).flatMap((group) => group.toolCalls);
 
 export const hasToolResult = (
   messages: LangChainMessage[],

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1779,6 +1779,28 @@ describe("useLangGraphRuntime", () => {
       });
     };
 
+    const addToolResultById = (
+      runtime: AssistantRuntime,
+      toolCallId: string,
+      result: unknown,
+    ) => {
+      const message = runtime.thread
+        .getState()
+        .messages.find((item) =>
+          item.content.some(
+            (part) =>
+              part.type === "tool-call" && part.toolCallId === toolCallId,
+          ),
+        );
+      if (!message) throw new Error(`missing ${toolCallId}`);
+      act(() => {
+        runtime.thread
+          .getMessageById(message.id)
+          .getMessagePartByToolCallId(toolCallId)
+          .addToolResult(result);
+      });
+    };
+
     it("defers a tool-result resume until the in-flight run drains, without dropping isRunning", async () => {
       const gate = deferred<void>();
       const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
@@ -2960,6 +2982,82 @@ describe("useLangGraphRuntime", () => {
       ]);
       expect(streamMock.mock.calls[3]?.[1].runConfig).toEqual({
         configurable: { model_name: "model-b" },
+      });
+    });
+
+    it("batches frontend tools from two AI messages in the same run", async () => {
+      const streamMock = vi.fn(async function* (
+        _messages: LangChainMessage[],
+        _config: { runConfig?: unknown },
+      ) {
+        if (streamMock.mock.calls.length === 1) {
+          yield {
+            event: "messages/complete",
+            data: [
+              {
+                id: "ai-1",
+                type: "ai" as const,
+                content: "",
+                tool_calls: [{ id: "tc-1", name: "my_tool", args: {} }],
+              },
+              {
+                id: "ai-2",
+                type: "ai" as const,
+                content: "",
+                tool_calls: [{ id: "tc-2", name: "my_tool", args: {} }],
+              },
+            ],
+          };
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          autoCancelPendingToolCalls: false,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: controls } = renderHook(
+        () => ({
+          send: useLangGraphSend(),
+          aui: useAui(),
+        }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        controls.current.send([{ type: "human", content: "first" }], {
+          runConfig: { configurable: { model_name: "model-a" } },
+        });
+      });
+      await waitFor(() => {
+        const parts = controls.current.aui.thread
+          .getState()
+          .messages.flatMap((m): readonly unknown[] => m.content);
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-1" }),
+        );
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-2" }),
+        );
+      });
+      await waitFor(() =>
+        expect(controls.current.aui.thread.getState().isRunning).toBe(false),
+      );
+
+      addToolResultById(runtimeResult.current, "tc-1", { result: "first" });
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      addToolResultById(runtimeResult.current, "tc-2", { result: "second" });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1" },
+        { type: "tool", tool_call_id: "tc-2" },
+      ]);
+      expect(streamMock.mock.calls[1]?.[1].runConfig).toEqual({
+        configurable: { model_name: "model-a" },
       });
     });
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -2985,6 +2985,67 @@ describe("useLangGraphRuntime", () => {
       });
     });
 
+    it("keeps unstamped loaded pending tools in one batch", async () => {
+      const streamMock = vi.fn(async function* () {});
+      const load = vi.fn(async () => ({
+        messages: [
+          { id: "h1", type: "human" as const, content: "hi" },
+          {
+            id: "ai-1",
+            type: "ai" as const,
+            content: "",
+            tool_calls: [{ id: "tc-1", name: "my_tool", args: {} }],
+          },
+          {
+            id: "ai-2",
+            type: "ai" as const,
+            content: "",
+            tool_calls: [{ id: "tc-2", name: "my_tool", args: {} }],
+          },
+        ],
+      }));
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          load,
+          autoCancelPendingToolCalls: false,
+          unstable_threadListAdapter: makeThreadListAdapter(),
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        await runtimeResult.current.threads.switchToThread("lg-thread-1");
+      });
+      await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+      await waitFor(() => {
+        const parts = runtimeResult.current.thread
+          .getState()
+          .messages.flatMap((m): readonly unknown[] => m.content);
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-1" }),
+        );
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-2" }),
+        );
+      });
+
+      addToolResultById(runtimeResult.current, "tc-1", { result: "first" });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(streamMock).not.toHaveBeenCalled();
+
+      addToolResultById(runtimeResult.current, "tc-2", { result: "second" });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      expect(streamMock.mock.calls[0]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1" },
+        { type: "tool", tool_call_id: "tc-2" },
+      ]);
+    });
+
     it("batches frontend tools from two AI messages in the same run", async () => {
       const streamMock = vi.fn(async function* (
         _messages: LangChainMessage[],

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -2856,6 +2856,113 @@ describe("useLangGraphRuntime", () => {
       });
     });
 
+    it("keeps pending tool resumes and run configs separated by turn", async () => {
+      const streamMock = vi.fn(async function* (
+        _messages: LangChainMessage[],
+        _config: { runConfig?: unknown },
+      ) {
+        if (streamMock.mock.calls.length === 1) {
+          yield {
+            event: "messages/complete",
+            data: [
+              {
+                id: "ai-1",
+                type: "ai" as const,
+                content: "",
+                tool_calls: [{ id: "tc-1", name: "my_tool", args: {} }],
+              },
+            ],
+          };
+        } else if (streamMock.mock.calls.length === 2) {
+          yield {
+            event: "messages/complete",
+            data: [
+              {
+                id: "ai-2",
+                type: "ai" as const,
+                content: "",
+                tool_calls: [{ id: "tc-2", name: "my_tool", args: {} }],
+              },
+            ],
+          };
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          autoCancelPendingToolCalls: false,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: controls } = renderHook(
+        () => ({
+          send: useLangGraphSend(),
+          aui: useAui(),
+        }),
+        { wrapper },
+      );
+
+      await act(async () => {
+        controls.current.send([{ type: "human", content: "first" }], {
+          runConfig: { configurable: { model_name: "model-a" } },
+        });
+      });
+      await waitFor(() => {
+        const parts = controls.current.aui.thread
+          .getState()
+          .messages.flatMap((m): readonly unknown[] => m.content);
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-1" }),
+        );
+      });
+      await waitFor(() =>
+        expect(controls.current.aui.thread.getState().isRunning).toBe(false),
+      );
+
+      await act(async () => {
+        controls.current.send([{ type: "human", content: "second" }], {
+          runConfig: { configurable: { model_name: "model-b" } },
+        });
+      });
+      await waitFor(() => {
+        const parts = controls.current.aui.thread
+          .getState()
+          .messages.flatMap((m): readonly unknown[] => m.content);
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-2" }),
+        );
+      });
+      await waitFor(() =>
+        expect(controls.current.aui.thread.getState().isRunning).toBe(false),
+      );
+
+      await act(async () => {
+        runtimeResult.current.thread
+          .getMessageById("ai-1")
+          .getMessagePartByToolCallId("tc-1")
+          .addToolResult({ result: "first" });
+        runtimeResult.current.thread
+          .getMessageById("ai-2")
+          .getMessagePartByToolCallId("tc-2")
+          .addToolResult({ result: "second" });
+      });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(4));
+      expect(streamMock.mock.calls[2]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1" },
+      ]);
+      expect(streamMock.mock.calls[2]?.[1].runConfig).toEqual({
+        configurable: { model_name: "model-a" },
+      });
+      expect(streamMock.mock.calls[3]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-2" },
+      ]);
+      expect(streamMock.mock.calls[3]?.[1].runConfig).toEqual({
+        configurable: { model_name: "model-b" },
+      });
+    });
+
     it("drops a late tool result for a call already answered by a new turn's auto-cancellation instead of resuming the graph", async () => {
       const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
         if (streamMock.mock.calls.length === 1) {

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -199,17 +199,19 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       for (const message of newMessages) {
         if (message.type !== "ai") continue;
         let owner = runConfig;
+        const isNewMessage = Boolean(
+          message.id && !messageOwnership.has(message.id),
+        );
         if (message.id) {
-          if (!messageOwnership.has(message.id))
-            messageOwnership.set(message.id, runConfig);
+          if (isNewMessage) messageOwnership.set(message.id, runConfig);
           owner = messageOwnership.get(message.id);
-          if (runId && !runIdByMessageIdRef.current.has(message.id))
+          if (runId && isNewMessage)
             runIdByMessageIdRef.current.set(message.id, runId);
         }
         for (const toolCall of message.tool_calls ?? []) {
-          if (!toolOwnership.has(toolCall.id))
-            toolOwnership.set(toolCall.id, owner);
-          if (runId && !runIdByToolCallIdRef.current.has(toolCall.id))
+          const isNewTool = !toolOwnership.has(toolCall.id);
+          if (isNewTool) toolOwnership.set(toolCall.id, owner);
+          if (runId && isNewTool)
             runIdByToolCallIdRef.current.set(toolCall.id, runId);
         }
       }
@@ -777,7 +779,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         }
         return;
       }
-      const runConfig = getToolRunConfig(batch[0]!.tool_call_id, messages);
+      const runConfig = batch
+        .map((message) => getToolRunConfig(message.tool_call_id, messages))
+        .find((config) => config !== undefined);
       pendingResumeRef.current.set(groupKey, batch);
       try {
         await handleSendMessage(batch, { runConfig });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -49,6 +49,7 @@ import {
 import { langGraphExtras } from "./runtimeExtras";
 import {
   filterUIMessagesBySurvivingIds,
+  getPendingToolCallGroups,
   getPendingToolCalls,
   hasToolResult,
   truncateLangChainMessages,
@@ -311,12 +312,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const toolResultBufferRef = useRef<
     Map<string, LangChainMessage & { type: "tool" }>
   >(new Map());
-  // The resume batch currently sitting in the run queue. Referenced so results
-  // arriving before it is sent merge into it instead of deadlocking the buffer
-  // (queued results are not in `messages` yet, so they still count as pending).
-  const pendingResumeRef = useRef<
-    (LangChainMessage & { type: "tool" })[] | null
-  >(null);
+  // Queued resume batches keyed by pending-call group. Sibling results that
+  // arrive before the batch is sent merge here (they are not in `messages`
+  // yet, so they still count as pending).
+  const pendingResumeRef = useRef(
+    new Map<string, (LangChainMessage & { type: "tool" })[]>(),
+  );
   const queueRef = useRef<MessageQueueController | null>(null);
   // The purpose rides along because only a refetch may be superseded by a
   // send: aborting an initial load would strand its history and loading flag.
@@ -374,13 +375,16 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   }> | null>(null);
   runQueueRef.current ??= createSerialRunQueue({
     run: ({ messages, config }, onComplete) => {
-      if (messages === pendingResumeRef.current) {
-        pendingResumeRef.current = null;
+      for (const [groupKey, batch] of pendingResumeRef.current) {
+        if (batch === messages) {
+          pendingResumeRef.current.delete(groupKey);
+          break;
+        }
       }
       runErrorBalanceRef.current = 0;
       return sendMessageRef.current(messages, config, () => {
         if (runErrorBalanceRef.current > 0) {
-          pendingResumeRef.current = null;
+          pendingResumeRef.current.clear();
           runQueueRef.current!.drop();
         }
         onComplete();
@@ -391,7 +395,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const runQueue = runQueueRef.current;
 
   const cancelActiveRun = useCallback(() => {
-    pendingResumeRef.current = null;
+    pendingResumeRef.current.clear();
     runQueue.drop();
     queueRef.current?.clear();
     cancel();
@@ -450,7 +454,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     // A new turn abandons any half-collected parallel tool batch and any
     // queued resume; the cancellations below answer the dangling tool calls.
     toolResultBufferRef.current.clear();
-    pendingResumeRef.current = null;
+    pendingResumeRef.current.clear();
     interruptRunConfigRef.current = undefined;
     runQueue.drop();
     const cancellations =
@@ -716,16 +720,15 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // the graph with a second tool message. A call awaiting human input has
       // no tool message yet and stays on the normal pending path.
       if (hasToolResult(messages, toolCallId)) return;
-      const runConfig = getToolRunConfig(toolCallId, messages);
-      // Buffer results until every pending tool call in the turn has one, then
-      // resume the graph with the full batch in a single run. Sending each
-      // result on its own would resume LangGraph while sibling tool calls of a
-      // parallel turn are still executing.
-      const queuedResume = pendingResumeRef.current;
+      const pendingGroup = getPendingToolCallGroups(messages).find((group) =>
+        group.toolCalls.some((toolCall) => toolCall.id === toolCallId),
+      );
+      const groupKey = pendingGroup?.key ?? `late:${toolCallId}`;
+      const queuedResume = pendingResumeRef.current.get(groupKey);
       const queuedIds = new Set(queuedResume?.map((m) => m.tool_call_id));
       const batch = bufferToolResult(
         toolResultBufferRef.current,
-        getPendingToolCalls(messages).filter((t) => !queuedIds.has(t.id)),
+        (pendingGroup?.toolCalls ?? []).filter((t) => !queuedIds.has(t.id)),
         {
           type: "tool",
           name: toolName,
@@ -746,21 +749,22 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         }
         return;
       }
-      pendingResumeRef.current = batch;
+      const runConfig = getToolRunConfig(batch[0]!.tool_call_id, messages);
+      pendingResumeRef.current.set(groupKey, batch);
       try {
         await handleSendMessage(batch, { runConfig });
       } catch (error) {
         if (!(error instanceof SerialRunQueueDropError)) throw error;
       } finally {
-        if (pendingResumeRef.current === batch) {
-          pendingResumeRef.current = null;
+        if (pendingResumeRef.current.get(groupKey) === batch) {
+          pendingResumeRef.current.delete(groupKey);
         }
       }
     },
     onEdit: getCheckpointId
       ? async (msg) => {
           toolResultBufferRef.current.clear();
-          pendingResumeRef.current = null;
+          pendingResumeRef.current.clear();
           runQueue.drop();
           queueRef.current?.clear();
           const truncated = truncateLangChainMessages(
@@ -818,7 +822,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
               throw new Error("Runtime does not support reloading messages.");
 
             toolResultBufferRef.current.clear();
-            pendingResumeRef.current = null;
+            pendingResumeRef.current.clear();
             runQueue.drop();
             const truncated = truncateLangChainMessages(
               threadMessagesRef.current,

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -51,7 +51,6 @@ import {
   filterUIMessagesBySurvivingIds,
   getPendingToolCallGroups,
   getPendingToolCalls,
-  pendingToolCallGroupKey,
   hasToolResult,
   truncateLangChainMessages,
 } from "./messageHelpers";

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -748,7 +748,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
           const runId = runIdByToolCallIdRef.current.get(toolCall.id);
           if (runId) return `run:${runId}`;
         }
-        return pendingToolCallGroupKey(message);
+        return "run:unknown";
       }).find((group) =>
         group.toolCalls.some((toolCall) => toolCall.id === toolCallId),
       );

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -51,6 +51,7 @@ import {
   filterUIMessagesBySurvivingIds,
   getPendingToolCallGroups,
   getPendingToolCalls,
+  pendingToolCallGroupKey,
   hasToolResult,
   truncateLangChainMessages,
 } from "./messageHelpers";
@@ -185,12 +186,17 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
 
   const runConfigByMessageIdRef = useRef(new Map<string, unknown>());
   const runConfigByToolCallIdRef = useRef(new Map<string, unknown>());
+  const runIdByMessageIdRef = useRef(new Map<string, string>());
+  const runIdByToolCallIdRef = useRef(new Map<string, string>());
+  const currentRunIdRef = useRef<string | null>(null);
+  const nextRunIdRef = useRef(0);
   const interruptRunConfigRef = useRef<unknown>(undefined);
 
   const rememberMessageOwnership = useCallback(
     (newMessages: LangChainMessage[], runConfig: unknown) => {
       const messageOwnership = runConfigByMessageIdRef.current;
       const toolOwnership = runConfigByToolCallIdRef.current;
+      const runId = currentRunIdRef.current;
       for (const message of newMessages) {
         if (message.type !== "ai") continue;
         let owner = runConfig;
@@ -198,10 +204,14 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
           if (!messageOwnership.has(message.id))
             messageOwnership.set(message.id, runConfig);
           owner = messageOwnership.get(message.id);
+          if (runId && !runIdByMessageIdRef.current.has(message.id))
+            runIdByMessageIdRef.current.set(message.id, runId);
         }
         for (const toolCall of message.tool_calls ?? []) {
           if (!toolOwnership.has(toolCall.id))
             toolOwnership.set(toolCall.id, owner);
+          if (runId && !runIdByToolCallIdRef.current.has(toolCall.id))
+            runIdByToolCallIdRef.current.set(toolCall.id, runId);
         }
       }
     },
@@ -240,6 +250,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     }
     for (const id of runConfigByToolCallIdRef.current.keys()) {
       if (!toolCallIds.has(id)) runConfigByToolCallIdRef.current.delete(id);
+    }
+    for (const id of runIdByMessageIdRef.current.keys()) {
+      if (!messageIds.has(id)) runIdByMessageIdRef.current.delete(id);
+    }
+    for (const id of runIdByToolCallIdRef.current.keys()) {
+      if (!toolCallIds.has(id)) runIdByToolCallIdRef.current.delete(id);
     }
   }, []);
 
@@ -375,6 +391,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   }> | null>(null);
   runQueueRef.current ??= createSerialRunQueue({
     run: ({ messages, config }, onComplete) => {
+      currentRunIdRef.current = String(++nextRunIdRef.current);
       for (const [groupKey, batch] of pendingResumeRef.current) {
         if (batch === messages) {
           pendingResumeRef.current.delete(groupKey);
@@ -619,6 +636,8 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         effectiveStateRef.current = undefined;
         runConfigByMessageIdRef.current.clear();
         runConfigByToolCallIdRef.current.clear();
+        runIdByMessageIdRef.current.clear();
+        runIdByToolCallIdRef.current.clear();
         interruptRunConfigRef.current = undefined;
         setOptimisticState(undefined);
         setValues(undefined);
@@ -720,7 +739,17 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // the graph with a second tool message. A call awaiting human input has
       // no tool message yet and stays on the normal pending path.
       if (hasToolResult(messages, toolCallId)) return;
-      const pendingGroup = getPendingToolCallGroups(messages).find((group) =>
+      const pendingGroup = getPendingToolCallGroups(messages, (message) => {
+        if (message.id) {
+          const runId = runIdByMessageIdRef.current.get(message.id);
+          if (runId) return `run:${runId}`;
+        }
+        for (const toolCall of message.tool_calls ?? []) {
+          const runId = runIdByToolCallIdRef.current.get(toolCall.id);
+          if (runId) return `run:${runId}`;
+        }
+        return pendingToolCallGroupKey(message);
+      }).find((group) =>
         group.toolCalls.some((toolCall) => toolCall.id === toolCallId),
       );
       const groupKey = pendingGroup?.key ?? `late:${toolCallId}`;


### PR DESCRIPTION
closes #6033

## summary

- partition pending frontend tools by a per-send run token so two turns with `autoCancelPendingToolCalls: false` resume as separate LangGraph runs
- one run that emits two AI messages (fan-out) still waits for every sibling tool before resuming
- reuse the #6024 `getToolRunConfig` maps; `bufferToolResult` keeps its existing signature
- `pendingResumeRef` is keyed by group so a queued resume cannot swallow another turn's results

## test plan

### already verified

- [x] `pnpm -C packages/react-langgraph exec vitest run src/messageHelpers.test.ts src/bufferToolResults.test.ts src/useLangGraphRuntime.test.tsx` -> 66/66 green
- [x] reverse: the two-turn test against main source waits for 4 stream calls and only gets 3

### reviewer should verify

- [ ] two frontend tools from successive turns with `autoCancelPendingToolCalls: false` resume under their originating `runConfig`
- [ ] two frontend tools from two AI messages in the same run still resume as one batch

## notes

- #6038 attempted this leftover by rewriting ownership; this PR keeps #6024's decode-boundary maps and adds a run token only for batch grouping