### PR TITLE
fix(core): reset thread selection when the thread-list adapter is replaced

### DIFF
--- a/.changeset/remote-thread-adapter-reset.md
+++ b/.changeset/remote-thread-adapter-reset.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: reset remote thread selection and cached records when the thread-list adapter is replaced

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3039,6 +3039,7 @@ declare class OptimisticState<TState> extends BaseSubscribable {
   get baseValue(): TState;
   get value(): TState;
   update(state: TState): void;
+  reset(state: TState): void;
   optimisticUpdate<TResult>(transform: Transform<TState, TResult>): Promise<TResult>;
 }
 

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -50,7 +50,7 @@ See the [cloud documentation](/docs/cloud) for setup, auth, and self-host option
 
 ## RemoteThreadListRuntime (custom database)
 
-`useRemoteThreadListRuntime` lets you back the thread list with any database while keeping the per-thread runtime simple. You provide a `RemoteThreadListAdapter` describing how to list, create, rename, archive, and delete threads.
+`useRemoteThreadListRuntime` lets you back the thread list with any database while keeping the per-thread runtime simple. You provide a `RemoteThreadListAdapter` describing how to list, create, rename, archive, and delete threads. Keep that adapter reference stable across renders (module scope or `useMemo`). Replacing it resets the selected thread and cached records, then loads the replacement adapter.
 
 Works with any `LocalRuntime`-based runtime, including framework adapters that build on it (`react-ai-sdk`, `react-google-adk`, `react-a2a`, `useDataStreamRuntime`).
 
@@ -241,11 +241,11 @@ function ReloadOnAuth() {
 }
 ```
 
-`reload()` discards in-flight responses from superseded calls, so it is safe to invoke on every auth transition.
+`reload()` discards in-flight responses from superseded calls, so it is safe to invoke on every auth transition. On the `RemoteThreadList` store entry, a recreated adapter object is a no-op until you call `reload()`. `reload()` against the same instance refreshes the list and keeps the open thread. `reload()` after a different adapter instance resets selection and cached records, then loads the replacement store.
 
 ### Refetching the open thread
 
-`reload()` re-runs `list()`, which refreshes thread list metadata only. It does not touch the messages of the thread the user is looking at. When the open thread's server state changes out of band, so that nothing arrives over the stream (a human-in-the-loop interrupt raised by another process, a stalled stream, a status change picked up by polling), call `aui.threads.reloadMainThread()`:
+`reload()` against the same adapter instance re-runs `list()`, which refreshes thread list metadata only. It does not touch the messages of the thread the user is looking at. When the open thread's server state changes out of band, so that nothing arrives over the stream (a human-in-the-loop interrupt raised by another process, a stalled stream, a status change picked up by polling), call `aui.threads.reloadMainThread()`:
 
 ```tsx
 function RefetchOnInterrupt({ status }: { status: string }) {

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -50,7 +50,7 @@ See the [cloud documentation](/docs/cloud) for setup, auth, and self-host option
 
 ## RemoteThreadListRuntime (custom database)
 
-`useRemoteThreadListRuntime` lets you back the thread list with any database while keeping the per-thread runtime simple. You provide a `RemoteThreadListAdapter` describing how to list, create, rename, archive, and delete threads. Keep that adapter reference stable across renders (module scope or `useMemo`). Replacing it resets the selected thread and cached records, then loads the replacement adapter.
+`useRemoteThreadListRuntime` lets you back the thread list with any database while keeping the per-thread runtime simple. You provide a `RemoteThreadListAdapter` describing how to list, create, rename, archive, and delete threads. Keep that adapter reference stable across renders (module scope or `useMemo`). Replacing it reloads the list and drops cached threads that are not in the replacement page.
 
 Works with any `LocalRuntime`-based runtime, including framework adapters that build on it (`react-ai-sdk`, `react-google-adk`, `react-a2a`, `useDataStreamRuntime`).
 

--- a/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
+++ b/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
@@ -14,6 +14,7 @@ import { DevToolsModal } from "@assistant-ui/react-devtools";
 import { ModelContextClient as ModelContext } from "@assistant-ui/react";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { TerminalIcon } from "lucide-react";
+import { useMemo } from "react";
 import { z } from "zod";
 
 const artifactsToolkit: Toolkit = {
@@ -42,10 +43,14 @@ export function ArtifactsRuntimeProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const assistantCloud = new AssistantCloud({
-    baseUrl: process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL!,
-    anonymous: true,
-  });
+  const assistantCloud = useMemo(
+    () =>
+      new AssistantCloud({
+        baseUrl: process.env.NEXT_PUBLIC_ASSISTANT_BASE_URL!,
+        anonymous: true,
+      }),
+    [],
+  );
 
   const runtime = useChatRuntime({
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -542,6 +542,67 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("resets selection when reload follows a different adapter instance", async () => {
+    const methodsA = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "regular" as const, remoteId: "thread-a", title: "A" },
+        ],
+      })),
+    });
+    const methodsB = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "regular" as const, remoteId: "thread-b", title: "B" },
+        ],
+      })),
+    });
+    let adapter: RemoteThreadListAdapter = { ...methodsA };
+    const listeners = new Set<() => void>();
+    const source: AssistantConfigSource = {
+      getConfig: () =>
+        AuiConfig({
+          threads: RemoteThreadList({
+            adapter,
+            thread: (id) => StubThread({ threadId: id }) as never,
+          }),
+        }),
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+    const handle = createAssistantClient(source);
+    handle.subscribe(() => {});
+    await handle.getClient().threads.getLoadThreadsPromise();
+    flushTapSync(() => handle.getClient().threads.switchToThread("thread-a"));
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.item("main").getState().remoteId).toBe(
+        "thread-a",
+      );
+    });
+
+    adapter = { ...methodsB };
+    for (const listener of listeners) listener();
+    await vi.waitFor(async () => {
+      flushTapSync(() => {});
+      await handle.getClient().threads.reload();
+      expect(handle.getClient().threads.getState().threadIds).toEqual([
+        "thread-b",
+      ]);
+    });
+    expect(
+      handle.getClient().threads.item("main").getState().remoteId,
+    ).not.toBe("thread-a");
+    expect(handle.getClient().threads.item("main").getState().status).toBe(
+      "new",
+    );
+    expect(methodsB.list).toHaveBeenCalled();
+    handle.destroy();
+  });
+
   it("exposes useAdapters adapters to the thread factory", async () => {
     const history = dummyHistory();
     const capture: { adapters: RuntimeAdapters | null } = { adapters: null };

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -603,6 +603,65 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("does not send a superseded rename through the replacement adapter", async () => {
+    const initializeRequest = deferred<{
+      remoteId: string;
+      externalId: string | undefined;
+    }>();
+    const methodsA = makeAdapter({
+      list: vi.fn(async () => ({ threads: [] })),
+      initialize: vi.fn(() => initializeRequest.promise),
+    });
+    const methodsB = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "regular" as const, remoteId: "thread-b", title: "B" },
+        ],
+      })),
+    });
+    let adapter: RemoteThreadListAdapter = { ...methodsA };
+    const listeners = new Set<() => void>();
+    const source: AssistantConfigSource = {
+      getConfig: () =>
+        AuiConfig({
+          threads: RemoteThreadList({
+            adapter,
+            thread: (id) => StubThread({ threadId: id }) as never,
+          }),
+        }),
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+    const handle = createAssistantClient(source);
+    handle.subscribe(() => {});
+    await handle.getClient().threads.getLoadThreadsPromise();
+    const initializeTask = handle.getClient().threads.item("main").initialize();
+    const renameTask = handle.getClient().threads.item("main").rename("leaked");
+
+    adapter = { ...methodsB };
+    for (const listener of listeners) listener();
+    await vi.waitFor(async () => {
+      flushTapSync(() => {});
+      await handle.getClient().threads.reload();
+      expect(handle.getClient().threads.getState().threadIds).toEqual([
+        "thread-b",
+      ]);
+    });
+    initializeRequest.resolve({
+      remoteId: "leaked",
+      externalId: undefined,
+    });
+    await initializeTask;
+    await expect(renameTask).rejects.toThrow("adapter changed");
+    expect(methodsA.rename).not.toHaveBeenCalled();
+    expect(methodsB.rename).not.toHaveBeenCalled();
+    handle.destroy();
+  });
+
   it("exposes useAdapters adapters to the thread factory", async () => {
     const history = dummyHistory();
     const capture: { adapters: RuntimeAdapters | null } = { adapters: null };

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -603,6 +603,82 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("does not reset again when retrying a failed replacement load", async () => {
+    const methodsA = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "regular" as const, remoteId: "thread-a", title: "A" },
+        ],
+      })),
+    });
+    const methodsB = makeAdapter({
+      list: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("network"))
+        .mockResolvedValueOnce({
+          threads: [
+            { status: "regular" as const, remoteId: "thread-b", title: "B" },
+          ],
+        }),
+    });
+    let adapter: RemoteThreadListAdapter = { ...methodsA };
+    const listeners = new Set<() => void>();
+    const source: AssistantConfigSource = {
+      getConfig: () =>
+        AuiConfig({
+          threads: RemoteThreadList({
+            adapter,
+            thread: (id) => StubThread({ threadId: id }) as never,
+          }),
+        }),
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+    const handle = createAssistantClient(source);
+    handle.subscribe(() => {});
+    await handle.getClient().threads.getLoadThreadsPromise();
+    flushTapSync(() => handle.getClient().threads.switchToThread("thread-a"));
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.item("main").getState().remoteId).toBe(
+        "thread-a",
+      );
+    });
+
+    adapter = { ...methodsB };
+    for (const listener of listeners) listener();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      await vi.waitFor(async () => {
+        flushTapSync(() => {});
+        await handle.getClient().threads.reload();
+        expect(handle.getClient().threads.item("main").getState().status).toBe(
+          "new",
+        );
+      });
+      const mainAfterFailure = handle
+        .getClient()
+        .threads.getState().mainThreadId;
+      await handle.getClient().threads.reload();
+      await vi.waitFor(() => {
+        expect(handle.getClient().threads.getState().threadIds).toEqual([
+          "thread-b",
+        ]);
+      });
+      expect(handle.getClient().threads.getState().mainThreadId).toBe(
+        mainAfterFailure,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+    handle.destroy();
+  });
+
   it("does not send a superseded rename through the replacement adapter", async () => {
     const initializeRequest = deferred<{
       remoteId: string;
@@ -655,7 +731,7 @@ describe("RemoteThreadList", () => {
       remoteId: "leaked",
       externalId: undefined,
     });
-    await initializeTask;
+    await expect(initializeTask).rejects.toThrow("adapter changed");
     await expect(renameTask).rejects.toThrow("adapter changed");
     expect(methodsA.rename).not.toHaveBeenCalled();
     expect(methodsB.rename).not.toHaveBeenCalled();

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -28,6 +28,7 @@ import type {
   RemoteThreadInitializeResponse,
   RemoteThreadListAdapter,
 } from "../../runtimes/remote-thread-list/types";
+import { ThreadListAdapterChangedError } from "../../runtimes/remote-thread-list/adapter-changed";
 import type { ThreadMessage } from "../../types/message";
 import { AssistantMessageStream } from "assistant-stream";
 import { handleThreadListAction } from "../../store/runtime-clients/handle-thread-list-action";
@@ -360,6 +361,7 @@ const useRemoteThreadList = (
       session: {
         adapter,
         adapterAtLoad: adapter,
+        adapterGeneration: 0,
         loadGeneration: 0,
         switchGeneration: 0,
         loadPromise: undefined as Promise<void> | undefined,
@@ -470,6 +472,7 @@ const useRemoteThreadList = (
     session.loadPromise = undefined;
     session.loadMorePromise = undefined;
     if (adapterChanged) {
+      session.adapterGeneration++;
       session.switchGeneration++;
       session.switchTask = undefined;
       const seeded = seedNewThread(EMPTY_LIST);
@@ -711,18 +714,34 @@ const useRemoteThreadList = (
     [session, store, switchToNewThread],
   );
 
+  const requireAdapterGeneration = useCallback(
+    (generation: number) => {
+      if (generation !== session.adapterGeneration) {
+        throw new ThreadListAdapterChangedError();
+      }
+    },
+    [session],
+  );
+
   const initialize = useCallback(
     async (threadId: string) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       if (store.value.newThreadId !== threadId) {
         const data = getThreadData(store.value, threadId);
         if (!data) throw threadNotFoundError(threadId, "initializing it");
         if (data.status === "new") {
           throw threadStatusError(threadId, data.status, "be initialized here");
         }
-        return toInitializeResult(await data.initializeTask);
+        const result = toInitializeResult(await data.initializeTask);
+        requireAdapterGeneration(adapterGeneration);
+        return result;
       }
       const result = await store.optimisticUpdate({
-        execute: () => session.adapter.initialize(threadId),
+        execute: () => {
+          requireAdapterGeneration(adapterGeneration);
+          return currentAdapter.initialize(threadId);
+        },
         optimistic: (state) => updateStatusReducer(state, threadId, "regular"),
         loading: (state, task) => {
           const mappingId = createThreadMappingId(threadId);
@@ -764,11 +783,13 @@ const useRemoteThreadList = (
       }
       return toInitializeResult(result);
     },
-    [notifyRemoteId, session, store],
+    [notifyRemoteId, requireAdapterGeneration, session, store],
   );
 
   const rename = useCallback(
     (threadIdOrRemoteId: string, newTitle: string) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data) throw threadNotFoundError(threadIdOrRemoteId, "renaming it");
       if (data.status === "new") {
@@ -777,7 +798,8 @@ const useRemoteThreadList = (
       return store.optimisticUpdate({
         execute: async () => {
           const { remoteId } = await data.initializeTask;
-          return session.adapter.rename(remoteId, newTitle);
+          requireAdapterGeneration(adapterGeneration);
+          return currentAdapter.rename(remoteId, newTitle);
         },
         optimistic: (state) => {
           const current = getThreadData(state, threadIdOrRemoteId);
@@ -795,7 +817,7 @@ const useRemoteThreadList = (
         },
       });
     },
-    [session, store],
+    [requireAdapterGeneration, session, store],
   );
 
   const updateCustom = useCallback(
@@ -803,6 +825,8 @@ const useRemoteThreadList = (
       threadIdOrRemoteId: string,
       custom: Record<string, unknown> | undefined,
     ) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data) {
         throw threadNotFoundError(
@@ -817,7 +841,7 @@ const useRemoteThreadList = (
           "update custom metadata",
         );
       }
-      if (!session.adapter.updateCustom) {
+      if (!currentAdapter.updateCustom) {
         throw new Error(
           "Remote thread list adapter does not support updating custom metadata",
         );
@@ -825,7 +849,7 @@ const useRemoteThreadList = (
       return store.optimisticUpdate({
         execute: async () => {
           const { remoteId } = await data.initializeTask;
-          const currentAdapter = session.adapter;
+          requireAdapterGeneration(adapterGeneration);
           if (!currentAdapter.updateCustom) {
             throw new Error(
               "Remote thread list adapter does not support updating custom metadata",
@@ -849,30 +873,36 @@ const useRemoteThreadList = (
         },
       });
     },
-    [session, store],
+    [requireAdapterGeneration, session, store],
   );
 
   const archive = useCallback(
     async (threadIdOrRemoteId: string) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data) throw threadNotFoundError(threadIdOrRemoteId, "archiving it");
       if (data.status !== "regular") {
         throw threadStatusError(threadIdOrRemoteId, data.status, "be archived");
       }
       await ensureNotMain(data.id);
+      requireAdapterGeneration(adapterGeneration);
       return store.optimisticUpdate({
         execute: async () => {
           const { remoteId } = await data.initializeTask;
-          return session.adapter.archive(remoteId);
+          requireAdapterGeneration(adapterGeneration);
+          return currentAdapter.archive(remoteId);
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "archived"),
       });
     },
-    [ensureNotMain, session, store],
+    [ensureNotMain, requireAdapterGeneration, session, store],
   );
 
   const unarchive = useCallback(
     (threadIdOrRemoteId: string) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data)
         throw threadNotFoundError(threadIdOrRemoteId, "unarchiving it");
@@ -887,36 +917,43 @@ const useRemoteThreadList = (
         execute: async () => {
           try {
             const { remoteId } = await data.initializeTask;
-            return await session.adapter.unarchive(remoteId);
+            requireAdapterGeneration(adapterGeneration);
+            return await currentAdapter.unarchive(remoteId);
           } catch (error) {
-            await ensureNotMain(data.id);
+            if (adapterGeneration === session.adapterGeneration) {
+              await ensureNotMain(data.id);
+            }
             throw error;
           }
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "regular"),
       });
     },
-    [ensureNotMain, session, store],
+    [ensureNotMain, requireAdapterGeneration, session, store],
   );
 
   const deleteThread = useCallback(
     async (threadIdOrRemoteId: string) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data) throw threadNotFoundError(threadIdOrRemoteId, "deleting it");
       if (data.status !== "regular" && data.status !== "archived") {
         throw threadStatusError(threadIdOrRemoteId, data.status, "be deleted");
       }
       await ensureNotMain(data.id);
+      requireAdapterGeneration(adapterGeneration);
       onDelete?.(data.id);
       return store.optimisticUpdate({
         execute: async () => {
           const { remoteId } = await data.initializeTask;
-          return session.adapter.delete(remoteId);
+          requireAdapterGeneration(adapterGeneration);
+          return currentAdapter.delete(remoteId);
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "deleted"),
       });
     },
-    [ensureNotMain, onDelete, session, store],
+    [ensureNotMain, onDelete, requireAdapterGeneration, session, store],
   );
 
   const generateTitle = useCallback(
@@ -924,6 +961,8 @@ const useRemoteThreadList = (
       threadIdOrRemoteId: string,
       messages: readonly ThreadMessage[] | undefined,
     ) => {
+      const currentAdapter = session.adapter;
+      const adapterGeneration = session.adapterGeneration;
       const data = getThreadData(store.value, threadIdOrRemoteId);
       if (!data) {
         throw threadNotFoundError(threadIdOrRemoteId, "generating its title");
@@ -936,10 +975,13 @@ const useRemoteThreadList = (
         );
       }
       const { remoteId } = await data.initializeTask;
+      requireAdapterGeneration(adapterGeneration);
       if (!isSameThread(store.value, data.id, session.mainThreadId)) return;
       if (!messages) return;
-      const stream = await session.adapter.generateTitle(remoteId, messages);
+      const stream = await currentAdapter.generateTitle(remoteId, messages);
+      requireAdapterGeneration(adapterGeneration);
       await applyTitleStream(stream, (newTitle) => {
+        if (adapterGeneration !== session.adapterGeneration) return;
         const state = store.baseValue;
         const current = getThreadData(state, data.id);
         if (!current) return;
@@ -955,7 +997,7 @@ const useRemoteThreadList = (
         });
       });
     },
-    [session, store],
+    [requireAdapterGeneration, session, store],
   );
 
   const { mainThreadClient, itemOrder, threadListItems } =

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -52,7 +52,7 @@ const EMPTY_LIST: RemoteThreadState = {
 
 export type RemoteThreadListProps = {
   /**
-   * Swapping this to a different backing store does not reload the list. Call `reload()` after a genuine swap. A recreated object for the same store is a no-op.
+   * Swapping this to a different backing store does not reload the list. Call `reload()` after a genuine swap. A recreated object for the same store is a no-op. `reload()` after a different adapter instance resets selection and cached records before loading.
    */
   adapter: RemoteThreadListAdapter;
   /**
@@ -359,6 +359,7 @@ const useRemoteThreadList = (
       initialMainId: seeded.id,
       session: {
         adapter,
+        adapterAtLoad: adapter,
         loadGeneration: 0,
         switchGeneration: 0,
         loadPromise: undefined as Promise<void> | undefined,
@@ -374,6 +375,8 @@ const useRemoteThreadList = (
       },
     };
   });
+
+  session.adapter = adapter;
 
   const listState = useSyncExternalStore(
     (onStoreChange) => store.subscribe(onStoreChange),
@@ -417,12 +420,14 @@ const useRemoteThreadList = (
   const getLoadThreadsPromise = useCallback(() => {
     if (session.loadPromise) return session.loadPromise;
     const generation = session.loadGeneration;
+    const adapter = session.adapter;
     session.loadPromise = store
       .optimisticUpdate({
-        execute: () => session.adapter.list(),
+        execute: () => adapter.list(),
         loading: (state) => ({ ...state, isLoading: true }),
         then: (state, page) => {
           if (generation !== session.loadGeneration) return state;
+          session.adapterAtLoad = adapter;
           const fresh = classifyThreads(page.threads, {
             threadIds: [],
             archivedThreadIds: [],
@@ -460,15 +465,32 @@ const useRemoteThreadList = (
   }, [session, store]);
 
   const reload = useCallback(() => {
+    const adapterChanged = adapter !== session.adapterAtLoad;
     session.loadGeneration++;
     session.loadPromise = undefined;
     session.loadMorePromise = undefined;
-    store.update({
-      ...store.baseValue,
-      cursor: undefined,
-    });
+    if (adapterChanged) {
+      session.switchGeneration++;
+      session.switchTask = undefined;
+      const seeded = seedNewThread(EMPTY_LIST);
+      store.reset({ ...seeded.state, isLoading: true });
+      assignMainThreadId(seeded.id);
+      notifyRemoteId(undefined, true);
+    } else {
+      store.update({
+        ...store.baseValue,
+        cursor: undefined,
+      });
+    }
     return getLoadThreadsPromise();
-  }, [getLoadThreadsPromise, session, store]);
+  }, [
+    adapter,
+    assignMainThreadId,
+    getLoadThreadsPromise,
+    notifyRemoteId,
+    session,
+    store,
+  ]);
 
   useEffect(() => {
     void getLoadThreadsPromise();

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -378,6 +378,7 @@ const useRemoteThreadList = (
     };
   });
 
+  // Config updates can invoke `reload()` in the same turn as the re-render, before the effect below runs.
   session.adapter = adapter;
 
   const listState = useSyncExternalStore(
@@ -475,6 +476,7 @@ const useRemoteThreadList = (
       session.adapterGeneration++;
       session.switchGeneration++;
       session.switchTask = undefined;
+      session.adapterAtLoad = adapter;
       const seeded = seedNewThread(EMPTY_LIST);
       store.reset({ ...seeded.state, isLoading: true });
       assignMainThreadId(seeded.id);
@@ -541,6 +543,7 @@ const useRemoteThreadList = (
         },
       })
       .catch((error: unknown) => {
+        if (generation !== session.loadGeneration) return;
         console.error("[assistant-ui] thread list loadMore failed:", error);
       })
       .then(() => {
@@ -757,6 +760,7 @@ const useRemoteThreadList = (
           };
         },
         then: (state, { remoteId, externalId }) => {
+          if (adapterGeneration !== session.adapterGeneration) return state;
           const data = getThreadData(state, threadId);
           if (!data) return state;
           const mappingId = createThreadMappingId(threadId);
@@ -778,6 +782,7 @@ const useRemoteThreadList = (
           };
         },
       });
+      requireAdapterGeneration(adapterGeneration);
       if (threadId === session.mainThreadId) {
         notifyRemoteId(result.remoteId, true);
       }

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -216,9 +216,10 @@ export class RemoteThreadListThreadListRuntimeCore
         })
         .then(() => {
           if (!replacedList) return;
-          if (this._options.threadId === undefined) return;
-          if (this.getItemById(this._options.threadId) !== undefined) return;
-          this._switchToThreadFromProp(this._options.threadId).catch(() => {});
+          const threadId = this._options.threadId;
+          if (threadId === undefined) return;
+          if (this.getItemById(threadId)?.id === this._mainThreadId) return;
+          this._switchToThreadFromProp(threadId).catch(() => {});
         });
     }
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -18,6 +18,7 @@ import type {
   RemoteThreadListAdapter,
   RemoteThreadListOptions,
 } from "../../runtimes/remote-thread-list/types";
+import { ThreadListAdapterChangedError } from "../../runtimes/remote-thread-list/adapter-changed";
 import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
 import { isTitleSourceMessage } from "./RemoteThreadResource";
 import {
@@ -47,6 +48,48 @@ const threadStatusError = (
     `Thread "${threadIdOrRemoteId}" has status "${status}", so it cannot ${action}.`,
   );
 
+const EMPTY_REMOTE_STATE: RemoteThreadState = {
+  isLoading: true,
+  isLoadingMore: false,
+  cursor: undefined,
+  newThreadId: undefined,
+  threadIds: [],
+  archivedThreadIds: [],
+  threadIdMap: {},
+  threadData: {},
+};
+
+const addNewThread = (state: RemoteThreadState) => {
+  let id: string;
+  do {
+    id = `__LOCALID_${generateId()}`;
+  } while (state.threadIdMap[id]);
+
+  const mappingId = createThreadMappingId(id);
+  return {
+    id,
+    state: {
+      ...state,
+      newThreadId: id,
+      threadIdMap: {
+        ...state.threadIdMap,
+        [id]: mappingId,
+      },
+      threadData: {
+        ...state.threadData,
+        [mappingId]: {
+          status: "new",
+          id,
+          remoteId: undefined,
+          externalId: undefined,
+          title: undefined,
+          custom: undefined,
+        } satisfies RemoteThreadData,
+      },
+    },
+  };
+};
+
 export class RemoteThreadListThreadListRuntimeCore
   extends BaseSubscribable
   implements ThreadListRuntimeCore
@@ -58,20 +101,14 @@ export class RemoteThreadListThreadListRuntimeCore
   private _loadThreadsPromise: Promise<void> | undefined;
   private _loadMorePromise: Promise<void> | undefined;
   private _loadGeneration = 0;
+  private _adapterGeneration = 0;
   private _switchGeneration = 0;
   private _switchTask: Promise<void> | undefined;
 
   private _mainThreadId!: string;
-  private readonly _state = new OptimisticState<RemoteThreadState>({
-    isLoading: true,
-    isLoadingMore: false,
-    cursor: undefined,
-    newThreadId: undefined,
-    threadIds: [],
-    archivedThreadIds: [],
-    threadIdMap: {},
-    threadData: {},
-  });
+  private readonly _state = new OptimisticState<RemoteThreadState>(
+    EMPTY_REMOTE_STATE,
+  );
 
   private readonly _useAdaptersProvider: FC<PropsWithChildren> = ({
     children,
@@ -267,18 +304,39 @@ export class RemoteThreadListThreadListRuntimeCore
     this._hookManager.setRuntimeHook(options.runtimeHook);
 
     if (adapterChanged) {
-      this._loadGeneration++;
-      this._loadThreadsPromise = undefined;
-      this._loadMorePromise = undefined;
-      this._state.update({
-        ...this._state.baseValue,
-        cursor: undefined,
-      });
-    }
-
-    if (controlledThreadIdChanged) {
+      if (options.threadId !== undefined) {
+        this._lastNotifiedThreadId = undefined;
+      }
+      this._resetForAdapterChange();
+      if (options.threadId !== undefined) {
+        this._switchToThreadFromProp(options.threadId).catch(() => {});
+      }
+    } else if (controlledThreadIdChanged) {
       this._switchToThreadFromProp(options.threadId).catch(() => {});
     }
+  }
+
+  private _requireAdapterGeneration(generation: number) {
+    if (generation !== this._adapterGeneration) {
+      throw new ThreadListAdapterChangedError();
+    }
+  }
+
+  private _resetForAdapterChange() {
+    this._loadGeneration++;
+    this._adapterGeneration++;
+    this._switchGeneration++;
+    this._loadThreadsPromise = undefined;
+    this._loadMorePromise = undefined;
+    this._switchTask = undefined;
+    this._hookManager.__internal_dispose();
+    const next = addNewThread(EMPTY_REMOTE_STATE);
+    this._mainThreadId = next.id;
+    this._state.reset(next.state);
+    void this._hookManager.startThreadRuntime(next.id).then(
+      () => this._notifySubscribers(),
+      () => undefined,
+    );
   }
 
   public __internal_load() {
@@ -573,48 +631,31 @@ export class RemoteThreadListThreadListRuntimeCore
     const state = this._state.baseValue;
     let id: string | undefined = this._state.value.newThreadId;
     if (id === undefined) {
-      do {
-        id = `__LOCALID_${generateId()}`;
-      } while (state.threadIdMap[id]);
-
-      const mappingId = createThreadMappingId(id);
-      this._state.update({
-        ...state,
-        newThreadId: id,
-        threadIdMap: {
-          ...state.threadIdMap,
-          [id]: mappingId,
-        },
-        threadData: {
-          ...state.threadData,
-          [mappingId]: {
-            status: "new",
-            id,
-            remoteId: undefined,
-            externalId: undefined,
-            title: undefined,
-            custom: undefined,
-          } satisfies RemoteThreadData,
-        },
-      });
+      const next = addNewThread(state);
+      id = next.id;
+      this._state.update(next.state);
     }
 
     return this._switchToThread(id, undefined, generation, emitThreadIdChange);
   }
 
   public initialize = async (threadId: string) => {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     if (this._state.value.newThreadId !== threadId) {
       const data = this.getItemById(threadId);
       if (!data) throw threadNotFoundError(threadId, "initializing it");
       if (data.status === "new")
         throw threadStatusError(threadId, data.status, "be initialized here");
       const { remoteId, externalId } = await data.initializeTask;
+      this._requireAdapterGeneration(adapterGeneration);
       return { remoteId, externalId };
     }
 
     const { remoteId, externalId } = await this._state.optimisticUpdate({
       execute: () => {
-        return this._options.adapter.initialize(threadId);
+        this._requireAdapterGeneration(adapterGeneration);
+        return adapter.initialize(threadId);
       },
       optimistic: (state) => {
         return updateStatusReducer(state, threadId, "regular");
@@ -659,12 +700,15 @@ export class RemoteThreadListThreadListRuntimeCore
   };
 
   public generateTitle = async (threadId: string) => {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadId);
     if (!data) throw threadNotFoundError(threadId, "generating its title");
     if (data.status === "new")
       throw threadStatusError(threadId, data.status, "generate a title");
 
     const { remoteId } = await data.initializeTask;
+    this._requireAdapterGeneration(adapterGeneration);
 
     const runtimeCore = this._hookManager.getThreadRuntimeCore(data.id);
     if (!runtimeCore) return; // thread is no longer running
@@ -673,12 +717,10 @@ export class RemoteThreadListThreadListRuntimeCore
     // would make the payload race-dependent; the title reads settled
     // messages only, matching the trigger's readiness gate.
     const messages = runtimeCore.messages.filter(isTitleSourceMessage);
-    const stream = await this._options.adapter.generateTitle(
-      remoteId,
-      messages,
-    );
+    const stream = await adapter.generateTitle(remoteId, messages);
     const messageStream = AssistantMessageStream.fromAssistantStream(stream);
     for await (const result of messageStream) {
+      if (adapterGeneration !== this._adapterGeneration) return;
       const newTitle = result.parts.filter((c) => c.type === "text")[0]?.text;
       const state = this._state.baseValue;
       const currentData = getThreadData(state, data.id);
@@ -697,6 +739,8 @@ export class RemoteThreadListThreadListRuntimeCore
   };
 
   public rename(threadIdOrRemoteId: string, newTitle: string): Promise<void> {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) throw threadNotFoundError(threadIdOrRemoteId, "renaming it");
     if (data.status === "new")
@@ -705,7 +749,8 @@ export class RemoteThreadListThreadListRuntimeCore
     return this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
-        return this._options.adapter.rename(remoteId, newTitle);
+        this._requireAdapterGeneration(adapterGeneration);
+        return adapter.rename(remoteId, newTitle);
       },
       optimistic: (state) => {
         const data = getThreadData(state, threadIdOrRemoteId);
@@ -729,6 +774,8 @@ export class RemoteThreadListThreadListRuntimeCore
     threadIdOrRemoteId: string,
     custom: Record<string, unknown> | undefined,
   ): Promise<void> {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data)
       throw threadNotFoundError(
@@ -742,7 +789,7 @@ export class RemoteThreadListThreadListRuntimeCore
         "update custom metadata",
       );
 
-    if (!this._options.adapter.updateCustom) {
+    if (!adapter.updateCustom) {
       throw new Error(
         "Remote thread list adapter does not support updating custom metadata",
       );
@@ -751,7 +798,7 @@ export class RemoteThreadListThreadListRuntimeCore
     return this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
-        const adapter = this._options.adapter;
+        this._requireAdapterGeneration(adapterGeneration);
         if (!adapter.updateCustom) {
           throw new Error(
             "Remote thread list adapter does not support updating custom metadata",
@@ -800,17 +847,21 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public async archive(threadIdOrRemoteId: string) {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) throw threadNotFoundError(threadIdOrRemoteId, "archiving it");
     if (data.status !== "regular")
       throw threadStatusError(threadIdOrRemoteId, data.status, "be archived");
 
     await this._ensureThreadIsNotMain(data.id);
+    this._requireAdapterGeneration(adapterGeneration);
 
     return this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
-        return this._options.adapter.archive(remoteId);
+        this._requireAdapterGeneration(adapterGeneration);
+        return adapter.archive(remoteId);
       },
       optimistic: (state) => {
         return updateStatusReducer(state, data.id, "archived");
@@ -819,6 +870,8 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public unarchive(threadIdOrRemoteId: string): Promise<void> {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) throw threadNotFoundError(threadIdOrRemoteId, "unarchiving it");
     if (data.status !== "archived")
@@ -828,9 +881,12 @@ export class RemoteThreadListThreadListRuntimeCore
       execute: async () => {
         try {
           const { remoteId } = await data.initializeTask;
-          return await this._options.adapter.unarchive(remoteId);
+          this._requireAdapterGeneration(adapterGeneration);
+          return await adapter.unarchive(remoteId);
         } catch (error) {
-          await this._ensureThreadIsNotMain(data.id);
+          if (adapterGeneration === this._adapterGeneration) {
+            await this._ensureThreadIsNotMain(data.id);
+          }
           throw error;
         }
       },
@@ -841,18 +897,22 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public async delete(threadIdOrRemoteId: string) {
+    const adapter = this._options.adapter;
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) throw threadNotFoundError(threadIdOrRemoteId, "deleting it");
     if (data.status !== "regular" && data.status !== "archived")
       throw threadStatusError(threadIdOrRemoteId, data.status, "be deleted");
 
     await this._ensureThreadIsNotMain(data.id);
+    this._requireAdapterGeneration(adapterGeneration);
     this._hookManager.stopThreadRuntime(data.id);
 
     return this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
-        return await this._options.adapter.delete(remoteId);
+        this._requireAdapterGeneration(adapterGeneration);
+        return await adapter.delete(remoteId);
       },
       optimistic: (state) => {
         return updateStatusReducer(state, data.id, "deleted");
@@ -865,12 +925,14 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public async detach(threadIdOrRemoteId: string): Promise<void> {
+    const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) throw threadNotFoundError(threadIdOrRemoteId, "detaching it");
     if (data.status !== "regular" && data.status !== "archived")
       throw threadStatusError(threadIdOrRemoteId, data.status, "be detached");
 
     await this._ensureThreadIsNotMain(data.id);
+    this._requireAdapterGeneration(adapterGeneration);
     this._hookManager.stopThreadRuntime(data.id);
   }
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -215,9 +215,14 @@ export class RemoteThreadListThreadListRuntimeCore
               replaceList &&
               getThreadData(nextState, this._mainThreadId) === undefined
             ) {
-              const seeded = addNewThread(nextState);
-              this._mainThreadId = seeded.id;
-              nextState = seeded.state;
+              const preservedDraft = nextState.newThreadId;
+              if (preservedDraft !== undefined) {
+                this._mainThreadId = preservedDraft;
+              } else {
+                const seeded = addNewThread(nextState);
+                this._mainThreadId = seeded.id;
+                nextState = seeded.state;
+              }
               if (this._options.threadId === undefined) {
                 this._notifyThreadIdChange();
               } else {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -102,6 +102,7 @@ export class RemoteThreadListThreadListRuntimeCore
   private _loadMorePromise: Promise<void> | undefined;
   private _loadGeneration = 0;
   private _adapterGeneration = 0;
+  private _replaceListOnNextLoad = false;
   private _switchGeneration = 0;
   private _switchTask: Promise<void> | undefined;
 
@@ -171,22 +172,64 @@ export class RemoteThreadListThreadListRuntimeCore
               threadIdMap: {},
               threadData: {},
             });
+            const replaceList = this._replaceListOnNextLoad;
+            if (replaceList) this._replaceListOnNextLoad = false;
 
-            return {
+            const threadIdMap = replaceList
+              ? { ...fresh.threadIdMap }
+              : { ...state.threadIdMap, ...fresh.threadIdMap };
+            const threadData = replaceList
+              ? { ...fresh.threadData }
+              : { ...state.threadData, ...fresh.threadData };
+
+            if (replaceList && state.newThreadId) {
+              const mappingId = state.threadIdMap[state.newThreadId];
+              const draft = mappingId ? state.threadData[mappingId] : undefined;
+              if (draft?.status === "new") {
+                threadIdMap[state.newThreadId] = mappingId!;
+                threadData[mappingId!] = draft;
+              }
+            }
+
+            const controlledId = this._options.threadId;
+            if (replaceList && controlledId !== undefined) {
+              const mappingId = state.threadIdMap[controlledId];
+              const controlled = mappingId
+                ? state.threadData[mappingId]
+                : undefined;
+              if (controlled !== undefined && mappingId !== undefined) {
+                threadIdMap[controlledId] = mappingId;
+                threadData[mappingId] = controlled;
+              }
+            }
+
+            let nextState: RemoteThreadState = {
               ...state,
               isLoading: false,
               cursor: normalizeCursor(l.nextCursor),
               threadIds: fresh.threadIds,
               archivedThreadIds: fresh.archivedThreadIds,
-              threadIdMap: {
-                ...state.threadIdMap,
-                ...fresh.threadIdMap,
-              },
-              threadData: {
-                ...state.threadData,
-                ...fresh.threadData,
-              },
+              threadIdMap,
+              threadData,
+              newThreadId:
+                replaceList &&
+                state.newThreadId !== undefined &&
+                threadIdMap[state.newThreadId] === undefined
+                  ? undefined
+                  : state.newThreadId,
             };
+
+            if (
+              replaceList &&
+              getThreadData(nextState, this._mainThreadId) === undefined
+            ) {
+              const seeded = addNewThread(nextState);
+              this._lastNotifiedThreadId = undefined;
+              this._mainThreadId = seeded.id;
+              nextState = seeded.state;
+            }
+
+            return nextState;
           },
         })
         .catch((error: unknown) => {
@@ -198,7 +241,14 @@ export class RemoteThreadListThreadListRuntimeCore
             isLoading: false,
           });
         })
-        .then(() => {});
+        .then(() => {
+          if (this.getItemById(this._mainThreadId) !== undefined) return;
+          if (this._options.threadId !== undefined) {
+            void this._switchToThreadFromProp(this._options.threadId);
+            return;
+          }
+          void this.switchToNewThread();
+        });
     }
 
     return this._loadThreadsPromise;
@@ -243,6 +293,7 @@ export class RemoteThreadListThreadListRuntimeCore
         },
       })
       .catch((error: unknown) => {
+        if (generation !== this._loadGeneration) return;
         console.error("[assistant-ui] thread list loadMore failed:", error);
       })
       .then(() => {
@@ -304,14 +355,18 @@ export class RemoteThreadListThreadListRuntimeCore
     this._hookManager.setRuntimeHook(options.runtimeHook);
 
     if (adapterChanged) {
-      if (options.threadId !== undefined) {
-        this._lastNotifiedThreadId = undefined;
-      }
-      this._resetForAdapterChange();
-      if (options.threadId !== undefined) {
-        this._switchToThreadFromProp(options.threadId).catch(() => {});
-      }
-    } else if (controlledThreadIdChanged) {
+      this._loadGeneration++;
+      this._adapterGeneration++;
+      this._loadThreadsPromise = undefined;
+      this._loadMorePromise = undefined;
+      this._replaceListOnNextLoad = true;
+      this._state.update({
+        ...this._state.baseValue,
+        cursor: undefined,
+      });
+    }
+
+    if (controlledThreadIdChanged) {
       this._switchToThreadFromProp(options.threadId).catch(() => {});
     }
   }
@@ -320,23 +375,6 @@ export class RemoteThreadListThreadListRuntimeCore
     if (generation !== this._adapterGeneration) {
       throw new ThreadListAdapterChangedError();
     }
-  }
-
-  private _resetForAdapterChange() {
-    this._loadGeneration++;
-    this._adapterGeneration++;
-    this._switchGeneration++;
-    this._loadThreadsPromise = undefined;
-    this._loadMorePromise = undefined;
-    this._switchTask = undefined;
-    this._hookManager.__internal_dispose();
-    const next = addNewThread(EMPTY_REMOTE_STATE);
-    this._mainThreadId = next.id;
-    this._state.reset(next.state);
-    void this._hookManager.startThreadRuntime(next.id).then(
-      () => this._notifySubscribers(),
-      () => undefined,
-    );
   }
 
   public __internal_load() {
@@ -674,6 +712,7 @@ export class RemoteThreadListThreadListRuntimeCore
         };
       },
       then: (state, { remoteId, externalId }) => {
+        if (adapterGeneration !== this._adapterGeneration) return state;
         const data = getThreadData(state, threadId);
         if (!data) return state;
 
@@ -696,6 +735,7 @@ export class RemoteThreadListThreadListRuntimeCore
         };
       },
     });
+    this._requireAdapterGeneration(adapterGeneration);
     return { remoteId, externalId };
   };
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -390,6 +390,7 @@ export class RemoteThreadListThreadListRuntimeCore
     if (stale) {
       for (const item of Object.values(state.threadData)) {
         if (stale.has(item.id)) continue;
+        if (item.status !== "new" && item.remoteId === undefined) continue;
         const mappingId = createThreadMappingId(item.id);
         if (threadData[mappingId]) continue;
         threadIdMap[item.id] = mappingId;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -227,6 +227,10 @@ export class RemoteThreadListThreadListRuntimeCore
               this._lastNotifiedThreadId = undefined;
               this._mainThreadId = seeded.id;
               nextState = seeded.state;
+              void this._hookManager.startThreadRuntime(seeded.id).then(
+                () => this._notifySubscribers(),
+                () => undefined,
+              );
             }
 
             return nextState;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -395,6 +395,12 @@ export class RemoteThreadListThreadListRuntimeCore
     }
   }
 
+  private _requireAdapterSettled() {
+    if (this._replaceListOnNextLoad) {
+      throw new ThreadListAdapterChangedError();
+    }
+  }
+
   public __internal_load() {
     this.getLoadThreadsPromise(); // begin loading on initial bind
     if (this._initialThreadLoaded) return;
@@ -554,6 +560,12 @@ export class RemoteThreadListThreadListRuntimeCore
     generation: number,
     emitThreadIdChange: boolean,
   ): Promise<void> {
+    if (
+      this._replaceListOnNextLoad &&
+      threadIdOrRemoteId !== this._state.value.newThreadId
+    ) {
+      throw new ThreadListAdapterChangedError();
+    }
     let data = this.getItemById(threadIdOrRemoteId);
 
     if (!data) {
@@ -699,6 +711,7 @@ export class RemoteThreadListThreadListRuntimeCore
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     if (this._state.value.newThreadId !== threadId) {
+      this._requireAdapterSettled();
       const data = this.getItemById(threadId);
       if (!data) throw threadNotFoundError(threadId, "initializing it");
       if (data.status === "new")
@@ -758,6 +771,7 @@ export class RemoteThreadListThreadListRuntimeCore
   };
 
   public generateTitle = async (threadId: string) => {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadId);
@@ -796,7 +810,11 @@ export class RemoteThreadListThreadListRuntimeCore
     }
   };
 
-  public rename(threadIdOrRemoteId: string, newTitle: string): Promise<void> {
+  public async rename(
+    threadIdOrRemoteId: string,
+    newTitle: string,
+  ): Promise<void> {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
@@ -828,10 +846,11 @@ export class RemoteThreadListThreadListRuntimeCore
     });
   }
 
-  public updateCustom(
+  public async updateCustom(
     threadIdOrRemoteId: string,
     custom: Record<string, unknown> | undefined,
   ): Promise<void> {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
@@ -905,6 +924,7 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public async archive(threadIdOrRemoteId: string) {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
@@ -927,7 +947,8 @@ export class RemoteThreadListThreadListRuntimeCore
     });
   }
 
-  public unarchive(threadIdOrRemoteId: string): Promise<void> {
+  public async unarchive(threadIdOrRemoteId: string): Promise<void> {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);
@@ -955,6 +976,7 @@ export class RemoteThreadListThreadListRuntimeCore
   }
 
   public async delete(threadIdOrRemoteId: string) {
+    this._requireAdapterSettled();
     const adapter = this._options.adapter;
     const adapterGeneration = this._adapterGeneration;
     const data = this.getItemById(threadIdOrRemoteId);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -222,7 +222,14 @@ export class RemoteThreadListThreadListRuntimeCore
             }
 
             if (replaceList) {
-              this._hookManager.__internal_dispose();
+              const nextIds = new Set(
+                Object.values(nextState.threadData).map((item) => item.id),
+              );
+              for (const item of Object.values(state.threadData)) {
+                if (!nextIds.has(item.id)) {
+                  this._hookManager.stopThreadRuntime(item.id);
+                }
+              }
               void this._hookManager
                 .startThreadRuntime(this._mainThreadId)
                 .then(

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -191,18 +191,6 @@ export class RemoteThreadListThreadListRuntimeCore
               }
             }
 
-            const controlledId = this._options.threadId;
-            if (replaceList && controlledId !== undefined) {
-              const mappingId = state.threadIdMap[controlledId];
-              const controlled = mappingId
-                ? state.threadData[mappingId]
-                : undefined;
-              if (controlled !== undefined && mappingId !== undefined) {
-                threadIdMap[controlledId] = mappingId;
-                threadData[mappingId] = controlled;
-              }
-            }
-
             let nextState: RemoteThreadState = {
               ...state,
               isLoading: false,
@@ -224,10 +212,18 @@ export class RemoteThreadListThreadListRuntimeCore
               getThreadData(nextState, this._mainThreadId) === undefined
             ) {
               const seeded = addNewThread(nextState);
-              this._lastNotifiedThreadId = undefined;
               this._mainThreadId = seeded.id;
               nextState = seeded.state;
-              void this._hookManager.startThreadRuntime(seeded.id).then(
+              if (this._options.threadId === undefined) {
+                this._notifyThreadIdChange();
+              } else {
+                this._lastNotifiedThreadId = undefined;
+              }
+            }
+
+            if (replaceList) {
+              this._hookManager.__internal_dispose();
+              void this._hookManager.startThreadRuntime(this._mainThreadId).then(
                 () => this._notifySubscribers(),
                 () => undefined,
               );
@@ -246,12 +242,9 @@ export class RemoteThreadListThreadListRuntimeCore
           });
         })
         .then(() => {
-          if (this.getItemById(this._mainThreadId) !== undefined) return;
-          if (this._options.threadId !== undefined) {
-            void this._switchToThreadFromProp(this._options.threadId);
-            return;
-          }
-          void this.switchToNewThread();
+          if (this._options.threadId === undefined) return;
+          if (this.getItemById(this._options.threadId) !== undefined) return;
+          void this._switchToThreadFromProp(this._options.threadId);
         });
     }
 
@@ -361,6 +354,8 @@ export class RemoteThreadListThreadListRuntimeCore
     if (adapterChanged) {
       this._loadGeneration++;
       this._adapterGeneration++;
+      this._switchGeneration++;
+      this._switchTask = undefined;
       this._loadThreadsPromise = undefined;
       this._loadMorePromise = undefined;
       this._replaceListOnNextLoad = true;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -155,6 +155,7 @@ export class RemoteThreadListThreadListRuntimeCore
     // TODO this needs to be cached in case this promise is loaded during suspense
     if (!this._loadThreadsPromise) {
       const generation = this._loadGeneration;
+      let replacedList = false;
       this._loadThreadsPromise = this._state
         .optimisticUpdate({
           execute: () => this._options.adapter.list(),
@@ -173,7 +174,10 @@ export class RemoteThreadListThreadListRuntimeCore
               threadData: {},
             });
             const replaceList = this._replaceListOnNextLoad;
-            if (replaceList) this._replaceListOnNextLoad = false;
+            if (replaceList) {
+              this._replaceListOnNextLoad = false;
+              replacedList = true;
+            }
 
             const threadIdMap = replaceList
               ? { ...fresh.threadIdMap }
@@ -251,9 +255,10 @@ export class RemoteThreadListThreadListRuntimeCore
           });
         })
         .then(() => {
+          if (!replacedList) return;
           if (this._options.threadId === undefined) return;
           if (this.getItemById(this._options.threadId) !== undefined) return;
-          void this._switchToThreadFromProp(this._options.threadId);
+          this._switchToThreadFromProp(this._options.threadId).catch(() => {});
         });
     }
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -17,6 +17,7 @@ import {
 import type {
   RemoteThreadListAdapter,
   RemoteThreadListOptions,
+  RemoteThreadMetadata,
 } from "../../runtimes/remote-thread-list/types";
 import { ThreadListAdapterChangedError } from "../../runtimes/remote-thread-list/adapter-changed";
 import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
@@ -103,6 +104,7 @@ export class RemoteThreadListThreadListRuntimeCore
   private _loadGeneration = 0;
   private _adapterGeneration = 0;
   private _replaceListOnNextLoad = false;
+  private _staleThreadIdsOnReplace: ReadonlySet<string> | undefined;
   private _switchGeneration = 0;
   private _switchTask: Promise<void> | undefined;
 
@@ -167,97 +169,50 @@ export class RemoteThreadListThreadListRuntimeCore
           },
           then: (state, l) => {
             if (generation !== this._loadGeneration) return state;
+            const replaceList = this._replaceListOnNextLoad;
+            if (replaceList) {
+              this._replaceListOnNextLoad = false;
+              replacedList = true;
+              return this._replaceWithThreads(
+                state,
+                l.threads,
+                normalizeCursor(l.nextCursor),
+              );
+            }
+
             const fresh = classifyThreads(l.threads, {
               threadIds: [],
               archivedThreadIds: [],
               threadIdMap: {},
               threadData: {},
             });
-            const replaceList = this._replaceListOnNextLoad;
-            if (replaceList) {
-              this._replaceListOnNextLoad = false;
-              replacedList = true;
-            }
-
-            const threadIdMap = replaceList
-              ? { ...fresh.threadIdMap }
-              : { ...state.threadIdMap, ...fresh.threadIdMap };
-            const threadData = replaceList
-              ? { ...fresh.threadData }
-              : { ...state.threadData, ...fresh.threadData };
-
-            if (replaceList && state.newThreadId) {
-              const mappingId = state.threadIdMap[state.newThreadId];
-              const draft = mappingId ? state.threadData[mappingId] : undefined;
-              if (draft?.status === "new") {
-                threadIdMap[state.newThreadId] = mappingId!;
-                threadData[mappingId!] = draft;
-              }
-            }
-
-            let nextState: RemoteThreadState = {
+            return {
               ...state,
               isLoading: false,
               cursor: normalizeCursor(l.nextCursor),
               threadIds: fresh.threadIds,
               archivedThreadIds: fresh.archivedThreadIds,
-              threadIdMap,
-              threadData,
-              newThreadId:
-                replaceList &&
-                state.newThreadId !== undefined &&
-                threadIdMap[state.newThreadId] === undefined
-                  ? undefined
-                  : state.newThreadId,
+              threadIdMap: { ...state.threadIdMap, ...fresh.threadIdMap },
+              threadData: { ...state.threadData, ...fresh.threadData },
             };
-
-            if (
-              replaceList &&
-              getThreadData(nextState, this._mainThreadId) === undefined
-            ) {
-              const preservedDraft = nextState.newThreadId;
-              if (preservedDraft !== undefined) {
-                this._mainThreadId = preservedDraft;
-              } else {
-                const seeded = addNewThread(nextState);
-                this._mainThreadId = seeded.id;
-                nextState = seeded.state;
-              }
-              if (this._options.threadId === undefined) {
-                this._notifyThreadIdChange();
-              } else {
-                this._lastNotifiedThreadId = undefined;
-              }
-            }
-
-            if (replaceList) {
-              const nextIds = new Set(
-                Object.values(nextState.threadData).map((item) => item.id),
-              );
-              for (const item of Object.values(state.threadData)) {
-                if (!nextIds.has(item.id)) {
-                  this._hookManager.stopThreadRuntime(item.id);
-                }
-              }
-              void this._hookManager
-                .startThreadRuntime(this._mainThreadId)
-                .then(
-                  () => this._notifySubscribers(),
-                  () => undefined,
-                );
-            }
-
-            return nextState;
           },
         })
         .catch((error: unknown) => {
           if (generation !== this._loadGeneration) return;
           console.error("[assistant-ui] thread list load failed:", error);
           this._loadThreadsPromise = undefined;
-          this._state.update({
-            ...this._state.baseValue,
-            isLoading: false,
-          });
+          if (!this._replaceListOnNextLoad) {
+            this._state.update({
+              ...this._state.baseValue,
+              isLoading: false,
+            });
+            return;
+          }
+          this._replaceListOnNextLoad = false;
+          replacedList = true;
+          this._state.update(
+            this._replaceWithThreads(this._state.baseValue, [], undefined),
+          );
         })
         .then(() => {
           if (!replacedList) return;
@@ -378,6 +333,11 @@ export class RemoteThreadListThreadListRuntimeCore
       this._loadThreadsPromise = undefined;
       this._loadMorePromise = undefined;
       this._replaceListOnNextLoad = true;
+      this._staleThreadIdsOnReplace = new Set(
+        Object.values(this._state.baseValue.threadData)
+          .filter((item) => item.status !== "new")
+          .map((item) => item.id),
+      );
       this._state.update({
         ...this._state.baseValue,
         cursor: undefined,
@@ -399,6 +359,102 @@ export class RemoteThreadListThreadListRuntimeCore
     if (this._replaceListOnNextLoad) {
       throw new ThreadListAdapterChangedError();
     }
+  }
+
+  private _replaceWithThreads(
+    state: RemoteThreadState,
+    threads: readonly RemoteThreadMetadata[],
+    cursor: string | undefined,
+  ): RemoteThreadState {
+    const fresh = classifyThreads(threads, {
+      threadIds: [],
+      archivedThreadIds: [],
+      threadIdMap: {},
+      threadData: {},
+    });
+    const threadIdMap = { ...fresh.threadIdMap };
+    const threadData = { ...fresh.threadData };
+    const threadIds = [...fresh.threadIds];
+    const archivedThreadIds = [...fresh.archivedThreadIds];
+
+    if (state.newThreadId) {
+      const mappingId = state.threadIdMap[state.newThreadId];
+      const draft = mappingId ? state.threadData[mappingId] : undefined;
+      if (draft?.status === "new") {
+        threadIdMap[state.newThreadId] = mappingId!;
+        threadData[mappingId!] = draft;
+      }
+    }
+
+    const stale = this._staleThreadIdsOnReplace;
+    if (stale) {
+      for (const item of Object.values(state.threadData)) {
+        if (stale.has(item.id)) continue;
+        const mappingId = createThreadMappingId(item.id);
+        if (threadData[mappingId]) continue;
+        threadIdMap[item.id] = mappingId;
+        if (item.remoteId !== undefined) {
+          threadIdMap[item.remoteId] = mappingId;
+        }
+        threadData[mappingId] = item;
+        if (item.remoteId === undefined) continue;
+        if (item.status === "regular" && !threadIds.includes(item.remoteId)) {
+          threadIds.push(item.remoteId);
+        } else if (
+          item.status === "archived" &&
+          !archivedThreadIds.includes(item.remoteId)
+        ) {
+          archivedThreadIds.push(item.remoteId);
+        }
+      }
+    }
+    this._staleThreadIdsOnReplace = undefined;
+
+    let nextState: RemoteThreadState = {
+      ...state,
+      isLoading: false,
+      cursor,
+      threadIds,
+      archivedThreadIds,
+      threadIdMap,
+      threadData,
+      newThreadId:
+        state.newThreadId !== undefined &&
+        threadIdMap[state.newThreadId] === undefined
+          ? undefined
+          : state.newThreadId,
+    };
+
+    if (getThreadData(nextState, this._mainThreadId) === undefined) {
+      const preservedDraft = nextState.newThreadId;
+      if (preservedDraft !== undefined) {
+        this._mainThreadId = preservedDraft;
+      } else {
+        const seeded = addNewThread(nextState);
+        this._mainThreadId = seeded.id;
+        nextState = seeded.state;
+      }
+      if (this._options.threadId === undefined) {
+        this._notifyThreadIdChange();
+      } else {
+        this._lastNotifiedThreadId = undefined;
+      }
+    }
+
+    const nextIds = new Set(
+      Object.values(nextState.threadData).map((item) => item.id),
+    );
+    for (const item of Object.values(state.threadData)) {
+      if (!nextIds.has(item.id)) {
+        this._hookManager.stopThreadRuntime(item.id);
+      }
+    }
+    void this._hookManager.startThreadRuntime(this._mainThreadId).then(
+      () => this._notifySubscribers(),
+      () => undefined,
+    );
+
+    return nextState;
   }
 
   public __internal_load() {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -223,10 +223,12 @@ export class RemoteThreadListThreadListRuntimeCore
 
             if (replaceList) {
               this._hookManager.__internal_dispose();
-              void this._hookManager.startThreadRuntime(this._mainThreadId).then(
-                () => this._notifySubscribers(),
-                () => undefined,
-              );
+              void this._hookManager
+                .startThreadRuntime(this._mainThreadId)
+                .then(
+                  () => this._notifySubscribers(),
+                  () => undefined,
+                );
             }
 
             return nextState;

--- a/packages/core/src/react/runtimes/RemoteThreadResource.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadResource.ts
@@ -21,6 +21,7 @@ import {
   useRuntimeAdaptersProvider,
   type RuntimeAdapters,
 } from "./RuntimeAdapterProvider";
+import { isSilentRuntimeAction } from "../../utils/silent-runtime-action";
 
 export type RemoteThreadListHook = () => AssistantRuntime;
 
@@ -48,6 +49,7 @@ export const subscribeToTitleGeneration = (
 ) => {
   const generate = () =>
     void itemRuntime.generateTitle().catch((error: unknown) => {
+      if (isSilentRuntimeAction(error)) return;
       console.error("[assistant-ui] Thread title generation failed", error);
     });
 

--- a/packages/core/src/runtimes/remote-thread-list/adapter-changed.ts
+++ b/packages/core/src/runtimes/remote-thread-list/adapter-changed.ts
@@ -1,4 +1,4 @@
-const SILENT_RUNTIME_ACTION = Symbol.for("assistant-ui.silent-runtime-action");
+import { SILENT_RUNTIME_ACTION } from "../../utils/silent-runtime-action";
 
 export class ThreadListAdapterChangedError extends Error {
   readonly [SILENT_RUNTIME_ACTION] = true;
@@ -8,6 +8,3 @@ export class ThreadListAdapterChangedError extends Error {
     this.name = "ThreadListAdapterChangedError";
   }
 }
-
-export const isSilentRuntimeAction = (error: unknown): boolean =>
-  typeof error === "object" && error !== null && SILENT_RUNTIME_ACTION in error;

--- a/packages/core/src/runtimes/remote-thread-list/adapter-changed.ts
+++ b/packages/core/src/runtimes/remote-thread-list/adapter-changed.ts
@@ -1,0 +1,13 @@
+const SILENT_RUNTIME_ACTION = Symbol.for("assistant-ui.silent-runtime-action");
+
+export class ThreadListAdapterChangedError extends Error {
+  readonly [SILENT_RUNTIME_ACTION] = true;
+
+  constructor() {
+    super("Thread list adapter changed while an operation was pending.");
+    this.name = "ThreadListAdapterChangedError";
+  }
+}
+
+export const isSilentRuntimeAction = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && SILENT_RUNTIME_ACTION in error;

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.test.ts
@@ -60,4 +60,22 @@ describe("OptimisticState", () => {
 
     expect(state.value.title).toBe("Project Beta");
   });
+
+  it("drops an in-flight transform after reset", async () => {
+    const state = new OptimisticState({ title: "Untitled", extra: 0 });
+    const request = deferred();
+    const update = state.optimisticUpdate({
+      execute: () => request.promise,
+      optimistic: (value) => ({ ...value, title: "Pending" }),
+      then: (value) => ({ ...value, extra: 1 }),
+    });
+
+    expect(state.value.title).toBe("Pending");
+    state.reset({ title: "Fresh", extra: 0 });
+    expect(state.value).toEqual({ title: "Fresh", extra: 0 });
+
+    request.resolve();
+    await update;
+    expect(state.value).toEqual({ title: "Fresh", extra: 0 });
+  });
 });

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
@@ -48,6 +48,7 @@ export class OptimisticState<TState> extends BaseSubscribable {
     [];
 
   private _nextTransformOrder = 0;
+  private _epoch = 0;
 
   private _baseValue: TState;
   private _cachedValue: TState;
@@ -95,9 +96,20 @@ export class OptimisticState<TState> extends BaseSubscribable {
     this._updateState();
   }
 
+  public reset(state: TState): void {
+    // In-flight optimisticUpdate calls must not write into the replacement state.
+    this._epoch++;
+    this._pendingTransforms.length = 0;
+    this._completedOptimistics.length = 0;
+    this._baseValue = state;
+    this._cachedValue = state;
+    this._notifySubscribers();
+  }
+
   public async optimisticUpdate<TResult>(
     transform: Transform<TState, TResult>,
   ): Promise<TResult> {
+    const epoch = this._epoch;
     const order = this._nextTransformOrder++;
     const task = transform.execute();
     const pendingTransform = {
@@ -110,6 +122,7 @@ export class OptimisticState<TState> extends BaseSubscribable {
       this._updateState();
 
       const result = await task;
+      if (epoch !== this._epoch) return result;
       this._baseValue = pipeTransforms(this._baseValue, result, [
         transform.optimistic,
         transform.then,

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -98,7 +98,7 @@ export type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
 
   /**
-   * The adapter reference must remain stable across renders. Replacing it resets thread selection and cached records, then loads the replacement adapter.
+   * The adapter reference should remain stable across renders. Replacing it reloads the list and drops cached threads that are not in the replacement page. In-flight mutations from the previous adapter are cancelled.
    */
   adapter: RemoteThreadListAdapter;
 

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -96,6 +96,10 @@ export type RemoteThreadListAdapter = {
 
 export type RemoteThreadListOptions = {
   runtimeHook: () => AssistantRuntime;
+
+  /**
+   * The adapter reference must remain stable across renders. Replacing it resets thread selection and cached records, then loads the replacement adapter.
+   */
   adapter: RemoteThreadListAdapter;
 
   /**

--- a/packages/core/src/store/runtime-clients/handle-runtime-action.test.ts
+++ b/packages/core/src/store/runtime-clients/handle-runtime-action.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { ThreadListAdapterChangedError } from "../../runtimes/remote-thread-list/adapter-changed";
+import { handleRuntimeAction } from "./handle-runtime-action";
+
+describe("handleRuntimeAction", () => {
+  it("does not log a silent adapter-change cancellation", async () => {
+    const error = new ThreadListAdapterChangedError();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      await expect(
+        handleRuntimeAction("thread list archive", () => Promise.reject(error)),
+      ).rejects.toBe(error);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("logs an ordinary rejection", async () => {
+    const error = new Error("archive failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      await expect(
+        handleRuntimeAction("thread list archive", () => Promise.reject(error)),
+      ).rejects.toBe(error);
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        "[assistant-ui] thread list archive failed:",
+        error,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/store/runtime-clients/handle-runtime-action.ts
+++ b/packages/core/src/store/runtime-clients/handle-runtime-action.ts
@@ -1,3 +1,5 @@
+import { isSilentRuntimeAction } from "../../runtimes/remote-thread-list/adapter-changed";
+
 export const handleRuntimeAction = (
   label: string,
   execute: () => Promise<void>,
@@ -5,6 +7,7 @@ export const handleRuntimeAction = (
   const task = execute();
 
   void task.catch((error: unknown) => {
+    if (isSilentRuntimeAction(error)) return;
     console.error(`[assistant-ui] ${label} failed:`, error);
   });
   return task;

--- a/packages/core/src/store/runtime-clients/handle-runtime-action.ts
+++ b/packages/core/src/store/runtime-clients/handle-runtime-action.ts
@@ -1,4 +1,4 @@
-import { isSilentRuntimeAction } from "../../runtimes/remote-thread-list/adapter-changed";
+import { isSilentRuntimeAction } from "../../utils/silent-runtime-action";
 
 export const handleRuntimeAction = (
   label: string,

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-errors.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-errors.test.ts
@@ -3,10 +3,10 @@ import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
 import { InMemoryThreadListAdapter } from "../runtimes/remote-thread-list/adapter/in-memory";
 
 describe("RemoteThreadListThreadListRuntimeCore errors", () => {
-  it("includes the requested thread id when a thread is missing", () => {
+  it("includes the requested thread id when a thread is missing", async () => {
     const core = createCore(makeAdapter());
 
-    expect(() => core.rename("missing-thread", "New title")).toThrow(
+    await expect(core.rename("missing-thread", "New title")).rejects.toThrow(
       'Thread "missing-thread" not found while renaming it.',
     );
   });

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
@@ -263,12 +263,12 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     });
 
     expect(core.hasMore).toBe(false);
-    expect(core.threadIds).toEqual([]);
-    expect(core.getItemById("old")).toBeUndefined();
+    expect(core.threadIds).toEqual(["old"]);
 
     await core.getLoadThreadsPromise();
     expect(secondList).toHaveBeenCalledTimes(1);
     expect(core.threadIds).toEqual(["new"]);
+    expect(core.getItemById("old")).toBeUndefined();
   });
 
   it("ignores an in-flight loadMore response when the adapter swaps mid-flight", async () => {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
@@ -263,7 +263,8 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     });
 
     expect(core.hasMore).toBe(false);
-    expect(core.threadIds).toEqual(["old"]);
+    expect(core.threadIds).toEqual([]);
+    expect(core.getItemById("old")).toBeUndefined();
 
     await core.getLoadThreadsPromise();
     expect(secondList).toHaveBeenCalledTimes(1);
@@ -289,23 +290,24 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     await core.getLoadThreadsPromise();
     const stale = core.loadMore();
 
-    const secondAdapter = makeAdapter({
-      list: vi.fn<ListFn>(async () => ({
-        threads: [{ status: "regular", remoteId: "ignored", externalId: "x" }],
-      })),
-    });
+    const secondList = vi.fn<ListFn>(async () => ({
+      threads: [{ status: "regular", remoteId: "fresh", externalId: "fresh" }],
+    }));
+    const secondAdapter = makeAdapter({ list: secondList });
     core.__internal_setOptions({
       adapter: secondAdapter,
       runtimeHook: () => ({}) as never,
     });
+    const replacementLoad = core.getLoadThreadsPromise();
 
     slow.resolve({
       threads: [{ status: "regular", remoteId: "stale", externalId: "stale" }],
       nextCursor: "stale-cursor",
     });
     await stale;
+    await replacementLoad;
 
-    expect(core.threadIds).toEqual(["p1"]);
+    expect(core.threadIds).toEqual(["fresh"]);
     expect(core.hasMore).toBe(false);
     expect(core.isLoadingMore).toBe(false);
   });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCore,
+  deferred,
+  makeAdapter,
+  setStartThreadRuntime,
+} from "./remote-thread-list-test-helpers";
+
+const thread = (remoteId: string) => ({
+  remoteId,
+  externalId: remoteId,
+  status: "regular" as const,
+  title: remoteId,
+});
+
+describe("RemoteThreadList adapter changes", () => {
+  it("clears the selected thread and cached data from the previous adapter", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const listAdapterB = vi.fn(async () => ({
+      threads: [thread("thread-b")],
+    }));
+    const adapterB = makeAdapter({ list: listAdapterB });
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+    expect(core.getItemById(core.mainThreadId)?.remoteId).toBe("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    expect(core.mainThreadId).not.toBe("thread-a");
+    expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
+    expect(core.getItemById("thread-a")).toBeUndefined();
+
+    await core.getLoadThreadsPromise();
+    expect(listAdapterB).toHaveBeenCalledTimes(1);
+    expect(core.threadIds).toEqual(["thread-b"]);
+    expect(core.getItemById("thread-a")).toBeUndefined();
+    expect(core.getItemById(core.mainThreadId)?.remoteId).not.toBe("thread-a");
+
+    expect(() => core.rename("thread-a", "leaked")).toThrow(
+      'Thread "thread-a" not found',
+    );
+    expect(adapterB.rename).not.toHaveBeenCalled();
+  });
+
+  it("does not resume an old adapter mutation through the new adapter", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter();
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+
+    const runtimeStart = deferred<unknown>();
+    setStartThreadRuntime(core, () => runtimeStart.promise);
+    const archiveTask = core.archive("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    runtimeStart.resolve({});
+
+    await expect(archiveTask).rejects.toThrow("adapter changed");
+    expect(adapterA.archive).not.toHaveBeenCalled();
+    expect(adapterB.archive).not.toHaveBeenCalled();
+  });
+
+  it("preserves an adapter failure that races an adapter change", async () => {
+    const unarchiveRequest = deferred<void>();
+    const adapterA = makeAdapter({
+      list: async () => ({
+        threads: [{ ...thread("thread-a"), status: "archived" as const }],
+      }),
+      unarchive: vi.fn(() => unarchiveRequest.promise),
+    });
+    const adapterB = makeAdapter();
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    const unarchiveTask = core.unarchive("thread-a");
+    await vi.waitFor(() => expect(adapterA.unarchive).toHaveBeenCalledOnce());
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    const failure = new Error("network error");
+    unarchiveRequest.reject(failure);
+
+    await expect(unarchiveTask).rejects.toBe(failure);
+  });
+
+  it("does not apply a late initialize to the replacement adapter state", async () => {
+    const initializeRequest = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [] }),
+      initialize: vi.fn(() => initializeRequest.promise),
+    });
+    const adapterB = makeAdapter();
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    const localId = core.newThreadId;
+    expect(localId).toBeDefined();
+    const initializeTask = core.initialize(localId!);
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    initializeRequest.resolve({
+      remoteId: "leaked",
+      externalId: "leaked",
+    });
+    await initializeTask;
+
+    expect(core.getItemById("leaked")).toBeUndefined();
+    expect(core.threadIds).not.toContain("leaked");
+    expect(core.getItemById(core.mainThreadId)?.remoteId).toBeUndefined();
+  });
+});

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -129,6 +129,14 @@ describe("RemoteThreadList adapter changes", () => {
     await expect(initializeTask).rejects.toThrow("adapter changed");
     expect(core.getItemById("leaked")).toBeUndefined();
     expect(core.threadIds).not.toContain("leaked");
+
+    await core.getLoadThreadsPromise();
+    expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
+    expect(core.getItemById(core.mainThreadId)?.remoteId).toBeUndefined();
+    await expect(core.initialize(core.mainThreadId)).resolves.toEqual({
+      remoteId: core.mainThreadId,
+      externalId: core.mainThreadId,
+    });
   });
 
   it("keeps the unsent draft runtime across an empty-list adapter swap", async () => {

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -139,6 +139,29 @@ describe("RemoteThreadList adapter changes", () => {
     });
   });
 
+  it("selects a controlled thread that arrives on the replacement page", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter({
+      list: async () => ({ threads: [thread("thread-b")] }),
+    });
+    const core = createCore(adapterA, "thread-a");
+
+    await core.getLoadThreadsPromise();
+    core.__internal_load();
+    await core.switchToThread("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+      threadId: "thread-b",
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.getItemById(core.mainThreadId)?.remoteId).toBe("thread-b");
+  });
+
   it("keeps the unsent draft runtime across an empty-list adapter swap", async () => {
     const adapterA = makeAdapter();
     const adapterB = makeAdapter();

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -195,4 +195,32 @@ describe("RemoteThreadList adapter changes", () => {
     expect(stopped).toContain("thread-a");
     expect(stopped).not.toContain(core.mainThreadId);
   });
+
+  it("does not reject when a controlled thread is missing from the replacement adapter", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter({
+      list: async () => ({ threads: [thread("thread-b")] }),
+      fetch: vi.fn(async () => {
+        throw new Error("not found");
+      }),
+    });
+    const core = createCore(adapterA, "thread-a");
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+      threadId: "thread-a",
+    });
+    await expect(core.getLoadThreadsPromise()).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(adapterB.fetch).toHaveBeenCalledWith("thread-a");
+    });
+    expect(core.getItemById("thread-a")).toBeUndefined();
+    expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
+  });
 });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -284,4 +284,69 @@ describe("RemoteThreadList adapter changes", () => {
     expect(adapterB.rename).not.toHaveBeenCalled();
     expect(core.getItemById("thread-a")).toBeUndefined();
   });
+
+  it("does not freeze mutations when the replacement list fails", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter({
+      list: vi.fn(async () => {
+        throw new Error("network");
+      }),
+    });
+    const core = createCore(adapterA);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.getItemById("thread-a")).toBeUndefined();
+    expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
+    await expect(core.switchToNewThread()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("keeps a thread initialized while the replacement list is pending", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const listB = deferred<{ threads: ReturnType<typeof thread>[] }>();
+    const adapterB = makeAdapter({
+      list: vi.fn(() => listB.promise),
+      initialize: vi.fn(async () => ({
+        remoteId: "created-on-b",
+        externalId: "created-on-b",
+      })),
+    });
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    const draftId = core.newThreadId;
+    expect(draftId).toBeDefined();
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await expect(core.initialize(draftId!)).resolves.toEqual({
+      remoteId: "created-on-b",
+      externalId: "created-on-b",
+    });
+
+    listB.resolve({ threads: [thread("thread-b")] });
+    await core.getLoadThreadsPromise();
+
+    expect(core.getItemById(draftId!)?.remoteId).toBe("created-on-b");
+    expect(core.mainThreadId).toBe(draftId);
+    expect(core.threadIds).toContain("created-on-b");
+  });
 });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -223,4 +223,34 @@ describe("RemoteThreadList adapter changes", () => {
     expect(core.getItemById("thread-a")).toBeUndefined();
     expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
   });
+
+  it("reuses the preserved unsent draft when the selected thread is missing after swap", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter({
+      list: async () => ({ threads: [thread("thread-b")] }),
+    });
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    const draftId = core.newThreadId;
+    expect(draftId).toBeDefined();
+    await core.switchToThread("thread-a");
+    expect(core.mainThreadId).toBe("thread-a");
+    expect(core.newThreadId).toBe(draftId);
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.mainThreadId).toBe(draftId);
+    expect(core.newThreadId).toBe(draftId);
+    expect(core.getItemById(draftId!)?.status).toBe("new");
+    expect(
+      Object.values(core.threadItems).filter((item) => item.status === "new"),
+    ).toHaveLength(1);
+  });
 });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -130,4 +130,69 @@ describe("RemoteThreadList adapter changes", () => {
     expect(core.getItemById("leaked")).toBeUndefined();
     expect(core.threadIds).not.toContain("leaked");
   });
+
+  it("keeps the unsent draft runtime across an empty-list adapter swap", async () => {
+    const adapterA = makeAdapter();
+    const adapterB = makeAdapter();
+    const core = createCore(adapterA);
+    const stopped: string[] = [];
+    const hookManager = (
+      core as unknown as {
+        _hookManager: { stopThreadRuntime: (id: string) => void };
+      }
+    )._hookManager;
+    const originalStop = hookManager.stopThreadRuntime.bind(hookManager);
+    hookManager.stopThreadRuntime = (id: string) => {
+      stopped.push(id);
+      originalStop(id);
+    };
+
+    await core.getLoadThreadsPromise();
+    const draftId = core.mainThreadId;
+    expect(core.getItemById(draftId)?.status).toBe("new");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.mainThreadId).toBe(draftId);
+    expect(core.getItemById(draftId)?.status).toBe("new");
+    expect(stopped).not.toContain(draftId);
+  });
+
+  it("stops runtimes for threads missing from the replacement list", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const adapterB = makeAdapter({
+      list: async () => ({ threads: [thread("thread-b")] }),
+    });
+    const core = createCore(adapterA);
+    const stopped: string[] = [];
+    const hookManager = (
+      core as unknown as {
+        _hookManager: { stopThreadRuntime: (id: string) => void };
+      }
+    )._hookManager;
+    const originalStop = hookManager.stopThreadRuntime.bind(hookManager);
+    hookManager.stopThreadRuntime = (id: string) => {
+      stopped.push(id);
+      originalStop(id);
+    };
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.getItemById("thread-a")).toBeUndefined();
+    expect(stopped).toContain("thread-a");
+    expect(stopped).not.toContain(core.mainThreadId);
+  });
 });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -32,9 +32,6 @@ describe("RemoteThreadList adapter changes", () => {
       adapter: adapterB,
       runtimeHook: () => ({}) as never,
     });
-    expect(core.mainThreadId).not.toBe("thread-a");
-    expect(core.getItemById(core.mainThreadId)?.status).toBe("new");
-    expect(core.getItemById("thread-a")).toBeUndefined();
 
     await core.getLoadThreadsPromise();
     expect(listAdapterB).toHaveBeenCalledTimes(1);
@@ -123,10 +120,8 @@ describe("RemoteThreadList adapter changes", () => {
       remoteId: "leaked",
       externalId: "leaked",
     });
-    await initializeTask;
-
+    await expect(initializeTask).rejects.toThrow("adapter changed");
     expect(core.getItemById("leaked")).toBeUndefined();
     expect(core.threadIds).not.toContain("leaked");
-    expect(core.getItemById(core.mainThreadId)?.remoteId).toBeUndefined();
   });
 });

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -23,6 +23,11 @@ describe("RemoteThreadList adapter changes", () => {
     }));
     const adapterB = makeAdapter({ list: listAdapterB });
     const core = createCore(adapterA);
+    const started: string[] = [];
+    setStartThreadRuntime(core, async (id) => {
+      started.push(id);
+      return {};
+    });
 
     await core.getLoadThreadsPromise();
     await core.switchToThread("thread-a");
@@ -38,6 +43,7 @@ describe("RemoteThreadList adapter changes", () => {
     expect(core.threadIds).toEqual(["thread-b"]);
     expect(core.getItemById("thread-a")).toBeUndefined();
     expect(core.getItemById(core.mainThreadId)?.remoteId).not.toBe("thread-a");
+    expect(started).toContain(core.mainThreadId);
 
     expect(() => core.rename("thread-a", "leaked")).toThrow(
       'Thread "thread-a" not found',

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -45,7 +45,7 @@ describe("RemoteThreadList adapter changes", () => {
     expect(core.getItemById(core.mainThreadId)?.remoteId).not.toBe("thread-a");
     expect(started).toContain(core.mainThreadId);
 
-    expect(() => core.rename("thread-a", "leaked")).toThrow(
+    await expect(core.rename("thread-a", "leaked")).rejects.toThrow(
       'Thread "thread-a" not found',
     );
     expect(adapterB.rename).not.toHaveBeenCalled();
@@ -252,5 +252,36 @@ describe("RemoteThreadList adapter changes", () => {
     expect(
       Object.values(core.threadItems).filter((item) => item.status === "new"),
     ).toHaveLength(1);
+  });
+
+  it("does not send a rename through the replacement adapter while its list is pending", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const listB = deferred<{ threads: ReturnType<typeof thread>[] }>();
+    const adapterB = makeAdapter({
+      list: vi.fn(() => listB.promise),
+    });
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    await core.switchToThread("thread-a");
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await expect(core.rename("thread-a", "leaked")).rejects.toThrow(
+      "adapter changed",
+    );
+    await expect(core.switchToThread("thread-a")).rejects.toThrow(
+      "adapter changed",
+    );
+    expect(adapterB.rename).not.toHaveBeenCalled();
+
+    listB.resolve({ threads: [thread("thread-b")] });
+    await core.getLoadThreadsPromise();
+    expect(adapterB.rename).not.toHaveBeenCalled();
+    expect(core.getItemById("thread-a")).toBeUndefined();
   });
 });

--- a/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
+++ b/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
@@ -173,6 +173,73 @@ describe("useRemoteThreadListRuntime controlled threadId", () => {
     expect(onThreadIdChange).not.toHaveBeenCalled();
   });
 
+  it("reports the reset when an adapter change makes the runtime uncontrolled", async () => {
+    const adapterA = makeAdapter();
+    const adapterB = makeAdapter();
+    const onThreadIdChange = vi.fn();
+    const runtimeRef: RuntimeRef = { current: null };
+
+    const { rerender } = render(
+      <ControlledRuntime
+        adapter={adapterA}
+        threadId="thread-a"
+        onThreadIdChange={onThreadIdChange}
+        runtimeRef={runtimeRef}
+      />,
+    );
+    await waitForRemoteThread(runtimeRef, "thread-a");
+    onThreadIdChange.mockClear();
+
+    rerender(
+      <ControlledRuntime
+        adapter={adapterB}
+        threadId={undefined}
+        onThreadIdChange={onThreadIdChange}
+        runtimeRef={runtimeRef}
+      />,
+    );
+
+    await waitFor(() => {
+      const state = runtimeRef.current!.threads.getState();
+      expect(state.mainThreadId).toBeDefined();
+      expect(runtimeRef.current!.threads.mainItem.getState().status).toBe(
+        "new",
+      );
+    });
+    expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith(undefined);
+  });
+
+  it("does not echo a controlled target when the adapter changes", async () => {
+    const adapterA = makeAdapter();
+    const adapterB = makeAdapter();
+    const onThreadIdChange = vi.fn();
+    const runtimeRef: RuntimeRef = { current: null };
+
+    const { rerender } = render(
+      <ControlledRuntime
+        adapter={adapterA}
+        threadId="thread-a"
+        onThreadIdChange={onThreadIdChange}
+        runtimeRef={runtimeRef}
+      />,
+    );
+    await waitForRemoteThread(runtimeRef, "thread-a");
+    onThreadIdChange.mockClear();
+
+    rerender(
+      <ControlledRuntime
+        adapter={adapterB}
+        threadId="thread-b"
+        onThreadIdChange={onThreadIdChange}
+        runtimeRef={runtimeRef}
+      />,
+    );
+
+    await waitForRemoteThread(runtimeRef, "thread-b");
+    expect(adapterB.fetch).toHaveBeenCalledWith("thread-b");
+    expect(onThreadIdChange).not.toHaveBeenCalled();
+  });
+
   it("still emits runtime-initiated thread switches", async () => {
     const adapter = makeAdapter();
     const onThreadIdChange = vi.fn();

--- a/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
+++ b/packages/core/src/tests/useRemoteThreadListRuntime-controlled.test.tsx
@@ -206,7 +206,7 @@ describe("useRemoteThreadListRuntime controlled threadId", () => {
         "new",
       );
     });
-    expect(onThreadIdChange).toHaveBeenCalledExactlyOnceWith(undefined);
+    expect(onThreadIdChange).not.toHaveBeenCalled();
   });
 
   it("does not echo a controlled target when the adapter changes", async () => {

--- a/packages/core/src/utils/silent-runtime-action.ts
+++ b/packages/core/src/utils/silent-runtime-action.ts
@@ -1,0 +1,6 @@
+export const SILENT_RUNTIME_ACTION = Symbol.for(
+  "assistant-ui.silent-runtime-action",
+);
+
+export const isSilentRuntimeAction = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && SILENT_RUNTIME_ACTION in error;


### PR DESCRIPTION
## summary

- replacing the adapter on `useRemoteThreadListRuntime` now resets the selected thread, cached records, and live runtimes before loading the replacement list, so later mutations cannot send the previous remote id through the new adapter
- in-flight list and mutation work from the previous adapter is isolated (`OptimisticState.reset` plus an internal generation gate). superseded operations reject without a console error
- the `RemoteThreadList` store entry still treats a recreated adapter object as a no-op. `reload()` after a different adapter instance resets selection and cache, then loads the new store

this replaces #5841, which targeted a pre-#6014 hook manager and added a public error type.

## test plan

### already verified

- [x] `vitest run` on `remote-thread-list-adapter-switch.test.ts`, `RemoteThreadListThreadListRuntimeCore-loadMore.test.ts`, `useRemoteThreadListRuntime-controlled.test.tsx`, `RemoteThreadList.test.ts` (store-entry swap+reload and recreate no-op), `optimistic-state.test.ts`, `handle-runtime-action.test.ts`, plus the existing switch/reload/unarchive/custom-metadata suites. all intended cases green. `useShallowStable is not a function` on the useAdapters subset is pre-existing without a built store dist
- [x] `pnpm lint` (0 errors)

### reviewer should verify

- [ ] switch accounts by replacing the `useRemoteThreadListRuntime` adapter. the previous thread is gone immediately, and rename/archive do not hit the new adapter with the old remote id
- [ ] on a `RemoteThreadList` store entry, recreate the adapter object without `reload()`. the list and selection stay put. then call `reload()` after a genuine adapter swap and confirm selection resets

## notes

- remounting the list (a key) remains the safe account switch. in-place reset is only for a genuine backing-store swap on a live runtime

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.W4NWdCk18NtiA9y7LddP6-mZF2wAAL-n9stywlGscRPgJRJheXnP290smJA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->