### PR TITLE
fix(assistant-stream): decode AI SDK v6 tool chunks in UIMessageStreamDecoder

### DIFF
--- a/.changeset/ui-message-stream-v6-tool-chunks.md
+++ b/.changeset/ui-message-stream-v6-tool-chunks.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: decode AI SDK v6 tool chunk names (tool-input-*/tool-output-*) in UIMessageStreamDecoder

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -24662,6 +24662,38 @@ type UIMessageStreamChunk = {
   isError?: boolean;
   messages?: ReadonlyJSONValue;
 } | {
+  type: "tool-input-start";
+  toolCallId: string;
+  toolName: string;
+  providerExecuted?: boolean;
+  dynamic?: boolean;
+} | {
+  type: "tool-input-delta";
+  toolCallId: string;
+  inputTextDelta: string;
+} | {
+  type: "tool-input-available";
+  toolCallId: string;
+  toolName: string;
+  input?: ReadonlyJSONValue;
+  providerExecuted?: boolean;
+  dynamic?: boolean;
+} | {
+  type: "tool-input-error";
+  toolCallId: string;
+  toolName: string;
+  input?: ReadonlyJSONValue;
+  errorText: string;
+} | {
+  type: "tool-output-available";
+  toolCallId: string;
+  output: ReadonlyJSONValue;
+  preliminary?: boolean;
+} | {
+  type: "tool-output-error";
+  toolCallId: string;
+  errorText: string;
+} | {
   type: "start-step";
   messageId?: string;
 } | {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -1001,6 +1001,145 @@ describe("UIMessageStreamDecoder", () => {
       expect(results[0]?.result).toEqual({ temp: 20 });
     });
 
+    it("decodes parallel tool input streams independently", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_a",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_b",
+          toolName: "time",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_a",
+          inputTextDelta: '{"city":',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_b",
+          inputTextDelta: '{"zone":"CET"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_a",
+          inputTextDelta: '"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_a",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_b",
+          toolName: "time",
+          input: { zone: "CET" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_a",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_b",
+          output: { time: "12:00" },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStarts = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStarts).toHaveLength(2);
+
+      const argsByPath = new Map<string, string>();
+      for (const c of chunks) {
+        if (c.type !== "text-delta") continue;
+        const key = JSON.stringify(c.path);
+        argsByPath.set(key, (argsByPath.get(key) ?? "") + c.textDelta);
+      }
+      expect(new Set(argsByPath.values())).toEqual(
+        new Set(['{"city":"Berlin"}', '{"zone":"CET"}']),
+      );
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results.map((r) => r.result)).toEqual(
+        expect.arrayContaining([{ temp: 20 }, { time: "12:00" }]),
+      );
+    });
+
+    it("drops a tool-input-delta arriving after the input settled instead of erroring", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"late":true}',
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"later":true}',
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+    });
+
     it("interleaves a streamed tool call with text like a real run", async () => {
       const events = [
         JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -1140,6 +1140,79 @@ describe("UIMessageStreamDecoder", () => {
       expect(result?.result).toEqual({ temp: 20 });
     });
 
+    it("ignores a tool-output for an id this decoder never saw", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_from_previous_response",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({ type: "text-start", id: "text_1" }),
+        JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
+        JSON.stringify({ type: "text-end" }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      expect(chunks.some((c) => c.type === "result")).toBe(false);
+      const text = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(text).toBe("Hello");
+    });
+
+    it("tolerates a duplicated tool-input-available for a settled tool call", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.result).toEqual({ temp: 20 });
+    });
+
     it("interleaves a streamed tool call with text like a real run", async () => {
       const events = [
         JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -783,4 +783,286 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(result?.result).toBe(NO_RESULT);
   });
+
+  describe("AI SDK v6 tool chunk names", () => {
+    it("decodes a streamed tool call (tool-input-start/delta/available, tool-output-available)", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "finish",
+          finishReason: "tool-calls",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+      if (toolCallStart?.part.type === "tool-call") {
+        expect(toolCallStart.part.toolName).toBe("weather");
+        expect(toolCallStart.part.toolCallId).toBe("call_abc");
+      }
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+      expect(result?.isError).toBe(false);
+    });
+
+    it("decodes a non-streamed tool-input-available without a prior tool-input-start", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+    });
+
+    it("maps tool-output-error to an error response", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-error",
+          toolCallId: "call_abc",
+          errorText: "city not found",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toBe("city not found");
+      expect(result?.isError).toBe(true);
+    });
+
+    it("maps tool-input-error to an error response", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-error",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+          errorText: "invalid input",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toBe("invalid input");
+      expect(result?.isError).toBe(true);
+    });
+
+    it("skips preliminary tool outputs and settles on the final one", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 0 },
+          preliminary: true,
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.result).toEqual({ temp: 20 });
+    });
+
+    it("interleaves a streamed tool call with text like a real run", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({ type: "start-step" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({ type: "start-step" }),
+        JSON.stringify({ type: "text-start", id: "text_1" }),
+        JSON.stringify({
+          type: "text-delta",
+          id: "text_1",
+          delta: "It is 20 degrees.",
+        }),
+        JSON.stringify({ type: "text-end" }),
+        JSON.stringify({
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+
+      const textStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "text",
+      );
+      expect(textStart).toBeDefined();
+    });
+  });
 });

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -175,6 +175,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
             case "tool-input-available":
             case "tool-input-error": {
+              if (settledArgsToolCallIds.has(chunk.toolCallId)) break;
+
               let toolCallController = toolCallControllers.get(
                 chunk.toolCallId,
               );
@@ -232,11 +234,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               const toolCallController = toolCallControllers.get(
                 chunk.toolCallId,
               );
-              if (!toolCallController) {
-                throw new Error(
-                  `Encountered tool result with unknown id: ${chunk.toolCallId}`,
-                );
-              }
+              if (!toolCallController) break;
               if (toolCallController.argsText === activeToolCallArgsText) {
                 activeToolCallArgsText = undefined;
               }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -40,6 +40,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
     super((readable) => {
       const toolCallControllers = new Map<string, ToolCallStreamController>();
       const streamedArgsToolCallIds = new Set<string>();
+      const settledArgsToolCallIds = new Set<string>();
       let activeToolCallArgsText: TextStreamController | undefined;
       let currentMessageId: string | undefined;
       let receivedDone = false;
@@ -114,8 +115,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               });
               break;
 
-            case "tool-call-start":
-            case "tool-input-start": {
+            case "tool-call-start": {
               activeToolCallArgsText?.close();
               activeToolCallArgsText = undefined;
 
@@ -134,11 +134,30 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               break;
             }
 
+            case "tool-input-start": {
+              if (toolCallControllers.has(chunk.toolCallId)) {
+                throw new Error(
+                  `Encountered duplicate tool call id: ${chunk.toolCallId}`,
+                );
+              }
+
+              toolCallControllers.set(
+                chunk.toolCallId,
+                controller.addToolCallPart({
+                  toolCallId: chunk.toolCallId,
+                  toolName: chunk.toolName,
+                }),
+              );
+              break;
+            }
+
             case "tool-call-delta":
               activeToolCallArgsText?.append(chunk.argsText);
               break;
 
             case "tool-input-delta": {
+              if (settledArgsToolCallIds.has(chunk.toolCallId)) break;
+
               const argsText = toolCallControllers.get(
                 chunk.toolCallId,
               )?.argsText;
@@ -172,10 +191,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               ) {
                 toolCallController.argsText.append(JSON.stringify(chunk.input));
               }
-              if (toolCallController.argsText === activeToolCallArgsText) {
-                activeToolCallArgsText = undefined;
-              }
               toolCallController.argsText.close();
+              settledArgsToolCallIds.add(chunk.toolCallId);
               if (chunk.type === "tool-input-error") {
                 toolCallController.setResponse({
                   result: chunk.errorText,
@@ -223,6 +240,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               if (toolCallController.argsText === activeToolCallArgsText) {
                 activeToolCallArgsText = undefined;
               }
+              settledArgsToolCallIds.add(chunk.toolCallId);
               toolCallController.setResponse(
                 chunk.type === "tool-output-error"
                   ? { result: chunk.errorText, isError: true }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -39,6 +39,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
   constructor(options: UIMessageStreamDecoderOptions = {}) {
     super((readable) => {
       const toolCallControllers = new Map<string, ToolCallStreamController>();
+      const streamedArgsToolCallIds = new Set<string>();
       let activeToolCallArgsText: TextStreamController | undefined;
       let currentMessageId: string | undefined;
       let receivedDone = false;
@@ -113,7 +114,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               });
               break;
 
-            case "tool-call-start": {
+            case "tool-call-start":
+            case "tool-input-start": {
               activeToolCallArgsText?.close();
               activeToolCallArgsText = undefined;
 
@@ -136,10 +138,52 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               activeToolCallArgsText?.append(chunk.argsText);
               break;
 
+            case "tool-input-delta": {
+              const argsText = toolCallControllers.get(
+                chunk.toolCallId,
+              )?.argsText;
+              if (argsText) {
+                argsText.append(chunk.inputTextDelta);
+                streamedArgsToolCallIds.add(chunk.toolCallId);
+              }
+              break;
+            }
+
             case "tool-call-end":
               activeToolCallArgsText?.close();
               activeToolCallArgsText = undefined;
               break;
+
+            case "tool-input-available":
+            case "tool-input-error": {
+              let toolCallController = toolCallControllers.get(
+                chunk.toolCallId,
+              );
+              if (!toolCallController) {
+                toolCallController = controller.addToolCallPart({
+                  toolCallId: chunk.toolCallId,
+                  toolName: chunk.toolName,
+                });
+                toolCallControllers.set(chunk.toolCallId, toolCallController);
+              }
+              if (
+                !streamedArgsToolCallIds.has(chunk.toolCallId) &&
+                chunk.input !== undefined
+              ) {
+                toolCallController.argsText.append(JSON.stringify(chunk.input));
+              }
+              if (toolCallController.argsText === activeToolCallArgsText) {
+                activeToolCallArgsText = undefined;
+              }
+              toolCallController.argsText.close();
+              if (chunk.type === "tool-input-error") {
+                toolCallController.setResponse({
+                  result: chunk.errorText,
+                  isError: true,
+                });
+              }
+              break;
+            }
 
             case "tool-result": {
               const toolCallController = toolCallControllers.get(
@@ -160,6 +204,30 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                   ? { messages: chunk.messages }
                   : {}),
               });
+              break;
+            }
+
+            case "tool-output-available":
+            case "tool-output-error": {
+              if (chunk.type === "tool-output-available" && chunk.preliminary)
+                break;
+
+              const toolCallController = toolCallControllers.get(
+                chunk.toolCallId,
+              );
+              if (!toolCallController) {
+                throw new Error(
+                  `Encountered tool result with unknown id: ${chunk.toolCallId}`,
+                );
+              }
+              if (toolCallController.argsText === activeToolCallArgsText) {
+                activeToolCallArgsText = undefined;
+              }
+              toolCallController.setResponse(
+                chunk.type === "tool-output-error"
+                  ? { result: chunk.errorText, isError: true }
+                  : { result: chunk.output },
+              );
               break;
             }
 

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
@@ -42,6 +42,36 @@ export type UIMessageStreamChunk =
       isError?: boolean;
       messages?: ReadonlyJSONValue;
     }
+  | {
+      type: "tool-input-start";
+      toolCallId: string;
+      toolName: string;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+    }
+  | { type: "tool-input-delta"; toolCallId: string; inputTextDelta: string }
+  | {
+      type: "tool-input-available";
+      toolCallId: string;
+      toolName: string;
+      input?: ReadonlyJSONValue;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+    }
+  | {
+      type: "tool-input-error";
+      toolCallId: string;
+      toolName: string;
+      input?: ReadonlyJSONValue;
+      errorText: string;
+    }
+  | {
+      type: "tool-output-available";
+      toolCallId: string;
+      output: ReadonlyJSONValue;
+      preliminary?: boolean;
+    }
+  | { type: "tool-output-error"; toolCallId: string; errorText: string }
   | { type: "start-step"; messageId?: string }
   | {
       type: "finish-step";


### PR DESCRIPTION
## Summary

- handle the real AI SDK v6 UI Message Stream tool chunk names in `UIMessageStreamDecoder`: `tool-input-start`, `tool-input-delta`, `tool-input-available`, `tool-input-error`, `tool-output-available`, `tool-output-error`
- `tool-input-available` covers both the streamed case (deltas already delivered — just closes the args text, no double-append) and the non-streamed case (no prior `tool-input-start` — creates the part and writes the full input JSON)
- `tool-input-error` and `tool-output-error` settle the part with `isError: true`; `preliminary: true` outputs are skipped so the part settles on the final output
- the previously handled `tool-call-start/delta/end` / `tool-result` names stay untouched for back-compat; the legacy single-active-args-controller behavior is isolated to those names — `tool-input-start` does not close the previous tool's args stream, so parallel v6 tool input streams decode independently, and out-of-order or duplicated chunks degrade gracefully instead of aborting the strict args stream: late deltas and repeated `tool-input-available`/`tool-input-error` for a settled id are dropped, and a `tool-output-*` for an id this decoder instance never saw (e.g. the resumed response of an approval flow, where the input streamed in the previous response) is ignored rather than thrown
- `tool-output-denied` / `tool-approval-request` / `tool-approval-response` remain intentionally unhandled: they map onto the tool-approval seam, which is a separate concern (see #6056)

## Why

Fixes #6153. The decoder's switch only knew tool chunk names the AI SDK never emits (`tool-call-start/delta/end`, `tool-result`), so every tool chunk from a real `streamText().toUIMessageStreamResponse()` backend fell into the ignore-unknown default — the assistant message rendered with no tool part and no warning. The `UIMessageChunk` union in both installed majors (`ai@6.0.257`, `ai@7.0.66`) confirms the real family is `tool-input-*`/`tool-output-*`. The text-side names were already shimmed (`delta`→`textDelta`, `source-url`, `file`-with-`url`); the tool family was the remaining gap, and this lands as additive decoder branches per the repo's protocol-coupling convention.

Root-cause verification: the issue's repro (a real v6 tool-call SSE stream through the decoder) produced zero tool-call part chunks before this change and produces the full part-start → args deltas → result sequence with it; the invented-name tests still pass unchanged.

`input` stays optional on the `tool-input-available`/`tool-input-error` chunk types deliberately: the wire is untyped at runtime and this repo's converter posture is to degrade (empty-object args) rather than crash on a missing field.

## Validation

- `pnpm --filter assistant-stream test` (34 files, 451 passed / 20 skipped; includes 10 new regression tests covering streamed, non-streamed, parallel-input, late-delta, duplicate-input, orphaned-output, input-error, output-error, preliminary-output, and interleaved-with-text cases against real wire fixtures)
- `pnpm turbo build --filter=assistant-stream`
- `pnpm lint`
- changeset: patch for `assistant-stream`
