### PR TITLE
fix(react-data-stream): keep mid-stream cancellation out of onError

### DIFF
--- a/.changeset/data-stream-abort-onerror.md
+++ b/.changeset/data-stream-abort-onerror.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: keep mid-stream cancellation out of onError

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -136,6 +136,36 @@ describe("useDataStreamRuntime request errors", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("normalizes non-Error stream failures for onError", async () => {
+    const onError = vi.fn();
+    const encoder = new TextEncoder();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        const body = new ReadableStream<Uint8Array>({
+          start(streamController) {
+            streamController.enqueue(encoder.encode('0:"Hello"\n'));
+            streamController.error("wire failure");
+          },
+        });
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "x-vercel-ai-data-stream": "v1" },
+          }),
+        );
+      }),
+    );
+
+    const adapter = createAdapter({ api: "/api/chat", onError });
+
+    await expect(runToCompletion(adapter, createRunOptions())).rejects.toBe(
+      "wire failure",
+    );
+    expect(onError).toHaveBeenCalledExactlyOnceWith(new Error("wire failure"));
+  });
+
   it.each(["throws", "rejects"] as const)(
     "preserves request failures when onError %s",
     async (failureMode) => {

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -92,6 +92,50 @@ describe("useDataStreamRuntime request errors", () => {
     expect(onError).toHaveBeenCalledExactlyOnceWith(error);
   });
 
+  it("keeps mid-stream cancellation separate from stream errors", async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException("Cancelled", "AbortError");
+    const onCancel = vi.fn();
+    const onError = vi.fn();
+    const encoder = new TextEncoder();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(streamController) {
+            streamController.enqueue(encoder.encode('0:"Hello"\n'));
+            init?.signal?.addEventListener(
+              "abort",
+              () => streamController.error(init.signal?.reason),
+              { once: true },
+            );
+          },
+        });
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+            headers: { "x-vercel-ai-data-stream": "v1" },
+          }),
+        );
+      }),
+    );
+
+    const adapter = createAdapter({ api: "/api/chat", onCancel, onError });
+    const run = async () => {
+      for await (const _ of adapter.run(
+        createRunOptions(controller.signal),
+      ) as AsyncGenerator) {
+        void _;
+        controller.abort(abortError);
+      }
+    };
+
+    await expect(run()).rejects.toBe(abortError);
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it.each(["throws", "rejects"] as const)(
     "preserves request failures when onError %s",
     async (failureMode) => {

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -249,7 +249,13 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
         unstable_getMessage(),
       );
     } catch (error: unknown) {
-      invokeRuntimeCallback("onError", this.options.onError, error as Error);
+      if (!(error instanceof Error && error.name === "AbortError")) {
+        invokeRuntimeCallback(
+          "onError",
+          this.options.onError,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
       throw error;
     } finally {
       abortSignal.removeEventListener("abort", handleAbort);


### PR DESCRIPTION
## Summary

`useDataStreamRuntime` invokes `onError` for cancellations that happen after response headers arrive. The pre-fetch catch filters `AbortError` before calling `onError` (pinned by the "keeps cancellation separate from request errors" test), but the streaming catch invokes `onError` unconditionally — and cancellation mid-stream surfaces as an error there: `cancelRun()`/`detach()` abort the signal with an `AbortError`, the in-flight `result.body` errors with that reason, and it propagates out of the `yield*`. So every user "stop" after headers fires **both** `onCancel` and `onError`, and every thread switch/unmount (`detach`, where `onCancel` is intentionally suppressed) fires a spurious `onError`. The streaming catch now applies the same `AbortError` filter (and the same non-`Error` normalization) as the pre-fetch catch.

## Why

`onError` is the application's failure channel — apps toast it, log it, or retry on it. A user pressing stop is not a failure, and the adapter already models that: the pre-fetch path filters aborts and routes them through `onCancel`. The streaming path bypassing the filter means the callback contract depends on *when* the user cancels, which no consumer can reasonably handle.

Related: #5995 tracks a similar concern in the `ai-sdk` adapter; that one is about the upstream SDK's internal promise chain in Chromium and remains unconfirmed — this PR fixes the reproducible variant in `react-data-stream`'s own adapter.

## Repro

```ts
// stream a response, then while it streams:
runtime.thread.cancelRun();
// main: onCancel fires AND onError fires with the AbortError
// fixed: only onCancel fires
```

## Validation

- New regression test "keeps mid-stream cancellation separate from stream errors": fetch resolves with a streaming body that errors with the signal's reason on abort; cancelling after the first yield must fire `onCancel` once and `onError` never. Fails on `main` (`onError` called once with the `AbortError`) and passes with this change.
- Full `@assistant-ui/react-data-stream` suite: 33 passed across 3 files. (A pre-existing `tsc` error in the test helper's iterator typing exists on `main` and is untouched.)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RirxzVCk0Z_rlzowdtCfvnBfjcMmZPP3eEEd4dxUppN1VUQF3qfoYv6Zdtk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->