### PR TITLE
fix(assistant-stream): make merge stream seal idempotent

### DIFF
--- a/.changeset/merge-seal-idempotent.md
+++ b/.changeset/merge-seal-idempotent.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: make merge stream seal idempotent

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -96,6 +96,21 @@ describe("tool-call writes after cancellation", () => {
   });
 });
 
+describe("controller close idempotence", () => {
+  it("tolerates a second close after the stream drains", async () => {
+    const [stream, controller] = createAssistantStreamController();
+    controller.appendText("hi");
+    controller.close();
+
+    const reader = stream.getReader();
+    while (!(await reader.read()).done) {
+      // drain
+    }
+
+    expect(() => controller.close()).not.toThrow();
+  });
+});
+
 describe("createAssistantStream task settlement", () => {
   it("emits callback failures without leaking an unhandled rejection", async () => {
     let chunks: AssistantStreamChunk[] = [];

--- a/packages/assistant-stream/src/core/utils/stream/merge.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.test.ts
@@ -65,3 +65,18 @@ describe("createMergeStream", () => {
     await vi.waitFor(() => expect(cancelSource).toHaveBeenCalledOnce());
   });
 });
+
+describe("createMergeStream seal", () => {
+  it("is idempotent once the underlying stream has closed", async () => {
+    const merger = createMergeStream();
+    merger.seal();
+
+    const reader = merger.readable.getReader();
+    while (!(await reader.read()).done) {
+      // drain
+    }
+
+    expect(() => merger.seal()).not.toThrow();
+    expect(merger.isSealed()).toBe(true);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -105,7 +105,7 @@ export const createMergeStream = () => {
       return errored;
     },
     seal() {
-      if (cancelled || errored) return;
+      if (sealed || cancelled || errored) return;
       sealed = true;
       if (list.length === 0) controller.close();
     },


### PR DESCRIPTION
## Summary

`createMergeStream().seal()` is not idempotent: it guards `cancelled || errored` but not `sealed`, so a second call re-enters `controller.close()` on the already-closed `ReadableStreamDefaultController` and throws `TypeError: Invalid state: Controller is already closed`. `AssistantStreamControllerImpl.close()` calls `merger.seal()` unconditionally, and `close()` is public API on `createAssistantStreamController()` — so closing a drained controller twice throws. `AssistantTransformStream.flush` also calls `runController.close()` after the transformer's own `flush`, so a transformer that closes in its flush hits the same double-close. The fix adds `sealed` to the early-return guard.

## Why

`close()` being safe to call twice is the established contract everywhere else in this package: the part controllers guard re-close (`_isClosed`), and `setResponse` documents "subsequent calls are ignored". The merge layer was the one spot where the second call escalated to an uncatchable-in-practice `TypeError` out of public API.

## Repro

```ts
const [stream, controller] = createAssistantStreamController();
controller.appendText("hi");
controller.close();
const reader = stream.getReader();
while (!(await reader.read()).done) {}
controller.close();
// main: TypeError: Invalid state: Controller is already closed
// fixed: no-op
```

## Validation

- Two regression tests: one at the merge layer (`seal()` twice on a drained merger) and one at the public API layer (`controller.close()` twice after draining). Both fail on `main` and pass with this change.
- Full `assistant-stream` suite green on both configs (463 passed / 20 skipped × v6 and peer-v5), `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dM6VPuRqZNSgWvqXSPVnwsbBIrsLmulOC-JdDuKzK1AmEnyzMUnEUL1jFG0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->