### PR TITLE
fix(react-o11y): flatten deeply nested traces iteratively

### DIFF
--- a/.changeset/deep-spans-flatten.md
+++ b/.changeset/deep-spans-flatten.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-o11y": patch
+---
+
+fix: flatten deeply nested observability traces without overflowing the call stack

--- a/packages/react-o11y/src/resources/SpanResource.test.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.test.tsx
@@ -4,14 +4,18 @@ import { AuiProvider, useAui } from "@assistant-ui/store";
 import * as SpanPrimitive from "../primitives/span";
 import { SpanResource, type SpanData } from "./SpanResource";
 
-const createSpan = (id: string, parentSpanId: string | null): SpanData => ({
+const createSpan = (
+  id: string,
+  parentSpanId: string | null,
+  startedAt = 0,
+): SpanData => ({
   id,
   parentSpanId,
   name: id,
   type: "test",
   status: "completed",
-  startedAt: 0,
-  endedAt: 1,
+  startedAt,
+  endedAt: startedAt + 1,
   latencyMs: 1,
 });
 
@@ -101,6 +105,32 @@ describe("SpanResource", () => {
     );
     expect(html).toContain(
       'data-span-id="orphan" data-parent-span-id="root" data-span-depth="0"',
+    );
+  });
+
+  it("preserves depth-first start-time ordering", () => {
+    const html = renderSpans([
+      createSpan("root", null),
+      createSpan("later", "root", 2),
+      createSpan("earlier", "root", 1),
+      createSpan("nested", "earlier", 3),
+    ]);
+
+    const spanIds = [...html.matchAll(/data-span-id="([^"]+)"/g)].map(
+      (match) => match[1],
+    );
+    expect(spanIds).toEqual(["root", "earlier", "nested", "later"]);
+  });
+
+  it("renders deeply nested parent chains without overflowing the stack", () => {
+    const spans = Array.from({ length: 20_000 }, (_, index) =>
+      createSpan(`span-${index}`, index === 0 ? null : `span-${index - 1}`),
+    );
+
+    const html = renderSpans(spans);
+
+    expect(html).toContain(
+      'data-span-id="span-19999" data-parent-span-id="span-19998" data-span-depth="19999"',
     );
   });
 });

--- a/packages/react-o11y/src/resources/SpanResource.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.tsx
@@ -156,17 +156,25 @@ function buildFlatList(
   }
 
   const result: SpanItemState[] = [];
-  function dfs(parentId: string | null) {
-    const kids = children.get(parentId);
-    if (!kids) return;
-    for (const span of kids) {
-      result.push({ ...span, isCollapsed: collapsedIds.has(span.id) });
-      if (!collapsedIds.has(span.id)) {
-        dfs(span.id);
+  const stack: SpanItemState[] = [];
+  const roots = children.get(null) ?? [];
+  for (let index = roots.length - 1; index >= 0; index--) {
+    stack.push(roots[index]!);
+  }
+
+  while (stack.length > 0) {
+    const span = stack.pop()!;
+    const isCollapsed = collapsedIds.has(span.id);
+    result.push({ ...span, isCollapsed });
+
+    if (!isCollapsed) {
+      const kids = children.get(span.id) ?? [];
+      for (let index = kids.length - 1; index >= 0; index--) {
+        stack.push(kids[index]!);
       }
     }
   }
-  dfs(null);
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

- replace recursive span-tree flattening with an explicit traversal stack
- preserve depth-first traversal, sibling start-time ordering, and collapsed-subtree behavior
- add regression coverage for a 20,000-span parent chain and traversal ordering

## Why

`SpanResource` normalized parents and calculated depth iteratively, but flattened the resulting tree recursively. A valid 20,000-span parent chain therefore threw `RangeError: Maximum call stack size exceeded` while preparing the visible span list. Using an explicit LIFO stack removes the JavaScript call-stack limit; children are pushed in reverse order so the rendered order remains unchanged.

## Validation

- reproduced the stack overflow with the new regression test before the implementation change
- `pnpm --filter @assistant-ui/react-o11y test` (2 files, 14 tests)
- `pnpm turbo build --filter=@assistant-ui/react-o11y...`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9amEwQWaRW_eWPEZ0rsljxwFaROfWjVfSIPQzsp6XOHG24cH4cI4UmLnqW4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->