### PR TITLE
fix(react-devtools): contain failed conversation switches

### DIFF
--- a/.changeset/devtools-client-switch-errors.md
+++ b/.changeset/devtools-client-switch-errors.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: contain failed DevTools conversation switches
+
+Custom `DevToolsClient.switchToThread` implementations can reject. React does not observe promises returned from click handlers, so a rejection becomes an unhandledRejection. `useDevToolsClient` now consumes both synchronous throws and rejected promises at the client boundary, matching `createInProcessClient`.

--- a/packages/react-devtools/src/data/useDevToolsClient.test.ts
+++ b/packages/react-devtools/src/data/useDevToolsClient.test.ts
@@ -1,0 +1,97 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { EMPTY_SNAPSHOT, type DevToolsClient } from "./types";
+import {
+  useDevToolsClient,
+  type DevToolsClientResult,
+} from "./useDevToolsClient";
+
+const fixtureClient = (
+  switchToThread?: DevToolsClient["switchToThread"],
+): DevToolsClient => {
+  const client: DevToolsClient = {
+    subscribe: () => () => {},
+    getSnapshot: () => EMPTY_SNAPSHOT,
+    clearEvents: () => {},
+  };
+  if (switchToThread) client.switchToThread = switchToThread;
+  return client;
+};
+
+const hookResult = (client: DevToolsClient): DevToolsClientResult => {
+  let result: DevToolsClientResult | undefined;
+  const Probe = () => {
+    result = useDevToolsClient(1, client);
+    return null;
+  };
+  renderToStaticMarkup(createElement(Probe));
+  if (result === undefined) {
+    throw new Error("expected useDevToolsClient to render");
+  }
+  return result;
+};
+
+const captureUnhandledRejections = async (run: () => void) => {
+  const rejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    rejections.push(reason);
+  };
+  const priorListeners = process.listeners("unhandledRejection");
+  process.removeAllListeners("unhandledRejection");
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    run();
+    // Node emits unhandledRejection on a later event-loop turn; fake timers cannot drive that.
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setImmediate(resolve);
+    await promise;
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandledRejection);
+    for (const listener of priorListeners) {
+      process.on("unhandledRejection", listener);
+    }
+  }
+  return rejections;
+};
+
+describe("useDevToolsClient switchToThread", () => {
+  it("forwards a successful switch", async () => {
+    const switchToThread = vi.fn(async () => {});
+    const run = hookResult(fixtureClient(switchToThread)).switchToThread;
+
+    await expect(run(1, "thread-1")).resolves.toBeUndefined();
+    expect(switchToThread).toHaveBeenCalledWith(1, "thread-1");
+  });
+
+  it("contains a synchronous client throw", () => {
+    const run = hookResult(
+      fixtureClient(() => {
+        throw new Error("failed");
+      }),
+    ).switchToThread;
+
+    expect(() => run(1, "thread-1")).not.toThrow();
+  });
+
+  it("does not leak a rejected switch as an unhandled rejection", async () => {
+    const error = new Error("failed");
+    const run = hookResult(
+      fixtureClient(() => Promise.reject(error)),
+    ).switchToThread;
+
+    const rejections = await captureUnhandledRejections(() => {
+      void run(1, "thread-1");
+    });
+
+    expect(rejections).toEqual([]);
+  });
+
+  it("lets an ignored rejected switch settle", async () => {
+    const run = hookResult(
+      fixtureClient(() => Promise.reject(new Error("failed"))),
+    ).switchToThread;
+
+    await expect(run(1, "thread-1")).resolves.toBeUndefined();
+  });
+});

--- a/packages/react-devtools/src/data/useDevToolsClient.ts
+++ b/packages/react-devtools/src/data/useDevToolsClient.ts
@@ -48,8 +48,13 @@ export const useDevToolsClient = (
 
   const switchToThread = useCallback(
     (apiId: number, threadId: string) => {
-      if (client.switchToThread) {
-        return client.switchToThread(apiId, threadId);
+      if (!client.switchToThread) return;
+      try {
+        return Promise.resolve(client.switchToThread(apiId, threadId)).catch(
+          () => {},
+        );
+      } catch {
+        return;
       }
     },
     [client],


### PR DESCRIPTION
## summary

- contain rejected custom `DevToolsClient.switchToThread` calls at `useDevToolsClient`, so load conversation and plugin tabs do not leak an unhandledRejection
- match `createInProcessClient`: swallow both sync throws and rejected promises at the client boundary
- supersedes #6141, which only wrapped the load conversation button

## test plan

### already verified

- [x] `vitest run` in `@assistant-ui/react-devtools` -> 113/113 green, including unhandledRejection and sync throw coverage on `useDevToolsClient`

### reviewer should verify

- [ ] click load conversation with a custom client whose `switchToThread` rejects; the panel stays up and the process does not report an unhandledRejection

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CJW67T-POnJRZgZB7UDggts1TWB3Oel-xwXTfsbFG_X_1uRD_KVlpb6dbKc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->