### PR TITLE
fix(core): prevent late history writes from restoring deleted threads

### DIFF
--- a/.changeset/prevent-deleted-local-thread-restores.md
+++ b/.changeset/prevent-deleted-local-thread-restores.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: prevent late history writes from restoring deleted local threads

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AsyncStorageLike } from "./LocalStorageThreadListAdapter";
+
+const mocks = vi.hoisted(() => ({
+  aui: undefined as unknown,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => mocks.aui,
+}));
+
+import { createLocalStorageAdapter } from "./LocalStorageThreadListAdapter";
+
+const storedMessage = {
+  id: "message-1",
+  role: "user" as const,
+  content: [],
+  attachments: [],
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  metadata: { custom: {} },
+};
+
+describe("createLocalStorageAdapter history races", () => {
+  it("does not restore a thread from a history append during deletion", async () => {
+    const threadsKey = "@assistant-ui:threads";
+    const messagesKey = "@assistant-ui:messages:thread-1";
+    const values = new Map<string, string>([
+      [
+        threadsKey,
+        JSON.stringify([{ remoteId: "thread-1", status: "regular" }]),
+      ],
+      [messagesKey, JSON.stringify({ messages: [] })],
+    ]);
+    let markMetadataDeleted!: () => void;
+    let releaseMessageRemoval!: () => void;
+    const metadataDeleted = new Promise<void>((resolve) => {
+      markMetadataDeleted = resolve;
+    });
+    const messageRemovalReleased = new Promise<void>((resolve) => {
+      releaseMessageRemoval = resolve;
+    });
+    const storage: AsyncStorageLike = {
+      getItem: async (key) => values.get(key) ?? null,
+      setItem: async (key, value) => {
+        values.set(key, value);
+        if (key === threadsKey && JSON.parse(value).length === 0) {
+          markMetadataDeleted();
+        }
+      },
+      removeItem: async (key) => {
+        if (key === messagesKey) await messageRemovalReleased;
+        values.delete(key);
+      },
+    };
+    const adapter = createLocalStorageAdapter({ storage });
+    mocks.aui = {
+      threadListItem: {
+        getState: () => ({ id: "thread-1", remoteId: "thread-1" }),
+        initialize: () => adapter.initialize("thread-1"),
+      },
+    };
+    const { result } = renderHook(() => adapter.unstable_useAdapters!());
+
+    const deletion = adapter.delete("thread-1");
+    await metadataDeleted;
+    const append = result.current.history!.append({
+      parentId: null,
+      message: storedMessage,
+    });
+
+    await act(async () => {
+      await append;
+      releaseMessageRemoval();
+      await deletion;
+    });
+
+    await expect(adapter.list()).resolves.toEqual({ threads: [] });
+    expect(values.has(messagesKey)).toBe(false);
+  });
+
+  it("allows history appends after a deletion fails", async () => {
+    const threadsKey = "@assistant-ui:threads";
+    const values = new Map<string, string>([
+      [
+        threadsKey,
+        JSON.stringify([{ remoteId: "thread-1", status: "regular" }]),
+      ],
+    ]);
+    let failDeletion = true;
+    const storage: AsyncStorageLike = {
+      getItem: async (key) => values.get(key) ?? null,
+      setItem: async (key, value) => {
+        if (key === threadsKey && failDeletion) {
+          failDeletion = false;
+          throw new Error("storage unavailable");
+        }
+        values.set(key, value);
+      },
+      removeItem: async (key) => {
+        values.delete(key);
+      },
+    };
+    const adapter = createLocalStorageAdapter({ storage });
+    mocks.aui = {
+      threadListItem: {
+        getState: () => ({ id: "thread-1", remoteId: "thread-1" }),
+        initialize: () => adapter.initialize("thread-1"),
+      },
+    };
+    const { result } = renderHook(() => adapter.unstable_useAdapters!());
+
+    await expect(adapter.delete("thread-1")).rejects.toThrow(
+      "storage unavailable",
+    );
+    await result.current.history!.append({
+      parentId: null,
+      message: storedMessage,
+    });
+
+    expect(
+      JSON.parse(values.get("@assistant-ui:messages:thread-1") ?? ""),
+    ).toMatchObject({ headId: "message-1" });
+  });
+});

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -64,6 +64,57 @@ const getMutationQueue = (storage: AsyncStorageLike): KeyedMutationQueue => {
   return queue;
 };
 
+type ThreadDeletionState = {
+  pending: number;
+  deleted: boolean;
+};
+
+class ThreadDeletionTracker {
+  private readonly states = new Map<string, ThreadDeletionState>();
+
+  isDeletingOrDeleted(threadId: string): boolean {
+    const state = this.states.get(threadId);
+    return state !== undefined && (state.pending > 0 || state.deleted);
+  }
+
+  begin(threadId: string): (succeeded: boolean) => void {
+    const state = this.states.get(threadId) ?? { pending: 0, deleted: false };
+    state.pending += 1;
+    this.states.set(threadId, state);
+
+    return (succeeded) => {
+      state.pending -= 1;
+      state.deleted ||= succeeded;
+      if (state.pending === 0 && !state.deleted) {
+        this.states.delete(threadId);
+      }
+    };
+  }
+}
+
+const deletionTrackers = new WeakMap<
+  AsyncStorageLike,
+  Map<string, ThreadDeletionTracker>
+>();
+
+const getDeletionTracker = (
+  storage: AsyncStorageLike,
+  prefix: string,
+): ThreadDeletionTracker => {
+  let trackers = deletionTrackers.get(storage);
+  if (!trackers) {
+    trackers = new Map();
+    deletionTrackers.set(storage, trackers);
+  }
+
+  let tracker = trackers.get(prefix);
+  if (!tracker) {
+    tracker = new ThreadDeletionTracker();
+    trackers.set(prefix, tracker);
+  }
+  return tracker;
+};
+
 type LocalStorageAdapterOptions = {
   storage: AsyncStorageLike;
   prefix?: string | undefined;
@@ -289,17 +340,20 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
   private getAui: () => ReturnType<typeof useAui>;
   private prefix: string;
   private mutationQueue: KeyedMutationQueue;
+  private deletionTracker: ThreadDeletionTracker;
 
   constructor(
     storage: AsyncStorageLike,
     getAui: () => ReturnType<typeof useAui>,
     prefix: string,
     mutationQueue: KeyedMutationQueue,
+    deletionTracker: ThreadDeletionTracker,
   ) {
     this.storage = storage;
     this.getAui = getAui;
     this.prefix = prefix;
     this.mutationQueue = mutationQueue;
+    this.deletionTracker = deletionTracker;
   }
 
   private get aui(): ReturnType<typeof useAui> {
@@ -319,7 +373,11 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
   }
 
   async append(item: ExportedMessageRepositoryItem): Promise<void> {
+    const threadId = this.aui.threadListItem.getState().id;
+    if (this.deletionTracker.isDeletingOrDeleted(threadId)) return;
+
     const { remoteId } = await this.aui.threadListItem.initialize();
+    if (this.deletionTracker.isDeletingOrDeleted(threadId)) return;
 
     const key = this._messagesKey(remoteId);
     await this.mutationQueue.run(key, async () => {
@@ -345,6 +403,7 @@ const useLocalStorageThreadAdapters = (
   storage: AsyncStorageLike,
   prefix: string,
   mutationQueue: KeyedMutationQueue,
+  deletionTracker: ThreadDeletionTracker,
 ): RuntimeAdapters => {
   const aui = useAui();
   // Not useEffectEvent: history adapter methods run during render (SSR load).
@@ -359,6 +418,7 @@ const useLocalStorageThreadAdapters = (
         () => auiRef.current,
         prefix,
         mutationQueue,
+        deletionTracker,
       ),
   );
   return useMemo(() => ({ history }), [history]);
@@ -368,12 +428,14 @@ const createHistoryProvider = (
   storage: AsyncStorageLike,
   prefix: string,
   mutationQueue: KeyedMutationQueue,
+  deletionTracker: ThreadDeletionTracker,
 ): FC<PropsWithChildren> => {
   const Provider: FC<PropsWithChildren> = ({ children }) => {
     const adapters = useLocalStorageThreadAdapters(
       storage,
       prefix,
       mutationQueue,
+      deletionTracker,
     );
     return (
       <RuntimeAdapterProvider adapters={adapters}>
@@ -392,6 +454,7 @@ export const createLocalStorageAdapter = (
   const threadsKey = `${prefix}threads`;
   const messagesKey = (threadId: string) => `${prefix}messages:${threadId}`;
   const mutationQueue = getMutationQueue(storage);
+  const deletionTracker = getDeletionTracker(storage, prefix);
 
   const loadThreadMetadata = async (): Promise<StoredThreadMetadata[]> => {
     const raw = await storage.getItem(threadsKey);
@@ -419,9 +482,19 @@ export const createLocalStorageAdapter = (
   };
 
   const adapter: RemoteThreadListAdapter = {
-    unstable_Provider: createHistoryProvider(storage, prefix, mutationQueue),
+    unstable_Provider: createHistoryProvider(
+      storage,
+      prefix,
+      mutationQueue,
+      deletionTracker,
+    ),
     unstable_useAdapters: function useLocalStorageAdapters() {
-      return useLocalStorageThreadAdapters(storage, prefix, mutationQueue);
+      return useLocalStorageThreadAdapters(
+        storage,
+        prefix,
+        mutationQueue,
+        deletionTracker,
+      );
     },
 
     async list(): Promise<RemoteThreadListResponse> {
@@ -485,13 +558,20 @@ export const createLocalStorageAdapter = (
     },
 
     async delete(remoteId: string): Promise<void> {
-      await mutationQueue.run(threadsKey, async () => {
-        const threads = await loadThreadMetadata();
-        const filtered = threads.filter((t) => t.remoteId !== remoteId);
-        await saveThreadMetadata(filtered);
-      });
-      const key = messagesKey(remoteId);
-      await mutationQueue.run(key, () => storage.removeItem(key));
+      const finishDeletion = deletionTracker.begin(remoteId);
+      let metadataDeleted = false;
+      try {
+        await mutationQueue.run(threadsKey, async () => {
+          const threads = await loadThreadMetadata();
+          const filtered = threads.filter((t) => t.remoteId !== remoteId);
+          await saveThreadMetadata(filtered);
+        });
+        metadataDeleted = true;
+        const key = messagesKey(remoteId);
+        await mutationQueue.run(key, () => storage.removeItem(key));
+      } finally {
+        finishDeletion(metadataDeleted);
+      }
     },
 
     async fetch(threadId: string): Promise<RemoteThreadMetadata> {


### PR DESCRIPTION
## Summary

- track local-storage thread deletion state across adapters sharing the same storage and prefix
- skip stale history appends before or after thread initialization once deletion starts
- release the deletion guard when metadata deletion fails, while retaining it after metadata is removed
- add a patch changeset for `@assistant-ui/core`

## Why

History persistence can run after a local-storage thread is deleted. Its call to `initialize()` recreates the deleted thread metadata, then writes the old messages back. The regression test exercises that race against the real adapter and verifies a failed metadata deletion does not block later valid appends.

## Reproduction

The bug reproduces on pre-fix commit `b355aefbe` by running the regression test from this PR against that source:

```sh
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git checkout b355aefbe
git show 864c4673e:packages/core/src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx > packages/core/src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx
pnpm install --frozen-lockfile
pnpm turbo build --filter=@assistant-ui/core
pnpm --filter @assistant-ui/core exec vitest run src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx -t "does not restore"
```

Expected pre-fix failure: the list contains `thread-1` after deletion because the late append reinitializes it. The same test passes on this PR.

## Testing

- `pnpm --filter @assistant-ui/core exec vitest run src/react/adapters/LocalStorageThreadListAdapter.test.ts src/react/adapters/LocalStorageThreadListAdapter.race.test.tsx`
- `pnpm turbo build --filter=@assistant-ui/core --output-logs=errors-only`
- focused oxlint and oxfmt checks