### PR TITLE
fix(cli): pass style-aware registry URLs during create

### DIFF
--- a/.changeset/cli-create-registry-urls.md
+++ b/.changeset/cli-create-registry-urls.md
@@ -1,0 +1,7 @@
+---
+"assistant-ui": patch
+---
+
+fix: resolve create-time assistant-ui components through style-aware registry URLs
+
+`assistant-ui create` now passes the same `r.assistant-ui.com` item URLs as `assistant-ui add`, instead of `@assistant-ui/<name>` names that depend on shadcn interpolating `components.json`.

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -9,6 +9,10 @@ import {
   type ParseError,
 } from "jsonc-parser";
 import { logger } from "./utils/logger";
+import {
+  getComponentsJsonStyle,
+  resolveRegistryItemUrl,
+} from "./utils/registry";
 import { runSpawn, SpawnExitError } from "./run-spawn";
 
 export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
@@ -249,7 +253,10 @@ export async function transformProject(
     const allShadcn = shadcnUI.includes("utils")
       ? shadcnUI
       : [...shadcnUI, "utils"];
-    const auiComponents = assistantUI.map((c) => `@assistant-ui/${c}`);
+    const style = getComponentsJsonStyle(projectDir);
+    const auiComponents = assistantUI.map((c) =>
+      resolveRegistryItemUrl(c, style),
+    );
     const components = [...allShadcn, ...auiComponents];
     logger.step(`Installing components: ${components.join(", ")}...`);
     const failure = await installShadcnRegistry(

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -535,9 +535,42 @@ describe("transformProject — hasLocalComponents: false", () => {
 
       const args = addCalls[0]![1] as string[];
       expect(args).toContain("button");
-      expect(args).toContain("@assistant-ui/thread");
+      expect(args).toContain("https://r.assistant-ui.com/base/thread.json");
       expect(args).not.toContain("button.tsx");
+      expect(args).not.toContain("@assistant-ui/thread");
       expect(args).not.toContain("@assistant-ui/thread.tsx");
+    });
+
+    it("uses the style-scoped registry URL from components.json", async () => {
+      writeJSON("components.json", { style: "base-nova" });
+      writeFile(
+        "app/page.tsx",
+        'import { Thread } from "@/components/assistant-ui/thread";\nimport { ThreadListSidebar } from "@/components/assistant-ui/threadlist-sidebar";\n',
+      );
+
+      await transformProject(testDir, {
+        ...defaultOpts,
+        skipInstall: false,
+        hasLocalComponents: false,
+      });
+
+      const addCalls = (spawn as Mock).mock.calls.filter(
+        ([cmd, args]: [string, string[]]) =>
+          cmd === TEST_DLX_CMD &&
+          args.includes("shadcn@latest") &&
+          args.includes("add"),
+      );
+      expect(addCalls).toHaveLength(1);
+
+      const args = addCalls[0]![1] as string[];
+      expect(args).toContain(
+        "https://r.assistant-ui.com/styles/base-nova/thread.json",
+      );
+      expect(args).toContain(
+        "https://r.assistant-ui.com/styles/base-nova/threadlist-sidebar.json",
+      );
+      expect(args).not.toContain("@assistant-ui/thread");
+      expect(args).not.toContain("@assistant-ui/threadlist-sidebar");
     });
 
     it("skips shadcn when skipInstall is true even without local components", async () => {


### PR DESCRIPTION
closes #6251

## summary

- `assistant-ui create` now asks shadcn for the same `r.assistant-ui.com` item URLs that `assistant-ui add` already uses, instead of `@assistant-ui/<name>` names that depend on shadcn interpolating `components.json`.
- that matches the reported failure shape (shadcn `sidebar` present, `thread` / `threadlist-sidebar` missing) without the post-install file probe in the closed #6252.

## test plan

### already verified

- [x] `pnpm exec vitest run test/lib/create-project.test.ts` from `packages/cli` -> 27 passed
- [x] published `npx assistant-ui@latest create --template default` already wrote both files on this machine; the change makes create stop depending on namespaced resolution

### reviewer should verify

- [ ] `npx assistant-ui create tmp-app --template default --use-npm --no-skills` and confirm `components/assistant-ui/thread.tsx` and `threadlist-sidebar.tsx` exist, then `npm run dev` loads `/`

## notes

- closed #6252 as the wrong fix (detect missing files after a stubbed zero-exit install).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.WkTqVMPqrdAJYrSEjgnbECsqGgslvflU0RPVdPm-M7LEOnBl8VsxDpJFFZ4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->