### PR TITLE
feat: host assistant-cloud thread lists on AISDKThreads

### DIFF
--- a/.changeset/aisdk-threads-cloud.md
+++ b/.changeset/aisdk-threads-cloud.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: host assistant-cloud thread lists on AISDKThreads via RemoteThreadList
+
+AISDKThreads({ cloud }) uses RemoteThreadList and remounts each thread like useChatRuntime. Cloud history withFormat resolves persistence per call so one adapter can serve many threads. useExternalHistory waits for threadListItem.remoteId instead of latching on the first empty paint.

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -26,6 +26,9 @@ declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknow
 
 type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "id" | "messages" | "transport"> & {
   transport?: ChatTransport<UI_MESSAGE> | (() => ChatTransport<UI_MESSAGE>) | undefined;
+  cloud?: AssistantCloud | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
 
 declare class AISDKToolkit {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -26,6 +26,9 @@ declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknow
 
 type AISDKThreadsOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "id" | "messages" | "transport"> & {
   transport?: ChatTransport<UI_MESSAGE> | (() => ChatTransport<UI_MESSAGE>) | undefined;
+  cloud?: AssistantCloud | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };
 
 declare class AISDKToolkit {

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
@@ -19,7 +19,7 @@ import { reactAiSdk_AISDKChat, reactAiSdk_AISDKThreads, reactAiSdk_AISDKToolkit,
 `AuiConfig` entry that runs the AI SDK chat as the `threads` scope. Hosts the
 same orchestration as `useChatRuntime` inside the client's own resource tree,
 so it works with any `AssistantClient` host, React or not. Single thread; the
-multi-thread and assistant-cloud surface stays on `useChatRuntime`. The chat
+multi-thread and assistant-cloud surface is [AISDKThreads](/docs/api-reference/integrations/react-ai-sdk#aisdkthreads). The chat
 id is captured when the entry mounts, so a later `id` change in the options
 has no effect.
 
@@ -27,14 +27,14 @@ has no effect.
 
 ### AISDKThreads
 
-`AuiConfig` entry that runs one AI SDK chat per thread behind an in-memory
-thread list. Hosts the same per-thread orchestration as [AISDKChat](/docs/api-reference/integrations/react-ai-sdk#aisdkchat)
-inside the client's own resource tree, so it works with any
-`AssistantClient` host, React or not. Threads live in memory for the
-client's lifetime and keep their history across switches; each thread's
-chat id is its thread id. Model context is registered on the visible
-thread only, so a background send carries no context. The assistant-cloud
-thread list stays on `useChatRuntime`.
+`AuiConfig` entry that runs one AI SDK chat per thread. Hosts the same
+per-thread orchestration as [AISDKChat](/docs/api-reference/integrations/react-ai-sdk#aisdkchat) inside the client's own
+resource tree, so it works with any `AssistantClient` host, React or not.
+Without `cloud`, threads live in memory for the client's lifetime and keep
+their history across switches; each thread's chat id is its thread id.
+With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
+cloud history reloads on a switch. An in-flight run does not continue in
+the background. Model context is registered on the visible thread only.
 
 <ParametersTable {...reactAiSdk_AISDKThreads} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
@@ -33,8 +33,9 @@ resource tree, so it works with any `AssistantClient` host, React or not.
 Without `cloud`, threads live in memory for the client's lifetime and keep
 their history across switches; each thread's chat id is its thread id.
 With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
-cloud history reloads on a switch. An in-flight run does not continue in
-the background. Model context is registered on the visible thread only.
+cloud history reloads on a switch. The store entry mounts only the visible
+thread, so a switch cancels an in-flight run after persisting ready
+messages. Model context is registered on the visible thread only.
 
 <ParametersTable {...reactAiSdk_AISDKThreads} />
 

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
@@ -34,8 +34,8 @@ Without `cloud`, threads live in memory for the client's lifetime and keep
 their history across switches; each thread's chat id is its thread id.
 With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
 cloud history reloads on a switch. The store entry mounts only the visible
-thread, so a switch cancels an in-flight run after persisting ready
-messages. Model context is registered on the visible thread only.
+thread, so a switch cancels an in-flight run. Model context is
+registered on the visible thread only.
 
 <ParametersTable {...reactAiSdk_AISDKThreads} />
 

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -19,7 +19,7 @@ This integration provides:
 
 ## How It Works
 
-The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` / `createAssistantClient` hosts. That host mounts only the visible thread, so a switch cancels an in-flight run after persisting ready messages. The runtime automatically:
+The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` / `createAssistantClient` hosts. That host mounts only the visible thread, so a switch cancels an in-flight run. The runtime automatically:
 
 1. Creates a cloud thread on the first user message
 2. Persists messages as they complete streaming

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -19,7 +19,7 @@ This integration provides:
 
 ## How It Works
 
-The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. The runtime automatically:
+The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the same cloud list for `AuiConfig` / `createAssistantClient` hosts. The runtime automatically:
 
 1. Creates a cloud thread on the first user message
 2. Persists messages as they complete streaming

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -19,7 +19,7 @@ This integration provides:
 
 ## How It Works
 
-The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the same cloud list for `AuiConfig` / `createAssistantClient` hosts. The runtime automatically:
+The `useChatRuntime` hook from `@assistant-ui/react-ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` / `createAssistantClient` hosts. That host mounts only the visible thread, so a switch cancels an in-flight run after persisting ready messages. The runtime automatically:
 
 1. Creates a cloud thread on the first user message
 2. Persists messages as they complete streaming

--- a/apps/docs/content/docs/cloud/index.mdx
+++ b/apps/docs/content/docs/cloud/index.mdx
@@ -16,7 +16,7 @@ Assistant Cloud is a hosted service that adds thread management, message persist
 
 | Backend | Standalone Mode | With assistant-ui |
 |---------|----------------|-------------------|
-| AI SDK | [`useCloudChat`](/docs/cloud/ai-sdk) | [`useChatRuntime`](/docs/cloud/ai-sdk-assistant-ui) |
+| AI SDK | [`useCloudChat`](/docs/cloud/ai-sdk) | [`useChatRuntime`](/docs/cloud/ai-sdk-assistant-ui) / `AISDKThreads` |
 | LangGraph | — | [`useLangGraphRuntime`](/docs/cloud/langgraph) |
 | Custom | — | Local Runtime |
 

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -37,10 +37,11 @@ const cloud = new AssistantCloud({
 const runtime = useLocalRuntime(modelAdapter, { cloud });
 ```
 
-Framework adapters take `cloud` directly:
+Framework adapters take `cloud` directly. The store-entry dual of `useChatRuntime({ cloud })` is `AISDKThreads({ cloud })`.
 
 ```tsx
 const runtime = useChatRuntime({ cloud });
+const threads = AISDKThreads({ cloud });
 const runtime = useLangGraphRuntime({ cloud /* stream, load, ... */ });
 const runtime = useAdkRuntime({ cloud, stream });
 ```

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -37,7 +37,7 @@ const cloud = new AssistantCloud({
 const runtime = useLocalRuntime(modelAdapter, { cloud });
 ```
 
-Framework adapters take `cloud` directly. The store-entry dual of `useChatRuntime({ cloud })` is `AISDKThreads({ cloud })`.
+Framework adapters take `cloud` directly. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` hosts. It mounts only the visible thread, so a switch cancels an in-flight run.
 
 ```tsx
 const runtime = useChatRuntime({ cloud });

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -37,7 +37,7 @@ const cloud = new AssistantCloud({
 const runtime = useLocalRuntime(modelAdapter, { cloud });
 ```
 
-Framework adapters take `cloud` directly. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` hosts. It mounts only the visible thread, so a switch cancels an in-flight run.
+Framework adapters take `cloud` directly. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` hosts. It mounts only the visible thread, so a switch cancels an in-flight run and that exchange is not persisted.
 
 ```tsx
 const runtime = useChatRuntime({ cloud });

--- a/packages/ai-sdk/src/runtime/AISDKChat.ts
+++ b/packages/ai-sdk/src/runtime/AISDKChat.ts
@@ -38,7 +38,7 @@ const useAISDKChat = <UI_MESSAGE extends UIMessage = UIMessage>(
  * `AuiConfig` entry that runs the AI SDK chat as the `threads` scope. Hosts the
  * same orchestration as `useChatRuntime` inside the client's own resource tree,
  * so it works with any `AssistantClient` host, React or not. Single thread; the
- * multi-thread and assistant-cloud surface stays on `useChatRuntime`. The chat
+ * multi-thread and assistant-cloud surface is {@link AISDKThreads}. The chat
  * id is captured when the entry mounts, so a later `id` change in the options
  * has no effect.
  */

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -129,9 +129,6 @@ describe("AISDKThreads cloud", () => {
       await vi.waitFor(() => {
         expect(chat.getCancelCount()).toBe(1);
       });
-      await vi.waitFor(() => {
-        expect(append).toHaveBeenCalled();
-      });
     } finally {
       handle.destroy();
     }

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -62,6 +62,7 @@ vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
 }));
 
 import { AISDKThreads } from "./AISDKThreads";
+import { createCancellableTransport } from "./__tests__/controlled-transport";
 
 describe("AISDKThreads cloud", () => {
   it("reloads history when switching a keyed cloud thread", async () => {
@@ -91,5 +92,44 @@ describe("AISDKThreads cloud", () => {
       expect(load.mock.calls.length).toBeGreaterThan(afterFirst);
     });
     handle.destroy();
+  });
+
+  it("stops an in-flight cloud chat when switching away", async () => {
+    const chat = createCancellableTransport();
+    const handle = createAssistantClient(
+      AuiConfig({
+        threads: AISDKThreads({
+          cloud: {} as AssistantCloud,
+          threadId: "t1",
+          transport: () => chat.transport,
+        }),
+      }),
+    );
+    handle.subscribe(() => {});
+    const aui = handle.getClient();
+    try {
+      await aui.threads.getLoadThreadsPromise();
+      await vi.waitFor(() => {
+        expect(handle.getClient().threads.getState().mainThreadId).toBe("t1");
+      });
+      await vi.waitFor(() => expect(load).toHaveBeenCalled());
+      await vi.waitFor(() => {
+        expect(handle.getClient().thread.getState().isLoading).toBe(false);
+      });
+      flushTapSync(() => handle.getClient().composer.setText("stream me"));
+      flushTapSync(() => handle.getClient().composer.send());
+      await vi.waitFor(() => {
+        expect(handle.getClient().thread.getState().isRunning).toBe(true);
+      });
+      flushTapSync(() => handle.getClient().threads.switchToThread("t2"));
+      await vi.waitFor(() => {
+        expect(handle.getClient().threads.getState().mainThreadId).toBe("t2");
+      });
+      await vi.waitFor(() => {
+        expect(chat.getCancelCount()).toBe(1);
+      });
+    } finally {
+      handle.destroy();
+    }
   });
 });

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig, createAssistantClient } from "@assistant-ui/store/client";
+import type { AssistantCloud } from "assistant-cloud";
+import type { RemoteThreadListAdapter } from "@assistant-ui/core";
+import type { ThreadHistoryAdapter } from "@assistant-ui/core";
+
+const load = vi.hoisted(() => vi.fn(async () => ({ messages: [] })));
+
+const mocks = vi.hoisted(() => {
+  const history: ThreadHistoryAdapter = {
+    load: async () => ({ messages: [] }),
+    append: async () => {},
+    withFormat: () => ({
+      load,
+      append: async () => {},
+      delete: async () => {},
+      reportTelemetry: () => {},
+    }),
+  };
+  const adapter: RemoteThreadListAdapter = {
+    list: vi.fn(async () => ({
+      threads: [
+        { status: "regular" as const, remoteId: "t1", title: "One" },
+        { status: "regular" as const, remoteId: "t2", title: "Two" },
+      ],
+    })),
+    initialize: vi.fn(async (threadId: string) => ({
+      remoteId: threadId,
+      externalId: undefined,
+    })),
+    rename: vi.fn(async () => {}),
+    archive: vi.fn(async () => {}),
+    unarchive: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    generateTitle: vi.fn(
+      async () =>
+        new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }) as never,
+    ),
+    fetch: vi.fn(async (id: string) => ({
+      status: "regular" as const,
+      remoteId: id,
+      externalId: undefined,
+      title: id,
+    })),
+    unstable_useAdapters: function useAdapters() {
+      return { history };
+    },
+  };
+  return { adapter };
+});
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useCloudThreadListAdapter: () => mocks.adapter,
+}));
+
+import { AISDKThreads } from "./AISDKThreads";
+
+describe("AISDKThreads cloud", () => {
+  it("reloads history when switching a keyed cloud thread", async () => {
+    const handle = createAssistantClient(
+      AuiConfig({
+        threads: AISDKThreads({
+          cloud: {} as AssistantCloud,
+          threadId: "t1",
+        }),
+      }),
+    );
+    handle.subscribe(() => {});
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().mainThreadId).toBe("t1");
+    });
+    await vi.waitFor(() => {
+      expect(load).toHaveBeenCalled();
+    });
+    const afterFirst = load.mock.calls.length;
+    flushTapSync(() => aui.threads.switchToThread("t2"));
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().mainThreadId).toBe("t2");
+    });
+    await vi.waitFor(() => {
+      expect(load.mock.calls.length).toBeGreaterThan(afterFirst);
+    });
+    handle.destroy();
+  });
+});

--- a/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.cloud.test.ts
@@ -8,6 +8,7 @@ import type { RemoteThreadListAdapter } from "@assistant-ui/core";
 import type { ThreadHistoryAdapter } from "@assistant-ui/core";
 
 const load = vi.hoisted(() => vi.fn(async () => ({ messages: [] })));
+const append = vi.hoisted(() => vi.fn(async () => {}));
 
 const mocks = vi.hoisted(() => {
   const history: ThreadHistoryAdapter = {
@@ -15,7 +16,7 @@ const mocks = vi.hoisted(() => {
     append: async () => {},
     withFormat: () => ({
       load,
-      append: async () => {},
+      append,
       delete: async () => {},
       reportTelemetry: () => {},
     }),
@@ -127,6 +128,9 @@ describe("AISDKThreads cloud", () => {
       });
       await vi.waitFor(() => {
         expect(chat.getCancelCount()).toBe(1);
+      });
+      await vi.waitFor(() => {
+        expect(append).toHaveBeenCalled();
       });
     } finally {
       handle.destroy();

--- a/packages/ai-sdk/src/runtime/AISDKThreads.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig, createAssistantClient } from "@assistant-ui/store/client";
 import { AISDKThreads } from "./AISDKThreads";
@@ -95,8 +96,6 @@ describe("AISDKThreads", () => {
     flushTapSync(() => aui.threads.switchToNewThread());
     expect(handle.getClient().thread.getState().messages).toHaveLength(0);
 
-    // The detached chat keeps consuming the stream while another thread is
-    // visible
     emit(
       { type: "text-delta", id: "t1", delta: " and finished" },
       { type: "text-end", id: "t1" },
@@ -318,6 +317,75 @@ describe("AISDKThreads", () => {
       handle.destroy();
     } finally {
       vi.unstubAllGlobals();
+    }
+  });
+
+  it("uses assistant-cloud for listing and lifecycle actions", async () => {
+    const cloudThread = (id: string) => ({
+      id,
+      title: id,
+      is_archived: false,
+      last_message_at: null,
+      external_id: null,
+      metadata: null,
+    });
+    const list = vi.fn(async () => ({
+      threads: [cloudThread("cloud-1"), cloudThread("cloud-2")],
+    }));
+    const create = vi.fn(async () => ({ thread_id: "cloud-created" }));
+    const deleteThread = vi.fn(async () => {});
+    const cloud = {
+      threads: {
+        list,
+        create,
+        update: vi.fn(async () => {}),
+        delete: deleteThread,
+        get: vi.fn(async (id: string) => cloudThread(id)),
+        messages: { list: vi.fn(async () => ({ messages: [] })) },
+      },
+      runs: { stream: vi.fn() },
+    } as unknown as AssistantCloud;
+    const handle = createAssistantClient(
+      AuiConfig({ threads: AISDKThreads({ cloud }) }),
+    );
+    handle.subscribe(() => {});
+    const aui = handle.getClient();
+    try {
+      await aui.threads.getLoadThreadsPromise();
+      await vi.waitFor(() => {
+        expect(aui.threads.getState().threadIds).toEqual([
+          "cloud-1",
+          "cloud-2",
+        ]);
+      });
+
+      flushTapSync(() => aui.threads.switchToThread("cloud-1"));
+      await vi.waitFor(() => {
+        expect(aui.threads.getState().mainThreadId).toBe("cloud-1");
+      });
+
+      flushTapSync(() => aui.threads.switchToThread("cloud-2"));
+      await vi.waitFor(() => {
+        expect(aui.threads.getState().mainThreadId).toBe("cloud-2");
+      });
+
+      flushTapSync(() => aui.threads.switchToNewThread());
+      const newThreadId = handle.getClient().threads.getState().mainThreadId;
+      await handle.getClient().threads.item("main").initialize();
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ external_id: undefined }),
+      );
+      await vi.waitFor(() => {
+        expect(
+          handle.getClient().threads.item({ id: newThreadId }).getState()
+            .remoteId,
+        ).toBe("cloud-created");
+      });
+
+      await handle.getClient().threads.item({ id: "cloud-1" }).delete();
+      expect(deleteThread).toHaveBeenCalledWith("cloud-1");
+    } finally {
+      handle.destroy();
     }
   });
 });

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { resource, useResource, withKey } from "@assistant-ui/tap";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Chat, type UIMessage } from "@ai-sdk/react";
 import type { ChatTransport } from "ai";
 import type { AssistantCloud } from "assistant-cloud";
@@ -115,6 +115,13 @@ const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
   );
   const { chat, transport } =
     owned ?? getOrCreateChatEntry(threadId, options, chats);
+
+  useEffect(() => {
+    if (!cloud) return undefined;
+    return () => {
+      void chat.stop().catch(() => {});
+    };
+  }, [chat, cloud]);
 
   const aui = useAui();
   const fallbackItem = useMemo(

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -1,19 +1,23 @@
 "use client";
 
-import { resource, useResource } from "@assistant-ui/tap";
+import { resource, useResource, withKey } from "@assistant-ui/tap";
 import { useMemo, useState } from "react";
 import { Chat, type UIMessage } from "@ai-sdk/react";
 import type { ChatTransport } from "ai";
+import type { AssistantCloud } from "assistant-cloud";
 import {
   InMemoryThreadList,
+  RemoteThreadList,
   inMemoryThreadListTransformScopes,
 } from "@assistant-ui/core/store";
 import { ThreadClient } from "@assistant-ui/core/store/internal";
+import { useCloudThreadListAdapter } from "@assistant-ui/core/react";
 import {
   attachTransformScopes,
   useAssistantClientRef,
   useAssistantScopeEffect,
 } from "@assistant-ui/store/client";
+import { useAui } from "@assistant-ui/store";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import {
   splitChatThreadOptions,
@@ -35,53 +39,85 @@ export type AISDKThreadsOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       | ChatTransport<UI_MESSAGE>
       | (() => ChatTransport<UI_MESSAGE>)
       | undefined;
+    /**
+     * When set, the thread list is a `RemoteThreadList` backed by this
+     * assistant-cloud. Omit it to keep the in-memory list. The thread
+     * factory is keyed so cloud history reloads on a switch, and an
+     * in-flight run does not continue in the background.
+     */
+    cloud?: AssistantCloud | undefined;
+    /**
+     * Controlled thread id for the cloud list. Ignored without `cloud`.
+     */
+    threadId?: string | undefined;
+    /**
+     * Called with the settled remote id when the cloud list changes thread.
+     */
+    onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };
+
+type AISDKThreadChatOptions<UI_MESSAGE extends UIMessage = UIMessage> = Omit<
+  AISDKThreadsOptions<UI_MESSAGE>,
+  "cloud" | "threadId" | "onThreadIdChange"
+>;
+
+type ChatEntry<UI_MESSAGE extends UIMessage> = {
+  chat: Chat<UI_MESSAGE>;
+  transport: ChatTransport<UI_MESSAGE>;
+};
+
+const createChatEntry = <UI_MESSAGE extends UIMessage>(
+  threadId: string,
+  options: AISDKThreadChatOptions<UI_MESSAGE> | undefined,
+): ChatEntry<UI_MESSAGE> => {
+  const { chatInit } = splitChatThreadOptions(
+    options as ChatThreadOptions<UI_MESSAGE> | undefined,
+  );
+  const transport =
+    typeof options?.transport === "function"
+      ? options.transport()
+      : options?.transport === undefined
+        ? new AssistantChatTransport()
+        : options.transport instanceof AssistantChatTransport
+          ? options.transport.__internal_clone()
+          : options.transport;
+  return {
+    chat: new Chat<UI_MESSAGE>({ ...chatInit, id: threadId, transport }),
+    transport,
+  };
+};
+
+const getOrCreateChatEntry = <UI_MESSAGE extends UIMessage>(
+  threadId: string,
+  options: AISDKThreadChatOptions<UI_MESSAGE> | undefined,
+  chats: Map<string, ChatEntry<UI_MESSAGE>>,
+): ChatEntry<UI_MESSAGE> => {
+  const existing = chats.get(threadId);
+  if (existing) return existing;
+  const created = createChatEntry(threadId, options);
+  chats.set(threadId, created);
+  return created;
+};
 
 const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
   threadId,
   options,
   chats,
+  cloud,
 }: {
   threadId: string;
-  options: AISDKThreadsOptions<UI_MESSAGE> | undefined;
-  chats: Map<
-    string,
-    { chat: Chat<UI_MESSAGE>; transport: ChatTransport<UI_MESSAGE> }
-  >;
+  options: AISDKThreadChatOptions<UI_MESSAGE> | undefined;
+  chats: Map<string, ChatEntry<UI_MESSAGE>>;
+  cloud: boolean;
 }) => {
-  // State lives on the chat instance, so a switched-away thread keeps its
-  // history and an in-flight run keeps streaming; the mounted resource is
-  // only the main thread's subscriber. The chat's own transport doubles as
-  // the wired one below, so model context and the thread item reach the
-  // wire.
-  let entry = chats.get(threadId);
-  if (!entry) {
-    const { chatInit } = splitChatThreadOptions(
-      options as ChatThreadOptions<UI_MESSAGE> | undefined,
-    );
-    // A factory result is already per thread. A plain AssistantChatTransport
-    // instance is cloned per thread: the docs teach the instance form, and
-    // per-thread wiring on a shared instance would leak the visible thread's
-    // context into background sends.
-    const transport =
-      typeof options?.transport === "function"
-        ? options.transport()
-        : options?.transport === undefined
-          ? new AssistantChatTransport()
-          : options.transport instanceof AssistantChatTransport
-            ? options.transport.__internal_clone()
-            : options.transport;
-    entry = {
-      chat: new Chat<UI_MESSAGE>({ ...chatInit, id: threadId, transport }),
-      transport,
-    };
-    chats.set(threadId, entry);
-  }
-  const { chat, transport } = entry;
+  const [owned] = useState(() =>
+    cloud ? createChatEntry(threadId, options) : undefined,
+  );
+  const { chat, transport } =
+    owned ?? getOrCreateChatEntry(threadId, options, chats);
 
-  // The thread is its own chat: the handed-over item initializes to the
-  // thread id so the transport resolves it as the request id.
-  const threadListItem = useMemo(
+  const aui = useAui();
+  const fallbackItem = useMemo(
     () => ({
       initialize: async () => ({
         remoteId: threadId,
@@ -95,8 +131,10 @@ const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
     {
       id: threadId,
       isMainThread: true,
-      getThreadListItem: () => threadListItem,
+      getThreadListItem: () =>
+        cloud && aui.threadListItem.source ? aui.threadListItem : fallbackItem,
       chat,
+      stopOnClientDestroy: cloud,
     },
   );
 
@@ -116,13 +154,9 @@ const AISDKChatThread = resource(useAISDKChatThread);
 const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: AISDKThreadsOptions<UI_MESSAGE>,
 ) => {
-  const [chats] = useState(
-    () =>
-      new Map<
-        string,
-        { chat: Chat<UI_MESSAGE>; transport: ChatTransport<UI_MESSAGE> }
-      >(),
-  );
+  const { cloud, threadId, onThreadIdChange, ...threadOptions } = options ?? {};
+  const [chats] = useState(() => new Map<string, ChatEntry<UI_MESSAGE>>());
+  const bindCloud = cloud !== undefined;
 
   useResourceCleanup(true, () => {
     for (const { chat } of chats.values()) {
@@ -130,29 +164,47 @@ const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
     }
   });
 
+  const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const thread = (id: string) => {
+    const element = AISDKChatThread({
+      threadId: id,
+      options: threadOptions,
+      chats,
+      cloud: bindCloud,
+    });
+    return bindCloud ? withKey(id, element) : element;
+  };
+
   return useResource(
-    InMemoryThreadList({
-      thread: (threadId) => AISDKChatThread({ threadId, options, chats }),
-      onDelete: (threadId) => {
-        void chats
-          .get(threadId)
-          ?.chat.stop()
-          .catch(() => {});
-        chats.delete(threadId);
-      },
-    }),
+    bindCloud
+      ? RemoteThreadList({
+          adapter: cloudAdapter,
+          thread,
+          threadId,
+          onThreadIdChange,
+        })
+      : InMemoryThreadList({
+          thread,
+          onDelete: (id) => {
+            void chats
+              .get(id)
+              ?.chat.stop()
+              .catch(() => {});
+            chats.delete(id);
+          },
+        }),
   );
 };
 
 /**
- * `AuiConfig` entry that runs one AI SDK chat per thread behind an in-memory
- * thread list. Hosts the same per-thread orchestration as {@link AISDKChat}
- * inside the client's own resource tree, so it works with any
- * `AssistantClient` host, React or not. Threads live in memory for the
- * client's lifetime and keep their history across switches; each thread's
- * chat id is its thread id. Model context is registered on the visible
- * thread only, so a background send carries no context. The assistant-cloud
- * thread list stays on `useChatRuntime`.
+ * `AuiConfig` entry that runs one AI SDK chat per thread. Hosts the same
+ * per-thread orchestration as {@link AISDKChat} inside the client's own
+ * resource tree, so it works with any `AssistantClient` host, React or not.
+ * Without `cloud`, threads live in memory for the client's lifetime and keep
+ * their history across switches; each thread's chat id is its thread id.
+ * With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
+ * cloud history reloads on a switch. An in-flight run does not continue in
+ * the background. Model context is registered on the visible thread only.
  */
 export const AISDKThreads = resource(useAISDKThreads);
 

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -139,7 +139,11 @@ const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
       id: threadId,
       isMainThread: true,
       getThreadListItem: () =>
-        cloud && aui.threadListItem.source ? aui.threadListItem : fallbackItem,
+        cloud
+          ? aui.threadListItem.source
+            ? aui.threadListItem
+            : undefined
+          : fallbackItem,
       chat,
       stopOnClientDestroy: cloud,
     },
@@ -210,8 +214,9 @@ const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
  * Without `cloud`, threads live in memory for the client's lifetime and keep
  * their history across switches; each thread's chat id is its thread id.
  * With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
- * cloud history reloads on a switch. An in-flight run does not continue in
- * the background. Model context is registered on the visible thread only.
+ * cloud history reloads on a switch. The store entry mounts only the visible
+ * thread, so a switch cancels an in-flight run after persisting ready
+ * messages. Model context is registered on the visible thread only.
  */
 export const AISDKThreads = resource(useAISDKThreads);
 

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -215,8 +215,8 @@ const useAISDKThreads = <UI_MESSAGE extends UIMessage = UIMessage>(
  * their history across switches; each thread's chat id is its thread id.
  * With `cloud`, the list is a `RemoteThreadList` and the factory is keyed so
  * cloud history reloads on a switch. The store entry mounts only the visible
- * thread, so a switch cancels an in-flight run after persisting ready
- * messages. Model context is registered on the visible thread only.
+ * thread, so a switch cancels an in-flight run. Model context is
+ * registered on the visible thread only.
  */
 export const AISDKThreads = resource(useAISDKThreads);
 

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -18,21 +18,23 @@ const mocks = vi.hoisted(() => ({
   listeners: new Set<() => void>(),
 }));
 
+const auiClient = {
+  threadListItem: {
+    get source() {
+      return mocks.hasThreadListItem ? "threads" : null;
+    },
+    getState: () => ({ remoteId: mocks.remoteId }),
+  },
+  subscribe: (listener: () => void) => {
+    mocks.listeners.add(listener);
+    return () => {
+      mocks.listeners.delete(listener);
+    };
+  },
+};
+
 vi.mock("@assistant-ui/store", () => ({
-  useAui: () => ({
-    threadListItem: {
-      get source() {
-        return mocks.hasThreadListItem ? "threads" : null;
-      },
-      getState: () => ({ remoteId: mocks.remoteId }),
-    },
-    subscribe: (listener: () => void) => {
-      mocks.listeners.add(listener);
-      return () => {
-        mocks.listeners.delete(listener);
-      };
-    },
-  }),
+  useAui: () => auiClient,
 }));
 
 import { MessageRepository } from "@assistant-ui/core/internal";
@@ -200,6 +202,50 @@ describe("useExternalHistory withFormat contract", () => {
     });
 
     await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not load history when remoteId appears during an active run", async () => {
+    mocks.hasThreadListItem = true;
+    const load = vi.fn().mockResolvedValue({ headId: null, messages: [] });
+    const adapter: ThreadHistoryAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue({
+        load,
+        append: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+    const runningRuntimeRef = {
+      current: {
+        thread: {
+          subscribe: () => () => {},
+          getState: () => ({ isRunning: true, messages: [{ id: "u1" }] }),
+          import: () => {},
+          export: () => ({ headId: null, messages: [] }),
+        },
+      } as unknown as AssistantRuntime,
+    };
+
+    renderHook(() =>
+      useExternalHistory(
+        runningRuntimeRef,
+        adapter,
+        toThreadMessages,
+        storageFormat,
+        onSetMessages,
+      ),
+    );
+
+    await act(async () => {});
+    expect(load).not.toHaveBeenCalled();
+
+    mocks.remoteId = "remote-thread";
+    await act(async () => {
+      for (const listener of mocks.listeners) listener();
+    });
+
+    await act(async () => {});
+    expect(load).not.toHaveBeenCalled();
   });
 
   it("reports loading before an asynchronous history load settles", async () => {

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -14,15 +14,23 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   remoteId: undefined as string | undefined,
+  hasThreadListItem: false,
+  listeners: new Set<() => void>(),
 }));
 
 vi.mock("@assistant-ui/store", () => ({
   useAui: () => ({
     threadListItem: {
       get source() {
-        return mocks.remoteId ? "threads" : null;
+        return mocks.hasThreadListItem ? "threads" : null;
       },
       getState: () => ({ remoteId: mocks.remoteId }),
+    },
+    subscribe: (listener: () => void) => {
+      mocks.listeners.add(listener);
+      return () => {
+        mocks.listeners.delete(listener);
+      };
     },
   }),
 }));
@@ -60,6 +68,8 @@ const onSetMessages = () => {};
 describe("useExternalHistory withFormat contract", () => {
   beforeEach(() => {
     mocks.remoteId = undefined;
+    mocks.hasThreadListItem = false;
+    mocks.listeners.clear();
   });
 
   it("throws when the adapter omits withFormat", () => {
@@ -125,7 +135,75 @@ describe("useExternalHistory withFormat contract", () => {
     expect(adapter.withFormat).toHaveBeenCalledWith(storageFormat);
   });
 
+  it("loads history when threadListItem.remoteId appears after the first paint", async () => {
+    const load = vi.fn().mockResolvedValue({ headId: null, messages: [] });
+    const adapter: ThreadHistoryAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue({
+        load,
+        append: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    const { rerender } = renderHook(() =>
+      useExternalHistory(
+        runtimeRef,
+        adapter,
+        toThreadMessages,
+        storageFormat,
+        onSetMessages,
+      ),
+    );
+
+    await act(async () => {});
+    expect(load).not.toHaveBeenCalled();
+
+    mocks.hasThreadListItem = true;
+    mocks.remoteId = "remote-thread";
+    await act(async () => {
+      for (const listener of mocks.listeners) listener();
+    });
+    rerender();
+
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+  });
+
+  it("loads when a mounted thread later receives a remoteId", async () => {
+    mocks.hasThreadListItem = true;
+    const load = vi.fn().mockResolvedValue({ headId: null, messages: [] });
+    const adapter: ThreadHistoryAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue({
+        load,
+        append: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    renderHook(() =>
+      useExternalHistory(
+        runtimeRef,
+        adapter,
+        toThreadMessages,
+        storageFormat,
+        onSetMessages,
+      ),
+    );
+
+    await act(async () => {});
+    expect(load).not.toHaveBeenCalled();
+
+    mocks.remoteId = "remote-thread";
+    await act(async () => {
+      for (const listener of mocks.listeners) listener();
+    });
+
+    await waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+  });
+
   it("reports loading before an asynchronous history load settles", async () => {
+    mocks.hasThreadListItem = true;
     mocks.remoteId = "remote-thread";
     let resolveLoad!: (repo: MessageFormatRepository<unknown>) => void;
     const load = vi.fn(
@@ -219,6 +297,12 @@ describe("toExportedMessageRepository", () => {
 });
 
 describe("useExternalHistory persistence", () => {
+  beforeEach(() => {
+    mocks.remoteId = undefined;
+    mocks.hasThreadListItem = false;
+    mocks.listeners.clear();
+  });
+
   type InnerMessage = { id: string; parts: string[] };
 
   const persistenceStorageFormat: MessageFormatAdapter<
@@ -311,6 +395,9 @@ describe("useExternalHistory persistence", () => {
     const persistenceRuntimeRef = {
       current: { thread } as AssistantRuntime,
     };
+
+    mocks.hasThreadListItem = true;
+    mocks.remoteId = "remote-thread";
 
     const { result, unmount } = renderHook(() =>
       useExternalHistory(

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -381,8 +381,8 @@ export const useExternalHistory = <TMessage>(
       if (persistTimerRef.current) {
         clearTimeout(persistTimerRef.current);
         persistTimerRef.current = null;
+        persistSettled(false);
       }
-      persistSettled(true);
     };
   }, [formatAdapter, storageFormatAdapter, runtimeRef]);
 

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -151,6 +151,13 @@ export const useExternalHistory = <TMessage>(
       });
     }
 
+    const threadState = runtimeRef.current.thread.getState();
+    if (threadState.isRunning || threadState.messages.length > 0) {
+      loadedRef.current = true;
+      setHasLoaded(true);
+      return undefined;
+    }
+
     loadedRef.current = true;
     void loadHistory();
     return undefined;
@@ -219,154 +226,154 @@ export const useExternalHistory = <TMessage>(
       // Debounce: wait one macrotask so agentic step flickers are absorbed
       if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
       persistTimerRef.current = setTimeout(() => {
-        persistTimerRef.current = null;
+        persistSettled(false);
+      }, 0);
+    });
 
-        const latest = runtimeRef.current.thread.getState();
-        if (latest.isRunning) return;
+    function persistSettled(ignoreRunning: boolean) {
+      persistTimerRef.current = null;
+      const latest = runtimeRef.current.thread.getState();
+      if (!ignoreRunning && latest.isRunning) return;
 
-        const boundaries = stepBoundariesRef.current;
-        const durationMs =
-          boundaries.length > 0 ? boundaries.at(-1) : undefined;
+      const boundaries = stepBoundariesRef.current;
+      const durationMs = boundaries.length > 0 ? boundaries.at(-1) : undefined;
 
-        // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
-        if (boundaries.length === 1 && durationMs != null) {
-          const lastAssistant = latest.messages.findLast(
-            (m) => m.role === "assistant",
-          );
-          if (lastAssistant) {
-            const tcCount = lastAssistant.content.filter(
-              (p) => p.type === "tool-call",
-            ).length;
-            if (tcCount > 0) {
-              const totalSteps = tcCount + 1;
-              const stepDur = durationMs / totalSteps;
-              boundaries.length = 0;
-              for (let i = 0; i < totalSteps; i++) {
-                boundaries.push(Math.round((i + 1) * stepDur));
-              }
+      // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
+      if (boundaries.length === 1 && durationMs != null) {
+        const lastAssistant = latest.messages.findLast(
+          (m) => m.role === "assistant",
+        );
+        if (lastAssistant) {
+          const tcCount = lastAssistant.content.filter(
+            (p) => p.type === "tool-call",
+          ).length;
+          if (tcCount > 0) {
+            const totalSteps = tcCount + 1;
+            const stepDur = durationMs / totalSteps;
+            boundaries.length = 0;
+            for (let i = 0; i < totalSteps; i++) {
+              boundaries.push(Math.round((i + 1) * stepDur));
             }
           }
         }
+      }
 
-        // Build per-step timestamps when there are multiple steps
-        const stepTimestamps =
-          boundaries.length > 1
-            ? boundaries.map((endMs, i) => ({
-                start_ms: i === 0 ? 0 : boundaries[i - 1]!,
-                end_ms: endMs,
-              }))
-            : undefined;
+      // Build per-step timestamps when there are multiple steps
+      const stepTimestamps =
+        boundaries.length > 1
+          ? boundaries.map((endMs, i) => ({
+              start_ms: i === 0 ? 0 : boundaries[i - 1]!,
+              end_ms: endMs,
+            }))
+          : undefined;
 
-        runStartRef.current = null;
-        stepBoundariesRef.current = [];
+      runStartRef.current = null;
+      stepBoundariesRef.current = [];
 
-        const telemetryOptions = {
-          ...(durationMs != null ? { durationMs } : undefined),
-          ...(stepTimestamps != null ? { stepTimestamps } : undefined),
-        };
+      const telemetryOptions = {
+        ...(durationMs != null ? { durationMs } : undefined),
+        ...(stepTimestamps != null ? { stepTimestamps } : undefined),
+      };
 
-        persistInFlightRef.current = persistInFlightRef.current
-          .then(async () => {
-            const changedRunMessageIds = new Set<string>();
-            for (const message of latest.messages) {
-              const externalMessages =
-                getExternalStoreMessages<TMessage>(message);
-              const previous = persistedExternalMessages.current.get(
-                message.id,
-              );
-              if (
-                previous === undefined ||
-                previous.length !== externalMessages.length ||
-                externalMessages.some((item, index) => item !== previous[index])
-              ) {
-                changedRunMessageIds.add(message.id);
-              }
+      persistInFlightRef.current = persistInFlightRef.current
+        .then(async () => {
+          const changedRunMessageIds = new Set<string>();
+          for (const message of latest.messages) {
+            const externalMessages =
+              getExternalStoreMessages<TMessage>(message);
+            const previous = persistedExternalMessages.current.get(message.id);
+            if (
+              previous === undefined ||
+              previous.length !== externalMessages.length ||
+              externalMessages.some((item, index) => item !== previous[index])
+            ) {
+              changedRunMessageIds.add(message.id);
             }
+          }
 
-            const { messages } = latest;
-            let lastInnerMessageId: string | null = null;
-            const failedUpdateIds = new Set<string>();
+          const { messages } = latest;
+          let lastInnerMessageId: string | null = null;
+          const failedUpdateIds = new Set<string>();
 
-            const getLastInnerId = (msgs: TMessage[]): string | null =>
-              msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
+          const getLastInnerId = (msgs: TMessage[]): string | null =>
+            msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
 
-            const toBatchItems = (msgs: TMessage[]) =>
-              msgs.map((msg, idx) => ({
-                parentId:
-                  idx === 0
-                    ? lastInnerMessageId
-                    : storageFormatAdapter.getId(msgs[idx - 1]!),
-                message: msg,
-              }));
+          const toBatchItems = (msgs: TMessage[]) =>
+            msgs.map((msg, idx) => ({
+              parentId:
+                idx === 0
+                  ? lastInnerMessageId
+                  : storageFormatAdapter.getId(msgs[idx - 1]!),
+              message: msg,
+            }));
 
-            for (const message of messages) {
-              const innerMessages = getExternalStoreMessages<TMessage>(message);
+          for (const message of messages) {
+            const innerMessages = getExternalStoreMessages<TMessage>(message);
 
-              const isTerminal =
-                message.status === undefined ||
-                message.status.type === "complete" ||
-                message.status.type === "incomplete";
-              const isAwaitingToolCalls = isAwaitingToolApproval(message);
-              // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
-              const isReady =
-                isTerminal ||
-                (isAwaitingToolCalls && formatAdapter.update !== undefined);
+            const isTerminal =
+              message.status === undefined ||
+              message.status.type === "complete" ||
+              message.status.type === "incomplete";
+            const isAwaitingToolCalls = isAwaitingToolApproval(message);
+            // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
+            const isReady =
+              isTerminal ||
+              (isAwaitingToolCalls && formatAdapter.update !== undefined);
 
-              if (!isReady) {
-                lastInnerMessageId =
-                  getLastInnerId(innerMessages) ?? lastInnerMessageId;
-                continue;
-              }
-
-              const isPersistedMessage = historyIds.current.has(message.id);
-              if (isPersistedMessage && !changedRunMessageIds.has(message.id)) {
-                lastInnerMessageId =
-                  getLastInnerId(innerMessages) ?? lastInnerMessageId;
-                continue;
-              }
-              if (!isPersistedMessage) {
-                historyIds.current.add(message.id);
-                deferredTelemetryIds.current.add(message.id);
-              }
-
-              const batchItems = toBatchItems(innerMessages);
-              for (const item of batchItems) {
-                const innerId = storageFormatAdapter.getId(item.message);
-                if (!persistedInnerIds.current.has(innerId)) {
-                  await formatAdapter.append(item);
-                  persistedInnerIds.current.add(innerId);
-                } else if (durationMs !== undefined) {
-                  try {
-                    await formatAdapter.update?.(item, innerId);
-                  } catch {
-                    // A failed update drops the message from the refreshed baseline so it retries on the next run stop.
-                    failedUpdateIds.add(message.id);
-                  }
-                }
-              }
-
+            if (!isReady) {
               lastInnerMessageId =
                 getLastInnerId(innerMessages) ?? lastInnerMessageId;
+              continue;
+            }
 
-              if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
-                deferredTelemetryIds.current.delete(message.id);
-                formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+            const isPersistedMessage = historyIds.current.has(message.id);
+            if (isPersistedMessage && !changedRunMessageIds.has(message.id)) {
+              lastInnerMessageId =
+                getLastInnerId(innerMessages) ?? lastInnerMessageId;
+              continue;
+            }
+            if (!isPersistedMessage) {
+              historyIds.current.add(message.id);
+              deferredTelemetryIds.current.add(message.id);
+            }
+
+            const batchItems = toBatchItems(innerMessages);
+            for (const item of batchItems) {
+              const innerId = storageFormatAdapter.getId(item.message);
+              if (!persistedInnerIds.current.has(innerId)) {
+                await formatAdapter.append(item);
+                persistedInnerIds.current.add(innerId);
+              } else if (durationMs !== undefined) {
+                try {
+                  await formatAdapter.update?.(item, innerId);
+                } catch {
+                  // A failed update drops the message from the refreshed baseline so it retries on the next run stop.
+                  failedUpdateIds.add(message.id);
+                }
               }
             }
 
-            const nextSnapshot = snapshotExternalMessages<TMessage>(
-              latest.messages,
-            );
-            for (const id of failedUpdateIds) {
-              nextSnapshot.delete(id);
+            lastInnerMessageId =
+              getLastInnerId(innerMessages) ?? lastInnerMessageId;
+
+            if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
+              deferredTelemetryIds.current.delete(message.id);
+              formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
             }
-            persistedExternalMessages.current = nextSnapshot;
-          })
-          .catch((error) => {
-            console.error("Failed to persist message history:", error);
-          });
-      }, 0);
-    });
+          }
+
+          const nextSnapshot = snapshotExternalMessages<TMessage>(
+            latest.messages,
+          );
+          for (const id of failedUpdateIds) {
+            nextSnapshot.delete(id);
+          }
+          persistedExternalMessages.current = nextSnapshot;
+        })
+        .catch((error) => {
+          console.error("Failed to persist message history:", error);
+        });
+    }
 
     return () => {
       unsubscribe();
@@ -374,6 +381,7 @@ export const useExternalHistory = <TMessage>(
         clearTimeout(persistTimerRef.current);
         persistTimerRef.current = null;
       }
+      persistSettled(true);
     };
   }, [formatAdapter, storageFormatAdapter, runtimeRef]);
 

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -67,6 +67,7 @@ export const useExternalHistory = <TMessage>(
   onSetMessages: (messages: TMessage[]) => void,
 ) => {
   const loadedRef = useRef(false);
+  const [itemEpoch, setItemEpoch] = useState(0);
 
   const aui = useAui();
   const optionalThreadListItem = useCallback(
@@ -99,7 +100,7 @@ export const useExternalHistory = <TMessage>(
   const isLoading = formatAdapter != null && !hasLoaded;
 
   useEffect(() => {
-    if (!formatAdapter || loadedRef.current) return;
+    if (!formatAdapter || loadedRef.current) return undefined;
 
     const loadHistory = async () => {
       try {
@@ -140,19 +141,26 @@ export const useExternalHistory = <TMessage>(
       }
     };
 
-    loadedRef.current = true;
-
-    if (!optionalThreadListItem()?.getState().remoteId) {
+    const remoteId = optionalThreadListItem()?.getState().remoteId;
+    if (!remoteId) {
       setHasLoaded(true);
-      return;
+      return aui.subscribe(() => {
+        if (optionalThreadListItem()?.getState().remoteId) {
+          setItemEpoch((n) => n + 1);
+        }
+      });
     }
 
-    loadHistory();
+    loadedRef.current = true;
+    void loadHistory();
+    return undefined;
   }, [
     formatAdapter,
     toThreadMessages,
     runtimeRef,
     optionalThreadListItem,
+    aui,
+    itemEpoch,
     storageFormatAdapter,
   ]);
 

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -180,6 +180,7 @@ export const useExternalHistory = <TMessage>(
 
   useEffect(() => {
     if (!formatAdapter) return;
+    const adapter = formatAdapter;
 
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
       const threadState = runtimeRef.current.thread.getState();
@@ -318,7 +319,7 @@ export const useExternalHistory = <TMessage>(
             // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
             const isReady =
               isTerminal ||
-              (isAwaitingToolCalls && formatAdapter.update !== undefined);
+              (isAwaitingToolCalls && adapter.update !== undefined);
 
             if (!isReady) {
               lastInnerMessageId =
@@ -341,11 +342,11 @@ export const useExternalHistory = <TMessage>(
             for (const item of batchItems) {
               const innerId = storageFormatAdapter.getId(item.message);
               if (!persistedInnerIds.current.has(innerId)) {
-                await formatAdapter.append(item);
+                await adapter.append(item);
                 persistedInnerIds.current.add(innerId);
               } else if (durationMs !== undefined) {
                 try {
-                  await formatAdapter.update?.(item, innerId);
+                  await adapter.update?.(item, innerId);
                 } catch {
                   // A failed update drops the message from the refreshed baseline so it retries on the next run stop.
                   failedUpdateIds.add(message.id);
@@ -358,7 +359,7 @@ export const useExternalHistory = <TMessage>(
 
             if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
               deferredTelemetryIds.current.delete(message.id);
-              formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+              adapter.reportTelemetry?.(batchItems, telemetryOptions);
             }
           }
 

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -71,15 +71,10 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
   });
 
   it("resolves formatted persistence against the current threadListItem", async () => {
-    let remoteId = "thread-1";
-    mocks.aui = {
-      threadListItem: {
-        getState: () => ({ remoteId }),
-      },
-    } as unknown as import("@assistant-ui/store").AssistantClient;
+    mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();
     const cloudRef = { current: cloud };
-    const { result } = renderHook(() =>
+    const { result, rerender } = renderHook(() =>
       useAssistantCloudThreadHistoryAdapter(cloudRef),
     );
     const formatted = result.current.withFormat<
@@ -100,7 +95,8 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
       format: "test",
     });
 
-    remoteId = "thread-2";
+    mocks.aui = mocks.makeClient("thread-2");
+    rerender();
     await formatted.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
       format: "test",

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -70,6 +70,43 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     });
   });
 
+  it("resolves formatted persistence against the current threadListItem", async () => {
+    let remoteId = "thread-1";
+    mocks.aui = {
+      threadListItem: {
+        getState: () => ({ remoteId }),
+      },
+    } as unknown as import("@assistant-ui/store").AssistantClient;
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const formatted = result.current.withFormat<
+      { id: string },
+      Record<string, unknown>
+    >({
+      format: "test",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message) => message.id,
+    });
+
+    await formatted.load();
+    expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
+      format: "test",
+    });
+
+    remoteId = "thread-2";
+    await formatted.load();
+    expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
+      format: "test",
+    });
+  });
+
   it("resolves the aui client at call time instead of capturing it", async () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -51,20 +51,18 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
   ): GenericThreadHistoryAdapter<TMessage> {
     const adapter = this;
-    const formatted = createFormattedPersistence(
-      this._persistence,
-      formatAdapter,
-    );
+    const getFormatted = () =>
+      createFormattedPersistence(adapter._persistence, formatAdapter);
     return {
       // Note: callers must also call reportTelemetry() for run tracking
       async append(item: MessageFormatItem<TMessage>) {
         const { remoteId } = await adapter.aui.threadListItem.initialize();
-        await formatted.append(remoteId, item);
+        await getFormatted().append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
         const remoteId = adapter.aui.threadListItem.getState().remoteId;
         if (!remoteId) return;
-        await formatted.update?.(remoteId, item, localMessageId);
+        await getFormatted().update?.(remoteId, item, localMessageId);
       },
       async delete() {
         throw new Error(
@@ -90,7 +88,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       async load(): Promise<MessageFormatRepository<TMessage>> {
         const remoteId = adapter.aui.threadListItem.getState().remoteId;
         if (!remoteId) return { messages: [] };
-        return formatted.load(remoteId);
+        return getFormatted().load(remoteId);
       },
     };
   }


### PR DESCRIPTION
closes #6067

## summary

- `AISDKThreads({ cloud })` lists and persists threads through `RemoteThreadList` and remounts each thread like `useChatRuntime`
- cloud history `withFormat` resolves persistence per call so one adapter can serve many threads
- `useExternalHistory` waits for `threadListItem.remoteId` instead of latching on the first empty paint

## test plan

### already verified

- [x] `vitest run src/runtime/AISDKThreads.test.ts src/runtime/AISDKThreads.cloud.test.ts src/runtime/useExternalHistory.test.ts --project default` -> 39/39 green
- [x] `vitest run src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx` -> 3/3 green
- [x] `vitest run src/runtime/useChatRuntime.test.ts src/runtime/useAISDKRuntime.test.ts src/runtime/useChatRuntime.integration.test.tsx --project default` -> 40/40 green

### reviewer should verify

- [ ] `AISDKThreads({ cloud })` lists cloud threads, reloads history on a switch, and a new thread's first send uses the cloud remote id on the wire

## notes

- supersedes #6070

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AZmo6FH878qzZ7bmaVnBcLjNuQETHcx1Kusr1v3sLMI8nQSVHBt0I1FlkSo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->