### PR TITLE
fix(core): preserve falsy assistant transport artifacts

### DIFF
--- a/.changeset/calm-tools-respond.md
+++ b/.changeset/calm-tools-respond.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve falsy assistant transport artifacts

--- a/packages/core/src/react/runtimes/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -4,6 +4,7 @@ import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAui } from "@assistant-ui/store";
+import { ToolResponse } from "assistant-stream";
 import { AssistantRuntimeProvider } from "../../AssistantRuntimeProvider";
 import {
   useAssistantTransportRuntime,
@@ -145,6 +146,63 @@ afterEach(() => {
 });
 
 describe("useAssistantTransportRuntime", () => {
+  it.each([false, 0, "", null])(
+    "preserves the falsy tool artifact %j",
+    async (artifact) => {
+      const fetchMock = installFetch();
+      const { aui } = mountRuntime({
+        converter: (_state, meta) => ({
+          messages: [
+            {
+              id: "a1",
+              role: "assistant",
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "tc1",
+                  toolName: "probe",
+                  args: {},
+                  argsText: "{}",
+                },
+              ],
+              createdAt: new Date(0),
+              status: { type: "requires-action", reason: "tool-calls" },
+              metadata: { custom: {} },
+            },
+          ],
+          isRunning: meta.isSending,
+        }),
+      });
+
+      await waitFor(() =>
+        expect(
+          aui()
+            .thread.message({ id: "a1" })
+            .part({ toolCallId: "tc1" })
+            .getState().type,
+        ).toBe("tool-call"),
+      );
+
+      act(() => {
+        aui()
+          .thread.message({ id: "a1" })
+          .part({ toolCallId: "tc1" })
+          .addToolResult(new ToolResponse({ result: "ok", artifact }));
+      });
+
+      await waitFor(() => expect(fetchMock.requests).toHaveLength(1));
+      expect(fetchMock.requests[0]!.body["commands"][0]).toHaveProperty(
+        "artifact",
+        artifact,
+      );
+
+      act(() => fetchMock.servers[0]!.close());
+      await waitFor(() =>
+        expect(aui().thread.getState().isRunning).toBe(false),
+      );
+    },
+  );
+
   it.each(["throws", "rejects"] as const)(
     "cancels the response body when onResponse %s",
     async (failureMode) => {

--- a/packages/core/src/react/runtimes/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/useAssistantTransportRuntime.ts
@@ -447,7 +447,9 @@ const useAssistantTransportThreadRuntime = <T>(
         result: toolOptions.result as ReadonlyJSONObject,
         toolName: toolOptions.toolName,
         isError: toolOptions.isError,
-        ...(toolOptions.artifact && { artifact: toolOptions.artifact }),
+        ...(toolOptions.artifact !== undefined && {
+          artifact: toolOptions.artifact,
+        }),
         ...(toolOptions.modelContent !== undefined && {
           modelContent: toolOptions.modelContent,
         }),


### PR DESCRIPTION
## Summary

- preserve tool artifacts when their value is `false`, `0`, `""`, or `null`
- continue omitting the artifact field only when it is `undefined`
- cover the public message-part API through the serialized Assistant Transport request

## Why

`artifact` is a JSON value, so falsy primitives are valid payloads. The existing truthiness check silently dropped those values before sending the `add-tool-result` command.

## Validation

- `pnpm --filter @assistant-ui/core test` (128 files, 1,295 tests)
- `pnpm turbo build --filter=@assistant-ui/core...`
- targeted `oxlint` and `oxfmt`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.PJ5xcwIjaKSbZDSHF4GT8uVGuLS_oK3iYJzo5LXOt096Z1F5j3PZMnjPSBI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->