### PR TITLE
fix(markdown): respect CommonMark backtick delimiters during currency escaping

### DIFF
--- a/.changeset/equal-backtick-delimiters.md
+++ b/.changeset/equal-backtick-delimiters.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: preserve currency markers inside CommonMark code spans and fences

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -212,6 +212,15 @@ describe("escapeCurrencyDollars", () => {
     ).toBe("10. ```\n    const price = $5;\n    ```\n\nafter \\$7");
   });
 
+  it("uses tab-expanded columns for list fence containers", () => {
+    expect(escapeCurrencyDollars("-\t```\n\tcode = $5\n\t```\nafter $7")).toBe(
+      "-\t```\n\tcode = $5\n\t```\nafter \\$7",
+    );
+    expect(escapeCurrencyDollars("-\t```\n    code\n  Pay $5 today")).toBe(
+      "-\t```\n    code\n  Pay \\$5 today",
+    );
+  });
+
   it("stops an unclosed blockquote fence when its container ends", () => {
     expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
       "> ```\n> code\n\nPay \\$5 today",

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -186,6 +186,28 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("recognizes fenced blocks inside list-item blockquotes", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- > ```\n  > const marker = ```;\n  > const price = $5;\n  > ```\nafter $7",
+      ),
+    ).toBe(
+      "- > ```\n  > const marker = ```;\n  > const price = $5;\n  > ```\nafter \\$7",
+    );
+  });
+
+  it("stops an unclosed blockquote fence when its container ends", () => {
+    expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
+      "> ```\n> code\n\nPay \\$5 today",
+    );
+  });
+
+  it("stops an unclosed list fence when its container ends", () => {
+    expect(escapeCurrencyDollars("- ```\n  code\n\nPay $5 today")).toBe(
+      "- ```\n  code\n\nPay \\$5 today",
+    );
+  });
+
   it("does not close a root fence on a list-marker backtick line", () => {
     expect(
       escapeCurrencyDollars("```\n- ```\nconst price = $5;\n```\nafter $7"),

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -186,6 +186,18 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not close a root fence on a list-marker backtick line", () => {
+    expect(
+      escapeCurrencyDollars("```\n- ```\nconst price = $5;\n```\nafter $7"),
+    ).toBe("```\n- ```\nconst price = $5;\n```\nafter \\$7");
+  });
+
+  it("does not close a root fence on a blockquote backtick line", () => {
+    expect(
+      escapeCurrencyDollars("```\n> ```\nconst price = $5;\n```\nafter $7"),
+    ).toBe("```\n> ```\nconst price = $5;\n```\nafter \\$7");
+  });
+
   it("escapes an amount when the prose before the next span carries latex syntax", () => {
     expect(
       escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -132,6 +132,26 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not rewrite currency inside a code span containing a longer backtick run", () => {
+    expect(escapeCurrencyDollars("`value ``` costs $5 ` after $7")).toBe(
+      "`value ``` costs $5 ` after \\$7",
+    );
+  });
+
+  it("does not close a fenced block on a backtick run inside its content", () => {
+    expect(
+      escapeCurrencyDollars(
+        "```\nconst marker = ```;\nconst price = $5;\n```\nafter $7",
+      ),
+    ).toBe("```\nconst marker = ```;\nconst price = $5;\n```\nafter \\$7");
+  });
+
+  it("accepts a closing fence longer than the opening fence", () => {
+    expect(escapeCurrencyDollars("```\n$5\n````\nafter $7")).toBe(
+      "```\n$5\n````\nafter \\$7",
+    );
+  });
+
   it("escapes an amount when the prose before the next span carries latex syntax", () => {
     expect(
       escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -196,6 +196,22 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("recognizes fenced blocks at a nested list content column", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- outer\n  - ```\n    const price = $5;\n    ```\n\nafter $7",
+      ),
+    ).toBe("- outer\n  - ```\n    const price = $5;\n    ```\n\nafter \\$7");
+  });
+
+  it("recognizes fenced blocks after a wide ordered-list marker", () => {
+    expect(
+      escapeCurrencyDollars(
+        "10. ```\n    const price = $5;\n    ```\n\nafter $7",
+      ),
+    ).toBe("10. ```\n    const price = $5;\n    ```\n\nafter \\$7");
+  });
+
   it("stops an unclosed blockquote fence when its container ends", () => {
     expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
       "> ```\n> code\n\nPay \\$5 today",

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -147,8 +147,42 @@ describe("escapeCurrencyDollars", () => {
   });
 
   it("accepts a closing fence longer than the opening fence", () => {
-    expect(escapeCurrencyDollars("```\n$5\n````\nafter $7")).toBe(
-      "```\n$5\n````\nafter \\$7",
+    expect(escapeCurrencyDollars("```\n$5\n````\nafter `code $7` and $9")).toBe(
+      "```\n$5\n````\nafter `code $7` and \\$9",
+    );
+  });
+
+  it("does not rewrite currency inside an unclosed fenced block", () => {
+    expect(escapeCurrencyDollars("```js\nconst price = $5;")).toBe(
+      "```js\nconst price = $5;",
+    );
+  });
+
+  it("recognizes fenced blocks with carriage-return line endings", () => {
+    expect(
+      escapeCurrencyDollars(
+        "```\rconst marker = ```;\rconst price = $5;\r```\rafter $7",
+      ),
+    ).toBe("```\rconst marker = ```;\rconst price = $5;\r```\rafter \\$7");
+  });
+
+  it("recognizes fenced blocks inside blockquotes", () => {
+    expect(
+      escapeCurrencyDollars(
+        "> ```\n> const marker = ```;\n> const price = $5;\n> ```\nafter $7",
+      ),
+    ).toBe(
+      "> ```\n> const marker = ```;\n> const price = $5;\n> ```\nafter \\$7",
+    );
+  });
+
+  it("recognizes fenced blocks inside list items", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- ```\n  const marker = ```;\n  const price = $5;\n  ```\nafter $7",
+      ),
+    ).toBe(
+      "- ```\n  const marker = ```;\n  const price = $5;\n  ```\nafter \\$7",
     );
   });
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -91,36 +91,48 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-/** Whether a line prefix permits a fenced code block at this position. */
-function isFencePrefix(prefix: string): boolean {
-  let remaining = prefix;
-  while (remaining.length > 0) {
-    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
-    if (blockquote) {
-      remaining = remaining.slice(blockquote[0].length);
-      continue;
-    }
+function peelBlockquotes(prefix: string): { depth: number; rest: string } {
+  let rest = prefix;
+  let depth = 0;
+  while (rest.length > 0) {
+    const blockquote = rest.match(/^ {0,3}>[ \t]?/);
+    if (!blockquote) break;
+    rest = rest.slice(blockquote[0].length);
+    depth += 1;
+  }
+  return { depth, rest };
+}
 
+function isFencePrefix(prefix: string): boolean {
+  let remaining = peelBlockquotes(prefix).rest;
+  while (remaining.length > 0) {
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
-    if (listItem) {
-      remaining = remaining.slice(listItem[0].length);
-      continue;
-    }
-    break;
+    if (!listItem) break;
+    remaining = remaining.slice(listItem[0].length);
   }
   return /^ {0,3}$/.test(remaining);
 }
 
-/** Closing-fence end on one line, or -1 when the line is not a closer. */
+function isClosingFencePrefix(prefix: string, quoteDepth: number): boolean {
+  const peeled = peelBlockquotes(prefix);
+  return peeled.depth === quoteDepth && /^ {0,3}$/.test(peeled.rest);
+}
+
 function closingFenceEnd(
   text: string,
   start: number,
   end: number,
   minimumLength: number,
+  quoteDepth: number,
 ): number {
   const line = text.slice(start, end);
   const runStart = line.indexOf("`");
-  if (runStart === -1 || !isFencePrefix(line.slice(0, runStart))) return -1;
+  if (
+    runStart === -1 ||
+    !isClosingFencePrefix(line.slice(0, runStart), quoteDepth)
+  ) {
+    return -1;
+  }
 
   const length = runLength(line, runStart, "`");
   if (length < minimumLength) return -1;
@@ -155,6 +167,7 @@ function codeSpanEnd(text: string, start: number): number {
         closingLineStart,
         closingLineEnd,
         delimiterLength,
+        peelBlockquotes(openingPrefix).depth,
       );
       if (close !== -1) return close;
       if (closingLineEnd === text.length) break;

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -66,35 +66,101 @@ function runLength(text: string, start: number, char: string): number {
   return length;
 }
 
+/** Start index of the line containing start. */
+function lineStart(text: string, start: number): number {
+  return (
+    Math.max(
+      text.lastIndexOf("\r", start - 1),
+      text.lastIndexOf("\n", start - 1),
+    ) + 1
+  );
+}
+
+/** End index of the line containing start, excluding its line ending. */
+function lineEnd(text: string, start: number): number {
+  const carriageReturn = text.indexOf("\r", start);
+  const lineFeed = text.indexOf("\n", start);
+  if (carriageReturn === -1) return lineFeed === -1 ? text.length : lineFeed;
+  if (lineFeed === -1) return carriageReturn;
+  return Math.min(carriageReturn, lineFeed);
+}
+
+/** Start index of the line after end, accounting for CRLF. */
+function nextLineStart(text: string, end: number): number {
+  if (end >= text.length) return text.length;
+  return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
+}
+
+/** Whether a line prefix permits a fenced code block at this position. */
+function isFencePrefix(prefix: string): boolean {
+  let remaining = prefix;
+  while (remaining.length > 0) {
+    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+    if (blockquote) {
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
+    if (listItem) {
+      remaining = remaining.slice(listItem[0].length);
+      continue;
+    }
+    break;
+  }
+  return /^ {0,3}$/.test(remaining);
+}
+
+/** Closing-fence end on one line, or -1 when the line is not a closer. */
+function closingFenceEnd(
+  text: string,
+  start: number,
+  end: number,
+  minimumLength: number,
+): number {
+  const line = text.slice(start, end);
+  const runStart = line.indexOf("`");
+  if (runStart === -1 || !isFencePrefix(line.slice(0, runStart))) return -1;
+
+  const length = runLength(line, runStart, "`");
+  if (length < minimumLength) return -1;
+  if (!/^[ \t]*$/.test(line.slice(runStart + length))) return -1;
+  return start + runStart + length;
+}
+
 /**
  * End index (exclusive) of the code span or fence whose backtick run starts at
- * `start`, or -1 when that run is never closed and its backticks read as literal
- * text.
+ * `start`. An unclosed fence extends through the end of the text; -1 means an
+ * inline code span is unclosed and its backticks read as literal text.
  */
 function codeSpanEnd(text: string, start: number): number {
   const delimiterLength = runLength(text, start, "`");
-  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
-  const openingIndent = text.slice(lineStart, start);
-  const openingLineEnd = text.indexOf("\n", start + delimiterLength);
-  const openingInfo = text.slice(
-    start + delimiterLength,
-    openingLineEnd === -1 ? text.length : openingLineEnd,
-  );
+  const openingLineStart = lineStart(text, start);
+  const openingPrefix = text.slice(openingLineStart, start);
+  const openingLineEnd = lineEnd(text, start + delimiterLength);
+  const openingInfo = text.slice(start + delimiterLength, openingLineEnd);
   const isFence =
     delimiterLength >= 3 &&
-    /^ {0,3}$/.test(openingIndent) &&
+    isFencePrefix(openingPrefix) &&
     !openingInfo.includes("`");
 
   if (isFence) {
-    if (openingLineEnd === -1) return -1;
-    const closingFence = new RegExp(
-      "^ {0,3}(`{" + delimiterLength + ",})[\\t ]*\\r?$",
-      "gm",
-    );
-    closingFence.lastIndex = openingLineEnd + 1;
-    const match = closingFence.exec(text);
-    if (!match) return -1;
-    return match.index + match[0].indexOf("`") + match[1]!.length;
+    if (openingLineEnd === text.length) return text.length;
+
+    let closingLineStart = nextLineStart(text, openingLineEnd);
+    while (closingLineStart <= text.length) {
+      const closingLineEnd = lineEnd(text, closingLineStart);
+      const close = closingFenceEnd(
+        text,
+        closingLineStart,
+        closingLineEnd,
+        delimiterLength,
+      );
+      if (close !== -1) return close;
+      if (closingLineEnd === text.length) break;
+      closingLineStart = nextLineStart(text, closingLineEnd);
+    }
+    return text.length;
   }
 
   let index = start + delimiterLength;

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -91,31 +91,74 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-type FenceContainer = { type: "blockquote" } | { type: "list"; indent: number };
+type FenceContainer =
+  | { type: "blockquote" }
+  | { type: "list"; indentColumns: number };
 
 type FenceContext = { containers: FenceContainer[] };
+
+function advanceColumn(column: number, text: string): number {
+  for (const char of text) {
+    column = char === "\t" ? column + (4 - (column % 4)) : column + 1;
+  }
+  return column;
+}
+
+function whitespaceColumns(text: string, column: number): number | null {
+  const startColumn = column;
+  for (const char of text) {
+    if (char !== " " && char !== "\t") return null;
+    column = advanceColumn(column, char);
+  }
+  return column - startColumn;
+}
+
+function consumeIndentColumns(
+  text: string,
+  column: number,
+  requiredColumns: number,
+): { remaining: string; column: number } | null {
+  const startColumn = column;
+  let index = 0;
+  while (column - startColumn < requiredColumns && index < text.length) {
+    const char = text[index]!;
+    if (char !== " " && char !== "\t") return null;
+    column = advanceColumn(column, char);
+    index++;
+  }
+  if (column - startColumn < requiredColumns) return null;
+  return { remaining: text.slice(index), column };
+}
 
 /** Container context for a fenced code block at this line prefix. */
 function fenceContext(prefix: string): FenceContext | null {
   let remaining = prefix;
+  let column = 0;
   const containers: FenceContainer[] = [];
   while (remaining.length > 0) {
     const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
     if (blockquote) {
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       containers.push({ type: "blockquote" });
       continue;
     }
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
     if (listItem) {
+      const listStartColumn = column;
       remaining = remaining.slice(listItem[0].length);
-      containers.push({ type: "list", indent: listItem[0].length });
+      column = advanceColumn(column, listItem[0]);
+      containers.push({
+        type: "list",
+        indentColumns: column - listStartColumn,
+      });
       continue;
     }
     break;
   }
 
-  if (!/^ {0,3}$/.test(remaining)) return null;
+  const remainingColumns = whitespaceColumns(remaining, column);
+  if (remainingColumns === null || remainingColumns > 3) return null;
   return { containers };
 }
 
@@ -123,27 +166,38 @@ function fenceContext(prefix: string): FenceContext | null {
 function consumeFenceContainers(
   prefix: string,
   context: FenceContext,
-): string | null {
+): { remaining: string; column: number } | null {
   let remaining = prefix;
+  let column = 0;
   for (const container of context.containers) {
     if (container.type === "blockquote") {
       const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!blockquote) return null;
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       continue;
     }
 
-    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
-    if (indent < container.indent) return null;
-    remaining = remaining.slice(container.indent);
+    const consumed = consumeIndentColumns(
+      remaining,
+      column,
+      container.indentColumns,
+    );
+    if (!consumed) return null;
+    ({ remaining, column } = consumed);
   }
-  return remaining;
+  return { remaining, column };
 }
 
 /** Whether a closing line remains in the opening fence's container. */
 function matchesFenceContext(prefix: string, context: FenceContext): boolean {
-  const remaining = consumeFenceContainers(prefix, context);
-  return remaining !== null && /^ {0,3}$/.test(remaining);
+  const consumed = consumeFenceContainers(prefix, context);
+  if (!consumed) return false;
+  const remainingColumns = whitespaceColumns(
+    consumed.remaining,
+    consumed.column,
+  );
+  return remainingColumns !== null && remainingColumns <= 3;
 }
 
 /** Whether a content line remains inside the fence's opening container. */
@@ -151,11 +205,13 @@ function continuesFenceContainer(line: string, context: FenceContext): boolean {
   if (context.containers.length === 0) return true;
 
   let remaining = line;
+  let column = 0;
   for (const [index, container] of context.containers.entries()) {
     if (container.type === "blockquote") {
       const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!blockquote) return false;
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       continue;
     }
 
@@ -164,9 +220,13 @@ function continuesFenceContainer(line: string, context: FenceContext): boolean {
         .slice(index + 1)
         .some((later) => later.type === "blockquote");
     }
-    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
-    if (indent < container.indent) return false;
-    remaining = remaining.slice(container.indent);
+    const consumed = consumeIndentColumns(
+      remaining,
+      column,
+      container.indentColumns,
+    );
+    if (!consumed) return false;
+    ({ remaining, column } = consumed);
   }
   return true;
 }

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -72,9 +72,40 @@ function runLength(text: string, start: number, char: string): number {
  * text.
  */
 function codeSpanEnd(text: string, start: number): number {
-  const fence = "`".repeat(runLength(text, start, "`"));
-  const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? -1 : closed + fence.length;
+  const delimiterLength = runLength(text, start, "`");
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  const openingIndent = text.slice(lineStart, start);
+  const openingLineEnd = text.indexOf("\n", start + delimiterLength);
+  const openingInfo = text.slice(
+    start + delimiterLength,
+    openingLineEnd === -1 ? text.length : openingLineEnd,
+  );
+  const isFence =
+    delimiterLength >= 3 &&
+    /^ {0,3}$/.test(openingIndent) &&
+    !openingInfo.includes("`");
+
+  if (isFence) {
+    if (openingLineEnd === -1) return -1;
+    const closingFence = new RegExp(
+      "^ {0,3}(`{" + delimiterLength + ",})[\\t ]*\\r?$",
+      "gm",
+    );
+    closingFence.lastIndex = openingLineEnd + 1;
+    const match = closingFence.exec(text);
+    if (!match) return -1;
+    return match.index + match[0].indexOf("`") + match[1]!.length;
+  }
+
+  let index = start + delimiterLength;
+  while (index < text.length) {
+    const next = text.indexOf("`", index);
+    if (next === -1) return -1;
+    const nextLength = runLength(text, next, "`");
+    if (nextLength === delimiterLength) return next + nextLength;
+    index = next + nextLength;
+  }
+  return -1;
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -91,31 +91,84 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-function peelBlockquotes(prefix: string): { depth: number; rest: string } {
-  let rest = prefix;
-  let depth = 0;
-  while (rest.length > 0) {
-    const blockquote = rest.match(/^ {0,3}>[ \t]?/);
-    if (!blockquote) break;
-    rest = rest.slice(blockquote[0].length);
-    depth += 1;
-  }
-  return { depth, rest };
-}
+type FenceContainer = { type: "blockquote" } | { type: "list"; indent: number };
 
-function isFencePrefix(prefix: string): boolean {
-  let remaining = peelBlockquotes(prefix).rest;
+type FenceContext = { containers: FenceContainer[] };
+
+/** Container context for a fenced code block at this line prefix. */
+function fenceContext(prefix: string): FenceContext | null {
+  let remaining = prefix;
+  const containers: FenceContainer[] = [];
   while (remaining.length > 0) {
+    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+    if (blockquote) {
+      remaining = remaining.slice(blockquote[0].length);
+      containers.push({ type: "blockquote" });
+      continue;
+    }
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
-    if (!listItem) break;
-    remaining = remaining.slice(listItem[0].length);
+    if (listItem) {
+      remaining = remaining.slice(listItem[0].length);
+      containers.push({ type: "list", indent: listItem[0].length });
+      continue;
+    }
+    break;
   }
-  return /^ {0,3}$/.test(remaining);
+
+  if (!/^ {0,3}$/.test(remaining)) return null;
+  return { containers };
 }
 
-function isClosingFencePrefix(prefix: string, quoteDepth: number): boolean {
-  const peeled = peelBlockquotes(prefix);
-  return peeled.depth === quoteDepth && /^ {0,3}$/.test(peeled.rest);
+/** Remove the opening container sequence from a later line prefix. */
+function consumeFenceContainers(
+  prefix: string,
+  context: FenceContext,
+): string | null {
+  let remaining = prefix;
+  for (const container of context.containers) {
+    if (container.type === "blockquote") {
+      const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!blockquote) return null;
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (indent < container.indent) return null;
+    remaining = remaining.slice(container.indent);
+  }
+  return remaining;
+}
+
+/** Whether a closing line remains in the opening fence's container. */
+function matchesFenceContext(prefix: string, context: FenceContext): boolean {
+  const remaining = consumeFenceContainers(prefix, context);
+  return remaining !== null && /^ {0,3}$/.test(remaining);
+}
+
+/** Whether a content line remains inside the fence's opening container. */
+function continuesFenceContainer(line: string, context: FenceContext): boolean {
+  if (context.containers.length === 0) return true;
+
+  let remaining = line;
+  for (const [index, container] of context.containers.entries()) {
+    if (container.type === "blockquote") {
+      const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!blockquote) return false;
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    if (/^[ \t]*$/.test(remaining)) {
+      return !context.containers
+        .slice(index + 1)
+        .some((later) => later.type === "blockquote");
+    }
+    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (indent < container.indent) return false;
+    remaining = remaining.slice(container.indent);
+  }
+  return true;
 }
 
 function closingFenceEnd(
@@ -123,13 +176,13 @@ function closingFenceEnd(
   start: number,
   end: number,
   minimumLength: number,
-  quoteDepth: number,
+  context: FenceContext,
 ): number {
   const line = text.slice(start, end);
   const runStart = line.indexOf("`");
   if (
     runStart === -1 ||
-    !isClosingFencePrefix(line.slice(0, runStart), quoteDepth)
+    !matchesFenceContext(line.slice(0, runStart), context)
   ) {
     return -1;
   }
@@ -151,10 +204,9 @@ function codeSpanEnd(text: string, start: number): number {
   const openingPrefix = text.slice(openingLineStart, start);
   const openingLineEnd = lineEnd(text, start + delimiterLength);
   const openingInfo = text.slice(start + delimiterLength, openingLineEnd);
+  const context = fenceContext(openingPrefix);
   const isFence =
-    delimiterLength >= 3 &&
-    isFencePrefix(openingPrefix) &&
-    !openingInfo.includes("`");
+    delimiterLength >= 3 && context !== null && !openingInfo.includes("`");
 
   if (isFence) {
     if (openingLineEnd === text.length) return text.length;
@@ -162,12 +214,16 @@ function codeSpanEnd(text: string, start: number): number {
     let closingLineStart = nextLineStart(text, openingLineEnd);
     while (closingLineStart <= text.length) {
       const closingLineEnd = lineEnd(text, closingLineStart);
+      const closingLine = text.slice(closingLineStart, closingLineEnd);
+      if (!continuesFenceContainer(closingLine, context)) {
+        return closingLineStart;
+      }
       const close = closingFenceEnd(
         text,
         closingLineStart,
         closingLineEnd,
         delimiterLength,
-        peelBlockquotes(openingPrefix).depth,
+        context,
       );
       if (close !== -1) return close;
       if (closingLineEnd === text.length) break;

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -212,6 +212,15 @@ describe("escapeCurrencyDollars", () => {
     ).toBe("10. ```\n    const price = $5;\n    ```\n\nafter \\$7");
   });
 
+  it("uses tab-expanded columns for list fence containers", () => {
+    expect(escapeCurrencyDollars("-\t```\n\tcode = $5\n\t```\nafter $7")).toBe(
+      "-\t```\n\tcode = $5\n\t```\nafter \\$7",
+    );
+    expect(escapeCurrencyDollars("-\t```\n    code\n  Pay $5 today")).toBe(
+      "-\t```\n    code\n  Pay \\$5 today",
+    );
+  });
+
   it("stops an unclosed blockquote fence when its container ends", () => {
     expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
       "> ```\n> code\n\nPay \\$5 today",

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -186,6 +186,28 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("recognizes fenced blocks inside list-item blockquotes", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- > ```\n  > const marker = ```;\n  > const price = $5;\n  > ```\nafter $7",
+      ),
+    ).toBe(
+      "- > ```\n  > const marker = ```;\n  > const price = $5;\n  > ```\nafter \\$7",
+    );
+  });
+
+  it("stops an unclosed blockquote fence when its container ends", () => {
+    expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
+      "> ```\n> code\n\nPay \\$5 today",
+    );
+  });
+
+  it("stops an unclosed list fence when its container ends", () => {
+    expect(escapeCurrencyDollars("- ```\n  code\n\nPay $5 today")).toBe(
+      "- ```\n  code\n\nPay \\$5 today",
+    );
+  });
+
   it("does not close a root fence on a list-marker backtick line", () => {
     expect(
       escapeCurrencyDollars("```\n- ```\nconst price = $5;\n```\nafter $7"),

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -186,6 +186,18 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not close a root fence on a list-marker backtick line", () => {
+    expect(
+      escapeCurrencyDollars("```\n- ```\nconst price = $5;\n```\nafter $7"),
+    ).toBe("```\n- ```\nconst price = $5;\n```\nafter \\$7");
+  });
+
+  it("does not close a root fence on a blockquote backtick line", () => {
+    expect(
+      escapeCurrencyDollars("```\n> ```\nconst price = $5;\n```\nafter $7"),
+    ).toBe("```\n> ```\nconst price = $5;\n```\nafter \\$7");
+  });
+
   it("escapes an amount when the prose before the next span carries latex syntax", () => {
     expect(
       escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -132,6 +132,26 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not rewrite currency inside a code span containing a longer backtick run", () => {
+    expect(escapeCurrencyDollars("`value ``` costs $5 ` after $7")).toBe(
+      "`value ``` costs $5 ` after \\$7",
+    );
+  });
+
+  it("does not close a fenced block on a backtick run inside its content", () => {
+    expect(
+      escapeCurrencyDollars(
+        "```\nconst marker = ```;\nconst price = $5;\n```\nafter $7",
+      ),
+    ).toBe("```\nconst marker = ```;\nconst price = $5;\n```\nafter \\$7");
+  });
+
+  it("accepts a closing fence longer than the opening fence", () => {
+    expect(escapeCurrencyDollars("```\n$5\n````\nafter $7")).toBe(
+      "```\n$5\n````\nafter \\$7",
+    );
+  });
+
   it("escapes an amount when the prose before the next span carries latex syntax", () => {
     expect(
       escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -196,6 +196,22 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("recognizes fenced blocks at a nested list content column", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- outer\n  - ```\n    const price = $5;\n    ```\n\nafter $7",
+      ),
+    ).toBe("- outer\n  - ```\n    const price = $5;\n    ```\n\nafter \\$7");
+  });
+
+  it("recognizes fenced blocks after a wide ordered-list marker", () => {
+    expect(
+      escapeCurrencyDollars(
+        "10. ```\n    const price = $5;\n    ```\n\nafter $7",
+      ),
+    ).toBe("10. ```\n    const price = $5;\n    ```\n\nafter \\$7");
+  });
+
   it("stops an unclosed blockquote fence when its container ends", () => {
     expect(escapeCurrencyDollars("> ```\n> code\n\nPay $5 today")).toBe(
       "> ```\n> code\n\nPay \\$5 today",

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -147,8 +147,42 @@ describe("escapeCurrencyDollars", () => {
   });
 
   it("accepts a closing fence longer than the opening fence", () => {
-    expect(escapeCurrencyDollars("```\n$5\n````\nafter $7")).toBe(
-      "```\n$5\n````\nafter \\$7",
+    expect(escapeCurrencyDollars("```\n$5\n````\nafter `code $7` and $9")).toBe(
+      "```\n$5\n````\nafter `code $7` and \\$9",
+    );
+  });
+
+  it("does not rewrite currency inside an unclosed fenced block", () => {
+    expect(escapeCurrencyDollars("```js\nconst price = $5;")).toBe(
+      "```js\nconst price = $5;",
+    );
+  });
+
+  it("recognizes fenced blocks with carriage-return line endings", () => {
+    expect(
+      escapeCurrencyDollars(
+        "```\rconst marker = ```;\rconst price = $5;\r```\rafter $7",
+      ),
+    ).toBe("```\rconst marker = ```;\rconst price = $5;\r```\rafter \\$7");
+  });
+
+  it("recognizes fenced blocks inside blockquotes", () => {
+    expect(
+      escapeCurrencyDollars(
+        "> ```\n> const marker = ```;\n> const price = $5;\n> ```\nafter $7",
+      ),
+    ).toBe(
+      "> ```\n> const marker = ```;\n> const price = $5;\n> ```\nafter \\$7",
+    );
+  });
+
+  it("recognizes fenced blocks inside list items", () => {
+    expect(
+      escapeCurrencyDollars(
+        "- ```\n  const marker = ```;\n  const price = $5;\n  ```\nafter $7",
+      ),
+    ).toBe(
+      "- ```\n  const marker = ```;\n  const price = $5;\n  ```\nafter \\$7",
     );
   });
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -91,36 +91,48 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-/** Whether a line prefix permits a fenced code block at this position. */
-function isFencePrefix(prefix: string): boolean {
-  let remaining = prefix;
-  while (remaining.length > 0) {
-    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
-    if (blockquote) {
-      remaining = remaining.slice(blockquote[0].length);
-      continue;
-    }
+function peelBlockquotes(prefix: string): { depth: number; rest: string } {
+  let rest = prefix;
+  let depth = 0;
+  while (rest.length > 0) {
+    const blockquote = rest.match(/^ {0,3}>[ \t]?/);
+    if (!blockquote) break;
+    rest = rest.slice(blockquote[0].length);
+    depth += 1;
+  }
+  return { depth, rest };
+}
 
+function isFencePrefix(prefix: string): boolean {
+  let remaining = peelBlockquotes(prefix).rest;
+  while (remaining.length > 0) {
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
-    if (listItem) {
-      remaining = remaining.slice(listItem[0].length);
-      continue;
-    }
-    break;
+    if (!listItem) break;
+    remaining = remaining.slice(listItem[0].length);
   }
   return /^ {0,3}$/.test(remaining);
 }
 
-/** Closing-fence end on one line, or -1 when the line is not a closer. */
+function isClosingFencePrefix(prefix: string, quoteDepth: number): boolean {
+  const peeled = peelBlockquotes(prefix);
+  return peeled.depth === quoteDepth && /^ {0,3}$/.test(peeled.rest);
+}
+
 function closingFenceEnd(
   text: string,
   start: number,
   end: number,
   minimumLength: number,
+  quoteDepth: number,
 ): number {
   const line = text.slice(start, end);
   const runStart = line.indexOf("`");
-  if (runStart === -1 || !isFencePrefix(line.slice(0, runStart))) return -1;
+  if (
+    runStart === -1 ||
+    !isClosingFencePrefix(line.slice(0, runStart), quoteDepth)
+  ) {
+    return -1;
+  }
 
   const length = runLength(line, runStart, "`");
   if (length < minimumLength) return -1;
@@ -155,6 +167,7 @@ function codeSpanEnd(text: string, start: number): number {
         closingLineStart,
         closingLineEnd,
         delimiterLength,
+        peelBlockquotes(openingPrefix).depth,
       );
       if (close !== -1) return close;
       if (closingLineEnd === text.length) break;

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -66,35 +66,101 @@ function runLength(text: string, start: number, char: string): number {
   return length;
 }
 
+/** Start index of the line containing start. */
+function lineStart(text: string, start: number): number {
+  return (
+    Math.max(
+      text.lastIndexOf("\r", start - 1),
+      text.lastIndexOf("\n", start - 1),
+    ) + 1
+  );
+}
+
+/** End index of the line containing start, excluding its line ending. */
+function lineEnd(text: string, start: number): number {
+  const carriageReturn = text.indexOf("\r", start);
+  const lineFeed = text.indexOf("\n", start);
+  if (carriageReturn === -1) return lineFeed === -1 ? text.length : lineFeed;
+  if (lineFeed === -1) return carriageReturn;
+  return Math.min(carriageReturn, lineFeed);
+}
+
+/** Start index of the line after end, accounting for CRLF. */
+function nextLineStart(text: string, end: number): number {
+  if (end >= text.length) return text.length;
+  return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
+}
+
+/** Whether a line prefix permits a fenced code block at this position. */
+function isFencePrefix(prefix: string): boolean {
+  let remaining = prefix;
+  while (remaining.length > 0) {
+    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+    if (blockquote) {
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
+    if (listItem) {
+      remaining = remaining.slice(listItem[0].length);
+      continue;
+    }
+    break;
+  }
+  return /^ {0,3}$/.test(remaining);
+}
+
+/** Closing-fence end on one line, or -1 when the line is not a closer. */
+function closingFenceEnd(
+  text: string,
+  start: number,
+  end: number,
+  minimumLength: number,
+): number {
+  const line = text.slice(start, end);
+  const runStart = line.indexOf("`");
+  if (runStart === -1 || !isFencePrefix(line.slice(0, runStart))) return -1;
+
+  const length = runLength(line, runStart, "`");
+  if (length < minimumLength) return -1;
+  if (!/^[ \t]*$/.test(line.slice(runStart + length))) return -1;
+  return start + runStart + length;
+}
+
 /**
  * End index (exclusive) of the code span or fence whose backtick run starts at
- * `start`, or -1 when that run is never closed and its backticks read as literal
- * text.
+ * `start`. An unclosed fence extends through the end of the text; -1 means an
+ * inline code span is unclosed and its backticks read as literal text.
  */
 function codeSpanEnd(text: string, start: number): number {
   const delimiterLength = runLength(text, start, "`");
-  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
-  const openingIndent = text.slice(lineStart, start);
-  const openingLineEnd = text.indexOf("\n", start + delimiterLength);
-  const openingInfo = text.slice(
-    start + delimiterLength,
-    openingLineEnd === -1 ? text.length : openingLineEnd,
-  );
+  const openingLineStart = lineStart(text, start);
+  const openingPrefix = text.slice(openingLineStart, start);
+  const openingLineEnd = lineEnd(text, start + delimiterLength);
+  const openingInfo = text.slice(start + delimiterLength, openingLineEnd);
   const isFence =
     delimiterLength >= 3 &&
-    /^ {0,3}$/.test(openingIndent) &&
+    isFencePrefix(openingPrefix) &&
     !openingInfo.includes("`");
 
   if (isFence) {
-    if (openingLineEnd === -1) return -1;
-    const closingFence = new RegExp(
-      "^ {0,3}(`{" + delimiterLength + ",})[\\t ]*\\r?$",
-      "gm",
-    );
-    closingFence.lastIndex = openingLineEnd + 1;
-    const match = closingFence.exec(text);
-    if (!match) return -1;
-    return match.index + match[0].indexOf("`") + match[1]!.length;
+    if (openingLineEnd === text.length) return text.length;
+
+    let closingLineStart = nextLineStart(text, openingLineEnd);
+    while (closingLineStart <= text.length) {
+      const closingLineEnd = lineEnd(text, closingLineStart);
+      const close = closingFenceEnd(
+        text,
+        closingLineStart,
+        closingLineEnd,
+        delimiterLength,
+      );
+      if (close !== -1) return close;
+      if (closingLineEnd === text.length) break;
+      closingLineStart = nextLineStart(text, closingLineEnd);
+    }
+    return text.length;
   }
 
   let index = start + delimiterLength;

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -91,31 +91,74 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-type FenceContainer = { type: "blockquote" } | { type: "list"; indent: number };
+type FenceContainer =
+  | { type: "blockquote" }
+  | { type: "list"; indentColumns: number };
 
 type FenceContext = { containers: FenceContainer[] };
+
+function advanceColumn(column: number, text: string): number {
+  for (const char of text) {
+    column = char === "\t" ? column + (4 - (column % 4)) : column + 1;
+  }
+  return column;
+}
+
+function whitespaceColumns(text: string, column: number): number | null {
+  const startColumn = column;
+  for (const char of text) {
+    if (char !== " " && char !== "\t") return null;
+    column = advanceColumn(column, char);
+  }
+  return column - startColumn;
+}
+
+function consumeIndentColumns(
+  text: string,
+  column: number,
+  requiredColumns: number,
+): { remaining: string; column: number } | null {
+  const startColumn = column;
+  let index = 0;
+  while (column - startColumn < requiredColumns && index < text.length) {
+    const char = text[index]!;
+    if (char !== " " && char !== "\t") return null;
+    column = advanceColumn(column, char);
+    index++;
+  }
+  if (column - startColumn < requiredColumns) return null;
+  return { remaining: text.slice(index), column };
+}
 
 /** Container context for a fenced code block at this line prefix. */
 function fenceContext(prefix: string): FenceContext | null {
   let remaining = prefix;
+  let column = 0;
   const containers: FenceContainer[] = [];
   while (remaining.length > 0) {
     const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
     if (blockquote) {
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       containers.push({ type: "blockquote" });
       continue;
     }
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
     if (listItem) {
+      const listStartColumn = column;
       remaining = remaining.slice(listItem[0].length);
-      containers.push({ type: "list", indent: listItem[0].length });
+      column = advanceColumn(column, listItem[0]);
+      containers.push({
+        type: "list",
+        indentColumns: column - listStartColumn,
+      });
       continue;
     }
     break;
   }
 
-  if (!/^ {0,3}$/.test(remaining)) return null;
+  const remainingColumns = whitespaceColumns(remaining, column);
+  if (remainingColumns === null || remainingColumns > 3) return null;
   return { containers };
 }
 
@@ -123,27 +166,38 @@ function fenceContext(prefix: string): FenceContext | null {
 function consumeFenceContainers(
   prefix: string,
   context: FenceContext,
-): string | null {
+): { remaining: string; column: number } | null {
   let remaining = prefix;
+  let column = 0;
   for (const container of context.containers) {
     if (container.type === "blockquote") {
       const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!blockquote) return null;
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       continue;
     }
 
-    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
-    if (indent < container.indent) return null;
-    remaining = remaining.slice(container.indent);
+    const consumed = consumeIndentColumns(
+      remaining,
+      column,
+      container.indentColumns,
+    );
+    if (!consumed) return null;
+    ({ remaining, column } = consumed);
   }
-  return remaining;
+  return { remaining, column };
 }
 
 /** Whether a closing line remains in the opening fence's container. */
 function matchesFenceContext(prefix: string, context: FenceContext): boolean {
-  const remaining = consumeFenceContainers(prefix, context);
-  return remaining !== null && /^ {0,3}$/.test(remaining);
+  const consumed = consumeFenceContainers(prefix, context);
+  if (!consumed) return false;
+  const remainingColumns = whitespaceColumns(
+    consumed.remaining,
+    consumed.column,
+  );
+  return remainingColumns !== null && remainingColumns <= 3;
 }
 
 /** Whether a content line remains inside the fence's opening container. */
@@ -151,11 +205,13 @@ function continuesFenceContainer(line: string, context: FenceContext): boolean {
   if (context.containers.length === 0) return true;
 
   let remaining = line;
+  let column = 0;
   for (const [index, container] of context.containers.entries()) {
     if (container.type === "blockquote") {
       const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!blockquote) return false;
       remaining = remaining.slice(blockquote[0].length);
+      column = advanceColumn(column, blockquote[0]);
       continue;
     }
 
@@ -164,9 +220,13 @@ function continuesFenceContainer(line: string, context: FenceContext): boolean {
         .slice(index + 1)
         .some((later) => later.type === "blockquote");
     }
-    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
-    if (indent < container.indent) return false;
-    remaining = remaining.slice(container.indent);
+    const consumed = consumeIndentColumns(
+      remaining,
+      column,
+      container.indentColumns,
+    );
+    if (!consumed) return false;
+    ({ remaining, column } = consumed);
   }
   return true;
 }

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -72,9 +72,40 @@ function runLength(text: string, start: number, char: string): number {
  * text.
  */
 function codeSpanEnd(text: string, start: number): number {
-  const fence = "`".repeat(runLength(text, start, "`"));
-  const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? -1 : closed + fence.length;
+  const delimiterLength = runLength(text, start, "`");
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  const openingIndent = text.slice(lineStart, start);
+  const openingLineEnd = text.indexOf("\n", start + delimiterLength);
+  const openingInfo = text.slice(
+    start + delimiterLength,
+    openingLineEnd === -1 ? text.length : openingLineEnd,
+  );
+  const isFence =
+    delimiterLength >= 3 &&
+    /^ {0,3}$/.test(openingIndent) &&
+    !openingInfo.includes("`");
+
+  if (isFence) {
+    if (openingLineEnd === -1) return -1;
+    const closingFence = new RegExp(
+      "^ {0,3}(`{" + delimiterLength + ",})[\\t ]*\\r?$",
+      "gm",
+    );
+    closingFence.lastIndex = openingLineEnd + 1;
+    const match = closingFence.exec(text);
+    if (!match) return -1;
+    return match.index + match[0].indexOf("`") + match[1]!.length;
+  }
+
+  let index = start + delimiterLength;
+  while (index < text.length) {
+    const next = text.indexOf("`", index);
+    if (next === -1) return -1;
+    const nextLength = runLength(text, next, "`");
+    if (nextLength === delimiterLength) return next + nextLength;
+    index = next + nextLength;
+  }
+  return -1;
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -91,31 +91,84 @@ function nextLineStart(text: string, end: number): number {
   return text[end] === "\r" && text[end + 1] === "\n" ? end + 2 : end + 1;
 }
 
-function peelBlockquotes(prefix: string): { depth: number; rest: string } {
-  let rest = prefix;
-  let depth = 0;
-  while (rest.length > 0) {
-    const blockquote = rest.match(/^ {0,3}>[ \t]?/);
-    if (!blockquote) break;
-    rest = rest.slice(blockquote[0].length);
-    depth += 1;
-  }
-  return { depth, rest };
-}
+type FenceContainer = { type: "blockquote" } | { type: "list"; indent: number };
 
-function isFencePrefix(prefix: string): boolean {
-  let remaining = peelBlockquotes(prefix).rest;
+type FenceContext = { containers: FenceContainer[] };
+
+/** Container context for a fenced code block at this line prefix. */
+function fenceContext(prefix: string): FenceContext | null {
+  let remaining = prefix;
+  const containers: FenceContainer[] = [];
   while (remaining.length > 0) {
+    const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+    if (blockquote) {
+      remaining = remaining.slice(blockquote[0].length);
+      containers.push({ type: "blockquote" });
+      continue;
+    }
     const listItem = remaining.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
-    if (!listItem) break;
-    remaining = remaining.slice(listItem[0].length);
+    if (listItem) {
+      remaining = remaining.slice(listItem[0].length);
+      containers.push({ type: "list", indent: listItem[0].length });
+      continue;
+    }
+    break;
   }
-  return /^ {0,3}$/.test(remaining);
+
+  if (!/^ {0,3}$/.test(remaining)) return null;
+  return { containers };
 }
 
-function isClosingFencePrefix(prefix: string, quoteDepth: number): boolean {
-  const peeled = peelBlockquotes(prefix);
-  return peeled.depth === quoteDepth && /^ {0,3}$/.test(peeled.rest);
+/** Remove the opening container sequence from a later line prefix. */
+function consumeFenceContainers(
+  prefix: string,
+  context: FenceContext,
+): string | null {
+  let remaining = prefix;
+  for (const container of context.containers) {
+    if (container.type === "blockquote") {
+      const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!blockquote) return null;
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (indent < container.indent) return null;
+    remaining = remaining.slice(container.indent);
+  }
+  return remaining;
+}
+
+/** Whether a closing line remains in the opening fence's container. */
+function matchesFenceContext(prefix: string, context: FenceContext): boolean {
+  const remaining = consumeFenceContainers(prefix, context);
+  return remaining !== null && /^ {0,3}$/.test(remaining);
+}
+
+/** Whether a content line remains inside the fence's opening container. */
+function continuesFenceContainer(line: string, context: FenceContext): boolean {
+  if (context.containers.length === 0) return true;
+
+  let remaining = line;
+  for (const [index, container] of context.containers.entries()) {
+    if (container.type === "blockquote") {
+      const blockquote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!blockquote) return false;
+      remaining = remaining.slice(blockquote[0].length);
+      continue;
+    }
+
+    if (/^[ \t]*$/.test(remaining)) {
+      return !context.containers
+        .slice(index + 1)
+        .some((later) => later.type === "blockquote");
+    }
+    const indent = remaining.match(/^[ \t]*/)?.[0].length ?? 0;
+    if (indent < container.indent) return false;
+    remaining = remaining.slice(container.indent);
+  }
+  return true;
 }
 
 function closingFenceEnd(
@@ -123,13 +176,13 @@ function closingFenceEnd(
   start: number,
   end: number,
   minimumLength: number,
-  quoteDepth: number,
+  context: FenceContext,
 ): number {
   const line = text.slice(start, end);
   const runStart = line.indexOf("`");
   if (
     runStart === -1 ||
-    !isClosingFencePrefix(line.slice(0, runStart), quoteDepth)
+    !matchesFenceContext(line.slice(0, runStart), context)
   ) {
     return -1;
   }
@@ -151,10 +204,9 @@ function codeSpanEnd(text: string, start: number): number {
   const openingPrefix = text.slice(openingLineStart, start);
   const openingLineEnd = lineEnd(text, start + delimiterLength);
   const openingInfo = text.slice(start + delimiterLength, openingLineEnd);
+  const context = fenceContext(openingPrefix);
   const isFence =
-    delimiterLength >= 3 &&
-    isFencePrefix(openingPrefix) &&
-    !openingInfo.includes("`");
+    delimiterLength >= 3 && context !== null && !openingInfo.includes("`");
 
   if (isFence) {
     if (openingLineEnd === text.length) return text.length;
@@ -162,12 +214,16 @@ function codeSpanEnd(text: string, start: number): number {
     let closingLineStart = nextLineStart(text, openingLineEnd);
     while (closingLineStart <= text.length) {
       const closingLineEnd = lineEnd(text, closingLineStart);
+      const closingLine = text.slice(closingLineStart, closingLineEnd);
+      if (!continuesFenceContainer(closingLine, context)) {
+        return closingLineStart;
+      }
       const close = closingFenceEnd(
         text,
         closingLineStart,
         closingLineEnd,
         delimiterLength,
-        peelBlockquotes(openingPrefix).depth,
+        context,
       );
       if (close !== -1) return close;
       if (closingLineEnd === text.length) break;


### PR DESCRIPTION
`escapeCurrencyDollars()` skipped code by finding the next occurrence of the opening backtick string. a longer run inside an inline code span, or a same-length run inside a fenced block, could be mistaken for the closer, so leftover `$5` was rewritten to `\$5`.

the scanner now uses CommonMark rules: inline spans close on an equal-length run; fenced blocks close only on a standalone fence line at the same blockquote depth as the opener (list markers are not valid closers). an unclosed fence owns the rest of the input, which is the streaming case.

mirrored in `@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.P7HYUct0DvEPTTSAgZRUsqL4OyE80BzmrH13EjDMI73wciLr0lXswOiirB8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->