### PR TITLE
fix(react-native,react-ink): honor thread.isEmpty in leftover ThreadIf

### DIFF
--- a/.changeset/deprecate-leftover-primitive-if.md
+++ b/.changeset/deprecate-leftover-primitive-if.md
@@ -1,0 +1,10 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-native": patch
+"@assistant-ui/react-ink": patch
+---
+
+deprecate leftover Primitive.If and Empty wrappers on react-native and react-ink, and point them at AuiIf
+
+ThreadIf now reads `thread.isEmpty` instead of `messages.length === 0`, matching the loading-aware field already used by ThreadEmpty and AuiIf. First-party examples and docs samples that still called the leftover wrappers now use `AuiIf` directly.

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3339,7 +3339,7 @@ type ThreadComposerState = BaseComposerState & {
   readonly type: "thread";
 };
 
-declare const ThreadEmpty: (_param57: ThreadEmptyProps) => import("react").JSX.Element | null;
+declare const ThreadEmpty: (_param57: ThreadEmptyProps) => import("react").JSX.Element;
 
 type ThreadEmptyProps = {
   children: ReactNode;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -2913,7 +2913,7 @@ type ThreadComposerState = BaseComposerState & {
   readonly type: "thread";
 };
 
-declare const ThreadEmpty: (_param37: ThreadEmptyProps) => import("react").JSX.Element | null;
+declare const ThreadEmpty: (_param37: ThreadEmptyProps) => import("react").JSX.Element;
 
 type ThreadEmptyProps = {
   children: ReactNode;

--- a/apps/docs/components/builder/builder-chat-sidebar.tsx
+++ b/apps/docs/components/builder/builder-chat-sidebar.tsx
@@ -170,7 +170,7 @@ export function PlaygroundChatThread({
       {onRunningChange && <RunningObserver onRunningChange={onRunningChange} />}
       <ThreadPrimitive.Root className="flex flex-1 flex-col overflow-hidden">
         <ThreadPrimitive.Viewport className="flex flex-1 scrollbar-none flex-col gap-3 overflow-y-auto px-3 pt-3">
-          <ThreadPrimitive.Empty>
+          <AuiIf condition={(s) => s.thread.isEmpty}>
             <div className="flex flex-1 flex-col items-center justify-center gap-4 py-8 text-center">
               <div>
                 <p className="text-sm font-medium">
@@ -195,7 +195,7 @@ export function PlaygroundChatThread({
                 ))}
               </div>
             </div>
-          </ThreadPrimitive.Empty>
+          </AuiIf>
 
           <ThreadPrimitive.Messages
             components={{ UserMessage, AssistantMessage }}

--- a/apps/docs/components/docs/samples/dictation.tsx
+++ b/apps/docs/components/docs/samples/dictation.tsx
@@ -172,8 +172,7 @@ const ComposerAction: FC = () => {
       <div className="flex items-center gap-1">
         <ComposerAddAttachment />
 
-        {/* Dictation Button - Show when not dictation */}
-        <ComposerPrimitive.If dictation={false}>
+        <AuiIf condition={(s) => s.composer.dictation == null}>
           <ComposerPrimitive.Dictate asChild>
             <TooltipIconButton
               tooltip="Voice input"
@@ -185,10 +184,9 @@ const ComposerAction: FC = () => {
               <MicIcon className="size-5" />
             </TooltipIconButton>
           </ComposerPrimitive.Dictate>
-        </ComposerPrimitive.If>
+        </AuiIf>
 
-        {/* Stop Dictation Button - Show when dictation */}
-        <ComposerPrimitive.If dictation>
+        <AuiIf condition={(s) => s.composer.dictation != null}>
           <ComposerPrimitive.StopDictation asChild>
             <TooltipIconButton
               tooltip="Stop dictation"
@@ -200,10 +198,10 @@ const ComposerAction: FC = () => {
               <Square className="size-4 animate-pulse fill-current" />
             </TooltipIconButton>
           </ComposerPrimitive.StopDictation>
-        </ComposerPrimitive.If>
+        </AuiIf>
       </div>
 
-      <ThreadPrimitive.If running={false}>
+      <AuiIf condition={(s) => !s.thread.isRunning}>
         <ComposerPrimitive.Send asChild>
           <TooltipIconButton
             tooltip="Send message"
@@ -217,9 +215,9 @@ const ComposerAction: FC = () => {
             <ArrowUpIcon className="aui-composer-send-icon size-5" />
           </TooltipIconButton>
         </ComposerPrimitive.Send>
-      </ThreadPrimitive.If>
+      </AuiIf>
 
-      <ThreadPrimitive.If running>
+      <AuiIf condition={(s) => s.thread.isRunning}>
         <ComposerPrimitive.Cancel asChild>
           <Button
             type="button"
@@ -231,7 +229,7 @@ const ComposerAction: FC = () => {
             <Square className="aui-composer-cancel-icon size-3.5 fill-white dark:fill-black" />
           </Button>
         </ComposerPrimitive.Cancel>
-      </ThreadPrimitive.If>
+      </AuiIf>
     </div>
   );
 };
@@ -281,12 +279,12 @@ const AssistantActionBar: FC = () => {
     >
       <ActionBarPrimitive.Copy asChild>
         <TooltipIconButton tooltip="Copy">
-          <MessagePrimitive.If copied>
+          <AuiIf condition={(s) => s.message.isCopied}>
             <CheckIcon />
-          </MessagePrimitive.If>
-          <MessagePrimitive.If copied={false}>
+          </AuiIf>
+          <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
-          </MessagePrimitive.If>
+          </AuiIf>
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
       <ActionBarPrimitive.Reload asChild>

--- a/apps/docs/components/docs/samples/thread-primitive.tsx
+++ b/apps/docs/components/docs/samples/thread-primitive.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AuiIf,
   ComposerPrimitive,
   ThreadPrimitive,
   MessagePrimitive,
@@ -15,7 +16,7 @@ export function ThreadPrimitiveSample() {
         <div className="mx-auto w-full max-w-lg">
           <ThreadPrimitive.Root className="flex h-[320px] flex-col">
             <ThreadPrimitive.Viewport className="flex flex-1 flex-col gap-3 overflow-y-auto scroll-smooth p-3">
-              <ThreadPrimitive.Empty>
+              <AuiIf condition={(s) => s.thread.isEmpty}>
                 <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
                   <p className="text-foreground text-sm font-medium">
                     Welcome!
@@ -24,7 +25,7 @@ export function ThreadPrimitiveSample() {
                     Ask a question to get started.
                   </p>
                 </div>
-              </ThreadPrimitive.Empty>
+              </AuiIf>
 
               <ThreadPrimitive.Messages
                 components={{

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/composer.mdx
@@ -336,11 +336,11 @@ Only takes effect when `submitMode` resolves to `"enter"` (the default); `"ctrlE
 )}
 
 ```tsx
-<ComposerPrimitive.If dictation>
+<AuiIf condition={(s) => s.composer.dictation != null}>
   <div className="dictation-preview">
     <ComposerPrimitive.DictationTranscript />
   </div>
-</ComposerPrimitive.If>
+</AuiIf>
 ```
 
 <ParametersTable {...ComposerPrimitiveDictationTranscriptProps} />

--- a/apps/docs/content/docs/ink/index.mdx
+++ b/apps/docs/content/docs/ink/index.mdx
@@ -127,6 +127,7 @@ Use primitives to compose your terminal chat interface:
 ```tsx title="components/thread.tsx"
 import { Box, Text } from "ink";
 import {
+  AuiIf,
   ThreadPrimitive,
   ComposerPrimitive,
   LoadingPrimitive,
@@ -170,11 +171,11 @@ const StatusIndicator = () => (
 export const Thread = () => {
   return (
     <ThreadPrimitive.Root>
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <Box marginBottom={1}>
           <Text dimColor>No messages yet. Start typing below!</Text>
         </Box>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <ThreadPrimitive.Messages>
         {() => <Message />}

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -103,9 +103,9 @@ Renders a single message at a specific index in the thread. Provides message con
 Renders its children only when the thread has no messages. Deprecated in favor of `AuiIf`.
 
 ```tsx
-<ThreadPrimitive.Empty>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <Text>Send a message to get started</Text>
-</ThreadPrimitive.Empty>
+</AuiIf>
 ```
 
 ### ThreadPrimitive.If
@@ -113,13 +113,13 @@ Renders its children only when the thread has no messages. Deprecated in favor o
 Conditional rendering based on thread state. Deprecated in favor of `AuiIf`.
 
 ```tsx
-<ThreadPrimitive.If empty>
+<AuiIf condition={(s) => s.thread.isEmpty}>
   <Text>No messages yet</Text>
-</ThreadPrimitive.If>
+</AuiIf>
 
-<ThreadPrimitive.If running>
+<AuiIf condition={(s) => s.thread.isRunning}>
   <ActivityIndicator />
-</ThreadPrimitive.If>
+</AuiIf>
 ```
 
 | Prop | Type | Description |

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -12,7 +12,7 @@ Many primitives share their core logic with `@assistant-ui/react` via `@assistan
 ## Thread
 
 ```tsx
-import { ThreadPrimitive } from "@assistant-ui/react-native";
+import { AuiIf, ThreadPrimitive } from "@assistant-ui/react-native";
 ```
 
 ### ThreadPrimitive.Root
@@ -100,9 +100,14 @@ Renders a single message at a specific index in the thread. Provides message con
 
 ### ThreadPrimitive.Empty
 
-Renders its children only when the thread has no messages. Deprecated in favor of `AuiIf`.
+Renders its children only when the thread is empty (no messages and not loading). Deprecated in favor of `AuiIf`.
 
 ```tsx
+<ThreadPrimitive.Empty>
+  <Text>Send a message to get started</Text>
+</ThreadPrimitive.Empty>
+
+// preferred
 <AuiIf condition={(s) => s.thread.isEmpty}>
   <Text>Send a message to get started</Text>
 </AuiIf>
@@ -113,6 +118,11 @@ Renders its children only when the thread has no messages. Deprecated in favor o
 Conditional rendering based on thread state. Deprecated in favor of `AuiIf`.
 
 ```tsx
+<ThreadPrimitive.If empty>
+  <Text>No messages yet</Text>
+</ThreadPrimitive.If>
+
+// preferred
 <AuiIf condition={(s) => s.thread.isEmpty}>
   <Text>No messages yet</Text>
 </AuiIf>

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S1/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S1/project/components/assistant-ui/thread.tsx
@@ -19,7 +19,7 @@ export function Thread() {
       </header>
 
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div>
               <h1 className="text-2xl font-semibold">How can I help?</h1>
@@ -28,7 +28,7 @@ export function Thread() {
               </p>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
 
         <ThreadPrimitive.Messages
           components={{

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S2/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S2/project/components/assistant-ui/thread.tsx
@@ -37,7 +37,7 @@ export function Thread() {
       </header>
 
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -62,7 +62,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
 
         <ThreadPrimitive.Messages
           components={{ UserMessage, AssistantMessage }}

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S3/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S3/project/components/assistant-ui/thread.tsx
@@ -37,7 +37,7 @@ export function Thread() {
         </p>
       </header>
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -62,7 +62,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
         <ThreadPrimitive.Messages
           components={{ UserMessage, AssistantMessage }}
         />

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S4/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S4/project/components/assistant-ui/thread.tsx
@@ -37,7 +37,7 @@ export function Thread() {
         </p>
       </header>
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -62,7 +62,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
         <ThreadPrimitive.Messages
           components={{ UserMessage, AssistantMessage }}
         />

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S5/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S5/project/components/assistant-ui/thread.tsx
@@ -44,7 +44,7 @@ export function Thread() {
         </p>
       </header>
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -69,7 +69,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
         <ThreadPrimitive.Messages
           components={{ UserMessage, AssistantMessage }}
         />

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S6/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S6/project/components/assistant-ui/thread.tsx
@@ -38,7 +38,7 @@ export function Thread() {
         </p>
       </header>
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -63,7 +63,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
         <ThreadPrimitive.Messages
           components={{ UserMessage, AssistantMessage }}
         />

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S7/project/components/assistant-ui/thread.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S7/project/components/assistant-ui/thread.tsx
@@ -49,7 +49,7 @@ export function Thread() {
         </p>
       </header>
       <ThreadPrimitive.Viewport className="flex min-w-0 flex-1 flex-col overflow-y-auto">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <div className="flex flex-1 items-center justify-center p-6 text-center">
             <div className="w-full max-w-2xl">
               <h1 className="text-2xl font-semibold">
@@ -74,7 +74,7 @@ export function Thread() {
               </div>
             </div>
           </div>
-        </ThreadPrimitive.Empty>
+        </AuiIf>
         <ThreadPrimitive.Messages>
           {({ message }) => {
             if (message.composer.isEditing) return <EditComposer />;

--- a/examples/with-chain-of-thought/app/MyThread.tsx
+++ b/examples/with-chain-of-thought/app/MyThread.tsx
@@ -19,6 +19,7 @@ import {
   ToolGroupTrigger,
 } from "@/components/assistant-ui/tool-group";
 import {
+  AuiIf,
   ComposerPrimitive,
   groupPartByType,
   MessagePrimitive,
@@ -35,9 +36,9 @@ export const MyThread: FC = () => {
       style={{ ["--thread-max-width" as string]: "44rem" }}
     >
       <ThreadPrimitive.Viewport className="flex flex-1 flex-col overflow-y-scroll scroll-smooth px-4 pt-8">
-        <ThreadPrimitive.Empty>
+        <AuiIf condition={(s) => s.thread.isEmpty}>
           <ThreadWelcome />
-        </ThreadPrimitive.Empty>
+        </AuiIf>
 
         <ThreadPrimitive.Messages>
           {({ message }) => {

--- a/examples/with-expo/components/assistant-ui/message.tsx
+++ b/examples/with-expo/components/assistant-ui/message.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { View, Text, Animated, Platform, StyleSheet } from "react-native";
 import { Image } from "expo-image";
 import {
+  AuiIf,
   useAuiState,
   MessagePrimitive,
   ErrorPrimitive,
@@ -130,12 +131,19 @@ function AssistantMessage() {
           />
         </ErrorPrimitive.Root>
       </View>
-      <MessagePrimitive.If running={false}>
+      <AuiIf
+        condition={(s) =>
+          !(
+            s.message.role === "assistant" &&
+            s.message.status.type === "running"
+          )
+        }
+      >
         <View style={styles.actionsRow}>
           <MessageBranchPicker align="flex-start" />
           <MessageActionBar />
         </View>
-      </MessagePrimitive.If>
+      </AuiIf>
     </MessagePrimitive.Root>
   );
 }

--- a/examples/with-expo/components/assistant-ui/thread.tsx
+++ b/examples/with-expo/components/assistant-ui/thread.tsx
@@ -8,7 +8,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MessageBubble } from "./message";
 import { Composer } from "./composer";
-import { ThreadPrimitive } from "@assistant-ui/react-native";
+import { AuiIf, ThreadPrimitive } from "@assistant-ui/react-native";
 import { useTheme } from "@/hooks/use-theme";
 import { Radius, Spacing } from "@/constants/theme";
 import { haptics } from "@/lib/haptics";
@@ -60,10 +60,10 @@ function EmptyState() {
 function ChatMessages() {
   return (
     <>
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <EmptyState />
-      </ThreadPrimitive.Empty>
-      <ThreadPrimitive.If empty={false}>
+      </AuiIf>
+      <AuiIf condition={(s) => !s.thread.isEmpty}>
         <ThreadPrimitive.MessagesFlatList
           style={styles.flex}
           contentContainerStyle={styles.messageList}
@@ -71,7 +71,7 @@ function ChatMessages() {
         >
           {() => <MessageBubble />}
         </ThreadPrimitive.MessagesFlatList>
-      </ThreadPrimitive.If>
+      </AuiIf>
     </>
   );
 }

--- a/examples/with-react-ink-web/app/thread.tsx
+++ b/examples/with-react-ink-web/app/thread.tsx
@@ -1,6 +1,7 @@
 // Mirrors examples/with-react-ink/src/components/thread.tsx; keep in sync.
 import { Box, Text, useStdout } from "ink";
 import {
+  AuiIf,
   ThreadPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
@@ -72,7 +73,7 @@ const Loading = () => (
 export const Thread = () => {
   return (
     <ThreadPrimitive.Root>
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <Box flexDirection="column" marginBottom={1}>
           <Text>
             A real LLM streaming into a real Ink render loop in your browser.
@@ -81,7 +82,7 @@ export const Thread = () => {
             {'  try: "what is assistant-ui?" or "how do I render markdown?"'}
           </Text>
         </Box>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <ThreadPrimitive.Messages>
         {({ message }) =>

--- a/examples/with-react-ink/src/components/thread.tsx
+++ b/examples/with-react-ink/src/components/thread.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import {
+  AuiIf,
   ThreadPrimitive,
   ComposerPrimitive,
   MessagePrimitive,
@@ -57,7 +58,7 @@ const Loading = () => (
 export const Thread = () => {
   return (
     <ThreadPrimitive.Root>
-      <ThreadPrimitive.Empty>
+      <AuiIf condition={(s) => s.thread.isEmpty}>
         <Box flexDirection="column" marginBottom={1}>
           <Text>
             Working in this project. <Text color="yellow">fetchUser()</Text> is
@@ -65,7 +66,7 @@ export const Thread = () => {
           </Text>
           <Text dimColor>{'  try: "make fetchUser retry on failure"'}</Text>
         </Box>
-      </ThreadPrimitive.Empty>
+      </AuiIf>
 
       <ThreadPrimitive.Messages>
         {({ message }) =>

--- a/packages/core/src/react/primitive-hooks/useThreadIsEmpty.ts
+++ b/packages/core/src/react/primitive-hooks/useThreadIsEmpty.ts
@@ -1,5 +1,8 @@
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use `useAuiState((s) => s.thread.isEmpty)` instead.
+ */
 export const useThreadIsEmpty = (): boolean => {
   return useAuiState((s) => s.thread.isEmpty);
 };

--- a/packages/core/src/react/primitive-hooks/useThreadIsRunning.ts
+++ b/packages/core/src/react/primitive-hooks/useThreadIsRunning.ts
@@ -1,5 +1,8 @@
 import { useAuiState } from "@assistant-ui/store";
 
+/**
+ * @deprecated Use `useAuiState((s) => s.thread.isRunning)` instead.
+ */
 export const useThreadIsRunning = (): boolean => {
   return useAuiState((s) => s.thread.isRunning);
 };

--- a/packages/react-ink/src/primitives/composer/ComposerIf.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerIf.tsx
@@ -1,1 +1,4 @@
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.composer...} />` instead.
+ */
 export { ComposerPrimitiveIf as ComposerIf } from "@assistant-ui/core/react";

--- a/packages/react-ink/src/primitives/composer/ComposerIf.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerIf.tsx
@@ -1,4 +1,1 @@
-/**
- * @deprecated Use `<AuiIf condition={(s) => s.composer...} />` instead.
- */
 export { ComposerPrimitiveIf as ComposerIf } from "@assistant-ui/core/react";

--- a/packages/react-ink/src/primitives/loading/LoadingElapsedTime.tsx
+++ b/packages/react-ink/src/primitives/loading/LoadingElapsedTime.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, type ComponentProps } from "react";
 
 import { Text } from "ink";
-import { useThreadIsRunning } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 
 const defaultFormat = (seconds: number) => {
@@ -24,7 +23,7 @@ export const LoadingElapsedTime = ({
   format = defaultFormat,
   ...textProps
 }: LoadingElapsedTimeProps) => {
-  const isRunning = useThreadIsRunning();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
   const streamStartTime = useAuiState((s) => {
     const lastMessage = s.thread.messages.at(-1);
 

--- a/packages/react-ink/src/primitives/loading/LoadingRoot.tsx
+++ b/packages/react-ink/src/primitives/loading/LoadingRoot.tsx
@@ -1,13 +1,13 @@
 import type { ComponentProps, ReactNode } from "react";
 import { Box } from "ink";
-import { useThreadIsRunning } from "@assistant-ui/core/react";
+import { useAuiState } from "@assistant-ui/store";
 
 export type LoadingRootProps = ComponentProps<typeof Box> & {
   children: ReactNode;
 };
 
 export const LoadingRoot = ({ children, ...boxProps }: LoadingRootProps) => {
-  const isRunning = useThreadIsRunning();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
 
   if (!isRunning) return null;
 

--- a/packages/react-ink/src/primitives/message/MessageIf.tsx
+++ b/packages/react-ink/src/primitives/message/MessageIf.tsx
@@ -9,6 +9,9 @@ export type MessageIfProps = {
   last?: boolean | undefined;
 };
 
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.message...} />` instead.
+ */
 export const MessageIf = ({
   children,
   user,

--- a/packages/react-ink/src/primitives/thread/ThreadEmpty.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadEmpty.tsx
@@ -1,12 +1,13 @@
 import type { ReactNode } from "react";
-import { useThreadIsEmpty } from "@assistant-ui/core/react";
+import { AuiIf } from "@assistant-ui/store";
 
 export type ThreadEmptyProps = {
   children: ReactNode;
 };
 
-export const ThreadEmpty = ({ children }: ThreadEmptyProps) => {
-  const isEmpty = useThreadIsEmpty();
-  if (!isEmpty) return null;
-  return <>{children}</>;
-};
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.thread.isEmpty} />` instead.
+ */
+export const ThreadEmpty = ({ children }: ThreadEmptyProps) => (
+  <AuiIf condition={(s) => s.thread.isEmpty}>{children}</AuiIf>
+);

--- a/packages/react-ink/src/primitives/thread/ThreadIf.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadIf.tsx
@@ -7,17 +7,14 @@ export type ThreadIfProps = {
   running?: boolean | undefined;
 };
 
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.thread...} />` instead.
+ */
 export const ThreadIf = ({ children, empty, running }: ThreadIfProps) => {
   const thread = useAuiState((s) => s.thread);
 
-  if (empty !== undefined) {
-    const isEmpty = thread.messages.length === 0;
-    if (empty !== isEmpty) return null;
-  }
-
-  if (running !== undefined) {
-    if (running !== thread.isRunning) return null;
-  }
+  if (empty !== undefined && empty !== thread.isEmpty) return null;
+  if (running !== undefined && running !== thread.isRunning) return null;
 
   return <>{children}</>;
 };

--- a/packages/react-native/src/primitives/composer/ComposerIf.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerIf.tsx
@@ -1,1 +1,4 @@
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.composer...} />` instead.
+ */
 export { ComposerPrimitiveIf as ComposerIf } from "@assistant-ui/core/react";

--- a/packages/react-native/src/primitives/composer/ComposerIf.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerIf.tsx
@@ -1,4 +1,1 @@
-/**
- * @deprecated Use `<AuiIf condition={(s) => s.composer...} />` instead.
- */
 export { ComposerPrimitiveIf as ComposerIf } from "@assistant-ui/core/react";

--- a/packages/react-native/src/primitives/message/MessageIf.tsx
+++ b/packages/react-native/src/primitives/message/MessageIf.tsx
@@ -9,6 +9,9 @@ export type MessageIfProps = {
   last?: boolean | undefined;
 };
 
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.message...} />` instead.
+ */
 export const MessageIf = ({
   children,
   user,

--- a/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Text } from "react-native";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as Store from "@assistant-ui/store";
 import { ThreadEmpty } from "./ThreadEmpty";
 
 const h = vi.hoisted(() => ({
@@ -11,15 +12,19 @@ const h = vi.hoisted(() => ({
 
 type ThreadSlice = { thread: { isEmpty: boolean } };
 
-vi.mock("@assistant-ui/store", () => ({
-  AuiIf: ({
-    condition,
-    children,
-  }: {
-    condition: (s: ThreadSlice) => boolean;
-    children: ReactNode;
-  }) => (condition({ thread: { isEmpty: h.isEmpty } }) ? children : null),
-}));
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof Store>();
+  return {
+    ...actual,
+    AuiIf: ({
+      condition,
+      children,
+    }: {
+      condition: (s: ThreadSlice) => boolean;
+      children: ReactNode;
+    }) => (condition({ thread: { isEmpty: h.isEmpty } }) ? children : null),
+  };
+});
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadEmpty.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Text } from "react-native";
@@ -8,8 +9,16 @@ const h = vi.hoisted(() => ({
   isEmpty: true,
 }));
 
-vi.mock("@assistant-ui/core/react", () => ({
-  useThreadIsEmpty: () => h.isEmpty,
+type ThreadSlice = { thread: { isEmpty: boolean } };
+
+vi.mock("@assistant-ui/store", () => ({
+  AuiIf: ({
+    condition,
+    children,
+  }: {
+    condition: (s: ThreadSlice) => boolean;
+    children: ReactNode;
+  }) => (condition({ thread: { isEmpty: h.isEmpty } }) ? children : null),
 }));
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/react-native/src/primitives/thread/ThreadEmpty.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadEmpty.tsx
@@ -1,12 +1,13 @@
 import type { ReactNode } from "react";
-import { useThreadIsEmpty } from "@assistant-ui/core/react";
+import { AuiIf } from "@assistant-ui/store";
 
 export type ThreadEmptyProps = {
   children: ReactNode;
 };
 
-export const ThreadEmpty = ({ children }: ThreadEmptyProps) => {
-  const isEmpty = useThreadIsEmpty();
-  if (!isEmpty) return null;
-  return <>{children}</>;
-};
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.thread.isEmpty} />` instead.
+ */
+export const ThreadEmpty = ({ children }: ThreadEmptyProps) => (
+  <AuiIf condition={(s) => s.thread.isEmpty}>{children}</AuiIf>
+);

--- a/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
@@ -2,16 +2,21 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Text } from "react-native";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as Store from "@assistant-ui/store";
 import { ThreadIf } from "./ThreadIf";
 
 const h = vi.hoisted(() => ({
   thread: { isEmpty: true, isRunning: false },
 }));
 
-vi.mock("@assistant-ui/store", () => ({
-  useAuiState: <T,>(selector: (s: { thread: typeof h.thread }) => T) =>
-    selector({ thread: h.thread }),
-}));
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof Store>();
+  return {
+    ...actual,
+    useAuiState: <T,>(selector: (s: { thread: typeof h.thread }) => T) =>
+      selector({ thread: h.thread }),
+  };
+});
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadIf.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThreadIf } from "./ThreadIf";
 
 const h = vi.hoisted(() => ({
-  thread: { messages: [] as unknown[], isRunning: false },
+  thread: { isEmpty: true, isRunning: false },
 }));
 
 vi.mock("@assistant-ui/store", () => ({
@@ -18,9 +18,8 @@ vi.mock("@assistant-ui/store", () => ({
 describe("ThreadIf", () => {
   let container: HTMLDivElement;
   let root: Root;
-
   beforeEach(() => {
-    h.thread.messages = [];
+    h.thread.isEmpty = true;
     h.thread.isRunning = false;
 
     container = document.createElement("div");
@@ -46,33 +45,29 @@ describe("ThreadIf", () => {
     return container.querySelector('[data-testid="child"]');
   };
 
-  const setMessages = (count: number) => {
-    h.thread.messages = Array.from({ length: count }, (_, i) => i);
-  };
-
   it("renders children when no guard is set", async () => {
-    setMessages(2);
+    h.thread.isEmpty = false;
     expect(await mount()).not.toBeNull();
   });
 
   describe("empty guard", () => {
     it("renders children when empty:true matches an empty thread", async () => {
-      setMessages(0);
+      h.thread.isEmpty = true;
       expect(await mount({ empty: true })).not.toBeNull();
     });
 
-    it("hides children when empty:true but the thread has messages", async () => {
-      setMessages(3);
+    it("hides children when empty:true but the thread is not empty", async () => {
+      h.thread.isEmpty = false;
       expect(await mount({ empty: true })).toBeNull();
     });
 
     it("renders children when empty:false matches a non-empty thread", async () => {
-      setMessages(3);
+      h.thread.isEmpty = false;
       expect(await mount({ empty: false })).not.toBeNull();
     });
 
     it("hides children when empty:false but the thread is empty", async () => {
-      setMessages(0);
+      h.thread.isEmpty = true;
       expect(await mount({ empty: false })).toBeNull();
     });
   });
@@ -101,19 +96,19 @@ describe("ThreadIf", () => {
 
   describe("combined guards", () => {
     it("renders children only when both empty and running match", async () => {
-      setMessages(0);
+      h.thread.isEmpty = true;
       h.thread.isRunning = true;
       expect(await mount({ empty: true, running: true })).not.toBeNull();
     });
 
     it("hides children when empty matches but running does not", async () => {
-      setMessages(0);
+      h.thread.isEmpty = true;
       h.thread.isRunning = false;
       expect(await mount({ empty: true, running: true })).toBeNull();
     });
 
     it("hides children when running matches but empty does not", async () => {
-      setMessages(2);
+      h.thread.isEmpty = false;
       h.thread.isRunning = true;
       expect(await mount({ empty: true, running: true })).toBeNull();
     });

--- a/packages/react-native/src/primitives/thread/ThreadIf.tsx
+++ b/packages/react-native/src/primitives/thread/ThreadIf.tsx
@@ -7,17 +7,14 @@ export type ThreadIfProps = {
   running?: boolean | undefined;
 };
 
+/**
+ * @deprecated Use `<AuiIf condition={(s) => s.thread...} />` instead.
+ */
 export const ThreadIf = ({ children, empty, running }: ThreadIfProps) => {
   const thread = useAuiState((s) => s.thread);
 
-  if (empty !== undefined) {
-    const isEmpty = thread.messages.length === 0;
-    if (empty !== isEmpty) return null;
-  }
-
-  if (running !== undefined) {
-    if (running !== thread.isRunning) return null;
-  }
+  if (empty !== undefined && empty !== thread.isEmpty) return null;
+  if (running !== undefined && running !== thread.isRunning) return null;
 
   return <>{children}</>;
 };

--- a/packages/react/src/primitives/branchPicker/BranchPickerRoot.tsx
+++ b/packages/react/src/primitives/branchPicker/BranchPickerRoot.tsx
@@ -6,7 +6,7 @@ import {
   forwardRef,
   type ComponentPropsWithoutRef,
 } from "react";
-import { MessagePrimitiveIf as If } from "../message/MessageIf";
+import { AuiIf } from "@assistant-ui/store";
 
 export namespace BranchPickerPrimitiveRoot {
   export type Element = ComponentRef<typeof Primitive.div>;
@@ -42,9 +42,11 @@ export const BranchPickerPrimitiveRoot = forwardRef<
   BranchPickerPrimitiveRoot.Props
 >(({ hideWhenSingleBranch, ...rest }, ref) => {
   return (
-    <If hasBranches={hideWhenSingleBranch ? true : undefined}>
+    <AuiIf
+      condition={(s) => !hideWhenSingleBranch || s.message.branchCount >= 2}
+    >
       <Primitive.div {...rest} ref={ref} />
-    </If>
+    </AuiIf>
   );
 });
 

--- a/packages/react/src/primitives/composer/ComposerDictationTranscript.tsx
+++ b/packages/react/src/primitives/composer/ComposerDictationTranscript.tsx
@@ -21,11 +21,11 @@ export namespace ComposerPrimitiveDictationTranscript {
  *
  * @example
  * ```tsx
- * <ComposerPrimitive.If dictation>
+ * <AuiIf condition={(s) => s.composer.dictation != null}>
  *   <div className="dictation-preview">
  *     <ComposerPrimitive.DictationTranscript />
  *   </div>
- * </ComposerPrimitive.If>
+ * </AuiIf>
  * ```
  */
 export const ComposerPrimitiveDictationTranscript = forwardRef<


### PR DESCRIPTION
## summary

- leftover `ThreadIf` on react-native and react-ink treated emptiness as `messages.length === 0`, so a loading thread still rendered empty UI
- it now reads `thread.isEmpty`; published If/Empty wrappers and the one-line hooks are marked deprecated in favor of `AuiIf`
- first-party examples and docs samples now call `AuiIf` directly

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-native exec vitest run src/primitives/thread/ThreadIf.test.tsx src/primitives/thread/ThreadEmpty.test.tsx` -> 14/14 green
- [x] `pnpm --filter @assistant-ui/core exec vitest run src/tests/external-thread-isEmpty.test.tsx` -> 6/6 green

### reviewer should verify

- [ ] start a thread with `isLoading: true` and no messages; leftover `ThreadIf empty` / `AuiIf` on `s.thread.isEmpty` should stay hidden until loading finishes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.KVE1AhZNcIRMYPmRRr74y6_09_O9-lpvNbGeLwoaSQ_oAGMQ7nxUGKUcoeI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->