### PR TITLE
fix(cloud-ai-sdk): feed title generation the conversation in chronological order

### DIFF
--- a/.changeset/cloud-title-order.md
+++ b/.changeset/cloud-title-order.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: feed title generation the conversation in chronological order

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
+import { generateThreadTitle } from "./generateThreadTitle";
+import { MESSAGE_FORMAT } from "../chat/MessagePersistence";
+
+const cloudMessage = (id: string, role: string, text: string) => ({
+  id,
+  format: MESSAGE_FORMAT,
+  content: { role, parts: [{ type: "text", text }] },
+});
+
+const titleStream = (title: string) =>
+  new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: "text-delta", textDelta: title });
+      controller.close();
+    },
+  });
+
+const createCloud = (messages: unknown[]) => {
+  const list = vi.fn().mockResolvedValue({ messages });
+  const update = vi.fn().mockResolvedValue(undefined);
+  const stream = vi.fn().mockResolvedValue(titleStream("Weather chat"));
+  const cloud = {
+    threads: { messages: { list }, update },
+    runs: { stream },
+  } as unknown as AssistantCloud;
+  return { cloud, list, update, stream };
+};
+
+describe("generateThreadTitle", () => {
+  it("feeds the title model the conversation in chronological order", async () => {
+    const { cloud, stream, update } = createCloud([
+      cloudMessage("m2", "assistant", "Sunny with light wind."),
+      cloudMessage("m1", "user", "What is the weather today?"),
+    ]);
+
+    const title = await generateThreadTitle(cloud, "thread-1");
+
+    expect(title).toBe("Weather chat");
+    expect(stream).toHaveBeenCalledExactlyOnceWith({
+      thread_id: "thread-1",
+      assistant_id: "system/thread_title",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is the weather today?" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Sunny with light wind." }],
+        },
+      ],
+    });
+    expect(update).toHaveBeenCalledExactlyOnceWith("thread-1", {
+      title: "Weather chat",
+    });
+  });
+});

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
@@ -16,7 +16,9 @@ export async function generateThreadTitle(
     return messages;
   };
 
-  const messages = await loadMessages();
+  // The list endpoint returns newest-first; the title model needs the
+  // conversation in chronological order.
+  const messages = (await loadMessages()).slice().reverse();
   if (messages.length === 0) return null;
 
   const aiSdkMessages = messages.filter(


### PR DESCRIPTION
## Summary

`generateThreadTitle` maps the raw result of `cloud.threads.messages.list(threadId)` straight into the `system/thread_title` run. That endpoint returns messages newest-first — both other consumers reverse it (`FormattedCloudPersistence`, pinned by its "load … reverses order" test, and `AssistantCloudThreadHistoryAdapter`) — so the title model receives the assistant's reply first and the user's opening message last. The loaded list is now reversed into chronological order before conversion.

## Why

Title quality: the model is asked to summarize a conversation it sees backwards; for multi-turn threads the opening question (usually the strongest title signal) arrives last. The fix matches the established convention at the only other two call sites of the same endpoint.

## Repro

```ts
// thread with user question then assistant reply; list() returns newest-first
await generateThreadTitle(cloud, threadId);
// main:  runs.stream receives [assistant reply, user question]
// fixed: runs.stream receives [user question, assistant reply]
```

## Validation

- New `generateThreadTitle.test.ts`: a newest-first list must reach `runs.stream` in chronological order (user first), and the streamed title is written back via `threads.update`. Fails on `main` (assistant-first payload) and passes with this change.
- Full `@assistant-ui/cloud-ai-sdk` suite: 94 passed across 13 files, `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2XQ0xnHdtz-svxZ55P2Wv4uSJ4mGuGPog1532kcl7co57Y2uOd9CTnO_9po?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->