### PR TITLE
fix(docs): show hiring banner to returning visitors

### DIFF
--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -18,6 +18,7 @@ import { NavItems, NavItemsRoot } from "@/components/shared/nav-items";
 import { HeaderBrandLink } from "@/components/shared/header-brand-link";
 import { headerBarClassName } from "@/components/shared/header-chrome";
 import { useScrolled } from "@/hooks/use-scrolled";
+import { useHomepageVisit } from "./use-homepage-visit";
 
 function SearchButton({ onToggle }: { onToggle: () => void }) {
   useEffect(() => {
@@ -95,19 +96,16 @@ export function Header({ stars }: { stars: number | null }) {
     "homepage-hiring-banner-dismissed",
   );
   const [visited, setVisited] = usePersistentBoolean("homepage-visited");
-  const [returningVisitor, setReturningVisitor] = useState(false);
+  const returningVisitor = useHomepageVisit({
+    pathname,
+    mounted,
+    visited,
+    setVisited,
+  });
 
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  useEffect(() => {
-    if (pathname !== "/") return;
-    // Show the banner only from the second homepage visit onward.
-    setReturningVisitor(visited);
-    if (!visited) setVisited(true);
-    // oxlint-disable-next-line react/exhaustive-deps
-  }, [pathname]);
 
   const isHome = pathname === "/";
   const showBanner = mounted && isHome && returningVisitor && !dismissed;

--- a/apps/docs/components/shared/use-homepage-visit.test.tsx
+++ b/apps/docs/components/shared/use-homepage-visit.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { act, useEffect, useState } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, expect, it } from "vitest";
+import {
+  createPersistedPreference,
+  usePersistedPreference,
+} from "../../lib/persisted-preference";
+import { useHomepageVisit } from "./use-homepage-visit";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const VISITED_KEY = "assistant-ui::docs:homepage-visited";
+const DISMISSED_KEY = "assistant-ui::docs:homepage-hiring-banner-dismissed";
+
+const createBooleanPreference = (key: string) =>
+  createPersistedPreference<boolean>({
+    key,
+    fallback: false,
+    read: (raw) => (raw === "true" ? true : raw === "false" ? false : null),
+    write: (value) => (value ? "true" : "false"),
+  });
+
+type VisitState = {
+  visited: boolean;
+  returningVisitor: boolean;
+  dismissed: boolean;
+  showBanner: boolean;
+};
+
+const renderVisit = async () => {
+  const visitedPreference = createBooleanPreference(VISITED_KEY);
+  const dismissedPreference = createBooleanPreference(DISMISSED_KEY);
+  const state: VisitState = {
+    visited: false,
+    returningVisitor: false,
+    dismissed: false,
+    showBanner: false,
+  };
+  let navigate: ((pathname: string) => void) | undefined;
+
+  function Probe() {
+    const [mounted, setMounted] = useState(false);
+    const [pathname, setPathname] = useState("/");
+    const visited = usePersistedPreference(visitedPreference);
+    const dismissed = usePersistedPreference(dismissedPreference);
+    const returningVisitor = useHomepageVisit({
+      pathname,
+      mounted,
+      visited,
+      setVisited: visitedPreference.set,
+    });
+
+    navigate = setPathname;
+    useEffect(() => setMounted(true), []);
+
+    state.visited = visited;
+    state.returningVisitor = returningVisitor;
+    state.dismissed = dismissed;
+    state.showBanner =
+      mounted && pathname === "/" && returningVisitor && !dismissed;
+    return <div>{String(state.showBanner)}</div>;
+  }
+
+  const container = document.createElement("div");
+  container.innerHTML = renderToString(<Probe />);
+  document.body.append(container);
+
+  let root: Root;
+  await act(async () => {
+    root = hydrateRoot(container, <Probe />);
+  });
+
+  return {
+    state,
+    navigate: (pathname: string) => navigate!(pathname),
+    dismiss: () => dismissedPreference.set(true),
+    unmount: async () => {
+      await act(async () => root.unmount());
+    },
+  };
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  localStorage.clear();
+});
+
+it("records the first homepage visit without showing the banner", async () => {
+  const view = await renderVisit();
+
+  expect(view.state).toEqual({
+    visited: true,
+    returningVisitor: false,
+    dismissed: false,
+    showBanner: false,
+  });
+  expect(localStorage.getItem(VISITED_KEY)).toBe("true");
+
+  await view.unmount();
+});
+
+it("shows the banner for a stored visit after hydration", async () => {
+  localStorage.setItem(VISITED_KEY, "true");
+
+  const view = await renderVisit();
+
+  expect(view.state).toEqual({
+    visited: true,
+    returningVisitor: true,
+    dismissed: false,
+    showBanner: true,
+  });
+
+  await view.unmount();
+});
+
+it("classifies a homepage return in the same session as returning", async () => {
+  const view = await renderVisit();
+
+  await act(async () => view.navigate("/docs"));
+  await act(async () => view.navigate("/"));
+
+  expect(view.state).toEqual({
+    visited: true,
+    returningVisitor: true,
+    dismissed: false,
+    showBanner: true,
+  });
+
+  await view.unmount();
+});
+
+it("keeps a dismissed banner hidden", async () => {
+  localStorage.setItem(VISITED_KEY, "true");
+  const view = await renderVisit();
+
+  await act(async () => view.dismiss());
+
+  expect(view.state).toEqual({
+    visited: true,
+    returningVisitor: true,
+    dismissed: true,
+    showBanner: false,
+  });
+  expect(localStorage.getItem(DISMISSED_KEY)).toBe("true");
+
+  await view.unmount();
+});

--- a/apps/docs/components/shared/use-homepage-visit.ts
+++ b/apps/docs/components/shared/use-homepage-visit.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from "react";
+
+type UseHomepageVisitOptions = {
+  pathname: string | null;
+  mounted: boolean;
+  visited: boolean;
+  setVisited: (value: boolean) => void;
+};
+
+export function useHomepageVisit({
+  pathname,
+  mounted,
+  visited,
+  setVisited,
+}: UseHomepageVisitOptions) {
+  const [returningVisitor, setReturningVisitor] = useState(false);
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (pathname !== "/") {
+      handledRef.current = false;
+      return;
+    }
+    if (!mounted || handledRef.current) return;
+
+    handledRef.current = true;
+    setReturningVisitor(visited);
+    if (!visited) setVisited(true);
+  }, [mounted, pathname, setVisited, visited]);
+
+  return returningVisitor;
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -110,6 +110,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "jsdom": "^30.0.1",
     "postcss": "^8.5.26",
     "react-grab": "^0.2.0",
     "tailwindcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       postcss:
         specifier: ^8.5.26
         version: 8.5.26


### PR DESCRIPTION
## Summary

- classify each homepage entry only after the persisted visit state has settled on the client
- keep the first homepage visit hidden while showing the hiring banner on later visits
- add SSR/hydration regressions for stored visits, same-session returns, and dismissal

Closes #6231

## Testing

- `pnpm --filter @assistant-ui/docs exec vitest run components/shared/use-homepage-visit.test.tsx`
- `pnpm test` in `apps/docs` (230 tests)
- `pnpm build` in `apps/docs`
- `pnpm exec tsc --noEmit -p apps/docs/tsconfig.json`
- scoped Oxlint and Oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iul_Iu7LY6y-14ZCS__zozTNccUtEwffLr7ATwZ2Tod89sKQUaQP_500E7w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->