### PR TITLE
fix(cloud-ai-sdk): make chat scope changes commit-safe

### DIFF
--- a/.changeset/calm-cloud-chats.md
+++ b/.changeset/calm-cloud-chats.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: preserve active chats when Cloud scope renders are interrupted

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { Chat } from "@ai-sdk/react";
 import type { UIMessage } from "@ai-sdk/react";
 import { ChatRegistry } from "./ChatRegistry";
@@ -32,40 +32,19 @@ export function useChatRegistry({
   registry: ChatRegistry;
   activeChat: Chat<UIMessage>;
 } {
-  const registryRef = useRef<ChatRegistry | null>(null);
-  const freshSessionKey = useRef<string | null>(null);
-  const prevThreadId = useRef<string | null>(threadId);
-  const scopeRef = useRef(scope);
-
-  if (scopeRef.current !== scope) {
-    scopeRef.current = scope;
-    registryRef.current = null;
-    freshSessionKey.current = null;
-    prevThreadId.current = threadId;
-  }
-
-  if (!registryRef.current) {
-    registryRef.current = createRegistry(createChat);
-  }
-  const registry = registryRef.current;
-
-  if (!freshSessionKey.current) {
-    freshSessionKey.current = createSessionId();
-  }
-
-  // When the user navigates away from a thread (threadId goes null),
-  // generate a fresh session key so the next new-chat gets its own Chat instance.
-  if (threadId === null && prevThreadId.current !== null) {
-    freshSessionKey.current = createSessionId();
-  }
-  prevThreadId.current = threadId;
-
-  if (!threadId && !freshSessionKey.current) {
-    freshSessionKey.current = createSessionId();
-  }
+  const scopedRegistry = useMemo(
+    () => ({ scope, registry: createRegistry(createChat) }),
+    [scope, createChat],
+  );
+  const registry = scopedRegistry.registry;
+  const isNewThread = threadId === null;
+  const freshSession = useMemo(
+    () => ({ scope, isNewThread, key: createSessionId() }),
+    [scope, isNewThread],
+  );
   const activeChatKey = threadId
     ? (registry.getChatKeyForThread(threadId) ?? threadId)
-    : freshSessionKey.current!;
+    : freshSession.key;
 
   const activeChat = registry.getOrCreate(activeChatKey, threadId);
 

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
+import { createElement, Suspense } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UseThreadsResult } from "../types";
 import { CloudChatCore } from "../core/CloudChatCore";
+import { ChatRegistry } from "./ChatRegistry";
 import { useCloudChat } from "./useCloudChat";
 
 function createThreads(
@@ -64,6 +66,41 @@ describe("useCloudChat thread switching", () => {
     rerender({ tid: null });
 
     expect(result.current.messages).toHaveLength(0);
+  });
+
+  it("keeps the committed chat active when a Cloud scope switch suspends", () => {
+    const stopAll = vi
+      .spyOn(ChatRegistry.prototype, "stopAll")
+      .mockResolvedValue(undefined);
+    const cloudA = { threads: {} };
+    const cloudB = { threads: {} };
+    const threadsA = createThreads(cloudA, null);
+    const threadsB = createThreads(cloudB, null);
+    const pending = new Promise<never>(() => {});
+
+    const Probe = ({
+      threads,
+      suspend,
+    }: {
+      threads: UseThreadsResult;
+      suspend: boolean;
+    }) => {
+      useCloudChat({ threads });
+      if (suspend) throw pending;
+      return null;
+    };
+    const renderProbe = (threads: UseThreadsResult, suspend: boolean) =>
+      createElement(
+        Suspense,
+        { fallback: null },
+        createElement(Probe, { threads, suspend }),
+      );
+
+    const view = render(renderProbe(threadsA, false));
+    view.rerender(renderProbe(threadsB, true));
+    view.rerender(renderProbe(threadsA, false));
+
+    expect(stopAll).not.toHaveBeenCalled();
   });
 
   it("retries an interrupted history load when switching back to a thread", () => {

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
 import { AssistantCloud } from "assistant-cloud";
 import type {
@@ -45,10 +45,15 @@ export function useCloudChat(
     transport,
   });
 
+  const createChat = useCallback(
+    (chatKey: string, registry: ChatRegistry) =>
+      core.createChat(chatKey, registry),
+    [core],
+  );
   const { registry, activeChat } = useChatRegistry({
     scope: threads.cloud,
     threadId: threads.threadId,
-    createChat: (chatKey, reg) => core.createChat(chatKey, reg),
+    createChat,
   });
 
   useThreadMessageLoader(threads.threadId, registry, core);

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ChatTransport } from "ai";
 import { DefaultChatTransport } from "ai";
@@ -17,19 +17,16 @@ export function useCloudChatCore(
   },
 ): CloudChatCore {
   const { threads, chatConfig, onSyncError, transport } = options;
+  const currentOptions = { threads, chatConfig, onSyncError };
+  const currentOptionsRef = useRef(currentOptions);
+  currentOptionsRef.current = currentOptions;
 
-  // Recreate when cloud identity changes (prevents stale persistence client)
-  const coreRef = useRef<CloudChatCore | null>(null);
-  if (!coreRef.current || coreRef.current.cloud !== cloud) {
-    coreRef.current = new CloudChatCore(cloud, {
-      threads,
-      chatConfig,
-      onSyncError,
-    });
-  }
-  const core = coreRef.current;
+  const core = useMemo(
+    () => new CloudChatCore(cloud, currentOptionsRef.current),
+    [cloud],
+  );
 
-  core.options = { threads, chatConfig, onSyncError };
+  core.options = currentOptions;
 
   // Track component lifetime for safe async operations
   const mountedRef = useRef(true);


### PR DESCRIPTION
## Summary

- make Cloud chat core and registry identity changes commit-safe
- keep chat creation stable across ordinary rerenders
- preserve the existing cleanup of registries from committed scope changes
- add a Suspense regression test covering an interrupted Cloud switch

## Problem

`useCloudChatCore()` and `useChatRegistry()` reset shared refs during render when the Cloud scope changed. A render for Cloud B could mutate those refs and then suspend without committing. Rendering Cloud A again would observe B's speculative mutations, replace A's registry, and call `stopAll()` on A's still-current chats.

The focused reproduction rendered Cloud A, suspended while rendering Cloud B, then returned to A. Before this change, A's registry was stopped once even though B never committed.

## Fix

Core, registry, and new-chat session identities are now derived with scope-keyed memoized values. Speculative renders therefore keep their identities on the work-in-progress render, while the existing effect continues to stop only the registry replaced by a committed scope change.

## Verification

- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk... build`
- focused Suspense regression: 3/3 tests pass
- targeted oxlint and oxfmt checks pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1GnQcerDlEK8n9oaOZ_kRf04fGVYPiuAvdIX3qXcHvJCntJqgTcmZP_Vxpk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->