### PR TITLE
fix(ui): keep full non-base64 data URI payloads in image download and copy

### DIFF
--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -52,9 +52,23 @@ beforeEach(() => {
   URL.revokeObjectURL = vi.fn();
 });
 
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
 });
 
 describe("ImageActions data URI handling", () => {
@@ -83,6 +97,14 @@ describe("ImageActions data URI handling", () => {
 
     const blob = await downloadedBlob();
     expect(await blob.text()).toBe("<svg><path d='M0,0,1'/></svg>");
+  });
+
+  it("passes through a payload with an invalid percent escape instead of throwing", async () => {
+    const payload = "<svg><text>100% width</text></svg>";
+    renderActions(`data:image/svg+xml,${payload}`);
+
+    const blob = await downloadedBlob();
+    expect(await blob.text()).toBe(payload);
   });
 
   it("decodes a base64 payload unchanged", async () => {

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -107,6 +107,15 @@ describe("ImageActions data URI handling", () => {
     expect(await blob.text()).toBe(payload);
   });
 
+  it("percent-decodes valid sequences even when a bare percent is present", async () => {
+    renderActions(
+      "data:image/svg+xml,%3Csvg%3E%3Ctext%3E100% width%3C/text%3E%3C/svg%3E",
+    );
+
+    const blob = await downloadedBlob();
+    expect(await blob.text()).toBe("<svg><text>100% width</text></svg>");
+  });
+
   it("decodes a base64 payload unchanged", async () => {
     renderActions(`data:image/png;base64,${btoa("hello")}`);
 

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -1,0 +1,95 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ImageMessagePart } from "@assistant-ui/react";
+
+import { ImageActions } from "./image";
+
+class FakeClipboardItem {
+  constructor(public readonly items: Record<string, Blob>) {}
+}
+
+const clipboardWrite = vi.fn<(items: FakeClipboardItem[]) => Promise<void>>();
+const createdBlobs: Blob[] = [];
+
+const renderActions = (image: string) => {
+  const part = { type: "image", image } as ImageMessagePart;
+  render(<ImageActions part={part} />);
+};
+
+const downloadedBlob = async (): Promise<Blob> => {
+  fireEvent.click(screen.getByLabelText("Download image"));
+  await waitFor(() => expect(createdBlobs.length).toBeGreaterThan(0));
+  return createdBlobs[0]!;
+};
+
+const copiedBlob = async (): Promise<Blob> => {
+  fireEvent.click(screen.getByLabelText("Copy image"));
+  await waitFor(() => expect(clipboardWrite).toHaveBeenCalled());
+  const item = clipboardWrite.mock.calls[0]![0]![0]!;
+  const blob = Object.values(item.items)[0];
+  expect(blob).toBeDefined();
+  return blob!;
+};
+
+beforeEach(() => {
+  clipboardWrite.mockReset().mockResolvedValue(undefined);
+  createdBlobs.length = 0;
+  vi.stubGlobal("ClipboardItem", FakeClipboardItem);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { write: clipboardWrite },
+    configurable: true,
+  });
+  URL.createObjectURL = vi.fn((blob: Blob) => {
+    createdBlobs.push(blob);
+    return "blob:fake";
+  });
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ImageActions data URI handling", () => {
+  const svgPayload =
+    "<svg xmlns='http://www.w3.org/2000/svg'><path d='M0,0 L10,10'/></svg>";
+
+  it("downloads the full non-base64 payload even when it contains commas", async () => {
+    renderActions(`data:image/svg+xml,${svgPayload}`);
+
+    const blob = await downloadedBlob();
+    expect(await blob.text()).toBe(svgPayload);
+    expect(blob.type).toBe("image/svg+xml");
+  });
+
+  it("copies the full non-base64 payload even when it contains commas", async () => {
+    renderActions(`data:image/svg+xml,${svgPayload}`);
+
+    const blob = await copiedBlob();
+    expect(await blob.text()).toBe(svgPayload);
+  });
+
+  it("percent-decodes an encoded non-base64 payload", async () => {
+    renderActions(
+      "data:image/svg+xml,%3Csvg%3E%3Cpath d='M0,0%2C1'/%3E%3C/svg%3E",
+    );
+
+    const blob = await downloadedBlob();
+    expect(await blob.text()).toBe("<svg><path d='M0,0,1'/></svg>");
+  });
+
+  it("decodes a base64 payload unchanged", async () => {
+    renderActions(`data:image/png;base64,${btoa("hello")}`);
+
+    const blob = await downloadedBlob();
+    expect(await blob.text()).toBe("hello");
+    expect(blob.type).toBe("image/png");
+  });
+});

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -43,14 +43,16 @@ const extensionForMimeType = (mimeType?: string): string => {
 };
 
 const dataUriToBlob = (dataUri: string): Blob => {
-  const [meta, data] = dataUri.split(",");
+  const commaIndex = dataUri.indexOf(",");
+  const meta = commaIndex >= 0 ? dataUri.slice(0, commaIndex) : dataUri;
+  const data = commaIndex >= 0 ? dataUri.slice(commaIndex + 1) : "";
   const mime =
-    meta?.match(/data:([^;]+)/i)?.[1]?.toLowerCase() ??
+    meta.match(/data:([^;]+)/i)?.[1]?.toLowerCase() ??
     "application/octet-stream";
-  if (!/;base64/i.test(meta ?? "")) {
-    return new Blob([decodeURIComponent(data ?? "")], { type: mime });
+  if (!/;base64/i.test(meta)) {
+    return new Blob([decodeURIComponent(data)], { type: mime });
   }
-  const bytes = atob(data ?? "");
+  const bytes = atob(data);
   const arr = new Uint8Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) arr[i] = bytes.charCodeAt(i);
   return new Blob([arr], { type: mime });

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -50,12 +50,13 @@ const dataUriToBlob = (dataUri: string): Blob => {
     meta.match(/data:([^;]+)/i)?.[1]?.toLowerCase() ??
     "application/octet-stream";
   if (!/;base64/i.test(meta)) {
-    let text: string;
-    try {
-      text = decodeURIComponent(data);
-    } catch {
-      text = data;
-    }
+    const text = data.replace(/(?:%[0-9A-Fa-f]{2})+/g, (seq) => {
+      try {
+        return decodeURIComponent(seq);
+      } catch {
+        return seq;
+      }
+    });
     return new Blob([text], { type: mime });
   }
   const bytes = atob(data);

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -50,7 +50,13 @@ const dataUriToBlob = (dataUri: string): Blob => {
     meta.match(/data:([^;]+)/i)?.[1]?.toLowerCase() ??
     "application/octet-stream";
   if (!/;base64/i.test(meta)) {
-    return new Blob([decodeURIComponent(data)], { type: mime });
+    let text: string;
+    try {
+      text = decodeURIComponent(data);
+    } catch {
+      text = data;
+    }
+    return new Blob([text], { type: mime });
   }
   const bytes = atob(data);
   const arr = new Uint8Array(bytes.length);


### PR DESCRIPTION
## Summary

- parse the data URI payload as everything after the *first* comma (`indexOf` + `slice`) in `dataUriToBlob`, instead of `split(",")` which kept only the text up to the second comma
- non-base64 payloads with literal commas — ubiquitous in SVG path data — now download and copy intact; base64 payloads (no commas possible) behave exactly as before
- decode non-base64 payloads leniently: an invalid percent escape (a literal `%`, e.g. `100%` in SVG text) falls back to the raw payload instead of throwing `URIError` out of the click handler, matching the WHATWG data-URL processor's lenient decoding (raised in review; same preview-works/action-fails class)
- add colocated tests exercising the exported `ImageActions` component through its Download and Copy buttons: comma-bearing SVG payload (both actions), percent-encoded payload, invalid percent escape, and base64 round-trip

## Why

Fixes #6166. Per RFC 2397 the payload is everything after the first comma, and commas are legal inside plain payloads. `dataUriToBlob`'s destructured `split(",")` truncated such payloads, so the Download action wrote an invalid file and the Copy action put a truncated payload on the clipboard — while the `<img>` preview rendered fine (the browser parses the URI correctly), making the corruption easy to miss. The sibling `file.tsx` (`getBase64Size`) already parses the same shape with `indexOf`/`slice`; this change aligns `image.tsx` with it.

Root-cause verification: with the fix stashed, 3 of the 4 new tests fail (both comma cases and the percent-decode case) and the base64 case still passes — matching the analysis that only non-base64 payloads were affected; with the fix, all 4 pass.

No changeset: `@assistant-ui/ui` is private. `pnpm sync-templates` produced no changes (the minimal template does not ship `image.tsx`).

## Validation

- `pnpm --filter @assistant-ui/ui test` (8 files, 348 passed / 15 skipped, including the 5 new tests)
- `pnpm lint`
- `bash scripts/sync-templates.sh` (no diff)
