### PR TITLE
fix(tap): flush updates dispatched from notifies during flushTapSync

### DIFF
--- a/.changeset/tap-flush-sync-notify-updates.md
+++ b/.changeset/tap-flush-sync-notify-updates.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: flush state updates dispatched from subscriber notifications during flushTapSync

--- a/packages/tap/src/__tests__/scheduler.notify.test.ts
+++ b/packages/tap/src/__tests__/scheduler.notify.test.ts
@@ -3,6 +3,7 @@ import {
   UpdateScheduler,
   flushTapSync,
   scheduleNotify,
+  scheduleTask,
 } from "../core/scheduler";
 
 describe("scheduleNotify", () => {
@@ -69,5 +70,49 @@ describe("scheduleNotify", () => {
     expect(
       (caught as AggregateError).errors.map((e) => (e as Error).message),
     ).toEqual(["task-boom", "notify-boom"]);
+  });
+});
+
+describe("updates dispatched from notifications", () => {
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+  it("flushes a markDirty dispatched from a macrotask-flush notification", async () => {
+    const events: string[] = [];
+    const follower = new UpdateScheduler(() => events.push("follower ran"));
+    const notifier = new UpdateScheduler(() =>
+      scheduleNotify(() => follower.markDirty()),
+    );
+
+    notifier.markDirty();
+    await tick();
+
+    expect(events).toEqual(["follower ran"]);
+    expect(follower.isDirty).toBe(false);
+  });
+
+  it("flushes a markDirty dispatched from a flushTapSync notification", async () => {
+    const events: string[] = [];
+    const follower = new UpdateScheduler(() => events.push("follower ran"));
+    const notifier = new UpdateScheduler(() =>
+      scheduleNotify(() => follower.markDirty()),
+    );
+
+    flushTapSync(() => notifier.markDirty());
+    await tick();
+
+    expect(events).toEqual(["follower ran"]);
+    expect(follower.isDirty).toBe(false);
+  });
+
+  it("runs a task scheduled from a flushTapSync notification", async () => {
+    const events: string[] = [];
+    const notifier = new UpdateScheduler(() =>
+      scheduleNotify(() => scheduleTask(() => events.push("task ran"))),
+    );
+
+    flushTapSync(() => notifier.markDirty());
+    await tick();
+
+    expect(events).toEqual(["task ran"]);
   });
 });

--- a/packages/tap/src/__tests__/scheduler.notify.test.ts
+++ b/packages/tap/src/__tests__/scheduler.notify.test.ts
@@ -5,6 +5,7 @@ import {
   scheduleNotify,
   scheduleTask,
 } from "../core/scheduler";
+import { waitForNextTick } from "./test-utils";
 
 describe("scheduleNotify", () => {
   it("delivers queued notifications when another drain task throws", () => {
@@ -74,8 +75,6 @@ describe("scheduleNotify", () => {
 });
 
 describe("updates dispatched from notifications", () => {
-  const tick = () => new Promise((resolve) => setTimeout(resolve, 20));
-
   it("flushes a markDirty dispatched from a macrotask-flush notification", async () => {
     const events: string[] = [];
     const follower = new UpdateScheduler(() => events.push("follower ran"));
@@ -84,7 +83,7 @@ describe("updates dispatched from notifications", () => {
     );
 
     notifier.markDirty();
-    await tick();
+    await waitForNextTick();
 
     expect(events).toEqual(["follower ran"]);
     expect(follower.isDirty).toBe(false);
@@ -98,7 +97,7 @@ describe("updates dispatched from notifications", () => {
     );
 
     flushTapSync(() => notifier.markDirty());
-    await tick();
+    await waitForNextTick();
 
     expect(events).toEqual(["follower ran"]);
     expect(follower.isDirty).toBe(false);
@@ -111,8 +110,26 @@ describe("updates dispatched from notifications", () => {
     );
 
     flushTapSync(() => notifier.markDirty());
-    await tick();
+    await waitForNextTick();
 
     expect(events).toEqual(["task ran"]);
+  });
+
+  it("flushes an update marked before the flushTapSync callback threw", async () => {
+    const events: string[] = [];
+    const scheduler = new UpdateScheduler(() => events.push("ran"));
+
+    expect(() =>
+      flushTapSync(() => {
+        scheduler.markDirty();
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(events).toEqual([]);
+    await waitForNextTick();
+
+    expect(events).toEqual(["ran"]);
+    expect(scheduler.isDirty).toBe(false);
   });
 });

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -177,6 +177,14 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
     return value;
   } finally {
+    // The notify drain at the end of flushScheduled runs while flushState
+    // still points at the temporary state, so a markDirty from a notify
+    // lands there. Hand that work to the restored state or it is lost.
+    const stranded = flushState.schedulers;
     flushState = prev;
+    if (stranded.size > 0) {
+      for (const scheduler of stranded) flushState.schedulers.add(scheduler);
+      scheduleFlush();
+    }
   }
 };


### PR DESCRIPTION
## Summary

- in `flushTapSync`'s `finally`, hand any schedulers left in the temporary flush state over to the restored global state and schedule a flush, instead of discarding them
- a `markDirty` (or `scheduleTask`, via the shared task scheduler) dispatched from a subscriber notification during a sync flush now lands on the next macrotask flush — exactly as it does when the same sequence runs through the normal macrotask path
- the normal sync drain is unchanged, and the stray macrotask the temporary state scheduled degrades to a no-op (the drain dirty-checks every scheduler)
- one additional deliberate behavior change (raised in review): marks made before a *throwing* callback were previously stranded with the scheduler wedged dirty; they now flush on the next macrotask, consistent with how a pre-throw `setState` behaves in React — covered by its own regression test

### Semantics: why defer rather than re-drain synchronously

`flushTapSync`'s documented contract — updates flushed synchronously, state readable immediately after — covers updates dispatched **by the callback**, and those still drain synchronously; `createAssistantClient`'s wrap keeps its guarantee, since its callback *is* the notify delivery, so rebinds dispatched during subscriber calls land before it returns. The rescued window is one generation later: an update dispatched from a notification that was *deferred during the drain*. Those land on the next flush on every other delivery path, so macrotask-parity is the coherent semantic. The alternative — re-draining until quiescent — would grant notification listeners a stronger guarantee than they have anywhere else, and a notify→markDirty→notify cycle that today harmlessly ping-pongs macrotasks would become a synchronous hang without a new cross-drain depth guard.

## Why

Fixes #6170. `flushScheduled`'s notify drain runs while `flushState` still points at `flushTapSync`'s temporary state (the restore in `flushTapSync`'s `finally` has not happened yet), so a state update dispatched from a notification is marked into a set that is about to be discarded. The scheduled macrotask then fires against the restored (empty) global state: the update never applies and the scheduler stays wedged dirty until an unrelated dispatch rescues it.

This is a live first-party path: `createAssistantClient` delivers every store notification inside `flushTapSync` (`packages/store/src/createAssistantClient.ts:183`), so any listener that imperatively updates client state in response to a store event sits in the lost-update window.

Root-cause verification: the two new `flushTapSync` regression tests fail on main (`follower` never runs, `isDirty` stuck true) and pass with the fix; the macrotask-path control passes on both, isolating the temporary-state discard as the cause.

## Validation

- `pnpm --filter @assistant-ui/tap test` (51 files, 579 tests; includes 4 new regression tests: macrotask control, notify-dispatched `markDirty` under `flushTapSync`, `scheduleTask` from a notify under `flushTapSync`, and pre-throw marks flushing after a throwing callback — all sequenced with the suite's `waitForNextTick` helper)
- `pnpm --filter @assistant-ui/store test` (24 files, 184 tests — the store is the main consumer of this path)
- `pnpm turbo build --filter=@assistant-ui/tap`
- `pnpm lint`
- changeset: patch for `@assistant-ui/tap`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qQXFALIUoJWKabXNU_PD_pxQF9jKQHmiFUYkNY2IuGYOEyjmEGNJqC5zkA4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->