### PR TITLE
fix(ci): make the api-surface check run on every Node and catch stale files under filters

### DIFF
--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -1007,10 +1008,19 @@ async function main() {
 }
 
 // import.meta.main requires Node >= 24.2; on older runtimes it is undefined
-// and the script would silently no-op with exit code 0.
+// and the script would silently no-op with exit code 0. Both sides are
+// realpath'd because Node resolves the main module through symlinks while
+// argv keeps the invoked path (e.g. /tmp vs /private/tmp on macOS).
+const realPath = (file) => {
+  try {
+    return realpathSync(file);
+  } catch {
+    return path.resolve(file);
+  }
+};
 const isMainEntry =
   process.argv[1] !== undefined &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  realPath(process.argv[1]) === realPath(fileURLToPath(import.meta.url));
 if (isMainEntry) {
   await main();
 }

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -1013,7 +1013,7 @@ async function main() {
 // argv keeps the invoked path (e.g. /tmp vs /private/tmp on macOS).
 const realPath = (file) => {
   try {
-    return realpathSync(file);
+    return realpathSync.native(file);
   } catch {
     return path.resolve(file);
   }

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -11,7 +11,7 @@ import {
 import { createRequire } from "node:module";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { optionArgs, optionValues } from "./lib/script-options.mjs";
 
 const repoRoot = process.cwd();
@@ -114,11 +114,7 @@ function declarationFilesForTarget(packageDir, typePath) {
   return files;
 }
 
-function collectPackages() {
-  const filteredPackageNames = turboFilters.length
-    ? collectTurboFilteredPackageNames(turboFilters)
-    : undefined;
-
+function collectPackages(filteredPackageNames) {
   return readdirSync(packagesRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
@@ -918,8 +914,29 @@ function writeOrCheck(file, content, changedFiles) {
   if (!checkMode) writeFileSync(file, content);
 }
 
+// A filtered run cannot judge files for unselected packages, but a file
+// matching no current publishable package (deleted, renamed, privatized) is
+// stale under any filter; only the unfiltered run may treat
+// not-regenerated-this-run as stale.
+export function selectStaleSurfaceFiles({
+  files,
+  generatedFiles,
+  knownFiles,
+  filtered,
+}) {
+  return files.filter(
+    (file) =>
+      file.endsWith(".ts") &&
+      !generatedFiles.has(file) &&
+      !(filtered && knownFiles.has(file)),
+  );
+}
+
 async function main() {
-  const packages = collectPackages();
+  const allPackages = collectPackages(undefined);
+  const packages = turboFilters.length
+    ? collectPackages(collectTurboFilteredPackageNames(turboFilters))
+    : allPackages;
   const generatedFiles = new Set();
   const changedFiles = [];
 
@@ -945,11 +962,21 @@ async function main() {
       writeOrCheck(outputFile, content, changedFiles);
     }
 
-    // Filtered checks only know about selected packages; stale cleanup needs the full package set.
-    if (turboFilters.length === 0 && existsSync(apiSurfaceRoot)) {
-      for (const entry of readdirSync(apiSurfaceRoot)) {
-        const file = path.join(apiSurfaceRoot, entry);
-        if (!entry.endsWith(".ts") || generatedFiles.has(file)) continue;
+    if (existsSync(apiSurfaceRoot)) {
+      const knownFiles = new Set(
+        allPackages.map(({ pkg }) =>
+          path.join(apiSurfaceRoot, packageFileName(pkg.name)),
+        ),
+      );
+      const stale = selectStaleSurfaceFiles({
+        files: readdirSync(apiSurfaceRoot).map((entry) =>
+          path.join(apiSurfaceRoot, entry),
+        ),
+        generatedFiles,
+        knownFiles,
+        filtered: turboFilters.length > 0,
+      });
+      for (const file of stale) {
         if (checkMode) {
           changedFiles.push({
             file: path.relative(repoRoot, file).replaceAll("\\", "/"),
@@ -979,6 +1006,11 @@ async function main() {
   }
 }
 
-if (import.meta.main) {
+// import.meta.main requires Node >= 24.2; on older runtimes it is undefined
+// and the script would silently no-op with exit code 0.
+const isMainEntry =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMainEntry) {
   await main();
 }

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { normalizeBundledDeclaration } from "./generate-api-surface.mjs";
+import {
+  normalizeBundledDeclaration,
+  selectStaleSurfaceFiles,
+} from "./generate-api-surface.mjs";
 
 const attachmentUnion = (first, second) =>
   `type X = (${first}) | (${second});\n`;
@@ -211,4 +214,56 @@ test("protected members stay in the surface", () => {
   assert.match(output, /protected render\(\): void/);
   assert.match(output, /#private;/);
   assert.equal(output.includes("hide"), false);
+});
+
+test("stale surface selection flags files for no current package under any filter", () => {
+  const files = [
+    "api-surface/a.ts",
+    "api-surface/gone.ts",
+    "api-surface/readme.md",
+  ];
+  const generatedFiles = new Set(["api-surface/a.ts"]);
+  const knownFiles = new Set(["api-surface/a.ts", "api-surface/b.ts"]);
+
+  assert.deepEqual(
+    selectStaleSurfaceFiles({
+      files,
+      generatedFiles,
+      knownFiles,
+      filtered: true,
+    }),
+    ["api-surface/gone.ts"],
+  );
+});
+
+test("a filtered run leaves files for unselected-but-existing packages alone", () => {
+  const files = ["api-surface/a.ts", "api-surface/b.ts"];
+  const generatedFiles = new Set(["api-surface/a.ts"]);
+  const knownFiles = new Set(["api-surface/a.ts", "api-surface/b.ts"]);
+
+  assert.deepEqual(
+    selectStaleSurfaceFiles({
+      files,
+      generatedFiles,
+      knownFiles,
+      filtered: true,
+    }),
+    [],
+  );
+});
+
+test("an unfiltered run treats not-regenerated files as stale", () => {
+  const files = ["api-surface/a.ts", "api-surface/b.ts", "api-surface/gone.ts"];
+  const generatedFiles = new Set(["api-surface/a.ts"]);
+  const knownFiles = new Set(["api-surface/a.ts", "api-surface/b.ts"]);
+
+  assert.deepEqual(
+    selectStaleSurfaceFiles({
+      files,
+      generatedFiles,
+      knownFiles,
+      filtered: false,
+    }),
+    ["api-surface/b.ts", "api-surface/gone.ts"],
+  );
 });


### PR DESCRIPTION
## Summary

- replace the `import.meta.main` entrypoint gate (Node ≥ 24.2 only; `undefined` → silent no-op with exit 0 on anything older) with a `process.argv[1]`-vs-`import.meta.url` comparison that works on every Node version and stays inert when the module is imported (the colocated test file imports `normalizeBundledDeclaration`). Both sides are realpath'd (review round 1): Node resolves the main module through symlinks while argv keeps the invoked path, so a symlinked checkout — e.g. macOS `/tmp` → `/private/tmp` — would otherwise recreate the very no-op this PR removes. Verified by invoking the script through an actual symlinked repo path: the check now executes
- run stale-surface detection on filtered runs too, for the case a filtered run can safely judge: a file matching **no current publishable workspace package** (deleted, renamed, privatized) is stale under any filter; files for unselected-but-existing packages stay out of a filtered run's jurisdiction, and the unfiltered run keeps its stronger not-regenerated-this-run rule
- the full package set comes from the existing `packages/*/package.json` enumeration (no build needed); the stale rule is extracted as the pure `selectStaleSurfaceFiles` helper with unit tests for all three modes

## Why

Fixes #6210. Both defects let "Check API surface" pass without checking:

- On Node < 24.2 (including 24.0/24.1, which satisfy `engines: ">=24"`, and the 20/22/23 runtimes contributors commonly have), the script printed nothing, checked nothing, and exited 0 — `check-api-surface.mjs` saw success. Reproduced directly on Node 23.11: silent exit 0 with a planted stale file present.
- Both CI invocations always pass `--filter`, and the stale-detection branch was gated on having none — so a surface file for a deleted/renamed/privatized package would stay committed forever with CI green, until an unfiltered local run attributed the unexplained deletion to someone's unrelated change.

Root-cause verification: on Node 23.11 the same filtered check that silently exited 0 before now executes and, with a planted `api-surface/zz-stale.ts`, reports it and exits 1 — while leaving the ~40 surface files of unselected-but-existing packages untouched; removing the plant returns "Checked 1 API surface file(s)", exit 0. `node --test scripts/generate-api-surface.test.mjs` (which imports the module) passes 17/17 without triggering `main`.

## Validation

- `node --test scripts/generate-api-surface.test.mjs` — 17 tests (3 new: filtered flags unknown-package files, filtered spares unselected-but-known, unfiltered keeps the stronger rule)
- end-to-end on Node 23.11 as above (previously the no-op runtime)
- `pnpm exec oxfmt` on the touched scripts
- scripts only — no published package changes, no changeset
