### PR TITLE
chore(react-native): drop two unreachable re-export shims

### DIFF
--- a/.changeset/drop-rn-remote-thread-list-shims.md
+++ b/.changeset/drop-rn-remote-thread-list-shims.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+chore: drop two unreachable re-export shims from react-native
+
+`src/runtimes/RemoteThreadListHookInstanceManager.tsx` and
+`src/runtimes/RemoteThreadListThreadListRuntimeCore.tsx` each re-exported one
+symbol from `@assistant-ui/core/react`, but nothing imported them, they were
+absent from `src/index.ts` and `src/internal.ts`, and the `"."`/`"./internal"`
+exports map made them unreachable to consumers. The public API surface is
+unchanged.

--- a/packages/react-native/src/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/react-native/src/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -1,1 +1,0 @@
-export { RemoteThreadListHookInstanceManager } from "@assistant-ui/core/react";

--- a/packages/react-native/src/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/react-native/src/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1,1 +1,0 @@
-export { RemoteThreadListThreadListRuntimeCore } from "@assistant-ui/core/react";


### PR DESCRIPTION
`src/runtimes/RemoteThreadListHookInstanceManager.tsx` and `src/runtimes/RemoteThreadListThreadListRuntimeCore.tsx` were one-line re-exports of `@assistant-ui/core/react`. Nothing in the repo imported them, neither appears in `src/index.ts` or `src/internal.ts`, and the package's `"."`/`"./internal"` exports map left them unreachable to consumers — a deep import would fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Because the exports map is `"."`/`"./internal"` only, the four emitted `dist/runtimes/RemoteThreadListHookInstanceManager.*` and `RemoteThreadListThreadListRuntimeCore.*` files were unreachable to any exports-aware resolver; they disappear with this change, and the api-surface snapshot is unchanged. (An earlier version of this description claimed the dist was byte-identical — a clean baseline-vs-branch build diff shows those four files were emitted and are now gone; corrected in the comments.) Deliberately not indexing these instead of deleting them: they are implementation-level core React exports, and re-exporting them from react-native would expand an append-only public surface for no consumer.

Verified: react-native tests, `tsc --noEmit`, `pnpm lint`, and `pnpm api-surface` (Node 24) with zero drift.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.v1zHl7StkswMfqgkAgeQqSdRUVTKzUISHqqmtO6A8xeBKSXu90-N97w0uRg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
