### PR TITLE
fix(registry): stop treating dotted basenames as explicit extensions

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1288,6 +1288,50 @@ test("relative import candidates cover extensions, directory indexes, and .js so
   );
 });
 
+test("a dotted basename without a recognized extension probes module and index forms", () => {
+  const from = "components/assistant-ui/thread.tsx";
+
+  assert.deepEqual(getRelativeImportCandidates("./tool.config", from), [
+    "components/assistant-ui/tool.config",
+    "components/assistant-ui/tool.config.tsx",
+    "components/assistant-ui/tool.config.ts",
+    "components/assistant-ui/tool.config.jsx",
+    "components/assistant-ui/tool.config.js",
+    "components/assistant-ui/tool.config/index.tsx",
+    "components/assistant-ui/tool.config/index.ts",
+    "components/assistant-ui/tool.config/index.jsx",
+    "components/assistant-ui/tool.config/index.js",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./thread.v2", from), [
+    "components/assistant-ui/thread.v2",
+    "components/assistant-ui/thread.v2.tsx",
+    "components/assistant-ui/thread.v2.ts",
+    "components/assistant-ui/thread.v2.jsx",
+    "components/assistant-ui/thread.v2.js",
+    "components/assistant-ui/thread.v2/index.tsx",
+    "components/assistant-ui/thread.v2/index.ts",
+    "components/assistant-ui/thread.v2/index.jsx",
+    "components/assistant-ui/thread.v2/index.js",
+  ]);
+});
+
+test("a recognized asset extension resolves to the literal file only", () => {
+  const from = "components/assistant-ui/thread.tsx";
+
+  assert.deepEqual(getRelativeImportCandidates("./globals.css", from), [
+    "components/assistant-ui/globals.css",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./logo.png", from), [
+    "components/assistant-ui/logo.png",
+  ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./tool.config.json", from), [
+    "components/assistant-ui/tool.config.json",
+  ]);
+});
+
 test("a sibling whose name begins with dots stays inside the installed tree", () => {
   assert.deepEqual(getRelativeImportCandidates("./..rc.json", "config.tsx"), [
     "..rc.json",

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1441,6 +1441,7 @@ test("install validation resolves a dotted alias basename to its shipped source"
   for (const providerPath of [
     "components/assistant-ui/tool.config.tsx",
     "components/assistant-ui/tool.config.ts",
+    "components/assistant-ui/tool.config/index.tsx",
   ]) {
     assert.equal(
       findingsFrom([
@@ -1456,6 +1457,28 @@ test("install validation resolves a dotted alias basename to its shipped source"
   assert.match(
     findingsFrom([componentItem([importer])]),
     /provides components\/assistant-ui\/tool\.config or components\/assistant-ui\/tool\.config\.tsx/,
+  );
+});
+
+test("install validation resolves an alias asset import behind a query suffix", () => {
+  const importer = {
+    path: "components/assistant-ui/thread.tsx",
+    content: 'import logoUrl from "@/components/assistant-ui/logo.svg?url";\n',
+  };
+
+  assert.equal(
+    findingsFrom([
+      componentItem([
+        importer,
+        { path: "components/assistant-ui/logo.svg", content: "<svg />\n" },
+      ]),
+    ]),
+    null,
+  );
+
+  assert.match(
+    findingsFrom([componentItem([importer])]),
+    /provides components\/assistant-ui\/logo\.svg/,
   );
 });
 

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1330,6 +1330,10 @@ test("a recognized asset extension resolves to the literal file only", () => {
   assert.deepEqual(getRelativeImportCandidates("./tool.config.json", from), [
     "components/assistant-ui/tool.config.json",
   ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./logo.PNG", from), [
+    "components/assistant-ui/logo.PNG",
+  ]);
 });
 
 test("a sibling whose name begins with dots stays inside the installed tree", () => {
@@ -1413,6 +1417,32 @@ test("install validation reports an import that escapes the installed tree", () 
   ]);
 
   assert.match(findings, /a file outside the installed tree/);
+});
+
+test("install validation resolves a dotted alias basename to its shipped source", () => {
+  const importer = {
+    path: "components/assistant-ui/thread.tsx",
+    content:
+      'import { toolConfig } from "@/components/assistant-ui/tool.config";\n',
+  };
+
+  assert.equal(
+    findingsFrom([
+      componentItem([
+        importer,
+        {
+          path: "components/assistant-ui/tool.config.tsx",
+          content: "export const toolConfig = {};\n",
+        },
+      ]),
+    ]),
+    null,
+  );
+
+  assert.match(
+    findingsFrom([componentItem([importer])]),
+    /provides components\/assistant-ui\/tool\.config or components\/assistant-ui\/tool\.config\.tsx/,
+  );
 });
 
 test("install validation resolves a sibling against the registryDependency install path", () => {

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1334,6 +1334,14 @@ test("a recognized asset extension resolves to the literal file only", () => {
   assert.deepEqual(getRelativeImportCandidates("./logo.PNG", from), [
     "components/assistant-ui/logo.PNG",
   ]);
+
+  assert.deepEqual(getRelativeImportCandidates("./legacy.JS", from), [
+    "components/assistant-ui/legacy.JS",
+    "components/assistant-ui/legacy.tsx",
+    "components/assistant-ui/legacy.ts",
+    "components/assistant-ui/legacy.jsx",
+    "components/assistant-ui/legacy.js",
+  ]);
 });
 
 test("a sibling whose name begins with dots stays inside the installed tree", () => {
@@ -1426,18 +1434,20 @@ test("install validation resolves a dotted alias basename to its shipped source"
       'import { toolConfig } from "@/components/assistant-ui/tool.config";\n',
   };
 
-  assert.equal(
-    findingsFrom([
-      componentItem([
-        importer,
-        {
-          path: "components/assistant-ui/tool.config.tsx",
-          content: "export const toolConfig = {};\n",
-        },
+  for (const providerPath of [
+    "components/assistant-ui/tool.config.tsx",
+    "components/assistant-ui/tool.config.ts",
+  ]) {
+    assert.equal(
+      findingsFrom([
+        componentItem([
+          importer,
+          { path: providerPath, content: "export const toolConfig = {};\n" },
+        ]),
       ]),
-    ]),
-    null,
-  );
+      null,
+    );
+  }
 
   assert.match(
     findingsFrom([componentItem([importer])]),

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1334,6 +1334,10 @@ test("a recognized asset extension resolves to the literal file only", () => {
   assert.deepEqual(getRelativeImportCandidates("./logo.PNG", from), [
     "components/assistant-ui/logo.PNG",
   ]);
+});
+
+test("an uppercase module extension still probes TypeScript sources", () => {
+  const from = "components/assistant-ui/thread.tsx";
 
   assert.deepEqual(getRelativeImportCandidates("./legacy.JS", from), [
     "components/assistant-ui/legacy.JS",

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -844,7 +844,12 @@ function getLocalComponentCandidates(specifier: string) {
   if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) return [componentPath];
   if (!extension) return [`${componentPath}.tsx`];
 
-  return [componentPath, `${componentPath}.tsx`];
+  return [
+    componentPath,
+    ...MODULE_EXTENSIONS.map(
+      (moduleExtension) => `${componentPath}${moduleExtension}`,
+    ),
+  ];
 }
 
 const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
@@ -896,10 +901,10 @@ export function getRelativeImportCandidates(
   );
   if (resolved === ".." || resolved.startsWith("../")) return null;
 
-  const extension = path.posix.extname(resolved);
+  const extension = path.posix.extname(resolved).toLowerCase();
   const candidates = new Set<string>();
 
-  if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) {
+  if (EXPLICIT_EXTENSIONS.has(extension)) {
     candidates.add(resolved);
     if (extension === ".js" || extension === ".jsx") {
       const base = resolved.slice(0, -extension.length);

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -836,13 +836,15 @@ function collectModuleSpecifiers(file: RegistryOutputFile) {
   return specifiers;
 }
 
-function getLocalComponentPath(specifier: string) {
+function getLocalComponentCandidates(specifier: string) {
   if (!specifier.startsWith("@/components/")) return null;
 
   const componentPath = specifier.slice(2);
-  if (path.extname(componentPath)) return componentPath;
+  const extension = path.extname(componentPath);
+  if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) return [componentPath];
+  if (!extension) return [`${componentPath}.tsx`];
 
-  return `${componentPath}.tsx`;
+  return [componentPath, `${componentPath}.tsx`];
 }
 
 const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
@@ -897,7 +899,7 @@ export function getRelativeImportCandidates(
   const extension = path.posix.extname(resolved);
   const candidates = new Set<string>();
 
-  if (EXPLICIT_EXTENSIONS.has(extension)) {
+  if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) {
     candidates.add(resolved);
     if (extension === ".js" || extension === ".jsx") {
       const base = resolved.slice(0, -extension.length);
@@ -1003,12 +1005,16 @@ export function validateRegistryInstallMetadata(
 
     for (const file of item.files ?? []) {
       for (const specifier of collectModuleSpecifiers(file)) {
-        const localComponentPath = getLocalComponentPath(specifier);
+        const localCandidates = getLocalComponentCandidates(specifier);
 
-        if (localComponentPath) {
-          if (!installContext.files.has(localComponentPath)) {
+        if (localCandidates) {
+          if (
+            !localCandidates.some((candidate) =>
+              installContext.files.has(candidate),
+            )
+          ) {
             findings.add(
-              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${localComponentPath}`,
+              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${localCandidates.join(" or ")}`,
             );
           }
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -839,7 +839,7 @@ function collectModuleSpecifiers(file: RegistryOutputFile) {
 function getLocalComponentCandidates(specifier: string) {
   if (!specifier.startsWith("@/components/")) return null;
 
-  const componentPath = specifier.slice(2);
+  const componentPath = specifier.replace(/[?#].*$/, "").slice(2);
   const extension = path.extname(componentPath);
   if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) return [componentPath];
   if (!extension) return [`${componentPath}.tsx`];
@@ -848,6 +848,9 @@ function getLocalComponentCandidates(specifier: string) {
     componentPath,
     ...MODULE_EXTENSIONS.map(
       (moduleExtension) => `${componentPath}${moduleExtension}`,
+    ),
+    ...MODULE_EXTENSIONS.map(
+      (moduleExtension) => `${componentPath}/index${moduleExtension}`,
     ),
   ];
 }

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -847,13 +847,42 @@ function getLocalComponentPath(specifier: string) {
 
 const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
 
+const EXPLICIT_EXTENSIONS = new Set([
+  ...MODULE_EXTENSIONS,
+  ".mjs",
+  ".cjs",
+  ".mts",
+  ".cts",
+  ".css",
+  ".json",
+  ".svg",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".avif",
+  ".ico",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".md",
+  ".mdx",
+  ".txt",
+]);
+
 /**
  * The install paths a relative specifier may resolve to once the item is
  * installed. A specifier is satisfied when the install closure provides any one
  * of them, which is what a bundler in the user's project will do: an explicit
  * extension, an extensionless module, a directory index, or the TypeScript
- * source behind a `.js` specifier. `null` means the specifier points outside
- * the installed tree, where no closure file can ever satisfy it.
+ * source behind a `.js` specifier. A dot in a basename is only treated as an
+ * explicit extension when it is one of the recognized module or asset
+ * extensions; a dotted module name (`./tool.config`) keeps the literal
+ * candidate and probes module and index forms too. `null` means the specifier
+ * points outside the installed tree, where no closure file can ever satisfy
+ * it.
  */
 export function getRelativeImportCandidates(
   specifier: string,
@@ -868,7 +897,7 @@ export function getRelativeImportCandidates(
   const extension = path.posix.extname(resolved);
   const candidates = new Set<string>();
 
-  if (extension) {
+  if (EXPLICIT_EXTENSIONS.has(extension)) {
     candidates.add(resolved);
     if (extension === ".js" || extension === ".jsx") {
       const base = resolved.slice(0, -extension.length);
@@ -877,6 +906,7 @@ export function getRelativeImportCandidates(
       }
     }
   } else {
+    if (extension) candidates.add(resolved);
     for (const moduleExtension of MODULE_EXTENSIONS) {
       candidates.add(`${resolved}${moduleExtension}`);
     }


### PR DESCRIPTION
## Summary

- gate the relative-import resolver's "explicit extension" branch on a recognized-extension set instead of any non-empty `path.posix.extname` result
- a dotted basename with an unrecognized "extension" (`./tool.config`, `./thread.v2`) now keeps its literal candidate **and** probes the module/index forms, the way `./badge` does
- recognized module extensions (`.tsx/.ts/.jsx/.js/.mjs/.cjs/.mts/.cts`) and asset extensions (`.css`, `.json`, `.svg`, images, fonts, `.md/.mdx/.txt`) keep today's literal-only behavior, so a stray `styles.css.tsx` still cannot satisfy a CSS import
- apply the same gate to the `@/components/*` alias resolver (`getLocalComponentCandidates`, formerly `getLocalComponentPath`), which carried the identical `extname` predicate: a dotted alias basename now yields the literal candidate plus the module-extension and directory-index probes, matching the relative resolver, and the call site checks membership of any candidate; the alias resolver also strips `?`/`#` suffixes before classifying, so `@/components/.../logo.svg?url` resolves like its relative counterpart
- normalize the extension to lowercase before classification, so `./logo.PNG` stays literal-only and `./legacy.JS` probes TypeScript sources the way `./legacy.js` does

## Why

Fixes #6123. `getRelativeImportCandidates` treated any dot in a basename as an explicit file extension, so a sibling named `tool.config.ts` imported as `./tool.config` resolved to the single literal candidate `tool.config` and could never be satisfied — a false self-containment failure at build time for a component that is in fact self-contained.

The naive fix (probe whenever the extension is unrecognized, dropping the literal) would weaken the working asset checks, so the resolver now distinguishes three cases: recognized extension → literal (plus TS-source probing behind `.js`/`.jsx`, unchanged); unrecognized dotted basename → literal plus module/index probing; no extension → module/index probing (unchanged). The extension set is intentionally conservative — happy to add or drop entries if maintainers want a different scope.

The alias-path fix follows review feedback on this PR: the issue scoped itself to the relative resolver, but `getLocalComponentPath` branched on the same predicate, so `@/components/assistant-ui/tool.config` hit the same false failure on the import style registry components predominantly use. Same root cause, same validator, so it lands here rather than as a follow-up. The dotted alias probe covers the module extensions and directory-index forms so both import styles accept the same shipped sources; the extensionless alias form keeps its existing `.tsx`-only mapping.

Verified with the repro from the issue: `./tool.config` returned `["components/assistant-ui/tool.config"]` before, and now returns the literal plus the eight module/index candidates; `./badge`, `./badge.tsx`, `./badge.js`, `./styles.css`, `./icon.svg?url`, and `./..rc.json` outputs are byte-identical to before.

## Validation

- `pnpm --filter @assistant-ui/shadcn-registry test` (44 tests, including new coverage for dotted basenames on both resolvers, uppercase asset extensions, and literal-only asset extensions)
- `pnpm --filter @assistant-ui/shadcn-registry build` (full registry build + self-containment validation over both payload trees)
- `pnpm lint`
