### PR TITLE
docs: fix imports and package names that do not resolve

### DIFF
--- a/apps/docs/content/docs/guides/message-timing.mdx
+++ b/apps/docs/content/docs/guides/message-timing.mdx
@@ -174,14 +174,16 @@ const runtime = useLangGraphRuntime({ stream: myStream });
 // useMessageTiming() works out of the box
 ```
 
-### AG-UI (`useAgUiThreadRuntime`)
+### AG-UI (`useAgUiRuntime`)
 
 Timing is tracked automatically on the client side by the AG-UI run aggregator. Each emitted message includes timing metadata computed from stream chunk observations.
 
 ```tsx
-import { useAgUiThreadRuntime } from "@assistant-ui/react-ag-ui";
+import { useAgUiRuntime } from "@assistant-ui/react-ag-ui";
+import { HttpAgent } from "@ag-ui/client";
 
-const runtime = useAgUiThreadRuntime({ runtimeUrl: "..." });
+const agent = new HttpAgent({ url: "http://localhost:8000/agent" });
+const runtime = useAgUiRuntime({ agent });
 // useMessageTiming() works out of the box
 ```
 

--- a/apps/docs/content/docs/ink/hooks.mdx
+++ b/apps/docs/content/docs/ink/hooks.mdx
@@ -129,7 +129,7 @@ const runtime = useLocalRuntime(chatModel, {
 | `adapters.dictation` | `DictationAdapter` | Adapter for speech-to-text input |
 | `adapters.feedback` | `FeedbackAdapter` | Adapter for message feedback (thumbs up/down) |
 | `adapters.suggestion` | `SuggestionAdapter` | Adapter for suggested prompts |
-| `cloud` | `AssistantCloud` | Cloud instance for thread persistence via `@assistant-ui/cloud` |
+| `cloud` | `AssistantCloud` | Cloud instance for thread persistence via `assistant-cloud` |
 | `unstable_humanToolNames` | `string[]` | Tool names that pause the run until a result is added via `addResult` |
 
 ### useRemoteThreadListRuntime

--- a/apps/docs/content/docs/react-native/adapters.mdx
+++ b/apps/docs/content/docs/react-native/adapters.mdx
@@ -15,7 +15,7 @@ The simplest way to add persistence. Pass a `cloud` option to `useLocalRuntime`:
 
 ```tsx
 import { useLocalRuntime } from "@assistant-ui/react-native";
-import { AssistantCloud } from "@assistant-ui/cloud";
+import { AssistantCloud } from "assistant-cloud";
 
 const cloud = new AssistantCloud({
   baseUrl: "https://backend.assistant-ui.com",

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -744,8 +744,8 @@ Register the components with `makeAssistantDataUI`, keyed by the `UIMessage`'s `
 import {
   AssistantRuntimeProvider,
   makeAssistantDataUI,
-  Thread,
 } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
 import { useStreamRuntime } from "@assistant-ui/react-langchain";
 
 const ChartUI = makeAssistantDataUI({

--- a/apps/docs/content/docs/runtimes/opencode/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/quickstart.mdx
@@ -41,7 +41,7 @@ export function MyRuntimeProvider({
 ### Render the Thread
 
 ```tsx title="app/page.tsx"
-import { Thread } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
 import { MyRuntimeProvider } from "./MyRuntimeProvider";
 
 export default function Page() {


### PR DESCRIPTION
## Summary

Five documentation snippets reference imports or packages that do not resolve; each was verified against the actual package exports (TypeScript export enumeration of the barrels, the audited `api-surface` files, and `npm view` for package names):

- `runtimes/opencode/quickstart.mdx` and `runtimes/langchain.mdx` imported `Thread` from `@assistant-ui/react`, which exports no such component — copying the snippet fails the build. Both now import from `@/components/assistant-ui/thread`, the registry path the LangChain page itself already uses in its other tabs.
- `react-native/adapters.mdx` instructed `import { AssistantCloud } from "@assistant-ui/cloud"` — that package name 404s on npm (`npm view @assistant-ui/cloud` → E404). The real package is `assistant-cloud` (0.1.41), which every other docs page uses. `ink/hooks.mdx` carried the same wrong name in its options table.
- `guides/message-timing.mdx` documented `useAgUiThreadRuntime({ runtimeUrl: "..." })` — neither the hook nor the option exists anywhere in `@assistant-ui/react-ag-ui` (repo-wide grep; absent from `api-surface/assistant-ui__react-ag-ui.ts`). Rewritten to the real API, `useAgUiRuntime({ agent })` with an `HttpAgent`, matching the AG-UI quickstart.

## Why

Each of these is a hard failure for a user following the page as written: an unresolvable named import, an npm 404, or a hook that never existed. No behavior or API changes — docs content only, outside the generator-owned api-reference tree.

## Validation

- repo-wide grep confirms zero remaining occurrences of `useAgUiThreadRuntime`, `@assistant-ui/cloud` (excluding the real `@assistant-ui/cloud-ai-sdk`), and `import { Thread } from "@assistant-ui/react"`
- replacement imports verified against the export surfaces: `@/components/assistant-ui/thread` (registry component), `assistant-cloud` (npm 0.1.41), `useAgUiRuntime`/`HttpAgent` (package exports and quickstart usage)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1DQcPnkTKkbcl4xuSZiNKFho_bfz_b269Z6KolXeURhrP5tg6QDMMNLh45E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->