### PR TITLE
fix(react-native,react-ink): accept platform render-function children on Pressable wrappers

### DIFF
--- a/.changeset/pressable-children-renderfn.md
+++ b/.changeset/pressable-children-renderfn.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+fix: let Pressable wrapper primitives accept the platform render-function children
+
+The wrapper prop types intersected the underlying `PressableProps["children"]` with `ReactNode`, which made the render-function branch unassignable. Ink consumers can now read `isFocused` and React Native consumers can now read `pressed` from function children, which the underlying `Pressable` already supported at runtime.

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -16,8 +16,8 @@ type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActi
 
 declare const ActionBarEdit: (_param1: ActionBarEditProps) => import("react").JSX.Element;
 
-type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ActionBarEditProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ActionBarFeedbackNegative: (_param2: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
@@ -38,8 +38,8 @@ type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress
 
 declare const ActionBarReload: (_param4: ActionBarReloadProps) => import("react").JSX.Element;
 
-type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ActionBarReloadProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type AddToolResultOptions = {
@@ -512,8 +512,8 @@ type AttachmentNameProps = ComponentProps<typeof Text>;
 
 declare const AttachmentRemove: (_param6: AttachmentRemoveProps) => import("react").JSX.Element;
 
-type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type AttachmentRemoveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const AttachmentRoot: (_param7: AttachmentRootProps) => import("react").JSX.Element;
@@ -773,8 +773,8 @@ type BranchPickerCountProps = ComponentProps<typeof Text>;
 
 declare const BranchPickerNext: (_param8: BranchPickerNextProps) => import("react").JSX.Element;
 
-type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type BranchPickerNextProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
@@ -783,14 +783,14 @@ type BranchPickerNumberProps = ComponentProps<typeof Text>;
 
 declare const BranchPickerPrevious: (_param9: BranchPickerPreviousProps) => import("react").JSX.Element;
 
-type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type BranchPickerPreviousProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ChainOfThoughtAccordionTrigger: (_param10: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
 
-type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
@@ -990,8 +990,8 @@ type CompleteAttachmentStatus = {
 
 declare const ComposerAddAttachment: (_param15: ComposerAddAttachmentProps) => import("react").JSX.Element;
 
-type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerAddAttachmentProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
@@ -1021,8 +1021,8 @@ type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
 declare const ComposerCancel: (_param16: ComposerCancelProps) => import("react").JSX.Element;
 
-type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerCancelProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ComposerIfFilters = {
@@ -1087,8 +1087,8 @@ declare const ComposerQuote: (_param18: ComposerQuoteProps) => import("react").J
 
 declare const ComposerQuoteDismiss: (_param19: ComposerQuoteDismissProps) => import("react").JSX.Element;
 
-type ComposerQuoteDismissProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerQuoteDismissProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ComposerQuoteProps = ComponentProps<typeof Box> & {
@@ -1208,8 +1208,8 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
 
 declare const ComposerSend: (_param22: ComposerSendProps) => import("react").JSX.Element;
 
-type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerSendProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ComposerState = {
@@ -2732,8 +2732,8 @@ type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Too
 
 declare const QueueItemRemove: (_param44: QueueItemRemoveProps) => import("react").JSX.Element;
 
-type QueueItemRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type QueueItemRemoveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type QueueItemState = {
@@ -2744,8 +2744,8 @@ type QueueItemState = {
 
 declare const QueueItemSteer: (_param45: QueueItemSteerProps) => import("react").JSX.Element;
 
-type QueueItemSteerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type QueueItemSteerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const QueueItemText: (_param46: QueueItemTextProps) => import("react").JSX.Element;
@@ -3234,8 +3234,8 @@ type SuggestionTitleProps = ComponentProps<typeof Text> & {
 
 declare const SuggestionTrigger: (_param55: SuggestionTriggerProps) => import("react").JSX.Element;
 
-type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type SuggestionTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;
 };
@@ -3367,8 +3367,8 @@ type ThreadIfProps = {
 
 declare const ThreadListItemArchive: (_param59: ThreadListItemArchiveProps) => import("react").JSX.Element;
 
-type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemArchiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
@@ -3389,8 +3389,8 @@ type ThreadListItemCoreState = {
 
 declare const ThreadListItemDelete: (_param60: ThreadListItemDeleteProps) => import("react").JSX.Element;
 
-type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemDeleteProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
@@ -3514,14 +3514,14 @@ type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 declare const ThreadListItemTrigger: (_param62: ThreadListItemTriggerProps) => import("react").JSX.Element;
 
-type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItemUnarchive: (_param63: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
 
-type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemUnarchiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItems: (_param64: ThreadListItemsProps) => import("react").JSX.Element;
@@ -3535,8 +3535,8 @@ type ThreadListItemsProps = {
 
 declare const ThreadListNew: (_param65: ThreadListNewProps) => import("react").JSX.Element;
 
-type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListNewProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListRoot: (_param66: ThreadListRootProps) => import("react").JSX.Element;
@@ -4035,8 +4035,8 @@ type ThreadSuggestion$1 = {
   prompt: string;
 };
 
-type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadSuggestionProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
   prompt: string;
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -14,8 +14,8 @@ type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActi
 
 declare const ActionBarEdit: (_param1: ActionBarEditProps) => import("react").JSX.Element;
 
-type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ActionBarEditProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ActionBarFeedbackNegative: (_param2: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
@@ -36,8 +36,8 @@ type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress
 
 declare const ActionBarReload: (_param4: ActionBarReloadProps) => import("react").JSX.Element;
 
-type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ActionBarReloadProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type AddToolResultOptions = {
@@ -510,8 +510,8 @@ type AttachmentNameProps = TextProps;
 
 declare const AttachmentRemove: (_param6: AttachmentRemoveProps) => import("react").JSX.Element;
 
-type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type AttachmentRemoveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const AttachmentRoot: (_param7: AttachmentRootProps) => import("react").JSX.Element;
@@ -765,8 +765,8 @@ type BranchPickerCountProps = TextProps;
 
 declare const BranchPickerNext: (_param8: BranchPickerNextProps) => import("react").JSX.Element;
 
-type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type BranchPickerNextProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
@@ -775,14 +775,14 @@ type BranchPickerNumberProps = TextProps;
 
 declare const BranchPickerPrevious: (_param9: BranchPickerPreviousProps) => import("react").JSX.Element;
 
-type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type BranchPickerPreviousProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ChainOfThoughtAccordionTrigger: (_param10: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
 
-type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
@@ -943,8 +943,8 @@ type CompleteAttachmentStatus = {
 
 declare const ComposerAddAttachment: (_param12: ComposerAddAttachmentProps) => import("react").JSX.Element;
 
-type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerAddAttachmentProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
@@ -974,8 +974,8 @@ type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
 declare const ComposerCancel: (_param13: ComposerCancelProps) => import("react").JSX.Element;
 
-type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerCancelProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ComposerIfFilters = {
@@ -1125,8 +1125,8 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
 
 declare const ComposerSend: (_param16: ComposerSendProps) => import("react").JSX.Element;
 
-type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ComposerSendProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ComposerState = {
@@ -2770,8 +2770,8 @@ type SuggestionTitleProps = TextProps & {
 
 declare const SuggestionTrigger: (_param30: SuggestionTriggerProps) => import("react").JSX.Element;
 
-type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type SuggestionTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;
 };
@@ -2891,8 +2891,8 @@ type ThreadIfProps = {
 
 declare const ThreadListItemArchive: (_param33: ThreadListItemArchiveProps) => import("react").JSX.Element;
 
-type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemArchiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
@@ -2913,8 +2913,8 @@ type ThreadListItemCoreState = {
 
 declare const ThreadListItemDelete: (_param34: ThreadListItemDeleteProps) => import("react").JSX.Element;
 
-type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemDeleteProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
@@ -3038,14 +3038,14 @@ type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 declare const ThreadListItemTrigger: (_param36: ThreadListItemTriggerProps) => import("react").JSX.Element;
 
-type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemTriggerProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItemUnarchive: (_param37: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
 
-type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListItemUnarchiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListItems: (_param38: ThreadListItemsProps) => import("react").JSX.Element;
@@ -3059,8 +3059,8 @@ type ThreadListItemsProps = Omit<FlatListProps<string>, "data" | "renderItem"> &
 
 declare const ThreadListNew: (_param39: ThreadListNewProps) => import("react").JSX.Element;
 
-type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadListNewProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
 };
 
 declare const ThreadListRoot: (_param40: ThreadListRootProps) => import("react").JSX.Element;
@@ -3546,8 +3546,8 @@ type ThreadSuggestion$1 = {
   prompt: string;
 };
 
-type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ThreadSuggestionProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: PressableProps["children"];
   prompt: string;
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;

--- a/packages/react-ink/src/primitives/actionBar/ActionBarEdit.tsx
+++ b/packages/react-ink/src/primitives/actionBar/ActionBarEdit.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useActionBarEdit } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ActionBarEditProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ActionBarEdit = ({

--- a/packages/react-ink/src/primitives/actionBar/ActionBarReload.tsx
+++ b/packages/react-ink/src/primitives/actionBar/ActionBarReload.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useActionBarReload } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ActionBarReloadProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ActionBarReload = ({

--- a/packages/react-ink/src/primitives/attachment/AttachmentRemove.tsx
+++ b/packages/react-ink/src/primitives/attachment/AttachmentRemove.tsx
@@ -1,10 +1,13 @@
-import { type ReactNode, useCallback } from "react";
+import { useCallback } from "react";
 
 import { useAui } from "@assistant-ui/store";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type AttachmentRemoveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const AttachmentRemove = ({

--- a/packages/react-ink/src/primitives/branchPicker/BranchPickerNext.tsx
+++ b/packages/react-ink/src/primitives/branchPicker/BranchPickerNext.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useBranchPickerNext } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type BranchPickerNextProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const BranchPickerNext = ({

--- a/packages/react-ink/src/primitives/branchPicker/BranchPickerPrevious.tsx
+++ b/packages/react-ink/src/primitives/branchPicker/BranchPickerPrevious.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useBranchPickerPrevious } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type BranchPickerPreviousProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const BranchPickerPrevious = ({

--- a/packages/react-ink/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
+++ b/packages/react-ink/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
@@ -1,12 +1,12 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback } from "react";
 import { useAuiState, useAui } from "@assistant-ui/store";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
 export type ChainOfThoughtAccordionTriggerProps = Omit<
   PressableProps,
-  "onPress"
+  "onPress" | "children"
 > & {
-  children: ReactNode;
+  children: PressableProps["children"];
 };
 
 export const ChainOfThoughtAccordionTrigger = ({

--- a/packages/react-ink/src/primitives/composer/ComposerAddAttachment.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerAddAttachment.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useComposerAddAttachment } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerAddAttachmentProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerAddAttachment = ({

--- a/packages/react-ink/src/primitives/composer/ComposerCancel.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerCancel.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useComposerCancel } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerCancelProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerCancel = ({

--- a/packages/react-ink/src/primitives/composer/ComposerQuoteDismiss.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerQuoteDismiss.tsx
@@ -1,10 +1,13 @@
-import { type ReactNode, useCallback } from "react";
+import { useCallback } from "react";
 
 import { useAui } from "@assistant-ui/store";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ComposerQuoteDismissProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerQuoteDismissProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerQuoteDismiss = ({

--- a/packages/react-ink/src/primitives/composer/ComposerSend.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerSend.tsx
@@ -1,9 +1,8 @@
-import type { ReactNode } from "react";
 import { useComposerSend } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerSendProps = Omit<PressableProps, "onPress" | "children"> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerSend = ({

--- a/packages/react-ink/src/primitives/queueItem/QueueItemRemove.tsx
+++ b/packages/react-ink/src/primitives/queueItem/QueueItemRemove.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useAui } from "@assistant-ui/store";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type QueueItemRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type QueueItemRemoveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const QueueItemRemove = ({

--- a/packages/react-ink/src/primitives/queueItem/QueueItemSteer.tsx
+++ b/packages/react-ink/src/primitives/queueItem/QueueItemSteer.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useAui } from "@assistant-ui/store";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type QueueItemSteerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type QueueItemSteerProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const QueueItemSteer = ({

--- a/packages/react-ink/src/primitives/suggestion/SuggestionTrigger.tsx
+++ b/packages/react-ink/src/primitives/suggestion/SuggestionTrigger.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from "react";
 import { useAuiState } from "@assistant-ui/store";
 import { useSuggestionTrigger } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type SuggestionTriggerProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;
 };

--- a/packages/react-ink/src/primitives/thread/ThreadSuggestion.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadSuggestion.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useSuggestionTrigger } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadSuggestionProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
   prompt: string;
   send?: boolean | undefined;
   clearComposer?: boolean | undefined;

--- a/packages/react-ink/src/primitives/threadList/ThreadListNew.tsx
+++ b/packages/react-ink/src/primitives/threadList/ThreadListNew.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useThreadListNew } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListNewProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListNew = ({

--- a/packages/react-ink/src/primitives/threadListItem/ThreadListItemArchive.tsx
+++ b/packages/react-ink/src/primitives/threadListItem/ThreadListItemArchive.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useThreadListItemArchive } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemArchiveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemArchive = ({

--- a/packages/react-ink/src/primitives/threadListItem/ThreadListItemDelete.tsx
+++ b/packages/react-ink/src/primitives/threadListItem/ThreadListItemDelete.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useThreadListItemDelete } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemDeleteProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemDelete = ({

--- a/packages/react-ink/src/primitives/threadListItem/ThreadListItemTrigger.tsx
+++ b/packages/react-ink/src/primitives/threadListItem/ThreadListItemTrigger.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useThreadListItemTrigger } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemTriggerProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemTrigger = ({

--- a/packages/react-ink/src/primitives/threadListItem/ThreadListItemUnarchive.tsx
+++ b/packages/react-ink/src/primitives/threadListItem/ThreadListItemUnarchive.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { useThreadListItemUnarchive } from "@assistant-ui/core/react";
 import { Pressable, type PressableProps } from "../internal/Pressable";
 
-export type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemUnarchiveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemUnarchive = ({

--- a/packages/react-native/src/primitives/actionBar/ActionBarEdit.tsx
+++ b/packages/react-native/src/primitives/actionBar/ActionBarEdit.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useActionBarEdit } from "@assistant-ui/core/react";
 
-export type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ActionBarEditProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ActionBarEdit = ({

--- a/packages/react-native/src/primitives/actionBar/ActionBarReload.tsx
+++ b/packages/react-native/src/primitives/actionBar/ActionBarReload.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useActionBarReload } from "@assistant-ui/core/react";
 
-export type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ActionBarReloadProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ActionBarReload = ({

--- a/packages/react-native/src/primitives/attachment/AttachmentRemove.tsx
+++ b/packages/react-native/src/primitives/attachment/AttachmentRemove.tsx
@@ -1,10 +1,13 @@
-import { type ReactNode, useCallback } from "react";
+import { useCallback } from "react";
 import { Pressable, type PressableProps } from "react-native";
 
 import { useAui } from "@assistant-ui/store";
 
-export type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type AttachmentRemoveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const AttachmentRemove = ({

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerNext.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerNext.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useBranchPickerNext } from "@assistant-ui/core/react";
 
-export type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type BranchPickerNextProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const BranchPickerNext = ({

--- a/packages/react-native/src/primitives/branchPicker/BranchPickerPrevious.tsx
+++ b/packages/react-native/src/primitives/branchPicker/BranchPickerPrevious.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useBranchPickerPrevious } from "@assistant-ui/core/react";
 
-export type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type BranchPickerPreviousProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const BranchPickerPrevious = ({

--- a/packages/react-native/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
+++ b/packages/react-native/src/primitives/chainOfThought/ChainOfThoughtAccordionTrigger.tsx
@@ -1,12 +1,12 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useAuiState, useAui } from "@assistant-ui/store";
 
 export type ChainOfThoughtAccordionTriggerProps = Omit<
   PressableProps,
-  "onPress"
+  "onPress" | "children"
 > & {
-  children: ReactNode;
+  children: PressableProps["children"];
 };
 
 export const ChainOfThoughtAccordionTrigger = ({

--- a/packages/react-native/src/primitives/composer/ComposerAddAttachment.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerAddAttachment.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useComposerAddAttachment } from "@assistant-ui/core/react";
 
-export type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerAddAttachmentProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 /**

--- a/packages/react-native/src/primitives/composer/ComposerCancel.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerCancel.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useComposerCancel } from "@assistant-ui/core/react";
 
-export type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerCancelProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerCancel = ({

--- a/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
@@ -113,4 +113,17 @@ describe("ComposerSend", () => {
 
     expect(h.send).toHaveBeenCalledTimes(1);
   });
+
+  it("passes the Pressable press state to function children", async () => {
+    await act(async () => {
+      root.render(
+        <ComposerSend testID="send">
+          {({ pressed }) => (pressed ? "pressed" : "idle")}
+        </ComposerSend>,
+      );
+    });
+
+    const el = container.querySelector('[data-testid="send"]');
+    expect(el?.textContent).toBe("idle");
+  });
 });

--- a/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerSend.test.tsx
@@ -123,7 +123,20 @@ describe("ComposerSend", () => {
       );
     });
 
-    const el = container.querySelector('[data-testid="send"]');
-    expect(el?.textContent).toBe("idle");
+    expect(container.querySelector('[data-testid="send"]')?.textContent).toBe(
+      "idle",
+    );
+
+    await act(async () => {
+      root.render(
+        <ComposerSend testID="send" testOnly_pressed>
+          {({ pressed }) => (pressed ? "pressed" : "idle")}
+        </ComposerSend>,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="send"]')?.textContent).toBe(
+      "pressed",
+    );
   });
 });

--- a/packages/react-native/src/primitives/composer/ComposerSend.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerSend.tsx
@@ -1,9 +1,8 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useComposerSend } from "@assistant-ui/core/react";
 
-export type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ComposerSendProps = Omit<PressableProps, "onPress" | "children"> & {
+  children: PressableProps["children"];
 };
 
 export const ComposerSend = ({

--- a/packages/react-native/src/primitives/suggestion/SuggestionTrigger.tsx
+++ b/packages/react-native/src/primitives/suggestion/SuggestionTrigger.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useAuiState } from "@assistant-ui/store";
 import { useSuggestionTrigger } from "@assistant-ui/core/react";
 
-export type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type SuggestionTriggerProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
   /**
    * When true, automatically sends the message.
    * When false, replaces or appends the composer text with the suggestion.

--- a/packages/react-native/src/primitives/thread/ThreadSuggestion.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadSuggestion.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useSuggestionTrigger } from "@assistant-ui/core/react";
 
-export type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadSuggestionProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
   /** The suggestion prompt. */
   prompt: string;
   /**

--- a/packages/react-native/src/primitives/threadList/ThreadListNew.tsx
+++ b/packages/react-native/src/primitives/threadList/ThreadListNew.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useThreadListNew } from "@assistant-ui/core/react";
 
-export type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListNewProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListNew = ({

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemArchive.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemArchive.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useThreadListItemArchive } from "@assistant-ui/core/react";
 
-export type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemArchiveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemArchive = ({

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemDelete.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemDelete.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useThreadListItemDelete } from "@assistant-ui/core/react";
 
-export type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemDeleteProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemDelete = ({

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemTrigger.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemTrigger.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useThreadListItemTrigger } from "@assistant-ui/core/react";
 
-export type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemTriggerProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemTrigger = ({

--- a/packages/react-native/src/primitives/threadListItem/ThreadListItemUnarchive.tsx
+++ b/packages/react-native/src/primitives/threadListItem/ThreadListItemUnarchive.tsx
@@ -1,9 +1,11 @@
-import type { ReactNode } from "react";
 import { Pressable, type PressableProps } from "react-native";
 import { useThreadListItemUnarchive } from "@assistant-ui/core/react";
 
-export type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+export type ThreadListItemUnarchiveProps = Omit<
+  PressableProps,
+  "onPress" | "children"
+> & {
+  children: PressableProps["children"];
 };
 
 export const ThreadListItemUnarchive = ({


### PR DESCRIPTION
The wrapper primitives around `Pressable` declare their props as `Omit<PressableProps, "onPress"> & { children: ReactNode }`. Because the underlying `PressableProps["children"]` is `ReactNode | ((state) => ReactNode)`, that intersection reduces the function branch to `((state) => ReactNode) & string`, so it can never be satisfied. Passing a render function fails with TS2322 on both platforms.

The result is that ink consumers cannot read `isFocused` to show which terminal action currently holds keyboard focus, and React Native consumers cannot read `pressed` to change content on press. Both are the platform's own idiom, and both already work at runtime: all 35 wrappers forward `children` untouched to the platform `Pressable`, which does the `typeof children === "function"` dispatch itself. Only the declared type blocked it.

Each wrapper now omits `children` alongside `onPress` and redeclares it as `PressableProps["children"]`, restoring the platform contract. The intersection is load-bearing on React Native, where `PressableProps.children` is optional and a bare `Omit` would silently make `children` optional on 16 published prop types; on ink, where it is required, the two forms are identical and I kept the explicit form so the paired RN and ink files stay line-for-line comparable.

This is a type-only change: the widening is additive (I checked every one of the 35 `Props["children"]` types still accepts everything `ReactNode` accepted, and the api-surface diff removes no export and touches nothing but those 35 declarations). The added React Native test exercises a function child through the wrapper, which had no coverage; ink's equivalent is already covered at `packages/react-ink/src/tests/Pressable.test.tsx`. Neither test is a regression guard — reverting the type change leaves both green, since the bug was never visible at runtime — and the repository has no CI type gate, so I'd rather say that than imply coverage that doesn't exist.

Fixes #6113

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uiEqLHHikn8Potx0mRM45b5ennIZlPMHsYUPEdRnCFSfY7C4NPicTqp1GFA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->