### PR TITLE
fix(ai-sdk): preserve denied tool calls when sending a new message

### DIFF
--- a/.changeset/ai-sdk-preserve-denied-tool-calls.md
+++ b/.changeset/ai-sdk-preserve-denied-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: preserve settled output-denied tool calls when sending a new message

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.denied-tool.test.tsx
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.denied-tool.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  adapter: undefined as ExternalStoreAdapter | undefined,
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@assistant-ui/core/react")>();
+  return {
+    ...original,
+    useExternalStoreRuntime: vi.fn((adapter: ExternalStoreAdapter) => {
+      mocks.adapter = adapter;
+      return {};
+    }),
+    useRuntimeAdapters: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("./useExternalHistory", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./useExternalHistory")>();
+  return {
+    ...original,
+    useExternalHistory: vi.fn(() => ({
+      isLoading: false,
+      deleteMessage: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+import { useAISDKRuntime } from "./useAISDKRuntime";
+
+describe("useAISDKRuntime pending tool completion", () => {
+  const setup = (toolPart: Record<string, unknown>) => {
+    const messages = [
+      {
+        id: "m1",
+        role: "assistant",
+        parts: [toolPart],
+      },
+    ];
+    let updated: any[] | undefined;
+    const setMessages = vi.fn(
+      (updater: (m: typeof messages) => typeof messages) => {
+        updated = typeof updater === "function" ? updater(messages) : updater;
+      },
+    );
+    const chat = {
+      id: "chat-1",
+      status: "ready",
+      error: undefined,
+      messages,
+      setMessages,
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      regenerate: vi.fn(),
+      addToolOutput: vi.fn(),
+      addToolApprovalResponse: vi.fn(),
+      stop: vi.fn(),
+    };
+
+    renderHook(() => useAISDKRuntime(chat as never));
+
+    return {
+      send: () =>
+        mocks.adapter!.onNew!({
+          role: "user",
+          parentId: "m1",
+          sourceId: null,
+          runConfig: {},
+          content: [{ type: "text", text: "next" }],
+          attachments: [],
+          createdAt: new Date(0),
+          metadata: { custom: {} },
+        } as never),
+      getUpdated: () => updated,
+    };
+  };
+
+  it("preserves a denied tool call and its approval record on the next send", async () => {
+    const { send, getUpdated } = setup({
+      type: "tool-search",
+      toolCallId: "call_1",
+      state: "output-denied",
+      input: { query: "x" },
+      approval: { id: "appr_1", approved: false, reason: "too dangerous" },
+    });
+
+    await send();
+
+    const updated = getUpdated();
+    const part = updated?.at(-1)?.parts?.[0];
+    expect(part?.state).toBe("output-denied");
+    expect(part?.approval).toEqual({
+      id: "appr_1",
+      approved: false,
+      reason: "too dangerous",
+    });
+    expect(part?.errorText).toBeUndefined();
+  });
+
+  it("still cancels a genuinely pending tool call on the next send", async () => {
+    const { send, getUpdated } = setup({
+      type: "tool-search",
+      toolCallId: "call_1",
+      state: "input-available",
+      input: { query: "x" },
+    });
+
+    await send();
+
+    const part = getUpdated()?.at(-1)?.parts?.[0];
+    expect(part?.state).toBe("output-error");
+    expect(part?.errorText).toBe(
+      "User cancelled tool call by sending a new message.",
+    );
+  });
+});

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -306,7 +306,11 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       let hasChanges = false;
       const parts = lastMessage.parts?.map((part) => {
         if (!isToolUIPart(part)) return part;
-        if (part.state === "output-available" || part.state === "output-error")
+        if (
+          part.state === "output-available" ||
+          part.state === "output-error" ||
+          part.state === "output-denied"
+        )
           return part;
 
         hasChanges = true;


### PR DESCRIPTION
## Summary

- treat `"output-denied"` as a settled state in `completePendingToolCalls`, alongside `"output-available"` and `"output-error"`, so a user's denial of a `needsApproval` tool survives the next send
- genuinely pending states (`input-streaming`, `input-available`, `approval-requested`, `approval-responded`) keep the existing cancellation rewrite — the sweep's actual purpose is unchanged
- add colocated regression tests for both paths: the denied part keeps its state and `approval` record; a pending part is still rewritten to the cancellation error

## Why

Fixes #6175. With the default `cancelPendingToolCallsOnSend: true`, the settled-state whitelist missed AI SDK v7's terminal `"output-denied"` state, so sending the next message rewrote a user's explicit denial into `{ state: "output-error", errorText: "User cancelled tool call by sending a new message." }` and stripped the `approval` record. That corrupts both the UI (a cancellation error rendered in place of the denial) and the model's context (the SDK's `convertToModelMessages` maps `output-denied` to an `execution-denied` tool result carrying the denial reason — the rewrite replaced that with a fake error string).

The sweep's own comment states the intent — "mark any tool **without a result** as cancelled" — and a denied tool has its result. Verified against `ai@7.0.66`: `output-denied` is a terminal member of the `ToolUIPart` state union with a required `approval` record, and `convertToModelMessages` handles it as a first-class tool outcome.

Root-cause verification: the denied-preservation regression test fails on main exactly as the issue describes (state rewritten, approval gone) and passes with the fix; the pending-cancellation control passes on both, confirming only the missing settled state changed.

## Validation

- `pnpm --filter @assistant-ui/ai-sdk test` (25 files, 248 tests, including the 2 new regression tests)
- `pnpm lint`
- changeset: patch for `@assistant-ui/ai-sdk`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2ni2qPLZ5TRGqQgwZQ88pAWsFmW4rpuRgayuEmANyp8STVhAnJLPLsHOd7k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

