### PR TITLE
fix(core): notify thread subscribers when a remote thread core is republished

### DIFF
--- a/.changeset/remote-thread-list-republish-notify.md
+++ b/.changeset/remote-thread-list-republish-notify.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: notify thread subscribers when a remote thread core is republished

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3644,6 +3644,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   }> | undefined;
   __internal_isThreadRunning(threadId: string): boolean;
   __internal_subscribeRunningChanged(callback: () => void): Unsubscribe$1;
+  __internal_subscribeRuntimeReplaced(callback: () => void): Unsubscribe$1;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
   __internal_setDefaultAdapters(adapters: RuntimeAdapters | null): void;

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -173,6 +173,18 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       this._trackRunning(instance);
     }
     this._notifySubscribers();
+    if (previousRuntime !== undefined && previousRuntime !== runtime) {
+      for (const callback of this.replacedSubscribers) callback();
+    }
+  }
+
+  private replacedSubscribers = new Set<() => void>();
+
+  public __internal_subscribeRuntimeReplaced(
+    callback: () => void,
+  ): Unsubscribe {
+    this.replacedSubscribers.add(callback);
+    return () => this.replacedSubscribers.delete(callback);
   }
 
   private _trackRunning(instance: RemoteThreadListHookInstance) {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.republish.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.republish.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { RemoteThreadListThreadListRuntimeCore } from "./RemoteThreadListThreadListRuntimeCore";
+import { ThreadListRuntimeImpl } from "../../runtime/api/thread-list-runtime";
+import { ReadonlyThreadRuntimeCore } from "../../runtimes/readonly/ReadonlyThreadRuntimeCore";
+import {
+  contextProvider,
+  makeAdapter,
+} from "../../tests/remote-thread-list-test-helpers";
+import type { ThreadMessage } from "../../types/message";
+
+const message = (id: string): ThreadMessage =>
+  ({
+    id,
+    role: "user",
+    content: [{ type: "text", text: id }],
+    createdAt: new Date(0),
+    attachments: [],
+    metadata: { custom: {} },
+  }) as unknown as ThreadMessage;
+
+const setup = () => {
+  const core = new RemoteThreadListThreadListRuntimeCore(
+    { adapter: makeAdapter(), runtimeHook: () => ({}) as never },
+    contextProvider,
+  );
+  const hookManager = (
+    core as unknown as {
+      _hookManager: {
+        _publishThreadRuntime: (
+          id: string,
+          runtime: ReadonlyThreadRuntimeCore,
+          generation: number,
+        ) => void;
+        instances: Map<string, { generation: number }>;
+      };
+    }
+  )._hookManager;
+  const threadId = core.mainThreadId!;
+  const publish = (runtime: ReadonlyThreadRuntimeCore) =>
+    hookManager._publishThreadRuntime(
+      threadId,
+      runtime,
+      hookManager.instances.get(threadId)!.generation,
+    );
+  return { core, publish };
+};
+
+describe("RemoteThreadListThreadListRuntimeCore republish", () => {
+  it("keeps the subscribed main thread state on the republished core", async () => {
+    const { core, publish } = setup();
+    const first = new ReadonlyThreadRuntimeCore();
+    first.setMessages([message("m1")]);
+    publish(first);
+
+    const thread = new ThreadListRuntimeImpl(core).main;
+    thread.subscribe(() => {});
+    expect(thread.getState().messages.map((m) => m.id)).toEqual(["m1"]);
+
+    const second = new ReadonlyThreadRuntimeCore();
+    second.setMessages([message("m2")]);
+    publish(second);
+    await Promise.resolve();
+
+    const ids = thread.getState().messages.map((m) => m.id);
+    expect(ids).toEqual(["m2"]);
+    for (const id of ids) {
+      expect(() => thread.getMessageById(id).getState()).not.toThrow();
+    }
+  });
+
+  it("notifies thread subscribers when the core is republished", async () => {
+    const { core, publish } = setup();
+    publish(new ReadonlyThreadRuntimeCore());
+
+    const thread = new ThreadListRuntimeImpl(core).main;
+    let notified = 0;
+    thread.subscribe(() => notified++);
+
+    const next = new ReadonlyThreadRuntimeCore();
+    next.setMessages([message("m1")]);
+    publish(next);
+    await Promise.resolve();
+
+    expect(notified).toBeGreaterThan(0);
+    expect(thread.getState().messages.map((m) => m.id)).toEqual(["m1"]);
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -237,6 +237,11 @@ export class RemoteThreadListThreadListRuntimeCore
     this._hookManager.__internal_subscribeRunningChanged(() =>
       this._notifySubscribers(),
     );
+    this._hookManager.__internal_subscribeRuntimeReplaced(() => {
+      // A republish can land during the thread resource's render, where a
+      // synchronous notify would re-enter store consumers mid-render.
+      void Promise.resolve().then(() => this._notifySubscribers());
+    });
     this.useProvider = create(() => ({
       Provider: this.resolveProvider(options.adapter),
     }));

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -240,7 +240,7 @@ export class RemoteThreadListThreadListRuntimeCore
     this._hookManager.__internal_subscribeRuntimeReplaced(() => {
       // A republish can land during the thread resource's render, where a
       // synchronous notify would re-enter store consumers mid-render.
-      void Promise.resolve().then(() => this._notifySubscribers());
+      queueMicrotask(() => this._notifySubscribers());
     });
     this.useProvider = create(() => ({
       Provider: this.resolveProvider(options.adapter),


### PR DESCRIPTION
## What

`RemoteThreadListThreadListRuntimeCore` now forwards a hook-manager *republish* (a thread resource publishing a different core for an already-attached thread) to its own subscribers, deferred to a microtask.

## Why

Production reported an unhandled `Entry not available in the store` thrown from the store's `MessageClientById` resource (`thread-runtime-client` → `runtime.getMessageById(id)` → `new ShallowMemoizeSubject` constructor). It escapes every error boundary because it's thrown inside a tap resource, not a component.

Root cause: the thread client reads its message ids from `ThreadRuntimeImpl.getState()`, a `ShallowMemoizeSubject` snapshot that only refreshes on notification, while `getMessageById` reads the live core via the `threads.main` `NestedSubscriptionSubject`. `RemoteThreadListHookInstanceManager._publishThreadRuntime` notified only the hook manager's own subscribers, and the thread list core only forwarded `runningChanged`. So when `RemoteThreadResource` republishes a new core (it does this on `threadBinding.outerSubscribe`, i.e. whenever the inner runtime swaps its main thread), the outer binding never learned the core changed: the snapshot still listed the old core's message ids, the new core had none of them, and the lookup threw. `switchToThread` and `reloadMainThread` already notify after *their* attaches, which is why only the unsolicited republish was exposed.

## How

- `RemoteThreadListHookInstanceManager` gains `__internal_subscribeRuntimeReplaced`, fired only when a publish replaces a previously attached, different core.
- The thread list core subscribes and notifies its subscribers in a microtask. Synchronous forwarding is not safe: the first publish of a remounted resource happens during its render, and a sync notify re-entered store consumers mid-render (`useEffectEvent cannot be called during render` in `src/tests`). The microtask matches how `switchToThread` already defers its post-attach notify.
- New contract test `RemoteThreadListThreadListRuntimeCore.republish.test.ts` publishes core A, subscribes, publishes core B, and asserts `getState().messages` and `getMessageById` agree. It reproduces the exact production error without the fix and passes with it.

`packages/react/src/legacy-runtime/runtime-cores/remote-thread-list/*` are re-exports of these files, so the legacy path is covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz7NSvUBpSUDhnZG7fs7y9


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.f6zSHeC5NcSkOoO713wFdbZXOyoB7pI0Ho2fNmMo5wz1XsaxpgTrzLXKRHY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->