### PR TITLE
fix(react-pi): validate event stream payloads

### DIFF
--- a/.changeset/react-pi-stream-event-validation.md
+++ b/.changeset/react-pi-stream-event-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: validate event stream payloads before updating thread state

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1136,6 +1136,7 @@ interface PiEventStreamOptions {
   fetchImpl?: typeof fetch;
   headers?: Record<string, string>;
   expectedThreadId?: string;
+  snapshotRecoveryUrl?: string;
   reconnectDelay?: () => Promise<void>;
 }
 

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1135,6 +1135,7 @@ interface PiEventStreamOptions {
   onError?: (error: unknown) => void;
   fetchImpl?: typeof fetch;
   headers?: Record<string, string>;
+  expectedThreadId?: string;
   reconnectDelay?: () => Promise<void>;
 }
 

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -243,7 +243,6 @@ describe("openPiEventStream", () => {
   it("delivers every known event type", async () => {
     const bodies = Object.values(knownEventBodies);
     const events: PiAnyClientEvent[] = [];
-    const errors: unknown[] = [];
     const fetchImpl = (async () =>
       sseResponse(
         bodies.map((body, index) =>
@@ -251,12 +250,16 @@ describe("openPiEventStream", () => {
         ),
       )) as unknown as typeof fetch;
 
-    await new Promise<void>((resolve) => {
-      const close = openPiEventStream({
+    await new Promise<void>((resolve, reject) => {
+      let close!: () => void;
+      close = openPiEventStream({
         url: "/events",
         fetchImpl,
         reconnectDelay: () => Promise.resolve(),
-        onError: (error) => errors.push(error),
+        onError: (error) => {
+          close();
+          reject(error);
+        },
         onEvent: (event) => {
           events.push(event);
           if (events.length === bodies.length) {
@@ -267,7 +270,6 @@ describe("openPiEventStream", () => {
       });
     });
 
-    expect(errors).toEqual([]);
     expect(events.map((event) => event.type)).toEqual(
       bodies.map((body) => body.type),
     );
@@ -889,6 +891,49 @@ describe("openPiEventStream", () => {
       expect.objectContaining({ type: "agent_start", threadId: "t1", seq: 2 }),
     ]);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("requests a snapshot after a malformed live-only event", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse([
+          rawSseFrame({ type: "message_end", threadId: "t1", seq: 1 }),
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([
+          sseFrame({
+            type: "snapshot",
+            threadId: "t1",
+            seq: 2,
+            snapshot: {
+              metadata: { id: "t1", status: "idle" },
+              messages: [],
+            },
+          }),
+        ]),
+      ) as unknown as typeof fetch;
+
+    const event = await new Promise<PiAnyClientEvent>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events?snapshot=false",
+        snapshotRecoveryUrl: "/events",
+        expectedThreadId: "t1",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onEvent: (value) => {
+          close();
+          resolve(value);
+        },
+      });
+    });
+
+    expect(event.type).toBe("snapshot");
+    expect(fetchImpl.mock.calls.map(([requestUrl]) => requestUrl)).toEqual([
+      "/events?snapshot=false",
+      "/events",
+    ]);
   });
 
   it("preserves forward-compatible values in known event types", async () => {

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -99,6 +99,9 @@ const sseResponse = (
 const sseFrame = (event: PiAnyClientEvent): string =>
   `data: ${JSON.stringify(event)}\n\n`;
 
+const rawSseFrame = (event: unknown): string =>
+  `data: ${JSON.stringify(event)}\n\n`;
+
 describe("openPiEventStream", () => {
   it("delivers parsed events from the stream", async () => {
     const events: PiAnyClientEvent[] = [];
@@ -551,6 +554,79 @@ describe("openPiEventStream", () => {
 
     expect(errors).toHaveLength(1);
     expect(events.map((e) => e.type)).toEqual(["agent_end"]);
+  });
+
+  it.each([
+    [
+      { type: "agent_start", threadId: 42, seq: 1 },
+      'expected a non-empty string "threadId"',
+    ],
+    [
+      { type: "message_start", threadId: "t1", seq: 1 },
+      'event "message_start" has an invalid payload',
+    ],
+  ])(
+    "reports malformed event payloads without delivering them",
+    async (malformedEvent, expectedMessage) => {
+      const events: PiAnyClientEvent[] = [];
+      const errors: unknown[] = [];
+      const fetchImpl = vi.fn(async () =>
+        sseResponse([
+          rawSseFrame(malformedEvent),
+          sseFrame({ type: "agent_end", threadId: "t1", seq: 2 }),
+        ]),
+      ) as unknown as typeof fetch;
+
+      await new Promise<void>((resolve) => {
+        const close = openPiEventStream({
+          url: "/events",
+          fetchImpl,
+          reconnectDelay: () => Promise.resolve(),
+          onError: (error) => errors.push(error),
+          onEvent: (event) => {
+            events.push(event);
+            close();
+            resolve();
+          },
+        });
+      });
+
+      expect(errors).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining(expectedMessage),
+        }),
+      ]);
+      expect(events.map((event) => event.type)).toEqual(["agent_end"]);
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("preserves forward-compatible unknown event types", async () => {
+    const event = await new Promise<PiAnyClientEvent>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl: (async () =>
+          sseResponse([
+            rawSseFrame({
+              type: "future_event",
+              threadId: "t1",
+              seq: 1,
+              payload: { value: true },
+            }),
+          ])) as unknown as typeof fetch,
+        onEvent: (value) => {
+          close();
+          resolve(value);
+        },
+      });
+    });
+
+    expect(event).toEqual({
+      type: "future_event",
+      threadId: "t1",
+      seq: 1,
+      payload: { value: true },
+    });
   });
 
   it("stops and does not surface abort as an error after close()", async () => {

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -708,6 +708,103 @@ describe("openPiEventStream", () => {
       { type: "message_start", threadId: "t1", seq: 1 },
       'event "message_start" has an invalid payload',
     ],
+    [
+      {
+        type: "message_start",
+        threadId: "t1",
+        seq: 1,
+        message: { role: "assistant", content: [] },
+      },
+      'event "message_start" has an invalid payload',
+    ],
+    [
+      {
+        type: "message_update",
+        threadId: "t1",
+        seq: 1,
+        message: assistantMessage,
+        assistantMessageEvent: { type: "text_delta" },
+      },
+      'event "message_update" has an invalid payload',
+    ],
+    [
+      {
+        type: "tool_execution_start",
+        threadId: "t1",
+        seq: 1,
+        toolCallId: "tool-1",
+        toolName: "search",
+      },
+      'event "tool_execution_start" has an invalid payload',
+    ],
+    [
+      {
+        type: "tool_execution_update",
+        threadId: "t1",
+        seq: 1,
+        toolCallId: "tool-1",
+      },
+      'event "tool_execution_update" has an invalid payload',
+    ],
+    [
+      {
+        type: "tool_execution_end",
+        threadId: "t1",
+        seq: 1,
+        toolCallId: "tool-1",
+        isError: false,
+      },
+      'event "tool_execution_end" has an invalid payload',
+    ],
+    [
+      {
+        type: "snapshot",
+        threadId: "t1",
+        seq: 1,
+        snapshot: {
+          metadata: { id: "t1", status: "idle" },
+          messages: [{ role: "assistant" }],
+        },
+      },
+      'event "snapshot" has an invalid payload',
+    ],
+    [
+      {
+        type: "queue_update",
+        threadId: "t1",
+        seq: 1,
+        steering: "steer",
+        followUp: [],
+      },
+      'event "queue_update" has an invalid payload',
+    ],
+    [
+      {
+        type: "context_usage",
+        threadId: "t1",
+        seq: 1,
+        contextUsage: { tokens: 1, contextWindow: "large", percent: 1 },
+      },
+      'event "context_usage" has an invalid payload',
+    ],
+    [
+      {
+        type: "extension_ui_request",
+        threadId: "t1",
+        seq: 1,
+        request: { id: "request-1", kind: "confirm", title: "Continue?" },
+      },
+      'event "extension_ui_request" has an invalid payload',
+    ],
+    [
+      {
+        type: "compaction_start",
+        threadId: "t1",
+        seq: 1,
+        reason: 1,
+      },
+      'event "compaction_start" has an invalid payload',
+    ],
   ])(
     "reports malformed event payloads without delivering them",
     async (malformedEvent, expectedMessage) => {
@@ -751,6 +848,48 @@ describe("openPiEventStream", () => {
       expect(fetchImpl).toHaveBeenCalledTimes(2);
     },
   );
+
+  it("reconnects when an event belongs to another thread", async () => {
+    const events: PiAnyClientEvent[] = [];
+    const errors: unknown[] = [];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse([
+          sseFrame({ type: "agent_start", threadId: "t2", seq: 1 }),
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([
+          sseFrame({ type: "agent_start", threadId: "t1", seq: 2 }),
+        ]),
+      ) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        expectedThreadId: "t1",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onError: (error) => errors.push(error),
+        onEvent: (event) => {
+          events.push(event);
+          close();
+          resolve();
+        },
+      });
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('expected thread "t1", received "t2"'),
+      }),
+    ]);
+    expect(events).toEqual([
+      expect.objectContaining({ type: "agent_start", threadId: "t1", seq: 2 }),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
 
   it("preserves forward-compatible values in known event types", async () => {
     const events: PiAnyClientEvent[] = [];

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSseDecoder, openPiEventStream } from "./eventSource";
-import type { PiAnyClientEvent } from "../types";
+import type {
+  PiAnyClientEvent,
+  PiAssistantMessage,
+  PiClientEventBody,
+} from "../types";
 
 describe("createSseDecoder", () => {
   it("decodes a single data frame", () => {
@@ -102,6 +106,112 @@ const sseFrame = (event: PiAnyClientEvent): string =>
 const rawSseFrame = (event: unknown): string =>
   `data: ${JSON.stringify(event)}\n\n`;
 
+const assistantMessage: PiAssistantMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: "Hello" }],
+  api: "anthropic-messages",
+  provider: "anthropic",
+  model: "claude",
+  usage: {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp: 1,
+};
+
+const knownEventBodies = {
+  snapshot: {
+    type: "snapshot",
+    snapshot: {
+      metadata: { id: "t1", title: "Thread", status: "idle" },
+      messages: [],
+    },
+  },
+  agent_start: { type: "agent_start" },
+  agent_end: { type: "agent_end", willRetry: false },
+  agent_settled: { type: "agent_settled" },
+  turn_start: { type: "turn_start", turnIndex: 1 },
+  turn_end: { type: "turn_end", turnIndex: 1 },
+  message_start: { type: "message_start", message: assistantMessage },
+  message_update: {
+    type: "message_update",
+    message: assistantMessage,
+    assistantMessageEvent: { type: "start", partial: assistantMessage },
+  },
+  message_end: { type: "message_end", message: assistantMessage },
+  tool_execution_start: {
+    type: "tool_execution_start",
+    toolCallId: "tool-1",
+    toolName: "search",
+    args: { query: "assistant-ui" },
+  },
+  tool_execution_update: {
+    type: "tool_execution_update",
+    toolCallId: "tool-1",
+    toolName: "search",
+    partialResult: { content: [] },
+  },
+  tool_execution_end: {
+    type: "tool_execution_end",
+    toolCallId: "tool-1",
+    result: { content: [] },
+    isError: false,
+  },
+  queue_update: {
+    type: "queue_update",
+    steering: ["steer"],
+    followUp: ["follow up"],
+  },
+  compaction_start: { type: "compaction_start", reason: "threshold" },
+  compaction_end: {
+    type: "compaction_end",
+    aborted: false,
+    willRetry: false,
+  },
+  entry_appended: {
+    type: "entry_appended",
+    entry: {
+      id: "entry-1",
+      parentId: null,
+      timestamp: "2026-08-18T00:00:00.000Z",
+      type: "custom",
+      customType: "test",
+    },
+  },
+  auto_retry_start: { type: "auto_retry_start", attempt: 1, delayMs: 100 },
+  auto_retry_end: { type: "auto_retry_end", success: true },
+  session_info_changed: { type: "session_info_changed", name: "Thread" },
+  thinking_level_changed: { type: "thinking_level_changed", level: "high" },
+  context_usage: {
+    type: "context_usage",
+    contextUsage: { tokens: 10, contextWindow: 100, percent: 10 },
+  },
+  extension_ui_request: {
+    type: "extension_ui_request",
+    request: {
+      id: "request-1",
+      kind: "confirm",
+      title: "Continue?",
+      message: "Allow the tool to continue?",
+    },
+  },
+  extension_ui_resolved: {
+    type: "extension_ui_resolved",
+    requestId: "request-1",
+  },
+  error: { type: "error", error: "model unavailable" },
+} satisfies {
+  [Type in PiClientEventBody["type"]]: Extract<
+    PiClientEventBody,
+    { type: Type }
+  >;
+};
+
 describe("openPiEventStream", () => {
   it("delivers parsed events from the stream", async () => {
     const events: PiAnyClientEvent[] = [];
@@ -128,6 +238,39 @@ describe("openPiEventStream", () => {
 
     expect(events.map((e) => e.type)).toEqual(["agent_start", "agent_end"]);
     expect(events[0]).toMatchObject({ threadId: "t1", seq: 1 });
+  });
+
+  it("delivers every known event type", async () => {
+    const bodies = Object.values(knownEventBodies);
+    const events: PiAnyClientEvent[] = [];
+    const errors: unknown[] = [];
+    const fetchImpl = (async () =>
+      sseResponse(
+        bodies.map((body, index) =>
+          rawSseFrame({ ...body, threadId: "t1", seq: index + 1 }),
+        ),
+      )) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onError: (error) => errors.push(error),
+        onEvent: (event) => {
+          events.push(event);
+          if (events.length === bodies.length) {
+            close();
+            resolve();
+          }
+        },
+      });
+    });
+
+    expect(errors).toEqual([]);
+    expect(events.map((event) => event.type)).toEqual(
+      bodies.map((body) => body.type),
+    );
   });
 
   it("accepts parameterized event stream content types", async () => {
@@ -570,12 +713,19 @@ describe("openPiEventStream", () => {
     async (malformedEvent, expectedMessage) => {
       const events: PiAnyClientEvent[] = [];
       const errors: unknown[] = [];
-      const fetchImpl = vi.fn(async () =>
-        sseResponse([
-          rawSseFrame(malformedEvent),
-          sseFrame({ type: "agent_end", threadId: "t1", seq: 2 }),
-        ]),
-      ) as unknown as typeof fetch;
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          sseResponse([
+            rawSseFrame(malformedEvent),
+            sseFrame({ type: "agent_end", threadId: "t1", seq: 99 }),
+          ]),
+        )
+        .mockResolvedValueOnce(
+          sseResponse([
+            sseFrame({ type: "agent_end", threadId: "t1", seq: 2 }),
+          ]),
+        ) as unknown as typeof fetch;
 
       await new Promise<void>((resolve) => {
         const close = openPiEventStream({
@@ -597,9 +747,52 @@ describe("openPiEventStream", () => {
         }),
       ]);
       expect(events.map((event) => event.type)).toEqual(["agent_end"]);
-      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(events[0]?.seq).toBe(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
     },
   );
+
+  it("preserves forward-compatible values in known event types", async () => {
+    const events: PiAnyClientEvent[] = [];
+    const fetchImpl = (async () =>
+      sseResponse([
+        rawSseFrame({
+          type: "compaction_start",
+          threadId: "t1",
+          seq: 1,
+          reason: "future_reason",
+        }),
+        rawSseFrame({
+          type: "extension_ui_request",
+          threadId: "t1",
+          seq: 2,
+          request: {
+            id: "request-1",
+            kind: "future_dialog",
+            title: "Future dialog",
+          },
+        }),
+      ])) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        onEvent: (event) => {
+          events.push(event);
+          if (events.length === 2) {
+            close();
+            resolve();
+          }
+        },
+      });
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({ type: "compaction_start" }),
+      expect.objectContaining({ type: "extension_ui_request" }),
+    ]);
+  });
 
   it("preserves forward-compatible unknown event types", async () => {
     const event = await new Promise<PiAnyClientEvent>((resolve) => {

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -759,6 +759,18 @@ describe("openPiEventStream", () => {
       'event "tool_execution_end" has an invalid payload',
     ],
     [
+      { type: "agent_start", threadId: "t1" },
+      'expected a non-negative safe integer "seq"',
+    ],
+    [
+      { type: "agent_start", threadId: "t1", seq: -1 },
+      'expected a non-negative safe integer "seq"',
+    ],
+    [
+      { type: "agent_start", threadId: "t1", seq: 1.5 },
+      'expected a non-negative safe integer "seq"',
+    ],
+    [
       {
         type: "snapshot",
         threadId: "t1",
@@ -766,6 +778,30 @@ describe("openPiEventStream", () => {
         snapshot: {
           metadata: { id: "t1", status: "idle" },
           messages: [{ role: "assistant" }],
+        },
+      },
+      'event "snapshot" has an invalid payload',
+    ],
+    [
+      {
+        type: "snapshot",
+        threadId: "t1",
+        seq: 1,
+        snapshot: {
+          metadata: { id: "t1", status: "idle" },
+          messages: [{ role: "bashExecution" }],
+        },
+      },
+      'event "snapshot" has an invalid payload',
+    ],
+    [
+      {
+        type: "snapshot",
+        threadId: "t1",
+        seq: 1,
+        snapshot: {
+          metadata: { id: "t1", status: "idle" },
+          messages: [{ role: "custom", content: "note" }],
         },
       },
       'event "snapshot" has an invalid payload',
@@ -891,6 +927,138 @@ describe("openPiEventStream", () => {
       expect.objectContaining({ type: "agent_start", threadId: "t1", seq: 2 }),
     ]);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts seq 0 and live assistant frames with pending stop reasons", async () => {
+    const liveAssistant = { ...assistantMessage, stopReason: "pending" };
+    const events: PiAnyClientEvent[] = [];
+    const fetchImpl = (async () =>
+      sseResponse([
+        sseFrame({ type: "agent_start", threadId: "t1", seq: 0 }),
+        rawSseFrame({
+          type: "message_start",
+          threadId: "t1",
+          seq: 1,
+          message: liveAssistant,
+        }),
+        rawSseFrame({
+          type: "message_update",
+          threadId: "t1",
+          seq: 2,
+          message: liveAssistant,
+          assistantMessageEvent: {
+            type: "start",
+            partial: liveAssistant,
+          },
+        }),
+      ])) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve, reject) => {
+      let close!: () => void;
+      close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        onError: (error) => {
+          close();
+          reject(error);
+        },
+        onEvent: (event) => {
+          events.push(event);
+          if (events.length === 3) {
+            close();
+            resolve();
+          }
+        },
+      });
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({ type: "agent_start", seq: 0 }),
+      expect.objectContaining({ type: "message_start", seq: 1 }),
+      expect.objectContaining({ type: "message_update", seq: 2 }),
+    ]);
+  });
+
+  it("accepts live tool calls whose arguments are still null", async () => {
+    const liveToolCall = {
+      ...assistantMessage,
+      stopReason: "pending",
+      content: [
+        { type: "toolCall", id: "tc1", name: "search", arguments: null },
+      ],
+    };
+    const event = await new Promise<PiAnyClientEvent>((resolve, reject) => {
+      let close!: () => void;
+      close = openPiEventStream({
+        url: "/events",
+        fetchImpl: (async () =>
+          sseResponse([
+            rawSseFrame({
+              type: "message_update",
+              threadId: "t1",
+              seq: 1,
+              message: liveToolCall,
+              assistantMessageEvent: {
+                type: "toolcall_start",
+                contentIndex: 0,
+                partial: liveToolCall,
+              },
+            }),
+          ])) as unknown as typeof fetch,
+        onError: (error) => {
+          close();
+          reject(error);
+        },
+        onEvent: (value) => {
+          close();
+          resolve(value);
+        },
+      });
+    });
+
+    expect(event).toMatchObject({
+      type: "message_update",
+      seq: 1,
+    });
+  });
+
+  it("accepts snapshots with renderable incomplete assistants", async () => {
+    const event = await new Promise<PiAnyClientEvent>((resolve, reject) => {
+      let close!: () => void;
+      close = openPiEventStream({
+        url: "/events",
+        fetchImpl: (async () =>
+          sseResponse([
+            rawSseFrame({
+              type: "snapshot",
+              threadId: "t1",
+              seq: 1,
+              snapshot: {
+                metadata: { id: "t1", status: "idle" },
+                messages: [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "Hello" }],
+                    responseModel: null,
+                    errorMessage: null,
+                  },
+                  { role: "bashExecution", command: "ls", output: "x" },
+                ],
+              },
+            }),
+          ])) as unknown as typeof fetch,
+        onError: (error) => {
+          close();
+          reject(error);
+        },
+        onEvent: (value) => {
+          close();
+          resolve(value);
+        },
+      });
+    });
+
+    expect(event.type).toBe("snapshot");
   });
 
   it("requests a snapshot after a malformed live-only event", async () => {

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -137,6 +137,8 @@ export interface PiEventStreamOptions {
   headers?: Record<string, string>;
   /** Thread ID expected in every event envelope. */
   expectedThreadId?: string;
+  /** Snapshot-enabled URL used to recover after a malformed known event. */
+  snapshotRecoveryUrl?: string;
   /** Reconnect backoff between a dropped stream and the next attempt. Rejections
    * are reported via `onError`, then followed by the default ~1s backoff. */
   reconnectDelay?: () => Promise<void>;
@@ -307,10 +309,12 @@ export const openPiEventStream = (
     fetchImpl = fetch,
     headers,
     expectedThreadId,
+    snapshotRecoveryUrl,
     reconnectDelay = defaultReconnectDelay,
   } = options;
 
   let closed = false;
+  let needsSnapshotRecovery = false;
   let cancelActiveReader: (() => void) | undefined;
   const abort = new AbortController();
   const reportCallbackError = (callbackError: unknown) => {
@@ -338,7 +342,11 @@ export const openPiEventStream = (
   const run = async () => {
     while (!closed) {
       try {
-        const response = await fetchImpl(url, {
+        const requestUrl =
+          needsSnapshotRecovery && snapshotRecoveryUrl
+            ? snapshotRecoveryUrl
+            : url;
+        const response = await fetchImpl(requestUrl, {
           method: "GET",
           signal: abort.signal,
           headers: { Accept: "text/event-stream", ...headers },
@@ -387,10 +395,17 @@ export const openPiEventStream = (
                 parsed = parseEventStreamPayload(frame.data, expectedThreadId);
               } catch (error) {
                 if (error instanceof InvalidKnownEventStreamPayloadError) {
+                  needsSnapshotRecovery = true;
                   throw error;
                 }
                 reportError(error);
                 continue;
+              }
+              if (
+                requestUrl === snapshotRecoveryUrl &&
+                parsed.type === "snapshot"
+              ) {
+                needsSnapshotRecovery = false;
               }
               if (!closed) emitEvent(parsed);
             }

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -20,6 +20,13 @@
 import { isRecord } from "@assistant-ui/core/internal";
 import { isKnownPiClientEventType } from "../eventTypes";
 import type { PiAnyClientEvent } from "../types";
+import {
+  isAssistantMessageDelta,
+  isCompleteTranscriptMessage,
+  isContextUsage,
+  isHostUiRequest,
+  isThreadSnapshot,
+} from "./validation";
 
 /** A decoded SSE frame. `data` is the concatenation of every `data:` line in the
  * frame (joined by `\n`, per the SSE spec); `event`/`id` are the last-seen field
@@ -128,6 +135,8 @@ export interface PiEventStreamOptions {
   fetchImpl?: typeof fetch;
   /** Extra request headers (e.g. auth). */
   headers?: Record<string, string>;
+  /** Thread ID expected in every event envelope. */
+  expectedThreadId?: string;
   /** Reconnect backoff between a dropped stream and the next attempt. Rejections
    * are reported via `onError`, then followed by the default ~1s backoff. */
   reconnectDelay?: () => Promise<void>;
@@ -156,86 +165,16 @@ const isOptionalString = (value: unknown): boolean =>
 const isOptionalBoolean = (value: unknown): boolean =>
   value === undefined || typeof value === "boolean";
 
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
 const isStringArray = (value: unknown): boolean =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
-
-const isUserContentPart = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
-  if (value.type === "image") {
-    return typeof value.data === "string" && typeof value.mimeType === "string";
-  }
-  return true;
-};
-
-const isUserContent = (value: unknown): boolean =>
-  typeof value === "string" ||
-  (Array.isArray(value) && value.every(isUserContentPart));
-
-const isAssistantContentPart = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
-  if (value.type === "thinking") return typeof value.thinking === "string";
-  if (value.type === "toolCall") {
-    return (
-      typeof value.id === "string" &&
-      typeof value.name === "string" &&
-      (value.arguments == null || isRecord(value.arguments))
-    );
-  }
-  return true;
-};
-
-const isMessage = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.role !== "string") return false;
-  if (value.role === "user" || value.role === "custom") {
-    return isUserContent(value.content);
-  }
-  if (value.role === "assistant") {
-    return (
-      Array.isArray(value.content) &&
-      value.content.every(isAssistantContentPart)
-    );
-  }
-  if (value.role === "toolResult") {
-    return (
-      typeof value.toolCallId === "string" &&
-      Array.isArray(value.content) &&
-      value.content.every(isUserContentPart)
-    );
-  }
-  return true;
-};
-
-const isContextUsage = (value: unknown): boolean =>
-  isRecord(value) &&
-  (value.tokens === null || typeof value.tokens === "number") &&
-  typeof value.contextWindow === "number" &&
-  (value.percent === null || typeof value.percent === "number");
-
-const isHostUiRequest = (value: unknown): boolean => {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.kind === "string" &&
-    typeof value.title === "string" &&
-    isOptionalString(value.toolCallId) &&
-    (value.timeoutMs === undefined || typeof value.timeoutMs === "number")
-  );
-};
 
 const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
   switch (event.type) {
     case "snapshot":
-      return (
-        isRecord(event.snapshot) &&
-        isRecord(event.snapshot.metadata) &&
-        typeof event.snapshot.metadata.id === "string" &&
-        event.snapshot.metadata.id.length > 0 &&
-        typeof event.snapshot.metadata.status === "string" &&
-        Array.isArray(event.snapshot.messages) &&
-        event.snapshot.messages.every(isMessage)
-      );
+      return isThreadSnapshot(event.snapshot);
     case "agent_start":
     case "agent_settled":
       return true;
@@ -246,26 +185,29 @@ const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
       return typeof event.turnIndex === "number";
     case "message_start":
     case "message_end":
-      return isMessage(event.message);
+      return isCompleteTranscriptMessage(event.message);
     case "message_update":
       return (
-        isMessage(event.message) &&
-        isRecord(event.assistantMessageEvent) &&
-        typeof event.assistantMessageEvent.type === "string"
+        isCompleteTranscriptMessage(event.message) &&
+        isAssistantMessageDelta(event.assistantMessageEvent)
       );
     case "tool_execution_start":
       return (
         typeof event.toolCallId === "string" &&
-        typeof event.toolName === "string"
+        typeof event.toolName === "string" &&
+        hasOwn(event, "args")
       );
     case "tool_execution_update":
       return (
-        typeof event.toolCallId === "string" && isOptionalString(event.toolName)
+        typeof event.toolCallId === "string" &&
+        isOptionalString(event.toolName) &&
+        hasOwn(event, "partialResult")
       );
     case "tool_execution_end":
       return (
         typeof event.toolCallId === "string" &&
-        typeof event.isError === "boolean"
+        typeof event.isError === "boolean" &&
+        hasOwn(event, "result")
       );
     case "queue_update":
       return isStringArray(event.steering) && isStringArray(event.followUp);
@@ -310,7 +252,10 @@ const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
 
 class InvalidKnownEventStreamPayloadError extends Error {}
 
-const parseEventStreamPayload = (data: string): PiAnyClientEvent => {
+const parseEventStreamPayload = (
+  data: string,
+  expectedThreadId?: string,
+): PiAnyClientEvent => {
   const event: unknown = JSON.parse(data);
   if (!isRecord(event)) {
     throw new Error("Invalid Pi event stream payload: expected an object");
@@ -331,6 +276,11 @@ const parseEventStreamPayload = (data: string): PiAnyClientEvent => {
   if (!Number.isSafeInteger(event.seq) || (event.seq as number) < 0) {
     throw new PayloadError(
       'Invalid Pi event stream payload: expected a non-negative safe integer "seq"',
+    );
+  }
+  if (expectedThreadId !== undefined && event.threadId !== expectedThreadId) {
+    throw new InvalidKnownEventStreamPayloadError(
+      `Invalid Pi event stream payload: expected thread "${expectedThreadId}", received "${event.threadId}"`,
     );
   }
   if (isKnownPiClientEventType(event.type) && !isKnownEventPayload(event)) {
@@ -356,6 +306,7 @@ export const openPiEventStream = (
     onError,
     fetchImpl = fetch,
     headers,
+    expectedThreadId,
     reconnectDelay = defaultReconnectDelay,
   } = options;
 
@@ -433,7 +384,7 @@ export const openPiEventStream = (
               if (frame.event === "ping" || frame.data === "") continue;
               let parsed: PiAnyClientEvent;
               try {
-                parsed = parseEventStreamPayload(frame.data);
+                parsed = parseEventStreamPayload(frame.data, expectedThreadId);
               } catch (error) {
                 if (error instanceof InvalidKnownEventStreamPayloadError) {
                   throw error;

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -17,7 +17,7 @@
  *
  * Browser-safe: imports no `@earendil-works/pi-*`.
  */
-import type { PiAnyClientEvent } from "../types";
+import type { PiAnyClientEvent, PiClientEventBody } from "../types";
 
 /** A decoded SSE frame. `data` is the concatenation of every `data:` line in the
  * frame (joined by `\n`, per the SSE spec); `event`/`id` are the last-seen field
@@ -148,6 +148,247 @@ const validateEventStreamContentType = (response: Response): void => {
   }
 };
 
+const KNOWN_EVENT_TYPES = {
+  snapshot: true,
+  agent_start: true,
+  agent_end: true,
+  agent_settled: true,
+  turn_start: true,
+  turn_end: true,
+  message_start: true,
+  message_update: true,
+  message_end: true,
+  tool_execution_start: true,
+  tool_execution_update: true,
+  tool_execution_end: true,
+  queue_update: true,
+  compaction_start: true,
+  compaction_end: true,
+  entry_appended: true,
+  auto_retry_start: true,
+  auto_retry_end: true,
+  session_info_changed: true,
+  thinking_level_changed: true,
+  context_usage: true,
+  extension_ui_request: true,
+  extension_ui_resolved: true,
+  error: true,
+} satisfies Record<PiClientEventBody["type"], true>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const isOptionalString = (value: unknown): boolean =>
+  value === undefined || typeof value === "string";
+
+const isOptionalBoolean = (value: unknown): boolean =>
+  value === undefined || typeof value === "boolean";
+
+const isStringArray = (value: unknown): boolean =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isUserContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "image") {
+    return typeof value.data === "string" && typeof value.mimeType === "string";
+  }
+  return true;
+};
+
+const isUserContent = (value: unknown): boolean =>
+  typeof value === "string" ||
+  (Array.isArray(value) && value.every(isUserContentPart));
+
+const isAssistantContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "thinking") return typeof value.thinking === "string";
+  if (value.type === "toolCall") {
+    return (
+      typeof value.id === "string" &&
+      typeof value.name === "string" &&
+      (value.arguments == null || isRecord(value.arguments))
+    );
+  }
+  return true;
+};
+
+const isMessage = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.role !== "string") return false;
+  if (value.role === "user" || value.role === "custom") {
+    return isUserContent(value.content);
+  }
+  if (value.role === "assistant") {
+    return (
+      Array.isArray(value.content) &&
+      value.content.every(isAssistantContentPart)
+    );
+  }
+  if (value.role === "toolResult") {
+    return (
+      typeof value.toolCallId === "string" &&
+      Array.isArray(value.content) &&
+      value.content.every(isUserContentPart)
+    );
+  }
+  return true;
+};
+
+const isContextUsage = (value: unknown): boolean =>
+  isRecord(value) &&
+  (value.tokens === null || typeof value.tokens === "number") &&
+  typeof value.contextWindow === "number" &&
+  (value.percent === null || typeof value.percent === "number");
+
+const isHostUiRequest = (value: unknown): boolean => {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.kind !== "string" ||
+    !isOptionalString(value.toolCallId) ||
+    (value.timeoutMs !== undefined && typeof value.timeoutMs !== "number")
+  ) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case "confirm":
+      return (
+        typeof value.title === "string" && typeof value.message === "string"
+      );
+    case "select":
+      return typeof value.title === "string" && isStringArray(value.options);
+    case "input":
+      return (
+        typeof value.title === "string" && isOptionalString(value.placeholder)
+      );
+    case "editor":
+      return typeof value.title === "string" && isOptionalString(value.prefill);
+    default:
+      return false;
+  }
+};
+
+const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
+  switch (event.type) {
+    case "snapshot":
+      return (
+        isRecord(event.snapshot) &&
+        isRecord(event.snapshot.metadata) &&
+        typeof event.snapshot.metadata.id === "string" &&
+        event.snapshot.metadata.id.length > 0 &&
+        typeof event.snapshot.metadata.status === "string" &&
+        Array.isArray(event.snapshot.messages) &&
+        event.snapshot.messages.every(isMessage)
+      );
+    case "agent_start":
+    case "agent_settled":
+      return true;
+    case "agent_end":
+      return isOptionalBoolean(event.willRetry);
+    case "turn_start":
+    case "turn_end":
+      return typeof event.turnIndex === "number";
+    case "message_start":
+    case "message_end":
+      return isMessage(event.message);
+    case "message_update":
+      return (
+        isMessage(event.message) &&
+        isRecord(event.assistantMessageEvent) &&
+        typeof event.assistantMessageEvent.type === "string"
+      );
+    case "tool_execution_start":
+      return (
+        typeof event.toolCallId === "string" &&
+        typeof event.toolName === "string"
+      );
+    case "tool_execution_update":
+      return (
+        typeof event.toolCallId === "string" && isOptionalString(event.toolName)
+      );
+    case "tool_execution_end":
+      return (
+        typeof event.toolCallId === "string" &&
+        typeof event.isError === "boolean"
+      );
+    case "queue_update":
+      return isStringArray(event.steering) && isStringArray(event.followUp);
+    case "compaction_start":
+      return (
+        event.reason === "manual" ||
+        event.reason === "threshold" ||
+        event.reason === "overflow"
+      );
+    case "compaction_end":
+      return (
+        typeof event.aborted === "boolean" &&
+        typeof event.willRetry === "boolean"
+      );
+    case "entry_appended":
+      return (
+        isRecord(event.entry) &&
+        typeof event.entry.id === "string" &&
+        (event.entry.parentId === null ||
+          typeof event.entry.parentId === "string") &&
+        typeof event.entry.timestamp === "string" &&
+        typeof event.entry.type === "string"
+      );
+    case "auto_retry_start":
+      return (
+        typeof event.attempt === "number" && typeof event.delayMs === "number"
+      );
+    case "auto_retry_end":
+      return typeof event.success === "boolean";
+    case "session_info_changed":
+      return isOptionalString(event.name);
+    case "thinking_level_changed":
+      return typeof event.level === "string";
+    case "context_usage":
+      return isContextUsage(event.contextUsage);
+    case "extension_ui_request":
+      return isHostUiRequest(event.request);
+    case "extension_ui_resolved":
+      return typeof event.requestId === "string";
+    case "error":
+      return typeof event.error === "string";
+    default:
+      return true;
+  }
+};
+
+const parseEventStreamPayload = (data: string): PiAnyClientEvent => {
+  const event: unknown = JSON.parse(data);
+  if (!isRecord(event)) {
+    throw new Error("Invalid Pi event stream payload: expected an object");
+  }
+  if (typeof event.type !== "string" || event.type.length === 0) {
+    throw new Error(
+      'Invalid Pi event stream payload: expected a non-empty string "type"',
+    );
+  }
+  if (typeof event.threadId !== "string" || event.threadId.length === 0) {
+    throw new Error(
+      'Invalid Pi event stream payload: expected a non-empty string "threadId"',
+    );
+  }
+  if (!Number.isSafeInteger(event.seq) || (event.seq as number) < 0) {
+    throw new Error(
+      'Invalid Pi event stream payload: expected a non-negative safe integer "seq"',
+    );
+  }
+  if (hasOwn(KNOWN_EVENT_TYPES, event.type) && !isKnownEventPayload(event)) {
+    throw new Error(
+      `Invalid Pi event stream payload: event "${event.type}" has an invalid payload`,
+    );
+  }
+  return event as PiAnyClientEvent;
+};
+
 /**
  * Open a reconnecting SSE stream. Returns a synchronous unsubscribe that aborts
  * the in-flight request and stops reconnecting. Frames named `ping` and empty
@@ -240,7 +481,7 @@ export const openPiEventStream = (
               if (frame.event === "ping" || frame.data === "") continue;
               let parsed: PiAnyClientEvent;
               try {
-                parsed = JSON.parse(frame.data) as PiAnyClientEvent;
+                parsed = parseEventStreamPayload(frame.data);
               } catch (error) {
                 reportError(error);
                 continue;

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -17,7 +17,9 @@
  *
  * Browser-safe: imports no `@earendil-works/pi-*`.
  */
-import type { PiAnyClientEvent, PiClientEventBody } from "../types";
+import { isRecord } from "@assistant-ui/core/internal";
+import { isKnownPiClientEventType } from "../eventTypes";
+import type { PiAnyClientEvent } from "../types";
 
 /** A decoded SSE frame. `data` is the concatenation of every `data:` line in the
  * frame (joined by `\n`, per the SSE spec); `event`/`id` are the last-seen field
@@ -148,39 +150,6 @@ const validateEventStreamContentType = (response: Response): void => {
   }
 };
 
-const KNOWN_EVENT_TYPES = {
-  snapshot: true,
-  agent_start: true,
-  agent_end: true,
-  agent_settled: true,
-  turn_start: true,
-  turn_end: true,
-  message_start: true,
-  message_update: true,
-  message_end: true,
-  tool_execution_start: true,
-  tool_execution_update: true,
-  tool_execution_end: true,
-  queue_update: true,
-  compaction_start: true,
-  compaction_end: true,
-  entry_appended: true,
-  auto_retry_start: true,
-  auto_retry_end: true,
-  session_info_changed: true,
-  thinking_level_changed: true,
-  context_usage: true,
-  extension_ui_request: true,
-  extension_ui_resolved: true,
-  error: true,
-} satisfies Record<PiClientEventBody["type"], true>;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
-  Object.prototype.hasOwnProperty.call(value, key);
-
 const isOptionalString = (value: unknown): boolean =>
   value === undefined || typeof value === "string";
 
@@ -245,32 +214,14 @@ const isContextUsage = (value: unknown): boolean =>
   (value.percent === null || typeof value.percent === "number");
 
 const isHostUiRequest = (value: unknown): boolean => {
-  if (
-    !isRecord(value) ||
-    typeof value.id !== "string" ||
-    typeof value.kind !== "string" ||
-    !isOptionalString(value.toolCallId) ||
-    (value.timeoutMs !== undefined && typeof value.timeoutMs !== "number")
-  ) {
-    return false;
-  }
-
-  switch (value.kind) {
-    case "confirm":
-      return (
-        typeof value.title === "string" && typeof value.message === "string"
-      );
-    case "select":
-      return typeof value.title === "string" && isStringArray(value.options);
-    case "input":
-      return (
-        typeof value.title === "string" && isOptionalString(value.placeholder)
-      );
-    case "editor":
-      return typeof value.title === "string" && isOptionalString(value.prefill);
-    default:
-      return false;
-  }
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.kind === "string" &&
+    typeof value.title === "string" &&
+    isOptionalString(value.toolCallId) &&
+    (value.timeoutMs === undefined || typeof value.timeoutMs === "number")
+  );
 };
 
 const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
@@ -319,11 +270,7 @@ const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
     case "queue_update":
       return isStringArray(event.steering) && isStringArray(event.followUp);
     case "compaction_start":
-      return (
-        event.reason === "manual" ||
-        event.reason === "threshold" ||
-        event.reason === "overflow"
-      );
+      return typeof event.reason === "string";
     case "compaction_end":
       return (
         typeof event.aborted === "boolean" &&
@@ -361,6 +308,8 @@ const isKnownEventPayload = (event: Record<string, unknown>): boolean => {
   }
 };
 
+class InvalidKnownEventStreamPayloadError extends Error {}
+
 const parseEventStreamPayload = (data: string): PiAnyClientEvent => {
   const event: unknown = JSON.parse(data);
   if (!isRecord(event)) {
@@ -371,18 +320,21 @@ const parseEventStreamPayload = (data: string): PiAnyClientEvent => {
       'Invalid Pi event stream payload: expected a non-empty string "type"',
     );
   }
+  const PayloadError = isKnownPiClientEventType(event.type)
+    ? InvalidKnownEventStreamPayloadError
+    : Error;
   if (typeof event.threadId !== "string" || event.threadId.length === 0) {
-    throw new Error(
+    throw new PayloadError(
       'Invalid Pi event stream payload: expected a non-empty string "threadId"',
     );
   }
   if (!Number.isSafeInteger(event.seq) || (event.seq as number) < 0) {
-    throw new Error(
+    throw new PayloadError(
       'Invalid Pi event stream payload: expected a non-negative safe integer "seq"',
     );
   }
-  if (hasOwn(KNOWN_EVENT_TYPES, event.type) && !isKnownEventPayload(event)) {
-    throw new Error(
+  if (isKnownPiClientEventType(event.type) && !isKnownEventPayload(event)) {
+    throw new InvalidKnownEventStreamPayloadError(
       `Invalid Pi event stream payload: event "${event.type}" has an invalid payload`,
     );
   }
@@ -483,6 +435,9 @@ export const openPiEventStream = (
               try {
                 parsed = parseEventStreamPayload(frame.data);
               } catch (error) {
+                if (error instanceof InvalidKnownEventStreamPayloadError) {
+                  throw error;
+                }
                 reportError(error);
                 continue;
               }

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -305,6 +305,52 @@ describe("createPiHttpClient", () => {
     ).resolves.toEqual(response);
   });
 
+  it("accepts tool calls with null arguments", async () => {
+    const response = {
+      ...snapshot,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "tc1", name: "search", arguments: null },
+          ],
+        },
+      ],
+    };
+    const { fn } = fakeFetch(() => json(response));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).resolves.toEqual(response);
+  });
+
+  it("rejects bash executions without a command", async () => {
+    const { fn } = fakeFetch(() =>
+      json({
+        ...snapshot,
+        messages: [{ role: "bashExecution", output: "x" }],
+      }),
+    );
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  });
+
+  it("accepts renderable bash executions without scalar metadata", async () => {
+    const response = {
+      ...snapshot,
+      messages: [{ role: "bashExecution", command: "ls", output: "x" }],
+    };
+    const { fn } = fakeFetch(() => json(response));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).resolves.toEqual(response);
+  });
+
   it("rejects tool results without a tool call id", async () => {
     const { fn } = fakeFetch(() =>
       json({

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -309,6 +309,9 @@ export const createPiHttpClient = (
           close: openPiEventStream({
             url: eventsUrl,
             expectedThreadId: threadId,
+            ...(!includeSnapshot && {
+              snapshotRecoveryUrl: `${threadUrl(threadId)}/events`,
+            }),
             fetchImpl,
             ...(headers ? { headers } : {}),
             ...(reconnectDelay ? { reconnectDelay } : {}),

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -28,6 +28,7 @@
  */
 import { isRecord } from "@assistant-ui/core/internal";
 import { openPiEventStream } from "./eventSource";
+import { isThreadMetadata, isThreadSnapshot } from "./validation";
 import type {
   PiClient,
   PiClientEvent,
@@ -96,61 +97,6 @@ const readJson = async (
   }
 };
 
-const isOptionalString = (value: unknown): boolean =>
-  value === undefined || typeof value === "string";
-
-const isOptionalBoolean = (value: unknown): boolean =>
-  value === undefined || typeof value === "boolean";
-
-const isOptionalNumber = (value: unknown): boolean =>
-  value === undefined || typeof value === "number";
-
-const isQueuedMessage = (value: unknown): boolean => {
-  if (!isRecord(value)) return false;
-  return (
-    typeof value.id === "string" &&
-    typeof value.mode === "string" &&
-    typeof value.content === "string"
-  );
-};
-
-const isThreadConfig = (value: unknown): boolean =>
-  value === undefined ||
-  (isRecord(value) &&
-    isOptionalString(value.provider) &&
-    isOptionalString(value.modelId) &&
-    isOptionalString(value.thinkingLevel));
-
-const isContextUsage = (value: unknown): boolean =>
-  value === undefined ||
-  (isRecord(value) &&
-    (value.tokens === null || typeof value.tokens === "number") &&
-    typeof value.contextWindow === "number" &&
-    (value.percent === null || typeof value.percent === "number"));
-
-const isThreadMetadata = (value: unknown): value is PiThreadMetadata => {
-  if (!isRecord(value)) return false;
-  return (
-    typeof value.id === "string" &&
-    value.id.length > 0 &&
-    typeof value.status === "string" &&
-    (value.queuedMessages === undefined ||
-      (Array.isArray(value.queuedMessages) &&
-        value.queuedMessages.every(isQueuedMessage))) &&
-    isOptionalString(value.title) &&
-    isOptionalString(value.workspacePath) &&
-    isOptionalBoolean(value.archived) &&
-    isOptionalString(value.runningRunId) &&
-    isThreadConfig(value.config) &&
-    isContextUsage(value.contextUsage) &&
-    isOptionalString(value.sessionFile) &&
-    isOptionalString(value.parentSessionPath) &&
-    isOptionalNumber(value.messageCount) &&
-    isOptionalString(value.createdAt) &&
-    isOptionalString(value.updatedAt)
-  );
-};
-
 const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
   if (!Array.isArray(value)) {
     throw invalidResponse("listing threads", "expected an array of threads.");
@@ -167,99 +113,11 @@ const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
   return value;
 };
 
-const isUserContentPart = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
-  if (value.type === "image") {
-    return typeof value.data === "string" && typeof value.mimeType === "string";
-  }
-  return true;
-};
-
-const isUserContent = (value: unknown): boolean =>
-  typeof value === "string" ||
-  (Array.isArray(value) && value.every(isUserContentPart));
-
-const isAssistantContentPart = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
-  if (value.type === "thinking") return typeof value.thinking === "string";
-  if (value.type === "toolCall") {
-    return (
-      typeof value.id === "string" &&
-      typeof value.name === "string" &&
-      (value.arguments == null || isRecord(value.arguments))
-    );
-  }
-  return true;
-};
-
-const isTranscriptMessage = (value: unknown): boolean => {
-  if (!isRecord(value) || typeof value.role !== "string") return false;
-  if (value.role === "user" || value.role === "custom")
-    return isUserContent(value.content);
-  if (value.role === "assistant") {
-    return (
-      Array.isArray(value.content) &&
-      value.content.every(isAssistantContentPart)
-    );
-  }
-  if (value.role === "toolResult") {
-    return (
-      typeof value.toolCallId === "string" &&
-      Array.isArray(value.content) &&
-      value.content.every(isUserContentPart)
-    );
-  }
-  return true;
-};
-
-const isHostUiRequest = (value: unknown): boolean => {
-  if (!isRecord(value)) return false;
-  if (typeof value.id !== "string" || typeof value.kind !== "string") {
-    return false;
-  }
-  if (
-    !isOptionalString(value.toolCallId) ||
-    !isOptionalNumber(value.timeoutMs)
-  ) {
-    return false;
-  }
-
-  if (value.kind === "confirm") {
-    return typeof value.title === "string" && typeof value.message === "string";
-  }
-  if (value.kind === "select") {
-    return (
-      typeof value.title === "string" &&
-      Array.isArray(value.options) &&
-      value.options.every((option) => typeof option === "string")
-    );
-  }
-  if (value.kind === "input") {
-    return (
-      typeof value.title === "string" && isOptionalString(value.placeholder)
-    );
-  }
-  if (value.kind === "editor") {
-    return typeof value.title === "string" && isOptionalString(value.prefill);
-  }
-  return true;
-};
-
 const parseThreadSnapshotResponse = (
   value: unknown,
   operation: "creating a thread" | "fetching a thread",
 ): PiThreadSnapshot => {
-  if (
-    !isRecord(value) ||
-    !isThreadMetadata(value.metadata) ||
-    !Array.isArray(value.messages) ||
-    !value.messages.every(isTranscriptMessage) ||
-    (value.hostUiRequests !== undefined &&
-      (!Array.isArray(value.hostUiRequests) ||
-        !value.hostUiRequests.every(isHostUiRequest)))
-  ) {
+  if (!isThreadSnapshot(value)) {
     throw invalidResponse(
       operation,
       'expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
@@ -450,6 +308,7 @@ export const createPiHttpClient = (
           closeTimer: undefined,
           close: openPiEventStream({
             url: eventsUrl,
+            expectedThreadId: threadId,
             fetchImpl,
             ...(headers ? { headers } : {}),
             ...(reconnectDelay ? { reconnectDelay } : {}),

--- a/packages/react-pi/src/client/validation.ts
+++ b/packages/react-pi/src/client/validation.ts
@@ -1,0 +1,297 @@
+import { isRecord } from "@assistant-ui/core/internal";
+import type {
+  PiAssistantMessage,
+  PiAssistantMessageDelta,
+  PiHostUiRequest,
+  PiThreadMetadata,
+  PiThreadSnapshot,
+  PiTranscriptMessage,
+} from "../types";
+
+const isOptionalString = (value: unknown): boolean =>
+  value === undefined || typeof value === "string";
+
+const isOptionalBoolean = (value: unknown): boolean =>
+  value === undefined || typeof value === "boolean";
+
+const isOptionalNumber = (value: unknown): boolean =>
+  value === undefined || typeof value === "number";
+
+const isStringArray = (value: unknown): boolean =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isUserContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "image") {
+    return typeof value.data === "string" && typeof value.mimeType === "string";
+  }
+  return true;
+};
+
+const isUserContent = (value: unknown): boolean =>
+  typeof value === "string" ||
+  (Array.isArray(value) && value.every(isUserContentPart));
+
+const isToolCall = (value: unknown): boolean =>
+  isRecord(value) &&
+  value.type === "toolCall" &&
+  typeof value.id === "string" &&
+  typeof value.name === "string" &&
+  isRecord(value.arguments) &&
+  isOptionalString(value.thoughtSignature);
+
+const isAssistantContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") {
+    return (
+      typeof value.text === "string" && isOptionalString(value.textSignature)
+    );
+  }
+  if (value.type === "thinking") {
+    return (
+      typeof value.thinking === "string" &&
+      isOptionalString(value.thinkingSignature) &&
+      isOptionalBoolean(value.redacted)
+    );
+  }
+  if (value.type === "toolCall") return isToolCall(value);
+  return true;
+};
+
+const isUsage = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.input === "number" &&
+  typeof value.output === "number" &&
+  typeof value.cacheRead === "number" &&
+  typeof value.cacheWrite === "number" &&
+  typeof value.totalTokens === "number" &&
+  isRecord(value.cost) &&
+  typeof value.cost.input === "number" &&
+  typeof value.cost.output === "number" &&
+  typeof value.cost.cacheRead === "number" &&
+  typeof value.cost.cacheWrite === "number" &&
+  typeof value.cost.total === "number";
+
+export const isAssistantMessage = (
+  value: unknown,
+): value is PiAssistantMessage =>
+  isRecord(value) &&
+  value.role === "assistant" &&
+  Array.isArray(value.content) &&
+  value.content.every(isAssistantContentPart) &&
+  typeof value.api === "string" &&
+  typeof value.provider === "string" &&
+  typeof value.model === "string" &&
+  isOptionalString(value.responseModel) &&
+  isOptionalString(value.responseId) &&
+  isUsage(value.usage) &&
+  typeof value.stopReason === "string" &&
+  isOptionalString(value.errorMessage) &&
+  typeof value.timestamp === "number";
+
+export const isCompleteTranscriptMessage = (
+  value: unknown,
+): value is PiTranscriptMessage => {
+  if (!isRecord(value) || typeof value.role !== "string") return false;
+
+  switch (value.role) {
+    case "user":
+      return (
+        isUserContent(value.content) && typeof value.timestamp === "number"
+      );
+    case "assistant":
+      return isAssistantMessage(value);
+    case "toolResult":
+      return (
+        typeof value.toolCallId === "string" &&
+        typeof value.toolName === "string" &&
+        Array.isArray(value.content) &&
+        value.content.every(isUserContentPart) &&
+        typeof value.isError === "boolean" &&
+        typeof value.timestamp === "number"
+      );
+    case "bashExecution":
+      return (
+        typeof value.command === "string" &&
+        typeof value.output === "string" &&
+        (value.exitCode === undefined || typeof value.exitCode === "number") &&
+        typeof value.cancelled === "boolean" &&
+        typeof value.truncated === "boolean" &&
+        isOptionalString(value.fullOutputPath) &&
+        typeof value.timestamp === "number" &&
+        isOptionalBoolean(value.excludeFromContext)
+      );
+    case "custom":
+      return (
+        typeof value.customType === "string" &&
+        isUserContent(value.content) &&
+        typeof value.display === "boolean" &&
+        typeof value.timestamp === "number"
+      );
+    case "branchSummary":
+      return (
+        typeof value.summary === "string" &&
+        typeof value.fromId === "string" &&
+        typeof value.timestamp === "number"
+      );
+    case "compactionSummary":
+      return (
+        typeof value.summary === "string" &&
+        typeof value.tokensBefore === "number" &&
+        typeof value.timestamp === "number"
+      );
+    default:
+      return true;
+  }
+};
+
+export const isTranscriptMessage = (
+  value: unknown,
+): value is PiTranscriptMessage => {
+  if (!isRecord(value) || typeof value.role !== "string") return false;
+  if (value.role === "user" || value.role === "custom") {
+    return isUserContent(value.content);
+  }
+  if (value.role === "assistant") {
+    return (
+      Array.isArray(value.content) &&
+      value.content.every(isAssistantContentPart)
+    );
+  }
+  if (value.role === "toolResult") {
+    return (
+      typeof value.toolCallId === "string" &&
+      Array.isArray(value.content) &&
+      value.content.every(isUserContentPart)
+    );
+  }
+  return true;
+};
+
+export const isAssistantMessageDelta = (
+  value: unknown,
+): value is PiAssistantMessageDelta => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+
+  const hasContentIndex =
+    Number.isSafeInteger(value.contentIndex) &&
+    (value.contentIndex as number) >= 0;
+
+  switch (value.type) {
+    case "start":
+      return isAssistantMessage(value.partial);
+    case "text_start":
+    case "thinking_start":
+    case "toolcall_start":
+      return hasContentIndex && isAssistantMessage(value.partial);
+    case "text_delta":
+    case "thinking_delta":
+    case "toolcall_delta":
+      return (
+        hasContentIndex &&
+        typeof value.delta === "string" &&
+        isAssistantMessage(value.partial)
+      );
+    case "text_end":
+    case "thinking_end":
+      return (
+        hasContentIndex &&
+        typeof value.content === "string" &&
+        isAssistantMessage(value.partial)
+      );
+    case "toolcall_end":
+      return (
+        hasContentIndex &&
+        isToolCall(value.toolCall) &&
+        isAssistantMessage(value.partial)
+      );
+    case "done":
+      return (
+        typeof value.reason === "string" && isAssistantMessage(value.message)
+      );
+    case "error":
+      return (
+        typeof value.reason === "string" && isAssistantMessage(value.error)
+      );
+    default:
+      return true;
+  }
+};
+
+export const isContextUsage = (value: unknown): boolean =>
+  isRecord(value) &&
+  (value.tokens === null || typeof value.tokens === "number") &&
+  typeof value.contextWindow === "number" &&
+  (value.percent === null || typeof value.percent === "number");
+
+export const isHostUiRequest = (value: unknown): value is PiHostUiRequest => {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.kind !== "string" ||
+    !isOptionalString(value.toolCallId) ||
+    !isOptionalNumber(value.timeoutMs)
+  ) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case "confirm":
+      return (
+        typeof value.title === "string" && typeof value.message === "string"
+      );
+    case "select":
+      return typeof value.title === "string" && isStringArray(value.options);
+    case "input":
+      return (
+        typeof value.title === "string" && isOptionalString(value.placeholder)
+      );
+    case "editor":
+      return typeof value.title === "string" && isOptionalString(value.prefill);
+    default:
+      return true;
+  }
+};
+
+const isQueuedMessage = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  typeof value.mode === "string" &&
+  typeof value.content === "string";
+
+const isThreadConfig = (value: unknown): boolean =>
+  value === undefined ||
+  (isRecord(value) &&
+    isOptionalString(value.provider) &&
+    isOptionalString(value.modelId) &&
+    isOptionalString(value.thinkingLevel));
+
+export const isThreadMetadata = (value: unknown): value is PiThreadMetadata =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  value.id.length > 0 &&
+  typeof value.status === "string" &&
+  (value.queuedMessages === undefined ||
+    (Array.isArray(value.queuedMessages) &&
+      value.queuedMessages.every(isQueuedMessage))) &&
+  isOptionalString(value.title) &&
+  isOptionalString(value.workspacePath) &&
+  isOptionalBoolean(value.archived) &&
+  isOptionalString(value.runningRunId) &&
+  isThreadConfig(value.config) &&
+  (value.contextUsage === undefined || isContextUsage(value.contextUsage)) &&
+  isOptionalString(value.sessionFile) &&
+  isOptionalString(value.parentSessionPath) &&
+  isOptionalNumber(value.messageCount) &&
+  isOptionalString(value.createdAt) &&
+  isOptionalString(value.updatedAt);
+
+export const isThreadSnapshot = (value: unknown): value is PiThreadSnapshot =>
+  isRecord(value) &&
+  isThreadMetadata(value.metadata) &&
+  Array.isArray(value.messages) &&
+  value.messages.every(isTranscriptMessage) &&
+  (value.hostUiRequests === undefined ||
+    (Array.isArray(value.hostUiRequests) &&
+      value.hostUiRequests.every(isHostUiRequest)));

--- a/packages/react-pi/src/client/validation.ts
+++ b/packages/react-pi/src/client/validation.ts
@@ -38,7 +38,7 @@ const isToolCall = (value: unknown): boolean =>
   value.type === "toolCall" &&
   typeof value.id === "string" &&
   typeof value.name === "string" &&
-  isRecord(value.arguments) &&
+  (value.arguments == null || isRecord(value.arguments)) &&
   isOptionalString(value.thoughtSignature);
 
 const isAssistantContentPart = (value: unknown): boolean => {
@@ -144,29 +144,6 @@ export const isCompleteTranscriptMessage = (
     default:
       return true;
   }
-};
-
-export const isTranscriptMessage = (
-  value: unknown,
-): value is PiTranscriptMessage => {
-  if (!isRecord(value) || typeof value.role !== "string") return false;
-  if (value.role === "user" || value.role === "custom") {
-    return isUserContent(value.content);
-  }
-  if (value.role === "assistant") {
-    return (
-      Array.isArray(value.content) &&
-      value.content.every(isAssistantContentPart)
-    );
-  }
-  if (value.role === "toolResult") {
-    return (
-      typeof value.toolCallId === "string" &&
-      Array.isArray(value.content) &&
-      value.content.every(isUserContentPart)
-    );
-  }
-  return true;
 };
 
 export const isAssistantMessageDelta = (
@@ -287,11 +264,46 @@ export const isThreadMetadata = (value: unknown): value is PiThreadMetadata =>
   isOptionalString(value.createdAt) &&
   isOptionalString(value.updatedAt);
 
+const isRenderableTranscriptMessage = (
+  value: unknown,
+): value is PiTranscriptMessage => {
+  if (!isRecord(value) || typeof value.role !== "string") return false;
+
+  switch (value.role) {
+    case "user":
+      return isUserContent(value.content);
+    case "assistant":
+      return (
+        Array.isArray(value.content) &&
+        value.content.every(isAssistantContentPart)
+      );
+    case "toolResult":
+      return (
+        typeof value.toolCallId === "string" &&
+        Array.isArray(value.content) &&
+        value.content.every(isUserContentPart)
+      );
+    case "bashExecution":
+      return (
+        typeof value.command === "string" && typeof value.output === "string"
+      );
+    case "custom":
+      return (
+        typeof value.customType === "string" && isUserContent(value.content)
+      );
+    case "branchSummary":
+    case "compactionSummary":
+      return typeof value.summary === "string";
+    default:
+      return true;
+  }
+};
+
 export const isThreadSnapshot = (value: unknown): value is PiThreadSnapshot =>
   isRecord(value) &&
   isThreadMetadata(value.metadata) &&
   Array.isArray(value.messages) &&
-  value.messages.every(isTranscriptMessage) &&
+  value.messages.every(isRenderableTranscriptMessage) &&
   (value.hostUiRequests === undefined ||
     (Array.isArray(value.hostUiRequests) &&
       value.hostUiRequests.every(isHostUiRequest)));

--- a/packages/react-pi/src/eventTypes.ts
+++ b/packages/react-pi/src/eventTypes.ts
@@ -1,0 +1,33 @@
+import type { PiClientEventBody } from "./types";
+
+const KNOWN_PI_CLIENT_EVENT_TYPES = {
+  snapshot: true,
+  agent_start: true,
+  agent_end: true,
+  agent_settled: true,
+  turn_start: true,
+  turn_end: true,
+  message_start: true,
+  message_update: true,
+  message_end: true,
+  tool_execution_start: true,
+  tool_execution_update: true,
+  tool_execution_end: true,
+  queue_update: true,
+  compaction_start: true,
+  compaction_end: true,
+  entry_appended: true,
+  auto_retry_start: true,
+  auto_retry_end: true,
+  session_info_changed: true,
+  thinking_level_changed: true,
+  context_usage: true,
+  extension_ui_request: true,
+  extension_ui_resolved: true,
+  error: true,
+} satisfies Record<PiClientEventBody["type"], true>;
+
+export const isKnownPiClientEventType = (
+  type: string,
+): type is PiClientEventBody["type"] =>
+  Object.prototype.hasOwnProperty.call(KNOWN_PI_CLIENT_EVENT_TYPES, type);

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -21,6 +21,7 @@ import {
   type PiThreadState,
 } from "./threadState";
 import { errorText } from "../utils";
+import { isKnownPiClientEventType } from "../eventTypes";
 import { projectPiThreadMessagesShared } from "./messageProjection";
 import {
   responseForApproval,
@@ -127,18 +128,6 @@ const METADATA_DIRTY_EVENT_TYPES: ReadonlySet<string> = new Set([
   "extension_ui_request",
   "extension_ui_resolved",
   "error",
-]);
-
-/** Everything the reducer understands: the two dirty sets plus the event types
- * it deliberately absorbs without marking anything dirty. */
-const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
-  ...MESSAGE_DIRTY_EVENT_TYPES,
-  ...METADATA_DIRTY_EVENT_TYPES,
-  "turn_start",
-  "turn_end",
-  "tool_execution_start",
-  "agent_settled",
-  "entry_appended",
 ]);
 
 /** Parse a `data:<mime>;base64,<data>` URL into Pi `ImageContent`. Non-data-URL
@@ -616,7 +605,7 @@ export class PiThreadController implements PiThreadControllerLike {
     // Pi 0.80.7 emits entry_appended only for custom extension entries. Keep
     // snapshot reconciliation for other variants if Pi broadens that event.
     const needsSnapshotRefresh =
-      !KNOWN_EVENT_TYPES.has(event.type) ||
+      !isKnownPiClientEventType(event.type) ||
       (event.type === "entry_appended" && event.entry?.type !== "custom");
     if (needsSnapshotRefresh) this.refreshInBackground();
   }


### PR DESCRIPTION
## Summary

- validate the shared `threadId` and `seq` event envelope before dispatch
- validate required fields for every known Pi event type and report malformed frames through `onError`
- preserve forward compatibility by continuing to accept unknown event types with a valid envelope

## Reproduction

A `message_start` SSE frame without its required `message` was previously delivered to the reducer. The reducer advanced `lastSeq` and appended `undefined`, leaving corrupted thread state until a later snapshot reconciliation.

## Test plan

- `vitest run` in `packages/react-pi` (188 tests)
- `pnpm --filter @assistant-ui/react-pi... build`
- focused malformed-envelope, malformed-known-event, and unknown-event regression coverage

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Cwh5vc7OXOupNx5UMlN_TapTm2szDW6QJA4_YEZ343ozrRea6T6z9OBMrUE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->