### PR TITLE
fix(core): tear down in-flight attachment adds when an edit is cancelled

### DIFF
--- a/.changeset/edit-composer-attachment-leak.md
+++ b/.changeset/edit-composer-attachment-leak.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: cancel an edit session's in-flight attachment adds so they cannot leak into a later session
+fix: cancelling an edit session cancels its in-flight attachment adds and removes its non-complete attachments through the attachment adapter

--- a/.changeset/edit-composer-attachment-leak.md
+++ b/.changeset/edit-composer-attachment-leak.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: cancel an edit session's in-flight attachment adds so they cannot leak into a later session

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -800,7 +800,9 @@ const useComposerClientResource = ({
       // and leaves the draft (and its pending adds) alone.
       if (type === "edit") {
         attachmentAddOperations.cancelAll();
-        void removePendingAttachments(attachmentsRef.current);
+        removePendingAttachments(attachmentsRef.current).catch((error) => {
+          console.error("Failed to remove cancelled edit attachments", error);
+        });
       }
       onCancel?.();
       if (type === "edit") setIsEditing(false);

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -800,7 +800,9 @@ const useComposerClientResource = ({
       // and leaves the draft (and its pending adds) alone.
       if (type === "edit") {
         attachmentAddOperations.cancelAll();
-        removePendingAttachments(attachmentsRef.current).catch((error) => {
+        const removed = attachmentsRef.current;
+        setAttachments([]);
+        removePendingAttachments(removed).catch((error) => {
           console.error("Failed to remove cancelled edit attachments", error);
         });
       }

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -795,6 +795,13 @@ const useComposerClientResource = ({
       }
     },
     cancel: () => {
+      // An edit session ends here, so its in-flight adapter adds must not
+      // land in a later session; the thread composer's cancel stops the run
+      // and leaves the draft (and its pending adds) alone.
+      if (type === "edit") {
+        attachmentAddOperations.cancelAll();
+        void removePendingAttachments(attachmentsRef.current);
+      }
       onCancel?.();
       if (type === "edit") setIsEditing(false);
     },

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -582,3 +582,111 @@ describe("ExternalThread attachments", () => {
     vi.restoreAllMocks();
   });
 });
+
+describe("cancelled edit sessions", () => {
+  const editSetup = (
+    add: (arg: { file: File }) => Promise<PendingAttachment>,
+  ) =>
+    renderThreadWithProps({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      onEdit: () => {},
+      attachmentAdapter: {
+        accept: "*",
+        add,
+        send: async () => ({}) as never,
+        remove: async () => {},
+      },
+    });
+
+  it("does not leak an in-flight add into the next edit session", async () => {
+    let resolveAdd!: (attachment: PendingAttachment) => void;
+    const aui = editSetup(
+      () =>
+        new Promise<PendingAttachment>((resolve) => {
+          resolveAdd = resolve;
+        }),
+    );
+    const composer = () => aui().thread.message({ id: "u1" }).composer();
+
+    await act(async () => {
+      composer().beginEdit();
+    });
+    let addPromise!: Promise<void>;
+    await act(async () => {
+      addPromise = composer().addAttachment(
+        new File(["data"], "notes.txt", { type: "text/plain" }),
+      );
+    });
+    await act(async () => {
+      composer().cancel();
+    });
+    await act(async () => {
+      composer().beginEdit();
+    });
+    await act(async () => {
+      resolveAdd({
+        id: "leak-1",
+        type: "document",
+        name: "notes.txt",
+        contentType: "text/plain",
+        file: new File(["data"], "notes.txt", { type: "text/plain" }),
+        status: { type: "pending", reason: "uploading", progress: 0 },
+      } as PendingAttachment);
+      await addPromise.catch(() => {});
+    });
+
+    expect(composer().getState().attachments).toEqual([]);
+  });
+
+  it("keeps the thread composer's in-flight add across a run cancel", async () => {
+    let resolveAdd!: (attachment: PendingAttachment) => void;
+    const aui = renderThreadWithProps({
+      onNew: () => {},
+      onCancel: () => {},
+      attachmentAdapter: {
+        accept: "*",
+        add: () =>
+          new Promise<PendingAttachment>((resolve) => {
+            resolveAdd = resolve;
+          }),
+        send: async () => ({}) as never,
+        remove: async () => {},
+      },
+    });
+    const composer = () => aui().thread().composer();
+
+    let addPromise!: Promise<void>;
+    await act(async () => {
+      addPromise = composer().addAttachment(
+        new File(["data"], "notes.txt", { type: "text/plain" }),
+      );
+    });
+    await act(async () => {
+      composer().cancel();
+    });
+    await act(async () => {
+      resolveAdd({
+        id: "draft-1",
+        type: "document",
+        name: "notes.txt",
+        contentType: "text/plain",
+        file: new File(["data"], "notes.txt", { type: "text/plain" }),
+        status: { type: "pending", reason: "uploading", progress: 0 },
+      } as PendingAttachment);
+      await addPromise;
+    });
+
+    expect(composer().getState().attachments).toMatchObject([
+      { id: "draft-1" },
+    ]);
+  });
+});

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -647,6 +647,66 @@ describe("cancelled edit sessions", () => {
     expect(composer().getState().attachments).toEqual([]);
   });
 
+  it("adapter-removes the session's pending attachments on cancel, sparing prefilled ones", async () => {
+    const remove = vi.fn(async () => {});
+    const aui = renderThreadWithProps({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [
+            {
+              id: "prefilled-1",
+              type: "document",
+              name: "existing.txt",
+              contentType: "text/plain",
+              content: [],
+              status: { type: "complete" },
+            } as unknown as CompleteAttachment,
+          ],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      onEdit: () => {},
+      attachmentAdapter: {
+        accept: "*",
+        add: async ({ file }: { file: File }) =>
+          ({
+            id: "pending-1",
+            type: "document",
+            name: file.name,
+            contentType: file.type,
+            file,
+            status: { type: "pending", reason: "uploading", progress: 0 },
+          }) as PendingAttachment,
+        send: async () => ({}) as never,
+        remove,
+      },
+    });
+    const composer = () => aui().thread.message({ id: "u1" }).composer();
+
+    await act(async () => {
+      composer().beginEdit();
+    });
+    await act(() =>
+      composer().addAttachment(
+        new File(["data"], "notes.txt", { type: "text/plain" }),
+      ),
+    );
+    expect(composer().getState().attachments).toHaveLength(2);
+
+    await act(async () => {
+      composer().cancel();
+    });
+
+    await waitFor(() => expect(remove).toHaveBeenCalledTimes(1));
+    expect(remove).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "pending-1" }),
+    );
+  });
+
   it("keeps the thread composer's in-flight add across a run cancel", async () => {
     let resolveAdd!: (attachment: PendingAttachment) => void;
     const aui = renderThreadWithProps({

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -705,6 +705,11 @@ describe("cancelled edit sessions", () => {
     expect(remove).toHaveBeenCalledWith(
       expect.objectContaining({ id: "pending-1" }),
     );
+
+    await act(async () => {
+      composer().cancel();
+    });
+    expect(remove).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the thread composer's in-flight add across a run cancel", async () => {


### PR DESCRIPTION
## Summary

- `cancel()` on the **edit** composer now runs the same attachment teardown as `send()` and `reset()`: `attachmentAddOperations.cancelAll()` plus adapter cleanup of the session's non-complete attachments — with a rejection handler on the floated cleanup, mirroring the `send()` float, so a rejecting `adapter.remove` cannot become an unhandled rejection (review round 1)
- the **thread** composer's `cancel()` is deliberately untouched — there it means "cancel the run", and the draft's in-flight adds must survive (pinned by a control test)

## Why

With an async `attachmentAdapter`, this sequence corrupted the next session: `beginEdit()` → `addAttachment(file)` (adapter `add` still pending) → `cancel()` → `beginEdit()` again → the cancelled session's `add` resolves → its `accept` callback upserts the attachment into the **new** session's list (or into the closed composer's state if the user never re-edits). `send()` and `reset()` both call `cancelAll()`, which makes late `accept`s no-ops; `cancel()` only flipped `isEditing`.

This is also a parity break with the legacy edit composer (`DefaultEditComposerRuntimeCore`), which constructs a fresh composer core per edit session and was therefore structurally immune.

Adapter cleanup reuses `removePendingAttachments`, which filters to non-complete attachments — the message's own prefilled (complete) attachments are never adapter-removed, and `beginEdit`'s `updateFromMessage` re-derives state, so no state clearing is needed beyond killing the operations.

### Reproduction (no linked issue; repro carried here)

The regression test drives the real `ExternalThread` through `useAui` with a deferred adapter `add`: begin edit, add a file, cancel, begin a fresh edit, then resolve the deferred add — on main the new session's attachments become `[{id: "leak-1", …}]`; with the fix they stay `[]`. The control test proves a thread-composer run-cancel still lets the draft's in-flight add land.

## Validation

- `pnpm --filter @assistant-ui/core test` (131 files, 1410 tests; 3 new: the leak regression, the adapter-cleanup case — a resolved pending attachment is adapter-removed on cancel while the message's prefilled complete attachment is spared, added per review since the first test's deferred add never exercised that half — and the thread-composer control; both edit-path tests verified failing on main)
- `pnpm lint`
- changeset: patch for `@assistant-ui/core`
