### PR TITLE
docs(ui): add branching response example to thread

### DIFF
--- a/apps/docs/components/docs/samples/thread/branching-response.tsx
+++ b/apps/docs/components/docs/samples/thread/branching-response.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Thread } from "@/components/assistant-ui/thread";
+import { AssistantRuntimeProvider, useLocalRuntime } from "@assistant-ui/react";
+import { SampleFrame } from "../sample-frame";
+
+export function Chat() {
+  const runtime = useLocalRuntime(
+    {
+      async *run() {
+        yield {
+          content: [
+            {
+              type: "text",
+              text: "assistant-ui ships primitives, runtimes, and a component registry for chat interfaces.",
+            },
+          ],
+        };
+      },
+    },
+    {
+      initialMessages: [
+        { role: "user", content: "What is assistant-ui?" },
+        {
+          role: "assistant",
+          content:
+            "assistant-ui provides composable primitives for AI chat interfaces.",
+        },
+      ],
+    },
+  );
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+
+export function ThreadBranchSample() {
+  return (
+    <SampleFrame className="bg-muted/40 h-120 overflow-hidden">
+      <Chat />
+    </SampleFrame>
+  );
+}

--- a/apps/docs/content/docs/ui/thread.mdx
+++ b/apps/docs/content/docs/ui/thread.mdx
@@ -5,6 +5,8 @@ platforms: ["react"]
 ---
 
 import { ThreadSample } from "@/components/docs/samples/thread";
+import { PreviewCode } from "@/components/docs/preview-code.server";
+import { ThreadBranchSample } from "@/components/docs/samples/thread/branching-response";
 
 A complete chat interface that combines message rendering, auto-scrolling, composer input,
 attachments, and conditional UI states. Fully customizable and composable.
@@ -151,6 +153,17 @@ const SuggestionItem = () => (
   </SuggestionPrimitive.Trigger>
 );
 ```
+
+### Branching Response
+
+Select the regenerate action below the assistant response to make an alternate branch. The built-in branch picker then shows `1 / 2` with arrows that switch between the two branches.
+
+<PreviewCode
+  file="components/docs/samples/thread/branching-response"
+  name="Chat"
+>
+  <ThreadBranchSample />
+</PreviewCode>
 
 ## Component Overrides
 

--- a/apps/docs/content/docs/ui/thread.mdx
+++ b/apps/docs/content/docs/ui/thread.mdx
@@ -156,7 +156,7 @@ const SuggestionItem = () => (
 
 ### Branching Response
 
-Select the regenerate action below the assistant response to make an alternate branch. The built-in branch picker then shows `1 / 2` with arrows that switch between the two branches.
+Select the refresh action below the assistant response to make an alternate branch. The built-in branch picker then shows `2 / 2` with arrows that switch between the two branches.
 
 <PreviewCode
   file="components/docs/samples/thread/branching-response"


### PR DESCRIPTION
The Thread docs page had no way to show the built-in branch picker, because the picker hides when a message has one branch. The reader can now make the second branch in a live example: a click on the regenerate action creates an alternate response, and the picker shows `1 / 2` with arrows that switch between the two branches. The demo contains no hidden seed code, thus the Code tab snippet is the complete example: the inner `Chat` component with `useLocalRuntime` and two seed messages. The new `### Branching Response` section sits at the end of `## Examples`.

Verified with `tsc --noEmit`, `pnpm lint`, and a full docs build. A regenerate click in the browser makes the `1 / 2` picker, and the two arrows switch the response text.

## Screenshots

![Thread docs page with the new branching response example outlined, picker at 2 / 2](https://artifacts.duncan.land/thread-branching-response.png)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.T6IzLkbXg8-S3K55-4OcEzxCJQiLvxtcPVewO_DpiNhGxGy4j5cBW_V10aQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->