### PR TITLE
fix(core): resolve InMemoryThreadList index selectors within their subset

### DIFF
--- a/.changeset/inmemory-thread-list-archived-index.md
+++ b/.changeset/inmemory-thread-list-archived-index.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: resolve InMemoryThreadList index selectors within the archived/regular subset

--- a/packages/core/src/react/client/InMemoryThreadList.test.tsx
+++ b/packages/core/src/react/client/InMemoryThreadList.test.tsx
@@ -146,3 +146,42 @@ describe("InMemoryThreadList delete", () => {
     expect(state.mainThreadId).not.toBe("main");
   });
 });
+
+describe("InMemoryThreadList item index selectors", () => {
+  it("resolves index selectors within the archived and regular subsets", async () => {
+    const { getAui } = setup();
+    await act(async () => {});
+
+    await act(async () => {
+      getAui().threads.switchToNewThread();
+    });
+    await act(async () => {});
+    const b = getAui().threads.getState().mainThreadId;
+
+    await act(async () => {
+      getAui().threads.switchToNewThread();
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      getAui().threads.item({ id: b }).archive();
+    });
+    await act(async () => {});
+
+    const state = getAui().threads.getState();
+    expect(state.archivedThreadIds).toEqual([b]);
+    expect(state.threadIds).toHaveLength(2);
+
+    for (const [index, id] of state.archivedThreadIds.entries()) {
+      expect(
+        getAui().threads.item({ index, archived: true }).getState().id,
+      ).toBe(id);
+    }
+    for (const [index, id] of state.threadIds.entries()) {
+      expect(getAui().threads.item({ index }).getState().id).toBe(id);
+      expect(
+        getAui().threads.item({ index, archived: false }).getState().id,
+      ).toBe(id);
+    }
+  });
+});

--- a/packages/core/src/react/client/InMemoryThreadList.test.tsx
+++ b/packages/core/src/react/client/InMemoryThreadList.test.tsx
@@ -183,5 +183,15 @@ describe("InMemoryThreadList item index selectors", () => {
         getAui().threads.item({ index, archived: false }).getState().id,
       ).toBe(id);
     }
+
+    expect(() =>
+      getAui().threads.item({ index: state.threadIds.length }),
+    ).toThrow("out of bounds");
+    expect(() =>
+      getAui().threads.item({
+        index: state.archivedThreadIds.length,
+        archived: true,
+      }),
+    ).toThrow("out of bounds");
   });
 });

--- a/packages/core/src/react/client/InMemoryThreadList.ts
+++ b/packages/core/src/react/client/InMemoryThreadList.ts
@@ -238,8 +238,8 @@ const useInMemoryThreadList = (
       }
       // The lookup is keyed over the combined thread array, while index
       // selectors address the regular/archived subset the primitives render.
-      const status = selector.archived ? "archived" : "regular";
-      const id = threads.filter((t) => t.status === status)[selector.index]?.id;
+      const ids = selector.archived ? state.archivedThreadIds : state.threadIds;
+      const id = ids[selector.index];
       if (id === undefined) return threadListItems.get({ index: -1 });
       const index = threads.findIndex((t) => t.id === id);
       return threadListItems.get({ index });

--- a/packages/core/src/react/client/InMemoryThreadList.ts
+++ b/packages/core/src/react/client/InMemoryThreadList.ts
@@ -236,7 +236,13 @@ const useInMemoryThreadList = (
         const index = threads.findIndex((t) => t.id === selector.id);
         return threadListItems.get({ index });
       }
-      return threadListItems.get(selector);
+      // The lookup is keyed over the combined thread array, while index
+      // selectors address the regular/archived subset the primitives render.
+      const status = selector.archived ? "archived" : "regular";
+      const id = threads.filter((t) => t.status === status)[selector.index]?.id;
+      if (id === undefined) return threadListItems.get({ index: -1 });
+      const index = threads.findIndex((t) => t.id === id);
+      return threadListItems.get({ index });
     },
     thread: () => mainThreadClient.methods,
   };


### PR DESCRIPTION
## Summary

- `InMemoryThreadList.item({ index, archived })` now resolves the id from the requested subset (archived vs regular) and maps it to the combined-lookup index, instead of forwarding the selector raw into the combined-array lookup
- an out-of-range subset index resolves to the lookup's `-1` miss, matching the `RemoteThreadList` sibling
- add a regression test asserting the subset contract for both flags: for every `i`, `item({ index: i, archived }).getState().id` equals `archivedThreadIds[i]` / `threadIds[i]`

## Why

Fixes #6198. The `threadListItems` lookup is keyed over the single combined `threads` array, while index selectors address the regular/archived subset that `ThreadListPrimitive.Items` renders (via `ThreadListItemByIndexProvider`'s `item({ index, archived })`). Forwarding the selector raw dropped the `archived` flag and indexed the mixed array, so with threads `[main, B(archived), C]`, `item({ index: 0, archived: true })` returned `main` instead of `B` and `item({ index: 1 })` returned archived `B` instead of `C` — every affected sidebar row rendered the wrong thread and its actions (`switchTo`, `rename`, `delete`) targeted the wrong thread.

Both sibling implementations already resolve subset-first (`RemoteThreadList`'s `item`, the store's thread-list runtime client); this brings `InMemoryThreadList` to the same contract, mirroring the `RemoteThreadList` shape.

Root-cause verification: the regression test fails on main with `expected 'main' to be 'thread-…'` (the exact wrong-thread resolution) and passes with the fix; the `id`/`"main"` selector paths and all existing selection/delete tests are unchanged.

## Validation

- `pnpm --filter @assistant-ui/core test` (131 files, 1407 tests, including the new regression test)
- `pnpm lint`
- changeset: patch for `@assistant-ui/core`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8PqjwhHmRzksLsXYrYt0DhtdjrIBPE0mH2YFTEYDBl3V-gCmQ0dMqoDDK6w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->