### PR TITLE
fix(tap): avoid uncached snapshot update loops

### DIFF
--- a/.changeset/tap-uncached-snapshot-loop.md
+++ b/.changeset/tap-uncached-snapshot-loop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: avoid corrective render loops for uncached external store snapshots

--- a/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
+++ b/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
@@ -225,14 +225,53 @@ describe("useSyncExternalStore", () => {
     );
   });
 
-  it("throws after 50 consecutive corrective renders from the commit check", () => {
+  it("does not chase uncached snapshots during the commit check", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     let dispatched = false;
+    let listener: (() => void) | undefined;
+    let state = 0;
     const fiber = createResourceFiber(
       function useUncached() {
         return useSyncExternalStore(
+          (onStoreChange) => {
+            listener = onStoreChange;
+            return () => {};
+          },
+          () => ({ state }),
+        );
+      },
+      createResourceFiberRoot((evaluate, apply) => {
+        if (!evaluate()) return;
+        apply();
+        dispatched = true;
+      }),
+      undefined,
+      null,
+    );
+
+    expect(renderResourceFiber(fiber, [])).toEqual({ state: 0 });
+    commitResourceFiber(fiber);
+    expect(dispatched).toBe(false);
+
+    state = 1;
+    listener?.();
+    expect(dispatched).toBe(true);
+
+    dispatched = false;
+    expect(renderResourceFiber(fiber, [])).toEqual({ state: 1 });
+    commitResourceFiber(fiber);
+    expect(dispatched).toBe(false);
+    unmountResourceFiber(fiber);
+  });
+
+  it("throws after 50 consecutive corrective renders from the commit check", () => {
+    let snapshot = {};
+    let dispatched = false;
+    const fiber = createResourceFiber(
+      function useChangingSnapshot() {
+        return useSyncExternalStore(
           () => () => {},
-          () => ({}),
+          () => snapshot,
         );
       },
       createResourceFiberRoot((evaluate, apply) => {
@@ -249,6 +288,7 @@ describe("useSyncExternalStore", () => {
     expect(() => {
       for (;;) {
         commits++;
+        snapshot = {};
         commitResourceFiber(fiber);
         if (!dispatched) break;
         dispatched = false;

--- a/packages/tap/src/react-hooks/useSyncExternalStore.ts
+++ b/packages/tap/src/react-hooks/useSyncExternalStore.ts
@@ -43,6 +43,25 @@ export const useSyncExternalStore = <T>(
     return true;
   });
 
+  const checkForCommitUpdates = useEffectEvent((): boolean => {
+    try {
+      const nextValue = getSnapshot();
+      if (Object.is(value, nextValue)) {
+        commitCheckDepth.current = 0;
+        return false;
+      }
+
+      // A second mismatch cannot converge through corrective renders.
+      if (!Object.is(nextValue, getSnapshot())) {
+        commitCheckDepth.current = 0;
+        return false;
+      }
+    } catch {
+      // a throwing getSnapshot counts as changed
+    }
+    return true;
+  });
+
   useEffect(() => {
     return subscribe(() => {
       if (checkForUpdates()) forceUpdate();
@@ -52,7 +71,7 @@ export const useSyncExternalStore = <T>(
   // Covers the tearing window between the render's getSnapshot() read and
   // the commit; only these checks count toward the loop guard.
   useEffect(() => {
-    if (!checkForUpdates()) return;
+    if (!checkForCommitUpdates()) return;
     if (++commitCheckDepth.current > 50) {
       commitCheckDepth.current = 0;
       throw new Error(


### PR DESCRIPTION
## What

- verify that commit-time snapshot corrections can converge before forcing a render
- keep notification-driven updates unchanged for stores whose snapshots are not identity-stable
- retain the maximum-depth guard for snapshots that genuinely keep changing between render and commit
- add focused regression coverage and a patch changeset

## Why

Closes #6133.

A clean install using the issue's dependency ranges resolves to React 19.2.8, `@assistant-ui/react@0.14.29`, `@assistant-ui/core@0.2.23`, `@assistant-ui/store@0.2.22`, and `@assistant-ui/tap@0.9.13`. A minimal `useLocalRuntime` setup with a stable adapter reproduces the reported exception exactly.

Tap 0.9.13's commit-time check can be selected by older compatible React/Core/Store minors whose thread-list snapshot returns an equivalent fresh object on each read. Each corrective render then sees another new reference and can never converge.

The commit check now confirms that two consecutive reads agree on the current snapshot before forcing a correction. Stable stores still receive render-to-commit tearing protection, while uncached stores continue updating through their subscription notifications without entering a corrective loop.

## Verification

- `@assistant-ui/tap` full suite: 51 files, 576 passed, 1 skipped
- focused `useSyncExternalStore` suite: 15 passed
- `aui-build` for `@assistant-ui/tap`
- oxlint and oxfmt on the changed files
- external pinned reproduction fails with the exact #6133 stack before the fix and completes for stable and inline adapters after the fix

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.C2MmYfpFuOBCgadZWNYU9nQDHRCYYUAiRu242xQhPqrnwdr3Alt7cqpO0so?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->