### PR TITLE
fix(assistant-stream): encode file parts on the data stream

### DIFF
--- a/.changeset/data-stream-file-parts.md
+++ b/.changeset/data-stream-file-parts.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: encode file parts on the data stream

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -525,6 +525,73 @@ describe("DataStreamDecoder interleaved tool-call args", () => {
   });
 });
 
+describe("file parts on the data stream", () => {
+  it("carries file parts on the wire", async () => {
+    const lines = await encodeChunks([
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "file",
+          data: "data:image/png;base64,AAAA",
+          mimeType: "image/png",
+        },
+      },
+      { type: "part-finish", path: [0] },
+    ]);
+
+    expect(lines).toEqual([
+      'k:{"data":"data:image/png;base64,AAAA","mimeType":"image/png"}',
+    ]);
+  });
+
+  it("round-trips a file part", async () => {
+    const lines = await encodeChunks([
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "file",
+          data: "data:image/png;base64,AAAA",
+          mimeType: "image/png",
+        },
+      },
+      { type: "part-finish", path: [0] },
+    ]);
+    const chunks = await decodeLines(lines);
+
+    expect(
+      chunks.some(
+        (c) =>
+          c.type === "part-start" &&
+          c.part.type === "file" &&
+          c.part.data === "data:image/png;base64,AAAA" &&
+          c.part.mimeType === "image/png",
+      ),
+    ).toBe(true);
+  });
+
+  it("carries the parentId on the wire", async () => {
+    const lines = await encodeChunks([
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "file",
+          data: "data:image/png;base64,AAAA",
+          mimeType: "image/png",
+          parentId: "p1",
+        },
+      },
+      { type: "part-finish", path: [0] },
+    ]);
+
+    expect(lines).toEqual([
+      'k:{"data":"data:image/png;base64,AAAA","mimeType":"image/png","parentId":"p1"}',
+    ]);
+  });
+});
+
 describe("DataStreamDecoder strict: false", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -571,6 +571,24 @@ describe("file parts on the data stream", () => {
     ).toBe(true);
   });
 
+  it("routes a decoded parentId onto the part", async () => {
+    const chunks = await decodeLines([
+      'b:{"toolCallId":"t1","toolName":"search"}',
+      'k:{"data":"data:image/png;base64,AAAA","mimeType":"image/png","parentId":"t1"}',
+    ]);
+
+    expect(
+      chunks.some(
+        (c) =>
+          c.type === "part-start" &&
+          c.part.type === "file" &&
+          c.part.data === "data:image/png;base64,AAAA" &&
+          c.part.mimeType === "image/png" &&
+          c.part.parentId === "t1",
+      ),
+    ).toBe(true);
+  });
+
   it("carries the parentId on the wire", async () => {
     const lines = await encodeChunks([
       {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -81,6 +81,13 @@ export class DataStreamEncoder
                   value,
                 });
               }
+              if (part.type === "file") {
+                const { type, ...value } = part;
+                controller.enqueue({
+                  type: DataStreamStreamChunkType.File,
+                  value,
+                });
+              }
               if (part.type === "data") {
                 const { type, ...value } = part;
                 controller.enqueue({
@@ -499,12 +506,17 @@ export class DataStreamDecoder extends PipeableTransformStream<
               });
               break;
 
-            case DataStreamStreamChunkType.File:
-              controller.appendFile({
+            case DataStreamStreamChunkType.File: {
+              const { parentId, ...fileData } = value;
+              const ctrl = parentId
+                ? controller.withParentId(parentId)
+                : controller;
+              ctrl.appendFile({
                 type: "file",
-                ...value,
+                ...fileData,
               });
               break;
+            }
 
             case DataStreamStreamChunkType.AuiDataPart:
               controller.appendData({

--- a/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
@@ -101,7 +101,11 @@ type DataStreamStreamChunkValue = {
   };
   [DataStreamStreamChunkType.RedactedReasoning]: { data: string };
   [DataStreamStreamChunkType.ReasoningSignature]: { signature: string };
-  [DataStreamStreamChunkType.File]: { data: string; mimeType: string };
+  [DataStreamStreamChunkType.File]: {
+    data: string;
+    mimeType: string;
+    parentId?: string;
+  };
 
   // aui-extensions
   [DataStreamStreamChunkType.AuiUpdateStateOperations]: GorpStreamOperation[];


### PR DESCRIPTION
## Summary

`DataStreamEncoder` silently drops `file` parts: the decoder has handled the `k:` (File) frame since it was introduced, but the encoder's `part-start` switch never emits it, so a stream built with `controller.appendFile(...)` loses the file entirely when serialized over the data-stream protocol. This adds the missing encoder branch, carries `parentId` on the frame the same way `Source` frames do, and routes a decoded `parentId` through `withParentId` to match the `Source` decode path.

## Why

Any server that attaches a file part to an assistant message (generated images, documents) and serves it through `DataStreamEncoder` sends nothing for that part — user-visible data loss with no error or warning. The wire chunk type already exists (`DataStreamStreamChunkType.File`) and the decoder already consumes it, so this is a pure fill-in of the missing encode direction; no new wire chunk type is introduced.

## Repro

```ts
const lines = await encodeChunks([
  {
    type: "part-start",
    path: [],
    part: { type: "file", data: "data:image/png;base64,AAAA", mimeType: "image/png" },
  },
  { type: "part-finish", path: [0] },
]);
// main: []            (part vanishes from the wire)
// fixed: ['k:{"data":"data:image/png;base64,AAAA","mimeType":"image/png"}']
```

## Validation

- Three new regression tests: the encoded `k:` frame, a full encode→decode round trip preserving `data`/`mimeType`, and `parentId` carried on the wire. All three fail on `main`'s encoder and pass with this change.
- Full `assistant-stream` suite: 460 passed / 20 skipped across 34 files (v6 and peer-v5 configs), `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sBFg8TotoK6c2IklHpOjtEBnhfFYtnJldrRggRzWB4M2x7Nr6pA9_pJkptA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->