### PR TITLE
fix(react-lexical): reparse drafts when directive formatters register

### DIFF
--- a/.changeset/lexical-reparse-formatter-drafts.md
+++ b/.changeset/lexical-reparse-formatter-drafts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: reparse an unedited composer draft when directive formatters register

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -9,6 +9,7 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   $isTextNode,
   $setCompositionKey,
@@ -38,15 +39,18 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 const createAui = (text: string) => {
+  let current = text;
   const runtime = {
-    getState: () => ({ text }),
+    getState: () => ({ text: current }),
     subscribe: () => () => {},
   };
 
   return {
     composer: {
       __internal_getRuntime: () => runtime,
-      setText: vi.fn(),
+      setText: vi.fn((next: string) => {
+        current = next;
+      }),
     },
   };
 };
@@ -218,7 +222,7 @@ describe("SyncPlugin", () => {
         </LexicalComposer>,
       );
 
-    mocks.aui = createAui("[[alice]]");
+    mocks.aui = createAui("hello [[alice]] world");
     await act(async () => {
       render(false);
     });
@@ -226,21 +230,35 @@ describe("SyncPlugin", () => {
       editor.update(() => {
         const textNode = $getParagraph().getFirstChild();
         if (!$isTextNode(textNode)) throw new Error("Expected text");
-        textNode.select(2, 2);
+        textNode.select(3, 3);
       });
     });
-    expect(
-      editor.getEditorState().read(() => $isRangeSelection($getSelection())),
-    ).toBe(true);
 
     await act(async () => {
       render(true);
     });
     expect(
-      editor
-        .getEditorState()
-        .read(() => $isDirectiveNode($getParagraph().getFirstChild())),
-    ).toBe(true);
+      editor.getEditorState().read(() => {
+        const children = $getParagraph().getChildren();
+        return [
+          $isTextNode(children[0]) ? children[0].getTextContent() : null,
+          $isDirectiveNode(children[1]),
+          $isTextNode(children[2]) ? children[2].getTextContent() : null,
+        ];
+      }),
+    ).toEqual(["hello ", true, " world"]);
+    expect(
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return null;
+        }
+        const node = selection.anchor.getNode();
+        return $isTextNode(node)
+          ? [node.getTextContent(), selection.anchor.offset]
+          : null;
+      }),
+    ).toEqual(["hello ", 3]);
   });
 
   it("does not reparse text the user edited before a formatter registers", async () => {
@@ -281,6 +299,7 @@ describe("SyncPlugin", () => {
     await act(async () => {
       render(true);
     });
+    expect(readEditorText(editor)).toBe("[[alice]]");
     expect(
       editor
         .getEditorState()
@@ -329,6 +348,17 @@ describe("SyncPlugin", () => {
         .getEditorState()
         .read(() => $isTextNode($getParagraph().getFirstChild())),
     ).toBe(true);
+
+    await act(async () => {
+      editor.update(() => {
+        $setCompositionKey(null);
+      });
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isDirectiveNode($getParagraph().getFirstChild())),
+    ).toBe(true);
   });
 
   it("keeps chips when the formatter that created them is removed", async () => {
@@ -371,6 +401,62 @@ describe("SyncPlugin", () => {
         return node.getKey();
       }),
     ).toBe(before);
+  });
+
+  it("keeps mixed-format chips when one formatter is removed", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-mixed-remove-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]\n:user[bob]");
+    await act(async () => {
+      render(true);
+    });
+    const before = editor.getEditorState().read(() => {
+      const [first, second] = $getRoot().getChildren();
+      if (!$isElementNode(first) || !$isElementNode(second)) {
+        throw new Error("Expected two paragraphs");
+      }
+      const alice = first.getFirstChild();
+      const bob = second.getFirstChild();
+      if (!$isDirectiveNode(alice) || !$isDirectiveNode(bob)) {
+        throw new Error("Expected mixed-format chips");
+      }
+      return { alice: alice.getKey(), bob: bob.getKey() };
+    });
+
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const [first, second] = $getRoot().getChildren();
+        if (!$isElementNode(first) || !$isElementNode(second)) {
+          throw new Error("Expected two paragraphs");
+        }
+        const alice = first.getFirstChild();
+        const bob = second.getFirstChild();
+        if (!$isDirectiveNode(alice) || !$isDirectiveNode(bob)) {
+          throw new Error("Expected chips to remain");
+        }
+        return { alice: alice.getKey(), bob: bob.getKey() };
+      }),
+    ).toEqual(before);
   });
 
   it("keeps hydrated metadata when a formatter only changes the label", async () => {

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -459,6 +459,62 @@ describe("SyncPlugin", () => {
     ).toEqual(before);
   });
 
+  it("keeps same-key chips when a formatter would drop one occurrence", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-same-key-remove-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]\n:user[alice]");
+    await act(async () => {
+      render(true);
+    });
+    const before = editor.getEditorState().read(() => {
+      const [first, second] = $getRoot().getChildren();
+      if (!$isElementNode(first) || !$isElementNode(second)) {
+        throw new Error("Expected two paragraphs");
+      }
+      const firstChip = first.getFirstChild();
+      const secondChip = second.getFirstChild();
+      if (!$isDirectiveNode(firstChip) || !$isDirectiveNode(secondChip)) {
+        throw new Error("Expected same-key chips");
+      }
+      return { first: firstChip.getKey(), second: secondChip.getKey() };
+    });
+
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const [first, second] = $getRoot().getChildren();
+        if (!$isElementNode(first) || !$isElementNode(second)) {
+          throw new Error("Expected two paragraphs");
+        }
+        const firstChip = first.getFirstChild();
+        const secondChip = second.getFirstChild();
+        if (!$isDirectiveNode(firstChip) || !$isDirectiveNode(secondChip)) {
+          throw new Error("Expected chips to remain");
+        }
+        return { first: firstChip.getKey(), second: secondChip.getKey() };
+      }),
+    ).toEqual(before);
+  });
+
   it("keeps hydrated metadata when a formatter only changes the label", async () => {
     const initialConfig = {
       namespace: "sync-plugin-metadata-test",

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -5,8 +5,22 @@ import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $getRoot, type LexicalEditor } from "lexical";
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  $setCompositionKey,
+  type LexicalEditor,
+} from "lexical";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Unstable_DirectiveFormatter } from "@assistant-ui/core";
+import {
+  $createDirectiveNode,
+  $isDirectiveNode,
+  DirectiveNode,
+} from "../nodes/DirectiveNode";
 import { SyncPlugin } from "./SyncPlugin";
 
 const mocks = vi.hoisted(() => ({
@@ -39,6 +53,44 @@ const createAui = (text: string) => {
 
 const readEditorText = (editor: LexicalEditor) =>
   editor.getEditorState().read(() => $getRoot().getTextContent());
+
+const $getParagraph = () => {
+  const paragraph = $getRoot().getFirstChild();
+  if (paragraph === null) throw new Error("Expected a paragraph");
+  return paragraph;
+};
+
+const createBracketFormatter = (
+  labelForId: (id: string) => string = (id) => id,
+): Unstable_DirectiveFormatter => ({
+  serialize: (item) => `[[${item.id}]]`,
+  parse: (text) => {
+    const segments: ReturnType<Unstable_DirectiveFormatter["parse"]>[number][] =
+      [];
+    const pattern = /\[\[([^\]]+)\]\]/g;
+    let lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      if (match.index > lastIndex) {
+        segments.push({
+          kind: "text",
+          text: text.slice(lastIndex, match.index),
+        });
+      }
+      const id = match[1]!;
+      segments.push({
+        kind: "mention",
+        type: "user",
+        id,
+        label: labelForId(id),
+      });
+      lastIndex = match.index + match[0].length;
+    }
+    if (lastIndex < text.length) {
+      segments.push({ kind: "text", text: text.slice(lastIndex) });
+    }
+    return segments;
+  },
+});
 
 function EditorProbe({
   capture,
@@ -103,5 +155,279 @@ describe("SyncPlugin", () => {
     });
 
     expect(readEditorText(editor)).toBe("");
+  });
+
+  it("reparses a restored draft when a formatter registers", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-formatter-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isTextNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isDirectiveNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+    expect(mocks.aui.composer.setText).not.toHaveBeenCalled();
+  });
+
+  it("still reparses after the caret moves", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-selection-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const textNode = $getParagraph().getFirstChild();
+        if (!$isTextNode(textNode)) throw new Error("Expected text");
+        textNode.select(2, 2);
+      });
+    });
+    expect(
+      editor.getEditorState().read(() => $isRangeSelection($getSelection())),
+    ).toBe(true);
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isDirectiveNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+  });
+
+  it("does not reparse text the user edited before a formatter registers", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-edit-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("hello");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const paragraph = $getParagraph();
+        const textNode = $createTextNode("[[alice]]");
+        paragraph.clear();
+        paragraph.append(textNode);
+        textNode.selectEnd();
+      });
+    });
+    expect(mocks.aui.composer.setText).toHaveBeenLastCalledWith("[[alice]]");
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isTextNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+  });
+
+  it("does not reparse while the editor is composing", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-compose-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(false);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const textNode = $getParagraph().getFirstChild();
+        if (!$isTextNode(textNode)) throw new Error("Expected text");
+        $setCompositionKey(textNode.getKey());
+      });
+    });
+    expect(editor.isComposing()).toBe(true);
+
+    await act(async () => {
+      render(true);
+    });
+    expect(
+      editor
+        .getEditorState()
+        .read(() => $isTextNode($getParagraph().getFirstChild())),
+    ).toBe(true);
+  });
+
+  it("keeps chips when the formatter that created them is removed", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-remove-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const formatter = createBracketFormatter();
+    const render = (registered: boolean) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={registered ? formatter : undefined} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render(true);
+    });
+    const before = editor.getEditorState().read(() => {
+      const node = $getParagraph().getFirstChild();
+      if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+      return node.getKey();
+    });
+
+    await act(async () => {
+      render(false);
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const node = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+        return node.getKey();
+      }),
+    ).toBe(before);
+  });
+
+  it("keeps hydrated metadata when a formatter only changes the label", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-metadata-test",
+      nodes: [DirectiveNode],
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const render = (labelForId: (id: string) => string) =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin formatter={createBracketFormatter(labelForId)} />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("[[alice]]");
+    await act(async () => {
+      render((id) => id);
+    });
+    await act(async () => {
+      editor.update(() => {
+        const node = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+        node.replace(
+          $createDirectiveNode(
+            {
+              ...node.getDirectiveItem(),
+              description: "Project owner",
+              metadata: { workspace: "acme" },
+            },
+            node.getDirectiveText(),
+          ),
+        );
+      });
+    });
+
+    await act(async () => {
+      render(() => "Alice");
+    });
+    expect(
+      editor.getEditorState().read(() => {
+        const node = $getParagraph().getFirstChild();
+        if (!$isDirectiveNode(node)) throw new Error("Expected a directive");
+        return node.getDirectiveItem();
+      }),
+    ).toEqual({
+      id: "alice",
+      type: "user",
+      label: "Alice",
+      description: "Project owner",
+      metadata: { workspace: "acme" },
+    });
   });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -150,31 +150,38 @@ function getEditorLines(editor: LexicalEditor): SegmentKey[][] | undefined {
   });
 }
 
-function collectEditorDirectiveKeys(editor: LexicalEditor) {
+function incrementCount(counts: Map<string, number>, key: string) {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+}
+
+function collectEditorDirectiveCounts(editor: LexicalEditor) {
   return editor.getEditorState().read(() => {
-    const keys = new Set<string>();
+    const counts = new Map<string, number>();
     for (const paragraph of $getRoot().getChildren()) {
       if (!$isElementNode(paragraph)) continue;
       for (const child of paragraph.getChildren()) {
         if (!$isDirectiveNode(child)) continue;
         const item = child.getDirectiveItem();
-        keys.add(directiveKey(item.id, item.type));
+        incrementCount(counts, directiveKey(item.id, item.type));
       }
     }
-    return keys;
+    return counts;
   });
 }
 
-function collectParsedMentionKeys(runtimeText: string, parse: CompositeParser) {
-  const keys = new Set<string>();
+function collectParsedMentionCounts(
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  const counts = new Map<string, number>();
   for (const line of getParsedLines(runtimeText, parse)) {
     for (const segment of line) {
       if (segment[0] === "mention") {
-        keys.add(directiveKey(segment[1], segment[2]));
+        incrementCount(counts, directiveKey(segment[1], segment[2]));
       }
     }
   }
-  return keys;
+  return counts;
 }
 
 function editorMatchesParser(
@@ -197,9 +204,9 @@ function shouldRebuildForParser(
 ) {
   if (getEditorLines(editor) === undefined) return false;
   if (editorMatchesParser(editor, runtimeText, parse)) return false;
-  const parsedKeys = collectParsedMentionKeys(runtimeText, parse);
-  for (const key of collectEditorDirectiveKeys(editor)) {
-    if (!parsedKeys.has(key)) return false;
+  const parsedCounts = collectParsedMentionCounts(runtimeText, parse);
+  for (const [key, count] of collectEditorDirectiveCounts(editor)) {
+    if ((parsedCounts.get(key) ?? 0) < count) return false;
   }
   return true;
 }
@@ -538,6 +545,10 @@ export function SyncPlugin({
       }
       if (editor.isComposing()) return;
       const runtimeText = lastSyncedTextRef.current;
+      if (editorMatchesParser(editor, runtimeText, parser)) {
+        lastAppliedParserRef.current = parser;
+        return;
+      }
       if (!shouldRebuildForParser(editor, runtimeText, parser)) return;
       applyRuntimeText(runtimeText, lastAppliedParserRef.current);
     };

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -13,19 +13,26 @@ import {
   $createTextNode,
   $createParagraphNode,
   $isElementNode,
+  $isLineBreakNode,
+  $isTextNode,
+  SKIP_DOM_SELECTION_TAG,
   type LexicalEditor,
 } from "lexical";
 import { useAui } from "@assistant-ui/store";
 import type {
   Unstable_DirectiveFormatter,
   Unstable_DirectiveSegment,
+  Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
 import {
   unstable_useTriggerPopoverRootContextOptional,
   type Unstable_RegisteredTrigger,
 } from "@assistant-ui/react";
-import { $createDirectiveNodeWithFormatter } from "../nodes/DirectiveNode";
+import {
+  $createDirectiveNodeWithFormatter,
+  $isDirectiveNode,
+} from "../nodes/DirectiveNode";
 
 type ParsedSegment = {
   readonly segment: Unstable_DirectiveSegment;
@@ -33,6 +40,17 @@ type ParsedSegment = {
 };
 
 type CompositeParser = (text: string) => readonly ParsedSegment[];
+
+type SegmentKey =
+  | readonly ["text", string]
+  | readonly ["mention", string, string, string];
+
+type PreservedDirective = Pick<
+  Unstable_TriggerItem,
+  "description" | "metadata"
+> & {
+  readonly label?: string;
+};
 
 /** Ordered, identity-deduped: prop formatter, trigger formatters, default tail. */
 export function collectFormatters(
@@ -74,20 +92,172 @@ export function composeParsers(
   };
 }
 
+const directiveKey = (id: string, type: string) => `${type}\0${id}`;
+
+function appendTextSegment(segments: SegmentKey[], text: string) {
+  if (text.length === 0) return;
+  const previous = segments.at(-1);
+  if (previous?.[0] === "text") {
+    segments[segments.length - 1] = ["text", previous[1] + text];
+  } else {
+    segments.push(["text", text]);
+  }
+}
+
+function getParsedLines(
+  runtimeText: string,
+  parse: CompositeParser,
+): SegmentKey[][] {
+  return runtimeText.split("\n").map((line) => {
+    const segments: SegmentKey[] = [];
+    for (const { segment } of parse(line)) {
+      if (segment.kind === "text") {
+        appendTextSegment(segments, segment.text);
+      } else {
+        segments.push(["mention", segment.id, segment.type, segment.label]);
+      }
+    }
+    return segments;
+  });
+}
+
+function countParsedMentions(runtimeText: string, parse: CompositeParser) {
+  return getParsedLines(runtimeText, parse).reduce(
+    (count, line) =>
+      count + line.filter((segment) => segment[0] === "mention").length,
+    0,
+  );
+}
+
+function getEditorLines(editor: LexicalEditor): SegmentKey[][] | undefined {
+  return editor.getEditorState().read(() => {
+    const lines: SegmentKey[][] = [];
+    for (const paragraph of $getRoot().getChildren()) {
+      if (!$isElementNode(paragraph)) return undefined;
+      let segments: SegmentKey[] = [];
+      for (const child of paragraph.getChildren()) {
+        if ($isLineBreakNode(child)) {
+          lines.push(segments);
+          segments = [];
+        } else if ($isTextNode(child)) {
+          appendTextSegment(segments, child.getTextContent());
+        } else if ($isDirectiveNode(child)) {
+          const item = child.getDirectiveItem();
+          segments.push(["mention", item.id, item.type, item.label]);
+        } else {
+          return undefined;
+        }
+      }
+      lines.push(segments);
+    }
+    return lines;
+  });
+}
+
+function countEditorDirectives(editor: LexicalEditor) {
+  return editor.getEditorState().read(() => {
+    let count = 0;
+    for (const paragraph of $getRoot().getChildren()) {
+      if (!$isElementNode(paragraph)) continue;
+      for (const child of paragraph.getChildren()) {
+        if ($isDirectiveNode(child)) count += 1;
+      }
+    }
+    return count;
+  });
+}
+
+function editorMatchesParser(
+  editor: LexicalEditor,
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  const editorLines = getEditorLines(editor);
+  if (editorLines === undefined) return false;
+  return (
+    JSON.stringify(editorLines) ===
+    JSON.stringify(getParsedLines(runtimeText, parse))
+  );
+}
+
+function shouldRebuildForParser(
+  editor: LexicalEditor,
+  runtimeText: string,
+  parse: CompositeParser,
+) {
+  if (editorMatchesParser(editor, runtimeText, parse)) return false;
+  if (
+    countEditorDirectives(editor) > 0 &&
+    countParsedMentions(runtimeText, parse) === 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function parsedLabelQueues(runtimeText: string, parse: CompositeParser) {
+  const queues = new Map<string, string[]>();
+  for (const line of runtimeText.split("\n")) {
+    for (const { segment } of parse(line)) {
+      if (segment.kind !== "mention") continue;
+      const key = directiveKey(segment.id, segment.type);
+      const labels = queues.get(key) ?? [];
+      labels.push(segment.label);
+      queues.set(key, labels);
+    }
+  }
+  return queues;
+}
+
+function collectPreservedDirectives(
+  runtimeText: string,
+  previousParse: CompositeParser,
+  nextParse: CompositeParser,
+) {
+  const previousLabels = parsedLabelQueues(runtimeText, previousParse);
+  const nextLabels = parsedLabelQueues(runtimeText, nextParse);
+  const preserved = new Map<string, PreservedDirective[]>();
+  for (const paragraph of $getRoot().getChildren()) {
+    if (!$isElementNode(paragraph)) continue;
+    for (const child of paragraph.getChildren()) {
+      if (!$isDirectiveNode(child)) continue;
+      const item = child.getDirectiveItem();
+      const key = directiveKey(item.id, item.type);
+      const previousLabel = previousLabels.get(key)?.shift();
+      const nextLabel = nextLabels.get(key)?.shift();
+      const items = preserved.get(key) ?? [];
+      items.push({
+        description: item.description,
+        metadata: item.metadata,
+        ...(previousLabel !== undefined && previousLabel === nextLabel
+          ? { label: item.label }
+          : {}),
+      });
+      preserved.set(key, items);
+    }
+  }
+  return preserved;
+}
+
 function syncRuntimeToLexical(
   editor: LexicalEditor,
   runtimeText: string,
   parse: CompositeParser,
+  previousParser: CompositeParser | undefined,
   onComplete: () => void,
 ) {
+  const parserOnly = previousParser !== undefined;
   editor.update(
     () => {
       const root = $getRoot();
+      const preserved = parserOnly
+        ? collectPreservedDirectives(runtimeText, previousParser, parse)
+        : undefined;
       root.clear();
 
       if (runtimeText.length === 0) {
         root.append($createParagraphNode());
-        root.selectEnd();
+        if (!parserOnly) root.selectEnd();
         return;
       }
 
@@ -102,12 +272,21 @@ function syncRuntimeToLexical(
               paragraph.append($createTextNode(segment.text));
             }
           } else {
+            const extra = preserved
+              ?.get(directiveKey(segment.id, segment.type))
+              ?.shift();
             paragraph.append(
               $createDirectiveNodeWithFormatter(
                 {
                   id: segment.id,
                   type: segment.type,
-                  label: segment.label,
+                  label: extra?.label ?? segment.label,
+                  ...(extra?.description !== undefined
+                    ? { description: extra.description }
+                    : {}),
+                  ...(extra?.metadata !== undefined
+                    ? { metadata: extra.metadata }
+                    : {}),
                 },
                 formatter,
               ),
@@ -118,9 +297,12 @@ function syncRuntimeToLexical(
         root.append(paragraph);
       }
 
-      root.selectEnd();
+      if (!parserOnly) root.selectEnd();
     },
-    { onUpdate: onComplete, tag: SYNC_TAG },
+    {
+      onUpdate: onComplete,
+      tag: parserOnly ? [SYNC_TAG, SKIP_DOM_SELECTION_TAG] : SYNC_TAG,
+    },
   );
 }
 
@@ -152,18 +334,26 @@ export function SyncPlugin({
 
   const triggers = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
+  const propParse = propFormatter?.parse;
+  const propSerialize = propFormatter?.serialize;
   const formatters = useMemo(
-    () => collectFormatters(triggers, propFormatter),
-    [triggers, propFormatter],
+    () =>
+      collectFormatters(
+        triggers,
+        propParse && propSerialize
+          ? { parse: propParse, serialize: propSerialize }
+          : undefined,
+      ),
+    [triggers, propParse, propSerialize],
   );
 
   const parser = useMemo(() => composeParsers(formatters), [formatters]);
-  const parserRef = useRef<CompositeParser>(parser);
-  parserRef.current = parser;
 
   const isSyncingFromLexicalRef = useRef(false);
   const isSyncingFromRuntimeRef = useRef(false);
+  const textDirtySinceSyncRef = useRef(false);
   const lastSyncedTextRef = useRef("");
+  const lastAppliedParserRef = useRef(parser);
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
@@ -190,6 +380,7 @@ export function SyncPlugin({
           const composer = aui.composer;
 
           if (fullText !== lastSyncedTextRef.current) {
+            textDirtySinceSyncRef.current = true;
             lastSyncedTextRef.current = fullText;
             composer.setText(fullText);
           }
@@ -204,13 +395,35 @@ export function SyncPlugin({
     const composerRuntime = aui.composer.__internal_getRuntime?.();
     if (!composerRuntime) return;
 
-    const initialText = composerRuntime.getState().text;
-    if (initialText !== lastSyncedTextRef.current) {
+    const applyRuntimeText = (
+      runtimeText: string,
+      previousParser: CompositeParser | undefined,
+    ) => {
       isSyncingFromRuntimeRef.current = true;
-      lastSyncedTextRef.current = initialText;
-      syncRuntimeToLexical(editor, initialText, parserRef.current, () => {
+      lastSyncedTextRef.current = runtimeText;
+      lastAppliedParserRef.current = parser;
+      textDirtySinceSyncRef.current = false;
+      syncRuntimeToLexical(editor, runtimeText, parser, previousParser, () => {
         isSyncingFromRuntimeRef.current = false;
       });
+    };
+
+    const initialText = composerRuntime.getState().text;
+    const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
+    const parserChanged = parser !== lastAppliedParserRef.current;
+
+    if (runtimeTextChanged) {
+      applyRuntimeText(initialText, undefined);
+    } else if (parserChanged) {
+      const previousParser = lastAppliedParserRef.current;
+      lastAppliedParserRef.current = parser;
+      if (
+        !textDirtySinceSyncRef.current &&
+        !editor.isComposing() &&
+        shouldRebuildForParser(editor, initialText, parser)
+      ) {
+        applyRuntimeText(initialText, previousParser);
+      }
     }
 
     return composerRuntime.subscribe(() => {
@@ -220,13 +433,9 @@ export function SyncPlugin({
 
       if (runtimeText === lastSyncedTextRef.current) return;
 
-      isSyncingFromRuntimeRef.current = true;
-      lastSyncedTextRef.current = runtimeText;
-      syncRuntimeToLexical(editor, runtimeText, parserRef.current, () => {
-        isSyncingFromRuntimeRef.current = false;
-      });
+      applyRuntimeText(runtimeText, undefined);
     });
-  }, [editor, aui]);
+  }, [editor, aui, parser]);
 
   return null;
 }

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -10,13 +10,17 @@ import {
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
   $getRoot,
+  $getSelection,
   $createTextNode,
   $createParagraphNode,
   $isElementNode,
   $isLineBreakNode,
+  $isRangeSelection,
   $isTextNode,
+  HISTORY_MERGE_TAG,
   SKIP_DOM_SELECTION_TAG,
   type LexicalEditor,
+  type LexicalNode,
 } from "lexical";
 import { useAui } from "@assistant-ui/store";
 import type {
@@ -58,10 +62,10 @@ export function collectFormatters(
   propFormatter: Unstable_DirectiveFormatter | undefined,
 ): readonly Unstable_DirectiveFormatter[] {
   const ordered: Unstable_DirectiveFormatter[] = [];
-  const seen = new Set<Unstable_DirectiveFormatter>();
+  const seen = new Set<Unstable_DirectiveFormatter["parse"]>();
   const push = (f: Unstable_DirectiveFormatter | undefined) => {
-    if (!f || seen.has(f)) return;
-    seen.add(f);
+    if (!f || seen.has(f.parse)) return;
+    seen.add(f.parse);
     ordered.push(f);
   };
   push(propFormatter);
@@ -121,14 +125,6 @@ function getParsedLines(
   });
 }
 
-function countParsedMentions(runtimeText: string, parse: CompositeParser) {
-  return getParsedLines(runtimeText, parse).reduce(
-    (count, line) =>
-      count + line.filter((segment) => segment[0] === "mention").length,
-    0,
-  );
-}
-
 function getEditorLines(editor: LexicalEditor): SegmentKey[][] | undefined {
   return editor.getEditorState().read(() => {
     const lines: SegmentKey[][] = [];
@@ -154,17 +150,31 @@ function getEditorLines(editor: LexicalEditor): SegmentKey[][] | undefined {
   });
 }
 
-function countEditorDirectives(editor: LexicalEditor) {
+function collectEditorDirectiveKeys(editor: LexicalEditor) {
   return editor.getEditorState().read(() => {
-    let count = 0;
+    const keys = new Set<string>();
     for (const paragraph of $getRoot().getChildren()) {
       if (!$isElementNode(paragraph)) continue;
       for (const child of paragraph.getChildren()) {
-        if ($isDirectiveNode(child)) count += 1;
+        if (!$isDirectiveNode(child)) continue;
+        const item = child.getDirectiveItem();
+        keys.add(directiveKey(item.id, item.type));
       }
     }
-    return count;
+    return keys;
   });
+}
+
+function collectParsedMentionKeys(runtimeText: string, parse: CompositeParser) {
+  const keys = new Set<string>();
+  for (const line of getParsedLines(runtimeText, parse)) {
+    for (const segment of line) {
+      if (segment[0] === "mention") {
+        keys.add(directiveKey(segment[1], segment[2]));
+      }
+    }
+  }
+  return keys;
 }
 
 function editorMatchesParser(
@@ -185,14 +195,120 @@ function shouldRebuildForParser(
   runtimeText: string,
   parse: CompositeParser,
 ) {
+  if (getEditorLines(editor) === undefined) return false;
   if (editorMatchesParser(editor, runtimeText, parse)) return false;
-  if (
-    countEditorDirectives(editor) > 0 &&
-    countParsedMentions(runtimeText, parse) === 0
-  ) {
-    return false;
+  const parsedKeys = collectParsedMentionKeys(runtimeText, parse);
+  for (const key of collectEditorDirectiveKeys(editor)) {
+    if (!parsedKeys.has(key)) return false;
   }
   return true;
+}
+
+function $getCollapsedRuntimeOffset(): number | undefined {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+    return undefined;
+  }
+  const anchor = selection.anchor;
+  let offset = 0;
+  const paragraphs = $getRoot().getChildren();
+  for (let i = 0; i < paragraphs.length; i++) {
+    const paragraph = paragraphs[i];
+    if (!$isElementNode(paragraph)) continue;
+    if (anchor.type === "element" && anchor.key === paragraph.getKey()) {
+      const children = paragraph.getChildren();
+      const childIndex = Math.min(anchor.offset, children.length);
+      for (let c = 0; c < childIndex; c++) {
+        offset += children[c]!.getTextContent().length;
+      }
+      return offset;
+    }
+    for (const child of paragraph.getChildren()) {
+      if (anchor.key === child.getKey()) {
+        return offset + (anchor.type === "text" ? anchor.offset : 0);
+      }
+      offset += child.getTextContent().length;
+    }
+    if (i < paragraphs.length - 1) offset += 1;
+  }
+  return undefined;
+}
+
+function $selectAtChild(parent: LexicalNode, index: number) {
+  if (!$isElementNode(parent)) return;
+  parent.select(index, index);
+}
+
+function $selectRuntimeOffset(offset: number) {
+  let remaining = offset;
+  const paragraphs = $getRoot().getChildren();
+  for (let i = 0; i < paragraphs.length; i++) {
+    const paragraph = paragraphs[i];
+    if (!$isElementNode(paragraph)) continue;
+    const children = paragraph.getChildren();
+    if (children.length === 0 && remaining === 0) {
+      paragraph.select(0, 0);
+      return;
+    }
+    for (const child of children) {
+      const length = child.getTextContent().length;
+      if ($isDirectiveNode(child)) {
+        if (remaining === 0) {
+          $selectAtChild(paragraph, child.getIndexWithinParent());
+          return;
+        }
+        if (remaining < length) {
+          const index = child.getIndexWithinParent();
+          $selectAtChild(
+            paragraph,
+            remaining * 2 <= length ? index : index + 1,
+          );
+          return;
+        }
+        remaining -= length;
+        continue;
+      }
+      if ($isTextNode(child)) {
+        if (remaining <= length) {
+          child.select(remaining, remaining);
+          return;
+        }
+        remaining -= length;
+        continue;
+      }
+      if (remaining < length) {
+        $selectAtChild(paragraph, child.getIndexWithinParent());
+        return;
+      }
+      remaining -= length;
+    }
+    if (i < paragraphs.length - 1) {
+      if (remaining === 0) {
+        paragraph.selectEnd();
+        return;
+      }
+      remaining -= 1;
+    } else if (remaining === 0) {
+      paragraph.selectEnd();
+      return;
+    }
+  }
+  $getRoot().selectEnd();
+}
+
+function isEditorFocused(editor: LexicalEditor) {
+  const rootElement = editor.getRootElement();
+  if (rootElement === null) return false;
+  const active = document.activeElement;
+  return (
+    active !== null && (active === rootElement || rootElement.contains(active))
+  );
+}
+
+function parserOnlyTags(editor: LexicalEditor) {
+  const tags = [SYNC_TAG, HISTORY_MERGE_TAG];
+  if (!isEditorFocused(editor)) tags.push(SKIP_DOM_SELECTION_TAG);
+  return tags;
 }
 
 function parsedLabelQueues(runtimeText: string, parse: CompositeParser) {
@@ -253,11 +369,13 @@ function syncRuntimeToLexical(
       const preserved = parserOnly
         ? collectPreservedDirectives(runtimeText, previousParser, parse)
         : undefined;
+      const caretOffset = parserOnly ? $getCollapsedRuntimeOffset() : undefined;
       root.clear();
 
       if (runtimeText.length === 0) {
         root.append($createParagraphNode());
         if (!parserOnly) root.selectEnd();
+        else if (caretOffset !== undefined) $selectRuntimeOffset(caretOffset);
         return;
       }
 
@@ -298,10 +416,11 @@ function syncRuntimeToLexical(
       }
 
       if (!parserOnly) root.selectEnd();
+      else if (caretOffset !== undefined) $selectRuntimeOffset(caretOffset);
     },
     {
       onUpdate: onComplete,
-      tag: parserOnly ? [SYNC_TAG, SKIP_DOM_SELECTION_TAG] : SYNC_TAG,
+      tag: parserOnly ? parserOnlyTags(editor) : SYNC_TAG,
     },
   );
 }
@@ -354,6 +473,7 @@ export function SyncPlugin({
   const textDirtySinceSyncRef = useRef(false);
   const lastSyncedTextRef = useRef("");
   const lastAppliedParserRef = useRef(parser);
+  const applyPendingParserRef = useRef(() => {});
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
@@ -388,6 +508,8 @@ export function SyncPlugin({
           isSyncingFromLexicalRef.current = false;
         }
       });
+
+      if (!editor.isComposing()) applyPendingParserRef.current();
     });
   }, [editor, aui]);
 
@@ -408,22 +530,27 @@ export function SyncPlugin({
       });
     };
 
+    const tryApplyParserChange = () => {
+      if (parser === lastAppliedParserRef.current) return;
+      if (textDirtySinceSyncRef.current) {
+        lastAppliedParserRef.current = parser;
+        return;
+      }
+      if (editor.isComposing()) return;
+      const runtimeText = lastSyncedTextRef.current;
+      if (!shouldRebuildForParser(editor, runtimeText, parser)) return;
+      applyRuntimeText(runtimeText, lastAppliedParserRef.current);
+    };
+
     const initialText = composerRuntime.getState().text;
     const runtimeTextChanged = initialText !== lastSyncedTextRef.current;
-    const parserChanged = parser !== lastAppliedParserRef.current;
+
+    applyPendingParserRef.current = tryApplyParserChange;
 
     if (runtimeTextChanged) {
       applyRuntimeText(initialText, undefined);
-    } else if (parserChanged) {
-      const previousParser = lastAppliedParserRef.current;
-      lastAppliedParserRef.current = parser;
-      if (
-        !textDirtySinceSyncRef.current &&
-        !editor.isComposing() &&
-        shouldRebuildForParser(editor, initialText, parser)
-      ) {
-        applyRuntimeText(initialText, previousParser);
-      }
+    } else {
+      tryApplyParserChange();
     }
 
     return composerRuntime.subscribe(() => {


### PR DESCRIPTION
## summary

- an unedited restored draft such as `[[alice]]` is reparsed into a directive chip when a formatter registers after mount
- caret movement and focus do not count as edits, so late registration still upgrades the draft
- chips are not demoted when that formatter is removed; hydrated description and metadata are kept when only the parsed label changes

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-lexical test` -> 43/43 green
- [x] `oxlint` and `oxfmt --check` on `SyncPlugin.tsx` and `SyncPlugin.test.tsx` -> clean

### reviewer should verify

- [ ] mount a composer with a restored `[[mention]]` draft, click into it, then register the mention formatter, and confirm the text becomes a chip without the caret jumping

## notes

supersedes #5776. that head is 232 behind main and treats any selection change as an edit, so focusing the composer before the formatter registers leaves the draft as plain text.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KWA5SoPcg8u4odohVtOOlhoM8gDD0DMQtgeM3Jn1CdjiT5_cPVICq8Fq284?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->