### PR TITLE
refactor(docs): unify persisted preferences behind one primitive

### DIFF
--- a/apps/docs/components/pages/docs/contexts/flavor.tsx
+++ b/apps/docs/components/pages/docs/contexts/flavor.tsx
@@ -1,74 +1,32 @@
 "use client";
 
-import { useSyncExternalStore, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import {
+  createPersistedPreference,
+  usePersistedPreference,
+} from "@/lib/persisted-preference";
 
 export type UiFlavor = "base" | "radix";
 
-const STORAGE_KEY = "aui-docs-flavor";
-const PARAM = "view";
-
-let flavor: UiFlavor = "base";
-let hydrated = false;
-const listeners = new Set<() => void>();
-
-function readStoredFlavor(): string | null {
-  try {
-    return window.localStorage.getItem(STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function readCurrent(): UiFlavor {
-  if (typeof window === "undefined") return "base";
-  const param = new URLSearchParams(window.location.search).get(PARAM);
-  if (param === "radix-ui") return "radix";
-  if (param === "base-ui") return "base";
-  return readStoredFlavor() === "radix" ? "radix" : "base";
-}
-
-function emit() {
-  for (const listener of listeners) listener();
-}
-
-function subscribe(listener: () => void) {
-  if (!hydrated) {
-    hydrated = true;
-    flavor = readCurrent();
-    window.addEventListener("popstate", () => {
-      flavor = readCurrent();
-      emit();
-    });
-  }
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
+const flavorPreference = createPersistedPreference<UiFlavor>({
+  key: "aui-docs-flavor",
+  fallback: "base",
+  read: (raw) => (raw === "radix" || raw === "base" ? raw : null),
+  url: {
+    param: "view",
+    read: (raw) =>
+      raw === "radix-ui" ? "radix" : raw === "base-ui" ? "base" : null,
+    write: (value) => (value === "radix" ? "radix-ui" : null),
+  },
+});
 
 export function setFlavor(next: UiFlavor) {
-  flavor = next;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, next);
-  } catch {
-    // Storage can be blocked (private mode, quota); the in-memory value and
-    // the url parameter still carry the selection.
-  }
-  const url = new URL(window.location.href);
-  if (next === "radix") {
-    url.searchParams.set(PARAM, "radix-ui");
-  } else {
-    url.searchParams.delete(PARAM);
-  }
-  window.history.replaceState(window.history.state, "", url);
-  emit();
+  flavorPreference.set(next);
 }
 
 export function useFlavor(): UiFlavor {
-  return useSyncExternalStore(
-    subscribe,
-    () => flavor,
-    () => "base" as const,
-  );
+  return usePersistedPreference(flavorPreference);
 }
 
 export function Flavored({

--- a/apps/docs/components/pages/docs/platform/context.test.ts
+++ b/apps/docs/components/pages/docs/platform/context.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, it } from "vitest";
+
+const STORAGE_KEY = "assistant-ui::docs:platform";
+
+type Handler = (event: unknown) => void;
+
+const setup = ({
+  search = "",
+  stored,
+}: {
+  search?: string;
+  stored?: string;
+}) => {
+  const store = new Map<string, string>();
+  if (stored !== undefined) store.set(STORAGE_KEY, stored);
+
+  let currentSearch = search;
+
+  (globalThis as { window?: unknown }).window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+    get location() {
+      return {
+        href: `https://docs.test/docs${currentSearch}`,
+        search: currentSearch,
+      };
+    },
+    history: {
+      state: null,
+      replaceState: (_state: unknown, _title: string, next: string) => {
+        currentSearch = new URL(next).search;
+      },
+    },
+    addEventListener: (_type: string, _handler: Handler) => {},
+    removeEventListener: (_type: string, _handler: Handler) => {},
+  };
+
+  return { store, getSearch: () => currentSearch };
+};
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+it("promotes a platform url parameter into storage", async () => {
+  const { store } = setup({ search: "?platform=rn" });
+  const { syncPlatformFromUrl } = await import("./context");
+
+  syncPlatformFromUrl();
+
+  expect(store.get(STORAGE_KEY)).toBe("rn");
+});
+
+it("leaves storage alone when the url names no platform", async () => {
+  const { store } = setup({ stored: "ink" });
+  const { syncPlatformFromUrl } = await import("./context");
+
+  syncPlatformFromUrl();
+
+  expect(store.get(STORAGE_KEY)).toBe("ink");
+});
+
+it("ignores an unknown platform in the url", async () => {
+  const { store } = setup({ search: "?platform=vue", stored: "rn" });
+  const { syncPlatformFromUrl } = await import("./context");
+
+  syncPlatformFromUrl();
+
+  expect(store.get(STORAGE_KEY)).toBe("rn");
+});
+
+it("clears the stored key when the url names the default platform", async () => {
+  const { store, getSearch } = setup({
+    search: "?platform=react",
+    stored: "rn",
+  });
+  const { syncPlatformFromUrl } = await import("./context");
+
+  syncPlatformFromUrl();
+
+  expect(store.has(STORAGE_KEY)).toBe(false);
+  expect(getSearch()).toBe("");
+});

--- a/apps/docs/components/pages/docs/platform/context.test.ts
+++ b/apps/docs/components/pages/docs/platform/context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 
 const STORAGE_KEY = "assistant-ui::docs:platform";
 
@@ -46,6 +46,7 @@ const setup = ({
 };
 
 afterEach(() => {
+  vi.resetModules();
   delete (globalThis as { window?: unknown }).window;
 });
 

--- a/apps/docs/components/pages/docs/platform/context.tsx
+++ b/apps/docs/components/pages/docs/platform/context.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
@@ -15,6 +14,10 @@ import {
   PLATFORMS,
   type Platform,
 } from "@/lib/constants";
+import {
+  createPersistedPreference,
+  usePersistedPreference,
+} from "@/lib/persisted-preference";
 
 export { DEFAULT_PLATFORM, PLATFORM_LABELS, PLATFORMS, type Platform };
 
@@ -26,6 +29,43 @@ export const PLATFORM_DOC_BASE_PATHS: Record<Platform, string> = {
 
 const STORAGE_KEY = "assistant-ui::docs:platform";
 const URL_PARAM = "platform";
+
+export function isPlatform(
+  value: string | null | undefined,
+): value is Platform {
+  return value != null && (PLATFORMS as readonly string[]).includes(value);
+}
+
+const platformPreference = createPersistedPreference<Platform>({
+  key: STORAGE_KEY,
+  fallback: DEFAULT_PLATFORM,
+  read: (raw) => (isPlatform(raw) ? raw : null),
+  url: {
+    param: URL_PARAM,
+    read: (raw) => (isPlatform(raw) ? raw : null),
+    write: (value) => (value === DEFAULT_PLATFORM ? null : value),
+  },
+});
+
+// Avoid useSearchParams so the docs layout stays statically renderable.
+function readPlatformParam(): Platform | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = new URLSearchParams(window.location.search).get(URL_PARAM);
+    return isPlatform(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+// Landing on a ?platform= url is an entry point the reader should keep for the
+// rest of the visit, so the parameter is promoted into storage instead of only
+// being read while it stays in the address bar.
+function syncPlatformFromUrl() {
+  platformPreference.resync();
+  const fromUrl = readPlatformParam();
+  if (fromUrl !== null) platformPreference.set(fromUrl);
+}
 
 interface PlatformContextValue {
   platform: Platform;
@@ -63,52 +103,6 @@ export function PlatformScope({
   );
 }
 
-export function isPlatform(
-  value: string | null | undefined,
-): value is Platform {
-  return value != null && (PLATFORMS as readonly string[]).includes(value);
-}
-
-const isBrowser = () => typeof window !== "undefined";
-
-// Avoid useSearchParams so the docs layout stays statically renderable.
-function readUrlPlatform(): Platform | null {
-  if (!isBrowser()) return null;
-  try {
-    const value = new URLSearchParams(window.location.search).get(URL_PARAM);
-    return isPlatform(value) ? value : null;
-  } catch {
-    return null;
-  }
-}
-
-function readStoredPlatform(): Platform | null {
-  if (!isBrowser()) return null;
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    return isPlatform(stored) ? stored : null;
-  } catch {
-    return null;
-  }
-}
-
-// replaceState keeps platform selection shareable without adding noisy
-// back/forward entries for every dropdown change.
-function writeUrlPlatform(next: Platform): void {
-  if (!isBrowser()) return;
-  try {
-    const url = new URL(window.location.href);
-    if (next === DEFAULT_PLATFORM) {
-      if (!url.searchParams.has(URL_PARAM)) return;
-      url.searchParams.delete(URL_PARAM);
-    } else {
-      if (url.searchParams.get(URL_PARAM) === next) return;
-      url.searchParams.set(URL_PARAM, next);
-    }
-    window.history.replaceState(window.history.state, "", url.toString());
-  } catch {}
-}
-
 function platformDocPathSuffix(
   pathname: string,
   platform: Extract<Platform, "rn" | "ink">,
@@ -143,93 +137,23 @@ export function getPlatformSwitchHref(
   return `${PLATFORM_DOC_BASE_PATHS[nextPlatform]}${currentPlatformSuffix}`;
 }
 
-// SSR-safe localStorage backing for useSyncExternalStore, with cross-tab sync
-// via the storage event.
-class PlatformStore {
-  private listeners = new Set<() => void>();
-  private urlPlatform: Platform | null = readUrlPlatform();
-  private storedPlatform: Platform | null = readStoredPlatform();
-
-  constructor() {
-    if (isBrowser()) {
-      window.addEventListener("storage", this.handleStorage);
-    }
-  }
-
-  private refreshFromBrowser = () => {
-    this.urlPlatform = readUrlPlatform();
-    this.storedPlatform = readStoredPlatform();
-  };
-
-  private handleStorage = (e: StorageEvent) => {
-    if (e.storageArea !== window.localStorage) return;
-    if (e.key !== STORAGE_KEY) return;
-    this.storedPlatform = readStoredPlatform();
-    this.notify();
-  };
-
-  private notify = () => {
-    this.listeners.forEach((l) => {
-      l();
-    });
-  };
-
-  subscribe = (listener: () => void) => {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
-  };
-
-  getSnapshot = (): Platform => {
-    return this.urlPlatform ?? this.storedPlatform ?? DEFAULT_PLATFORM;
-  };
-
-  getServerSnapshot = (): Platform => DEFAULT_PLATFORM;
-
-  setValue = (next: Platform) => {
-    if (!isBrowser()) return;
-    try {
-      window.localStorage.setItem(STORAGE_KEY, next);
-      this.storedPlatform = next;
-    } catch {}
-    writeUrlPlatform(next);
-    this.urlPlatform = next === DEFAULT_PLATFORM ? null : next;
-    this.notify();
-  };
-
-  syncUrlAndStore = () => {
-    this.refreshFromBrowser();
-    const next = this.getSnapshot();
-    if (next === this.storedPlatform) return;
-    this.setValue(next);
-  };
-}
-
-const platformStore = new PlatformStore();
-
 export function PlatformProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-
-  const platform = useSyncExternalStore(
-    platformStore.subscribe,
-    platformStore.getSnapshot,
-    platformStore.getServerSnapshot,
-  );
+  const platform = usePersistedPreference(platformPreference);
 
   useEffect(() => {
-    platformStore.syncUrlAndStore();
+    syncPlatformFromUrl();
   }, [pathname]);
 
   useEffect(() => {
-    window.addEventListener("popstate", platformStore.syncUrlAndStore);
+    window.addEventListener("popstate", syncPlatformFromUrl);
     return () => {
-      window.removeEventListener("popstate", platformStore.syncUrlAndStore);
+      window.removeEventListener("popstate", syncPlatformFromUrl);
     };
   }, []);
 
   const setPlatform = useCallback((next: Platform) => {
-    platformStore.setValue(next);
+    platformPreference.set(next);
   }, []);
 
   return (

--- a/apps/docs/components/pages/docs/platform/context.tsx
+++ b/apps/docs/components/pages/docs/platform/context.tsx
@@ -61,7 +61,7 @@ function readPlatformParam(): Platform | null {
 // Landing on a ?platform= url is an entry point the reader should keep for the
 // rest of the visit, so the parameter is promoted into storage instead of only
 // being read while it stays in the address bar.
-function syncPlatformFromUrl() {
+export function syncPlatformFromUrl() {
   platformPreference.resync();
   const fromUrl = readPlatformParam();
   if (fromUrl !== null) platformPreference.set(fromUrl);

--- a/apps/docs/components/pages/elements/install-command.tsx
+++ b/apps/docs/components/pages/elements/install-command.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { mono } from "@/components/elements/surfaces";
 import { CopyButton } from "@/components/shared/copy-button";
+import {
+  createPersistedPreference,
+  usePersistedPreference,
+} from "@/lib/persisted-preference";
 
 const MANAGERS = [
   { key: "npm", runner: "npx", install: "npm install" },
@@ -14,7 +17,11 @@ const MANAGERS = [
 
 type ManagerKey = (typeof MANAGERS)[number]["key"];
 
-const STORAGE_KEY = "aui-elements-pm";
+const managerPreference = createPersistedPreference<ManagerKey>({
+  key: "aui-elements-pm",
+  fallback: "npm",
+  read: (raw) => MANAGERS.find((entry) => entry.key === raw)?.key ?? null,
+});
 
 export function InstallCommand({
   registryName,
@@ -23,14 +30,7 @@ export function InstallCommand({
   registryName?: string;
   npmPackage?: string;
 }) {
-  const [manager, setManager] = useState<ManagerKey>("npm");
-
-  useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (MANAGERS.some((entry) => entry.key === stored)) {
-      setManager(stored as ManagerKey);
-    }
-  }, []);
+  const manager = usePersistedPreference(managerPreference);
 
   const active = MANAGERS.find((entry) => entry.key === manager)!;
   const command = npmPackage
@@ -49,10 +49,7 @@ export function InstallCommand({
                 key={entry.key}
                 type="button"
                 aria-pressed={selected}
-                onClick={() => {
-                  setManager(entry.key);
-                  localStorage.setItem(STORAGE_KEY, entry.key);
-                }}
+                onClick={() => managerPreference.set(entry.key)}
                 className={cn(
                   mono,
                   "h-6 rounded-full px-2.5 transition-[color,background-color] duration-150 motion-reduce:transition-none",

--- a/apps/docs/hooks/use-persistent-boolean.ts
+++ b/apps/docs/hooks/use-persistent-boolean.ts
@@ -1,121 +1,48 @@
 "use client";
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
+import {
+  createPersistedPreference,
+  usePersistedPreference,
+  type PersistedPreference,
+} from "@/lib/persisted-preference";
 
 const STORAGE_PREFIX = "assistant-ui::docs";
 
-const isBrowser = () => typeof window !== "undefined";
+const preferences = new Map<string, PersistedPreference<boolean>>();
 
-class PersistentBooleanStore {
-  private listeners = new Set<() => void>();
-  private storageKey: string;
-  private defaultValue: boolean;
-
-  constructor(key: string, defaultValue: boolean) {
-    this.storageKey = `${STORAGE_PREFIX}:${key}`;
-    this.defaultValue = defaultValue;
-
-    if (isBrowser()) {
-      // Listen for storage events from other tabs/windows
-      window.addEventListener("storage", this.handleStorageChange);
-    }
-  }
-
-  private handleStorageChange = (event: StorageEvent) => {
-    if (event.storageArea !== window.localStorage) return;
-    if (event.key !== this.storageKey) return;
-    this.notifyListeners();
-  };
-
-  private notifyListeners = () => {
-    this.listeners.forEach((listener) => listener());
-  };
-
-  subscribe = (listener: () => void) => {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
-  };
-
-  getSnapshot = () => {
-    if (!isBrowser()) return this.defaultValue;
-    try {
-      const stored = window.localStorage.getItem(this.storageKey);
-      if (stored === null) return this.defaultValue;
-      return stored === "true";
-    } catch {
-      return this.defaultValue;
-    }
-  };
-
-  getServerSnapshot = () => {
-    return this.defaultValue;
-  };
-
-  setValue = (value: boolean) => {
-    if (!isBrowser()) return;
-    try {
-      if (value === this.defaultValue) {
-        window.localStorage.removeItem(this.storageKey);
-      } else {
-        window.localStorage.setItem(this.storageKey, value ? "true" : "false");
-      }
-      this.notifyListeners();
-    } catch {
-      // ignore write errors (e.g., storage disabled)
-    }
-  };
-
-  destroy = () => {
-    if (isBrowser()) {
-      window.removeEventListener("storage", this.handleStorageChange);
-    }
-    this.listeners.clear();
-  };
-}
-
-// Store instances cache to avoid creating multiple stores for the same key
-const storeInstances = new Map<string, PersistentBooleanStore>();
-
-const getStore = (key: string, defaultValue: boolean) => {
+const getPreference = (key: string, fallback: boolean) => {
   const storageKey = `${STORAGE_PREFIX}:${key}`;
-  let store = storeInstances.get(storageKey);
+  let preference = preferences.get(storageKey);
 
-  if (!store) {
-    store = new PersistentBooleanStore(key, defaultValue);
-    storeInstances.set(storageKey, store);
+  if (!preference) {
+    preference = createPersistedPreference<boolean>({
+      key: storageKey,
+      fallback,
+      read: (raw) => (raw === "true" ? true : raw === "false" ? false : null),
+      write: (value) => (value ? "true" : "false"),
+    });
+    preferences.set(storageKey, preference);
   }
 
-  return store;
+  return preference;
 };
 
 export const usePersistentBoolean = (
   key: string,
   initialValue: boolean = false,
 ) => {
-  const store = getStore(key, initialValue);
-
-  const value = useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    store.getServerSnapshot,
-  );
+  const preference = getPreference(key, initialValue);
+  const value = usePersistedPreference(preference);
 
   const update = useCallback(
-    (next: boolean | ((prev: boolean) => boolean)) => {
-      const nextValue =
-        typeof next === "function"
-          ? (next as (prevValue: boolean) => boolean)(store.getSnapshot())
-          : next;
-      store.setValue(nextValue);
+    (next: boolean | ((previous: boolean) => boolean)) => {
+      preference.set(
+        typeof next === "function" ? next(preference.get()) : next,
+      );
     },
-    [store],
+    [preference],
   );
 
-  const reset = useCallback(() => {
-    store.setValue(initialValue);
-  }, [store, initialValue]);
-
-  return [value, update, reset] as const;
+  return [value, update] as const;
 };

--- a/apps/docs/lib/persisted-preference.test.ts
+++ b/apps/docs/lib/persisted-preference.test.ts
@@ -123,6 +123,12 @@ it("ignores a stored value it cannot parse", () => {
   expect(setup({ stored: "solid" }).preference.get()).toBe("base");
 });
 
+it("falls back to the stored value when the url parameter is unparseable", () => {
+  expect(
+    setup({ stored: "radix", search: "?view=solid" }).preference.get(),
+  ).toBe("radix");
+});
+
 it("lets a url parameter outrank the stored value", () => {
   expect(
     setup({ stored: "base", search: "?view=radix-ui" }).preference.get(),
@@ -206,4 +212,13 @@ it("works without a url mapping", () => {
 
   expect(store.get("flavor")).toBe("radix");
   expect(getSearch()).toBe("");
+});
+
+it("keeps a url-less selection across popstate when storage is blocked", () => {
+  const { preference, emit } = setup({ url: false, storageThrows: true });
+
+  preference.set("radix");
+  emit("popstate", {});
+
+  expect(preference.get()).toBe("radix");
 });

--- a/apps/docs/lib/persisted-preference.test.ts
+++ b/apps/docs/lib/persisted-preference.test.ts
@@ -235,3 +235,12 @@ it("re-reads the url when a later subscriber joins", () => {
 
   expect(preference.get()).toBe("radix");
 });
+
+it("keeps a url-less selection when a later subscriber joins and storage is blocked", () => {
+  const { preference } = setup({ url: false, storageThrows: true });
+
+  preference.set("radix");
+  preference.subscribe(() => {});
+
+  expect(preference.get()).toBe("radix");
+});

--- a/apps/docs/lib/persisted-preference.test.ts
+++ b/apps/docs/lib/persisted-preference.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, expect, it } from "vitest";
+import { createPersistedPreference } from "./persisted-preference";
+
+type Flavor = "base" | "radix";
+
+type Handler = (event: unknown) => void;
+
+type SetupOptions = {
+  search?: string;
+  stored?: string;
+  storageThrows?: boolean;
+  url?: boolean;
+};
+
+const setup = ({
+  search = "",
+  stored,
+  storageThrows = false,
+  url = true,
+}: SetupOptions = {}) => {
+  const store = new Map<string, string>();
+  if (stored !== undefined) store.set("flavor", stored);
+
+  const listeners = new Map<string, Set<Handler>>();
+  let currentSearch = search;
+
+  const localStorage = storageThrows
+    ? {
+        getItem: () => {
+          throw new Error("blocked");
+        },
+        setItem: () => {
+          throw new Error("blocked");
+        },
+        removeItem: () => {
+          throw new Error("blocked");
+        },
+      }
+    : {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+      };
+
+  const window = {
+    localStorage,
+    get location() {
+      return {
+        href: `https://docs.test/page${currentSearch}`,
+        search: currentSearch,
+      };
+    },
+    history: {
+      state: { marker: 1 },
+      replaceState: (_state: unknown, _title: string, next: string) => {
+        currentSearch = new URL(next).search;
+      },
+    },
+    addEventListener: (type: string, handler: Handler) => {
+      const set = listeners.get(type) ?? new Set<Handler>();
+      set.add(handler);
+      listeners.set(type, set);
+    },
+    removeEventListener: (type: string, handler: Handler) => {
+      listeners.get(type)?.delete(handler);
+    },
+  };
+
+  (globalThis as { window?: unknown }).window = window;
+
+  const preference = createPersistedPreference<Flavor>({
+    key: "flavor",
+    fallback: "base",
+    read: (raw) => (raw === "base" || raw === "radix" ? raw : null),
+    ...(url
+      ? {
+          url: {
+            param: "view",
+            read: (raw: string) =>
+              raw === "radix-ui" ? "radix" : raw === "base-ui" ? "base" : null,
+            write: (value: Flavor) => (value === "radix" ? "radix-ui" : null),
+          },
+        }
+      : {}),
+  });
+
+  let notifications = 0;
+  preference.subscribe(() => {
+    notifications += 1;
+  });
+
+  const emit = (type: string, event: unknown) => {
+    for (const handler of listeners.get(type) ?? []) handler(event);
+  };
+
+  return {
+    preference,
+    store,
+    emit,
+    localStorage,
+    getSearch: () => currentSearch,
+    getNotifications: () => notifications,
+  };
+};
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+it("falls back when nothing is stored", () => {
+  expect(setup().preference.get()).toBe("base");
+});
+
+it("reads a stored value", () => {
+  expect(setup({ stored: "radix" }).preference.get()).toBe("radix");
+});
+
+it("ignores a stored value it cannot parse", () => {
+  expect(setup({ stored: "solid" }).preference.get()).toBe("base");
+});
+
+it("lets a url parameter outrank the stored value", () => {
+  expect(
+    setup({ stored: "base", search: "?view=radix-ui" }).preference.get(),
+  ).toBe("radix");
+});
+
+it("persists a non-fallback value and mirrors it into the url", () => {
+  const { preference, store, getSearch } = setup();
+
+  preference.set("radix");
+
+  expect(preference.get()).toBe("radix");
+  expect(store.get("flavor")).toBe("radix");
+  expect(getSearch()).toBe("?view=radix-ui");
+});
+
+it("clears the stored key and the url parameter when set back to the fallback", () => {
+  const { preference, store, getSearch } = setup({
+    stored: "radix",
+    search: "?view=radix-ui",
+  });
+
+  preference.set("base");
+
+  expect(preference.get()).toBe("base");
+  expect(store.has("flavor")).toBe(false);
+  expect(getSearch()).toBe("");
+});
+
+it("refreshes on a storage event for its own key only", () => {
+  const { preference, store, emit, localStorage } = setup();
+
+  store.set("flavor", "radix");
+  emit("storage", { storageArea: localStorage, key: "unrelated" });
+  expect(preference.get()).toBe("base");
+
+  emit("storage", { storageArea: localStorage, key: "flavor" });
+  expect(preference.get()).toBe("radix");
+});
+
+it("re-reads the url on popstate", () => {
+  const { preference, emit, getSearch } = setup();
+  expect(preference.get()).toBe("base");
+
+  preference.set("radix");
+  expect(getSearch()).toBe("?view=radix-ui");
+
+  emit("popstate", {});
+  expect(preference.get()).toBe("radix");
+});
+
+it("keeps the selection for the session when storage is blocked", () => {
+  const { preference, getSearch } = setup({ storageThrows: true });
+
+  preference.set("radix");
+
+  expect(preference.get()).toBe("radix");
+  expect(getSearch()).toBe("?view=radix-ui");
+});
+
+it("holds a stable snapshot between notifications", () => {
+  const { preference, store, getNotifications } = setup();
+  const before = getNotifications();
+
+  store.set("flavor", "radix");
+
+  expect(preference.get()).toBe("base");
+  expect(getNotifications()).toBe(before);
+});
+
+it("reports the fallback as the server snapshot", () => {
+  expect(setup({ stored: "radix" }).preference.getServerSnapshot()).toBe(
+    "base",
+  );
+});
+
+it("works without a url mapping", () => {
+  const { preference, store, getSearch } = setup({ url: false });
+
+  preference.set("radix");
+
+  expect(store.get("flavor")).toBe("radix");
+  expect(getSearch()).toBe("");
+});

--- a/apps/docs/lib/persisted-preference.test.ts
+++ b/apps/docs/lib/persisted-preference.test.ts
@@ -103,6 +103,9 @@ const setup = ({
     emit,
     localStorage,
     getSearch: () => currentSearch,
+    setSearch: (next: string) => {
+      currentSearch = next;
+    },
     getNotifications: () => notifications,
   };
 };
@@ -219,6 +222,16 @@ it("keeps a url-less selection across popstate when storage is blocked", () => {
 
   preference.set("radix");
   emit("popstate", {});
+
+  expect(preference.get()).toBe("radix");
+});
+
+it("re-reads the url when a later subscriber joins", () => {
+  const { preference, setSearch } = setup({});
+  expect(preference.get()).toBe("base");
+
+  setSearch("?view=radix-ui");
+  preference.subscribe(() => {});
 
   expect(preference.get()).toBe("radix");
 });

--- a/apps/docs/lib/persisted-preference.ts
+++ b/apps/docs/lib/persisted-preference.ts
@@ -106,7 +106,6 @@ export function createPersistedPreference<T>({
     subscribe: (listener) => {
       if (!listening) {
         listening = true;
-        snapshot = compute();
         window.addEventListener("storage", handleStorage);
         // Without a url mapping a history entry carries no selection, so
         // recomputing on popstate could only discard one that storage failed
@@ -114,6 +113,10 @@ export function createPersistedPreference<T>({
         if (url) window.addEventListener("popstate", refresh);
       }
       listeners.add(listener);
+      // A client-side navigation changes the url without a popstate, so the
+      // cached snapshot is re-derived for every subscriber rather than only
+      // for the first.
+      refresh();
       return () => {
         listeners.delete(listener);
       };

--- a/apps/docs/lib/persisted-preference.ts
+++ b/apps/docs/lib/persisted-preference.ts
@@ -106,17 +106,17 @@ export function createPersistedPreference<T>({
     subscribe: (listener) => {
       if (!listening) {
         listening = true;
+        snapshot = compute();
         window.addEventListener("storage", handleStorage);
-        // Without a url mapping a history entry carries no selection, so
-        // recomputing on popstate could only discard one that storage failed
-        // to persist.
         if (url) window.addEventListener("popstate", refresh);
+      } else if (url) {
+        // A client-side navigation changes the url without firing popstate, so
+        // a later subscriber re-derives it. Without a url mapping there is
+        // nothing to re-derive, and recomputing could only discard a selection
+        // that storage failed to persist.
+        refresh();
       }
       listeners.add(listener);
-      // A client-side navigation changes the url without a popstate, so the
-      // cached snapshot is re-derived for every subscriber rather than only
-      // for the first.
-      refresh();
       return () => {
         listeners.delete(listener);
       };

--- a/apps/docs/lib/persisted-preference.ts
+++ b/apps/docs/lib/persisted-preference.ts
@@ -108,7 +108,10 @@ export function createPersistedPreference<T>({
         listening = true;
         snapshot = compute();
         window.addEventListener("storage", handleStorage);
-        window.addEventListener("popstate", refresh);
+        // Without a url mapping a history entry carries no selection, so
+        // recomputing on popstate could only discard one that storage failed
+        // to persist.
+        if (url) window.addEventListener("popstate", refresh);
       }
       listeners.add(listener);
       return () => {

--- a/apps/docs/lib/persisted-preference.ts
+++ b/apps/docs/lib/persisted-preference.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+type UrlMapping<T> = {
+  param: string;
+  read: (raw: string) => T | null;
+  write: (value: T) => string | null;
+};
+
+type PersistedPreferenceOptions<T> = {
+  key: string;
+  fallback: T;
+  read: (raw: string) => T | null;
+  write?: (value: T) => string;
+  url?: UrlMapping<T>;
+};
+
+export type PersistedPreference<T> = {
+  get: () => T;
+  getServerSnapshot: () => T;
+  set: (value: T) => void;
+  subscribe: (listener: () => void) => () => void;
+  resync: () => void;
+};
+
+const isBrowser = () => typeof window !== "undefined";
+
+export function createPersistedPreference<T>({
+  key,
+  fallback,
+  read,
+  write = String,
+  url,
+}: PersistedPreferenceOptions<T>): PersistedPreference<T> {
+  const listeners = new Set<() => void>();
+  // useSyncExternalStore requires a snapshot that changes only when a listener
+  // fires, so the value is cached rather than read from the browser per call.
+  let snapshot = fallback;
+  let listening = false;
+
+  const readStored = (): T | null => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw === null ? null : read(raw);
+    } catch {
+      return null;
+    }
+  };
+
+  const readUrl = (): T | null => {
+    if (!url) return null;
+    try {
+      const raw = new URLSearchParams(window.location.search).get(url.param);
+      return raw === null ? null : url.read(raw);
+    } catch {
+      return null;
+    }
+  };
+
+  // A url parameter is an explicit, shareable choice, so it outranks whatever
+  // this browser stored earlier.
+  const compute = (): T =>
+    isBrowser() ? (readUrl() ?? readStored() ?? fallback) : fallback;
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const refresh = () => {
+    const next = compute();
+    if (next === snapshot) return;
+    snapshot = next;
+    notify();
+  };
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.storageArea !== window.localStorage) return;
+    if (event.key !== null && event.key !== key) return;
+    refresh();
+  };
+
+  // replaceState keeps the selection shareable without adding a back/forward
+  // entry for every toggle.
+  const writeUrl = (value: T) => {
+    if (!url) return;
+    try {
+      const next = url.write(value);
+      const target = new URL(window.location.href);
+      if (next === null) {
+        if (!target.searchParams.has(url.param)) return;
+        target.searchParams.delete(url.param);
+      } else {
+        if (target.searchParams.get(url.param) === next) return;
+        target.searchParams.set(url.param, next);
+      }
+      window.history.replaceState(window.history.state, "", target.toString());
+    } catch {}
+  };
+
+  return {
+    get: () => snapshot,
+    getServerSnapshot: () => fallback,
+    resync: refresh,
+
+    subscribe: (listener) => {
+      if (!listening) {
+        listening = true;
+        snapshot = compute();
+        window.addEventListener("storage", handleStorage);
+        window.addEventListener("popstate", refresh);
+      }
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    set: (value) => {
+      if (!isBrowser()) return;
+      try {
+        if (value === fallback) {
+          window.localStorage.removeItem(key);
+        } else {
+          window.localStorage.setItem(key, write(value));
+        }
+      } catch {
+        // Storage can be blocked (private mode, quota); the cached snapshot and
+        // the url parameter still carry the selection for this session.
+      }
+      writeUrl(value);
+      snapshot = value;
+      notify();
+    },
+  };
+}
+
+export function usePersistedPreference<T>(
+  preference: PersistedPreference<T>,
+): T {
+  return useSyncExternalStore(
+    preference.subscribe,
+    preference.get,
+    preference.getServerSnapshot,
+  );
+}


### PR DESCRIPTION
## summary

- the docs app had grown four independent implementations of the same pattern (a user-selected value in localStorage, optionally mirrored into a url parameter, read through `useSyncExternalStore`). `createPersistedPreference` in `lib/persisted-preference.ts` replaces all four.
- the four were: `hooks/use-persistent-boolean.ts` (class store + storage events), `components/pages/docs/platform/context.tsx` (a second class store, plus url sync), `components/pages/docs/contexts/flavor.tsx` (a hand-rolled module singleton), and `components/pages/elements/install-command.tsx` (`useState` + a mount effect).
- the install command gains cross-tab sync as a result. its old mount effect had no `storage` listener, so a second tab never picked up a package manager change.
- net effect on the four call sites is 537 lines down to 357, with the shared behavior in one tested place.

## breaking changes

- none. storage keys are unchanged on purpose: unifying the naming (there are three conventions today) would strand every reader's saved selection for no functional gain.

## test plan

### already verified

- [x] `vitest run` in `apps/docs`: 34 files, 210 tests green (up from 33/198; the new file is a 12-case contract test).
- [x] the contract test was mutation-checked. flipping url/storage precedence, dropping the remove-at-fallback branch, and dropping the storage-key filter each fail exactly one case, and reverting turns them green again.
- [x] `tsc --noEmit` in `apps/docs` clean, `oxlint` and `oxfmt --check` clean.
- [x] browser pass on a dev server, no hydration errors: flavor switch on `/standalone/accordion` writes `?view=radix-ui` plus storage and swaps the rendered registry url from `/base/accordion.json` to `/accordion.json`; it survives navigation to `/standalone/select` with no parameter; switching back to the fallback removes both the parameter and the key.
- [x] `/docs?platform=rn` promotes the parameter into storage and survives navigation to a bare `/docs`; switching to React removes the key; switching to React Ink routes to `/docs/ink` and stores `ink`.
- [x] cross-tab: two tabs on `/elements/loading-state`, picking yarn in one flips the other from pnpm to yarn live.

### reviewer should verify

- [ ] the flavor url parameter still round-trips on the other standalone pages that use `<FlavorSwitcher />` (`/standalone/select` is covered above, `/standalone/accordion` too).

## notes

- setting a value equal to the fallback now removes the key instead of writing it. two of the four already behaved this way, and it reads back identically in all four since a missing key falls back.
- promoting a `?platform=` entry point into storage stays in the platform module rather than becoming a flag on the primitive. flavor does not want that behavior, and a flag with one caller is a configuration surface with no second use.
- `package-manager-tabs.tsx` is deliberately not folded in. it is per-block tab state that has never persisted, so giving it persistence is a product decision rather than deduplication. `lib/umami-sampling.ts` also keeps its own key: it is an analytics sampling bucket written from an inline head script, not a user preference.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qjYwZwfIu9DRiM1eH0m5D2q7cjUqJBYATANSWaEmxZwgtW2eCvy4shkSLYw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->