### PR TITLE
fix(core): derive stable fallback ids for id-less converted messages

### DIFF
--- a/.changeset/external-store-stable-fallback-ids.md
+++ b/.changeset/external-store-stable-fallback-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep prepended history messages when convertMessage returns no id

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -139,8 +139,11 @@ export class ExternalStoreThreadRuntimeCore
   // Fallback ids must be stable per store message, not positional: a cached
   // conversion keeps the id it was created with, so an index-derived id
   // collides with fresh conversions once the list shifts (e.g. prepending
-  // older history), and the duplicate sweep would drop a real message.
+  // older history), and the duplicate sweep would drop a real message. The
+  // ids come from a counter rather than generateId so a server render and
+  // its hydration pass assign identical ids.
   private _fallbackIds = new WeakMap<WeakKey, string>();
+  private _nextFallbackId = 0;
 
   private _store!: ExternalStoreAdapter<any>;
 
@@ -302,7 +305,7 @@ export class ExternalStoreThreadRuntimeCore
 
             let fallbackId = this._fallbackIds.get(m);
             if (fallbackId === undefined) {
-              fallbackId = generateId();
+              fallbackId = (this._nextFallbackId++).toString();
               this._fallbackIds.set(m, fallbackId);
             }
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -141,7 +141,8 @@ export class ExternalStoreThreadRuntimeCore
   // collides with fresh conversions once the list shifts (e.g. prepending
   // older history), and the duplicate sweep would drop a real message. The
   // ids come from a counter rather than generateId so a server render and
-  // its hydration pass assign identical ids.
+  // its hydration pass assign identical ids, and carry a reserved prefix so
+  // they cannot collide with an explicit host id.
   private _fallbackIds = new WeakMap<WeakKey, string>();
   private _nextFallbackId = 0;
 
@@ -305,7 +306,7 @@ export class ExternalStoreThreadRuntimeCore
 
             let fallbackId = this._fallbackIds.get(m);
             if (fallbackId === undefined) {
-              fallbackId = (this._nextFallbackId++).toString();
+              fallbackId = `__external_store_fallback_${this._nextFallbackId++}`;
               this._fallbackIds.set(m, fallbackId);
             }
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -136,6 +136,12 @@ export class ExternalStoreThreadRuntimeCore
 
   private _converter = new ThreadMessageConverter();
 
+  // Fallback ids must be stable per store message, not positional: a cached
+  // conversion keeps the id it was created with, so an index-derived id
+  // collides with fresh conversions once the list shifts (e.g. prepending
+  // older history), and the duplicate sweep would drop a real message.
+  private _fallbackIds = new WeakMap<WeakKey, string>();
+
   private _store!: ExternalStoreAdapter<any>;
 
   private _getInitializePromise?: () => Promise<unknown> | undefined;
@@ -294,10 +300,16 @@ export class ExternalStoreThreadRuntimeCore
             )
               return cache;
 
+            let fallbackId = this._fallbackIds.get(m);
+            if (fallbackId === undefined) {
+              fallbackId = generateId();
+              this._fallbackIds.set(m, fallbackId);
+            }
+
             const messageLike = store.convertMessage(m, idx);
             const newMessage = fromThreadMessageLike(
               messageLike,
-              idx.toString(),
+              fallbackId,
               autoStatus,
             );
             bindExternalStoreMessage(newMessage, m);

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1210,20 +1210,40 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
   });
 
   it("assigns identical fallback ids across separate core instances", () => {
-    const m1 = { text: "one" };
-    const m2 = { role: "assistant" as const, text: "two" };
+    const makeMessages = () => [
+      { text: "one" },
+      { role: "assistant" as const, text: "two" },
+    ];
 
     const server = new ExternalStoreThreadRuntimeCore(
       mockContextProvider,
-      storeWith([m1, m2]),
+      storeWith(makeMessages()),
     );
     const client = new ExternalStoreThreadRuntimeCore(
       mockContextProvider,
-      storeWith([m1, m2]),
+      storeWith(makeMessages()),
     );
 
     expect(client.messages.map((m) => m.id)).toEqual(
       server.messages.map((m) => m.id),
     );
+  });
+
+  it("does not collide a fallback id with an explicit host id", () => {
+    const messages = [{ id: "0", text: "explicit-zero" }, { text: "id-less" }];
+    const convertWithId = (m: { id?: string; text: string }) =>
+      ({
+        ...(m.id !== undefined ? { id: m.id } : {}),
+        role: "user",
+        content: [{ type: "text", text: m.text }],
+      }) as ThreadMessageLike;
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ messages, convertMessage: convertWithId }),
+    );
+
+    expect(runtime.messages).toHaveLength(2);
+    expect(new Set(runtime.messages.map((m) => m.id)).size).toBe(2);
   });
 });

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1208,4 +1208,22 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
     expect(idsAfter.slice(1)).toEqual(idsBefore);
     expect(new Set(idsAfter).size).toBe(3);
   });
+
+  it("assigns identical fallback ids across separate core instances", () => {
+    const m1 = { text: "one" };
+    const m2 = { role: "assistant" as const, text: "two" };
+
+    const server = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      storeWith([m1, m2]),
+    );
+    const client = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      storeWith([m1, m2]),
+    );
+
+    expect(client.messages.map((m) => m.id)).toEqual(
+      server.messages.map((m) => m.id),
+    );
+  });
 });

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1155,3 +1155,57 @@ describe("ExternalStoreThreadRuntimeCore - message queue", () => {
     expect(queue.remove).toHaveBeenCalledWith("q1");
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
+  const convertMessage = (m: { role?: "user" | "assistant"; text: string }) =>
+    ({
+      role: m.role ?? "user",
+      content: [{ type: "text", text: m.text }],
+    }) as ThreadMessageLike;
+
+  const storeWith = (
+    messages: { role?: "user" | "assistant"; text: string }[],
+  ) => makeStore({ messages, convertMessage });
+
+  it("keeps a prepended history message", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const m0 = { text: "older-user" };
+      const m1 = { text: "newer-user" };
+      const m2 = { role: "assistant" as const, text: "newer-assistant" };
+
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        storeWith([m1, m2]),
+      );
+      expect(runtime.messages).toHaveLength(2);
+
+      runtime.__internal_setAdapter(storeWith([m0, m1, m2]));
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(runtime.messages).toHaveLength(3);
+      expect(
+        runtime.messages.map((m) => (m.content[0] as { text: string }).text),
+      ).toEqual(["older-user", "newer-user", "newer-assistant"]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps converted ids stable across index shifts", () => {
+    const m1 = { text: "newer-user" };
+    const m2 = { role: "assistant" as const, text: "newer-assistant" };
+
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      storeWith([m1, m2]),
+    );
+    const idsBefore = runtime.messages.map((m) => m.id);
+
+    runtime.__internal_setAdapter(storeWith([{ text: "older-user" }, m1, m2]));
+
+    const idsAfter = runtime.messages.map((m) => m.id);
+    expect(idsAfter.slice(1)).toEqual(idsBefore);
+    expect(new Set(idsAfter).size).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- derive the fallback id for a converted message (host's `convertMessage` returned no `id`) from a per-object `WeakMap` backed by a per-core monotonic counter instead of the message's array index
- the counter (rather than `generateId`, raised in review) keeps ids deterministic, so a server render and its hydration pass assign identical `data-message-id` values; the ids carry a reserved `__external_store_fallback_` prefix (raised in review round 2) so a synthetic id can never collide with an explicit host id and trip the duplicate sweep
- a message now keeps one id for its lifetime regardless of index shifts, so a prepended history message no longer collides with cached conversions and gets dropped by the duplicate-id sweep
- explicit host-provided ids are untouched, and the duplicate sweep still handles genuinely duplicated explicit ids (existing contract test unchanged)

## Why

Fixes #6172. `fromThreadMessageLike`'s fallback id was positional (`idx.toString()`), while `ThreadMessageConverter` caches conversions per host message object — a cache hit returns the message with the id from its *original* index. Prepending older history (`[m1, m2]` → `[m0, m1, m2]`, classic load-older pagination) converts `m0` fresh at index 0 with id `"0"` while cached `m1` keeps its stale `"0"`; the duplicate-id sweep keeps the last occurrence and the message the host just added silently vanishes.

The stable-id fix addresses the root cause (positional identity for cached objects) rather than the symptom: re-deriving positional ids on shift would instead re-id every cached message, churning the message repository on each prepend.

Root-cause verification: both new regression tests fail on main exactly as the issue describes (duplicate-id warn, prepended message gone) and pass with the fix; the full core suite (1406 tests) passes, confirming nothing relied on the positional fallback values.

Note: `useExternalMessageConverter` (`packages/core/src/react/runtimes/external-message-converter.ts`) carries the same positional-fallback pattern in a different pipeline; flagged in #6172 as a potential follow-up rather than widening this diff.

## Validation

- `pnpm --filter @assistant-ui/core test` (130 files, 1406 tests; includes 4 new regression tests: prepended history survives, converted ids stay stable across index shifts, two separately constructed cores assign identical ids from independent content-equal objects (the SSR/hydration property, keyed to conversion order rather than object identity per review), and a synthetic id never collides with an explicit host id)
- `pnpm lint`
- changeset: patch for `@assistant-ui/core`
