### PR TITLE
fix(core): propagate frame tool cancellation

### DIFF
--- a/.changeset/assistant-frame-tool-cancellation.md
+++ b/.changeset/assistant-frame-tool-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: propagate AssistantFrame tool cancellation across the frame boundary

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1938,13 +1938,16 @@ type FrameMessage = {
   toolName: string;
   args: unknown;
 } | {
+  type: "tool-cancel";
+  id: string;
+} | {
   type: "tool-result";
   id: string;
   result?: unknown;
   error?: string;
 };
 
-type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
+type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-cancel" | "tool-result";
 
 type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "frontend";

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2246,13 +2246,16 @@ type FrameMessage = {
   toolName: string;
   args: unknown;
 } | {
+  type: "tool-cancel";
+  id: string;
+} | {
   type: "tool-result";
   id: string;
   result?: unknown;
   error?: string;
 };
 
-type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
+type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-cancel" | "tool-result";
 
 type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "frontend";

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -46,7 +46,15 @@ const createHost = () => {
   const execute = host.getModelContext().tools?.search?.execute;
   if (!execute) throw new Error("Expected the search tool to be available");
 
-  return { dispatchMessage, execute, host, postMessage };
+  const getToolCallId = () => {
+    const call = postMessage.mock.calls.find(
+      ([data]) => data.message.type === "tool-call",
+    );
+    if (!call) throw new Error("Expected a tool call to be posted");
+    return call[0].message.id as string;
+  };
+
+  return { dispatchMessage, execute, getToolCallId, host, postMessage };
 };
 
 beforeEach(() => {
@@ -60,14 +68,14 @@ afterEach(() => {
 
 describe("AssistantFrameHost", () => {
   it("resolves tool calls from frame results", async () => {
-    const { dispatchMessage, execute, host } = createHost();
+    const { dispatchMessage, execute, getToolCallId, host } = createHost();
     const result = Promise.resolve(
       execute({ query: "weather" }, executionContext),
     );
 
     dispatchMessage({
       type: "tool-result",
-      id: "tool-0",
+      id: getToolCallId(),
       result: "sunny",
     });
 
@@ -77,8 +85,9 @@ describe("AssistantFrameHost", () => {
   });
 
   it("rejects pending tool calls when disposed", async () => {
-    const { execute, host, postMessage } = createHost();
+    const { execute, getToolCallId, host, postMessage } = createHost();
     const result = Promise.resolve(execute({}, executionContext));
+    const toolCallId = getToolCallId();
 
     host.dispose();
 
@@ -88,7 +97,7 @@ describe("AssistantFrameHost", () => {
     expect(postMessage).toHaveBeenLastCalledWith(
       {
         channel: FRAME_MESSAGE_CHANNEL,
-        message: { type: "tool-cancel", id: "tool-0" },
+        message: { type: "tool-cancel", id: toolCallId },
       },
       "*",
     );
@@ -96,7 +105,7 @@ describe("AssistantFrameHost", () => {
   });
 
   it("rejects pending tool calls when execution is aborted", async () => {
-    const { execute, host, postMessage } = createHost();
+    const { execute, getToolCallId, host, postMessage } = createHost();
     const abortController = new AbortController();
     const abortError = new Error("Run cancelled");
     abortError.name = "AbortError";
@@ -111,6 +120,7 @@ describe("AssistantFrameHost", () => {
     );
     const onRejected = vi.fn();
     void result.catch(onRejected);
+    const toolCallId = getToolCallId();
 
     abortController.abort(abortError);
     await Promise.resolve();
@@ -119,12 +129,47 @@ describe("AssistantFrameHost", () => {
     expect(postMessage).toHaveBeenLastCalledWith(
       {
         channel: FRAME_MESSAGE_CHANNEL,
-        message: { type: "tool-cancel", id: "tool-0" },
+        message: { type: "tool-cancel", id: toolCallId },
       },
       "*",
     );
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();
+  });
+
+  it("cancels tool calls when they time out", async () => {
+    const { execute, getToolCallId, host, postMessage } = createHost();
+    const result = Promise.resolve(execute({}, executionContext));
+    const toolCallId = getToolCallId();
+    const rejection = expect(result).rejects.toThrow(
+      'Tool call "search" timed out',
+    );
+
+    await vi.advanceTimersByTimeAsync(30000);
+
+    await rejection;
+    expect(postMessage).toHaveBeenLastCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: { type: "tool-cancel", id: toolCallId },
+      },
+      "*",
+    );
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
+  it("uses unique tool IDs across host instances", () => {
+    const first = createHost();
+    const second = createHost();
+
+    void first.execute({}, executionContext).catch(() => undefined);
+    void second.execute({}, executionContext).catch(() => undefined);
+
+    expect(first.getToolCallId()).not.toBe(second.getToolCallId());
+
+    first.host.dispose();
+    second.host.dispose();
   });
 
   it("does not post tool calls when execution is already aborted", async () => {

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -77,7 +77,7 @@ describe("AssistantFrameHost", () => {
   });
 
   it("rejects pending tool calls when disposed", async () => {
-    const { execute, host } = createHost();
+    const { execute, host, postMessage } = createHost();
     const result = Promise.resolve(execute({}, executionContext));
 
     host.dispose();
@@ -85,11 +85,18 @@ describe("AssistantFrameHost", () => {
     await expect(result).rejects.toThrow(
       "AssistantFrameHost has been disposed",
     );
+    expect(postMessage).toHaveBeenLastCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: { type: "tool-cancel", id: "tool-0" },
+      },
+      "*",
+    );
     expect(vi.getTimerCount()).toBe(0);
   });
 
   it("rejects pending tool calls when execution is aborted", async () => {
-    const { execute, host } = createHost();
+    const { execute, host, postMessage } = createHost();
     const abortController = new AbortController();
     const abortError = new Error("Run cancelled");
     abortError.name = "AbortError";
@@ -109,6 +116,13 @@ describe("AssistantFrameHost", () => {
     await Promise.resolve();
 
     expect(onRejected).toHaveBeenCalledWith(abortError);
+    expect(postMessage).toHaveBeenLastCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: { type: "tool-cancel", id: "tool-0" },
+      },
+      "*",
+    );
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();
   });

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -2,6 +2,7 @@ import type { ModelContextProvider, ModelContext } from "../types";
 import type { Unsubscribe } from "../../types/unsubscribe";
 import type { Tool } from "assistant-stream";
 import { notifySubscribers as notifyStateSubscribers } from "../../subscribable/subscribable";
+import { generateId } from "../../utils/id";
 import {
   type FrameMessage,
   FRAME_MESSAGE_CHANNEL,
@@ -58,7 +59,6 @@ export class AssistantFrameHost implements ModelContextProvider {
       reject: (error: any) => void;
     }
   >();
-  private _requestCounter = 0;
   private _iframeWindow: Window;
   private _targetOrigin: string;
   private _disposed = false;
@@ -130,7 +130,7 @@ export class AssistantFrameHost implements ModelContextProvider {
     return this.sendRequest(
       {
         type: "tool-call",
-        id: `tool-${this._requestCounter++}`,
+        id: `tool-${generateId()}`,
         toolName,
         args,
       },

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -159,6 +159,7 @@ export class AssistantFrameHost implements ModelContextProvider {
         if (!abortSignal) return;
         const pending = this._pendingRequests.get(message.id);
         if (pending) {
+          this.cancelToolCall(message.id);
           pending.reject(getAbortReason(abortSignal));
           this._pendingRequests.delete(message.id);
         }
@@ -182,6 +183,7 @@ export class AssistantFrameHost implements ModelContextProvider {
       timeoutId = setTimeout(() => {
         const pending = this._pendingRequests.get(message.id);
         if (pending) {
+          this.cancelToolCall(message.id);
           pending.reject(new Error(timeoutMessage));
           this._pendingRequests.delete(message.id);
         }
@@ -193,6 +195,16 @@ export class AssistantFrameHost implements ModelContextProvider {
         this._targetOrigin,
       );
     });
+  }
+
+  private cancelToolCall(id: string) {
+    this._iframeWindow.postMessage(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: { type: "tool-cancel", id } satisfies FrameMessage,
+      },
+      this._targetOrigin,
+    );
   }
 
   private requestContext() {
@@ -225,7 +237,8 @@ export class AssistantFrameHost implements ModelContextProvider {
     window.removeEventListener("message", this.handleMessage);
     this._subscribers.clear();
     const error = new Error("AssistantFrameHost has been disposed");
-    for (const pending of this._pendingRequests.values()) {
+    for (const [id, pending] of this._pendingRequests) {
+      this.cancelToolCall(id);
       pending.reject(error);
     }
     this._pendingRequests.clear();

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -125,7 +125,7 @@ describe("AssistantFrameProvider", () => {
     dispatchToolCancel("*");
 
     expect(toolSignal?.aborted).toBe(true);
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(parentWindow.postMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.objectContaining({ type: "tool-result" }),
@@ -216,13 +216,26 @@ describe("AssistantFrameProvider", () => {
     AssistantFrameProvider.dispose();
 
     expect(toolSignal?.aborted).toBe(true);
-    await Promise.resolve();
-    expect(parentWindow.postMessage).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.objectContaining({ type: "tool-result" }),
-      }),
-      expect.anything(),
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: {
+          type: "tool-result",
+          id: "tool-call-1",
+          error: "AssistantFrameProvider has been disposed",
+        },
+      },
+      { targetOrigin: "*" },
     );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const toolResults = vi
+      .mocked(parentWindow.postMessage)
+      .mock.calls.filter(
+        ([data]) =>
+          (data as { message?: { type?: string } }).message?.type ===
+          "tool-result",
+      );
+    expect(toolResults).toHaveLength(1);
   });
 
   it("upgrades a wildcard origin policy when a strict provider registers", async () => {

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -9,20 +9,22 @@ describe("AssistantFrameProvider", () => {
   let messageHandler: ((event: MessageEvent) => void) | undefined;
   let parentWindow: Window;
 
-  const toolCall = {
-    channel: FRAME_MESSAGE_CHANNEL,
-    message: {
-      type: "tool-call",
-      id: "tool-call-1",
-      toolName: "sensitiveTool",
-      args: {},
-    },
-  };
-
-  const dispatchToolCall = (origin: string, source: Window = parentWindow) => {
+  const dispatchToolCall = (
+    origin: string,
+    source: Window = parentWindow,
+    id = "tool-call-1",
+  ) => {
     messageHandler?.(
       new MessageEvent("message", {
-        data: toolCall,
+        data: {
+          channel: FRAME_MESSAGE_CHANNEL,
+          message: {
+            type: "tool-call",
+            id,
+            toolName: "sensitiveTool",
+            args: {},
+          },
+        },
         origin,
         source,
       }),
@@ -32,12 +34,13 @@ describe("AssistantFrameProvider", () => {
   const dispatchToolCancel = (
     origin: string,
     source: Window = parentWindow,
+    id = "tool-call-1",
   ) => {
     messageHandler?.(
       new MessageEvent("message", {
         data: {
           channel: FRAME_MESSAGE_CHANNEL,
-          message: { type: "tool-cancel", id: "tool-call-1" },
+          message: { type: "tool-cancel", id },
         },
         origin,
         source,
@@ -120,6 +123,97 @@ describe("AssistantFrameProvider", () => {
     await vi.waitFor(() => expect(toolSignal).toBeDefined());
 
     dispatchToolCancel("*");
+
+    expect(toolSignal?.aborted).toBe(true);
+    await Promise.resolve();
+    expect(parentWindow.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ type: "tool-result" }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("cancels only the matching in-flight tool call", async () => {
+    const signals = new Map<string, AbortSignal>();
+    const execute = vi.fn(
+      async (
+        _args: unknown,
+        context: { toolCallId: string; abortSignal: AbortSignal },
+      ) => {
+        signals.set(context.toolCallId, context.abortSignal);
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
+    });
+
+    dispatchToolCall("*", parentWindow, "tool-a");
+    dispatchToolCall("*", parentWindow, "tool-b");
+    await vi.waitFor(() => expect(signals.size).toBe(2));
+
+    dispatchToolCancel("*", parentWindow, "tool-a");
+
+    expect(signals.get("tool-a")?.aborted).toBe(true);
+    expect(signals.get("tool-b")?.aborted).toBe(false);
+  });
+
+  it("aborts an earlier call when a duplicate ID arrives", async () => {
+    const signals: AbortSignal[] = [];
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        signals.push(context.abortSignal);
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
+    });
+
+    dispatchToolCall("*", parentWindow, "duplicate");
+    await vi.waitFor(() => expect(signals).toHaveLength(1));
+    dispatchToolCall("*", parentWindow, "duplicate");
+    await vi.waitFor(() => expect(signals).toHaveLength(2));
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+  });
+
+  it("aborts in-flight tool calls when the provider is disposed", async () => {
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
+    });
+
+    dispatchToolCall("*");
+    await vi.waitFor(() => expect(toolSignal).toBeDefined());
+
+    AssistantFrameProvider.dispose();
 
     expect(toolSignal?.aborted).toBe(true);
     await Promise.resolve();

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -29,6 +29,22 @@ describe("AssistantFrameProvider", () => {
     );
   };
 
+  const dispatchToolCancel = (
+    origin: string,
+    source: Window = parentWindow,
+  ) => {
+    messageHandler?.(
+      new MessageEvent("message", {
+        data: {
+          channel: FRAME_MESSAGE_CHANNEL,
+          message: { type: "tool-cancel", id: "tool-call-1" },
+        },
+        origin,
+        source,
+      }),
+    );
+  };
+
   beforeEach(() => {
     parentWindow = {
       postMessage: vi.fn(),
@@ -78,6 +94,41 @@ describe("AssistantFrameProvider", () => {
     dispatchToolCall("https://parent.example");
 
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+  });
+
+  it("aborts in-flight tool calls when the parent cancels them", async () => {
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute } },
+      }),
+    });
+
+    dispatchToolCall("*");
+    await vi.waitFor(() => expect(toolSignal).toBeDefined());
+
+    dispatchToolCancel("*");
+
+    expect(toolSignal?.aborted).toBe(true);
+    await Promise.resolve();
+    expect(parentWindow.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ type: "tool-result" }),
+      }),
+      expect.anything(),
+    );
   });
 
   it("upgrades a wildcard origin policy when a strict provider registers", async () => {

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -37,7 +37,10 @@ export class AssistantFrameProvider {
     ModelContextProvider,
     Unsubscribe | undefined
   >();
-  private _activeToolCalls = new Map<string, AbortController>();
+  private _activeToolCalls = new Map<
+    string,
+    { abortController: AbortController; event: MessageEvent }
+  >();
   private _targetOrigin: string;
   private _strictRegistrations = 0;
 
@@ -105,8 +108,9 @@ export class AssistantFrameProvider {
   ) {
     const tool = this.getModelContext().tools?.[message.toolName];
     const abortController = new AbortController();
-    this._activeToolCalls.get(message.id)?.abort();
-    this._activeToolCalls.set(message.id, abortController);
+    this._activeToolCalls.get(message.id)?.abortController.abort();
+    const activeCall = { abortController, event };
+    this._activeToolCalls.set(message.id, activeCall);
 
     let result: any;
     let error: string | undefined;
@@ -131,7 +135,7 @@ export class AssistantFrameProvider {
       }
     }
 
-    if (this._activeToolCalls.get(message.id) !== abortController) return;
+    if (this._activeToolCalls.get(message.id) !== activeCall) return;
     this._activeToolCalls.delete(message.id);
 
     this.sendMessage(event, {
@@ -142,10 +146,10 @@ export class AssistantFrameProvider {
   }
 
   private cancelToolCall(id: string) {
-    const abortController = this._activeToolCalls.get(id);
-    if (!abortController) return;
+    const activeCall = this._activeToolCalls.get(id);
+    if (!activeCall) return;
     this._activeToolCalls.delete(id);
-    abortController.abort();
+    activeCall.abortController.abort();
   }
 
   private sendMessage(event: MessageEvent, message: FrameMessage) {
@@ -226,7 +230,14 @@ export class AssistantFrameProvider {
       instance._providerUnsubscribes.forEach((unsubscribe) => unsubscribe?.());
       instance._providerUnsubscribes.clear();
       instance._providers.clear();
-      instance._activeToolCalls.forEach((controller) => controller.abort());
+      instance._activeToolCalls.forEach(({ abortController, event }, id) => {
+        abortController.abort();
+        instance.sendMessage(event, {
+          type: "tool-result",
+          id,
+          error: "AssistantFrameProvider has been disposed",
+        });
+      });
       instance._activeToolCalls.clear();
 
       AssistantFrameProvider._instance = null;

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -37,6 +37,7 @@ export class AssistantFrameProvider {
     ModelContextProvider,
     Unsubscribe | undefined
   >();
+  private _activeToolCalls = new Map<string, AbortController>();
   private _targetOrigin: string;
   private _strictRegistrations = 0;
 
@@ -91,6 +92,10 @@ export class AssistantFrameProvider {
       case "tool-call":
         this.handleToolCall(message, event);
         break;
+
+      case "tool-cancel":
+        this.cancelToolCall(message.id);
+        break;
     }
   }
 
@@ -99,6 +104,9 @@ export class AssistantFrameProvider {
     event: MessageEvent,
   ) {
     const tool = this.getModelContext().tools?.[message.toolName];
+    const abortController = new AbortController();
+    this._activeToolCalls.get(message.id)?.abort();
+    this._activeToolCalls.set(message.id, abortController);
 
     let result: any;
     let error: string | undefined;
@@ -110,7 +118,7 @@ export class AssistantFrameProvider {
         result = tool.execute
           ? await tool.execute(message.args, {
               toolCallId: message.id,
-              abortSignal: new AbortController().signal,
+              abortSignal: abortController.signal,
               human: async () => {
                 throw new Error(
                   "Tool human input is not supported in frame context",
@@ -123,11 +131,21 @@ export class AssistantFrameProvider {
       }
     }
 
+    if (this._activeToolCalls.get(message.id) !== abortController) return;
+    this._activeToolCalls.delete(message.id);
+
     this.sendMessage(event, {
       type: "tool-result",
       id: message.id,
       ...(error ? { error } : { result }),
     });
+  }
+
+  private cancelToolCall(id: string) {
+    const abortController = this._activeToolCalls.get(id);
+    if (!abortController) return;
+    this._activeToolCalls.delete(id);
+    abortController.abort();
   }
 
   private sendMessage(event: MessageEvent, message: FrameMessage) {
@@ -208,6 +226,8 @@ export class AssistantFrameProvider {
       instance._providerUnsubscribes.forEach((unsubscribe) => unsubscribe?.());
       instance._providerUnsubscribes.clear();
       instance._providers.clear();
+      instance._activeToolCalls.forEach((controller) => controller.abort());
+      instance._activeToolCalls.clear();
 
       AssistantFrameProvider._instance = null;
     }

--- a/packages/core/src/model-context/frame/types.ts
+++ b/packages/core/src/model-context/frame/types.ts
@@ -14,6 +14,7 @@ export type FrameMessageType =
   | "model-context-request"
   | "model-context-update"
   | "tool-call"
+  | "tool-cancel"
   | "tool-result";
 
 export type FrameMessage =
@@ -29,6 +30,10 @@ export type FrameMessage =
       id: string;
       toolName: string;
       args: unknown;
+    }
+  | {
+      type: "tool-cancel";
+      id: string;
     }
   | {
       type: "tool-result";


### PR DESCRIPTION
## Summary

- add an additive `tool-cancel` frame message for in-flight AssistantFrame tools
- send cancellation when the host aborts, times out, or disposes a pending tool call
- abort the provider-side execution signal and suppress late results after cancellation

## Reproduction

Cancelling a host tool call rejected the host promise, but the tool running in the frame received an independent signal that remained active. The operation could therefore continue network work or side effects after the run was stopped.

The wire change is backward-compatible: older providers ignore the new message, while newer providers continue to support hosts that never send it.

## Test plan

- `vitest run` in `packages/core` (1,292 tests)
- `pnpm --filter @assistant-ui/core... build`
- focused host and provider cancellation regression coverage

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Ww5ppbRmAHQOsFfyr0WlEw6xPRpMN0UyWZRWesWBs00sqnJB9LTcppXnlDw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->