### PR TITLE
docs: memoize the HttpAgent in the message-timing snippet

### DIFF
--- a/apps/docs/content/docs/guides/message-timing.mdx
+++ b/apps/docs/content/docs/guides/message-timing.mdx
@@ -179,10 +179,14 @@ const runtime = useLangGraphRuntime({ stream: myStream });
 Timing is tracked automatically on the client side by the AG-UI run aggregator. Each emitted message includes timing metadata computed from stream chunk observations.
 
 ```tsx
+import { useMemo } from "react";
 import { useAgUiRuntime } from "@assistant-ui/react-ag-ui";
 import { HttpAgent } from "@ag-ui/client";
 
-const agent = new HttpAgent({ url: "http://localhost:8000/agent" });
+const agent = useMemo(
+  () => new HttpAgent({ url: "http://localhost:8000/agent" }),
+  [],
+);
 const runtime = useAgUiRuntime({ agent });
 // useMessageTiming() works out of the box
 ```


### PR DESCRIPTION
## Summary

- memoize the `HttpAgent` in the message-timing guide's AG-UI snippet (`useMemo` + import), matching the AG-UI quickstart

## Why

Follow-up to the review on #6206 (merged before the nit could ride along): the snippet constructed the agent in render, so every pass would hand `useAgUiRuntime` a fresh `HttpAgent` and `updateOptions` would swap it mid-run, discarding the agent's accumulated state. The quickstart memoizes for exactly this reason; this keeps the two pages teaching the same pattern.

## Validation

- docs content only; snippet now mirrors `runtimes/ag-ui/quickstart.mdx`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JkjGQV8qTGMyLgF7lKlgY1oOo-8p6iHoOWUahWTRLXS_gGNys3FxkBVtvz4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->