### PR TITLE
fix(core): reject archived index selectors on SingleThreadList

### DIFF
--- a/.changeset/single-thread-list-archived-index.md
+++ b/.changeset/single-thread-list-archived-index.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: reject archived index selectors on SingleThreadList instead of resolving the regular thread

--- a/packages/core/src/store/clients/single-thread-list.ts
+++ b/packages/core/src/store/clients/single-thread-list.ts
@@ -93,7 +93,10 @@ const useSingleThreadList = ({
         !(
           typeof selector === "object" &&
           "index" in selector &&
-          selector.index === 0
+          selector.index === 0 &&
+          // Index selectors address their archived/regular subset, and the
+          // archived subset here is always empty.
+          !selector.archived
         )
       ) {
         throw new Error(

--- a/packages/core/src/tests/single-thread-list-item.test.tsx
+++ b/packages/core/src/tests/single-thread-list-item.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import type { FC } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import { ExternalThread } from "../store/clients/external-thread";
+import { SingleThreadList } from "../store/clients/single-thread-list";
+
+let aui!: ReturnType<typeof useAui>;
+
+const Capture: FC = () => {
+  aui = useAui();
+  return null;
+};
+
+const App: FC = () => {
+  const value = useAui({
+    threads: SingleThreadList({ thread: ExternalThread({ messages: [] }) }),
+  });
+  return (
+    <AuiProvider value={value}>
+      <Capture />
+    </AuiProvider>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SingleThreadList item selectors", () => {
+  it("resolves index selectors within the regular subset only", () => {
+    render(<App />);
+
+    const mainId = aui.threads.item("main").getState().id;
+    expect(aui.threads.item({ index: 0 }).getState().id).toBe(mainId);
+    expect(aui.threads.item({ index: 0, archived: false }).getState().id).toBe(
+      mainId,
+    );
+
+    expect(aui.threads.getState().archivedThreadIds).toEqual([]);
+    expect(() => aui.threads.item({ index: 0, archived: true })).toThrow(
+      "unknown item selector",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `SingleThreadList.item({ index: 0, archived: true })` now throws the module's unknown-selector error instead of resolving the single **regular** thread; `{ index: 0 }` and `{ index: 0, archived: false }` are unchanged

## Why

Index selectors address their archived/regular subset — the contract #6199 established for `InMemoryThreadList` and that `RemoteThreadList` and the thread-list runtime client already implement. `SingleThreadList`, auto-mounted by any `ExternalThread` without an explicit threads scope, accepted `{ index: 0 }` without inspecting `archived`, so an archived row resolved the regular main item even though `archivedThreadIds` is always empty here — the same wrong-thread class as #6198, on the one list client the earlier fix didn't cover. The rejection reuses this module's existing unknown-selector throw, matching its own error style for out-of-contract selectors.

### Reproduction (no linked issue; repro carried here)

The regression test mounts the real auto-mount configuration (`SingleThreadList({ thread: ExternalThread(...) })` via `useAui`): on main, `item({ index: 0, archived: true })` returns the regular main item (`status: "regular"`) despite `archivedThreadIds` being `[]`; with the fix it throws. Verified failing on main.

## Validation

- `pnpm --filter @assistant-ui/core test` (132 files, 1411 tests; 1 new regression test covering both accepted forms and the rejected archived form)
- `pnpm lint`
- changeset: patch for `@assistant-ui/core`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.W7WninMmA0nT-CRH-MvJgcavBJVdjN1cRj0umdQ9iZWUV7mgKmHeAMKwUwU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->