### PR TITLE
fix(core): treat empty frame tool errors as failures

### DIFF
--- a/.changeset/frame-empty-error.md
+++ b/.changeset/frame-empty-error.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: report frame tool failures whose error message is empty

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -84,6 +84,23 @@ describe("AssistantFrameHost", () => {
     host.dispose();
   });
 
+  it("rejects tool results that carry an empty error message", async () => {
+    const { dispatchMessage, execute, getToolCallId, host } = createHost();
+    const result = Promise.resolve(
+      execute({ query: "weather" }, executionContext),
+    );
+
+    dispatchMessage({
+      type: "tool-result",
+      id: getToolCallId(),
+      error: "",
+    });
+
+    await expect(result).rejects.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
   it("rejects pending tool calls when disposed", async () => {
     const { execute, getToolCallId, host, postMessage } = createHost();
     const result = Promise.resolve(execute({}, executionContext));

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -101,6 +101,24 @@ describe("AssistantFrameHost", () => {
     host.dispose();
   });
 
+  it("resolves results from guests that serialize an absent error as null", async () => {
+    const { dispatchMessage, execute, getToolCallId, host } = createHost();
+    const result = Promise.resolve(
+      execute({ query: "weather" }, executionContext),
+    );
+
+    dispatchMessage({
+      type: "tool-result",
+      id: getToolCallId(),
+      result: "sunny",
+      error: null,
+    } as unknown as FrameMessage);
+
+    await expect(result).resolves.toBe("sunny");
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
   it("rejects pending tool calls when disposed", async () => {
     const { execute, getToolCallId, host, postMessage } = createHost();
     const result = Promise.resolve(execute({}, executionContext));

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -90,7 +90,7 @@ export class AssistantFrameHost implements ModelContextProvider {
       case "tool-result": {
         const pending = this._pendingRequests.get(message.id);
         if (pending) {
-          if (message.error) {
+          if (message.error !== undefined) {
             pending.reject(new Error(message.error));
           } else {
             pending.resolve(message.result);

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -90,7 +90,7 @@ export class AssistantFrameHost implements ModelContextProvider {
       case "tool-result": {
         const pending = this._pendingRequests.get(message.id);
         if (pending) {
-          if (message.error !== undefined) {
+          if (typeof message.error === "string") {
             pending.reject(new Error(message.error));
           } else {
             pending.resolve(message.result);

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -99,6 +99,32 @@ describe("AssistantFrameProvider", () => {
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
   });
 
+  it("reports a failure even when the thrown error has an empty message", async () => {
+    const execute = vi.fn(async () => {
+      throw new Error();
+    });
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: {
+          sensitiveTool: { execute },
+        },
+      }),
+    });
+
+    dispatchToolCall("https://parent.example");
+
+    await vi.waitFor(() => {
+      const frame = (
+        parentWindow.postMessage as ReturnType<typeof vi.fn>
+      ).mock.calls
+        .map(([data]) => data)
+        .find((data) => data?.message?.type === "tool-result");
+      expect(frame).toBeDefined();
+      expect(frame.message).toHaveProperty("error");
+      expect(frame.message).not.toHaveProperty("result");
+    });
+  });
+
   it("aborts in-flight tool calls when the parent cancels them", async () => {
     let toolSignal: AbortSignal | undefined;
     const execute = vi.fn(

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -141,7 +141,7 @@ export class AssistantFrameProvider {
     this.sendMessage(event, {
       type: "tool-result",
       id: message.id,
-      ...(error ? { error } : { result }),
+      ...(error !== undefined ? { error } : { result }),
     });
   }
 


### PR DESCRIPTION
## Summary

A frame tool that throws an error with an empty message is silently converted into a *successful* tool call. `AssistantFrameProvider` serializes the failure with `...(error ? { error } : { result })`, so an empty `e.message` (`throw new Error()`) falls through to the success shape and posts `{ result: undefined }`; `AssistantFrameHost` has the same truthiness check (`if (message.error)`) on the receiving side, so even an explicit `error: ""` frame resolves the pending call instead of rejecting it. Both checks now test for presence (`error !== undefined`) instead of truthiness.

## Why

`throw new Error()` with no message is common, and outside the frame boundary it correctly fails the tool call. Across the frame protocol the same throw resolves to `undefined`, so the assistant sees a successful call with no result — the failure is unobservable to the host application. `error` is only ever assigned on the failure paths in `handleToolCall`, so presence is the correct discriminator; the wire type (`error?: string`) already models it.

## Repro

```ts
// inside the frame
tools: {
  search: {
    execute: async () => {
      throw new Error(); // empty message
    },
  },
}
// host side, before this change:
await execute(args, ctx); // resolves undefined — no rejection, no error surfaced
```

## Validation

- Two new regression tests: the provider posts a `tool-result` frame carrying `error` (not `result`) for an empty-message throw, and the host rejects a `tool-result` frame with `error: ""`. Both fail on `main` and pass with this change.
- Full `@assistant-ui/core` suite: 1413 passed across 132 files.
- Wire compatibility: an old host receiving the new `error: ""` frame resolves success, which is identical to today's behavior — partial upgrades regress nothing; upgrading both sides fixes the conversion.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8VfDYKe63CcHF-QFVincX-V6UQwacc5egaUOaqFWJBYwAOuu3GEVz7Qged4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->