### PR TITLE
fix(core): traverse long message branches iteratively

### DIFF
--- a/.changeset/tall-trees-walk.md
+++ b/.changeset/tall-trees-walk.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: traverse long message branches without recursive stack growth

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -407,7 +407,9 @@ export class MessageRepository {
         const childId = pending.pop()!;
         const childMessage = this.messages.get(childId);
         if (childMessage) {
-          pending.push(...childMessage.children);
+          for (const descendantId of childMessage.children) {
+            pending.push(descendantId);
+          }
           this.messages.delete(childId);
         }
       }

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -116,11 +116,17 @@ export class MessageRepository {
   };
 
   private updateLevels(message: RepositoryMessage, newLevel: number) {
-    message.level = newLevel;
-    for (const childId of message.children) {
-      const childMessage = this.messages.get(childId);
-      if (childMessage) {
-        this.updateLevels(childMessage, newLevel + 1);
+    const pending = [{ message, level: newLevel }];
+
+    while (pending.length > 0) {
+      const current = pending.pop()!;
+      current.message.level = current.level;
+
+      for (const childId of current.message.children) {
+        const childMessage = this.messages.get(childId);
+        if (childMessage) {
+          pending.push({ message: childMessage, level: current.level + 1 });
+        }
       }
     }
   }
@@ -396,16 +402,15 @@ export class MessageRepository {
     const previousHead = this.head;
 
     if (message.children.length > 0) {
-      const deleteDescendants = (msg: RepositoryMessage) => {
-        for (const childId of msg.children) {
-          const childMessage = this.messages.get(childId);
-          if (childMessage) {
-            deleteDescendants(childMessage);
-            this.messages.delete(childId);
-          }
+      const pending = [...message.children];
+      while (pending.length > 0) {
+        const childId = pending.pop()!;
+        const childMessage = this.messages.get(childId);
+        if (childMessage) {
+          pending.push(...childMessage.children);
+          this.messages.delete(childId);
         }
-      };
-      deleteDescendants(message);
+      }
 
       message.children = [];
       message.next = null;

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -81,9 +81,9 @@ type RepositoryMessage = RepositoryParent & {
 const findHead = (
   message: RepositoryMessage | RepositoryParent,
 ): RepositoryMessage | null => {
-  if (message.next) return findHead(message.next);
-  if ("current" in message) return message;
-  return null;
+  let current = message;
+  while (current.next) current = current.next;
+  return "current" in current ? current : null;
 };
 
 class CachedValue<T> {

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -222,6 +222,30 @@ describe("MessageRepository", () => {
       expect(messages2.map((m) => m.id)).toEqual(["parent-id", "branch2-id"]);
     });
 
+    it("should switch to a branch with a long message history", () => {
+      const messageCount = 12_000;
+      const messages = [
+        { message: createTestMessage({ id: "root" }), parentId: null },
+      ];
+
+      for (let index = 0; index < messageCount; index++) {
+        messages.push({
+          message: createTestMessage({ id: `branch-${index}` }),
+          parentId: index === 0 ? "root" : `branch-${index - 1}`,
+        });
+      }
+
+      messages.push({
+        message: createTestMessage({ id: "alternate" }),
+        parentId: "root",
+      });
+
+      repository.import({ headId: "alternate", messages });
+      repository.switchToBranch("branch-0");
+
+      expect(repository.headId).toBe(`branch-${messageCount - 1}`);
+    });
+
     it("should throw error when switching to a non-existent branch", () => {
       expect(() => {
         repository.switchToBranch("non-existent-id");

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -180,6 +180,24 @@ describe("MessageRepository", () => {
   });
 
   describe("Branch management", () => {
+    const createLongBranchMessages = (
+      messageCount: number,
+    ): Array<{ message: ThreadMessage; parentId: string | null }> => {
+      const messages: Array<{
+        message: ThreadMessage;
+        parentId: string | null;
+      }> = [{ message: createTestMessage({ id: "root" }), parentId: null }];
+
+      for (let index = 0; index < messageCount; index++) {
+        messages.push({
+          message: createTestMessage({ id: `branch-${index}` }),
+          parentId: index === 0 ? "root" : `branch-${index - 1}`,
+        });
+      }
+
+      return messages;
+    };
+
     it("should create multiple branches from a parent message", () => {
       const parent = createTestMessage({ id: "parent-id" });
       const branch1 = createTestMessage({ id: "branch1-id" });
@@ -224,16 +242,7 @@ describe("MessageRepository", () => {
 
     it("should switch to a branch with a long message history", () => {
       const messageCount = 12_000;
-      const messages = [
-        { message: createTestMessage({ id: "root" }), parentId: null },
-      ];
-
-      for (let index = 0; index < messageCount; index++) {
-        messages.push({
-          message: createTestMessage({ id: `branch-${index}` }),
-          parentId: index === 0 ? "root" : `branch-${index - 1}`,
-        });
-      }
+      const messages = createLongBranchMessages(messageCount);
 
       messages.push({
         message: createTestMessage({ id: "alternate" }),
@@ -244,6 +253,36 @@ describe("MessageRepository", () => {
       repository.switchToBranch("branch-0");
 
       expect(repository.headId).toBe(`branch-${messageCount - 1}`);
+    });
+
+    it("should reparent a branch with a long message history", () => {
+      const messageCount = 12_000;
+      repository.import({
+        headId: `branch-${messageCount - 1}`,
+        messages: createLongBranchMessages(messageCount),
+      });
+
+      repository.deleteMessage("branch-0", "root");
+
+      expect(repository.getMessage("branch-1")).toMatchObject({
+        parentId: "root",
+        index: 1,
+      });
+      expect(repository.headId).toBe(`branch-${messageCount - 1}`);
+    });
+
+    it("should reset a branch with a long message history", () => {
+      const messageCount = 12_000;
+
+      repository.import({
+        headId: "root",
+        messages: createLongBranchMessages(messageCount),
+      });
+
+      expect(repository.getMessages().map((message) => message.id)).toEqual([
+        "root",
+      ]);
+      expect(() => repository.getMessage("branch-0")).toThrow();
     });
 
     it("should throw error when switching to a non-existent branch", () => {

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -240,8 +240,8 @@ describe("MessageRepository", () => {
       expect(messages2.map((m) => m.id)).toEqual(["parent-id", "branch2-id"]);
     });
 
-    it("should switch to a branch with a long message history", () => {
-      const messageCount = 12_000;
+    it("should operate on a long message history without overflowing the stack", () => {
+      const messageCount = 30_000;
       const messages = createLongBranchMessages(messageCount);
 
       messages.push({
@@ -253,14 +253,6 @@ describe("MessageRepository", () => {
       repository.switchToBranch("branch-0");
 
       expect(repository.headId).toBe(`branch-${messageCount - 1}`);
-    });
-
-    it("should reparent a branch with a long message history", () => {
-      const messageCount = 12_000;
-      repository.import({
-        headId: `branch-${messageCount - 1}`,
-        messages: createLongBranchMessages(messageCount),
-      });
 
       repository.deleteMessage("branch-0", "root");
 
@@ -269,21 +261,14 @@ describe("MessageRepository", () => {
         index: 1,
       });
       expect(repository.headId).toBe(`branch-${messageCount - 1}`);
-    });
 
-    it("should reset a branch with a long message history", () => {
-      const messageCount = 12_000;
-
-      repository.import({
-        headId: "root",
-        messages: createLongBranchMessages(messageCount),
-      });
+      repository.resetHead("root");
 
       expect(repository.getMessages().map((message) => message.id)).toEqual([
         "root",
       ]);
-      expect(() => repository.getMessage("branch-0")).toThrow();
-    });
+      expect(() => repository.getMessage("branch-1")).toThrow();
+    }, 20_000);
 
     it("should throw error when switching to a non-existent branch", () => {
       expect(() => {


### PR DESCRIPTION
## Summary

- replace recursive branch-head, level-update, and descendant-deletion walks with iterative traversals
- avoid argument-count limits while queuing very wide descendant sets
- cover switch, reparent, and reset operations in one 30,000-message regression
- add a patch changeset for @assistant-ui/core

## Why

On main at 4e6bff52e, switching to the start of a 30,000-message branch throws RangeError: Maximum call stack size exceeded. The same recursive shape also exists when updating descendant levels and deleting descendants during reset, so valid long histories can exhaust the JavaScript call stack in multiple branch operations.

The iterative walks preserve branch behavior while keeping stack usage constant. Descendant IDs are appended individually so very wide branches also avoid engine argument-count limits.

## Reproduction

The regression imports one 30,000-message branch plus an alternate branch, then:

1. switches from the alternate branch to the deep branch
2. deletes the first deep message and reparents the remaining branch
3. resets the root and removes the deep descendants

The recursive implementation fails at this depth; the iterative implementation completes all three operations.

## Validation

- pnpm --filter @assistant-ui/core test (128 files, 1,292 tests)
- pnpm --filter @assistant-ui/core build
- pnpm lint

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.byDe2nA47phqUTezkaRSpCCMH5-A3mmP3WEtf83K51GLkIBM-3mgJW1FbkM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->