### PR TITLE
fix(markdown): require equal-length inline backtick closers

### DIFF
--- a/.changeset/equal-inline-backtick-runs.md
+++ b/.changeset/equal-inline-backtick-runs.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: preserve currency inside one- and two-backtick code spans that contain longer backtick runs

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -135,9 +135,19 @@ describe("escapeCurrencyDollars", () => {
     ).toBe("Use ``value ````` costs $5 `` after \\$7");
   });
 
+  it("escapes currency after an inline opener with no equal-length closer", () => {
+    expect(escapeCurrencyDollars("`a ``b`` $5")).toBe("`a ``b`` \\$5");
+  });
+
   it("does not rewrite a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
       "```\nconst price = $5;\n```",
+    );
+  });
+
+  it("accepts a longer closing run for a fenced block", () => {
+    expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
+      "```\nconst price = $5;\n````",
     );
   });
 

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -126,6 +126,15 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not close one- or two-backtick code spans on a longer run", () => {
+    expect(escapeCurrencyDollars("`value ``` costs $5 ` after $7")).toBe(
+      "`value ``` costs $5 ` after \\$7",
+    );
+    expect(
+      escapeCurrencyDollars("Use ``value ````` costs $5 `` after $7"),
+    ).toBe("Use ``value ````` costs $5 `` after \\$7");
+  });
+
   it("does not rewrite a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
       "```\nconst price = $5;\n```",

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -72,9 +72,17 @@ function runLength(text: string, start: number, char: string): number {
  * text.
  */
 function codeSpanEnd(text: string, start: number): number {
-  const fence = "`".repeat(runLength(text, start, "`"));
-  const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? -1 : closed + fence.length;
+  const delimiterLength = runLength(text, start, "`");
+  const delimiter = "`".repeat(delimiterLength);
+  let closed = text.indexOf(delimiter, start + delimiterLength);
+
+  while (delimiterLength < 3 && closed !== -1) {
+    const closedLength = runLength(text, closed, "`");
+    if (closedLength === delimiterLength) break;
+    closed = text.indexOf(delimiter, closed + closedLength);
+  }
+
+  return closed === -1 ? -1 : closed + delimiterLength;
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -76,6 +76,7 @@ function codeSpanEnd(text: string, start: number): number {
   const delimiter = "`".repeat(delimiterLength);
   let closed = text.indexOf(delimiter, start + delimiterLength);
 
+  // Fences may close on a longer run; one- and two-backtick inline spans may not.
   while (delimiterLength < 3 && closed !== -1) {
     const closedLength = runLength(text, closed, "`");
     if (closedLength === delimiterLength) break;

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -135,9 +135,19 @@ describe("escapeCurrencyDollars", () => {
     ).toBe("Use ``value ````` costs $5 `` after \\$7");
   });
 
+  it("escapes currency after an inline opener with no equal-length closer", () => {
+    expect(escapeCurrencyDollars("`a ``b`` $5")).toBe("`a ``b`` \\$5");
+  });
+
   it("does not rewrite a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
       "```\nconst price = $5;\n```",
+    );
+  });
+
+  it("accepts a longer closing run for a fenced block", () => {
+    expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
+      "```\nconst price = $5;\n````",
     );
   });
 

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -126,6 +126,15 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("does not close one- or two-backtick code spans on a longer run", () => {
+    expect(escapeCurrencyDollars("`value ``` costs $5 ` after $7")).toBe(
+      "`value ``` costs $5 ` after \\$7",
+    );
+    expect(
+      escapeCurrencyDollars("Use ``value ````` costs $5 `` after $7"),
+    ).toBe("Use ``value ````` costs $5 `` after \\$7");
+  });
+
   it("does not rewrite a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
       "```\nconst price = $5;\n```",

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -72,9 +72,17 @@ function runLength(text: string, start: number, char: string): number {
  * text.
  */
 function codeSpanEnd(text: string, start: number): number {
-  const fence = "`".repeat(runLength(text, start, "`"));
-  const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? -1 : closed + fence.length;
+  const delimiterLength = runLength(text, start, "`");
+  const delimiter = "`".repeat(delimiterLength);
+  let closed = text.indexOf(delimiter, start + delimiterLength);
+
+  while (delimiterLength < 3 && closed !== -1) {
+    const closedLength = runLength(text, closed, "`");
+    if (closedLength === delimiterLength) break;
+    closed = text.indexOf(delimiter, closed + closedLength);
+  }
+
+  return closed === -1 ? -1 : closed + delimiterLength;
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -76,6 +76,7 @@ function codeSpanEnd(text: string, start: number): number {
   const delimiter = "`".repeat(delimiterLength);
   let closed = text.indexOf(delimiter, start + delimiterLength);
 
+  // Fences may close on a longer run; one- and two-backtick inline spans may not.
   while (delimiterLength < 3 && closed !== -1) {
     const closedLength = runLength(text, closed, "`");
     if (closedLength === delimiterLength) break;


### PR DESCRIPTION
closes #6158

## summary

- preserve currency inside one- and two-backtick inline code spans when a longer backtick run appears before the actual closer
- skip only longer inline runs; keep the existing 3+ backtick fence heuristic unchanged in both markdown packages
- mirror the regression coverage across react-markdown and react-streamdown

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-markdown exec vitest run src/preprocess.test.ts` -> 30/30 green
- [x] `pnpm --filter @assistant-ui/react-streamdown exec vitest run src/__tests__/preprocess.test.ts` -> 30/30 green
- [x] oxfmt and oxlint on all four changed source/test files

### reviewer should verify

- [ ] run `escapeCurrencyDollars` on an inline span containing a longer backtick run; currency inside the span should stay unchanged while currency after its equal-length closer is escaped

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ONaPlPj17hJsAGhbERLCpt0PVAjeZL2vTPZLOMfY65UczjDY4k_kRO1-rRQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->