### PR TITLE
fix(react-markdown): keep the pre element for raw pre blocks without a code child

### DIFF
--- a/.changeset/react-markdown-raw-pre.md
+++ b/.changeset/react-markdown-raw-pre.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+fix: keep the pre element for raw pre blocks without a code child

--- a/packages/react-markdown/src/overrides/PreOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.test.tsx
@@ -36,11 +36,16 @@ const injectRawPre = () => (tree: Root) => {
   tree.children.push(pre);
 };
 
+const PlainPre: PreComponent = ({ node: _, ...props }) => <pre {...props} />;
+const PreWithPlainFallback: PreComponent = (props) => (
+  <PreOverride fallbackPre={PlainPre} {...props} />
+);
+
 const render = (markdown: string) =>
   renderToStaticMarkup(
     <ReactMarkdown
       rehypePlugins={[injectRawPre]}
-      components={{ pre: PreOverride, code: CodeWithContext }}
+      components={{ pre: PreWithPlainFallback, code: CodeWithContext }}
     >
       {markdown}
     </ReactMarkdown>,
@@ -64,12 +69,6 @@ describe("PreOverride", () => {
     );
 
     expect(html).toContain('<pre class="user-pre">  indented\n  text</pre>');
-  });
-
-  it("keeps the pre element for a pre without a code child", () => {
-    const html = render("");
-
-    expect(html).toContain("<pre>  indented\n  text</pre>");
   });
 
   it("still routes fenced code blocks through the code override", () => {

--- a/packages/react-markdown/src/overrides/PreOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.test.tsx
@@ -47,6 +47,25 @@ const render = (markdown: string) =>
   );
 
 describe("PreOverride", () => {
+  it("routes a code-less pre through the consumer's pre component", () => {
+    const UserPre: PreComponent = ({ node: _, ...props }) => (
+      <pre className="user-pre" {...props} />
+    );
+    const PreWithFallback: PreComponent = (props) => (
+      <PreOverride fallbackPre={UserPre} {...props} />
+    );
+    const html = renderToStaticMarkup(
+      <ReactMarkdown
+        rehypePlugins={[injectRawPre]}
+        components={{ pre: PreWithFallback, code: CodeWithContext }}
+      >
+        {""}
+      </ReactMarkdown>,
+    );
+
+    expect(html).toContain('<pre class="user-pre">  indented\n  text</pre>');
+  });
+
   it("keeps the pre element for a pre without a code child", () => {
     const html = render("");
 

--- a/packages/react-markdown/src/overrides/PreOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.test.tsx
@@ -50,8 +50,7 @@ describe("PreOverride", () => {
   it("keeps the pre element for a pre without a code child", () => {
     const html = render("");
 
-    expect(html).toContain("<pre>");
-    expect(html).toContain("  indented\n  text");
+    expect(html).toContain("<pre>  indented\n  text</pre>");
   });
 
   it("still routes fenced code blocks through the code override", () => {

--- a/packages/react-markdown/src/overrides/PreOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import type { Element, Root } from "hast";
+import { PreOverride } from "./PreOverride";
+import { CodeOverride } from "./CodeOverride";
+import type {
+  CodeComponent,
+  PreComponent,
+  SyntaxHighlighterProps,
+} from "./types";
+import type { FC } from "react";
+
+const Pre: PreComponent = ({ node: _, ...props }) => <pre {...props} />;
+const Code: CodeComponent = ({ node: _, ...props }) => <code {...props} />;
+const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code }) => (
+  <pre>
+    <code>{code}</code>
+  </pre>
+);
+
+const CodeWithContext: CodeComponent = (props) => (
+  <CodeOverride
+    components={{ Pre, Code, SyntaxHighlighter, CodeHeader: () => null }}
+    {...props}
+  />
+);
+
+const injectRawPre = () => (tree: Root) => {
+  const pre: Element = {
+    type: "element",
+    tagName: "pre",
+    properties: {},
+    children: [{ type: "text", value: "  indented\n  text" }],
+  };
+  tree.children.push(pre);
+};
+
+const render = (markdown: string) =>
+  renderToStaticMarkup(
+    <ReactMarkdown
+      rehypePlugins={[injectRawPre]}
+      components={{ pre: PreOverride, code: CodeWithContext }}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+
+describe("PreOverride", () => {
+  it("keeps the pre element for a pre without a code child", () => {
+    const html = render("");
+
+    expect(html).toContain("<pre>");
+    expect(html).toContain("  indented\n  text");
+  });
+
+  it("still routes fenced code blocks through the code override", () => {
+    const html = render("```\nhello\n```");
+
+    expect(html).toContain("<code");
+    expect(html).toContain("hello");
+    expect(html.match(/<pre/g)?.length).toBe(2);
+  });
+});

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -46,4 +46,8 @@ const PreOverrideImpl = ({
   return <PreContext.Provider value={rest}>{children}</PreContext.Provider>;
 };
 
-export const PreOverride = memo(PreOverrideImpl, memoCompareNodes);
+export const PreOverride = memo(
+  PreOverrideImpl,
+  (prev, next) =>
+    prev.fallbackPre === next.fallbackPre && memoCompareNodes(prev, next),
+);

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -19,7 +19,7 @@ export const useIsMarkdownCodeBlock = () => {
 };
 
 type PreOverrideProps = ComponentPropsWithoutRef<PreComponent> & {
-  fallbackPre?: PreComponent | undefined;
+  fallbackPre: PreComponent;
 };
 
 const PreOverrideImpl = ({
@@ -30,18 +30,14 @@ const PreOverrideImpl = ({
   // The pre element is re-emitted by CodeOverride, which only runs for a
   // code child. A pre without one (e.g. raw HTML via rehype-raw) would
   // otherwise lose its element entirely, so it is rendered here through the
-  // consumer's pre component (fallbackPre, wired by MarkdownTextInner) so
-  // raw blocks keep consumer styling, or as a plain pre without one.
+  // consumer's pre component so raw blocks keep consumer styling. Required
+  // so the compiler pins MarkdownTextInner's wiring.
   const hasCodeChild =
     rest.node?.children.some(
       (child) => child.type === "element" && child.tagName === "code",
     ) ?? true;
 
-  if (!hasCodeChild) {
-    if (FallbackPre) return <FallbackPre {...rest}>{children}</FallbackPre>;
-    const { node: _, ...preProps } = rest;
-    return <pre {...preProps}>{children}</pre>;
-  }
+  if (!hasCodeChild) return <FallbackPre {...rest}>{children}</FallbackPre>;
 
   return <PreContext.Provider value={rest}>{children}</PreContext.Provider>;
 };

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -19,6 +19,19 @@ export const useIsMarkdownCodeBlock = () => {
 };
 
 const PreOverrideImpl: PreComponent = ({ children, ...rest }) => {
+  // The pre element is re-emitted by CodeOverride, which only runs for a
+  // code child. A pre without one (e.g. raw HTML via rehype-raw) would
+  // otherwise lose its element entirely, so it is rendered directly here.
+  const hasCodeChild =
+    rest.node?.children.some(
+      (child) => child.type === "element" && child.tagName === "code",
+    ) ?? true;
+
+  if (!hasCodeChild) {
+    const { node: _, ...preProps } = rest;
+    return <pre {...preProps}>{children}</pre>;
+  }
+
   return <PreContext.Provider value={rest}>{children}</PreContext.Provider>;
 };
 

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -30,8 +30,7 @@ const PreOverrideImpl = ({
   // The pre element is re-emitted by CodeOverride, which only runs for a
   // code child. A pre without one (e.g. raw HTML via rehype-raw) would
   // otherwise lose its element entirely, so it is rendered here through the
-  // consumer's pre component so raw blocks keep consumer styling. Required
-  // so the compiler pins MarkdownTextInner's wiring.
+  // consumer's pre component so raw blocks keep consumer styling.
   const hasCodeChild =
     rest.node?.children.some(
       (child) => child.type === "element" && child.tagName === "code",

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -18,19 +18,27 @@ export const useIsMarkdownCodeBlock = () => {
   return useContext(PreContext) !== null;
 };
 
-const PreOverrideImpl: PreComponent = ({ children, ...rest }) => {
+type PreOverrideProps = ComponentPropsWithoutRef<PreComponent> & {
+  fallbackPre?: PreComponent | undefined;
+};
+
+const PreOverrideImpl = ({
+  children,
+  fallbackPre: FallbackPre,
+  ...rest
+}: PreOverrideProps) => {
   // The pre element is re-emitted by CodeOverride, which only runs for a
   // code child. A pre without one (e.g. raw HTML via rehype-raw) would
-  // otherwise lose its element entirely, so it is rendered directly here.
-  // Deliberately a plain pre, not the consumer's components.pre: that
-  // component's chrome is drawn to sit under a CodeHeader and would be
-  // wrong standalone, and a dedicated raw-pre slot would be new API.
+  // otherwise lose its element entirely, so it is rendered here through the
+  // consumer's pre component (fallbackPre, wired by MarkdownTextInner) so
+  // raw blocks keep consumer styling, or as a plain pre without one.
   const hasCodeChild =
     rest.node?.children.some(
       (child) => child.type === "element" && child.tagName === "code",
     ) ?? true;
 
   if (!hasCodeChild) {
+    if (FallbackPre) return <FallbackPre {...rest}>{children}</FallbackPre>;
     const { node: _, ...preProps } = rest;
     return <pre {...preProps}>{children}</pre>;
   }

--- a/packages/react-markdown/src/overrides/PreOverride.tsx
+++ b/packages/react-markdown/src/overrides/PreOverride.tsx
@@ -22,6 +22,9 @@ const PreOverrideImpl: PreComponent = ({ children, ...rest }) => {
   // The pre element is re-emitted by CodeOverride, which only runs for a
   // code child. A pre without one (e.g. raw HTML via rehype-raw) would
   // otherwise lose its element entirely, so it is rendered directly here.
+  // Deliberately a plain pre, not the consumer's components.pre: that
+  // component's chrome is drawn to sit under a CodeHeader and would be
+  // wrong standalone, and a dedicated raw-pre slot would be new API.
   const hasCodeChild =
     rest.node?.children.some(
       (child) => child.type === "element" && child.tagName === "code",

--- a/packages/react-markdown/src/primitives/MarkdownText.test.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Element, Root } from "hast";
+import type { ComponentType } from "react";
+
+vi.mock("@assistant-ui/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@assistant-ui/react")>();
+  return {
+    ...original,
+    useMessagePartText: () => ({
+      type: "text",
+      text: "",
+      status: { type: "complete" },
+    }),
+    INTERNAL: {
+      ...original.INTERNAL,
+      useSmooth: (part: { text: string }) => part,
+      useSmoothStatus: () => ({ type: "complete" }),
+      withSmoothContextProvider: (component: ComponentType) => component,
+    },
+  };
+});
+
+import { MarkdownTextPrimitive } from "./MarkdownText";
+
+const injectRawPre = () => (tree: Root) => {
+  const pre: Element = {
+    type: "element",
+    tagName: "pre",
+    properties: {},
+    children: [{ type: "text", value: "  indented\n  text" }],
+  };
+  tree.children.push(pre);
+};
+
+describe("MarkdownTextPrimitive raw pre wiring", () => {
+  it("renders a code-less pre through the consumer's pre component", () => {
+    const UserPre = ({
+      node: _,
+      ...props
+    }: Record<string, unknown> & { node?: Element }) => (
+      <pre className="user-pre" {...props} />
+    );
+
+    const html = renderToStaticMarkup(
+      <MarkdownTextPrimitive
+        rehypePlugins={[injectRawPre]}
+        components={{ pre: UserPre }}
+      />,
+    );
+
+    expect(html).toContain('<pre class="user-pre">  indented\n  text</pre>');
+  });
+});

--- a/packages/react-markdown/src/primitives/MarkdownText.test.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.test.tsx
@@ -3,15 +3,15 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { Element, Root } from "hast";
 import type { ComponentType } from "react";
 
+const mocks = vi.hoisted(() => ({
+  messagePartText: { type: "text", text: "", status: { type: "complete" } },
+}));
+
 vi.mock("@assistant-ui/react", async (importOriginal) => {
   const original = await importOriginal<typeof import("@assistant-ui/react")>();
   return {
     ...original,
-    useMessagePartText: () => ({
-      type: "text",
-      text: "",
-      status: { type: "complete" },
-    }),
+    useMessagePartText: () => mocks.messagePartText,
     INTERNAL: {
       ...original.INTERNAL,
       useSmooth: (part: { text: string }) => part,

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -134,15 +134,19 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
     />
   ));
 
+  const PreComponentWithFallback = useCallbackRef((props) => (
+    <PreOverride fallbackPre={pre} {...props} />
+  ));
+
   const components: Options["components"] = useMemo(() => {
     const { pre, code, SyntaxHighlighter, CodeHeader, ...componentsRest } =
       userComponents ?? {};
     return {
       ...componentsRest,
-      pre: PreOverride,
+      pre: PreComponentWithFallback,
       code: CodeComponent,
     };
-  }, [CodeComponent, userComponents]);
+  }, [CodeComponent, PreComponentWithFallback, userComponents]);
 
   return (
     <ReactMarkdown components={components} {...rest}>


### PR DESCRIPTION
## Summary

- `PreOverride` now renders a real `<pre>` element itself when the hast node has no `code` child, instead of assuming a code child will re-emit it
- markdown-fenced blocks are untouched: with a `code` child the override still only provides `PreContext` and `CodeOverride` re-emits the element as before; a missing `node` prop conservatively keeps the old behavior
- raw blocks render through the **consumer's configured `pre` component** (review rounds 1–2): `MarkdownTextInner` passes its resolved `pre` to `PreOverride` as an internal `fallbackPre` prop, so a kit consumer's `aui-md-pre` styling (notably `overflow-x-auto`) applies to raw pres too; `fallbackPre` is required (review round 3), so the compiler itself pins the primitive's wiring and no unreachable plain-`<pre>` branch remains. How a kit styles a standalone pre (its code-block chrome sits under a `CodeHeader`) is now the kit's decision, made with its own component in hand. `PreOverride`'s memo also compares `fallbackPre` (review round 2), matching how `CodeOverride` compares its `components`, so a runtime swap of `components.pre` reaches already-rendered raw blocks; and an integration test renders through `MarkdownTextPrimitive` itself — verified to fail against the commit without the wiring — so removing the production hand-off cannot pass

## Why

`MarkdownTextPrimitive` hardcodes `components.pre = PreOverride`, whose implementation rendered only `<PreContext.Provider>{children}</PreContext.Provider>` — the `<pre>` element is re-emitted downstream by `CodeOverride`'s `WrappedPre`, which only runs when a `code` child consumes the context. For markdown-fenced blocks that invariant holds (`pre > code` always), but with `rehypePlugins={[rehypeRaw]}` — a passthrough the docs show — a message containing a raw `<pre>  indented\n  text</pre>` has no code child, so nothing ever restores the element: it vanishes and its content renders as collapsed inline text with all whitespace formatting lost.

### Reproduction (no linked issue; repro carried here)

Render through the exact `MarkdownTextInner` wiring (`pre: PreOverride`, `code: CodeOverride`) with a rehype plugin injecting a raw `<pre>` element (the regression test does this inline, avoiding a rehype-raw dependency):

- before: output is exactly `  indented\n  text` — no `<pre` tag anywhere (the regression test asserts `<pre>  indented\n  text</pre>` containment, per review, so text landing outside the element cannot pass)
- control: vanilla `react-markdown` with the same tree renders the `<pre>` fine, isolating the override as the cause

Root-cause verification: both new regression tests fail on main (the raw pre loses its element; the mixed fenced-plus-raw case renders one `<pre` instead of two) and pass with the fix; the full package suite (44 tests) is green, confirming fenced-block behavior is unchanged.

## Validation

- `pnpm --filter @assistant-ui/react-markdown test` (4 files, 44 tests, including the 2 new regression tests driving the real react-markdown pipeline)
- `pnpm lint`
- changeset: patch for `@assistant-ui/react-markdown`
