### PR TITLE
fix(agent-launcher): propagate child process signals

### DIFF
--- a/.changeset/bright-agents-signal.md
+++ b/.changeset/bright-agents-signal.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/agent-launcher": patch
+---
+
+fix: propagate child process termination signals

--- a/packages/agent-launcher/README.md
+++ b/packages/agent-launcher/README.md
@@ -25,4 +25,4 @@ launch({
 });
 ```
 
-The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit and re-raises the child's termination signal on the parent when the child is killed by a signal. Re-raising removes the parent's listeners for that signal so the default disposition applies; `launch` assumes it owns the process lifetime.
+The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit and re-raises the child's termination signal on the parent when the child is killed by a signal. Re-raising removes the parent's listeners for that signal so the default disposition applies; `launch` assumes it owns the process lifetime. If the signal does not terminate the parent, `launch` exits with the conventional `128 + signal number` status.

--- a/packages/agent-launcher/README.md
+++ b/packages/agent-launcher/README.md
@@ -25,4 +25,4 @@ launch({
 });
 ```
 
-The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit.
+The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit and re-raises the child's termination signal on the parent when the child is killed by a signal.

--- a/packages/agent-launcher/README.md
+++ b/packages/agent-launcher/README.md
@@ -25,4 +25,4 @@ launch({
 });
 ```
 
-The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit and re-raises the child's termination signal on the parent when the child is killed by a signal.
+The child process inherits `stdio`, so output streams directly to the parent terminal. `launch` exits the parent with the child's status code on non-zero exit and re-raises the child's termination signal on the parent when the child is killed by a signal. Re-raising removes the parent's listeners for that signal so the default disposition applies; `launch` assumes it owns the process lifetime.

--- a/packages/agent-launcher/package.json
+++ b/packages/agent-launcher/package.json
@@ -27,7 +27,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run"
   },
   "dependencies": {
     "cross-spawn": "^7.0.6"
@@ -35,7 +36,8 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/cross-spawn": "^6.0.6",
-    "@types/node": "^26.2.0"
+    "@types/node": "^26.2.0",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -12,9 +16,15 @@ vi.mock("cross-spawn", async (importOriginal) => ({
 import { launch } from "./launch";
 
 describe("launch", () => {
+  const temporaryDirectories: string[] = [];
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
+
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("propagates child process termination signals", () => {
@@ -27,9 +37,52 @@ describe("launch", () => {
       signal: "SIGTERM",
     });
     const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const removeAllListeners = vi
+      .spyOn(process, "removeAllListeners")
+      .mockReturnValue(process);
 
     launch({ pluginDir: "/tmp/plugin", prompt: "test" });
 
+    expect(removeAllListeners).toHaveBeenCalledWith("SIGTERM");
     expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    expect(removeAllListeners.mock.invocationCallOrder[0]).toBeLessThan(
+      kill.mock.invocationCallOrder[0]!,
+    );
   });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves signal termination when the parent has a signal handler",
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), "aui-agent-launcher-"));
+      temporaryDirectories.push(directory);
+
+      const executable = join(directory, "claude");
+      writeFileSync(
+        executable,
+        '#!/usr/bin/env node\nprocess.kill(process.pid, "SIGTERM");\n',
+      );
+      chmodSync(executable, 0o755);
+
+      const launchUrl = new URL("./launch.ts", import.meta.url).href;
+      const script = `
+        process.on("SIGTERM", () => process.exit(0));
+        const { launch } = await import(${JSON.stringify(launchUrl)});
+        launch({ pluginDir: "/tmp/plugin", prompt: "test" });
+      `;
+      const result = spawnSync(
+        process.execPath,
+        ["--input-type=module", "--eval", script],
+        {
+          env: {
+            ...process.env,
+            NODE_NO_WARNINGS: "1",
+            PATH: `${directory}${delimiter}${process.env.PATH ?? ""}`,
+          },
+        },
+      );
+
+      expect(result.status).toBeNull();
+      expect(result.signal).toBe("SIGTERM");
+    },
+  );
 });

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -27,7 +27,7 @@ describe("launch", () => {
     }
   });
 
-  it("propagates child process termination signals", () => {
+  it("falls back to a signal exit code if re-raising does not terminate", () => {
     mocks.sync.mockReturnValue({
       pid: 123,
       output: [],
@@ -40,14 +40,20 @@ describe("launch", () => {
     const removeAllListeners = vi
       .spyOn(process, "removeAllListeners")
       .mockReturnValue(process);
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
 
-    launch({ pluginDir: "/tmp/plugin", prompt: "test" });
+    expect(() => launch({ pluginDir: "/tmp/plugin", prompt: "test" })).toThrow(
+      "process.exit",
+    );
 
     expect(removeAllListeners).toHaveBeenCalledWith("SIGTERM");
     expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
     expect(removeAllListeners.mock.invocationCallOrder[0]).toBeLessThan(
       kill.mock.invocationCallOrder[0]!,
     );
+    expect(exit).toHaveBeenCalledWith(143);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -4,7 +4,8 @@ const mocks = vi.hoisted(() => ({
   sync: vi.fn(),
 }));
 
-vi.mock("cross-spawn", () => ({
+vi.mock("cross-spawn", async (importOriginal) => ({
+  ...(await importOriginal()),
   default: { sync: mocks.sync },
 }));
 

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sync: vi.fn(),
+}));
+
+vi.mock("cross-spawn", () => ({
+  default: { sync: mocks.sync },
+}));
+
+import { launch } from "./launch";
+
+describe("launch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("propagates child process termination signals", () => {
+    mocks.sync.mockReturnValue({
+      pid: 123,
+      output: [],
+      stdout: null,
+      stderr: null,
+      status: null,
+      signal: "SIGTERM",
+    });
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+
+    launch({ pluginDir: "/tmp/plugin", prompt: "test" });
+
+    expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+  });
+});

--- a/packages/agent-launcher/src/launch.ts
+++ b/packages/agent-launcher/src/launch.ts
@@ -47,6 +47,11 @@ export function launch(options: LaunchOptions): void {
     throw result.error;
   }
 
+  if (result.signal !== null) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+
   if (result.status !== null && result.status !== 0) {
     process.exit(result.status);
   }

--- a/packages/agent-launcher/src/launch.ts
+++ b/packages/agent-launcher/src/launch.ts
@@ -48,6 +48,7 @@ export function launch(options: LaunchOptions): void {
   }
 
   if (result.signal !== null) {
+    process.removeAllListeners(result.signal);
     process.kill(process.pid, result.signal);
     return;
   }

--- a/packages/agent-launcher/src/launch.ts
+++ b/packages/agent-launcher/src/launch.ts
@@ -1,3 +1,4 @@
+import { constants } from "node:os";
 import spawn from "cross-spawn";
 
 export interface LaunchOptions {
@@ -50,7 +51,7 @@ export function launch(options: LaunchOptions): void {
   if (result.signal !== null) {
     process.removeAllListeners(result.signal);
     process.kill(process.pid, result.signal);
-    return;
+    process.exit(128 + (constants.signals[result.signal] ?? 0));
   }
 
   if (result.status !== null && result.status !== 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3562,6 +3562,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/ai-sdk:
     dependencies:


### PR DESCRIPTION
## Summary

- restore the default disposition for a child termination signal before re-raising it on the launcher process
- fall back to the conventional 128 plus signal number exit status when signal delivery does not terminate the parent
- document the process-ownership and signal propagation contract for the published launch API
- add unit coverage and a real subprocess regression with an installed parent signal handler
- add the package test script and a patch changeset

## Why

When cross-spawn reports a child terminated by a signal, status is null and signal contains a value such as SIGTERM. The launcher previously ignored that result and returned as though Claude had exited successfully.

Merely signalling the parent is not sufficient because the assistant-ui CLI installs SIGINT and SIGTERM handlers that exit with code 0. Removing handlers for the child signal first restores its default terminating behavior. If delivery is ignored, such as for PID 1, the fallback exit status still preserves a non-success outcome.

## Reproduction

The subprocess regression installs an exit-zero SIGTERM handler in the launcher process and runs a fake Claude child that terminates by SIGTERM. Without the fix, the parent exits with status 0. With the fix, the parent result has status null and signal SIGTERM.

A focused unit test simulates signal delivery returning without termination and verifies the SIGTERM fallback exits with status 143.

## Validation

- pnpm --filter @assistant-ui/agent-launcher test (2 tests)
- pnpm --filter @assistant-ui/agent-launcher build
- targeted oxlint and oxfmt checks
- frozen lockfile validation