### PR TITLE
fix(core): suppress stale cancellation resyncs

### DIFF
--- a/.changeset/quiet-runs-rest.md
+++ b/.changeset/quiet-runs-rest.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: prevent cancelled external-store runs from resyncing after teardown

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -674,6 +674,8 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
+    const generation = captureThreadRuntimeGeneration(this);
+
     // Abort any in-flight client-side tool executions. Fire-and-forget —
     // the abort resolves once executions settle, but we don't gate the
     // cancel on it.
@@ -731,6 +733,8 @@ export class ExternalStoreThreadRuntimeCore
     // tick. Read the repository at flush time and re-apply the rollbacks to
     // it, instead of stamping a snapshot captured above over the newer state.
     setTimeout(() => {
+      if (!isThreadRuntimeGenerationCurrent(this, generation)) return;
+
       this.dropEmptyOptimisticHead();
       if (movedLeaf) {
         const current = this.repository.getMessages();

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -8,6 +8,7 @@ import type { ModelContextProvider } from "../model-context/types";
 import type { AppendMessage, ThreadMessage } from "../types/message";
 import { createMessageQueue } from "../runtime/queue/message-queue";
 import { getThreadMessageText } from "../utils/text";
+import { invalidateThreadRuntime } from "../runtime/utils/thread-runtime-lifecycle";
 
 const createContextProvider = (): ModelContextProvider => ({
   getModelContext: () => ({}),
@@ -302,6 +303,25 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       const texts = lastCall.map(getThreadMessageText);
       expect(texts).toContain("partial answer (stopped)");
       expect(texts).not.toContain("partial answer");
+    });
+
+    it("does not resync after the runtime is invalidated", async () => {
+      const setMessages = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [createAssistantMessage("a1", "partial answer")],
+          isRunning: true,
+          onCancel: vi.fn(),
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      invalidateThreadRuntime(core);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(setMessages).not.toHaveBeenCalled();
     });
 
     it("re-applies the user leaf rollback when the store updates before the flush", async () => {


### PR DESCRIPTION
## Summary

- stop deferred external-store cancellation resyncs after the runtime is invalidated
- preserve the existing same-runtime resync behavior for cancellation/store races
- add a focused teardown regression and patch changeset

## Why

`cancelRun()` defers its final `setMessages()` resync to the next macrotask so a server-side cancellation update can land first. If the runtime is unmounted or replaced during that gap, the deferred callback still writes through the detached adapter.

A focused reproduction on current `main` called `cancelRun()`, invalidated the runtime, and observed one stale `setMessages()` call. The callback now captures the runtime generation and exits when teardown advances it.

## Verification

- 15/15 cancellation-path tests
- focused oxlint and oxfmt checks
- `@assistant-ui/core` build
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Rc4e8CQxAcNKhDiqRCAL0Kdl5TEDwgp52S5w3R1NW57JwxI92Sif5HHZkik?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->