### PR TITLE
fix(assistant-stream): reject non-canonical gorp array indices

### DIFF
--- a/.changeset/gorp-array-index.md
+++ b/.changeset/gorp-array-index.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: reject non-canonical gorp array indices

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -93,14 +93,6 @@ describe("GorpStreamAccumulator", () => {
       error.mockRestore();
     });
 
-    it("accepts numeric index segments from the wire", () => {
-      const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
-      acc.append([
-        { type: "set", path: ["list", 0] as unknown as string[], value: "x" },
-      ]);
-      expect(acc.state).toEqual({ list: ["x", "b"] });
-    });
-
     it("skips negative array indices", () => {
       const error = vi.spyOn(console, "error").mockImplementation(() => {});
       const acc = new GorpStreamAccumulator({ list: ["a"] }, { strict: false });
@@ -108,6 +100,14 @@ describe("GorpStreamAccumulator", () => {
       expect(acc.state).toEqual({ list: ["a"] });
       expect(error).toHaveBeenCalledOnce();
     });
+  });
+
+  it("accepts numeric index segments from the wire", () => {
+    const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
+    acc.append([
+      { type: "set", path: ["list", 0] as unknown as string[], value: "x" },
+    ]);
+    expect(acc.state).toEqual({ list: ["x", "b"] });
   });
 
   it("throws on fractional array indices by default", () => {

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -64,6 +64,34 @@ describe("GorpStreamAccumulator", () => {
       error.mockRestore();
     });
 
+    it("skips fractional array indices", () => {
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const acc = new GorpStreamAccumulator(
+        { list: ["a", "b"] },
+        { strict: false },
+      );
+      acc.append([{ type: "set", path: ["list", "0.5"], value: "x" }]);
+      expect(acc.state).toEqual({ list: ["a", "b"] });
+      expect(error).toHaveBeenCalledOnce();
+      error.mockRestore();
+    });
+
+    it("skips empty and non-canonical numeric array indices", () => {
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      const acc = new GorpStreamAccumulator(
+        { list: ["a", "b"] },
+        { strict: false },
+      );
+      acc.append([
+        { type: "set", path: ["list", ""], value: "x" },
+        { type: "set", path: ["list", " "], value: "x" },
+        { type: "set", path: ["list", "1e0"], value: "x" },
+        { type: "set", path: ["list", "01"], value: "x" },
+      ]);
+      expect(acc.state).toEqual({ list: ["a", "b"] });
+      error.mockRestore();
+    });
+
     it("skips negative array indices", () => {
       const error = vi.spyOn(console, "error").mockImplementation(() => {});
       const acc = new GorpStreamAccumulator({ list: ["a"] }, { strict: false });
@@ -71,6 +99,21 @@ describe("GorpStreamAccumulator", () => {
       expect(acc.state).toEqual({ list: ["a"] });
       expect(error).toHaveBeenCalledOnce();
     });
+  });
+
+  it("throws on fractional array indices by default", () => {
+    const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
+    expect(() =>
+      acc.append([{ type: "set", path: ["list", "0.5"], value: "x" }]),
+    ).toThrow(/Expected array index/);
+  });
+
+  it("throws on an empty-string array index by default", () => {
+    const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
+    expect(() =>
+      acc.append([{ type: "set", path: ["list", ""], value: "x" }]),
+    ).toThrow(/Expected array index/);
+    expect(acc.state).toEqual({ list: ["a", "b"] });
   });
 
   it("throws on out-of-bounds array inserts by default", () => {

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -89,7 +89,16 @@ describe("GorpStreamAccumulator", () => {
         { type: "set", path: ["list", "01"], value: "x" },
       ]);
       expect(acc.state).toEqual({ list: ["a", "b"] });
+      expect(error).toHaveBeenCalledTimes(4);
       error.mockRestore();
+    });
+
+    it("accepts numeric index segments from the wire", () => {
+      const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
+      acc.append([
+        { type: "set", path: ["list", 0] as unknown as string[], value: "x" },
+      ]);
+      expect(acc.state).toEqual({ list: ["x", "b"] });
     });
 
     it("skips negative array indices", () => {

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -80,7 +80,7 @@ export class GorpStreamAccumulator {
     assertSafePathSegment(key);
     if (Array.isArray(state)) {
       let idx = Number(key);
-      if (Number.isNaN(idx))
+      if (!Number.isInteger(idx) || String(idx) !== key)
         throw new Error(`Expected array index at [${path.join(", ")}]`);
       if (idx < 0) throw new Error(`Insert array index out of bounds`);
       if (idx > state.length) {

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -80,7 +80,9 @@ export class GorpStreamAccumulator {
     assertSafePathSegment(key);
     if (Array.isArray(state)) {
       let idx = Number(key);
-      if (!Number.isInteger(idx) || String(idx) !== key)
+      // The wire can deliver numeric segments (op.path is only type-checked,
+      // not runtime-validated), so canonicality is compared via String(key).
+      if (!Number.isInteger(idx) || String(idx) !== String(key))
         throw new Error(`Expected array index at [${path.join(", ")}]`);
       if (idx < 0) throw new Error(`Insert array index out of bounds`);
       if (idx > state.length) {


### PR DESCRIPTION
## Summary

`GorpStreamAccumulator.updatePath` validates array indices with `Number.isNaN(Number(key))`, which admits several non-index strings. On state `{ list: ["a", "b"] }`:

- `"0.5"` is accepted and writes property `"0.5"` on the array copy — the value silently vanishes from `JSON.stringify` and React state, with no error or warning
- `""` and `" "` coerce to `0` and overwrite `list[0]`
- `"1e0"`, `"01"`, and similar numeric aliases write real elements through non-canonical strings

The guard now requires a canonical non-negative integer segment (`Number.isInteger(idx) && String(idx) === key`), routing everything else through the existing invalid-index handling: throw in strict mode, skip-with-`console.error` in non-strict mode.

## Why

The module's own tests pin exactly this intent — "skips non-numeric array indices" (`"x"`) and "skips negative array indices" (`"-1"`) — the `Number.isNaN` check just fails to cover the coercion edge cases, so a malformed or hostile `update-state` op path corrupts `unstable_state` silently instead of hitting the intended rejection path. Negative canonical indices (`"-1"`) still route to their distinct out-of-bounds error, so both pinned behaviors are unchanged.

## Repro

```ts
const acc = new GorpStreamAccumulator({ list: ["a", "b"] });
acc.append([{ type: "set", path: ["list", "0.5"], value: "x" }]);
// main: no error; acc.state.list carries a hidden "0.5" property that disappears on serialization
// fixed: throws "Expected array index at [list, 0.5]" (skipped with console.error when strict: false)
acc.append([{ type: "set", path: ["list", ""], value: "x" }]);
// main: overwrites list[0]
// fixed: rejected the same way
```

## Validation

- Four regression tests: strict mode throws for `"0.5"` and `""`; non-strict mode skips `"0.5"` and the batch `""`/`" "`/`"1e0"`/`"01"` leaving state untouched. All four fail on `main` and pass with this change.
- Full `assistant-stream` suite green on both configs (467 passed / 20 skipped × v6 and peer-v5), `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Z1tNQs1YXRXaMBPhpETJ5Bl0AKdpbStQle-VDtuipGQ2Ibfa3PTfyOnMxL8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->