### PR TITLE
fix(core): preserve mid-load thread transitions when a stale list lands

### DIFF
--- a/.changeset/remote-thread-list-load-race.md
+++ b/.changeset/remote-thread-list-load-race.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep threads initialized during a list() flight in the thread list when the stale response lands

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3457,6 +3457,7 @@ type RemoteThreadData = {
   readonly status: "new";
   readonly title: undefined;
   readonly custom: undefined;
+  readonly localOrigin?: true;
 } | {
   readonly id: string;
   readonly initializeTask: Promise<RemoteThreadInitializeResponse>;
@@ -3465,6 +3466,7 @@ type RemoteThreadData = {
   readonly status: "archived" | "regular";
   readonly title?: string | undefined;
   readonly custom: undefined;
+  readonly localOrigin?: true;
 } | {
   readonly id: string;
   readonly initializeTask: Promise<RemoteThreadInitializeResponse>;
@@ -3474,6 +3476,7 @@ type RemoteThreadData = {
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
+  readonly localOrigin?: true;
 };
 
 type RemoteThreadInitializeResponse = {

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -234,6 +234,34 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("keeps a thread initialized during the list() flight after switching away", async () => {
+    const listDeferred =
+      deferred<Awaited<ReturnType<RemoteThreadListAdapter["list"]>>>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => listDeferred.promise),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+
+    const loadPromise = aui.threads.getLoadThreadsPromise();
+    const initializedId = aui.threads.getState().mainThreadId;
+    await aui.threads.item("main").initialize();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toContain(initializedId);
+    });
+
+    listDeferred.resolve({ threads: [] });
+    await loadPromise;
+
+    flushTapSync(() => aui.threads.switchToNewThread());
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).not.toBe(initializedId);
+    });
+
+    expect(aui.threads.getState().threadIds).toContain(initializedId);
+    handle.destroy();
+  });
+
   it("switches to a listed thread and back to a new thread", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -250,7 +250,9 @@ describe("RemoteThreadList", () => {
       expect(aui.threads.getState().threadIds).toContain(initializedId);
     });
 
-    listDeferred.resolve({ threads: [] });
+    listDeferred.resolve({
+      threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+    });
     await loadPromise;
 
     flushTapSync(() => aui.threads.switchToNewThread());
@@ -258,7 +260,8 @@ describe("RemoteThreadList", () => {
       expect(aui.threads.getState().mainThreadId).not.toBe(initializedId);
     });
 
-    expect(aui.threads.getState().threadIds).toContain(initializedId);
+    expect(aui.threads.getState().threadIds[0]).toBe(initializedId);
+    expect(aui.threads.getState().threadIds).toContain("t1");
     handle.destroy();
   });
 

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -455,7 +455,7 @@ const useRemoteThreadList = (
               ...fresh.threadData,
             },
           };
-          return preserveMidLoadTransitions(merged, statusAtRequest);
+          return preserveMidLoadTransitions(merged, state, statusAtRequest);
         },
       })
       .catch((error: unknown) => {

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -25,6 +25,7 @@ import {
   type RemoteThreadState,
   preserveMidLoadTransitions,
   statusSnapshot,
+  LOCAL_THREAD_ID_PREFIX,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadInitializeResponse,
@@ -106,7 +107,7 @@ const seedNewThread = (
 ): { id: string; state: RemoteThreadState } => {
   let id: string;
   do {
-    id = `__LOCALID_${generateId()}`;
+    id = `${LOCAL_THREAD_ID_PREFIX}${generateId()}`;
   } while (state.threadIdMap[id]);
   const mappingId = createThreadMappingId(id);
   return {

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -128,6 +128,7 @@ const seedNewThread = (
           externalId: undefined,
           title: undefined,
           custom: undefined,
+          localOrigin: true,
         },
       },
     },

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -455,10 +455,7 @@ const useRemoteThreadList = (
               ...fresh.threadData,
             },
           };
-          return {
-            ...merged,
-            ...preserveMidLoadTransitions(merged, fresh, statusAtRequest),
-          };
+          return preserveMidLoadTransitions(merged, statusAtRequest);
         },
       })
       .catch((error: unknown) => {

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -23,6 +23,8 @@ import {
   updateStatusReducer,
   type RemoteThreadData,
   type RemoteThreadState,
+  preserveMidLoadTransitions,
+  statusSnapshot,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadInitializeResponse,
@@ -424,6 +426,7 @@ const useRemoteThreadList = (
     if (session.loadPromise) return session.loadPromise;
     const generation = session.loadGeneration;
     const adapter = session.adapter;
+    const statusAtRequest = statusSnapshot(store.baseValue);
     session.loadPromise = store
       .optimisticUpdate({
         execute: () => adapter.list(),
@@ -437,7 +440,7 @@ const useRemoteThreadList = (
             threadIdMap: {},
             threadData: {},
           });
-          return {
+          const merged = {
             ...state,
             isLoading: false,
             cursor: normalizeCursor(page.nextCursor),
@@ -451,6 +454,10 @@ const useRemoteThreadList = (
               ...state.threadData,
               ...fresh.threadData,
             },
+          };
+          return {
+            ...merged,
+            ...preserveMidLoadTransitions(merged, fresh, statusAtRequest),
           };
         },
       })

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -13,6 +13,8 @@ import {
   getThreadData,
   normalizeCursor,
   updateStatusReducer,
+  preserveMidLoadTransitions,
+  statusSnapshot,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadListAdapter,
@@ -158,6 +160,7 @@ export class RemoteThreadListThreadListRuntimeCore
     if (!this._loadThreadsPromise) {
       const generation = this._loadGeneration;
       let replacedList = false;
+      const statusAtRequest = statusSnapshot(this._state.baseValue);
       this._loadThreadsPromise = this._state
         .optimisticUpdate({
           execute: () => this._options.adapter.list(),
@@ -186,7 +189,7 @@ export class RemoteThreadListThreadListRuntimeCore
               threadIdMap: {},
               threadData: {},
             });
-            return {
+            const merged = {
               ...state,
               isLoading: false,
               cursor: normalizeCursor(l.nextCursor),
@@ -194,6 +197,10 @@ export class RemoteThreadListThreadListRuntimeCore
               archivedThreadIds: fresh.archivedThreadIds,
               threadIdMap: { ...state.threadIdMap, ...fresh.threadIdMap },
               threadData: { ...state.threadData, ...fresh.threadData },
+            };
+            return {
+              ...merged,
+              ...preserveMidLoadTransitions(merged, fresh, statusAtRequest),
             };
           },
         })

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -198,7 +198,7 @@ export class RemoteThreadListThreadListRuntimeCore
               threadIdMap: { ...state.threadIdMap, ...fresh.threadIdMap },
               threadData: { ...state.threadData, ...fresh.threadData },
             };
-            return preserveMidLoadTransitions(merged, statusAtRequest);
+            return preserveMidLoadTransitions(merged, state, statusAtRequest);
           },
         })
         .catch((error: unknown) => {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -15,6 +15,7 @@ import {
   updateStatusReducer,
   preserveMidLoadTransitions,
   statusSnapshot,
+  LOCAL_THREAD_ID_PREFIX,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadListAdapter,
@@ -65,7 +66,7 @@ const EMPTY_REMOTE_STATE: RemoteThreadState = {
 const addNewThread = (state: RemoteThreadState) => {
   let id: string;
   do {
-    id = `__LOCALID_${generateId()}`;
+    id = `${LOCAL_THREAD_ID_PREFIX}${generateId()}`;
   } while (state.threadIdMap[id]);
 
   const mappingId = createThreadMappingId(id);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -198,10 +198,7 @@ export class RemoteThreadListThreadListRuntimeCore
               threadIdMap: { ...state.threadIdMap, ...fresh.threadIdMap },
               threadData: { ...state.threadData, ...fresh.threadData },
             };
-            return {
-              ...merged,
-              ...preserveMidLoadTransitions(merged, fresh, statusAtRequest),
-            };
+            return preserveMidLoadTransitions(merged, statusAtRequest);
           },
         })
         .catch((error: unknown) => {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -88,6 +88,7 @@ const addNewThread = (state: RemoteThreadState) => {
           externalId: undefined,
           title: undefined,
           custom: undefined,
+          localOrigin: true,
         } satisfies RemoteThreadData,
       },
     },

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -132,10 +132,15 @@ export const preserveMidLoadTransitions = (
   }
 
   if (prependRegular.length === 0 && prependArchived.length === 0) return state;
+  // Newest transition first, as successive updateStatusReducer prepends
+  // would have left them.
   return {
     ...state,
-    threadIds: [...prependRegular, ...state.threadIds],
-    archivedThreadIds: [...prependArchived, ...state.archivedThreadIds],
+    threadIds: [...prependRegular.reverse(), ...state.threadIds],
+    archivedThreadIds: [
+      ...prependArchived.reverse(),
+      ...state.archivedThreadIds,
+    ],
   };
 };
 

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -11,6 +11,7 @@ export type RemoteThreadData =
       readonly status: "new";
       readonly title: undefined;
       readonly custom: undefined;
+      readonly localOrigin?: true;
     }
   | {
       readonly id: string;
@@ -20,6 +21,7 @@ export type RemoteThreadData =
       readonly status: "regular" | "archived";
       readonly title?: string | undefined;
       readonly custom: undefined;
+      readonly localOrigin?: true;
     }
   | {
       readonly id: string;
@@ -30,6 +32,7 @@ export type RemoteThreadData =
       readonly title?: string | undefined;
       readonly lastMessageAt?: Date | undefined;
       readonly custom?: Record<string, unknown> | undefined;
+      readonly localOrigin?: true;
     };
 
 export type THREAD_MAPPING_ID = string & { __brand: "THREAD_MAPPING_ID" };
@@ -39,8 +42,6 @@ export function createThreadMappingId(id: string): THREAD_MAPPING_ID {
 }
 
 export const LOCAL_THREAD_ID_PREFIX = "__LOCALID_";
-export const isLocalThreadId = (id: string) =>
-  id.startsWith(LOCAL_THREAD_ID_PREFIX);
 
 export const normalizeCursor = (c: string | undefined): string | undefined =>
   c || undefined;
@@ -107,13 +108,13 @@ export type RemoteThreadState = {
 // completed-optimistic replay cannot re-add it because the merged threadData
 // already carries the final status. Threads whose status moved from new (or
 // nonexistent) at request time to regular/archived are re-inserted at the
-// top, in the order the pre-response lists carried them (updateStatusReducer
-// prepends, so that order is newest first; object enumeration is not a
-// reliable stand-in, since integer-like keys enumerate out of insertion
-// order). Threads the server already knew stay governed by the response, so
+// top, in the order the pre-response lists carried them: updateStatusReducer
+// prepends as transitions happen, so the pre-response lists hold newest
+// first, which threadData insertion order need not match. Threads the server already knew stay governed by the response, so
 // a server-side deletion is not resurrected — and a thread unknown to the
-// snapshot is only rescued when it is a local creation, so a deep-linked
-// thread the fetch path deliberately appended at the tail is not hoisted.
+// snapshot is only rescued when it carries the localOrigin marker stamped at
+// draft creation, so a deep-linked thread the fetch path deliberately
+// appended at the tail is not hoisted, whatever its remote id looks like.
 export const preserveMidLoadTransitions = (
   state: RemoteThreadState,
   priorOrder: Pick<RemoteThreadState, "threadIds" | "archivedThreadIds">,
@@ -130,7 +131,7 @@ export const preserveMidLoadTransitions = (
   for (const data of Object.values(state.threadData)) {
     const before = statusAtRequest.get(data.id);
     if (before !== undefined && before !== "new") continue;
-    if (before === undefined && !isLocalThreadId(data.id)) continue;
+    if (before === undefined && data.localOrigin !== true) continue;
 
     if (data.status === "regular" && !contains(regular, data)) {
       rescuedRegular.push(data);

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -98,6 +98,47 @@ export type RemoteThreadState = {
   readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
 };
 
+// A list() response predating a mid-flight local transition (a thread
+// initialized while the request was running) omits that thread, and the
+// completed-optimistic replay cannot re-add it because the merged threadData
+// already carries the final status. Threads whose status moved from new (or
+// nonexistent) at request time to regular/archived are re-appended; threads
+// the server already knew stay governed by the response, so a server-side
+// deletion is not resurrected.
+export const preserveMidLoadTransitions = (
+  state: RemoteThreadState,
+  fresh: Pick<RemoteThreadState, "threadIds" | "archivedThreadIds">,
+  statusAtRequest: ReadonlyMap<string, RemoteThreadData["status"]>,
+): Pick<RemoteThreadState, "threadIds" | "archivedThreadIds"> => {
+  const threadIds = [...fresh.threadIds];
+  const archivedThreadIds = [...fresh.archivedThreadIds];
+
+  const contains = (ids: readonly string[], data: RemoteThreadData) =>
+    ids.includes(data.id) ||
+    (data.remoteId !== undefined && ids.includes(data.remoteId));
+
+  for (const data of Object.values(state.threadData)) {
+    const before = statusAtRequest.get(data.id);
+    if (before !== undefined && before !== "new") continue;
+
+    if (data.status === "regular" && !contains(threadIds, data)) {
+      threadIds.push(data.id);
+    } else if (
+      data.status === "archived" &&
+      !contains(archivedThreadIds, data)
+    ) {
+      archivedThreadIds.push(data.id);
+    }
+  }
+
+  return { threadIds, archivedThreadIds };
+};
+
+export const statusSnapshot = (
+  state: RemoteThreadState,
+): ReadonlyMap<string, RemoteThreadData["status"]> =>
+  new Map(Object.values(state.threadData).map((d) => [d.id, d.status]));
+
 export const getThreadData = (
   state: RemoteThreadState,
   threadIdOrRemoteId: string,

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -38,6 +38,10 @@ export function createThreadMappingId(id: string): THREAD_MAPPING_ID {
   return id as THREAD_MAPPING_ID;
 }
 
+export const LOCAL_THREAD_ID_PREFIX = "__LOCALID_";
+export const isLocalThreadId = (id: string) =>
+  id.startsWith(LOCAL_THREAD_ID_PREFIX);
+
 export const normalizeCursor = (c: string | undefined): string | undefined =>
   c || undefined;
 
@@ -107,7 +111,9 @@ export type RemoteThreadState = {
 // prepends, so that order is newest first; object enumeration is not a
 // reliable stand-in, since integer-like keys enumerate out of insertion
 // order). Threads the server already knew stay governed by the response, so
-// a server-side deletion is not resurrected.
+// a server-side deletion is not resurrected — and a thread unknown to the
+// snapshot is only rescued when it is a local creation, so a deep-linked
+// thread the fetch path deliberately appended at the tail is not hoisted.
 export const preserveMidLoadTransitions = (
   state: RemoteThreadState,
   priorOrder: Pick<RemoteThreadState, "threadIds" | "archivedThreadIds">,
@@ -124,6 +130,7 @@ export const preserveMidLoadTransitions = (
   for (const data of Object.values(state.threadData)) {
     const before = statusAtRequest.get(data.id);
     if (before !== undefined && before !== "new") continue;
+    if (before === undefined && !isLocalThreadId(data.id)) continue;
 
     if (data.status === "regular" && !contains(regular, data)) {
       rescuedRegular.push(data);

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -103,17 +103,20 @@ export type RemoteThreadState = {
 // completed-optimistic replay cannot re-add it because the merged threadData
 // already carries the final status. Threads whose status moved from new (or
 // nonexistent) at request time to regular/archived are re-inserted at the
-// top, where updateStatusReducer would have placed them; threads the server
-// already knew stay governed by the response, so a server-side deletion is
-// not resurrected.
+// top, in the order the pre-response lists carried them (updateStatusReducer
+// prepends, so that order is newest first; object enumeration is not a
+// reliable stand-in, since integer-like keys enumerate out of insertion
+// order). Threads the server already knew stay governed by the response, so
+// a server-side deletion is not resurrected.
 export const preserveMidLoadTransitions = (
   state: RemoteThreadState,
+  priorOrder: Pick<RemoteThreadState, "threadIds" | "archivedThreadIds">,
   statusAtRequest: ReadonlyMap<string, RemoteThreadData["status"]>,
 ): RemoteThreadState => {
   const regular = new Set(state.threadIds);
   const archived = new Set(state.archivedThreadIds);
-  const prependRegular: string[] = [];
-  const prependArchived: string[] = [];
+  const rescuedRegular: RemoteThreadData[] = [];
+  const rescuedArchived: RemoteThreadData[] = [];
 
   const contains = (ids: ReadonlySet<string>, data: RemoteThreadData) =>
     ids.has(data.id) || (data.remoteId !== undefined && ids.has(data.remoteId));
@@ -123,22 +126,38 @@ export const preserveMidLoadTransitions = (
     if (before !== undefined && before !== "new") continue;
 
     if (data.status === "regular" && !contains(regular, data)) {
-      prependRegular.push(data.id);
+      rescuedRegular.push(data);
       regular.add(data.id);
     } else if (data.status === "archived" && !contains(archived, data)) {
-      prependArchived.push(data.id);
+      rescuedArchived.push(data);
       archived.add(data.id);
     }
   }
 
-  if (prependRegular.length === 0 && prependArchived.length === 0) return state;
-  // Newest transition first, as successive updateStatusReducer prepends
-  // would have left them.
+  if (rescuedRegular.length === 0 && rescuedArchived.length === 0) return state;
+
+  const position = (ids: readonly string[], data: RemoteThreadData) => {
+    const byId = ids.indexOf(data.id);
+    if (byId !== -1) return byId;
+    const byRemoteId =
+      data.remoteId !== undefined ? ids.indexOf(data.remoteId) : -1;
+    return byRemoteId !== -1 ? byRemoteId : Number.MAX_SAFE_INTEGER;
+  };
+  rescuedRegular.sort(
+    (a, b) =>
+      position(priorOrder.threadIds, a) - position(priorOrder.threadIds, b),
+  );
+  rescuedArchived.sort(
+    (a, b) =>
+      position(priorOrder.archivedThreadIds, a) -
+      position(priorOrder.archivedThreadIds, b),
+  );
+
   return {
     ...state,
-    threadIds: [...prependRegular.reverse(), ...state.threadIds],
+    threadIds: [...rescuedRegular.map((d) => d.id), ...state.threadIds],
     archivedThreadIds: [
-      ...prependArchived.reverse(),
+      ...rescuedArchived.map((d) => d.id),
       ...state.archivedThreadIds,
     ],
   };

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -102,36 +102,41 @@ export type RemoteThreadState = {
 // initialized while the request was running) omits that thread, and the
 // completed-optimistic replay cannot re-add it because the merged threadData
 // already carries the final status. Threads whose status moved from new (or
-// nonexistent) at request time to regular/archived are re-appended; threads
-// the server already knew stay governed by the response, so a server-side
-// deletion is not resurrected.
+// nonexistent) at request time to regular/archived are re-inserted at the
+// top, where updateStatusReducer would have placed them; threads the server
+// already knew stay governed by the response, so a server-side deletion is
+// not resurrected.
 export const preserveMidLoadTransitions = (
   state: RemoteThreadState,
-  fresh: Pick<RemoteThreadState, "threadIds" | "archivedThreadIds">,
   statusAtRequest: ReadonlyMap<string, RemoteThreadData["status"]>,
-): Pick<RemoteThreadState, "threadIds" | "archivedThreadIds"> => {
-  const threadIds = [...fresh.threadIds];
-  const archivedThreadIds = [...fresh.archivedThreadIds];
+): RemoteThreadState => {
+  const regular = new Set(state.threadIds);
+  const archived = new Set(state.archivedThreadIds);
+  const prependRegular: string[] = [];
+  const prependArchived: string[] = [];
 
-  const contains = (ids: readonly string[], data: RemoteThreadData) =>
-    ids.includes(data.id) ||
-    (data.remoteId !== undefined && ids.includes(data.remoteId));
+  const contains = (ids: ReadonlySet<string>, data: RemoteThreadData) =>
+    ids.has(data.id) || (data.remoteId !== undefined && ids.has(data.remoteId));
 
   for (const data of Object.values(state.threadData)) {
     const before = statusAtRequest.get(data.id);
     if (before !== undefined && before !== "new") continue;
 
-    if (data.status === "regular" && !contains(threadIds, data)) {
-      threadIds.push(data.id);
-    } else if (
-      data.status === "archived" &&
-      !contains(archivedThreadIds, data)
-    ) {
-      archivedThreadIds.push(data.id);
+    if (data.status === "regular" && !contains(regular, data)) {
+      prependRegular.push(data.id);
+      regular.add(data.id);
+    } else if (data.status === "archived" && !contains(archived, data)) {
+      prependArchived.push(data.id);
+      archived.add(data.id);
     }
   }
 
-  return { threadIds, archivedThreadIds };
+  if (prependRegular.length === 0 && prependArchived.length === 0) return state;
+  return {
+    ...state,
+    threadIds: [...prependRegular, ...state.threadIds],
+    archivedThreadIds: [...prependArchived, ...state.archivedThreadIds],
+  };
 };
 
 export const statusSnapshot = (

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -10,9 +10,11 @@ import {
   type RemoteThreadState,
 } from "../runtimes/remote-thread-list/remote-thread-state";
 
+type ListResult = Awaited<ReturnType<ReturnType<typeof makeAdapter>["list"]>>;
+
 describe("RemoteThreadListThreadListRuntimeCore load race", () => {
-  it("keeps a thread initialized during the list() flight", async () => {
-    const listDeferred = deferred<{ threads: never[] }>();
+  it("keeps a thread initialized during the list() flight at the top", async () => {
+    const listDeferred = deferred<ListResult>();
     const adapter = makeAdapter({ list: vi.fn(() => listDeferred.promise) });
     const core = createCore(adapter);
 
@@ -23,11 +25,16 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     await core.initialize(newId);
     expect(core.threadIds).toContain(newId);
 
-    listDeferred.resolve({ threads: [] });
+    listDeferred.resolve({
+      threads: [
+        { status: "regular", remoteId: "t1", externalId: "t1", title: "One" },
+      ],
+    });
     await loadPromise;
 
     expect(core.getItemById(newId)?.status).toBe("regular");
-    expect(core.threadIds).toContain(newId);
+    expect(core.threadIds[0]).toBe(newId);
+    expect(core.threadIds).toContain("t1");
   });
 });
 
@@ -38,13 +45,14 @@ describe("preserveMidLoadTransitions", () => {
       remoteId?: string;
       status: "new" | "regular" | "archived";
     }[],
+    lists: { threadIds?: string[]; archivedThreadIds?: string[] } = {},
   ): RemoteThreadState => ({
     isLoading: false,
     isLoadingMore: false,
     cursor: undefined,
     newThreadId: undefined,
-    threadIds: [],
-    archivedThreadIds: [],
+    threadIds: lists.threadIds ?? [],
+    archivedThreadIds: lists.archivedThreadIds ?? [],
     threadIdMap: Object.fromEntries(
       data.map((d) => [d.id, createThreadMappingId(d.id)]),
     ),
@@ -69,31 +77,44 @@ describe("preserveMidLoadTransitions", () => {
     const state = stateWith([{ id: "t1", remoteId: "t1", status: "regular" }]);
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: [], archivedThreadIds: [] },
       new Map([["t1", "regular"]]),
     );
     expect(result.threadIds).toEqual([]);
   });
 
   it("does not duplicate a thread the response contains by remoteId", () => {
-    const state = stateWith([
-      { id: "local-1", remoteId: "remote-1", status: "regular" },
-    ]);
-    const result = preserveMidLoadTransitions(
-      state,
-      { threadIds: ["remote-1"], archivedThreadIds: [] },
-      new Map(),
+    const state = stateWith(
+      [{ id: "local-1", remoteId: "remote-1", status: "regular" }],
+      { threadIds: ["remote-1"] },
     );
+    const result = preserveMidLoadTransitions(state, new Map());
     expect(result.threadIds).toEqual(["remote-1"]);
   });
 
-  it("re-appends an archived mid-flight transition", () => {
+  it("prepends a mid-flight transition ahead of listed threads", () => {
+    const state = stateWith(
+      [
+        { id: "local-1", remoteId: "remote-1", status: "regular" },
+        { id: "t1", remoteId: "t1", status: "regular" },
+      ],
+      { threadIds: ["t1"] },
+    );
+    const result = preserveMidLoadTransitions(
+      state,
+      new Map([
+        ["local-1", "new"],
+        ["t1", "regular"],
+      ]),
+    );
+    expect(result.threadIds).toEqual(["local-1", "t1"]);
+  });
+
+  it("re-inserts an archived mid-flight transition", () => {
     const state = stateWith([
       { id: "local-1", remoteId: "remote-1", status: "archived" },
     ]);
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: [], archivedThreadIds: [] },
       new Map([["local-1", "new"]]),
     );
     expect(result.archivedThreadIds).toEqual(["local-1"]);

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createCore,
+  makeAdapter,
+  deferred,
+} from "./remote-thread-list-test-helpers";
+import {
+  preserveMidLoadTransitions,
+  createThreadMappingId,
+  type RemoteThreadState,
+} from "../runtimes/remote-thread-list/remote-thread-state";
+
+describe("RemoteThreadListThreadListRuntimeCore load race", () => {
+  it("keeps a thread initialized during the list() flight", async () => {
+    const listDeferred = deferred<{ threads: never[] }>();
+    const adapter = makeAdapter({ list: vi.fn(() => listDeferred.promise) });
+    const core = createCore(adapter);
+
+    const loadPromise = core.getLoadThreadsPromise();
+
+    await core.switchToNewThread();
+    const newId = core.newThreadId!;
+    await core.initialize(newId);
+    expect(core.threadIds).toContain(newId);
+
+    listDeferred.resolve({ threads: [] });
+    await loadPromise;
+
+    expect(core.getItemById(newId)?.status).toBe("regular");
+    expect(core.threadIds).toContain(newId);
+  });
+});
+
+describe("preserveMidLoadTransitions", () => {
+  const stateWith = (
+    data: {
+      id: string;
+      remoteId?: string;
+      status: "new" | "regular" | "archived";
+    }[],
+  ): RemoteThreadState => ({
+    isLoading: false,
+    isLoadingMore: false,
+    cursor: undefined,
+    newThreadId: undefined,
+    threadIds: [],
+    archivedThreadIds: [],
+    threadIdMap: Object.fromEntries(
+      data.map((d) => [d.id, createThreadMappingId(d.id)]),
+    ),
+    threadData: Object.fromEntries(
+      data.map((d) => [
+        createThreadMappingId(d.id),
+        {
+          id: d.id,
+          remoteId: d.remoteId,
+          externalId: undefined,
+          status: d.status,
+          initializeTask: Promise.resolve({
+            remoteId: d.remoteId ?? d.id,
+            externalId: undefined,
+          }),
+        },
+      ]),
+    ) as RemoteThreadState["threadData"],
+  });
+
+  it("does not resurrect a thread the server already knew and omitted", () => {
+    const state = stateWith([{ id: "t1", remoteId: "t1", status: "regular" }]);
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: [], archivedThreadIds: [] },
+      new Map([["t1", "regular"]]),
+    );
+    expect(result.threadIds).toEqual([]);
+  });
+
+  it("does not duplicate a thread the response contains by remoteId", () => {
+    const state = stateWith([
+      { id: "local-1", remoteId: "remote-1", status: "regular" },
+    ]);
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: ["remote-1"], archivedThreadIds: [] },
+      new Map(),
+    );
+    expect(result.threadIds).toEqual(["remote-1"]);
+  });
+
+  it("re-appends an archived mid-flight transition", () => {
+    const state = stateWith([
+      { id: "local-1", remoteId: "remote-1", status: "archived" },
+    ]);
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: [], archivedThreadIds: [] },
+      new Map([["local-1", "new"]]),
+    );
+    expect(result.archivedThreadIds).toEqual(["local-1"]);
+  });
+});

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -77,6 +77,7 @@ describe("preserveMidLoadTransitions", () => {
     const state = stateWith([{ id: "t1", remoteId: "t1", status: "regular" }]);
     const result = preserveMidLoadTransitions(
       state,
+      { threadIds: ["t1"], archivedThreadIds: [] },
       new Map([["t1", "regular"]]),
     );
     expect(result.threadIds).toEqual([]);
@@ -87,7 +88,11 @@ describe("preserveMidLoadTransitions", () => {
       [{ id: "local-1", remoteId: "remote-1", status: "regular" }],
       { threadIds: ["remote-1"] },
     );
-    const result = preserveMidLoadTransitions(state, new Map());
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: ["local-1"], archivedThreadIds: [] },
+      new Map(),
+    );
     expect(result.threadIds).toEqual(["remote-1"]);
   });
 
@@ -101,6 +106,7 @@ describe("preserveMidLoadTransitions", () => {
     );
     const result = preserveMidLoadTransitions(
       state,
+      { threadIds: ["local-1", "t1"], archivedThreadIds: [] },
       new Map([
         ["local-1", "new"],
         ["t1", "regular"],
@@ -109,7 +115,7 @@ describe("preserveMidLoadTransitions", () => {
     expect(result.threadIds).toEqual(["local-1", "t1"]);
   });
 
-  it("orders multiple rescued threads newest first", () => {
+  it("orders multiple rescued threads by their live pre-response order", () => {
     const state = stateWith(
       [
         { id: "local-1", remoteId: "remote-1", status: "regular" },
@@ -117,8 +123,25 @@ describe("preserveMidLoadTransitions", () => {
       ],
       { threadIds: ["t1"] },
     );
-    const result = preserveMidLoadTransitions(state, new Map());
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: ["local-2", "local-1"], archivedThreadIds: [] },
+      new Map(),
+    );
     expect(result.threadIds).toEqual(["local-2", "local-1", "t1"]);
+  });
+
+  it("is not confused by integer-like ids enumerating out of order", () => {
+    const state = stateWith([
+      { id: "1", status: "regular" },
+      { id: "2", status: "regular" },
+    ]);
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: ["1", "2"], archivedThreadIds: [] },
+      new Map(),
+    );
+    expect(result.threadIds).toEqual(["1", "2"]);
   });
 
   it("re-inserts an archived mid-flight transition", () => {
@@ -127,6 +150,7 @@ describe("preserveMidLoadTransitions", () => {
     ]);
     const result = preserveMidLoadTransitions(
       state,
+      { threadIds: [], archivedThreadIds: ["local-1"] },
       new Map([["local-1", "new"]]),
     );
     expect(result.archivedThreadIds).toEqual(["local-1"]);

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -85,12 +85,12 @@ describe("preserveMidLoadTransitions", () => {
 
   it("does not duplicate a thread the response contains by remoteId", () => {
     const state = stateWith(
-      [{ id: "local-1", remoteId: "remote-1", status: "regular" }],
+      [{ id: "__LOCALID_1", remoteId: "remote-1", status: "regular" }],
       { threadIds: ["remote-1"] },
     );
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: ["local-1"], archivedThreadIds: [] },
+      { threadIds: ["__LOCALID_1"], archivedThreadIds: [] },
       new Map(),
     );
     expect(result.threadIds).toEqual(["remote-1"]);
@@ -118,41 +118,40 @@ describe("preserveMidLoadTransitions", () => {
   it("orders multiple rescued threads by their live pre-response order", () => {
     const state = stateWith(
       [
-        { id: "local-1", remoteId: "remote-1", status: "regular" },
-        { id: "local-2", remoteId: "remote-2", status: "regular" },
+        { id: "__LOCALID_1", remoteId: "remote-1", status: "regular" },
+        { id: "__LOCALID_2", remoteId: "remote-2", status: "regular" },
       ],
       { threadIds: ["t1"] },
     );
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: ["local-2", "local-1"], archivedThreadIds: [] },
+      { threadIds: ["__LOCALID_1", "__LOCALID_2"], archivedThreadIds: [] },
       new Map(),
     );
-    expect(result.threadIds).toEqual(["local-2", "local-1", "t1"]);
+    expect(result.threadIds).toEqual(["__LOCALID_1", "__LOCALID_2", "t1"]);
   });
 
-  it("is not confused by integer-like ids enumerating out of order", () => {
-    const state = stateWith([
-      { id: "1", status: "regular" },
-      { id: "2", status: "regular" },
-    ]);
+  it("leaves a fetched non-local thread governed by the response", () => {
+    const state = stateWith([{ id: "t9", remoteId: "t9", status: "regular" }], {
+      threadIds: ["t1"],
+    });
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: ["1", "2"], archivedThreadIds: [] },
+      { threadIds: ["t1", "t9"], archivedThreadIds: [] },
       new Map(),
     );
-    expect(result.threadIds).toEqual(["1", "2"]);
+    expect(result.threadIds).toEqual(["t1"]);
   });
 
   it("re-inserts an archived mid-flight transition", () => {
     const state = stateWith([
-      { id: "local-1", remoteId: "remote-1", status: "archived" },
+      { id: "__LOCALID_1", remoteId: "remote-1", status: "archived" },
     ]);
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: [], archivedThreadIds: ["local-1"] },
-      new Map([["local-1", "new"]]),
+      { threadIds: [], archivedThreadIds: ["__LOCALID_1"] },
+      new Map([["__LOCALID_1", "new"]]),
     );
-    expect(result.archivedThreadIds).toEqual(["local-1"]);
+    expect(result.archivedThreadIds).toEqual(["__LOCALID_1"]);
   });
 });

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -109,6 +109,18 @@ describe("preserveMidLoadTransitions", () => {
     expect(result.threadIds).toEqual(["local-1", "t1"]);
   });
 
+  it("orders multiple rescued threads newest first", () => {
+    const state = stateWith(
+      [
+        { id: "local-1", remoteId: "remote-1", status: "regular" },
+        { id: "local-2", remoteId: "remote-2", status: "regular" },
+      ],
+      { threadIds: ["t1"] },
+    );
+    const result = preserveMidLoadTransitions(state, new Map());
+    expect(result.threadIds).toEqual(["local-2", "local-1", "t1"]);
+  });
+
   it("re-inserts an archived mid-flight transition", () => {
     const state = stateWith([
       { id: "local-1", remoteId: "remote-1", status: "archived" },

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -44,6 +44,7 @@ describe("preserveMidLoadTransitions", () => {
       id: string;
       remoteId?: string;
       status: "new" | "regular" | "archived";
+      localOrigin?: true;
     }[],
     lists: { threadIds?: string[]; archivedThreadIds?: string[] } = {},
   ): RemoteThreadState => ({
@@ -64,6 +65,7 @@ describe("preserveMidLoadTransitions", () => {
           remoteId: d.remoteId,
           externalId: undefined,
           status: d.status,
+          ...(d.localOrigin ? { localOrigin: true as const } : {}),
           initializeTask: Promise.resolve({
             remoteId: d.remoteId ?? d.id,
             externalId: undefined,
@@ -85,7 +87,14 @@ describe("preserveMidLoadTransitions", () => {
 
   it("does not duplicate a thread the response contains by remoteId", () => {
     const state = stateWith(
-      [{ id: "__LOCALID_1", remoteId: "remote-1", status: "regular" }],
+      [
+        {
+          id: "__LOCALID_1",
+          remoteId: "remote-1",
+          status: "regular",
+          localOrigin: true,
+        },
+      ],
       { threadIds: ["remote-1"] },
     );
     const result = preserveMidLoadTransitions(
@@ -118,17 +127,27 @@ describe("preserveMidLoadTransitions", () => {
   it("orders multiple rescued threads by their live pre-response order", () => {
     const state = stateWith(
       [
-        { id: "__LOCALID_1", remoteId: "remote-1", status: "regular" },
-        { id: "__LOCALID_2", remoteId: "remote-2", status: "regular" },
+        {
+          id: "__LOCALID_1",
+          remoteId: "remote-1",
+          status: "regular",
+          localOrigin: true,
+        },
+        {
+          id: "__LOCALID_2",
+          remoteId: "remote-2",
+          status: "regular",
+          localOrigin: true,
+        },
       ],
       { threadIds: ["t1"] },
     );
     const result = preserveMidLoadTransitions(
       state,
-      { threadIds: ["__LOCALID_1", "__LOCALID_2"], archivedThreadIds: [] },
+      { threadIds: ["__LOCALID_2", "__LOCALID_1"], archivedThreadIds: [] },
       new Map(),
     );
-    expect(result.threadIds).toEqual(["__LOCALID_1", "__LOCALID_2", "t1"]);
+    expect(result.threadIds).toEqual(["__LOCALID_2", "__LOCALID_1", "t1"]);
   });
 
   it("leaves a fetched non-local thread governed by the response", () => {
@@ -143,9 +162,27 @@ describe("preserveMidLoadTransitions", () => {
     expect(result.threadIds).toEqual(["t1"]);
   });
 
+  it("does not trust a remote id that mimics the local prefix", () => {
+    const state = stateWith(
+      [{ id: "__LOCALID_evil", remoteId: "__LOCALID_evil", status: "regular" }],
+      { threadIds: ["t1"] },
+    );
+    const result = preserveMidLoadTransitions(
+      state,
+      { threadIds: ["t1", "__LOCALID_evil"], archivedThreadIds: [] },
+      new Map(),
+    );
+    expect(result.threadIds).toEqual(["t1"]);
+  });
+
   it("re-inserts an archived mid-flight transition", () => {
     const state = stateWith([
-      { id: "__LOCALID_1", remoteId: "remote-1", status: "archived" },
+      {
+        id: "__LOCALID_1",
+        remoteId: "remote-1",
+        status: "archived",
+        localOrigin: true,
+      },
     ]);
     const result = preserveMidLoadTransitions(
       state,


### PR DESCRIPTION
## Summary

- capture each thread's status when a `list()` request is dispatched; when the non-replace response lands, re-insert threads whose status transitioned locally during the flight (a snapshot `new` draft, or a thread unknown to the snapshot carrying the `localOrigin` marker stamped at draft creation) and which the response does not contain — deep-linked threads inserted by the fetch path stay governed by the response and keep their deliberate tail placement, and the marker is explicit state rather than an id-shape inference, so an adapter-supplied remote id that mimics the local prefix cannot be misclassified (review rounds 4–5) — **prepended in their live pre-response order**, matching where successive `updateStatusReducer` prepends placed them, so the rescued conversations render at the top of the sidebar in the right order (review rounds 1–3)
- the rule is implemented once as `preserveMidLoadTransitions(state, statusAtRequest)` in `remote-thread-state.ts` (full-state signature and Set-based membership per review) and applied at both call sites carrying the identical wholesale-replace `then`: the legacy `RemoteThreadListThreadListRuntimeCore` and the tap client's `RemoteThreadList`
- server-side deletions are not resurrected: a thread the server already knew (status `regular`/`archived` at request time) stays governed by the response; response-contained threads are deduped by both local and remote id

## Why

Fixes #6202. The classic first-load flow — app mounts, `list()` goes out, the user immediately sends their first message — lost the newly created conversation from the sidebar the moment the stale response landed: the `then` replaces `threadIds` wholesale, and the completed-optimistic replay (built for this stale-`then` class) is defeated in exactly the initialize case because the merged `threadData` already carries the final status, so `updateStatusReducer`'s `lastStatus === newStatus` early return skips re-inserting the id. End state before the fix: the item exists with status `regular`, `mainThreadId` points at it, but `threadIds` is empty — the open conversation is missing from `ThreadListPrimitive.Items` until reload.

The delete/archive variants of the race replay fine (their optimistic transforms re-run) and stay covered by `OptimisticState-list-race.test.ts`; the adapter-swap path (`_replaceWithThreads`) already preserves initialized local threads. This change gives the normal load path the equivalent preservation, keyed on mid-flight status transitions so it cannot resurrect server-side deletions on reload.

Root-cause verification: both new surface tests fail on main exactly as the issue describes — the legacy-core test with `expected [] to include '__LOCALID_…'`, and the tap-client test after switching away from the initialized thread (where the bug is otherwise masked by `collectItemOrder` appending `mainThreadId`) — and pass with the fix. The helper's unit tests pin the no-resurrection and no-duplication properties.

### Review decisions

- **Why not repair the optimistic replay instead** (raised in review): making `updateStatusReducer` self-heal list membership on its `lastStatus === newStatus` path would extend every completed optimistic transform's effect indefinitely — a later list load would re-insert threads whose archive/initialize transforms are still in the replay set even after the server deleted them. The request-scoped snapshot bounds preservation to transitions that happened during that one flight, which is the narrowest rule that fixes the race without resurrections.
- **The response-contains-alias scenario** (raised in review): verified by running the same probe against main — the state after a stale response that lists a mid-flight-initialized thread under its remote id is byte-identical with and without this change, so that seam's behavior is pre-existing and untouched by this diff.

- **Batch ordering does not infer from object enumeration** (review rounds 3 and 5): the rescued batch is sorted by each thread's position in the pre-response lists — the live order successive `updateStatusReducer` prepends actually produced, which `threadData` insertion order need not match. The live-order unit test passes a prior order that diverges from insertion order, so deleting the sort fails it.

## Validation

- `pnpm --filter @assistant-ui/core test` (132 files, 1415 tests; includes 10 new tests: the initialize-during-flight race on both the legacy core and the tap client — each resolving a non-empty stale list and asserting the rescued thread lands at the top — plus 6 unit tests on `preserveMidLoadTransitions` covering no-resurrection, remoteId dedup, top placement ahead of listed threads, live-order preservation for multiple rescues (with fixtures where enumeration order and live order disagree), a fetched non-local thread staying response-governed, a remote id mimicking the local prefix not being trusted, and the archived transition)
- `pnpm lint`
- changeset: patch for `@assistant-ui/core`
