### PR TITLE
fix(core): stop superseded local runs before tool continuation

### DIFF
--- a/.changeset/tidy-runs-continue.md
+++ b/.changeset/tidy-runs-continue.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: stop superseded local runs before tool continuation

--- a/.changeset/tidy-runs-continue.md
+++ b/.changeset/tidy-runs-continue.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: stop superseded local runs before tool continuation
+fix: settle aborted and superseded local runs without continuing them, while keeping approval pauses answerable after cancel

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -783,6 +783,30 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     });
   });
 
+  it("preserves an approval pause when cancelled during teardown", async () => {
+    let releaseTeardown!: () => void;
+    const teardown = new Promise<void>((resolve) => {
+      releaseTeardown = resolve;
+    });
+    const thread = createThread({
+      async *run() {
+        yield toolCallResult("deploy", { id: "approval-1" });
+        await teardown;
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("deploy"));
+    await flush();
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("requires-action");
+
+    thread.cancelRun();
+    releaseTeardown();
+    await appendPromise;
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("requires-action");
+  });
+
   it("keeps a replacement run cancellable after the previous run settles", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -750,6 +750,39 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     });
   });
 
+  it("preserves a terminal adapter status when cancelled during teardown", async () => {
+    let releaseTeardown!: () => void;
+    const teardown = new Promise<void>((resolve) => {
+      releaseTeardown = resolve;
+    });
+    const thread = createThread({
+      async *run() {
+        yield {
+          content: [{ type: "text", text: "done" }],
+          status: { type: "complete", reason: "stop" },
+        };
+        await teardown;
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("first"));
+    await flush();
+
+    expect(thread.messages.at(-1)?.status).toEqual({
+      type: "complete",
+      reason: "stop",
+    });
+
+    thread.cancelRun();
+    releaseTeardown();
+    await appendPromise;
+
+    expect(thread.messages.at(-1)?.status).toEqual({
+      type: "complete",
+      reason: "stop",
+    });
+  });
+
   it("keeps a replacement run cancellable after the previous run settles", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -759,6 +759,66 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     await secondAppend;
   });
 
+  it("ignores a stale result after addToolResult replaces the same message", async () => {
+    let releaseFirst!: () => void;
+    let resolveSecond!: (result: ChatModelRunResult) => void;
+    const firstTeardown = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread({
+      run(options) {
+        runs.push(options);
+        if (runs.length === 1) {
+          return (async function* () {
+            yield toolCallResult("send_email");
+            await firstTeardown;
+            yield toolCallResult("stale_tool");
+          })();
+        }
+        return secondResult;
+      },
+    });
+
+    const firstAppend = thread.append(userMessage("send an email"));
+    await flush();
+    const messageId = thread.messages.at(-1)!.id;
+
+    thread.addToolResult({
+      messageId,
+      toolCallId: "call-send_email",
+      toolName: "send_email",
+      result: { approved: true },
+      isError: false,
+    });
+    await flush();
+
+    expect(runs).toHaveLength(2);
+    expect(runs[1]?.abortSignal.aborted).toBe(false);
+
+    releaseFirst();
+    await firstAppend;
+
+    const toolCall = thread.messages
+      .find((item) => item.id === messageId)
+      ?.content.find(
+        (part) =>
+          part.type === "tool-call" && part.toolCallId === "call-send_email",
+      );
+    expect(toolCall?.result).toEqual({ approved: true });
+    expect(runs[1]?.abortSignal.aborted).toBe(false);
+
+    resolveSecond({ content: [{ type: "text", text: "replacement" }] });
+    await vi.waitFor(() => {
+      expect(
+        thread.messages.find((item) => item.id === messageId)?.status.type,
+      ).toBe("complete");
+    });
+  });
+
   it("does not continue after cancelRun when a delayed tool call resolves", async () => {
     let resolveFirst!: (result: ChatModelRunResult) => void;
     const firstResult = new Promise<ChatModelRunResult>((resolve) => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -719,6 +719,46 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     await secondAppend;
   });
 
+  it("cancels a superseded approval pause", async () => {
+    let resolveFirst!: (result: ChatModelRunResult) => void;
+    let resolveSecond!: (result: ChatModelRunResult) => void;
+    const firstResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread({
+      run(options) {
+        runs.push(options);
+        return runs.length === 1 ? firstResult : secondResult;
+      },
+    });
+
+    const firstAppend = thread.append(userMessage("first"));
+    await flush();
+    const supersededMessageId = thread.messages.at(-1)!.id;
+    const secondAppend = thread.append({
+      ...userMessage("second"),
+      parentId: supersededMessageId,
+    });
+    await flush();
+
+    resolveFirst(toolCallResult("deploy", { id: "approval-1" }));
+    await firstAppend;
+
+    expect(
+      thread.messages.find((item) => item.id === supersededMessageId)?.status,
+    ).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+
+    resolveSecond({ content: [{ type: "text", text: "replacement" }] });
+    await secondAppend;
+  });
+
   it("does not continue after cancelRun when a delayed tool call resolves", async () => {
     let resolveFirst!: (result: ChatModelRunResult) => void;
     const firstResult = new Promise<ChatModelRunResult>((resolve) => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -819,6 +819,33 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     });
   });
 
+  it("ignores a superseded result after its message is removed", async () => {
+    let resolveFirst!: (result: ChatModelRunResult) => void;
+    const firstResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let runCount = 0;
+    const thread = createThread({
+      run() {
+        runCount++;
+        if (runCount === 1) return firstResult;
+        return Promise.resolve({
+          content: [{ type: "text", text: "replacement" }],
+        });
+      },
+    });
+
+    const firstAppend = thread.append(userMessage("first"));
+    await flush();
+    await thread.append(userMessage("second"));
+    thread.reset();
+
+    resolveFirst(toolCallResult("lookup_weather"));
+
+    await expect(firstAppend).resolves.toBeUndefined();
+    expect(thread.messages).toHaveLength(0);
+  });
+
   it("does not continue after cancelRun when a delayed tool call resolves", async () => {
     let resolveFirst!: (result: ChatModelRunResult) => void;
     const firstResult = new Promise<ChatModelRunResult>((resolve) => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -673,7 +673,7 @@ describe("LocalThreadRuntimeCore tool approvals", () => {
 });
 
 describe("LocalThreadRuntimeCore cancellation", () => {
-  it("does not let a superseded run abort its replacement during tool continuation", async () => {
+  it("settles a superseded tool-call result without aborting its replacement", async () => {
     let resolveFirst!: (result: ChatModelRunResult) => void;
     let resolveSecond!: (result: ChatModelRunResult) => void;
     const firstResult = new Promise<ChatModelRunResult>((resolve) => {
@@ -692,7 +692,11 @@ describe("LocalThreadRuntimeCore cancellation", () => {
 
     const firstAppend = thread.append(userMessage("first"));
     await flush();
-    const secondAppend = thread.append(userMessage("second"));
+    const supersededMessageId = thread.messages.at(-1)!.id;
+    const secondAppend = thread.append({
+      ...userMessage("second"),
+      parentId: supersededMessageId,
+    });
     await flush();
 
     expect(runs).toHaveLength(2);
@@ -700,15 +704,50 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     expect(runs[1]?.abortSignal.aborted).toBe(false);
 
     resolveFirst(toolCallResult("lookup_weather"));
-    await flush();
-    const runCountAfterFirstSettled = runs.length;
-    const replacementWasAborted = runs[1]?.abortSignal.aborted;
+    await firstAppend;
+
+    expect(runs).toHaveLength(2);
+    expect(runs[1]?.abortSignal.aborted).toBe(false);
+    expect(
+      thread.messages.find((item) => item.id === supersededMessageId)?.status,
+    ).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
 
     resolveSecond({ content: [{ type: "text", text: "replacement" }] });
-    await Promise.all([firstAppend, secondAppend]);
+    await secondAppend;
+  });
 
-    expect(runCountAfterFirstSettled).toBe(2);
-    expect(replacementWasAborted).toBe(false);
+  it("does not continue after cancelRun when a delayed tool call resolves", async () => {
+    let resolveFirst!: (result: ChatModelRunResult) => void;
+    const firstResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread({
+      run(options) {
+        runs.push(options);
+        if (runs.length === 1) return firstResult;
+        return Promise.resolve({
+          content: [{ type: "text", text: "unexpected continuation" }],
+          status: { type: "complete", reason: "stop" },
+        });
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("first"));
+    await flush();
+
+    thread.cancelRun();
+    resolveFirst(toolCallResult("lookup_weather"));
+    await appendPromise;
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
   });
 
   it("keeps a replacement run cancellable after the previous run settles", async () => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -819,6 +819,63 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     });
   });
 
+  it("ignores stale chunks after a partial tool result updates the active message", async () => {
+    let releaseTeardown!: () => void;
+    const teardown = new Promise<void>((resolve) => {
+      releaseTeardown = resolve;
+    });
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread({
+      run(options) {
+        runs.push(options);
+        return (async function* () {
+          yield {
+            content: [
+              toolCallPart("send_email"),
+              toolCallPart("deploy", { id: "approval-1" }),
+            ],
+            status: {
+              type: "requires-action",
+              reason: "tool-calls",
+            },
+          } satisfies ChatModelRunResult;
+          await teardown;
+          yield { content: [{ type: "text", text: "stale" }] };
+        })();
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("send and deploy"));
+    await flush();
+    const messageId = thread.messages.at(-1)!.id;
+
+    thread.addToolResult({
+      messageId,
+      toolCallId: "call-send_email",
+      toolName: "send_email",
+      result: { approved: true },
+      isError: false,
+    });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+
+    releaseTeardown();
+    await appendPromise;
+
+    const message = thread.messages.find((item) => item.id === messageId);
+    const sendEmail = message?.content.find(
+      (part) =>
+        part.type === "tool-call" && part.toolCallId === "call-send_email",
+    );
+    const deploy = message?.content.find(
+      (part) => part.type === "tool-call" && part.toolCallId === "call-deploy",
+    );
+    expect(sendEmail?.result).toEqual({ approved: true });
+    expect(deploy?.approval?.approved).toBeUndefined();
+    expect(message?.status.type).toBe("requires-action");
+  });
+
   it("ignores a superseded result after its message is removed", async () => {
     let resolveFirst!: (result: ChatModelRunResult) => void;
     const firstResult = new Promise<ChatModelRunResult>((resolve) => {
@@ -910,7 +967,7 @@ describe("LocalThreadRuntimeCore cancellation", () => {
     });
   });
 
-  it("preserves an approval pause when cancelled during teardown", async () => {
+  it("preserves an approval pause when the adapter yields after cancellation", async () => {
     let releaseTeardown!: () => void;
     const teardown = new Promise<void>((resolve) => {
       releaseTeardown = resolve;
@@ -919,6 +976,7 @@ describe("LocalThreadRuntimeCore cancellation", () => {
       async *run() {
         yield toolCallResult("deploy", { id: "approval-1" });
         await teardown;
+        yield { content: [{ type: "text", text: "late" }] };
       },
     });
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -872,7 +872,7 @@ describe("LocalThreadRuntimeCore cancellation", () => {
       (part) => part.type === "tool-call" && part.toolCallId === "call-deploy",
     );
     expect(sendEmail?.result).toEqual({ approved: true });
-    expect(deploy?.approval?.approved).toBeUndefined();
+    expect(deploy?.approval).toEqual({ id: "approval-1" });
     expect(message?.status.type).toBe("requires-action");
   });
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -673,6 +673,44 @@ describe("LocalThreadRuntimeCore tool approvals", () => {
 });
 
 describe("LocalThreadRuntimeCore cancellation", () => {
+  it("does not let a superseded run abort its replacement during tool continuation", async () => {
+    let resolveFirst!: (result: ChatModelRunResult) => void;
+    let resolveSecond!: (result: ChatModelRunResult) => void;
+    const firstResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondResult = new Promise<ChatModelRunResult>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread({
+      run(options) {
+        runs.push(options);
+        return runs.length === 1 ? firstResult : secondResult;
+      },
+    });
+
+    const firstAppend = thread.append(userMessage("first"));
+    await flush();
+    const secondAppend = thread.append(userMessage("second"));
+    await flush();
+
+    expect(runs).toHaveLength(2);
+    expect(runs[0]?.abortSignal.aborted).toBe(true);
+    expect(runs[1]?.abortSignal.aborted).toBe(false);
+
+    resolveFirst(toolCallResult("lookup_weather"));
+    await flush();
+    const runCountAfterFirstSettled = runs.length;
+    const replacementWasAborted = runs[1]?.abortSignal.aborted;
+
+    resolveSecond({ content: [{ type: "text", text: "replacement" }] });
+    await Promise.all([firstAppend, secondAppend]);
+
+    expect(runCountAfterFirstSettled).toBe(2);
+    expect(replacementWasAborted).toBe(false);
+  });
+
   it("keeps a replacement run cancellable after the previous run settles", async () => {
     let releaseFirst!: () => void;
     let releaseSecond!: () => void;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -565,8 +565,14 @@ export class LocalThreadRuntimeCore
     const initialData = message.metadata?.unstable_data;
     const initialSteps = message.metadata?.steps;
     const initialCustom = message.metadata?.custom;
+    let hasStoredMessage = true;
+    try {
+      this.repository.getMessage(message.id);
+    } catch {
+      hasStoredMessage = false;
+    }
     const ownsMessage = () => {
-      if (this._activeRun === run) return true;
+      if (!hasStoredMessage) return this._activeRun === run;
       try {
         return this.repository.getMessage(message.id).message === message;
       } catch {
@@ -621,6 +627,7 @@ export class LocalThreadRuntimeCore
           : undefined),
       };
       this.repository.addOrUpdateMessage(parentId, message);
+      hasStoredMessage = true;
       this._notifySubscribers();
     };
 
@@ -659,6 +666,12 @@ export class LocalThreadRuntimeCore
         this.adapters.chatModel.run.bind(this.adapters.chatModel);
 
       const abortSignal = abortController.signal;
+      const shouldCancelMessage = () =>
+        abortSignal.aborted &&
+        (message.status.type === "running" ||
+          (message.status.type === "requires-action" &&
+            (this._activeRun !== run ||
+              shouldContinue(message, this._options.unstable_humanToolNames))));
       const threadId = this._getThreadId?.();
       const promiseOrGenerator = runCallback({
         messages,
@@ -677,9 +690,11 @@ export class LocalThreadRuntimeCore
       if (Symbol.asyncIterator in promiseOrGenerator) {
         for await (const r of promiseOrGenerator) {
           if (abortSignal.aborted) {
-            updateMessage({
-              status: { type: "incomplete", reason: "cancelled" },
-            });
+            if (shouldCancelMessage()) {
+              updateMessage({
+                status: { type: "incomplete", reason: "cancelled" },
+              });
+            }
             break;
           }
 
@@ -689,20 +704,13 @@ export class LocalThreadRuntimeCore
         updateMessage(await promiseOrGenerator);
       }
 
-      if (
-        abortSignal.aborted &&
-        message.status.type === "requires-action" &&
-        (this._activeRun !== run ||
-          shouldContinue(message, this._options.unstable_humanToolNames))
-      ) {
+      if (shouldCancelMessage()) {
         updateMessage({
           status: { type: "incomplete", reason: "cancelled" },
         });
       } else if (message.status.type === "running") {
         updateMessage({
-          status: abortSignal.aborted
-            ? { type: "incomplete", reason: "cancelled" }
-            : { type: "complete", reason: "unknown" },
+          status: { type: "complete", reason: "unknown" },
         });
       }
     } catch (e) {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -678,13 +678,15 @@ export class LocalThreadRuntimeCore
         updateMessage(await promiseOrGenerator);
       }
 
-      if (abortSignal.aborted) {
+      if (abortSignal.aborted && message.status.type === "requires-action") {
         updateMessage({
           status: { type: "incomplete", reason: "cancelled" },
         });
       } else if (message.status.type === "running") {
         updateMessage({
-          status: { type: "complete", reason: "unknown" },
+          status: abortSignal.aborted
+            ? { type: "incomplete", reason: "cancelled" }
+            : { type: "complete", reason: "unknown" },
         });
       }
     } catch (e) {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -501,6 +501,7 @@ export class LocalThreadRuntimeCore
           message,
           runConfig,
           alreadyPersisted,
+          run,
           runCallback,
         );
         runCallback = undefined;
@@ -549,6 +550,7 @@ export class LocalThreadRuntimeCore
     message: ThreadAssistantMessage,
     runConfig: RunConfig | undefined,
     alreadyPersisted: boolean,
+    run: { cancelled: boolean },
     runCallback?: ChatModelAdapter["run"],
   ) {
     const messages = parentId ? this.repository.getMessages(parentId) : [];
@@ -680,7 +682,9 @@ export class LocalThreadRuntimeCore
 
       if (
         abortSignal.aborted &&
-        shouldContinue(message, this._options.unstable_humanToolNames)
+        message.status.type === "requires-action" &&
+        (this._activeRun !== run ||
+          shouldContinue(message, this._options.unstable_humanToolNames))
       ) {
         updateMessage({
           status: { type: "incomplete", reason: "cancelled" },

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -571,6 +571,7 @@ export class LocalThreadRuntimeCore
     } catch {
       hasStoredMessage = false;
     }
+    // Other writers replace the stored message object, so identity distinguishes this run from a newer owner.
     const ownsMessage = () => {
       if (!hasStoredMessage) return this._activeRun === run;
       try {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -565,7 +565,11 @@ export class LocalThreadRuntimeCore
     const initialData = message.metadata?.unstable_data;
     const initialSteps = message.metadata?.steps;
     const initialCustom = message.metadata?.custom;
+    const ownsMessage = () =>
+      this._activeRun === run ||
+      this.repository.getMessage(message.id).message === message;
     const updateMessage = (m: Partial<ChatModelRunResult>) => {
+      if (!ownsMessage()) return;
       const newSteps = m.metadata?.steps;
       const steps = newSteps
         ? [...(initialSteps ?? []), ...newSteps]
@@ -736,7 +740,7 @@ export class LocalThreadRuntimeCore
 
       // Pauses are written only for adapters that can rewrite the entry later;
       // an append-only adapter would strand a half-finished run in history.
-      if (isTerminal || (isPausing && history?.update)) {
+      if (ownsMessage() && (isTerminal || (isPausing && history?.update))) {
         const write =
           alreadyPersisted && history?.update
             ? history.update.bind(history)

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -678,11 +678,13 @@ export class LocalThreadRuntimeCore
         updateMessage(await promiseOrGenerator);
       }
 
-      if (message.status.type === "running") {
+      if (abortSignal.aborted) {
         updateMessage({
-          status: abortSignal.aborted
-            ? { type: "incomplete", reason: "cancelled" }
-            : { type: "complete", reason: "unknown" },
+          status: { type: "incomplete", reason: "cancelled" },
+        });
+      } else if (message.status.type === "running") {
+        updateMessage({
+          status: { type: "complete", reason: "unknown" },
         });
       }
     } catch (e) {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -565,9 +565,14 @@ export class LocalThreadRuntimeCore
     const initialData = message.metadata?.unstable_data;
     const initialSteps = message.metadata?.steps;
     const initialCustom = message.metadata?.custom;
-    const ownsMessage = () =>
-      this._activeRun === run ||
-      this.repository.getMessage(message.id).message === message;
+    const ownsMessage = () => {
+      if (this._activeRun === run) return true;
+      try {
+        return this.repository.getMessage(message.id).message === message;
+      } catch {
+        return false;
+      }
+    };
     const updateMessage = (m: Partial<ChatModelRunResult>) => {
       if (!ownsMessage()) return;
       const newSteps = m.metadata?.steps;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -504,6 +504,7 @@ export class LocalThreadRuntimeCore
           runCallback,
         );
         runCallback = undefined;
+        if (this._activeRun !== run) break;
       } while (shouldContinue(message, this._options.unstable_humanToolNames));
     } finally {
       this._notifyEventSubscribers("runEnd", {});

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -678,7 +678,10 @@ export class LocalThreadRuntimeCore
         updateMessage(await promiseOrGenerator);
       }
 
-      if (abortSignal.aborted && message.status.type === "requires-action") {
+      if (
+        abortSignal.aborted &&
+        shouldContinue(message, this._options.unstable_humanToolNames)
+      ) {
         updateMessage({
           status: { type: "incomplete", reason: "cancelled" },
         });


### PR DESCRIPTION
## Summary

- stop a LocalRuntime run from entering another tool roundtrip after a newer run replaces it
- preserve the replacement run's active abort controller
- add a regression test covering a delayed tool-call result from the superseded run

## Why

A chat-model adapter may finish after its abort signal is raised. If that stale result requests another automatic tool step, the old run currently enters `performRoundtrip()` again. That method aborts the shared current controller, so it cancels the newer replacement run.

The runtime already tracks the active run. This change checks that ownership after each roundtrip and exits before tool continuation when the run has been superseded.

## Verification

- regression without the guard: 3 adapter calls instead of 2, and the replacement signal is aborted
- `local-thread-runtime-core.test.ts`: 60 tests passed
- `@assistant-ui/core` build passed
- targeted oxlint and oxfmt passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BhnKA_XhU_UsDJLIFDs6qa-NQ9u6KqESRJ9FYJghhDuaFjLZP13Gg1xCcSk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->