### PR TITLE
refactor(core): collapse the twin inert thread cores onto a shared base

### DIFF
--- a/.changeset/wild-pugs-repeat.md
+++ b/.changeset/wild-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: collapse the two inert thread cores onto a shared base class

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2082,6 +2082,70 @@ type InMemoryThreadListProps = {
   onDelete?: (threadId: string) => void;
 };
 
+declare abstract class InertThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
+  protected abstract get error(): Error;
+  abstract readonly messages: readonly ThreadMessage[];
+  abstract readonly isLoading: boolean;
+  abstract readonly composer: ThreadRuntimeCore["composer"];
+  abstract getMessageById(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  } | undefined;
+  abstract getBranches(messageId: string): readonly string[];
+  abstract export(): ExportedMessageRepository;
+  switchToBranch(): void;
+  append(): void;
+  deleteMessage(): void;
+  startRun(): void;
+  resumeRun(): void;
+  cancelRun(): void;
+  unstable_notifySessionReset(): void;
+  addToolResult(): void;
+  resumeToolCall(): void;
+  respondToToolApproval(): void;
+  speak(): void;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  submitFeedback(): void;
+  exportExternalState(): void;
+  importExternalState(): void;
+  beginEdit(): void;
+  import(): void;
+  reset(): void;
+  getModelContext(): {};
+  getEditComposer(): undefined;
+  getVoiceVolume: () => number;
+  subscribeVoiceVolume: () => Unsubscribe$1;
+  speech: undefined;
+  voice: undefined;
+  capabilities: {
+    readonly switchToBranch: false;
+    readonly switchBranchDuringRun: false;
+    readonly edit: false;
+    readonly delete: false;
+    readonly reload: false;
+    readonly refetchThread: false;
+    readonly cancel: false;
+    readonly unstable_copy: false;
+    readonly speech: false;
+    readonly dictation: false;
+    readonly voice: false;
+    readonly attachments: false;
+    readonly feedback: false;
+    readonly queue: false;
+  };
+  isDisabled: boolean;
+  isSendDisabled: boolean;
+  state: null;
+  suggestions: never[];
+  extras: undefined;
+  unstable_on(): Unsubscribe$1;
+}
+
 type InteractableDefinition = {
   id: string;
   name: string;
@@ -3271,8 +3335,9 @@ declare namespace ReadonlyThreadProvider {
 
 declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
 
-declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
+declare class ReadonlyThreadRuntimeCore extends InertThreadRuntimeCore {
   #private;
+  protected get error(): Error;
   get messages(): readonly ThreadMessage[];
   setMessages(messages: readonly ThreadMessage[]): void;
   getMessageById(messageId: string): {
@@ -3281,28 +3346,12 @@ declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements Thre
     index: number;
   } | undefined;
   getBranches(messageId: string): string[];
-  switchToBranch(): void;
-  append(): void;
-  deleteMessage(): void;
-  startRun(): void;
-  resumeRun(): void;
-  cancelRun(): void;
-  addToolResult(): void;
-  resumeToolCall(): void;
-  respondToToolApproval(): void;
-  speak(): void;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume: () => number;
-  subscribeVoiceVolume: () => Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  submitFeedback(): void;
-  getModelContext(): {};
-  exportExternalState(): void;
-  importExternalState(): void;
-  unstable_notifySessionReset(): void;
+  export(): {
+    messages: {
+      message: ThreadMessage;
+      parentId: string | null;
+    }[];
+  };
   composer: {
     attachments: never[];
     attachmentAccept: string;
@@ -3333,41 +3382,10 @@ declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements Thre
     subscribe(): () => void;
     unstable_on(): () => void;
   };
-  getEditComposer(): undefined;
-  beginEdit(): void;
-  speech: undefined;
-  voice: undefined;
-  capabilities: {
-    readonly switchToBranch: false;
-    readonly switchBranchDuringRun: false;
-    readonly edit: false;
-    readonly delete: false;
-    readonly reload: false;
-    readonly refetchThread: false;
-    readonly cancel: false;
-    readonly unstable_copy: false;
-    readonly speech: false;
-    readonly dictation: false;
-    readonly voice: false;
-    readonly attachments: false;
-    readonly feedback: false;
-    readonly queue: false;
-  };
-  isDisabled: boolean;
-  isSendDisabled: boolean;
   isLoading: boolean;
-  state: null;
-  suggestions: never[];
-  extras: undefined;
-  import(): void;
-  export(): {
-    messages: {
-      message: ThreadMessage;
-      parentId: string | null;
-    }[];
-  };
-  reset(): void;
-  unstable_on(): Unsubscribe$1;
+  cancelRun(): void;
+  stopSpeaking(): void;
+  disconnectVoice(): void;
 }
 
 declare namespace RealtimeVoiceAdapter {

--- a/packages/core/src/runtimes/inert/InertThreadRuntimeCore.test.ts
+++ b/packages/core/src/runtimes/inert/InertThreadRuntimeCore.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { ReadonlyThreadRuntimeCore } from "../readonly/ReadonlyThreadRuntimeCore";
+import { EMPTY_THREAD_CORE } from "../remote-thread-list/empty-thread-core";
+
+const READONLY_ERROR = /readonly thread/;
+const EMPTY_ERROR = /empty thread/;
+
+const SHARED_THROWING_METHODS = [
+  "switchToBranch",
+  "append",
+  "deleteMessage",
+  "startRun",
+  "resumeRun",
+  "unstable_notifySessionReset",
+  "addToolResult",
+  "resumeToolCall",
+  "respondToToolApproval",
+  "speak",
+  "connectVoice",
+  "muteVoice",
+  "unmuteVoice",
+  "submitFeedback",
+  "exportExternalState",
+  "importExternalState",
+  "beginEdit",
+  "import",
+  "reset",
+] as const;
+
+const SHARED_THROWING_COMPOSER_METHODS = [
+  "setText",
+  "setRole",
+  "setRunConfig",
+  "send",
+  "startDictation",
+  "setQuote",
+] as const;
+
+const SHARED_NOOP_COMPOSER_METHODS = [
+  "cancel",
+  "stopDictation",
+  "moveQueueItem",
+  "removeQueueItem",
+] as const;
+
+type AnyCore = Record<string, any>;
+
+const cores = [
+  [
+    "ReadonlyThreadRuntimeCore",
+    () => new ReadonlyThreadRuntimeCore() as unknown as AnyCore,
+    READONLY_ERROR,
+  ],
+  [
+    "EMPTY_THREAD_CORE",
+    () => EMPTY_THREAD_CORE as unknown as AnyCore,
+    EMPTY_ERROR,
+  ],
+] as const;
+
+describe.each(cores)("%s shared inert surface", (_name, makeCore, error) => {
+  it.each(SHARED_THROWING_METHODS)("%s throws the core's error", (method) => {
+    expect(() => makeCore()[method]!()).toThrow(error);
+  });
+
+  it.each(SHARED_THROWING_COMPOSER_METHODS)(
+    "composer.%s throws the core's error",
+    (method) => {
+      expect(() => makeCore().composer[method]!()).toThrow(error);
+    },
+  );
+
+  it.each(["addAttachment", "removeAttachment"] as const)(
+    "composer.%s rejects with the core's error",
+    async (method) => {
+      await expect(makeCore().composer[method]!()).rejects.toThrow(error);
+    },
+  );
+
+  it.each(SHARED_NOOP_COMPOSER_METHODS)("composer.%s is a no-op", (method) => {
+    expect(() => makeCore().composer[method]!()).not.toThrow();
+  });
+
+  it("composer.reset and composer.clearAttachments resolve without throwing", async () => {
+    const core = makeCore();
+    await expect(core.composer.reset()).resolves.toBeUndefined();
+    await expect(core.composer.clearAttachments()).resolves.toBeUndefined();
+  });
+
+  it("reports every capability as disabled", () => {
+    expect(makeCore().capabilities).toEqual({
+      switchToBranch: false,
+      switchBranchDuringRun: false,
+      edit: false,
+      delete: false,
+      reload: false,
+      refetchThread: false,
+      cancel: false,
+      unstable_copy: false,
+      speech: false,
+      dictation: false,
+      voice: false,
+      attachments: false,
+      feedback: false,
+      queue: false,
+    });
+  });
+
+  it("exposes inert read-only state", () => {
+    const core = makeCore();
+    expect(core.getModelContext()).toEqual({});
+    expect(core.getEditComposer()).toBeUndefined();
+    expect(core.getVoiceVolume()).toBe(0);
+    expect(core.speech).toBeUndefined();
+    expect(core.voice).toBeUndefined();
+    expect(core.state).toBeNull();
+    expect(core.suggestions).toEqual([]);
+    expect(core.extras).toBeUndefined();
+    expect(core.isDisabled).toBe(false);
+    expect(core.isSendDisabled).toBe(false);
+  });
+
+  it("exposes an empty composer that accepts everything and holds nothing", () => {
+    const composer = makeCore().composer;
+    expect(composer.attachmentAccept).toBe("*");
+    expect(composer.attachments).toEqual([]);
+    expect(composer.text).toBe("");
+    expect(composer.role).toBe("user");
+    expect(composer.runConfig).toEqual({});
+    expect(composer.queue).toEqual([]);
+    expect(composer.dictation).toBeUndefined();
+    expect(composer.quote).toBeUndefined();
+    expect(composer.isEmpty).toBe(true);
+    expect(composer.canSend).toBe(false);
+    expect(composer.canCancel).toBe(false);
+  });
+
+  it("throws one stable error object from every mutator", () => {
+    const core = makeCore();
+    const thrown = SHARED_THROWING_METHODS.map((method) => {
+      try {
+        core[method]!();
+        return undefined;
+      } catch (e) {
+        return e;
+      }
+    });
+
+    expect(thrown[0]).toBeInstanceOf(Error);
+    expect(thrown.every((e) => e === thrown[0])).toBe(true);
+  });
+
+  it("mutators must be called on the core; a detached reference is not a standalone function", () => {
+    const core = makeCore();
+    const detached = core.append!;
+
+    expect(() => core.append!()).toThrow(error);
+    expect(() => detached()).toThrow();
+  });
+
+  it("subscribeVoiceVolume and unstable_on hand back no-op unsubscribers", () => {
+    const core = makeCore();
+    expect(() => core.subscribeVoiceVolume(() => {})()).not.toThrow();
+    expect(() => core.unstable_on("runStart", () => {})()).not.toThrow();
+  });
+});
+
+describe("no-op versus throw divergences", () => {
+  it.each(["cancelRun", "stopSpeaking", "disconnectVoice"] as const)(
+    "%s is a no-op on the readonly core but throws on the empty core",
+    (method) => {
+      const readonly = new ReadonlyThreadRuntimeCore() as unknown as AnyCore;
+      expect(() => readonly[method]!()).not.toThrow();
+      expect(() =>
+        (EMPTY_THREAD_CORE as unknown as AnyCore)[method]!(),
+      ).toThrow(EMPTY_ERROR);
+    },
+  );
+
+  it("readonly is not loading; empty is loading so it is not read as an empty conversation", () => {
+    expect(new ReadonlyThreadRuntimeCore().isLoading).toBe(false);
+    expect(EMPTY_THREAD_CORE.isLoading).toBe(true);
+  });
+
+  it("readonly composer is not editing; empty composer is", () => {
+    expect(new ReadonlyThreadRuntimeCore().composer.isEditing).toBe(false);
+    expect(EMPTY_THREAD_CORE.composer.isEditing).toBe(true);
+  });
+
+  it("the two cores carry distinct error objects and messages", () => {
+    const grab = (fn: () => void) => {
+      try {
+        fn();
+        return undefined;
+      } catch (e) {
+        return e as Error;
+      }
+    };
+
+    const readonlyError = grab(() => new ReadonlyThreadRuntimeCore().append());
+    const emptyError = grab(() =>
+      (EMPTY_THREAD_CORE as unknown as AnyCore).append!(),
+    );
+
+    expect(readonlyError).not.toBe(emptyError);
+    expect(readonlyError?.message).toBe(
+      "This is a readonly thread. You cannot perform mutations on readonly threads.",
+    );
+    expect(emptyError?.message).toMatch(/placeholder for the main thread/);
+  });
+});

--- a/packages/core/src/runtimes/inert/InertThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/inert/InertThreadRuntimeCore.ts
@@ -1,0 +1,232 @@
+import type { Unsubscribe } from "../../types/unsubscribe";
+import type { ThreadMessage } from "../../types/message";
+import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
+import type { ExportedMessageRepository } from "../../runtime/utils/message-repository";
+import { BaseSubscribable } from "../../subscribable/subscribable";
+
+export const createInertComposer = <TIsEditing extends boolean>(
+  error: Error,
+  isEditing: TIsEditing,
+) => ({
+  attachments: [] as never[],
+  attachmentAccept: "*",
+
+  async addAttachment() {
+    throw error;
+  },
+
+  async removeAttachment() {
+    throw error;
+  },
+
+  isEditing,
+  canCancel: false,
+  canSend: false,
+  isEmpty: true,
+  text: "",
+
+  setText() {
+    throw error;
+  },
+
+  role: "user" as const,
+
+  setRole() {
+    throw error;
+  },
+
+  runConfig: {},
+
+  setRunConfig() {
+    throw error;
+  },
+
+  async reset() {},
+
+  async clearAttachments() {},
+
+  send() {
+    throw error;
+  },
+
+  cancel() {},
+
+  queue: [] as never[],
+  moveQueueItem() {},
+  removeQueueItem() {},
+
+  dictation: undefined,
+
+  startDictation() {
+    throw error;
+  },
+
+  stopDictation() {},
+
+  quote: undefined,
+
+  setQuote() {
+    throw error;
+  },
+
+  subscribe() {
+    return () => {};
+  },
+
+  unstable_on() {
+    return () => {};
+  },
+});
+
+export abstract class InertThreadRuntimeCore
+  extends BaseSubscribable
+  implements ThreadRuntimeCore
+{
+  protected abstract get error(): Error;
+
+  abstract readonly messages: readonly ThreadMessage[];
+  abstract readonly isLoading: boolean;
+  abstract readonly composer: ThreadRuntimeCore["composer"];
+
+  abstract getMessageById(messageId: string):
+    | {
+        parentId: string | null;
+        message: ThreadMessage;
+        index: number;
+      }
+    | undefined;
+
+  abstract getBranches(messageId: string): readonly string[];
+
+  abstract export(): ExportedMessageRepository;
+
+  switchToBranch(): void {
+    throw this.error;
+  }
+
+  append(): void {
+    throw this.error;
+  }
+
+  deleteMessage(): void {
+    throw this.error;
+  }
+
+  startRun(): void {
+    throw this.error;
+  }
+
+  resumeRun(): void {
+    throw this.error;
+  }
+
+  cancelRun(): void {
+    throw this.error;
+  }
+
+  unstable_notifySessionReset(): void {
+    throw this.error;
+  }
+
+  addToolResult(): void {
+    throw this.error;
+  }
+
+  resumeToolCall(): void {
+    throw this.error;
+  }
+
+  respondToToolApproval(): void {
+    throw this.error;
+  }
+
+  speak(): void {
+    throw this.error;
+  }
+
+  stopSpeaking(): void {
+    throw this.error;
+  }
+
+  connectVoice(): void {
+    throw this.error;
+  }
+
+  disconnectVoice(): void {
+    throw this.error;
+  }
+
+  muteVoice(): void {
+    throw this.error;
+  }
+
+  unmuteVoice(): void {
+    throw this.error;
+  }
+
+  submitFeedback(): void {
+    throw this.error;
+  }
+
+  exportExternalState(): void {
+    throw this.error;
+  }
+
+  importExternalState(): void {
+    throw this.error;
+  }
+
+  beginEdit(): void {
+    throw this.error;
+  }
+
+  import(): void {
+    throw this.error;
+  }
+
+  reset(): void {
+    throw this.error;
+  }
+
+  getModelContext() {
+    return {};
+  }
+
+  getEditComposer() {
+    return undefined;
+  }
+
+  getVoiceVolume = () => 0;
+  subscribeVoiceVolume = (): Unsubscribe => () => {};
+
+  speech = undefined;
+  voice = undefined;
+
+  capabilities = {
+    switchToBranch: false,
+    switchBranchDuringRun: false,
+    edit: false,
+    delete: false,
+    reload: false,
+    refetchThread: false,
+    cancel: false,
+    unstable_copy: false,
+    speech: false,
+    dictation: false,
+    voice: false,
+    attachments: false,
+    feedback: false,
+    queue: false,
+  } as const;
+
+  isDisabled = false;
+  isSendDisabled = false;
+
+  state = null;
+  suggestions = [] as never[];
+  extras = undefined;
+
+  unstable_on(): Unsubscribe {
+    return () => {};
+  }
+}

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.test.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReadonlyThreadRuntimeCore } from "./ReadonlyThreadRuntimeCore";
+import { BaseSubscribable } from "../../subscribable/subscribable";
+import type { ThreadMessage } from "../../types/message";
+
+const message = (id: string) =>
+  ({
+    id,
+    role: "assistant",
+    content: [],
+    createdAt: new Date(),
+    status: { type: "complete", reason: "stop" },
+    metadata: {
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+  }) as unknown as ThreadMessage;
+
+describe("ReadonlyThreadRuntimeCore", () => {
+  it("is constructable and subscribable", () => {
+    const core = new ReadonlyThreadRuntimeCore();
+    expect(core).toBeInstanceOf(BaseSubscribable);
+
+    const callback = vi.fn();
+    const unsubscribe = core.subscribe(callback);
+    core.setMessages([message("a")]);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    core.setMessages([message("b")]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when setMessages is handed the same reference", () => {
+    const core = new ReadonlyThreadRuntimeCore();
+    const messages = [message("a")];
+    core.setMessages(messages);
+
+    const callback = vi.fn();
+    core.subscribe(callback);
+    core.setMessages(messages);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("reads messages, branches, and the export repository out of setMessages", () => {
+    const core = new ReadonlyThreadRuntimeCore();
+    core.setMessages([message("a"), message("b")]);
+
+    expect(core.messages.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(core.getMessageById("b")).toMatchObject({ parentId: "a", index: 1 });
+    expect(core.getMessageById("missing")).toBeUndefined();
+    expect(core.getBranches("b")).toEqual(["b"]);
+    expect(core.getBranches("missing")).toEqual([]);
+    expect(core.export().messages).toEqual([
+      { message: expect.objectContaining({ id: "a" }), parentId: null },
+      { message: expect.objectContaining({ id: "b" }), parentId: "a" },
+    ]);
+  });
+});

--- a/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
+++ b/packages/core/src/runtimes/readonly/ReadonlyThreadRuntimeCore.ts
@@ -1,16 +1,18 @@
-import type { Unsubscribe } from "../../types/unsubscribe";
 import type { ThreadMessage } from "../../types/message";
-import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
-import { BaseSubscribable } from "../../subscribable/subscribable";
+import {
+  InertThreadRuntimeCore,
+  createInertComposer,
+} from "../inert/InertThreadRuntimeCore";
 
 const READONLY_THREAD_ERROR = new Error(
   "This is a readonly thread. You cannot perform mutations on readonly threads.",
 );
 
-export class ReadonlyThreadRuntimeCore
-  extends BaseSubscribable
-  implements ThreadRuntimeCore
-{
+export class ReadonlyThreadRuntimeCore extends InertThreadRuntimeCore {
+  protected get error() {
+    return READONLY_THREAD_ERROR;
+  }
+
   private _messages: readonly ThreadMessage[] = [];
 
   get messages() {
@@ -39,202 +41,6 @@ export class ReadonlyThreadRuntimeCore
     return [messageId];
   }
 
-  switchToBranch(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  append(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  deleteMessage(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  startRun(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  resumeRun(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  cancelRun(): void {}
-
-  addToolResult(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  resumeToolCall(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  respondToToolApproval(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  speak(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  stopSpeaking(): void {}
-
-  connectVoice(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  disconnectVoice(): void {}
-
-  getVoiceVolume = () => 0;
-  subscribeVoiceVolume = (): Unsubscribe => () => {};
-
-  muteVoice(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  unmuteVoice(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  submitFeedback(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  getModelContext() {
-    return {};
-  }
-
-  exportExternalState() {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  importExternalState(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  unstable_notifySessionReset(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  composer = {
-    attachments: [] as never[],
-    attachmentAccept: "*",
-
-    async addAttachment() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    async removeAttachment() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    isEditing: false as const,
-    canCancel: false,
-    canSend: false,
-    isEmpty: true,
-    text: "",
-
-    setText() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    role: "user" as const,
-
-    setRole() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    runConfig: {},
-
-    setRunConfig() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    async reset() {
-      // noop
-    },
-
-    async clearAttachments() {
-      // noop
-    },
-
-    send() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    cancel() {
-      // noop
-    },
-
-    queue: [] as never[],
-    moveQueueItem() {},
-    removeQueueItem() {},
-
-    dictation: undefined,
-
-    startDictation() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    stopDictation() {
-      // noop
-    },
-
-    quote: undefined,
-
-    setQuote() {
-      throw READONLY_THREAD_ERROR;
-    },
-
-    subscribe() {
-      return () => {};
-    },
-
-    unstable_on() {
-      return () => {};
-    },
-  };
-
-  getEditComposer() {
-    return undefined;
-  }
-
-  beginEdit(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
-  speech = undefined;
-  voice = undefined;
-
-  capabilities = {
-    switchToBranch: false,
-    switchBranchDuringRun: false,
-    edit: false,
-    delete: false,
-    reload: false,
-    refetchThread: false,
-    cancel: false,
-    unstable_copy: false,
-    speech: false,
-    dictation: false,
-    voice: false,
-    attachments: false,
-    feedback: false,
-    queue: false,
-  } as const;
-
-  isDisabled = false;
-  isSendDisabled = false;
-  isLoading = false;
-
-  state = null;
-  suggestions = [] as never[];
-  extras = undefined;
-
-  import(): void {
-    throw READONLY_THREAD_ERROR;
-  }
-
   export() {
     return {
       messages: this._messages.map((message, idx) => ({
@@ -244,11 +50,13 @@ export class ReadonlyThreadRuntimeCore
     };
   }
 
-  reset(): void {
-    throw READONLY_THREAD_ERROR;
-  }
+  composer = createInertComposer(READONLY_THREAD_ERROR, false);
 
-  unstable_on(): Unsubscribe {
-    return () => {};
-  }
+  isLoading = false;
+
+  override cancelRun(): void {}
+
+  override stopSpeaking(): void {}
+
+  override disconnectVoice(): void {}
 }

--- a/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
+++ b/packages/core/src/runtimes/remote-thread-list/empty-thread-core.ts
@@ -1,238 +1,43 @@
+import type { Unsubscribe } from "../../types/unsubscribe";
 import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
+import {
+  InertThreadRuntimeCore,
+  createInertComposer,
+} from "../inert/InertThreadRuntimeCore";
 
 const EMPTY_THREAD_ERROR = new Error(
   "This is the empty thread, a placeholder for the main thread. You cannot perform any actions on this thread instance. This error is probably because you tried to call a thread method in your render function. Call the method inside a `useEffect` hook instead.",
 );
-export const EMPTY_THREAD_CORE: ThreadRuntimeCore = {
+
+class EmptyThreadRuntimeCore extends InertThreadRuntimeCore {
+  protected get error() {
+    return EMPTY_THREAD_ERROR;
+  }
+
+  messages = [] as never[];
+
+  composer = createInertComposer(EMPTY_THREAD_ERROR, true);
+
+  isLoading = true;
+
   getMessageById() {
     return undefined;
-  },
+  }
 
   getBranches() {
     return [];
-  },
-
-  switchToBranch() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  append() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  deleteMessage() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  startRun() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  resumeRun() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  cancelRun() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  addToolResult() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  resumeToolCall() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  respondToToolApproval() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  speak() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  stopSpeaking() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  connectVoice() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  disconnectVoice() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  getVoiceVolume: () => 0,
-  subscribeVoiceVolume: () => () => {},
-
-  muteVoice() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  unmuteVoice() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  submitFeedback() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  getModelContext() {
-    return {};
-  },
-
-  exportExternalState() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  importExternalState() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  unstable_notifySessionReset() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  composer: {
-    attachments: [],
-    attachmentAccept: "*",
-
-    async addAttachment() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    async removeAttachment() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    isEditing: true,
-
-    canCancel: false,
-    canSend: false,
-    isEmpty: true,
-
-    text: "",
-
-    setText() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    role: "user",
-
-    setRole() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    runConfig: {},
-
-    setRunConfig() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    async reset() {
-      // noop
-    },
-
-    async clearAttachments() {
-      // noop
-    },
-
-    send() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    cancel() {
-      // noop
-    },
-
-    queue: [] as never[],
-    moveQueueItem() {},
-    removeQueueItem() {},
-
-    dictation: undefined,
-
-    startDictation() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    stopDictation() {
-      // noop
-    },
-
-    quote: undefined,
-
-    setQuote() {
-      throw EMPTY_THREAD_ERROR;
-    },
-
-    subscribe() {
-      return () => {};
-    },
-
-    unstable_on() {
-      return () => {};
-    },
-  },
-
-  getEditComposer() {
-    return undefined;
-  },
-
-  beginEdit() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  speech: undefined,
-  voice: undefined,
-
-  capabilities: {
-    switchToBranch: false,
-    switchBranchDuringRun: false,
-    edit: false,
-    delete: false,
-    reload: false,
-    refetchThread: false,
-    cancel: false,
-    unstable_copy: false,
-    speech: false,
-    dictation: false,
-    voice: false,
-    attachments: false,
-    feedback: false,
-    queue: false,
-  },
-
-  isDisabled: false,
-  isSendDisabled: false,
-  isLoading: true,
-
-  messages: [],
-
-  state: null,
-
-  suggestions: [],
-
-  extras: undefined,
-
-  subscribe() {
-    return () => {};
-  },
-
-  import() {
-    throw EMPTY_THREAD_ERROR;
-  },
+  }
 
   export() {
     return { messages: [] };
-  },
+  }
 
-  reset() {
-    throw EMPTY_THREAD_ERROR;
-  },
-
-  unstable_on() {
+  // The singleton never notifies, so retaining subscribers on a module-level
+  // instance would leak them for the lifetime of the process.
+  override subscribe(): Unsubscribe {
     return () => {};
-  },
-};
+  }
+}
+
+export const EMPTY_THREAD_CORE: ThreadRuntimeCore =
+  new EmptyThreadRuntimeCore();

--- a/packages/core/src/tests/empty-thread-core.test.ts
+++ b/packages/core/src/tests/empty-thread-core.test.ts
@@ -1,7 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { EMPTY_THREAD_CORE } from "../runtimes/remote-thread-list/empty-thread-core";
 
 describe("EMPTY_THREAD_CORE", () => {
+  it("stays a stable singleton", () => {
+    expect(EMPTY_THREAD_CORE).toBe(EMPTY_THREAD_CORE);
+  });
+
+  it("subscribe is inert and never retains a callback on the singleton", () => {
+    const subscribers = (EMPTY_THREAD_CORE as unknown as Record<string, any>)
+      ._subscribers;
+    expect(subscribers).toBeInstanceOf(Set);
+    const before = subscribers.size;
+
+    const callback = vi.fn();
+    const unsubscribe = EMPTY_THREAD_CORE.subscribe(callback);
+    EMPTY_THREAD_CORE.subscribe(vi.fn());
+
+    expect(unsubscribe).toBeInstanceOf(Function);
+    expect(() => unsubscribe()).not.toThrow();
+    expect(callback).not.toHaveBeenCalled();
+    expect(subscribers.size).toBe(before);
+  });
+
+  it("reads no messages, branches, or exported repository", () => {
+    expect(EMPTY_THREAD_CORE.getMessageById("a")).toBeUndefined();
+    expect(EMPTY_THREAD_CORE.getBranches("a")).toEqual([]);
+    expect(EMPTY_THREAD_CORE.export()).toEqual({ messages: [] });
+  });
+
   it("has isLoading=true so it is not mistaken for an empty conversation", () => {
     expect(EMPTY_THREAD_CORE.isLoading).toBe(true);
   });


### PR DESCRIPTION
`ReadonlyThreadRuntimeCore` and `EMPTY_THREAD_CORE` each spelled out a near-complete inert `ThreadRuntimeCore` — the same throwing mutators, the same inert composer, the same all-false capability set — differing only in error text and a handful of behaviors, and already drifting. Both now extend an abstract `InertThreadRuntimeCore`; each subclass keeps only its real differences.

Readonly stays constructable, subscribable and `setMessages`-capable; the empty core stays a singleton and overrides `subscribe` back to a no-op so the module-level instance cannot retain callbacks. Both internal exports and every member survive (now inherited) with an unchanged export list — the api-surface diff is pure member relocation onto the base, with zero changed `export {` lines and no member changing kind.

Net −155 implementation lines. Every no-op-versus-throw divergence between the two cores has an explicit test: `cancelRun`/`stopSpeaking`/`disconnectVoice` no-op on readonly and throw on empty, composer `isEditing` false/true, `isLoading`, the message accessors, distinct error identities, and the empty core's inert `subscribe`.

### Two deliberate divergences from the previous behavior

Both are internal-only (`ReadonlyThreadRuntimeCore` and `EMPTY_THREAD_CORE` are exported solely from `@assistant-ui/core/internal`), and nothing in the repo depends on either. Calling any method on a core is unchanged in both cases.

**1. Mutators are receiver-bound.** They now `throw this.error` instead of a module constant, so a *detached* call — `const f = core.append; f()` — throws a `TypeError` rather than the core's own error. Attached calls are identical. This is pinned by a test rather than left to be rediscovered.

I measured both alternatives and they cost more than the divergence:

- *Arrow-field mutators* (what a naive fix reaches for) work, but move 25 members from methods to properties in the published surface (`append(): void` → `append: () => void`), break any downstream subclass that overrides one as a method (TS2425), and move all mutators from the prototype to own enumerable properties — trading this divergence for a bigger one on the readonly core.
- *A class factory* whose methods close over the error fails declaration emit: `TS4094: Property '_notifySubscribers' of exported anonymous class type may not be private or protected`, because an exported class cannot extend an anonymous class carrying `BaseSubscribable`'s protected members. It is only rescuable by hand-writing and hand-syncing a ~40-member interface, which would give back most of what the dedup removes.

**2. The empty core's own-property shape.** `EMPTY_THREAD_CORE` was a plain object literal, so its methods were own and enumerable; as a class instance they live on the prototype. `{...EMPTY_THREAD_CORE}` and `Object.keys` therefore return a different set. Its only consumer returns the object as a whole.

Verified: core 1379 tests, react 408, `tsc --noEmit` byte-identical to the upstream baseline, api-surface regenerated under Node 24 with zero drift, oxlint/oxfmt clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9zorEFRAgNIF8JFKHbCbOHQuRW3YQVVhPQ2Qmr3FCZZLq9sQCbseU_7gZUc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
