### PR TITLE
docs: add OrcaRouter to LLM gateway integrations

### DIFF
--- a/apps/docs/content/docs/integrations/gateways/index.mdx
+++ b/apps/docs/content/docs/integrations/gateways/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: LLM Gateway Integrations
-description: Route AI chat traffic through OpenAI-compatible LLM gateways (OpenRouter, LiteLLM, Portkey, etc.) for cost, fallback, and BYOK in assistant-ui apps.
+description: Route AI chat traffic through OpenAI-compatible LLM gateways (OpenRouter, LiteLLM, Portkey, OrcaRouter, etc.) for cost, fallback, and BYOK in assistant-ui apps.
 ---
 
 import { HeliconeIcon } from "@/components/icons/helicone";
@@ -15,6 +15,7 @@ For pure observability (proxy that logs every call) see [Helicone](/docs/integra
 | Gateway | Base URL | Auth header | Distinguishing feature |
 | --- | --- | --- | --- |
 | [OpenRouter](#openrouter) | `https://openrouter.ai/api/v1` | `Authorization: Bearer <key>` | Catalog of 100+ models with `vendor/model` IDs |
+| [OrcaRouter](#orcarouter) | `https://api.orcarouter.ai/v1` | `Authorization: Bearer <key>` | Zero-trust gateway for AI agents, auto model routing |
 | [Portkey](#portkey) | `https://api.portkey.ai/v1` | `x-portkey-api-key` | Config-driven multi-provider fallback |
 | [LiteLLM Proxy](#litellm-proxy) | Self-hosted | `Authorization: Bearer <virtual key>` | OSS, self-host, virtual keys per tenant |
 
@@ -22,7 +23,7 @@ If your need is only request logging, Helicone fits the same shape and is docume
 
 ## Common pattern
 
-All three gateways below speak OpenAI's API. Wire them with `createOpenAI`:
+All four gateways below speak OpenAI's API. Wire them with `createOpenAI`:
 
 ```ts title="app/api/chat/route.ts"
 import { createOpenAI } from "@ai-sdk/openai";
@@ -83,6 +84,36 @@ export async function POST(req: Request) {
 
 When to pick: you want a single bill across many models, or you let users pick the model from a long list, or you need to run open-weights models without managing the inference yourself.
 
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is a gateway that fronts many providers behind one OpenAI-compatible endpoint, with automatic model routing. The model ID is `orcarouter/auto` to let the gateway pick the best model, or any upstream `provider/model` ID (e.g., `anthropic/claude-sonnet-4.6`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+```sh title=".env.local"
+ORCAROUTER_API_KEY=sk-orca-...
+```
+
+```ts title="app/api/chat/route.ts"
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText, convertToModelMessages } from "ai";
+import type { UIMessage } from "ai";
+
+const orcarouter = createOpenAI({
+  baseURL: "https://api.orcarouter.ai/v1",
+  apiKey: process.env.ORCAROUTER_API_KEY,
+});
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const result = streamText({
+    model: orcarouter("orcarouter/auto"),
+    messages: await convertToModelMessages(messages),
+  });
+  return result.toUIMessageStreamResponse();
+}
+```
+
+When to pick: you want automatic model routing with a single API key, or you need gateway-level security (prompt/response screening and default-deny tool-call governance) for agent workloads without changing application code.
+
 ## Portkey
 
 [Portkey](https://portkey.ai/) is a gateway plus observability with a config-driven router. The differentiating feature is the *config*: a server-defined object that describes routing rules (try Anthropic first, fall back to OpenAI, fall back to a local model), retries, and caching.
@@ -141,7 +172,7 @@ When to pick: self-host requirement, BYOK metering for end-users, or unified bil
 ## Notes
 
 - **Server-side only.** A gateway key is a write capability against your billing account. Never set it in client code; the route handler is the right boundary.
-- **Streaming, tools, attachments.** All three gateways are transparent to the AI SDK; everything that works against OpenAI directly works through them.
+- **Streaming, tools, attachments.** All four gateways are transparent to the AI SDK; everything that works against OpenAI directly works through them.
 - **Combining with observability.** A gateway and an observability tool are not mutually exclusive. Helicone in front of OpenRouter is a common stack: OpenRouter does the routing, Helicone logs the calls.
 
 ## Related

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -71,7 +71,7 @@ OpenAI-compatible proxies that add catalog routing, fallback, BYOK, or self-host
 <Cards>
   <Card
     title="LLM gateways"
-    description="OpenRouter, Portkey, LiteLLM Proxy. Swap baseURL, route across providers."
+    description="OpenRouter, OrcaRouter, Portkey, LiteLLM Proxy. Swap baseURL, route across providers."
     href="/docs/integrations/gateways"
   />
 </Cards>


### PR DESCRIPTION
# Add OrcaRouter to LLM Gateway Integrations

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named LLM gateway integration, mirroring the existing OpenRouter / Portkey / LiteLLM Proxy wiring.

## What changed

- **`apps/docs/content/docs/integrations/gateways/index.mdx`**
  - New `## OrcaRouter` section: wire it with `createOpenAI({ baseURL: "https://api.orcarouter.ai/v1", apiKey: process.env.ORCAROUTER_API_KEY })` and model `orcarouter/auto` (or any upstream `provider/model` ID).
  - Compare-table row with base URL and auth header, matching the existing gateway rows.
  - Updated "All three gateways" → "All four gateways" prose.
- **`apps/docs/content/docs/integrations/index.mdx`** — updated the Gateways card description to list OrcaRouter.

No published package changes, so no changeset is required.

## Why

OrcaRouter is an OpenAI-compatible LLM gateway that fronts many providers behind a single endpoint with automatic model routing (`orcarouter/auto`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- The documented wiring was verified against the live endpoint: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/auto` returns **HTTP 200**.
- Docs-only MDX change; `apps/docs` is private and excluded from the oxlint/oxfmt `lint` job and changeset requirement.

Disclosure: I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8GSxVfw6uUr3-7Rq7doAtLeVcTg5Dlm6kwdA5ionZwNBCLQ5WDeKsD-pmvU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->