### PR TITLE
fix(core): contain a synchronously throwing clipboard writer in useActionBarCopy

### DIFF
--- a/.changeset/copy-sync-throw.md
+++ b/.changeset/copy-sync-throw.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: contain a synchronously throwing clipboard writer in useActionBarCopy

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
@@ -82,6 +82,21 @@ describe("useActionBarCopy", () => {
     expect(mocks.setIsCopied).not.toHaveBeenCalled();
   });
 
+  it("does not report copy success when the clipboard handler throws synchronously", async () => {
+    const copyToClipboard = vi.fn(() => {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'writeText')",
+      );
+    });
+    const { result } = renderHook(() => useActionBarCopy({ copyToClipboard }));
+
+    expect(() => result.current.copy()).not.toThrow();
+    await Promise.resolve();
+
+    expect(copyToClipboard).toHaveBeenCalledWith("Hello");
+    expect(mocks.setIsCopied).not.toHaveBeenCalled();
+  });
+
   it("keeps copy success visible for the full duration after copying again", async () => {
     vi.useFakeTimers();
     const copyToClipboard = vi.fn();

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -40,9 +40,19 @@ export const useActionBarCopy = ({
     if (!valueToCopy) return;
     const scopeGeneration = scopeGenerationRef.current;
 
-    // The rejection handler swallows clipboard write failures (permission denied,
-    // API unavailable) so they don't surface as unhandled promise rejections.
-    Promise.resolve(copyToClipboard(valueToCopy)).then(
+    // The writer runs synchronously inside the press so the user-gesture gating
+    // of navigator.clipboard survives (WebKit scopes it to the stack); the try
+    // contains a synchronously throwing caller-supplied writer, and the rejection
+    // handler swallows clipboard failures (permission denied, API unavailable) so
+    // they don't surface as unhandled rejections.
+    let write: void | Promise<void>;
+    try {
+      write = copyToClipboard(valueToCopy);
+    } catch {
+      return;
+    }
+
+    Promise.resolve(write).then(
       () => {
         if (scopeGeneration !== scopeGenerationRef.current) return;
 


### PR DESCRIPTION
`useActionBarCopy` invokes the caller-supplied clipboard writer as an argument to `Promise.resolve(...)`:

```js
Promise.resolve(copyToClipboard(valueToCopy)).then(onOk, () => {});
```

The writer therefore runs before `.then` attaches a rejection handler, so a **synchronous** throw escapes it entirely and propagates out of `copy()` into the caller's press handler. The comment above that line claims the rejection handler swallows "permission denied, API unavailable" failures; for the synchronous case it does not.

`@assistant-ui/react` is unaffected — its first-party writer already guards `!navigator.clipboard` and returns a rejected promise. The reachable paths are React Native and Ink, where `ActionBarCopy` takes the platform clipboard writer as a public prop, so the writer is user code. The common trigger is a clipboard native module that isn't linked, where `Clipboard.setString` throws `TypeError` synchronously rather than rejecting.

On Ink this is worse than a failed copy: `Pressable` calls `onPress()` from inside ink's `useInput` stdin handler, outside React's render and outside any error boundary, so the throw is an uncaught exception that terminates the process — the TUI exits on a keypress. On React Native it surfaces as a redbox.

AGENTS.md requires that code "must not throw on … unavailable platform APIs".

**Fix.** Invoke the writer inside a `try`, and pass its result to `Promise.resolve`. This mirrors the guard already present in the Svelte implementation of the same primitive (`packages/svelte/src/primitives/actionBar.ts`), including keeping the writer on the synchronous stack — deferring it into the promise chain would push it past the event-dispatch stack that WebKit scopes clipboard user-activation to, breaking copy in Safari. The comment is mirrored from that sibling verbatim so the relationship between the two implementations stays visible.

A synchronous throw now behaves exactly as an async rejection already does: no copied state, no timer. That does mean a developer whose clipboard module isn't linked gets a button that silently does nothing instead of a crash. That trade-off is deliberate — it matches both the existing async path and the Svelte implementation, and crashing the Ink process on a keypress is the worse failure. Surfacing a dev-mode warning would be a behavior change and belongs in its own PR.

**Testing.** Added a case to `useActionBarCopy.test.ts` covering a writer that throws synchronously; it fails on `main` with the TypeError escaping `copy()` and passes with the fix. Full `@assistant-ui/core` suite passes (128 files, 1292 tests).

Fixes #6111


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TSMAst05gPTObaudH39VKwn4ssz2eNFpDcw27oq28ml9zgPtore2PanjLhE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->