### PR TITLE
fix(cloud-ai-sdk): clear hidden archived thread selections

### DIFF
--- a/.changeset/tidy-cloud-archives.md
+++ b/.changeset/tidy-cloud-archives.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: clear selected Cloud threads hidden by remote archival

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -55,6 +55,40 @@ describe("useThreads", () => {
     vi.restoreAllMocks();
   });
 
+  it("clears a selected thread archived outside the current client", async () => {
+    const activeThread = createThreadListResponse("Active", "thread-1")
+      .threads[0]!;
+    const archivedThread = { ...activeThread, is_archived: true };
+    let isArchived = false;
+    const cloud = {
+      threads: {
+        list: vi.fn(async () => ({
+          threads: isArchived ? [] : [activeThread],
+        })),
+        get: vi.fn(async () => archivedThread),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result } = renderHook(() =>
+      useThreads({ cloud, includeArchived: false, enabled: false }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    act(() => result.current.selectThread("thread-1"));
+
+    isArchived = true;
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.threadId).toBeNull();
+  });
+
   it("returns fallback and exposes error when an action fails", async () => {
     const cloud = {
       threads: {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -60,12 +60,13 @@ describe("useThreads", () => {
       .threads[0]!;
     const archivedThread = { ...activeThread, is_archived: true };
     let isArchived = false;
+    const get = vi.fn(async () => archivedThread);
     const cloud = {
       threads: {
         list: vi.fn(async () => ({
           threads: isArchived ? [] : [activeThread],
         })),
-        get: vi.fn(async () => archivedThread),
+        get,
         create: vi.fn(),
         delete: vi.fn(),
         update: vi.fn(),
@@ -85,6 +86,7 @@ describe("useThreads", () => {
       await result.current.refresh();
     });
 
+    expect(get).toHaveBeenCalledWith("thread-1");
     expect(result.current.threads).toEqual([]);
     expect(result.current.threadId).toBeNull();
   });

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -89,6 +89,53 @@ describe("useThreads", () => {
     expect(result.current.threadId).toBeNull();
   });
 
+  it("preserves a remotely archived selection made visible during refresh", async () => {
+    const activeThread = createThreadListResponse("Active", "thread-1")
+      .threads[0]!;
+    const archivedThread = { ...activeThread, is_archived: true };
+    const verification = createDeferred<typeof archivedThread>();
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: [activeThread] })
+      .mockResolvedValueOnce({ threads: [] });
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn().mockReturnValueOnce(verification.promise),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result, rerender } = renderHook(
+      ({ includeArchived }) =>
+        useThreads({ cloud, includeArchived, enabled: false }),
+      { initialProps: { includeArchived: false } },
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    act(() => result.current.selectThread("thread-1"));
+
+    let refreshPromise!: Promise<boolean>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(result.current.threads).toEqual([]);
+      expect(cloud.threads.get).toHaveBeenCalledWith("thread-1");
+    });
+
+    rerender({ includeArchived: true });
+    await act(async () => {
+      verification.resolve(archivedThread);
+      await refreshPromise;
+    });
+
+    expect(result.current.threadId).toBe("thread-1");
+  });
+
   it("returns fallback and exposes error when an action fails", async () => {
     const cloud = {
       threads: {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -106,10 +106,14 @@ describe("useThreads", () => {
         delete: vi.fn(),
         update: vi.fn(),
       },
-    } as never;
+    };
     const { result, rerender } = renderHook(
       ({ includeArchived }) =>
-        useThreads({ cloud, includeArchived, enabled: false }),
+        useThreads({
+          cloud: cloud as never,
+          includeArchived,
+          enabled: false,
+        }),
       { initialProps: { includeArchived: false } },
     );
 

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -182,7 +182,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
             try {
               const selectedThread = await cloud.threads.get(selectedThreadId);
               shouldClearSelectedThread =
-                !includeArchived && selectedThread.is_archived;
+                !includeArchivedRef.current && selectedThread.is_archived;
             } catch (error) {
               shouldClearSelectedThread =
                 typeof error === "object" &&

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -173,23 +173,25 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
 
           if (!isLatest()) return true;
 
-          let selectedThreadDeleted = false;
+          let shouldClearSelectedThread = false;
           if (
             selectedThreadWasListed &&
             selectedThreadId !== null &&
             !nextThreadIds.has(selectedThreadId)
           ) {
             try {
-              await cloud.threads.get(selectedThreadId);
+              const selectedThread = await cloud.threads.get(selectedThreadId);
+              shouldClearSelectedThread =
+                !includeArchived && selectedThread.is_archived;
             } catch (error) {
-              selectedThreadDeleted =
+              shouldClearSelectedThread =
                 typeof error === "object" &&
                 error !== null &&
                 "status" in error &&
                 error.status === 404;
             }
           }
-          if (selectedThreadDeleted) {
+          if (shouldClearSelectedThread) {
             commit(() =>
               setSelection((current) =>
                 current.scope === scope && current.threadId === selectedThreadId


### PR DESCRIPTION
## Summary

- clear the selected thread when a refresh confirms it was archived remotely
- use the latest archive visibility when asynchronous selection verification finishes
- retain the existing protection for active threads temporarily omitted from a list response
- add focused remote-archive and option-change regression tests

## Problem

When `includeArchived` is false, a thread archived by another client disappears from the active-thread list. The refresh path probes a missing selected thread, but previously cleared the selection only for a 404 response. If `threads.get()` returned the existing archived thread, the visible list became empty while `threadId` remained selected. Subsequent chat activity could continue through that hidden archived thread.

The focused reproduction selected `thread-1`, changed the server response to archived, and refreshed. Before this change, `threads` was empty but `threadId` remained `"thread-1"`.

## Fix

When a previously listed selection disappears, refresh now clears it if `threads.get()` confirms either that the thread was deleted or that it is archived while archived threads are currently hidden. Reading the latest `includeArchived` value after the asynchronous verification prevents an in-flight refresh from clearing a thread that became visible while the request was pending.

A still-active thread returned by `get()` remains selected, preserving the eventual-consistency behavior.

## Verification

- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk... build`
- focused `useThreads` suite: 28/28 tests pass
- targeted oxlint and oxfmt checks pass

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.roJ7ZDnuspSkxLcHRYXaL-_jqUXHqUt7a696bTGKqIMQY7NkNSGBfLgSZhg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->