### PR TITLE
feat(ai-sdk): expose the useChat throttle option

### DIFF
--- a/.changeset/blue-chats-throttle.md
+++ b/.changeset/blue-chats-throttle.md
@@ -2,4 +2,4 @@
 "@assistant-ui/ai-sdk": patch
 ---
 
-fix: forward the chat update throttle through `useChatRuntime`
+fix: expose the chat update throttle in `useChatRuntime` options

--- a/.changeset/blue-chats-throttle.md
+++ b/.changeset/blue-chats-throttle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: forward the chat update throttle through `useChatRuntime`

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1,4 +1,4 @@
-import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, UseChatOptions, useChat } from "@ai-sdk/react";
+import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, useChat } from "@ai-sdk/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -520,7 +520,8 @@ type ChatModelRunResult = {
   };
 };
 
-type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & Pick<UseChatOptions<UI_MESSAGE>, "throttle"> & ExternalStoreSharedOptions & {
+type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
+  throttle?: number | undefined;
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1,4 +1,4 @@
-import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, useChat } from "@ai-sdk/react";
+import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, UseChatOptions, useChat } from "@ai-sdk/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -520,7 +520,7 @@ type ChatModelRunResult = {
   };
 };
 
-type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
+type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & Pick<UseChatOptions<UI_MESSAGE>, "throttle"> & ExternalStoreSharedOptions & {
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1,4 +1,4 @@
-import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, UseChatOptions, useChat } from "@ai-sdk/react";
+import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, useChat } from "@ai-sdk/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -520,7 +520,8 @@ type ChatModelRunResult = {
   };
 };
 
-type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & Pick<UseChatOptions<UI_MESSAGE>, "throttle"> & ExternalStoreSharedOptions & {
+type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
+  throttle?: number | undefined;
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1,4 +1,4 @@
-import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, useChat } from "@ai-sdk/react";
+import { Chat, CreateUIMessage, UIMessage as UIMessage$1, UseChatHelpers, UseChatOptions, useChat } from "@ai-sdk/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -520,7 +520,7 @@ type ChatModelRunResult = {
   };
 };
 
-type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
+type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & Pick<UseChatOptions<UI_MESSAGE>, "throttle"> & ExternalStoreSharedOptions & {
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];

--- a/examples/with-openui/app/page.tsx
+++ b/examples/with-openui/app/page.tsx
@@ -13,7 +13,6 @@ import { shouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk"
 
 export default function Home() {
   const runtime = useChatRuntime({
-    throttle: 50,
     sendAutomaticallyWhen: shouldContinueAfterOpenUIPrompt,
   });
 

--- a/examples/with-openui/app/page.tsx
+++ b/examples/with-openui/app/page.tsx
@@ -13,6 +13,7 @@ import { shouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk"
 
 export default function Home() {
   const runtime = useChatRuntime({
+    throttle: 50,
     sendAutomaticallyWhen: shouldContinueAfterOpenUIPrompt,
   });
 

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -96,6 +96,19 @@ describe("useChatRuntime", () => {
     window.sessionStorage.clear();
   });
 
+  it("forwards the chat update throttle to useChat", () => {
+    mocks.useChat.mockReturnValue({
+      resumeStream: vi.fn(),
+      status: "ready",
+    });
+
+    renderHook(() => useChatRuntime({ throttle: 50 }));
+
+    expect(mocks.useChat).toHaveBeenCalledWith(
+      expect.objectContaining({ throttle: 50 }),
+    );
+  });
+
   it("waits for external history to load before resuming a stream", async () => {
     mocks.state.isLoadingHistory = true;
     const resumeStream = vi.fn().mockResolvedValue(undefined);

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -96,17 +96,20 @@ describe("useChatRuntime", () => {
     window.sessionStorage.clear();
   });
 
-  it("forwards the chat update throttle to useChat", () => {
+  it("forwards a defined chat update throttle to useChat", () => {
     mocks.useChat.mockReturnValue({
       resumeStream: vi.fn(),
       status: "ready",
     });
 
     renderHook(() => useChatRuntime({ throttle: 50 }));
+    renderHook(() => useChatRuntime({ throttle: undefined }));
 
-    expect(mocks.useChat).toHaveBeenCalledWith(
+    expect(mocks.useChat).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({ throttle: 50 }),
     );
+    expect(mocks.useChat.mock.calls[1]?.[0]).not.toHaveProperty("throttle");
   });
 
   it("waits for external history to load before resuming a stream", async () => {

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import { useChat, type Chat, type UIMessage } from "@ai-sdk/react";
+import {
+  useChat,
+  type Chat,
+  type UIMessage,
+  type UseChatOptions,
+} from "@ai-sdk/react";
 import {
   pickExternalStoreSharedOptions,
   type AssistantRuntime,
@@ -31,6 +36,7 @@ import { useResourceCleanup } from "./useResourceCleanup";
 
 export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> &
+    Pick<UseChatOptions<UI_MESSAGE>, "throttle"> &
     ExternalStoreSharedOptions & {
       adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
       toCreateMessage?: CustomToCreateMessageFunction;

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useChat,
-  type Chat,
-  type UIMessage,
-  type UseChatOptions,
-} from "@ai-sdk/react";
+import { useChat, type Chat, type UIMessage } from "@ai-sdk/react";
 import {
   pickExternalStoreSharedOptions,
   type AssistantRuntime,
@@ -36,8 +31,8 @@ import { useResourceCleanup } from "./useResourceCleanup";
 
 export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> &
-    Pick<UseChatOptions<UI_MESSAGE>, "throttle"> &
     ExternalStoreSharedOptions & {
+      throttle?: number | undefined;
       adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
@@ -128,6 +123,7 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
   const {
     adapters,
     transport,
+    throttle,
     toCreateMessage,
     isDisabled: _isDisabled,
     isSendDisabled: _isSendDisabled,
@@ -147,6 +143,7 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
   return {
     adapters,
     transport,
+    throttle,
     toCreateMessage,
     onResume,
     onResumeToolCall,
@@ -163,6 +160,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const {
     adapters,
     transport: transportOptions,
+    throttle,
     toCreateMessage,
     onResume,
     onResumeToolCall,
@@ -187,6 +185,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...chatOptions,
     id,
     transport,
+    ...(throttle !== undefined && { throttle }),
     ...(externalChat !== undefined && { chat: externalChat }),
   });
 


### PR DESCRIPTION
## Summary

- expose the AI SDK `useChat` throttle option on `useChatRuntime` / `ChatThreadOptions`
- accept explicit `undefined` under `exactOptionalPropertyTypes` and omit it at the AI SDK boundary
- test forwarding a numeric throttle and omitting an undefined value

## Scope

Runtime forwarding for numeric throttle values already worked through the chat option remainder. This closes the public type gap that prevented typed consumers from configuring the hook-level option, including conditional values such as `throttle: enabled ? 50 : undefined`.

`throttle` is peeled out of the `ChatInit` remainder so `new Chat(...)` does not receive a hook-only option. The OpenUI example is left unthrottled; the chart render loop in https://github.com/thesysdev/openui/issues/990 is an upstream issue, not something a 50 ms update throttle should paper over.

AI SDK reference: https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat#throttle

## Verification

- focused `useChatRuntime` suite
- api-surface snapshots updated for `@assistant-ui/ai-sdk` and `@assistant-ui/react-ai-sdk`