### PR TITLE
docs(ui): add active threads example to thread list page

### DIFF
--- a/apps/docs/components/docs/samples/thread-list/active-threads.tsx
+++ b/apps/docs/components/docs/samples/thread-list/active-threads.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  AssistantRuntimeProvider,
+  useExternalStoreRuntime,
+  type ExternalStoreThreadData,
+  type ThreadMessage,
+} from "@assistant-ui/react";
+import { ThreadList } from "@/components/assistant-ui/thread-list";
+import { SampleFrame } from "@/components/docs/samples/sample-frame";
+
+export function ActiveThreadList() {
+  const [threads, setThreads] = useState<ExternalStoreThreadData<"regular">[]>([
+    { id: "launch-plan", status: "regular", title: "Plan the product launch" },
+    { id: "api-review", status: "regular", title: "Review the API design" },
+    { id: "release-notes", status: "regular", title: "Draft release notes" },
+  ]);
+  const [archived, setArchived] = useState<
+    ExternalStoreThreadData<"archived">[]
+  >([]);
+  const [activeId, setActiveId] = useState("launch-plan");
+  const nextId = useRef(1);
+
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [],
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: activeId,
+        threads,
+        archivedThreads: archived,
+        onSwitchToThread: setActiveId,
+        onSwitchToNewThread: () => {
+          const id = `new-thread-${nextId.current++}`;
+          setThreads((current) => [{ id, status: "regular" }, ...current]);
+          setActiveId(id);
+        },
+        onArchive: (id) => {
+          const selected = threads.find((thread) => thread.id === id);
+          const remaining = threads.filter((thread) => thread.id !== id);
+          setThreads(remaining);
+          if (selected) {
+            setArchived((current) => [
+              { ...selected, status: "archived" as const },
+              ...current,
+            ]);
+          }
+          if (activeId === id) setActiveId(remaining[0]?.id ?? "new");
+        },
+        onDelete: (id) => {
+          const remaining = threads.filter((thread) => thread.id !== id);
+          setThreads(remaining);
+          if (activeId === id) setActiveId(remaining[0]?.id ?? "new");
+        },
+      },
+    },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadList />
+    </AssistantRuntimeProvider>
+  );
+}
+
+export function ThreadListActiveSample() {
+  return (
+    <SampleFrame className="bg-background h-auto min-h-96 p-6">
+      <div className="mx-auto w-full max-w-sm">
+        <ActiveThreadList />
+      </div>
+    </SampleFrame>
+  );
+}

--- a/apps/docs/components/docs/samples/thread-list/active-threads.tsx
+++ b/apps/docs/components/docs/samples/thread-list/active-threads.tsx
@@ -53,6 +53,13 @@ export function ActiveThreadList() {
           setThreads(remaining);
           if (activeId === id) setActiveId(remaining[0]?.id ?? "new");
         },
+        onRename: (id, title) => {
+          setThreads((current) =>
+            current.map((thread) =>
+              thread.id === id ? { ...thread, title } : thread,
+            ),
+          );
+        },
       },
     },
   });

--- a/apps/docs/content/docs/ui/thread-list.mdx
+++ b/apps/docs/content/docs/ui/thread-list.mdx
@@ -5,6 +5,8 @@ platforms: ["react"]
 ---
 
 import { ThreadListSample } from "@/components/docs/samples/threadlist";
+import { PreviewCode } from "@/components/docs/preview-code.server";
+import { ThreadListActiveSample } from "@/components/docs/samples/thread-list/active-threads";
 
 <ThreadListSample />
 
@@ -103,6 +105,16 @@ import { ThreadListPrimitive, ThreadListItemPrimitive } from "@assistant-ui/reac
   </ThreadListPrimitive.Items>
 </ThreadListPrimitive.Root>
 ```
+
+## Examples
+
+### Active Threads
+
+Select a different seeded conversation, or use the search field to filter the threads by title.
+
+<PreviewCode file="components/docs/samples/thread-list/active-threads" name="ActiveThreadList">
+  <ThreadListActiveSample />
+</PreviewCode>
 
 ## API Reference
 


### PR DESCRIPTION
The Thread List page now shows a live example with three seeded threads. Readers can move the active state to a different thread and can filter the list with the search field. Before this change, the page had only the hero demo, and the hero demo starts without threads, thus selection and search were not visible.

The sample supplies the threads to `ThreadList` through `useExternalStoreRuntime`. The Code tab shows the complete runtime wiring of the inner `ActiveThreadList` component, without `SampleFrame` and without docs-internal imports. This structure is the same inner and outer split as the merged attachment examples.

Three sibling PRs add the New Thread, Archive a Thread, and Sidebar Composition examples to the same `## Examples` section.

Related: assistant-ui/assistant-ui#5644, assistant-ui/assistant-ui#5645

## Screenshots

### Active Threads example (annotated)

![Active Threads example on the docs page](https://artifacts.duncan.land/thread-list-active-threads.png)

## Verification

The command `pnpm -C apps/docs build` exits 0. A browser check of the production build shows the active state, the switch behavior, and the search filter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NxKCRRoseHV8DcqYGVHympnuiC21JpUwD8uKwH20ZJ13beJ74oARxpbmM34?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->