### PR TITLE
fix(cloud): surface the response text when a JSON error body has no message

### DIFF
--- a/.changeset/cloud-error-message.md
+++ b/.changeset/cloud-error-message.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: surface the response text when a JSON error body has no message

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -139,16 +139,19 @@ export class AssistantCloudAPI {
 
     if (!response.ok) {
       const text = await response.text();
+      let message: string | undefined;
       try {
         const body = JSON.parse(text);
-        throw new CloudAPIError(body.message, response.status);
-      } catch (error) {
-        if (error instanceof CloudAPIError) throw error;
-        throw new CloudAPIError(
-          `Request failed with status ${response.status}, ${text}`,
-          response.status,
-        );
+        if (typeof body?.message === "string" && body.message.length > 0) {
+          message = body.message;
+        }
+      } catch {
+        // non-JSON bodies fall through to the status fallback
       }
+      throw new CloudAPIError(
+        message ?? `Request failed with status ${response.status}, ${text}`,
+        response.status,
+      );
     }
 
     return response;

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -145,9 +145,7 @@ export class AssistantCloudAPI {
         if (typeof body?.message === "string" && body.message.length > 0) {
           message = body.message;
         }
-      } catch {
-        // non-JSON bodies fall through to the status fallback
-      }
+      } catch {}
       throw new CloudAPIError(
         message ?? `Request failed with status ${response.status}, ${text}`,
         response.status,

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -169,6 +169,31 @@ describe("AssistantCloudAPI", () => {
     expect(error.status).toBe(400);
   });
 
+  it("falls back to the response text when the JSON error body has no message", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: new Headers(),
+      text: vi
+        .fn()
+        .mockResolvedValue(JSON.stringify({ error: "rate limited" })),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    const error = await api.makeRawRequest("/threads").catch((e) => e);
+    expect(error).toBeInstanceOf(CloudAPIError);
+    expect(error.message).toBe(
+      'Request failed with status 429, {"error":"rate limited"}',
+    );
+    expect(error.status).toBe(429);
+  });
+
   it("throws generic error with status for non-JSON error responses", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary

For a parseable JSON error body, `AssistantCloudAPI.makeRawRequest` throws `new CloudAPIError(body.message, status)` unconditionally. When the body has no `message` key — `{"error":"rate limited"}`, `{"errors":[…]}` — that constructs an error with an **empty message**, and because the throw happens inside the `try`, the `error instanceof CloudAPIError` guard in the catch rethrows it before the informative `Request failed with status …, <text>` fallback can run. The parse/extract step is now separated from the throw: a string `message` from the body is used when present, and everything else (non-JSON bodies included) gets the status + response-text fallback.

## Why

An empty error message is the worst possible diagnostic — the caller sees a `CloudAPIError` with no text while the response body actually contained the reason. The informative fallback already existed; the control flow just made it unreachable for JSON bodies of any shape other than `{message}`.

## Repro

```ts
// server responds 429 {"error":"rate limited"}
await api.makeRawRequest("/threads");
// main:  CloudAPIError with message "" 
// fixed: CloudAPIError with message 'Request failed with status 429, {"error":"rate limited"}'
```

## Validation

- New regression test: a JSON error body without `message` must surface the status + raw text. Fails on `main` (empty message) and passes with this change; the existing `{message}` and non-JSON fallback tests pin the other two paths unchanged.
- Full `assistant-cloud` suite: 82 passed across 11 files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uiuWrQK9BSI2RxgpGmLlMJgE_FgribdT4SRj_BqJI-Dpa0U_lpAEQiYnwBA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->