### PR TITLE
fix(registry): validate relative sibling imports for self-containment

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1272,13 +1272,17 @@ test("relative import candidates cover extensions, directory indexes, and .js so
     "components/assistant-ui/badge.jsx",
   ]);
 
+  assert.deepEqual(getRelativeImportCandidates("./icon.svg?url", from), [
+    "components/assistant-ui/icon.svg",
+  ]);
+
   assert.equal(
     getRelativeImportCandidates("../icons/github", from)[0],
     "components/icons/github.tsx",
   );
 
-  assert.deepEqual(
+  assert.equal(
     getRelativeImportCandidates("../../../outside/thing", from),
-    [],
+    null,
   );
 });

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -9,6 +9,7 @@ const {
   expandBundledRegistryDependencies,
   getRadixVariantSourcePath,
   getRelativeImportCandidates,
+  validateRegistryInstallMetadata,
   validateBasePassDidNotReadRadixSources,
   validateBaseTreeRadixImports,
   validateBaseVariantContent,
@@ -1284,5 +1285,104 @@ test("relative import candidates cover extensions, directory indexes, and .js so
   assert.equal(
     getRelativeImportCandidates("../../../outside/thing", from),
     null,
+  );
+});
+
+test("a sibling whose name begins with dots stays inside the installed tree", () => {
+  assert.deepEqual(getRelativeImportCandidates("./..rc.json", "config.tsx"), [
+    "..rc.json",
+  ]);
+
+  assert.equal(getRelativeImportCandidates("..", "config.tsx"), null);
+  assert.equal(getRelativeImportCandidates("../outside", "config.tsx"), null);
+});
+
+const componentItem = (files, extra = {}) => ({
+  name: "demo",
+  type: "registry:component",
+  files,
+  ...extra,
+});
+
+const findingsFrom = (payloads) => {
+  try {
+    validateRegistryInstallMetadata(payloads);
+  } catch (error) {
+    return error.message;
+  }
+  return null;
+};
+
+test("install validation flags a relative import with no providing file", () => {
+  const findings = findingsFrom([
+    componentItem([
+      {
+        path: "components/assistant-ui/thread.tsx",
+        content: 'import { Badge } from "./badge";\n',
+      },
+    ]),
+  ]);
+
+  assert.match(findings, /thread\.tsx imports "\.\/badge"/);
+  assert.match(findings, /components\/assistant-ui\/badge\.tsx/);
+});
+
+test("install validation resolves a sibling through file.target, not file.path", () => {
+  const files = [
+    {
+      path: "packages/ui/src/components/assistant-ui/thread.tsx",
+      target: "components/assistant-ui/thread.tsx",
+      content: 'import { Badge } from "./badge";\n',
+    },
+    {
+      path: "packages/ui/src/components/assistant-ui/badge.tsx",
+      target: "components/assistant-ui/badge.tsx",
+      content: "export const Badge = () => null;\n",
+    },
+  ];
+
+  assert.equal(findingsFrom([componentItem(files)]), null);
+
+  // Drop only the target mapping: the sibling is no longer installed beside
+  // the importer, so the same import must now be reported.
+  const withoutTargets = files.map(({ path, content }) => ({ path, content }));
+  assert.equal(findingsFrom([componentItem(withoutTargets)]), null);
+
+  const targetMismatch = [
+    files[0],
+    { ...files[1], target: "components/elsewhere/badge.tsx" },
+  ];
+  assert.match(
+    findingsFrom([componentItem(targetMismatch)]),
+    /imports "\.\/badge"/,
+  );
+});
+
+test("install validation reports an import that escapes the installed tree", () => {
+  const findings = findingsFrom([
+    componentItem([
+      {
+        path: "components/assistant-ui/thread.tsx",
+        content: 'import { helper } from "../../../outside/helper";\n',
+      },
+    ]),
+  ]);
+
+  assert.match(findings, /a file outside the installed tree/);
+});
+
+test("install validation resolves a sibling against the registryDependency install path", () => {
+  // A shadcn registryDependency installs to components/ui/<name>.tsx, so it
+  // satisfies a sibling import only from inside that directory.
+  const importing = (path) =>
+    componentItem([{ path, content: 'import { Badge } from "./badge";\n' }], {
+      registryDependencies: ["badge"],
+    });
+
+  assert.equal(findingsFrom([importing("components/ui/menu.tsx")]), null);
+
+  assert.match(
+    findingsFrom([importing("components/assistant-ui/thread.tsx")]),
+    /imports "\.\/badge", but no file or registryDependency provides/,
   );
 });

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1343,8 +1343,8 @@ test("install validation resolves a sibling through file.target, not file.path",
 
   assert.equal(findingsFrom([componentItem(files)]), null);
 
-  // Drop only the target mapping: the sibling is no longer installed beside
-  // the importer, so the same import must now be reported.
+  // Without targets both paths fall back to their authored locations, which are
+  // still siblings, so only a mismatched target proves the target is what wins.
   const withoutTargets = files.map(({ path, content }) => ({ path, content }));
   assert.equal(findingsFrom([componentItem(withoutTargets)]), null);
 

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -8,6 +8,7 @@ const {
   createRadixRegistryItem,
   expandBundledRegistryDependencies,
   getRadixVariantSourcePath,
+  getRelativeImportCandidates,
   validateBasePassDidNotReadRadixSources,
   validateBaseTreeRadixImports,
   validateBaseVariantContent,
@@ -1240,4 +1241,44 @@ test("every element's sibling imports are declared as registry dependencies", as
       );
     }
   }
+});
+
+test("relative import candidates cover extensions, directory indexes, and .js sources", () => {
+  const from = "components/assistant-ui/sources.tsx";
+
+  assert.deepEqual(getRelativeImportCandidates("./badge", from), [
+    "components/assistant-ui/badge.tsx",
+    "components/assistant-ui/badge.ts",
+    "components/assistant-ui/badge.jsx",
+    "components/assistant-ui/badge.js",
+    "components/assistant-ui/badge/index.tsx",
+    "components/assistant-ui/badge/index.ts",
+    "components/assistant-ui/badge/index.jsx",
+    "components/assistant-ui/badge/index.js",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./badge.tsx", from), [
+    "components/assistant-ui/badge.tsx",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./styles.css", from), [
+    "components/assistant-ui/styles.css",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./badge.js", from), [
+    "components/assistant-ui/badge.js",
+    "components/assistant-ui/badge.tsx",
+    "components/assistant-ui/badge.ts",
+    "components/assistant-ui/badge.jsx",
+  ]);
+
+  assert.equal(
+    getRelativeImportCandidates("../icons/github", from)[0],
+    "components/icons/github.tsx",
+  );
+
+  assert.deepEqual(
+    getRelativeImportCandidates("../../../outside/thing", from),
+    [],
+  );
 });

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -863,7 +863,7 @@ export function getRelativeImportCandidates(
   const resolved = path.posix.normalize(
     path.posix.join(path.posix.dirname(fromPath), modulePath),
   );
-  if (resolved.startsWith("..")) return null;
+  if (resolved === ".." || resolved.startsWith("../")) return null;
 
   const extension = path.posix.extname(resolved);
   const candidates = new Set<string>();
@@ -951,7 +951,9 @@ function collectInstallContext(
   return { files, packages };
 }
 
-function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
+export function validateRegistryInstallMetadata(
+  payloads: RegistryOutputItem[],
+) {
   const itemByName = new Map(payloads.map((item) => [item.name, item]));
   const findings = new Set<string>();
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -849,20 +849,21 @@ const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
 
 /**
  * The install paths a relative specifier may resolve to once the item is
- * installed, ordered most-likely first. A specifier is satisfied when the
- * install closure provides any one of them, which is what a bundler in the
- * user's project will do: an explicit extension, an extensionless module, a
- * directory index, or the TypeScript source behind a `.js` specifier. An empty
- * list means the target escapes the installed tree and cannot be checked.
+ * installed. A specifier is satisfied when the install closure provides any one
+ * of them, which is what a bundler in the user's project will do: an explicit
+ * extension, an extensionless module, a directory index, or the TypeScript
+ * source behind a `.js` specifier. `null` means the specifier points outside
+ * the installed tree, where no closure file can ever satisfy it.
  */
 export function getRelativeImportCandidates(
   specifier: string,
   fromPath: string,
 ) {
+  const modulePath = specifier.replace(/[?#].*$/, "");
   const resolved = path.posix.normalize(
-    path.posix.join(path.posix.dirname(fromPath), specifier),
+    path.posix.join(path.posix.dirname(fromPath), modulePath),
   );
-  if (resolved.startsWith("..")) return [];
+  if (resolved.startsWith("..")) return null;
 
   const extension = path.posix.extname(resolved);
   const candidates = new Set<string>();
@@ -918,7 +919,9 @@ function collectInstallContext(
 
   seen.add(item.name);
 
-  const files = new Set(item.files?.map((file) => file.path) ?? []);
+  const files = new Set(
+    item.files?.map((file) => file.target ?? file.path) ?? [],
+  );
   const packages = new Set([
     ...(item.dependencies ?? []),
     ...(item.devDependencies ?? []),
@@ -981,14 +984,22 @@ function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
         }
 
         if (specifier.startsWith(".")) {
-          const candidates = getRelativeImportCandidates(specifier, file.path);
+          const installedPath = file.target ?? file.path;
+          const candidates = getRelativeImportCandidates(
+            specifier,
+            installedPath,
+          );
 
           if (
-            candidates.length > 0 &&
+            candidates === null ||
             !candidates.some((candidate) => installContext.files.has(candidate))
           ) {
             findings.add(
-              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${candidates[0]}`,
+              `${item.name}: ${installedPath} imports "${specifier}", but no file or registryDependency provides ${
+                candidates === null
+                  ? "a file outside the installed tree"
+                  : candidates.join(" or ")
+              }`,
             );
           }
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -845,6 +845,48 @@ function getLocalComponentPath(specifier: string) {
   return `${componentPath}.tsx`;
 }
 
+const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
+
+/**
+ * The install paths a relative specifier may resolve to once the item is
+ * installed, ordered most-likely first. A specifier is satisfied when the
+ * install closure provides any one of them, which is what a bundler in the
+ * user's project will do: an explicit extension, an extensionless module, a
+ * directory index, or the TypeScript source behind a `.js` specifier. An empty
+ * list means the target escapes the installed tree and cannot be checked.
+ */
+export function getRelativeImportCandidates(
+  specifier: string,
+  fromPath: string,
+) {
+  const resolved = path.posix.normalize(
+    path.posix.join(path.posix.dirname(fromPath), specifier),
+  );
+  if (resolved.startsWith("..")) return [];
+
+  const extension = path.posix.extname(resolved);
+  const candidates = new Set<string>();
+
+  if (extension) {
+    candidates.add(resolved);
+    if (extension === ".js" || extension === ".jsx") {
+      const base = resolved.slice(0, -extension.length);
+      for (const moduleExtension of MODULE_EXTENSIONS) {
+        candidates.add(`${base}${moduleExtension}`);
+      }
+    }
+  } else {
+    for (const moduleExtension of MODULE_EXTENSIONS) {
+      candidates.add(`${resolved}${moduleExtension}`);
+    }
+    for (const moduleExtension of MODULE_EXTENSIONS) {
+      candidates.add(`${resolved}/index${moduleExtension}`);
+    }
+  }
+
+  return [...candidates];
+}
+
 function collectCssPackageImports(value: unknown, imports = new Set<string>()) {
   if (typeof value === "string") {
     for (const match of value.matchAll(
@@ -938,7 +980,22 @@ function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
           continue;
         }
 
-        if (specifier.startsWith(".") || specifier.startsWith("@/")) {
+        if (specifier.startsWith(".")) {
+          const candidates = getRelativeImportCandidates(specifier, file.path);
+
+          if (
+            candidates.length > 0 &&
+            !candidates.some((candidate) => installContext.files.has(candidate))
+          ) {
+            findings.add(
+              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${candidates[0]}`,
+            );
+          }
+
+          continue;
+        }
+
+        if (specifier.startsWith("@/")) {
           continue;
         }
 


### PR DESCRIPTION
The install-metadata validator skipped every specifier starting with a dot, so a registry file could import a sibling module that no file or registryDependency provides and still build green; `shadcn add` would then land a file with an unresolvable import. Two shipped components (sources.tsx and directive-text.tsx, both importing `./badge`) were only correct by hand.

Resolve each relative specifier against the importing file's install path and accept it when the closure provides any candidate a bundler would resolve: an explicit extension, an extensionless .ts/.tsx/.js/.jsx module, a directory index, or the TypeScript source behind a `.js` specifier. Anything resolving outside the installed tree is reported as an escape rather than guessed at, so a naive `./x` → `./x.tsx` rule cannot raise false positives. The current registry passes unchanged, and the check fires when badge.json is removed (verified).

A second commit applies review follow-ups: resolve against the file's install target rather than its authored path (they differ for the ai-sdk quick-start page), strip bundler query/fragment suffixes (`./icon.svg?url`), report tree-escaping imports instead of silently skipping them, and name every accepted candidate in the finding.

Verified: registry build + 34/34 validator tests (6 new resolver assertions); five mutants all caught.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tfkXpl65au_i_bICJKTKRqYw_5JM4Toe7zuUoFYAjlcIk7PX0DTI0BwqIRM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->