### PR TITLE
fix(react-devtools): handle conversation load failures

### DIFF
--- a/.changeset/tidy-devtools-switch.md
+++ b/.changeset/tidy-devtools-switch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: handle failed DevTools conversation switches

--- a/packages/react-devtools/src/shell/tabs/ThreadTab.test.tsx
+++ b/packages/react-devtools/src/shell/tabs/ThreadTab.test.tsx
@@ -1,0 +1,59 @@
+import type { ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+let capturedOnClick: (() => unknown) | undefined;
+
+vi.mock("../../views/ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../views/ui")>()),
+  ControlButton: ({ onClick, children }: ComponentProps<"button">) => {
+    capturedOnClick = onClick as () => unknown;
+    return <button>{children}</button>;
+  },
+}));
+
+import { ThreadTab } from "./ThreadTab";
+
+const renderUnloadedConversation = (
+  switchToThread: (threadId: string) => void | Promise<void>,
+) => {
+  renderToStaticMarkup(
+    <ThreadTab
+      apiId={1}
+      data={{
+        id: 1,
+        state: {
+          threads: {
+            threadIds: ["thread-1"],
+            archivedThreadIds: [],
+            threadItems: [{ id: "thread-1" }],
+          },
+        },
+        logs: [],
+        threadSnapshots: {},
+      }}
+      clearEvents={() => {}}
+      theme="light"
+      selection={null}
+      setSelection={() => {}}
+      switchToThread={switchToThread}
+    />,
+  );
+};
+
+describe("ThreadTab", () => {
+  it("handles rejected conversation switches", async () => {
+    renderUnloadedConversation(() => Promise.reject(new Error("failed")));
+
+    expect(capturedOnClick?.()).toBeUndefined();
+    await Promise.resolve();
+  });
+
+  it("handles synchronous conversation switch errors", () => {
+    renderUnloadedConversation(() => {
+      throw new Error("failed");
+    });
+
+    expect(() => capturedOnClick?.()).not.toThrow();
+  });
+});

--- a/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
+++ b/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
@@ -53,7 +53,13 @@ const UnloadedConversation = ({
       not cached in DevTools.
     </EmptyState>
     {switchToThread ? (
-      <ControlButton onClick={() => switchToThread(threadId)}>
+      <ControlButton
+        onClick={() => {
+          try {
+            void Promise.resolve(switchToThread(threadId)).catch(() => {});
+          } catch {}
+        }}
+      >
         Load conversation
       </ControlButton>
     ) : null}


### PR DESCRIPTION
## Summary

- consume rejected custom-client thread switches from the DevTools Load conversation button
- contain synchronous client errors as well as asynchronous rejections
- add focused coverage for both failure modes

## Why

`DevToolsClient.switchToThread()` may return a promise, but React does not observe promises returned from click handlers. A custom or remote DevTools client that rejects therefore produces a global `unhandledRejection`.

The default in-process client already treats thread-switch failures as non-fatal. The button now applies the same behavior for every client without changing successful switching.

## Verification

- regression before the fix: `Unhandled Rejection: switch failed`
- `@assistant-ui/react-devtools` tests: 111 passed
- `@assistant-ui/react-devtools` build passed
- targeted oxlint and oxfmt passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QI9eRR3FOS8AvyquIHMU3_5MLhzPbmEC914MPCzVy5EPS5GIwqu6PBoGNLc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->