### PR TITLE
docs(ui): correct cancelled-state prose on tool-fallback page

### DIFF
--- a/apps/docs/content/docs/ui/tool-fallback.mdx
+++ b/apps/docs/content/docs/ui/tool-fallback.mdx
@@ -68,7 +68,7 @@ Shows a loading spinner and shimmer animation while the tool is executing.
 
 ### Cancelled State
 
-The call shows the "Cancelled tool" label with muted content.
+The "Cancelled tool" label has a line through it. The arguments are muted after you open the call.
 
 <ToolFallbackCancelledSample />
 

--- a/apps/docs/content/docs/ui/tool-fallback.mdx
+++ b/apps/docs/content/docs/ui/tool-fallback.mdx
@@ -68,7 +68,7 @@ Shows a loading spinner and shimmer animation while the tool is executing.
 
 ### Cancelled State
 
-Shows a muted appearance when a tool call was cancelled.
+The call shows the "Cancelled tool" label with muted content.
 
 <ToolFallbackCancelledSample />
 


### PR DESCRIPTION
The Cancelled State prose did not mention the visible "Cancelled tool" label, thus this PR corrects one line of prose. The fixture does not change.

## Screenshot

![Cancelled State example](https://artifacts.duncan.land/tool-fallback-demo-cancelled.png)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.a9ErK5RMGemZ53SYNcOMpP-7tF0NEHCxgMq6Dq66jWV6mDQHkQZd_Hkcwik?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->