### PR TITLE
fix(react-lexical): keep leading blank lines in the editor readback

### DIFF
--- a/.changeset/lexical-leading-blank-lines.md
+++ b/.changeset/lexical-leading-blank-lines.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: keep leading blank lines when reading composer text back from the editor

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -572,4 +572,71 @@ describe("SyncPlugin", () => {
       metadata: { workspace: "acme" },
     });
   });
+
+  it("preserves leading blank lines through an editor readback", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-test",
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const aui = createAui("\nhello");
+    mocks.aui = aui;
+    await act(async () => {
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+    });
+    expect(
+      editor.getEditorState().read(() => $getRoot().getChildrenSize()),
+    ).toBe(2);
+
+    await act(async () => {
+      editor.update(() => {
+        const lastParagraph = $getRoot().getLastChild();
+        if (!$isElementNode(lastParagraph)) throw new Error("no paragraph");
+        lastParagraph.append($createTextNode("!"));
+      });
+    });
+
+    expect(aui.composer.setText).toHaveBeenLastCalledWith("\nhello!");
+  });
+
+  it("preserves multiple leading blank lines", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-test",
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const aui = createAui("\n\nx");
+    mocks.aui = aui;
+    await act(async () => {
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+    });
+
+    await act(async () => {
+      editor.update(() => {
+        const lastParagraph = $getRoot().getLastChild();
+        if (!$isElementNode(lastParagraph)) throw new Error("no paragraph");
+        lastParagraph.append($createTextNode("!"));
+      });
+    });
+
+    expect(aui.composer.setText).toHaveBeenLastCalledWith("\n\nx!");
+  });
 });

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -494,8 +494,11 @@ export function SyncPlugin({
           const rootNode = $getRoot();
           let fullText = "";
 
-          for (const paragraph of rootNode.getChildren()) {
-            if (fullText.length > 0) {
+          // Joined per paragraph boundary, not on accumulated length: leading
+          // empty paragraphs contribute no text, and gating on length would
+          // silently drop their newlines from what gets sent.
+          for (const [index, paragraph] of rootNode.getChildren().entries()) {
+            if (index > 0) {
               fullText += "\n";
             }
             if (!$isElementNode(paragraph)) continue;

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -494,14 +494,15 @@ export function SyncPlugin({
           const rootNode = $getRoot();
           let fullText = "";
 
-          // Joined per paragraph boundary, not on accumulated length: leading
-          // empty paragraphs contribute no text, and gating on length would
-          // silently drop their newlines from what gets sent.
-          for (const [index, paragraph] of rootNode.getChildren().entries()) {
-            if (index > 0) {
+          // One newline per paragraph boundary; empty paragraphs are lines
+          // too.
+          let lineIndex = 0;
+          for (const paragraph of rootNode.getChildren()) {
+            if (!$isElementNode(paragraph)) continue;
+            if (lineIndex > 0) {
               fullText += "\n";
             }
-            if (!$isElementNode(paragraph)) continue;
+            lineIndex++;
             for (const child of paragraph.getChildren()) {
               fullText += child.getTextContent();
             }


### PR DESCRIPTION
## Summary

- the `SyncPlugin` readback now joins paragraphs per boundary instead of gating the separator on accumulated text length, so leading empty paragraphs keep their newlines in what reaches `composer.setText`
- only **element** children count as lines (review round 1): a non-element root child (e.g. a host-registered decorator node) no longer mints a boundary newline — which also changes `[p("a"), decorator, p("b")]` from main's `"a\n\nb"` to `"a\nb"`, deliberately, since the decorator contributes no line; a raw index over all root children would instead have introduced a spurious leading newline when the first child is a decorator

## Why

Composer text that starts with a newline — a draft restored from persistence, `composer.setText`, or `beginEdit` on a message beginning with a blank line — syncs into Lexical as one paragraph per line, the first ones empty. On the next non-sync editor update the readback joined with `if (fullText.length > 0) fullText += "\n"`, which skips the separator for every leading empty paragraph (`fullText` is still `""` through them), so `composer.setText` received the text with all leading blank lines removed — one for `"\nhello"`, both for `"\n\nx"` — while the editor still visibly displayed them. What the user sees and what gets sent diverge. The sibling code paths (`getEditorLines`, the cursor plugin's offset walk) already join per line rather than by accumulated length.

### Reproduction (no linked issue; repro carried here)

The regression tests mount the real `SyncPlugin` with the package's own harness: runtime text `"\nhello"` syncs to a two-paragraph editor; appending `"!"` via `editor.update` triggers the readback — on main `setText` receives `"hello!"` (and `"\n\nx"` becomes `"x!"`); with the fix it receives `"\nhello!"` / `"\n\nx!"`. Both tests verified failing on main.

## Validation

- `pnpm --filter @assistant-ui/react-lexical test` (5 files, 47 tests; 2 new regression tests for single and multiple leading blank lines)
- `pnpm lint`
- changeset: patch for `@assistant-ui/react-lexical`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2ZxwOsvnQ9QeRL4o--_6fj828YGM0OCaijimfyRoflxDSPU1N46AMQvsOEM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->