### PR TITLE
fix(langgraph-backend): defer frontend tool calls that share a message with a server call

### DIFF
--- a/python/assistant-transport-backend-langgraph/main.py
+++ b/python/assistant-transport-backend-langgraph/main.py
@@ -340,10 +340,20 @@ async def tool_executor_node(state: GraphState) -> dict[str, Any]:
     if not hasattr(last_message, 'tool_calls') or not last_message.tool_calls:
         return {"messages": []}
 
+    # Names of request-provided frontend tools. These are executed on the client,
+    # so the backend must defer them rather than answer them here. Only a name in
+    # neither the frontend tools nor TOOL_BY_NAME is a genuine error.
+    frontend_tool_names = set(state.get("tools") or {})
+
     # Process each tool call
     tool_messages = []
     for tool_call in last_message.tool_calls:
         tool_name = tool_call["name"]
+        if tool_name in frontend_tool_names and tool_name not in TOOL_BY_NAME:
+            # Frontend-owned tool: return it to the client instead of answering it
+            # server side. Emitting a ToolMessage here would tell the model its own
+            # tool does not exist and the client would never receive the call.
+            continue
         if tool_name == "task_tool":
             # Extract task description
             task_description = tool_call["args"].get("task_description", "")

--- a/python/assistant-transport-backend-langgraph/test_tool_executor_node.py
+++ b/python/assistant-transport-backend-langgraph/test_tool_executor_node.py
@@ -1,0 +1,90 @@
+"""Tests for tool_executor_node frontend/server tool ownership routing.
+
+Regression coverage for the case where an assistant message mixes a
+server-owned tool call with a request-provided frontend tool call. The
+frontend call must be deferred to the client, not answered server side with
+an "Unknown tool" error, while a genuinely unknown name must still be errored
+so the turn does not wedge with an unanswered call.
+"""
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+import main
+
+
+def _results_by_name(output):
+    return {tm.name: json.loads(tm.content) for tm in output["messages"]}
+
+
+@pytest.mark.asyncio
+async def test_mixed_message_defers_frontend_tool_and_runs_server_tool():
+    ai = AIMessage(
+        content="I'll call a tool for that.",
+        tool_calls=[
+            {"id": "sum_001", "name": "calculate_sum", "args": {"numbers": [2, 3]}},
+            {"id": "weather_001", "name": "get_weather", "args": {"location": "SF"}},
+        ],
+    )
+    frontend_tools = {
+        "get_weather": {
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    }
+    state = {"messages": [ai], "tools": frontend_tools}
+
+    assert main.should_call_tools(state) == "tools"
+
+    results = _results_by_name(await main.tool_executor_node(state))
+
+    # Server-owned call is executed and answered.
+    assert results["calculate_sum"]["sum"] == 5
+    # Frontend call is deferred to the client, not answered with an error.
+    assert "get_weather" not in results
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_still_errors():
+    ai = AIMessage(
+        content="x",
+        tool_calls=[
+            {"id": "sum_002", "name": "calculate_sum", "args": {"numbers": [1, 1]}},
+            {"id": "bogus_001", "name": "does_not_exist", "args": {}},
+        ],
+    )
+    frontend_tools = {
+        "get_weather": {
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    }
+    state = {"messages": [ai], "tools": frontend_tools}
+
+    results = _results_by_name(await main.tool_executor_node(state))
+
+    assert results["calculate_sum"]["sum"] == 2
+    # A name in neither the frontend tools nor the server tools is a real error.
+    assert results["does_not_exist"] == {"error": "Unknown tool: does_not_exist"}
+
+
+@pytest.mark.asyncio
+async def test_frontend_only_message_routes_to_end():
+    ai = AIMessage(
+        content="weather please",
+        tool_calls=[
+            {"id": "weather_001", "name": "get_weather", "args": {"location": "SF"}},
+        ],
+    )
+    state = {
+        "messages": [ai],
+        "tools": {
+            "get_weather": {
+                "description": "Get the weather",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        },
+    }
+    # A message with only frontend calls never reaches the executor.
+    assert main.should_call_tools(state) == "end"


### PR DESCRIPTION
## What

Fixes the reference LangGraph backend (`python/assistant-transport-backend-langgraph/main.py`) so that a frontend tool call which shares an assistant message with a server-owned tool call is correctly deferred to the client instead of being answered server-side with `Unknown tool`.

Closes #6245

## The bug

Routing was per-message but execution was per-call:

1. `should_call_tools` returns `"tools"` when **any** call in the last message is in `TOOL_BY_NAME`.
2. `tool_executor_node` then iterates over **every** call in that message. For a request-provided frontend name, `TOOL_BY_NAME.get(name)` is `None`, so it emitted `{"error": f"Unknown tool: {name}"}`.

So for a turn like *"add 2 and 3, and then get the weather"* — one server call (`calculate_sum`) plus one frontend call (`get_weather`) — the frontend call was answered with an error, the client never received it, and the model was told its own tool did not exist. A message containing only frontend calls was already handled correctly (`should_call_tools` returns `"end"`); the defect was specific to the mixed case.

## The fix

In `tool_executor_node`, skip any call whose name is a request-provided frontend tool (present in `state["tools"]`) and not in `TOOL_BY_NAME`, so it is returned to the client. The information needed to distinguish the two cases is already in scope, as the issue notes: a name in `state["tools"]` is a frontend tool to defer; a name in neither `state["tools"]` nor `TOOL_BY_NAME` keeps the existing error path so a genuinely hallucinated call still ends with an answered call and does not wedge the turn.

+16 / -0 in `main.py`, plus a new test file.

## Tests

Added `test_tool_executor_node.py` (pytest + pytest-asyncio, matching the repo's `[project.optional-dependencies].dev`):

- `test_mixed_message_defers_frontend_tool_and_runs_server_tool` — the mixed case: `calculate_sum` is executed (`sum == 5`) and `get_weather` is **not** in the produced tool messages.
- `test_unknown_tool_still_errors` — a name in neither set (`does_not_exist`) still yields `{"error": "Unknown tool: does_not_exist"}`.
- `test_frontend_only_message_routes_to_end` — a frontend-only message routes to `"end"` (never reaches the executor), documenting the already-correct case.

## Validation (real results on my machine)

Python 3.11, fresh venv with the package's deps + `pytest pytest-asyncio ruff`:

```
$ python3 -m pytest test_tool_executor_node.py -v
test_mixed_message_defers_frontend_tool_and_runs_server_tool PASSED
test_unknown_tool_still_errors PASSED
test_frontend_only_message_routes_to_end PASSED
3 passed in 1.26s

$ python3 -m ruff check main.py test_tool_executor_node.py
All checks passed!
```

Verified genuine RED→GREEN: with the source fix reverted (`git stash push main.py`), `test_mixed_message_defers_frontend_tool_and_runs_server_tool` fails with `AssertionError: assert 'get_weather' not in {..., 'get_weather': {'error': 'Unknown tool: get_weather'}}`; restoring the fix makes all three pass.

I invoked `tool_executor_node`/`should_call_tools` directly with a hand-built `AIMessage` (the path the issue describes as provable without a model), so no `OPENAI_API_KEY` or live model was needed. I did **not** run the full end-to-end reproduction against a live model (the model-driven path in step 3 of the issue). The message-ordering note in the issue (Anthropic `tool_result` adjacency for a later-abandoned deferred call) is a separate concern and is not addressed here.

First-time contributor to this repo — happy to adjust naming, test placement, or scope.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._7pjx478IGhhJE_tBg1kA1egzzNFKm6SzHFbGk4oWKzBfviG7ZpzOUGpRhg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->