### PR TITLE
fix(assistant-stream): decode AI SDK v6 tool chunks

### DIFF
--- a/.changeset/ui-message-stream-v6-tool-chunks.md
+++ b/.changeset/ui-message-stream-v6-tool-chunks.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: decode AI SDK v6 tool-input/tool-output chunks in UIMessageStreamDecoder

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -896,6 +896,47 @@ describe("UIMessageStreamDecoder", () => {
       expect(result?.result).toEqual({ temp: 20 });
     });
 
+    it("prefers tool-input-available.input over earlier deltas", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"cit',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+    });
+
     it("maps tool-output-error to an error response", async () => {
       const events = [
         JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -783,4 +783,541 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(result?.result).toBe(NO_RESULT);
   });
+
+  describe("AI SDK v6 tool chunk names", () => {
+    it("decodes a streamed tool call (tool-input-start/delta/available, tool-output-available)", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "finish",
+          finishReason: "tool-calls",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+      if (toolCallStart?.part.type === "tool-call") {
+        expect(toolCallStart.part.toolName).toBe("weather");
+        expect(toolCallStart.part.toolCallId).toBe("call_abc");
+      }
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+      expect(result?.isError).toBe(false);
+    });
+
+    it("decodes a non-streamed tool-input-available without a prior tool-input-start", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+    });
+
+    it("maps tool-output-error to an error response", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-error",
+          toolCallId: "call_abc",
+          errorText: "city not found",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toBe("city not found");
+      expect(result?.isError).toBe(true);
+    });
+
+    it("maps tool-input-error to an error response", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-error",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+          errorText: "invalid input",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toBe("invalid input");
+      expect(result?.isError).toBe(true);
+    });
+
+    it("keeps unparsed tool-input-error input as args text", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-error",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: '{"city":',
+          errorText: "invalid input",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toBe("invalid input");
+      expect(result?.isError).toBe(true);
+    });
+
+    it("skips preliminary tool outputs and settles on the final one", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 0 },
+          preliminary: true,
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.result).toEqual({ temp: 20 });
+    });
+
+    it("decodes parallel tool input streams independently", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_a",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_b",
+          toolName: "time",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_a",
+          inputTextDelta: '{"city":',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_b",
+          inputTextDelta: '{"zone":"CET"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_a",
+          inputTextDelta: '"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_a",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_b",
+          toolName: "time",
+          input: { zone: "CET" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_a",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_b",
+          output: { time: "12:00" },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStarts = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStarts).toHaveLength(2);
+
+      const argsByPath = new Map<string, string>();
+      for (const c of chunks) {
+        if (c.type !== "text-delta") continue;
+        const key = JSON.stringify(c.path);
+        argsByPath.set(key, (argsByPath.get(key) ?? "") + c.textDelta);
+      }
+      expect(new Set(argsByPath.values())).toEqual(
+        new Set(['{"city":"Berlin"}', '{"zone":"CET"}']),
+      );
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results.map((r) => r.result)).toEqual(
+        expect.arrayContaining([{ temp: 20 }, { time: "12:00" }]),
+      );
+    });
+
+    it("drops a tool-input-delta arriving after the input settled instead of erroring", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"late":true}',
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"later":true}',
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+    });
+
+    it("ignores a tool-output for an id this decoder never saw", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_from_previous_response",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({ type: "text-start", id: "text_1" }),
+        JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
+        JSON.stringify({ type: "text-end" }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      expect(chunks.some((c) => c.type === "result")).toBe(false);
+      const text = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(text).toBe("Hello");
+    });
+
+    it("tolerates a duplicated tool-input-available for a settled tool call", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter(
+          (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+            c.type === "text-delta",
+        )
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('{"city":"Berlin"}');
+
+      const results = chunks.filter(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.result).toEqual({ temp: 20 });
+    });
+
+    it("interleaves a streamed tool call with text like a real run", async () => {
+      const events = [
+        JSON.stringify({ type: "start", messageId: "msg_123" }),
+        JSON.stringify({ type: "start-step" }),
+        JSON.stringify({
+          type: "tool-input-start",
+          toolCallId: "call_abc",
+          toolName: "weather",
+        }),
+        JSON.stringify({
+          type: "tool-input-delta",
+          toolCallId: "call_abc",
+          inputTextDelta: '{"city":"Berlin"}',
+        }),
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: { city: "Berlin" },
+        }),
+        JSON.stringify({
+          type: "tool-output-available",
+          toolCallId: "call_abc",
+          output: { temp: 20 },
+        }),
+        JSON.stringify({ type: "start-step" }),
+        JSON.stringify({ type: "text-start", id: "text_1" }),
+        JSON.stringify({
+          type: "text-delta",
+          id: "text_1",
+          delta: "It is 20 degrees.",
+        }),
+        JSON.stringify({ type: "text-end" }),
+        JSON.stringify({
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const toolCallStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "tool-call",
+      );
+      expect(toolCallStart).toBeDefined();
+
+      const result = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "result" } =>
+          c.type === "result",
+      );
+      expect(result?.result).toEqual({ temp: 20 });
+
+      const textStart = chunks.find(
+        (c): c is AssistantStreamChunk & { type: "part-start" } =>
+          c.type === "part-start" && c.part.type === "text",
+      );
+      expect(textStart).toBeDefined();
+    });
+  });
 });

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -42,6 +42,42 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
       let activeToolCallArgsText: TextStreamController | undefined;
       let currentMessageId: string | undefined;
       let receivedDone = false;
+      type PendingTool = {
+        toolCallId: string;
+        toolName: string;
+        deltas: string[];
+        emitted: boolean;
+        resultEmitted: boolean;
+        pendingResult?: { result: unknown; isError: boolean };
+      };
+      const pendingTools = new Map<string, PendingTool>();
+      const emitPendingTool = (
+        out: TransformStreamDefaultController<UIMessageStreamChunk>,
+        tool: PendingTool,
+      ) => {
+        if (!tool.emitted) {
+          tool.emitted = true;
+          out.enqueue({
+            type: "tool-call-start",
+            id: generateId(),
+            toolCallId: tool.toolCallId,
+            toolName: tool.toolName,
+          });
+          for (const argsText of tool.deltas) {
+            out.enqueue({ type: "tool-call-delta", argsText });
+          }
+          out.enqueue({ type: "tool-call-end" });
+        }
+        if (tool.pendingResult && !tool.resultEmitted) {
+          out.enqueue({
+            type: "tool-result",
+            toolCallId: tool.toolCallId,
+            result: tool.pendingResult.result,
+            ...(tool.pendingResult.isError ? { isError: true } : {}),
+          } as UIMessageStreamChunk);
+          tool.resultEmitted = true;
+        }
+      };
 
       const transform = new AssistantTransformStream<UIMessageStreamChunk>({
         transform(chunk, controller) {
@@ -221,6 +257,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               }
 
               if (event.data === "[DONE]") {
+                for (const tool of pendingTools.values()) {
+                  emitPendingTool(controller, tool);
+                }
                 receivedDone = true;
                 controller.terminate();
                 return;
@@ -294,6 +333,90 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                   finishReason: chunk.finishReason ?? "unknown",
                   usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
                 });
+                return;
+              }
+              if (chunk.type === "tool-input-start") {
+                if (typeof chunk.toolCallId !== "string") return;
+                if (pendingTools.has(chunk.toolCallId)) return;
+                pendingTools.set(chunk.toolCallId, {
+                  toolCallId: chunk.toolCallId,
+                  toolName:
+                    typeof chunk.toolName === "string" ? chunk.toolName : "",
+                  deltas: [],
+                  emitted: false,
+                  resultEmitted: false,
+                });
+                return;
+              }
+              if (chunk.type === "tool-input-delta") {
+                if (typeof chunk.toolCallId !== "string") return;
+                if (typeof chunk.inputTextDelta !== "string") return;
+                const tool = pendingTools.get(chunk.toolCallId);
+                if (!tool || tool.emitted) return;
+                tool.deltas.push(chunk.inputTextDelta);
+                return;
+              }
+              if (
+                chunk.type === "tool-input-available" ||
+                chunk.type === "tool-input-error"
+              ) {
+                if (typeof chunk.toolCallId !== "string") return;
+                let tool = pendingTools.get(chunk.toolCallId);
+                if (!tool) {
+                  tool = {
+                    toolCallId: chunk.toolCallId,
+                    toolName:
+                      typeof chunk.toolName === "string" ? chunk.toolName : "",
+                    deltas: [],
+                    emitted: false,
+                    resultEmitted: false,
+                  };
+                  pendingTools.set(chunk.toolCallId, tool);
+                }
+                if (tool.emitted) return;
+                if (tool.deltas.length === 0 && chunk.input !== undefined) {
+                  tool.deltas.push(
+                    typeof chunk.input === "string"
+                      ? chunk.input
+                      : JSON.stringify(chunk.input),
+                  );
+                }
+                if (chunk.type === "tool-input-error") {
+                  tool.pendingResult = {
+                    result:
+                      typeof chunk.errorText === "string"
+                        ? chunk.errorText
+                        : "",
+                    isError: true,
+                  };
+                }
+                emitPendingTool(controller, tool);
+                return;
+              }
+              if (
+                chunk.type === "tool-output-available" ||
+                chunk.type === "tool-output-error"
+              ) {
+                if (typeof chunk.toolCallId !== "string") return;
+                if (
+                  chunk.type === "tool-output-available" &&
+                  chunk.preliminary
+                ) {
+                  return;
+                }
+                const tool = pendingTools.get(chunk.toolCallId);
+                if (!tool || tool.resultEmitted) return;
+                tool.pendingResult =
+                  chunk.type === "tool-output-error"
+                    ? {
+                        result:
+                          typeof chunk.errorText === "string"
+                            ? chunk.errorText
+                            : "",
+                        isError: true,
+                      }
+                    : { result: chunk.output, isError: false };
+                if (tool.emitted) emitPendingTool(controller, tool);
                 return;
               }
 

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -13,6 +13,7 @@ import type {
   UIMessageStreamDataChunk,
 } from "./chunk-types";
 import { generateId } from "../../utils/generateId";
+import type { ReadonlyJSONValue } from "../../../utils/json/json-value";
 
 export type { UIMessageStreamChunk, UIMessageStreamDataChunk };
 
@@ -48,7 +49,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
         deltas: string[];
         emitted: boolean;
         resultEmitted: boolean;
-        pendingResult?: { result: unknown; isError: boolean };
+        pendingResult?: { result: ReadonlyJSONValue; isError: boolean };
       };
       const pendingTools = new Map<string, PendingTool>();
       const emitPendingTool = (
@@ -74,7 +75,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
             toolCallId: tool.toolCallId,
             result: tool.pendingResult.result,
             ...(tool.pendingResult.isError ? { isError: true } : {}),
-          } as UIMessageStreamChunk);
+          });
           tool.resultEmitted = true;
         }
       };
@@ -374,12 +375,12 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                   pendingTools.set(chunk.toolCallId, tool);
                 }
                 if (tool.emitted) return;
-                if (tool.deltas.length === 0 && chunk.input !== undefined) {
-                  tool.deltas.push(
+                if (chunk.input !== undefined) {
+                  tool.deltas = [
                     typeof chunk.input === "string"
                       ? chunk.input
                       : JSON.stringify(chunk.input),
-                  );
+                  ];
                 }
                 if (chunk.type === "tool-input-error") {
                   tool.pendingResult = {
@@ -415,7 +416,10 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                             : "",
                         isError: true,
                       }
-                    : { result: chunk.output, isError: false };
+                    : {
+                        result: chunk.output as ReadonlyJSONValue,
+                        isError: false,
+                      };
                 if (tool.emitted) emitPendingTool(controller, tool);
                 return;
               }


### PR DESCRIPTION
closes #6153

## summary

- decode real AI SDK v6/v7 `tool-input-*` / `tool-output-*` chunks in `UIMessageStreamDecoder` so `useDataStreamRuntime` shows tool parts again
- map those wire names onto the published `tool-call-start` / `tool-call-delta` / `tool-call-end` / `tool-result` members at the SSE parse boundary (same shape as #4854). the published `UIMessageStreamChunk` union is unchanged
- buffer deltas until input settles, then emit a sequential published burst so parallel v6 tools do not close each other's args streams. drop orphan `tool-output-*` (approval resume) instead of throwing

## test plan

### already verified

- [x] `pnpm exec vitest run src/core/serialization/ui-message-stream/UIMessageStream.test.ts` in `packages/assistant-stream` -> 36/36
- [x] `pnpm exec vitest run` in `packages/assistant-stream` -> 456 passed / 20 skipped

### reviewer should verify

- [ ] a `streamText().toUIMessageStreamResponse()` backend with a tool call renders a tool part (args + result) through `useDataStreamRuntime`

## notes

- supersedes the approach in #6154, which grew the published union and added transform switch cases

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pr0dQVh72U1SOE7IqN2WDg5AGRfhR4cLPQZ8Z6iJuh6gwxFHWII_fCHX5WI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->