### PR TITLE
fix(assistant-stream): guard tool-call stream writes after consumer cancellation

### DIFF
--- a/.changeset/tool-call-cancel-crash.md
+++ b/.changeset/tool-call-cancel-crash.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: guard tool-call stream writes after consumer cancellation

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   createAssistantStream,
+  createAssistantStreamController,
   createAssistantStreamResponse,
 } from "./assistant-stream";
 import { AssistantStream } from "../AssistantStream";
@@ -53,6 +54,47 @@ const captureUnhandledRejections = async (
     process.off("unhandledRejection", listener);
   }
 };
+
+describe("tool-call writes after cancellation", () => {
+  it("ignores setResponse after the consumer cancels", async () => {
+    const unhandledRejections = await captureUnhandledRejections(async () => {
+      const [stream, controller] = createAssistantStreamController();
+      const toolCall = controller.addToolCallPart({
+        toolCallId: "t1",
+        toolName: "search",
+      });
+
+      const reader = stream.getReader();
+      await reader.cancel("consumer stopped");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      toolCall.setResponse({ result: "ok" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(unhandledRejections).toEqual([]);
+  });
+
+  it("ignores args appends and close after the consumer cancels", async () => {
+    const unhandledRejections = await captureUnhandledRejections(async () => {
+      const [stream, controller] = createAssistantStreamController();
+      const toolCall = controller.addToolCallPart({
+        toolCallId: "t1",
+        toolName: "search",
+      });
+
+      const reader = stream.getReader();
+      await reader.cancel("consumer stopped");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      toolCall.argsText.append('{"q":1}');
+      toolCall.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(unhandledRejections).toEqual([]);
+  });
+});
 
 describe("createAssistantStream task settlement", () => {
   it("emits callback failures without leaking an unhandled rejection", async () => {

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -19,6 +19,17 @@ export type ToolCallStreamController = {
 class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _isClosed = false;
 
+  // enqueue() throwing TypeError is the portable termination signal for
+  // ReadableStream controllers; after the consumer cancels, writes are
+  // intentionally discarded instead of surfacing as unhandled rejections.
+  private _enqueue(chunk: AssistantStreamChunk) {
+    try {
+      this._controller.enqueue(chunk);
+    } catch (error) {
+      if (!(error instanceof TypeError)) throw error;
+    }
+  }
+
   private _mergeTask: Promise<void>;
   private _controller: ReadableStreamDefaultController<AssistantStreamChunk>;
 
@@ -39,19 +50,19 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
           switch (chunk.type) {
             case "text-delta":
               hasArgsText = true;
-              this._controller.enqueue(chunk);
+              this._enqueue(chunk);
               break;
 
             case "part-finish":
               if (!hasArgsText) {
                 // if no argsText was provided, assume empty object
-                this._controller.enqueue({
+                this._enqueue({
                   type: "text-delta",
                   textDelta: "{}",
                   path: [],
                 });
               }
-              this._controller.enqueue({
+              this._enqueue({
                 type: "tool-call-args-text-finish",
                 path: [],
               });
@@ -79,7 +90,7 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
     // indistinguishable from one that never finished.
     const result = response.result;
 
-    this._controller.enqueue({
+    this._enqueue({
       type: "result",
       path: [],
       ...(response.artifact !== undefined
@@ -104,11 +115,15 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
     this._argsTextController.close();
     await this._mergeTask;
 
-    this._controller.enqueue({
+    this._enqueue({
       type: "part-finish",
       path: [],
     });
-    this._controller.close();
+    try {
+      this._controller.close();
+    } catch (error) {
+      if (!(error instanceof TypeError)) throw error;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

After the consumer cancels an `AssistantStream`, any write on an open tool-call part crashes the process: `ToolCallStreamControllerImpl.setResponse()` enqueues its `result` chunk into the already-cancelled part controller, the `TypeError` rejects an `async` method no caller awaits, and the unhandled rejection terminates Node under the default `--unhandled-rejections=throw`. The args-text merge task is an independent second path to the same crash: after cancellation, `argsText.append()` (or the implicit `{}` default and `tool-call-args-text-finish` emitted by `close()`) throws inside the internal `pipeTo` writer, rejecting a merge task that is likewise not awaited.

All tool-call controller writes now go through a `TypeError`-tolerant enqueue (and `close()` tolerates an already-terminated controller), so post-cancellation writes are discarded instead of surfacing as unhandled rejections.

## Why

This is the server-killing variant of a bug class the repo has already fixed twice at other layers: `ToolExecutionStream` guards with `enqueueIfOpen` (TypeError is the portable termination signal for stream controllers), and the sibling text module's args append was guarded in #5296. The tool-call module was the remaining unguarded writer. A realistic trigger needs nothing exotic: an HTTP route serving `createAssistantStreamResponse` with an open tool call, a client that disconnects mid-run, and the tool's `setResponse` firing afterwards — one dropped connection takes down the process.

Discarding the writes (rather than erroring) matches the existing semantics: the consumer walked away, and both established guards treat post-termination writes as intentional no-ops.

## Repro

```ts
const [stream, controller] = createAssistantStreamController();
const toolCall = controller.addToolCallPart({ toolCallId: "t1", toolName: "search" });
const reader = stream.getReader();
await reader.cancel("consumer stopped");
toolCall.setResponse({ result: "ok" });
// main: unhandled rejection (TypeError: Invalid state: Controller is already closed) → process exit
// fixed: no-op
```

## Validation

- Two regression tests in the module's existing `captureUnhandledRejections` harness (the same invariant the suite already pins for non-tool-call paths): `setResponse` after cancel, and `argsText.append()` + `close()` after cancel. Both fail on `main` (one captured rejection each) and pass with this change.
- Full `assistant-stream` suite green on both configs (463 passed / 20 skipped × v6 and peer-v5), `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Tcfu1sJYwop5drTL6i0bVBOc2nBkp_oHaXGG9iOz5jvjV_sejSfSz0rKib0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->