### PR TITLE
fix(react-google-adk): keep every text part of a multi-part event

### DIFF
--- a/.changeset/adk-multi-text-parts.md
+++ b/.changeset/adk-multi-text-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: keep every text and reasoning part of a multi-part ADK event

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -1477,3 +1477,86 @@ describe("AdkEventAccumulator - user message handling", () => {
     });
   });
 });
+
+describe("AdkEventAccumulator - multiple parts in one event", () => {
+  it("keeps every text part of a single non-partial event in order", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: { role: "model", parts: [{ text: "A" }, { text: "B" }] },
+      }),
+    );
+
+    expect(msgs[0]?.content).toEqual([
+      { type: "text", text: "A" },
+      { type: "text", text: "B" },
+    ]);
+  });
+
+  it("preserves the Gemini code-execution shape", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: {
+          role: "model",
+          parts: [
+            { text: "Here is the code:" },
+            { executableCode: { code: "print(1)", language: "python" } },
+            { codeExecutionResult: { outcome: "OUTCOME_OK", output: "1" } },
+            { text: "The result is 1." },
+          ],
+        },
+      }),
+    );
+
+    expect(msgs[0]?.content).toEqual([
+      { type: "text", text: "Here is the code:" },
+      { type: "code", code: "print(1)", language: "python" },
+      { type: "code_result", output: "1", outcome: "OUTCOME_OK" },
+      { type: "text", text: "The result is 1." },
+    ]);
+  });
+
+  it("keeps every reasoning part of a single non-partial event", () => {
+    const acc = new AdkEventAccumulator();
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: {
+          role: "model",
+          parts: [
+            { text: "First thought", thought: true },
+            { text: "Second thought", thought: true },
+          ],
+        },
+      }),
+    );
+
+    expect(msgs[0]?.content).toEqual([
+      { type: "reasoning", text: "First thought" },
+      { type: "reasoning", text: "Second thought" },
+    ]);
+  });
+
+  it("still replaces the streamed buffer with the final text", () => {
+    const acc = new AdkEventAccumulator();
+    acc.processEvent(makeTextEvent("Hel", true));
+    acc.processEvent(makeTextEvent("lo", true));
+    const msgs = acc.processEvent(
+      makeEvent({
+        author: "agent",
+        content: {
+          role: "model",
+          parts: [{ text: "Hello" }, { text: "Again" }],
+        },
+      }),
+    );
+
+    expect(msgs[0]?.content).toEqual([
+      { type: "text", text: "Hello" },
+      { type: "text", text: "Again" },
+    ]);
+  });
+});

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -191,6 +191,8 @@ export class AdkEventAccumulator {
   private messagesMap = new Map<string, AdkMessage>();
   private currentMessageId: string | null = null;
   private partialTextBuffer = "";
+  private finalTextReplacedThisEvent = false;
+  private finalReasoningReplacedThisEvent = false;
   private partialReasoningBuffer = "";
   private accumulatedStateDelta: Record<string, unknown> = {};
   private accumulatedArtifactDelta: Record<string, number> = {};
@@ -387,6 +389,11 @@ export class AdkEventAccumulator {
       }
     }
 
+    // Replace-semantics close out the streamed partial buffer, which only
+    // the first final text/reasoning part of an event may do; later parts
+    // of the same event are distinct content and append.
+    this.finalTextReplacedThisEvent = false;
+    this.finalReasoningReplacedThisEvent = false;
     for (const [index, part] of parts.entries()) {
       this.processPart(part, event, index);
     }
@@ -472,9 +479,12 @@ export class AdkEventAccumulator {
       if (event.partial) {
         this.partialReasoningBuffer += part.text;
         this.replaceLastReasoningContent(msg, this.partialReasoningBuffer);
-      } else {
+      } else if (!this.finalReasoningReplacedThisEvent) {
+        this.finalReasoningReplacedThisEvent = true;
         this.partialReasoningBuffer = "";
         this.replaceLastReasoningContent(msg, part.text);
+      } else {
+        this.appendContent(msg, { type: "reasoning", text: part.text });
       }
       return;
     }
@@ -485,9 +495,12 @@ export class AdkEventAccumulator {
       if (event.partial) {
         this.partialTextBuffer += part.text;
         this.replaceLastTextContent(msg, this.partialTextBuffer);
-      } else {
+      } else if (!this.finalTextReplacedThisEvent) {
+        this.finalTextReplacedThisEvent = true;
         this.partialTextBuffer = "";
         this.replaceLastTextContent(msg, part.text);
+      } else {
+        this.appendContent(msg, { type: "text", text: part.text });
       }
       return;
     }


### PR DESCRIPTION
## Summary

- `AdkEventAccumulator` no longer destroys earlier text (or reasoning) parts when a single non-partial event carries several of them: the replace-the-streamed-buffer semantics now apply only to the **first** final text/reasoning part of an event, and later parts of the same event append as distinct content
- streaming behavior is unchanged — partial events still accumulate into the buffer, and the final event's first text still replaces it in place

## Why

`processPart` handled every part independently, and for each plain-text part of a non-partial event it called `replaceLastTextContent`, which overwrites the last existing text part. That replace is only correct for the streaming case (the final aggregated event repeating the partial buffer); for distinct text parts within one event, each part clobbered its predecessor — and when code parts sat between them, the survivor also landed in the wrong position.

The standard Gemini built-in code-execution response, which ADK forwards verbatim, is exactly this shape: `[{text: "Here is the code:"}, {executableCode}, {codeExecutionResult}, {text: "The result is 1."}]` — before this fix it rendered as `[{text: "The result is 1."}, {code}, {code_result}]`: the leading text destroyed and the surviving text before the code block instead of after. The same defect applied to multiple `thought` parts. Existing tests only ever used one text part per event.

### Reproduction (no linked issue; repro carried here)

Feed the event above (or trivially `parts: [{text: "A"}, {text: "B"}]`) into `processEvent` — the four new regression tests fail on main exactly as described (parts destroyed, wrong order) and pass with the fix, including a streamed-then-final case proving the buffer-replacement contract is intact.

### Known residual, recorded in review

If a final event's first text part were preceded by non-text parts in the same event while a streamed buffer exists (streamed text, then a final `[code, result, text]`), the replace would keep the text at the streamed part's earlier position. That aggregate-order-diverges-from-streamed-order shape has not been observed on the ADK wire; handling it would need move-semantics, deferred until a real payload demonstrates it.

## Validation

- `pnpm --filter @assistant-ui/react-google-adk test` (11 files, 323 tests; 4 new regression tests: two-text ordering, the full Gemini code-execution shape, multiple reasoning parts, and streamed-buffer replacement with a trailing extra part)
- `pnpm lint`
- changeset: patch for `@assistant-ui/react-google-adk`
