### PR TITLE
docs: add Browser AI integration guide

### DIFF
--- a/apps/docs/components/icons/browser-ai.tsx
+++ b/apps/docs/components/icons/browser-ai.tsx
@@ -1,0 +1,21 @@
+export function BrowserAIIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg aria-hidden="true" {...props} viewBox="0 0 24 24" fill="none">
+      <rect
+        x="2"
+        y="4"
+        width="20"
+        height="16"
+        rx="2.5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+      />
+      <path d="M2 8.5h20" stroke="currentColor" strokeWidth="1.6" />
+      <circle cx="5" cy="6.25" r="0.9" fill="currentColor" />
+      <path
+        fill="currentColor"
+        d="m12 10.5 1.05 2.7 2.7 1.05-2.7 1.05L12 18l-1.05-2.7-2.7-1.05 2.7-1.05z"
+      />
+    </svg>
+  );
+}

--- a/apps/docs/content/docs/integrations/frameworks/browser-ai.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/browser-ai.mdx
@@ -78,7 +78,7 @@ export class BrowserAIChatTransport implements ChatTransport<UIMessage> {
   ): Promise<ReadableStream<UIMessageChunk>> {
     const result = streamText({
       model: browserAI(),
-      messages: convertToModelMessages(options.messages),
+      messages: await convertToModelMessages(options.messages),
       abortSignal: options.abortSignal,
     });
 

--- a/apps/docs/content/docs/integrations/frameworks/browser-ai.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/browser-ai.mdx
@@ -1,0 +1,221 @@
+---
+title: Browser AI Integration
+description: Run the model inside the browser tab with Browser AI — Chrome and Edge built-in AI, WebLLM, or Transformers.js — wired into assistant-ui through a client-side AI SDK transport.
+---
+
+import { BrowserAIIcon } from "@/components/icons/browser-ai";
+import { VercelIcon } from "@/components/icons/vercel";
+
+[Browser AI](https://browser-ai.dev/) is a set of AI SDK community providers that run the model **inside the browser tab** instead of on a server: the Chrome and Edge built-in Prompt API, open-source models through [WebLLM](https://github.com/mlc-ai/web-llm), and Hugging Face models through [Transformers.js](https://huggingface.co/docs/transformers.js). There is no API route, no provider key, and no prompt data leaving the device.
+
+<Callout type="info">
+This is an integration guide, not a runtime adapter. assistant-ui does not ship a `@assistant-ui/react-browser-ai` package. Browser AI wires into the standard [AI SDK runtime](/docs/runtimes/ai-sdk/v7) — but because inference happens in the tab, you replace the default transport (which POSTs to `/api/chat`) with one that calls `streamText` locally.
+</Callout>
+
+## Pick a package
+
+| Package | Models | Notes |
+| --- | --- | --- |
+| `@browser-ai/core` | Chrome / Edge built-in AI (Prompt API) | Browser-managed model, nothing for you to host. Requires a supporting browser. |
+| `@browser-ai/web-llm` | Open-source models via WebGPU | You choose the model id. First run downloads weights, then they are cached. |
+| `@browser-ai/transformers-js` | Hugging Face models via WebGPU or WASM | Smallest models and the widest browser support; also covers embeddings and transcription. |
+
+All three implement the same AI SDK provider interface, so the transport below is identical apart from the `model` line.
+
+## Requirements
+
+- AI SDK v7 (`ai@^7`) and `@assistant-ui/react-ai-sdk`.
+- A browser with WebGPU for `web-llm` and for WebGPU-backed Transformers.js models.
+- For `@browser-ai/core`, a Chrome or Edge version that ships the built-in AI APIs. See the [Chrome documentation](https://developer.chrome.com/docs/ai/built-in) for current availability.
+- A client component. The providers touch browser-only APIs, so they must not be imported into a server component or a route handler.
+
+## Setup
+
+<Steps>
+<Step>
+
+### Install dependencies
+
+<InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-ai-sdk", "@browser-ai/core", "ai"]} />
+
+Swap `@browser-ai/core` for `@browser-ai/web-llm` or `@browser-ai/transformers-js` to use those engines.
+
+</Step>
+<Step>
+
+### Add the Thread component
+
+```sh
+npx assistant-ui@latest add thread
+```
+
+</Step>
+<Step>
+
+### Write a client-side transport
+
+The transport takes the place of your API route: it converts the UI messages, runs `streamText` against the in-browser model, and returns the UI message stream the runtime consumes.
+
+```ts title="lib/browser-ai-transport.ts"
+import {
+  convertToModelMessages,
+  streamText,
+  toUIMessageStream,
+  type ChatRequestOptions,
+  type ChatTransport,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
+import { browserAI } from "@browser-ai/core";
+
+export class BrowserAIChatTransport implements ChatTransport<UIMessage> {
+  async sendMessages(
+    options: {
+      chatId: string;
+      messages: UIMessage[];
+      abortSignal: AbortSignal | undefined;
+    } & ChatRequestOptions,
+  ): Promise<ReadableStream<UIMessageChunk>> {
+    const result = streamText({
+      model: browserAI(),
+      messages: convertToModelMessages(options.messages),
+      abortSignal: options.abortSignal,
+    });
+
+    return toUIMessageStream({ stream: result.stream });
+  }
+
+  async reconnectToStream(): Promise<ReadableStream<UIMessageChunk> | null> {
+    return null;
+  }
+}
+```
+
+`reconnectToStream` returns `null` because there is no server holding the stream — if the tab closes, the generation is gone.
+
+</Step>
+<Step>
+
+### Pass the transport to the runtime
+
+```tsx title="app/MyRuntimeProvider.tsx"
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { BrowserAIChatTransport } from "@/lib/browser-ai-transport";
+
+export function MyRuntimeProvider({ children }: { children: ReactNode }) {
+  const transport = useMemo(() => new BrowserAIChatTransport(), []);
+  const runtime = useChatRuntime({ transport });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+Everything the AI SDK runtime normally provides — streaming, branching, editing, regeneration, cancellation, the adapter slots — keeps working, because only the transport changed.
+
+</Step>
+</Steps>
+
+## Reporting model download progress
+
+WebLLM and Transformers.js fetch weights on first use, which can take a while on a cold cache. Both providers accept a progress callback in their model settings, so surface it in your UI rather than leaving the composer looking hung:
+
+```tsx title="app/MyRuntimeProvider.tsx"
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { webLLM } from "@browser-ai/web-llm";
+import { WebLLMChatTransport } from "@/lib/web-llm-transport";
+
+export function MyRuntimeProvider({ children }: { children: ReactNode }) {
+  const [progress, setProgress] = useState<number | null>(null);
+
+  const transport = useMemo(
+    () =>
+      new WebLLMChatTransport(
+        webLLM("Llama-3.2-3B-Instruct-q4f16_1-MLC", {
+          initProgressCallback: (report) => {
+            setProgress(report.progress === 1 ? null : report.progress);
+          },
+        }),
+      ),
+    [],
+  );
+
+  const runtime = useChatRuntime({ transport });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {progress !== null && (
+        <div className="px-4 py-2 text-sm">
+          Downloading model... {Math.round(progress * 100)}%
+        </div>
+      )}
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+Have the transport take the model as a constructor argument so the callback is wired once and the download is not restarted on every render.
+
+## Falling back to a server model
+
+Browser support is uneven, so treat the in-browser model as an enhancement. Each package exports a capability check — `doesBrowserSupportBrowserAI`, `doesBrowserSupportWebLLM`, `doesBrowserSupportTransformersJS` — that you can use to pick a transport at mount time:
+
+```tsx
+"use client";
+
+import { useMemo } from "react";
+import { DefaultChatTransport } from "ai";
+import { doesBrowserSupportBrowserAI } from "@browser-ai/core";
+import { BrowserAIChatTransport } from "@/lib/browser-ai-transport";
+
+const transport = useMemo(
+  () =>
+    doesBrowserSupportBrowserAI()
+      ? new BrowserAIChatTransport()
+      : new DefaultChatTransport({ api: "/api/chat" }),
+  [],
+);
+```
+
+The server branch is an ordinary [AI SDK route](/docs/runtimes/ai-sdk/v7); the UI is the same either way.
+
+## Things to know
+
+- **Tools.** Tool calling depends on the engine and the model. Check the [Browser AI docs](https://browser-ai.dev/docs) for the package you picked before relying on [tools](/docs/tools/defining-tools).
+- **First-token latency.** A cold model pays for download plus initialization. Warm the engine on page load if the first message should feel instant.
+- **Persistence.** Nothing is stored server-side by default. Use [custom thread persistence](/docs/integrations/persistence/custom-adapter) or [AssistantCloud](/docs/cloud) if threads must outlive the tab.
+- **No resumable streams.** [Resumable streaming](/docs/guides/resumable-streams) needs a server-held stream and does not apply here.
+
+## Related
+
+<Cards>
+  <Card
+    icon={<VercelIcon width={20} height={20} />}
+    title="AI SDK runtime"
+    description="The runtime that handles the client side of this integration."
+    href="/docs/runtimes/ai-sdk/v7"
+  />
+  <Card
+    icon={<BrowserAIIcon width={20} height={20} />}
+    title="Browser AI documentation"
+    description="Provider reference for Chrome built-in AI, WebLLM, and Transformers.js."
+    href="https://browser-ai.dev/docs"
+  />
+  <Card
+    title="LocalRuntime"
+    description="Skip the AI SDK entirely and call the model from a ChatModelAdapter."
+    href="/docs/runtimes/custom/local-runtime"
+  />
+</Cards>

--- a/apps/docs/content/docs/integrations/frameworks/meta.json
+++ b/apps/docs/content/docs/integrations/frameworks/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Frameworks",
   "description": "Framework integration guides for running assistant backends and agent frameworks with assistant-ui.",
-  "pages": ["ai-sdk", "cloudflare-agents", "mastra"]
+  "pages": ["ai-sdk", "browser-ai", "cloudflare-agents", "mastra"]
 }

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -7,6 +7,7 @@ import { CloudflareIcon } from "@/components/icons/cloudflare";
 import { HeliconeIcon } from "@/components/icons/helicone";
 import { MastraIcon } from "@/components/icons/mastra";
 import { LangfuseIcon } from "@/components/icons/langfuse";
+import { BrowserAIIcon } from "@/components/icons/browser-ai";
 import { LangChainIcon } from "@/components/icons/langchain";
 import { McpIcon } from "@/components/icons/mcp";
 import { VercelIcon } from "@/components/icons/vercel";
@@ -22,7 +23,7 @@ flowchart LR
     server -->|"observability proxies (e.g. Helicone, Langfuse)"| provider
 ```
 
-Integrations live on the server. **Agent frameworks** like Mastra take over the API route. **Gateways** swap the upstream provider URL. **Observability** logs or traces every call. **Auth** gates the route and scopes per-user data. **Persistence** and **attachments** are adapter recipes for storing chat data outside the default in-memory path.
+Most integrations live on the server. **Agent frameworks** like Mastra take over the API route. **Gateways** swap the upstream provider URL. **Observability** logs or traces every call. **Auth** gates the route and scopes per-user data. **Persistence** and **attachments** are adapter recipes for storing chat data outside the default in-memory path. **Browser AI** is the exception: it swaps the transport so the model runs in the tab and there is no server hop at all.
 
 ## Frameworks
 
@@ -36,6 +37,12 @@ Framework integrations that pair with assistant-ui at the API-route layer.
     href="/docs/integrations/frameworks/ai-sdk"
   />
   <PlatformOnly platforms={["react"]}>
+    <Card
+      icon={<BrowserAIIcon width={20} height={20} />}
+      title="Browser AI"
+      description="Chrome built-in AI, WebLLM, Transformers.js. Runs in the tab through a client-side AI SDK transport."
+      href="/docs/integrations/frameworks/browser-ai"
+    />
     <Card
       icon={<CloudflareIcon width={20} height={20} />}
       title="Cloudflare Agents"

--- a/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/pick-a-runtime.mdx
@@ -6,6 +6,7 @@ description: Decision guide for choosing the right runtime, by framework or by f
 import { A2AIcon } from "@/components/icons/a2a";
 import { AdkIcon } from "@/components/icons/adk";
 import { AguiIcon } from "@/components/icons/agui";
+import { BrowserAIIcon } from "@/components/icons/browser-ai";
 import { ClaudeIcon } from "@/components/icons/claude";
 import { CloudflareIcon } from "@/components/icons/cloudflare";
 import { LangChainIcon } from "@/components/icons/langchain";
@@ -85,6 +86,12 @@ For frameworks without a dedicated adapter, these wiring guides route through an
 
   <Cards>
     <Card
+      icon={<BrowserAIIcon width={20} height={20} />}
+      title="Browser AI"
+      description="Chrome built-in AI, WebLLM, or Transformers.js running in the tab. Wired through the Vercel AI SDK runtime with a client-side transport."
+      href="/docs/integrations/frameworks/browser-ai"
+    />
+    <Card
       icon={<CloudflareIcon width={20} height={20} />}
       title="Cloudflare Agents"
       description="Stateful agents on Durable Objects with WebSocket streaming. Wired through the Vercel AI SDK runtime."
@@ -116,6 +123,7 @@ If you do not know your framework yet, or your backend is custom, pick by what y
 | Keep messages in redux, zustand, tanstack-query, etc. | [ExternalStoreRuntime](/docs/runtimes/custom/external-store) |
 | Backend that already speaks the data stream protocol | [DataStream](/docs/runtimes/custom/data-stream) |
 | Stream full agent state snapshots (not just messages) | [AssistantTransport](/docs/runtimes/custom/assistant-transport) |
+| Run the model in the browser, no server hop | [Browser AI](/docs/integrations/frameworks/browser-ai) |
 
 If none of the framework adapters fits, start at [custom backend](/docs/runtimes/custom/overview).
 


### PR DESCRIPTION
## What

Adds an integration guide for [Browser AI](https://browser-ai.dev/) under `integrations/frameworks`, plus its entries in the frameworks nav, the integrations index, and `pick-a-runtime`.

Browser AI is a set of AI SDK community providers ([listed on ai-sdk.dev](https://ai-sdk.dev/providers/community-providers)) that run the model inside the browser tab: the Chrome/Edge built-in Prompt API, open-source models via WebLLM, and Hugging Face models via Transformers.js. It's referenced in the Chrome for Developers [Prompt API + Vercel AI SDK](https://developer.chrome.com/blog/prompt-api-with-vercel-ai) post. I maintain it.

## Why

The docs cover local *serving* (Ollama through a route) but nothing that runs in the tab, and the integrations section is entirely server-side. People wiring an in-browser model to assistant-ui currently have to work out for themselves that the AI SDK runtime already handles it — the only thing that changes is the transport.

## How

No new adapter package and no changes to any published package. The guide shows a `ChatTransport` that calls `streamText` against the in-browser provider and returns `toUIMessageStream(...)`, passed straight to `useChatRuntime({ transport })`. Everything else (branching, editing, regeneration, cancellation, adapter slots) comes along unchanged.

The page also covers the two things that actually bite in the browser: reporting weight-download progress via the provider's `initProgressCallback`, and falling back to a normal server route with the exported capability checks when the browser doesn't support the engine.

One line outside the new page needed a factual touch-up: the integrations index asserted "Integrations live on the server", which this integration is the exception to.

Docs-only, so no changeset. Happy to open an issue first and close this if you'd rather discuss placement — a case could also be made for putting it under `runtimes/custom` instead of `integrations/frameworks`.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.caB0i3gFeq4ktmj5jYGLrbzD9wolW1IO1CtSvpcFT9-tYWlUdGDPpSpzLDc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->