### PR TITLE
fix(with-expo): add button accessibility roles

### DIFF
--- a/examples/with-expo/app/_layout.tsx
+++ b/examples/with-expo/app/_layout.tsx
@@ -32,6 +32,7 @@ function NewChatButton() {
   return (
     <Pressable
       accessibilityLabel="New chat"
+      accessibilityRole="button"
       hitSlop={8}
       onPress={() => {
         haptics.selection();

--- a/examples/with-expo/components/assistant-ui/composer.tsx
+++ b/examples/with-expo/components/assistant-ui/composer.tsx
@@ -109,6 +109,7 @@ function AttachButton() {
   return (
     <Pressable
       accessibilityLabel="Add image"
+      accessibilityRole="button"
       onPress={pickImage}
       hitSlop={6}
       style={({ pressed }) => [

--- a/examples/with-expo/components/thread-list/ThreadListDrawer.tsx
+++ b/examples/with-expo/components/thread-list/ThreadListDrawer.tsx
@@ -22,6 +22,7 @@ export function ThreadListDrawer({ navigation }: DrawerContentComponentProps) {
     >
       <ThreadListPrimitive.Root style={styles.root}>
         <Pressable
+          accessibilityRole="button"
           onPressIn={haptics.selection}
           onPress={() => {
             aui.threads.switchToNewThread();

--- a/examples/with-expo/components/thread-list/ThreadListItem.tsx
+++ b/examples/with-expo/components/thread-list/ThreadListItem.tsx
@@ -18,6 +18,7 @@ export function ThreadListItem({ onSelect }: { onSelect: () => void }) {
   return (
     <ThreadListItemPrimitive.Root>
       <Pressable
+        accessibilityRole="button"
         onPressIn={haptics.selection}
         onPress={() => {
           aui.threadListItem.switchTo();


### PR DESCRIPTION
## Summary

- mark the four hand-rolled `Pressable` controls in `with-expo` as buttons
- preserve their existing labels, handlers, haptics, navigation, and styles
- improve VoiceOver and TalkBack semantics for the affected controls

## Testing

- `oxfmt --check` on the four changed files
- `oxlint` on the four changed files
- `turbo build --filter=with-expo...` — 11/11 tasks passed
- `tsc --noEmit` — changed files pass; the full example still reports two existing errors in `hooks/anonymous-session-fetch.test.ts`

Closes #6127

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Z9vk9tyErOJgiKmssU6EuFFBlG4ubxLVH7YdOxtfRDyKSwLDgkIw6TCtQy8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->