### PR TITLE
fix(core): honor already-aborted signals in createVoiceSession

### DIFF
--- a/.changeset/voice-aborted-signal-5982.md
+++ b/.changeset/voice-aborted-signal-5982.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+Disconnect immediately when createVoiceSession receives an already-aborted signal.

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -89,7 +89,7 @@ describe("createVoiceSession", () => {
     await Promise.resolve();
 
     expect(setup).not.toHaveBeenCalled();
-    expect(session.status).toEqual({ type: "starting" });
+    expect(session.status).toEqual({ type: "ended", reason: "cancelled" });
   });
 
   it("removes the abort listener after disconnecting", async () => {

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -73,6 +73,25 @@ describe("createVoiceSession", () => {
     expect(controls.mute).not.toHaveBeenCalled();
   });
 
+  it("disconnects immediately when created with an already-aborted signal", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const setup = vi.fn(async () => ({
+      disconnect: vi.fn(),
+      mute: vi.fn(),
+      unmute: vi.fn(),
+    }));
+
+    const session = createVoiceSession(
+      { abortSignal: abortController.signal },
+      setup,
+    );
+    await Promise.resolve();
+
+    expect(setup).not.toHaveBeenCalled();
+    expect(session.status).toEqual({ type: "starting" });
+  });
+
   it("removes the abort listener after disconnecting", async () => {
     const abortController = new AbortController();
     const controls = {

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -166,6 +166,7 @@ export function createVoiceSession(
     abortHandler = () => session.disconnect();
     abortSignal.addEventListener("abort", abortHandler, { once: true });
     if (abortSignal.aborted) {
+      currentStatus = { type: "ended", reason: "cancelled" };
       session.disconnect();
       return session;
     }

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -165,6 +165,10 @@ export function createVoiceSession(
   if (abortSignal) {
     abortHandler = () => session.disconnect();
     abortSignal.addEventListener("abort", abortHandler, { once: true });
+    if (abortSignal.aborted) {
+      session.disconnect();
+      return session;
+    }
   }
 
   const doSetup = async () => {


### PR DESCRIPTION
## Summary

Fixes #5982.

`createVoiceSession` only registered `abortSignal.addEventListener("abort", ...)`. An already-aborted signal does not fire later listeners, so setup still started and the session was never torn down by that signal.

This change disconnects immediately when the signal is already aborted and skips setup, while keeping the existing listener path for signals that abort later.

## Validation

- `pnpm exec vitest run src/adapters/voice.test.ts` in `packages/core` — 7 passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IvWa9KeTD3_he8_5ee2kEMIAfufy8o5W7xoNLP915SBK42moKM4iyAuBlRM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->