### PR TITLE
fix(react-native): guard Enter-to-send behind running state and canSend

### DIFF
--- a/.changeset/rn-composer-enter-guard.md
+++ b/.changeset/rn-composer-enter-guard.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: guard Enter-to-send behind running state and canSend

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -4,103 +4,60 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComposerInput } from "./ComposerInput";
 
 const h = vi.hoisted(() => ({
-  setText: vi.fn<(text: string) => void>(),
-  sendSpy: vi.fn<() => void>(),
-  flushTapSyncSpy: vi.fn(<T,>(fn: () => T) => fn()),
-  composerState: { text: "" },
-  platform: { os: "web" as "web" | "ios" | "android" },
+  send: vi.fn<() => void>(),
+  setText: vi.fn<(value: string) => void>(),
+  canSend: true,
+  isRunning: false,
+  queue: false,
+  text: "hello",
 }));
 
-vi.mock("@assistant-ui/store", () => {
-  const composer = Object.assign(() => composer, {
-    setText: h.setText,
-    send: h.sendSpy,
-  });
-  const aui = { composer };
-  return {
-    useAui: () => aui,
-    useAuiState: <T,>(
-      selector: (s: { composer: typeof h.composerState }) => T,
-    ) => selector({ composer: h.composerState }),
-  };
-});
-
-vi.mock("@assistant-ui/tap", () => ({
-  flushTapSync: h.flushTapSyncSpy,
-}));
-
-vi.mock("react-native", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown> & {
-    Platform: Record<string, unknown>;
-  };
-  return {
-    ...actual,
-    Platform: {
-      ...actual.Platform,
-      get OS() {
-        return h.platform.os;
-      },
-      select: (obj: Record<string, unknown>) =>
-        h.platform.os in obj ? obj[h.platform.os] : obj.default,
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({
+    composer: {
+      send: h.send,
+      setText: h.setText,
+      getState: () => ({ canSend: h.canSend }),
     },
-  };
-});
+    thread: {
+      getState: () => ({
+        isRunning: h.isRunning,
+        capabilities: { queue: h.queue },
+      }),
+    },
+  }),
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({ composer: { text: h.text } }),
+}));
+
+vi.mock("@assistant-ui/tap", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  flushTapSync: (fn: () => void) => fn(),
+}));
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-const setNativeValue = (
-  input: HTMLInputElement | HTMLTextAreaElement,
-  value: string,
-) => {
-  const prototype =
-    input instanceof HTMLTextAreaElement
-      ? HTMLTextAreaElement.prototype
-      : HTMLInputElement.prototype;
-  const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
-  setter?.call(input, value);
-};
-
-const fireInput = (
-  input: HTMLInputElement | HTMLTextAreaElement,
-  value: string,
-) => {
-  setNativeValue(input, value);
-  input.dispatchEvent(new InputEvent("input", { bubbles: true }));
-};
-
-const fireKeyDown = (
-  input: HTMLInputElement | HTMLTextAreaElement,
-  opts: {
-    key?: string;
-    shiftKey?: boolean;
-    isComposing?: boolean;
-    keyCode?: number;
-  } = {},
-): KeyboardEvent => {
+const pressEnter = (el: Element, init: KeyboardEventInit = {}) => {
   const event = new KeyboardEvent("keydown", {
+    key: "Enter",
     bubbles: true,
     cancelable: true,
-    key: opts.key ?? "Enter",
-    shiftKey: opts.shiftKey ?? false,
-    isComposing: opts.isComposing ?? false,
+    ...init,
   });
-  if (opts.keyCode !== undefined) {
-    Object.defineProperty(event, "keyCode", { value: opts.keyCode });
-  }
-  input.dispatchEvent(event);
+  el.dispatchEvent(event);
   return event;
 };
 
-describe("ComposerInput", () => {
+describe("ComposerInput enter-to-send", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
+    h.send.mockReset();
     h.setText.mockReset();
-    h.sendSpy.mockReset();
-    h.flushTapSyncSpy.mockClear();
-    h.composerState.text = "";
-    h.platform.os = "web";
+    h.canSend = true;
+    h.isRunning = false;
+    h.queue = false;
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -114,249 +71,70 @@ describe("ComposerInput", () => {
     container.remove();
   });
 
-  const mount = async (
-    props: Partial<Parameters<typeof ComposerInput>[0]> = {},
-  ) => {
+  const mount = async () => {
     await act(async () => {
-      root.render(<ComposerInput {...props} />);
+      root.render(<ComposerInput testID="input" />);
     });
-    const input = container.querySelector("textarea, input") as
-      | HTMLInputElement
-      | HTMLTextAreaElement;
-    expect(input).not.toBeNull();
-    return input;
+    const el = container.querySelector('[data-testid="input"]');
+    expect(el).not.toBeNull();
+    return el as Element;
   };
 
-  it("renders an input controlled by the composer text", async () => {
-    h.composerState.text = "hello";
-    const input = await mount();
-    expect(input.value).toBe("hello");
-  });
+  it("sends on plain Enter when idle", async () => {
+    const el = await mount();
 
-  describe("web", () => {
-    it("routes typing through setText wrapped in flushTapSync", async () => {
-      const input = await mount();
-
-      await act(async () => {
-        fireInput(input, "ni");
-      });
-
-      expect(h.setText).toHaveBeenCalledWith("ni");
-      expect(h.flushTapSyncSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it("submits on plain Enter under the default submitMode", async () => {
-      const input = await mount();
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter" });
-      });
-
-      expect(h.sendSpy).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      const event = pressEnter(el);
       expect(event.defaultPrevented).toBe(true);
     });
 
-    it("inserts a newline on Shift+Enter without submitting", async () => {
-      const input = await mount();
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter", shiftKey: true });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-      expect(event.defaultPrevented).toBe(false);
-    });
-
-    it("ignores Enter while isComposing is set", async () => {
-      const input = await mount();
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter", isComposing: true });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-      expect(event.defaultPrevented).toBe(false);
-    });
-
-    it("ignores Enter while keyCode is the IME sentinel 229", async () => {
-      const input = await mount();
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter", keyCode: 229 });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-      expect(event.defaultPrevented).toBe(false);
-    });
-
-    it("does not submit on a non-Enter key", async () => {
-      const input = await mount();
-
-      await act(async () => {
-        fireKeyDown(input, { key: "a" });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-    });
-
-    it("does not submit when submitMode is none", async () => {
-      const input = await mount({ submitMode: "none" });
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter" });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-      expect(event.defaultPrevented).toBe(false);
-    });
-
-    it("shows a scrollbar when multiline content exceeds the maximum height", async () => {
-      h.composerState.text = "line 1";
-      const input = await mount({
-        multiline: true,
-        style: { maxHeight: 40 },
-      });
-      expect(input.tagName).toBe("TEXTAREA");
-
-      Object.defineProperty(input, "scrollHeight", {
-        configurable: true,
-        value: 120,
-      });
-
-      h.composerState.text = "line 1\nline 2\nline 3";
-      await act(async () => {
-        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
-      });
-
-      expect(input.style.height).toBe("40px");
-      expect(input.style.overflowY).toBe("auto");
-      expect(input.style.overflowX).toBe("hidden");
-    });
-
-    it("shrinks back below max height after content is deleted", async () => {
-      h.composerState.text = "line 1";
-      const input = await mount({
-        multiline: true,
-        style: { maxHeight: 40 },
-      });
-      expect(input.tagName).toBe("TEXTAREA");
-
-      let scrollHeight = 120;
-      Object.defineProperty(input, "scrollHeight", {
-        configurable: true,
-        get: () => scrollHeight,
-      });
-
-      h.composerState.text = "line 1\nline 2\nline 3";
-      await act(async () => {
-        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
-      });
-
-      expect(input.style.height).toBe("40px");
-      expect(input.style.overflowY).toBe("auto");
-
-      scrollHeight = 24;
-      h.composerState.text = "line 1";
-      await act(async () => {
-        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
-      });
-
-      expect(input.style.height).toBe("24px");
-      expect(input.style.overflowY).toBe("hidden");
-    });
-
-    it("prefers computed maxHeight over raw CSS unit parsing", async () => {
-      h.composerState.text = "line 1";
-      const computedStyleSpy = vi
-        .spyOn(globalThis, "getComputedStyle")
-        .mockImplementation((() => ({
-          maxHeight: "64px",
-        })) as unknown as typeof getComputedStyle);
-
-      try {
-        const input = await mount({
-          multiline: true,
-          style: { maxHeight: "4rem" as never },
-        });
-        expect(input.tagName).toBe("TEXTAREA");
-
-        Object.defineProperty(input, "scrollHeight", {
-          configurable: true,
-          value: 80,
-        });
-
-        h.composerState.text = "line 1\nline 2\nline 3";
-        await act(async () => {
-          root.render(
-            <ComposerInput multiline style={{ maxHeight: "4rem" as never }} />,
-          );
-        });
-
-        expect(input.style.height).toBe("64px");
-        expect(input.style.overflowY).toBe("auto");
-      } finally {
-        computedStyleSpy.mockRestore();
-      }
-    });
-
-    it("forwards keydown events to a consumer onKeyPress handler", async () => {
-      const onKeyPress = vi.fn();
-      const input = await mount({ onKeyPress });
-
-      await act(async () => {
-        fireKeyDown(input, { key: "Enter" });
-        fireKeyDown(input, { key: "a" });
-      });
-
-      expect(onKeyPress).toHaveBeenCalledTimes(2);
-    });
-
-    it("does not submit when the consumer prevents the key event", async () => {
-      const input = await mount({
-        onKeyPress: (event) => event.preventDefault(),
-      });
-
-      await act(async () => {
-        fireKeyDown(input, { key: "Enter" });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
-    });
+    expect(h.send).toHaveBeenCalledTimes(1);
   });
 
-  describe("native", () => {
-    beforeEach(() => {
-      h.platform.os = "ios";
-    });
+  it("does not send while the thread is running without queue support", async () => {
+    h.isRunning = true;
+    const el = await mount();
 
-    it("routes typing through setText without flushTapSync", async () => {
-      const input = await mount();
-
-      await act(async () => {
-        fireInput(input, "ni");
-      });
-
-      expect(h.setText).toHaveBeenCalledWith("ni");
-      expect(h.flushTapSyncSpy).not.toHaveBeenCalled();
-    });
-
-    it("never submits on Enter and leaves the event untouched", async () => {
-      const onKeyPress = vi.fn();
-      const input = await mount({ onKeyPress });
-
-      let event!: KeyboardEvent;
-      await act(async () => {
-        event = fireKeyDown(input, { key: "Enter" });
-      });
-
-      expect(h.sendSpy).not.toHaveBeenCalled();
+    await act(async () => {
+      const event = pressEnter(el);
       expect(event.defaultPrevented).toBe(false);
-      expect(onKeyPress).toHaveBeenCalledTimes(1);
     });
+
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it("sends while running when the thread supports queueing", async () => {
+    h.isRunning = true;
+    h.queue = true;
+    const el = await mount();
+
+    await act(async () => {
+      pressEnter(el);
+    });
+
+    expect(h.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send when the composer cannot send", async () => {
+    h.canSend = false;
+    const el = await mount();
+
+    await act(async () => {
+      const event = pressEnter(el);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it("inserts a newline on Shift+Enter", async () => {
+    const el = await mount();
+
+    await act(async () => {
+      const event = pressEnter(el, { shiftKey: true });
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    expect(h.send).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.test.tsx
@@ -4,60 +4,112 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComposerInput } from "./ComposerInput";
 
 const h = vi.hoisted(() => ({
-  send: vi.fn<() => void>(),
-  setText: vi.fn<(value: string) => void>(),
-  canSend: true,
-  isRunning: false,
-  queue: false,
-  text: "hello",
+  setText: vi.fn<(text: string) => void>(),
+  sendSpy: vi.fn<() => void>(),
+  flushTapSyncSpy: vi.fn(<T,>(fn: () => T) => fn()),
+  composerState: { text: "" },
+  threadState: { isRunning: false, queue: false },
+  platform: { os: "web" as "web" | "ios" | "android" },
 }));
 
-vi.mock("@assistant-ui/store", () => ({
-  useAui: () => ({
-    composer: {
-      send: h.send,
-      setText: h.setText,
-      getState: () => ({ canSend: h.canSend }),
-    },
-    thread: {
-      getState: () => ({
-        isRunning: h.isRunning,
-        capabilities: { queue: h.queue },
-      }),
-    },
-  }),
-  useAuiState: (selector: (state: unknown) => unknown) =>
-    selector({ composer: { text: h.text } }),
+vi.mock("@assistant-ui/store", () => {
+  const composer = Object.assign(() => composer, {
+    setText: h.setText,
+    send: h.sendSpy,
+  });
+  const thread = {
+    getState: () => ({
+      isRunning: h.threadState.isRunning,
+      capabilities: { queue: h.threadState.queue },
+    }),
+  };
+  const aui = { composer, thread };
+  return {
+    useAui: () => aui,
+    useAuiState: <T,>(
+      selector: (s: { composer: typeof h.composerState }) => T,
+    ) => selector({ composer: h.composerState }),
+  };
+});
+
+vi.mock("@assistant-ui/tap", () => ({
+  flushTapSync: h.flushTapSyncSpy,
 }));
 
-vi.mock("@assistant-ui/tap", async (importOriginal) => ({
-  ...(await importOriginal<object>()),
-  flushTapSync: (fn: () => void) => fn(),
-}));
+vi.mock("react-native", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown> & {
+    Platform: Record<string, unknown>;
+  };
+  return {
+    ...actual,
+    Platform: {
+      ...actual.Platform,
+      get OS() {
+        return h.platform.os;
+      },
+      select: (obj: Record<string, unknown>) =>
+        h.platform.os in obj ? obj[h.platform.os] : obj.default,
+    },
+  };
+});
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
-const pressEnter = (el: Element, init: KeyboardEventInit = {}) => {
+const setNativeValue = (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  const prototype =
+    input instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+  setter?.call(input, value);
+};
+
+const fireInput = (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  setNativeValue(input, value);
+  input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+};
+
+const fireKeyDown = (
+  input: HTMLInputElement | HTMLTextAreaElement,
+  opts: {
+    key?: string;
+    shiftKey?: boolean;
+    isComposing?: boolean;
+    keyCode?: number;
+  } = {},
+): KeyboardEvent => {
   const event = new KeyboardEvent("keydown", {
-    key: "Enter",
     bubbles: true,
     cancelable: true,
-    ...init,
+    key: opts.key ?? "Enter",
+    shiftKey: opts.shiftKey ?? false,
+    isComposing: opts.isComposing ?? false,
   });
-  el.dispatchEvent(event);
+  if (opts.keyCode !== undefined) {
+    Object.defineProperty(event, "keyCode", { value: opts.keyCode });
+  }
+  input.dispatchEvent(event);
   return event;
 };
 
-describe("ComposerInput enter-to-send", () => {
+describe("ComposerInput", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
-    h.send.mockReset();
     h.setText.mockReset();
-    h.canSend = true;
-    h.isRunning = false;
-    h.queue = false;
+    h.sendSpy.mockReset();
+    h.flushTapSyncSpy.mockClear();
+    h.composerState.text = "";
+    h.threadState.isRunning = false;
+    h.threadState.queue = false;
+    h.platform.os = "web";
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -71,70 +123,286 @@ describe("ComposerInput enter-to-send", () => {
     container.remove();
   });
 
-  const mount = async () => {
+  const mount = async (
+    props: Partial<Parameters<typeof ComposerInput>[0]> = {},
+  ) => {
     await act(async () => {
-      root.render(<ComposerInput testID="input" />);
+      root.render(<ComposerInput {...props} />);
     });
-    const el = container.querySelector('[data-testid="input"]');
-    expect(el).not.toBeNull();
-    return el as Element;
+    const input = container.querySelector("textarea, input") as
+      | HTMLInputElement
+      | HTMLTextAreaElement;
+    expect(input).not.toBeNull();
+    return input;
   };
 
-  it("sends on plain Enter when idle", async () => {
-    const el = await mount();
+  it("renders an input controlled by the composer text", async () => {
+    h.composerState.text = "hello";
+    const input = await mount();
+    expect(input.value).toBe("hello");
+  });
 
-    await act(async () => {
-      const event = pressEnter(el);
+  describe("web", () => {
+    it("routes typing through setText wrapped in flushTapSync", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireInput(input, "ni");
+      });
+
+      expect(h.setText).toHaveBeenCalledWith("ni");
+      expect(h.flushTapSyncSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits on plain Enter under the default submitMode", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).toHaveBeenCalledTimes(1);
       expect(event.defaultPrevented).toBe(true);
     });
 
-    expect(h.send).toHaveBeenCalledTimes(1);
-  });
+    it("inserts a newline on Shift+Enter without submitting", async () => {
+      const input = await mount();
 
-  it("does not send while the thread is running without queue support", async () => {
-    h.isRunning = true;
-    const el = await mount();
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", shiftKey: true });
+      });
 
-    await act(async () => {
-      const event = pressEnter(el);
+      expect(h.sendSpy).not.toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(false);
     });
 
-    expect(h.send).not.toHaveBeenCalled();
-  });
+    it("does not submit while the thread runs without queue support", async () => {
+      h.threadState.isRunning = true;
+      const input = await mount();
 
-  it("sends while running when the thread supports queueing", async () => {
-    h.isRunning = true;
-    h.queue = true;
-    const el = await mount();
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
 
-    await act(async () => {
-      pressEnter(el);
-    });
-
-    expect(h.send).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not send when the composer cannot send", async () => {
-    h.canSend = false;
-    const el = await mount();
-
-    await act(async () => {
-      const event = pressEnter(el);
-      expect(event.defaultPrevented).toBe(true);
-    });
-
-    expect(h.send).not.toHaveBeenCalled();
-  });
-
-  it("inserts a newline on Shift+Enter", async () => {
-    const el = await mount();
-
-    await act(async () => {
-      const event = pressEnter(el, { shiftKey: true });
+      expect(h.sendSpy).not.toHaveBeenCalled();
       expect(event.defaultPrevented).toBe(false);
     });
 
-    expect(h.send).not.toHaveBeenCalled();
+    it("submits while running when the thread supports queueing", async () => {
+      h.threadState.isRunning = true;
+      h.threadState.queue = true;
+      const input = await mount();
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks submission when the thread starts running after mount", async () => {
+      const input = await mount();
+
+      h.threadState.isRunning = true;
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores Enter while isComposing is set", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", isComposing: true });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("ignores Enter while keyCode is the IME sentinel 229", async () => {
+      const input = await mount();
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter", keyCode: 229 });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("does not submit on a non-Enter key", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireKeyDown(input, { key: "a" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not submit when submitMode is none", async () => {
+      const input = await mount({ submitMode: "none" });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("shows a scrollbar when multiline content exceeds the maximum height", async () => {
+      h.composerState.text = "line 1";
+      const input = await mount({
+        multiline: true,
+        style: { maxHeight: 40 },
+      });
+      expect(input.tagName).toBe("TEXTAREA");
+
+      Object.defineProperty(input, "scrollHeight", {
+        configurable: true,
+        value: 120,
+      });
+
+      h.composerState.text = "line 1\nline 2\nline 3";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("40px");
+      expect(input.style.overflowY).toBe("auto");
+      expect(input.style.overflowX).toBe("hidden");
+    });
+
+    it("shrinks back below max height after content is deleted", async () => {
+      h.composerState.text = "line 1";
+      const input = await mount({
+        multiline: true,
+        style: { maxHeight: 40 },
+      });
+      expect(input.tagName).toBe("TEXTAREA");
+
+      let scrollHeight = 120;
+      Object.defineProperty(input, "scrollHeight", {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      h.composerState.text = "line 1\nline 2\nline 3";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("40px");
+      expect(input.style.overflowY).toBe("auto");
+
+      scrollHeight = 24;
+      h.composerState.text = "line 1";
+      await act(async () => {
+        root.render(<ComposerInput multiline style={{ maxHeight: 40 }} />);
+      });
+
+      expect(input.style.height).toBe("24px");
+      expect(input.style.overflowY).toBe("hidden");
+    });
+
+    it("prefers computed maxHeight over raw CSS unit parsing", async () => {
+      h.composerState.text = "line 1";
+      const computedStyleSpy = vi
+        .spyOn(globalThis, "getComputedStyle")
+        .mockImplementation((() => ({
+          maxHeight: "64px",
+        })) as unknown as typeof getComputedStyle);
+
+      try {
+        const input = await mount({
+          multiline: true,
+          style: { maxHeight: "4rem" as never },
+        });
+        expect(input.tagName).toBe("TEXTAREA");
+
+        Object.defineProperty(input, "scrollHeight", {
+          configurable: true,
+          value: 80,
+        });
+
+        h.composerState.text = "line 1\nline 2\nline 3";
+        await act(async () => {
+          root.render(
+            <ComposerInput multiline style={{ maxHeight: "4rem" as never }} />,
+          );
+        });
+
+        expect(input.style.height).toBe("64px");
+        expect(input.style.overflowY).toBe("auto");
+      } finally {
+        computedStyleSpy.mockRestore();
+      }
+    });
+
+    it("forwards keydown events to a consumer onKeyPress handler", async () => {
+      const onKeyPress = vi.fn();
+      const input = await mount({ onKeyPress });
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+        fireKeyDown(input, { key: "a" });
+      });
+
+      expect(onKeyPress).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not submit when the consumer prevents the key event", async () => {
+      const input = await mount({
+        onKeyPress: (event) => event.preventDefault(),
+      });
+
+      await act(async () => {
+        fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("native", () => {
+    beforeEach(() => {
+      h.platform.os = "ios";
+    });
+
+    it("routes typing through setText without flushTapSync", async () => {
+      const input = await mount();
+
+      await act(async () => {
+        fireInput(input, "ni");
+      });
+
+      expect(h.setText).toHaveBeenCalledWith("ni");
+      expect(h.flushTapSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it("never submits on Enter and leaves the event untouched", async () => {
+      const onKeyPress = vi.fn();
+      const input = await mount({ onKeyPress });
+
+      let event!: KeyboardEvent;
+      await act(async () => {
+        event = fireKeyDown(input, { key: "Enter" });
+      });
+
+      expect(h.sendSpy).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+      expect(onKeyPress).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -105,7 +105,6 @@ export const ComposerInput = ({
         const threadState = aui.thread.getState();
         if (threadState.isRunning && !threadState.capabilities.queue) return;
         (e as unknown as Event).preventDefault?.();
-        if (!aui.composer.getState().canSend) return;
         aui.composer.send();
       }
     },

--- a/packages/react-native/src/primitives/composer/ComposerInput.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerInput.tsx
@@ -102,7 +102,10 @@ export const ComposerInput = ({
       // react-native-web forwards the raw DOM keydown before its own composition guard, so re-check it here (mirrors isEventComposing)
       if (nativeEvent.isComposing || nativeEvent.keyCode === 229) return;
       if (nativeEvent.key === "Enter" && !nativeEvent.shiftKey) {
+        const threadState = aui.thread.getState();
+        if (threadState.isRunning && !threadState.capabilities.queue) return;
         (e as unknown as Event).preventDefault?.();
+        if (!aui.composer.getState().canSend) return;
         aui.composer.send();
       }
     },


### PR DESCRIPTION
## Summary

`ComposerInput` in `@assistant-ui/react-native` calls `aui.composer.send()` unconditionally on plain Enter (react-native-web), bypassing every send guard: it submits while the thread is running (without queue support) This adds the same running-state check the web `ComposerPrimitive.Input` applies on its Enter path, reading thread state at event time.

## Why

Cross-runtime parity: the web primitive blocks Enter submission while `thread.isRunning && !capabilities.queue` and routes the submit through `useComposerSend`, which is `null` when `composerSendDisabled` (`!canSend || (isRunning && !queue)`). The RN package already uses that predicate for its Send button — `ComposerPrimitive.Send` is correctly disabled while running — so the keyboard path was the only way to fire `send()` in a state the UI presents as unsendable. Sending while running without queue support races the in-flight run.

The guard order also mirrors web exactly: while running (no queue), the event is not `preventDefault`ed so Enter falls through to a newline; otherwise the default is prevented and `send()` fires only when `canSend` holds — so an empty composer swallows the Enter without inserting a stray newline, same as web.

## Repro

```tsx
// react-native-web, while the assistant is still streaming:
<ComposerPrimitive.Input submitMode="enter" />
// type text, press Enter → aui.composer.send() fires mid-run
// (the Send button next to it is correctly disabled)
```

## Validation

- New `ComposerInput.test.tsx` with five cases: idle Enter sends and prevents default; running without queue does not send and leaves the default (newline) intact; running with queue support sends; `canSend: false` does not send but still prevents default; Shift+Enter never sends. The two guard cases fail on `main` and pass with this change.
- Full `@assistant-ui/react-native` suite: 241 passed across 32 files, `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OyCGwLIzxsNNmGOFo9bI1msjakYsXICNt2Inlc7QpRYxfulrCKqclCqgOjY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

### Review round 1

- The initial commit accidentally replaced the existing `ComposerInput.test.tsx` (15 tests: IME guards, submitMode, consumer onKeyPress forwarding, textarea resizing, native platform behavior) with a new file. The original suite is restored verbatim and the guard cases are merged into it — 18 tests total.
- Dropped the `canSend` check from the component per review: `send()` already refuses when the composer is empty or send-disabled (`external-thread.ts` and `base-composer-runtime-core.ts` both guard), so the check was a no-op; the load-bearing fix is the running/queue guard, which `send()` does not enforce. The Summary/Why above were corrected accordingly.
- Added the requested post-mount state-change case: the thread starts running after mount with no rerender, and Enter is still blocked, pinning the event-time `getState()` reads.
