### PR TITLE
fix: playground canvas tabs connecting to content

### DIFF
--- a/apps/docs/components/xulux/canvas/XuluxCanvasTabBar.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvasTabBar.tsx
@@ -19,11 +19,10 @@ type Props = {
 };
 
 const triggerClassName = cn(
-  "group/tab-trigger h-8 max-w-[min(220px,40vw)] min-w-[90px] !flex-none shrink-0 grow-0 basis-auto gap-1.5 rounded-t-[10px] rounded-b-none px-3 text-xs transition-colors duration-200",
+  "group/tab-trigger !h-8 max-w-[min(220px,40vw)] min-w-[90px] !flex-none shrink-0 grow-0 basis-auto gap-1.5 !rounded-t-[10px] !rounded-b-none px-3 text-xs transition-colors duration-200",
   "border-border/60 border border-b-0",
-  "data-[state=inactive]:text-muted-foreground data-[state=inactive]:bg-[#f1f3f4]/90",
-  "dark:data-[state=inactive]:bg-[#2a2a2d]/90",
-  "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+  "text-muted-foreground bg-[#f1f3f4]/90 dark:bg-[#2a2a2d]/90",
+  "data-active:bg-background data-active:text-foreground dark:data-active:bg-background dark:data-active:text-foreground data-active:shadow-sm",
 );
 
 export function XuluxCanvasTabBar({ tabs, isLoading = false, actions }: Props) {
@@ -51,7 +50,7 @@ export function XuluxCanvasTabBar({ tabs, isLoading = false, actions }: Props) {
               <Icon className="size-3.5 shrink-0" />
               <span className="min-w-0 flex-1 truncate">{tab.label}</span>
               {isLoading ? (
-                <Loader2 className="text-muted-foreground hidden size-3 shrink-0 animate-spin group-data-[state=active]/tab-trigger:inline-block" />
+                <Loader2 className="text-muted-foreground hidden size-3 shrink-0 animate-spin group-data-active/tab-trigger:inline-block" />
               ) : null}
             </TabsTrigger>
           );


### PR DESCRIPTION
## Summary

- make the playground canvas tabs fill their tab strip so the active tab connects directly to the content panel
- preserve the intended square bottom corners and browser-tab shape
- update active and loading styles to use Base UI's `data-active` state

## Root cause

The canvas tab bar still targeted Radix's `data-state` attributes after the shared tabs component moved to Base UI. Its local height and corner classes were also being overridden by the shared size and outline variants, leaving a visible gap and rounded bottom corners between the active tab and its panel.

## Validation

- `oxlint apps/docs/components/xulux/canvas/XuluxCanvasTabBar.tsx`
- `oxfmt --check apps/docs/components/xulux/canvas/XuluxCanvasTabBar.tsx`
- `git diff --check`
- verified the compiled Tailwind CSS includes the full-height, square-bottom, `data-active`, and active-loader rules

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.K6YoZuPpWyK5ouZTpux_lQijO9A8hqO-NQ-TrbEG88e3Uj3KTrgUc1DAsZ8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->