### PR TITLE
refactor: own the run report tool call shape in assistant-cloud

### DIFF
--- a/.changeset/cloud-run-telemetry-primitives.md
+++ b/.changeset/cloud-run-telemetry-primitives.md
@@ -1,0 +1,9 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/core": patch
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+refactor: own the run-report tool call shape in assistant-cloud
+
+the run telemetry primitives (span truncation, MCP result summarization, tool call serialization, provider usage normalization) were copied verbatim into both `@assistant-ui/core`'s cloud history adapter and `@assistant-ui/cloud-ai-sdk`, and the two copies had already drifted on `sampling_calls`. assistant-cloud already declared the wire type both copies were re-declaring, so the builder now lives beside it: `createRunTelemetryToolCall`, `normalizeRunTelemetryUsage`, `truncateRunTelemetryText`, and the `AssistantCloudRunReportToolCall` type it produces. both callers consume those instead of their own copy; the reported payload is unchanged.

--- a/.changeset/cloud-run-telemetry-primitives.md
+++ b/.changeset/cloud-run-telemetry-primitives.md
@@ -4,6 +4,4 @@
 "@assistant-ui/cloud-ai-sdk": patch
 ---
 
-refactor: own the run-report tool call shape in assistant-cloud
-
-the run telemetry primitives (span truncation, MCP result summarization, tool call serialization, provider usage normalization) were copied verbatim into both `@assistant-ui/core`'s cloud history adapter and `@assistant-ui/cloud-ai-sdk`, and the two copies had already drifted on `sampling_calls`. assistant-cloud already declared the wire type both copies were re-declaring, so the builder now lives beside it: `createRunTelemetryToolCall`, `normalizeRunTelemetryUsage`, `truncateRunTelemetryText`, and the `AssistantCloudRunReportToolCall` type it produces. both callers consume those instead of their own copy; the reported payload is unchanged.
+refactor: move the run report tool call shape and its serialization into assistant-cloud

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -105,13 +105,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -124,6 +124,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -458,15 +469,25 @@ type ReadonlyJSONObject = {
 
 type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
+type RunTelemetryToolCallInit = {
+  toolName: string;
+  toolCallId: string;
+  args?: unknown;
+  argsText?: string | undefined;
+  result?: unknown;
+  toolSource?: "mcp" | "frontend" | "backend" | undefined;
+};
+
+type RunTelemetryUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+};
+
+type RunTelemetryUsageInit = RunTelemetryUsage & {
+  promptTokens?: number;
+  completionTokens?: number;
 };
 
 type SamplingCallData = {
@@ -511,6 +532,8 @@ declare const createFormattedPersistence: <TMessage, TStorageFormat>(persistence
   isPersisted: (messageId: string) => boolean;
 };
 
+declare function createRunTelemetryToolCall(init: RunTelemetryToolCallInit): AssistantCloudRunReportToolCall;
+
 declare function createSamplingCollector(): {
   collect: (data: SamplingCallData) => number;
   getCalls: () => SamplingCallData[];
@@ -518,8 +541,12 @@ declare function createSamplingCollector(): {
 };
 
 declare namespace entry_root_exports {
-  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudTelemetryConfig, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, SamplingCallData, createFormattedPersistence, createSamplingCollector, wrapSamplingHandler };
+  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, normalizeRunTelemetryUsage, truncateRunTelemetryText, wrapSamplingHandler };
 }
+
+declare function normalizeRunTelemetryUsage(usage: RunTelemetryUsageInit): RunTelemetryUsage | undefined;
+
+declare function truncateRunTelemetryText(value: string): string;
 
 declare function wrapSamplingHandler(handler: McpSamplingHandler, onSamplingCall: (data: SamplingCallData) => void): McpSamplingHandler;
 

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -190,13 +190,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -209,6 +209,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1405,17 +1416,6 @@ type ReasoningMessagePart = {
 
 type ReloadConfig = {
   runConfig?: RunConfig;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type ReservedAccessorProps = "name" | "query" | "source";

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -109,13 +109,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -128,6 +128,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -402,17 +413,6 @@ type ReadonlyJSONObject = {
 };
 
 type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
 
 type SamplingCallData = {
   model_id?: string;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -205,13 +205,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -224,6 +224,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -3881,17 +3892,6 @@ type RemoteThreadState = {
   readonly archivedThreadIds: readonly string[];
   readonly threadIdMap: Readonly<Record<string, THREAD_MAPPING_ID>>;
   readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -190,13 +190,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -209,6 +209,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1405,17 +1416,6 @@ type ReasoningMessagePart = {
 
 type ReloadConfig = {
   runConfig?: RunConfig;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type ReservedAccessorProps = "name" | "query" | "source";

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -117,13 +117,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -136,6 +136,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1215,17 +1226,6 @@ type ReasoningMessagePart = {
 
 type ReloadConfig = {
   runConfig?: RunConfig;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RunConfig = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -486,13 +486,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -505,6 +505,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1728,17 +1739,6 @@ type RemoteThreadMetadata = {
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RespondToToolApprovalOptions = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -189,13 +189,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -208,6 +208,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -2882,17 +2893,6 @@ type RemoteThreadMetadata = {
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -127,13 +127,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -146,6 +146,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1435,17 +1446,6 @@ type RemoteThreadMetadata = {
 type RemoveUIMessage = {
   type: "remove-ui";
   id: string;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RespondToToolApprovalOptions = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -129,13 +129,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -148,6 +148,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -1598,17 +1609,6 @@ type RemoteThreadMetadata = {
 type RemoveUIMessage = {
   type: "remove-ui";
   id: string;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RespondToToolApprovalOptions = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -187,13 +187,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -206,6 +206,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -2548,17 +2559,6 @@ type RemoteThreadMetadata = {
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -350,13 +350,13 @@ type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "error" | "incomplete";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];
@@ -369,6 +369,17 @@ type AssistantCloudRunReport = {
   duration_ms?: number;
   output_text?: string;
   metadata?: Record<string, unknown>;
+};
+
+type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
 declare class AssistantCloudRuns {
@@ -3704,17 +3715,6 @@ type RemoteThreadMetadata = {
   readonly title?: string | undefined;
   readonly lastMessageAt?: Date | undefined;
   readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
 };
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
@@ -1,64 +1,18 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { getToolName, isStaticToolUIPart, isToolUIPart } from "ai";
-import type { SamplingCallData } from "assistant-cloud";
-
-const MAX_SPAN_CONTENT = 50_000;
-
-function truncateStr(value: string): string {
-  if (value.length <= MAX_SPAN_CONTENT) return value;
-  return value.slice(0, MAX_SPAN_CONTENT);
-}
-
-function safeStringify(value: unknown): string | undefined {
-  if (value == null) return undefined;
-  try {
-    return truncateStr(JSON.stringify(value));
-  } catch {
-    return undefined;
-  }
-}
-
-const BASE64_PATTERN = /^[A-Za-z0-9+/]{100,}={0,2}$/;
-
-function summarizeMcpResult(value: unknown): string | undefined {
-  if (value == null) return undefined;
-  try {
-    const parsed = typeof value === "string" ? JSON.parse(value) : value;
-    if (Array.isArray(parsed)) {
-      const summarized = parsed.map((item) => {
-        if (item && typeof item === "object" && item.type) {
-          if (
-            (item.type === "image" || item.type === "audio") &&
-            typeof item.data === "string" &&
-            BASE64_PATTERN.test(item.data.slice(0, 200))
-          ) {
-            const sizeKB = ((item.data.length * 3) / 4 / 1024).toFixed(1);
-            return { ...item, data: `[${item.type}: ${sizeKB}KB]` };
-          }
-        }
-        return item;
-      });
-      return truncateStr(JSON.stringify(summarized));
-    }
-  } catch {
-    // not JSON array, fall through
-  }
-  return safeStringify(value);
-}
-
-export type TelemetryToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
-  sampling_calls?: SamplingCallData[];
-};
+import {
+  type AssistantCloudRunReportToolCall,
+  createRunTelemetryToolCall,
+  normalizeRunTelemetryUsage,
+  type RunTelemetryUsageInit,
+  type SamplingCallData,
+  truncateRunTelemetryText,
+} from "assistant-cloud";
 
 export type RunTelemetryData = {
   assistantMessageId: string;
   status: "completed" | "incomplete";
-  toolCalls?: TelemetryToolCall[];
+  toolCalls?: AssistantCloudRunReportToolCall[];
   totalSteps?: number;
   outputText?: string;
   inputTokens?: number;
@@ -68,69 +22,20 @@ export type RunTelemetryData = {
   modelId?: string;
 };
 
-type UsageFields = {
-  inputTokens?: number;
-  outputTokens?: number;
-  promptTokens?: number;
-  completionTokens?: number;
-  reasoningTokens?: number;
-  cachedInputTokens?: number;
-};
-
-function normalizeUsage(usage: UsageFields):
-  | {
-      inputTokens?: number;
-      outputTokens?: number;
-      reasoningTokens?: number;
-      cachedInputTokens?: number;
-    }
-  | undefined {
-  const inputTokens = usage.inputTokens ?? usage.promptTokens;
-  const outputTokens = usage.outputTokens ?? usage.completionTokens;
-
-  if (
-    inputTokens == null &&
-    outputTokens == null &&
-    usage.reasoningTokens == null &&
-    usage.cachedInputTokens == null
-  ) {
-    return undefined;
-  }
-
-  return {
-    ...(inputTokens != null ? { inputTokens } : undefined),
-    ...(outputTokens != null ? { outputTokens } : undefined),
-    ...(usage.reasoningTokens != null
-      ? { reasoningTokens: usage.reasoningTokens }
-      : undefined),
-    ...(usage.cachedInputTokens != null
-      ? { cachedInputTokens: usage.cachedInputTokens }
-      : undefined),
-  };
-}
-
 type Part = UIMessage["parts"][number];
 type ToolPart = Extract<Part, { toolCallId: string }>;
 
-function buildToolCall(part: ToolPart): TelemetryToolCall {
+function buildToolCall(part: ToolPart): AssistantCloudRunReportToolCall {
   // dynamic-tool → mcp, static `tool-*` → frontend. matches server-side
   // createAssistantRun (apps/cloud-api/src/endpoints/runs/stream.ts).
   const isMcp = !isStaticToolUIPart(part);
-  const call: TelemetryToolCall = {
-    tool_name: getToolName(part),
-    tool_call_id: part.toolCallId,
-    tool_source: isMcp ? "mcp" : "frontend",
-  };
-
-  const input = "input" in part ? part.input : undefined;
-  const toolArgs = safeStringify(input);
-  if (toolArgs !== undefined) call.tool_args = toolArgs;
-
-  const output = "output" in part ? part.output : undefined;
-  const toolResult = isMcp ? summarizeMcpResult(output) : safeStringify(output);
-  if (toolResult !== undefined) call.tool_result = toolResult;
-
-  return call;
+  return createRunTelemetryToolCall({
+    toolName: getToolName(part),
+    toolCallId: part.toolCallId,
+    args: "input" in part ? part.input : undefined,
+    result: "output" in part ? part.output : undefined,
+    toolSource: isMcp ? "mcp" : "frontend",
+  });
 }
 
 export function extractRunTelemetry(
@@ -146,7 +51,7 @@ export function extractRunTelemetry(
   if (!assistant) return null;
 
   const textParts: string[] = [];
-  const toolCalls: TelemetryToolCall[] = [];
+  const toolCalls: AssistantCloudRunReportToolCall[] = [];
   let stepCount = 0;
 
   for (const part of assistant.parts) {
@@ -160,7 +65,9 @@ export function extractRunTelemetry(
   }
 
   const hasText = textParts.length > 0;
-  const outputText = hasText ? truncateStr(textParts.join("")) : undefined;
+  const outputText = hasText
+    ? truncateRunTelemetryText(textParts.join(""))
+    : undefined;
   // fallback heuristic; callers with the onFinish event should override via deriveStatus.
   const status: RunTelemetryData["status"] = hasText
     ? "completed"
@@ -169,8 +76,8 @@ export function extractRunTelemetry(
   const metadata = assistant.metadata as Record<string, unknown> | undefined;
   const modelId =
     typeof metadata?.modelId === "string" ? metadata.modelId : undefined;
-  const usage = metadata?.usage as UsageFields | undefined;
-  const normalizedUsage = usage ? normalizeUsage(usage) : undefined;
+  const usage = metadata?.usage as RunTelemetryUsageInit | undefined;
+  const normalizedUsage = usage ? normalizeRunTelemetryUsage(usage) : undefined;
 
   const rawSamplingCalls = metadata?.samplingCalls;
   const samplingCallsMap =

--- a/packages/cloud/src/AssistantCloudRuns.ts
+++ b/packages/cloud/src/AssistantCloudRuns.ts
@@ -1,5 +1,5 @@
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
-import type { SamplingCallData } from "./instrumentMcpSampling";
+import type { AssistantCloudRunReportToolCall } from "./runTelemetry";
 import { AssistantStream, PlainTextDecoder } from "assistant-stream";
 import {
   CloudResponseError,
@@ -13,17 +13,6 @@ type AssistantCloudRunsStreamBody = {
   messages: readonly unknown[]; // TODO type
 };
 
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
 // NOTE: Keep this payload shape aligned with the strict runtime validator in
 // assistant-cloud: apps/aui-cloud-api/src/endpoints/runs/create.ts
 // (createRunSchema). New telemetry fields must be added in both repos together.
@@ -31,13 +20,13 @@ export type AssistantCloudRunReport = {
   thread_id: string;
   status: "completed" | "incomplete" | "error";
   total_steps?: number;
-  tool_calls?: ReportToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   steps?: {
     input_tokens?: number;
     output_tokens?: number;
     reasoning_tokens?: number;
     cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
+    tool_calls?: AssistantCloudRunReportToolCall[];
     start_ms?: number;
     end_ms?: number;
   }[];

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -3,6 +3,15 @@ export type { AssistantCloudTelemetryConfig } from "./AssistantCloudAPI";
 export { CloudAPIError } from "./AssistantCloudAPI";
 export { CloudResponseError } from "./cloudResponse";
 export type { AssistantCloudRunReport } from "./AssistantCloudRuns";
+export {
+  createRunTelemetryToolCall,
+  normalizeRunTelemetryUsage,
+  truncateRunTelemetryText,
+  type AssistantCloudRunReportToolCall,
+  type RunTelemetryToolCallInit,
+  type RunTelemetryUsage,
+  type RunTelemetryUsageInit,
+} from "./runTelemetry";
 export { AssistantCloud } from "./AssistantCloud";
 export { CloudMessagePersistence } from "./CloudMessagePersistence";
 export {

--- a/packages/cloud/src/runTelemetry.test.ts
+++ b/packages/cloud/src/runTelemetry.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRunTelemetryToolCall,
+  normalizeRunTelemetryUsage,
+  truncateRunTelemetryText,
+} from "./runTelemetry";
+
+const MAX = 50_000;
+
+describe("truncateRunTelemetryText", () => {
+  it("passes text at or under the cap through unchanged", () => {
+    expect(truncateRunTelemetryText("hello")).toBe("hello");
+    const exact = "a".repeat(MAX);
+    expect(truncateRunTelemetryText(exact)).toBe(exact);
+  });
+
+  it("clamps text over the cap", () => {
+    expect(truncateRunTelemetryText("a".repeat(MAX + 1))).toHaveLength(MAX);
+  });
+});
+
+describe("createRunTelemetryToolCall", () => {
+  it("serializes args and omits tool_source when the caller gives none", () => {
+    expect(
+      createRunTelemetryToolCall({
+        toolName: "calculator",
+        toolCallId: "call-1",
+        args: { a: 1 },
+        result: { sum: 1 },
+      }),
+    ).toEqual({
+      tool_name: "calculator",
+      tool_call_id: "call-1",
+      tool_args: '{"a":1}',
+      tool_result: '{"sum":1}',
+    });
+  });
+
+  it("clamps serialized args and results", () => {
+    const call = createRunTelemetryToolCall({
+      toolName: "t",
+      toolCallId: "call-1",
+      args: { blob: "a".repeat(MAX) },
+      result: { blob: "a".repeat(MAX) },
+    });
+    expect(call.tool_args).toHaveLength(MAX);
+    expect(call.tool_result).toHaveLength(MAX);
+  });
+
+  it("forwards argsText verbatim, including past the cap", () => {
+    const argsText = "a".repeat(MAX + 10);
+    const call = createRunTelemetryToolCall({
+      toolName: "t",
+      toolCallId: "call-1",
+      argsText,
+      args: { ignored: true },
+    });
+    expect(call.tool_args).toBe(argsText);
+  });
+
+  it("omits fields whose value cannot be serialized", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(
+      createRunTelemetryToolCall({
+        toolName: "t",
+        toolCallId: "call-1",
+        args: circular,
+        result: undefined,
+      }),
+    ).toEqual({ tool_name: "t", tool_call_id: "call-1" });
+  });
+
+  it("summarizes base64 image and audio blocks in an mcp result", () => {
+    const call = createRunTelemetryToolCall({
+      toolName: "t",
+      toolCallId: "call-1",
+      toolSource: "mcp",
+      result: [
+        { type: "text", text: "keep me" },
+        { type: "image", data: "A".repeat(4096) },
+      ],
+    });
+    expect(call.tool_source).toBe("mcp");
+    expect(call.tool_result).toContain("keep me");
+    expect(call.tool_result).toContain("[image: 3.0KB]");
+    expect(call.tool_result).not.toContain("A".repeat(200));
+  });
+
+  it("leaves a non-mcp result unsummarized", () => {
+    const result = [{ type: "image", data: "A".repeat(4096) }];
+    const call = createRunTelemetryToolCall({
+      toolName: "t",
+      toolCallId: "call-1",
+      toolSource: "frontend",
+      result,
+    });
+    expect(call.tool_source).toBe("frontend");
+    expect(call.tool_result).toBe(JSON.stringify(result));
+  });
+});
+
+describe("normalizeRunTelemetryUsage", () => {
+  it("prefers the current names over the legacy ones", () => {
+    expect(
+      normalizeRunTelemetryUsage({
+        inputTokens: 1,
+        outputTokens: 2,
+        promptTokens: 90,
+        completionTokens: 90,
+      }),
+    ).toEqual({ inputTokens: 1, outputTokens: 2 });
+  });
+
+  it("falls back to the legacy prompt and completion names", () => {
+    expect(
+      normalizeRunTelemetryUsage({ promptTokens: 3, completionTokens: 4 }),
+    ).toEqual({ inputTokens: 3, outputTokens: 4 });
+  });
+
+  it("keeps a zero count and omits an absent one", () => {
+    expect(
+      normalizeRunTelemetryUsage({ inputTokens: 0, cachedInputTokens: 5 }),
+    ).toEqual({ inputTokens: 0, cachedInputTokens: 5 });
+  });
+
+  it("returns undefined when no count is present", () => {
+    expect(normalizeRunTelemetryUsage({})).toBeUndefined();
+  });
+});

--- a/packages/cloud/src/runTelemetry.ts
+++ b/packages/cloud/src/runTelemetry.ts
@@ -17,7 +17,7 @@ export type AssistantCloudRunReportToolCall = {
 
 /**
  * Clamps a string to the size the runs endpoint accepts for a single span
- * field. Apply it to any free-form text placed on a run report.
+ * field.
  */
 export function truncateRunTelemetryText(value: string): string {
   if (value.length <= MAX_TELEMETRY_TEXT_LENGTH) return value;
@@ -63,7 +63,10 @@ export type RunTelemetryToolCallInit = {
   toolName: string;
   toolCallId: string;
   args?: unknown;
-  /** Pre-serialized arguments, used in place of serializing `args`. */
+  /**
+   * Pre-serialized arguments, used in place of serializing `args`. Forwarded
+   * verbatim, so the caller owns clamping it to the span size.
+   */
   argsText?: string | undefined;
   result?: unknown;
   toolSource?: "mcp" | "frontend" | "backend" | undefined;

--- a/packages/cloud/src/runTelemetry.ts
+++ b/packages/cloud/src/runTelemetry.ts
@@ -1,0 +1,136 @@
+import type { SamplingCallData } from "./instrumentMcpSampling";
+
+const MAX_TELEMETRY_TEXT_LENGTH = 50_000;
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]{100,}={0,2}$/;
+
+export type AssistantCloudRunReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "mcp" | "frontend" | "backend";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+/**
+ * Clamps a string to the size the runs endpoint accepts for a single span
+ * field. Apply it to any free-form text placed on a run report.
+ */
+export function truncateRunTelemetryText(value: string): string {
+  if (value.length <= MAX_TELEMETRY_TEXT_LENGTH) return value;
+  return value.slice(0, MAX_TELEMETRY_TEXT_LENGTH);
+}
+
+function safeStringify(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  try {
+    return truncateRunTelemetryText(JSON.stringify(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function summarizeMcpResult(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    if (Array.isArray(parsed)) {
+      const summarized = parsed.map((item) => {
+        if (item && typeof item === "object" && item.type) {
+          if (
+            (item.type === "image" || item.type === "audio") &&
+            typeof item.data === "string" &&
+            BASE64_PATTERN.test(item.data.slice(0, 200))
+          ) {
+            const sizeKB = ((item.data.length * 3) / 4 / 1024).toFixed(1);
+            return { ...item, data: `[${item.type}: ${sizeKB}KB]` };
+          }
+        }
+        return item;
+      });
+      return truncateRunTelemetryText(JSON.stringify(summarized));
+    }
+  } catch {
+    // not JSON array, fall through
+  }
+  return safeStringify(value);
+}
+
+export type RunTelemetryToolCallInit = {
+  toolName: string;
+  toolCallId: string;
+  args?: unknown;
+  /** Pre-serialized arguments, used in place of serializing `args`. */
+  argsText?: string | undefined;
+  result?: unknown;
+  toolSource?: "mcp" | "frontend" | "backend" | undefined;
+};
+
+/**
+ * Serializes one tool call into the shape the runs endpoint accepts. An `mcp`
+ * source has its result summarized, because MCP content blocks carry inline
+ * base64 image and audio payloads that would otherwise dominate the report.
+ */
+export function createRunTelemetryToolCall(
+  init: RunTelemetryToolCallInit,
+): AssistantCloudRunReportToolCall {
+  const { toolName, toolCallId, args, argsText, result, toolSource } = init;
+  const call: AssistantCloudRunReportToolCall = {
+    tool_name: toolName,
+    tool_call_id: toolCallId,
+  };
+  const toolArgs = argsText ?? safeStringify(args);
+  if (toolArgs !== undefined) call.tool_args = toolArgs;
+  const toolResult =
+    toolSource === "mcp" ? summarizeMcpResult(result) : safeStringify(result);
+  if (toolResult !== undefined) call.tool_result = toolResult;
+  if (toolSource) call.tool_source = toolSource;
+  return call;
+}
+
+export type RunTelemetryUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+};
+
+export type RunTelemetryUsageInit = RunTelemetryUsage & {
+  promptTokens?: number;
+  completionTokens?: number;
+};
+
+/**
+ * Resolves the token counts a provider reports under either the current or the
+ * legacy prompt/completion names. Returns undefined when no count is present,
+ * so callers can tell an empty usage object from a zeroed one.
+ */
+export function normalizeRunTelemetryUsage(
+  usage: RunTelemetryUsageInit,
+): RunTelemetryUsage | undefined {
+  const inputTokens = usage.inputTokens ?? usage.promptTokens;
+  const outputTokens = usage.outputTokens ?? usage.completionTokens;
+
+  if (
+    inputTokens == null &&
+    outputTokens == null &&
+    usage.reasoningTokens == null &&
+    usage.cachedInputTokens == null
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(inputTokens != null ? { inputTokens } : undefined),
+    ...(outputTokens != null ? { outputTokens } : undefined),
+    ...(usage.reasoningTokens != null
+      ? { reasoningTokens: usage.reasoningTokens }
+      : undefined),
+    ...(usage.cachedInputTokens != null
+      ? { cachedInputTokens: usage.cachedInputTokens }
+      : undefined),
+  };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "@assistant-ui/tap": "^0.9.0",
     "@types/react": "*",
     "react": "^18 || ^19",
-    "assistant-cloud": "^0.1.31",
+    "assistant-cloud": "^0.1.42",
     "zustand": "^5.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -9,8 +9,13 @@ import type {
 import type { ExportedMessageRepositoryItem } from "../../../runtime/utils/message-repository";
 import {
   type AssistantCloud,
+  type AssistantCloudRunReportToolCall,
   CloudMessagePersistence,
   createFormattedPersistence,
+  createRunTelemetryToolCall,
+  normalizeRunTelemetryUsage,
+  type RunTelemetryUsageInit,
+  truncateRunTelemetryText,
 } from "assistant-cloud";
 import { auiV0Decode, auiV0Encode } from "./auiV0";
 import { type AssistantClient, getClientId, useAui } from "@assistant-ui/store";
@@ -268,85 +273,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   }
 }
 
-const MAX_SPAN_CONTENT = 50_000;
-
-function truncateStr(value: string): string {
-  if (value.length <= MAX_SPAN_CONTENT) return value;
-  return value.slice(0, MAX_SPAN_CONTENT);
-}
-
-function safeStringify(value: unknown): string | undefined {
-  if (value == null) return undefined;
-  try {
-    return truncateStr(JSON.stringify(value));
-  } catch {
-    return undefined;
-  }
-}
-
-type TelemetryToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "mcp" | "frontend" | "backend";
-};
-
-const BASE64_PATTERN = /^[A-Za-z0-9+/]{100,}={0,2}$/;
-
-function summarizeMcpResult(value: unknown): string | undefined {
-  if (value == null) return undefined;
-  try {
-    const parsed = typeof value === "string" ? JSON.parse(value) : value;
-    if (Array.isArray(parsed)) {
-      const summarized = parsed.map((item) => {
-        if (item && typeof item === "object" && item.type) {
-          if (
-            (item.type === "image" || item.type === "audio") &&
-            typeof item.data === "string" &&
-            BASE64_PATTERN.test(item.data.slice(0, 200))
-          ) {
-            const sizeKB = ((item.data.length * 3) / 4 / 1024).toFixed(1);
-            return { ...item, data: `[${item.type}: ${sizeKB}KB]` };
-          }
-        }
-        return item;
-      });
-      return truncateStr(JSON.stringify(summarized));
-    }
-  } catch {
-    // not JSON array, fall through
-  }
-  return safeStringify(value);
-}
-
-function buildToolCall(
-  toolName: string,
-  toolCallId: string,
-  args: unknown,
-  result: unknown,
-  argsText?: string,
-  toolSource?: "mcp" | "frontend" | "backend",
-): TelemetryToolCall {
-  const call: TelemetryToolCall = {
-    tool_name: toolName,
-    tool_call_id: toolCallId,
-  };
-  const toolArgs = argsText ?? safeStringify(args);
-  if (toolArgs !== undefined) call.tool_args = toolArgs;
-  const toolResult =
-    toolSource === "mcp" ? summarizeMcpResult(result) : safeStringify(result);
-  if (toolResult !== undefined) call.tool_result = toolResult;
-  if (toolSource) call.tool_source = toolSource;
-  return call;
-}
-
 type TelemetryStepData = {
   input_tokens?: number;
   output_tokens?: number;
   reasoning_tokens?: number;
   cached_input_tokens?: number;
-  tool_calls?: TelemetryToolCall[];
+  tool_calls?: AssistantCloudRunReportToolCall[];
   start_ms?: number;
   end_ms?: number;
 };
@@ -369,7 +301,7 @@ function mergeStepTimestamps(
 
 type TelemetryData = {
   status: "completed" | "incomplete" | "error";
-  toolCalls?: TelemetryToolCall[];
+  toolCalls?: AssistantCloudRunReportToolCall[];
   totalSteps?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -446,13 +378,19 @@ export function extractAuiV0<T>(content: T): TelemetryData | null {
   const toolCalls = msg.content
     ?.filter((p) => p.type === "tool-call" && p.toolName && p.toolCallId)
     .map((p) =>
-      buildToolCall(p.toolName!, p.toolCallId!, p.args, p.result, p.argsText),
+      createRunTelemetryToolCall({
+        toolName: p.toolName!,
+        toolCallId: p.toolCallId!,
+        args: p.args,
+        result: p.result,
+        argsText: p.argsText,
+      }),
     );
 
   const textParts = msg.content?.filter((p) => p.type === "text" && p.text);
   const outputText =
     textParts && textParts.length > 0
-      ? truncateStr(textParts.map((p) => p.text).join(""))
+      ? truncateRunTelemetryText(textParts.map((p) => p.text).join(""))
       : undefined;
 
   const steps = msg.metadata?.steps;
@@ -564,29 +502,28 @@ function isDynamicToolPart(p: AiSdkV6Part): boolean {
   return p.type === "dynamic-tool" || p.type.startsWith("dynamic-tool-");
 }
 
-function partToToolCall(p: AiSdkV6Part): TelemetryToolCall {
+function partToToolCall(p: AiSdkV6Part): AssistantCloudRunReportToolCall {
   const toolSource: "mcp" | undefined = isDynamicToolPart(p)
     ? "mcp"
     : undefined;
-  return buildToolCall(
-    p.toolName ?? p.type.slice(5),
-    p.toolCallId!,
-    p.args ?? p.input,
-    p.result ?? p.output,
-    undefined,
+  return createRunTelemetryToolCall({
+    toolName: p.toolName ?? p.type.slice(5),
+    toolCallId: p.toolCallId!,
+    args: p.args ?? p.input,
+    result: p.result ?? p.output,
     toolSource,
-  );
+  });
 }
 
 function collectAiSdkV6Parts(parts: readonly AiSdkV6Part[]): {
   textParts: string[];
-  toolCalls: TelemetryToolCall[];
-  stepsData: { tool_calls: TelemetryToolCall[] }[];
+  toolCalls: AssistantCloudRunReportToolCall[];
+  stepsData: { tool_calls: AssistantCloudRunReportToolCall[] }[];
 } {
   const textParts: string[] = [];
-  const toolCalls: TelemetryToolCall[] = [];
-  const stepsData: { tool_calls: TelemetryToolCall[] }[] = [];
-  let currentStepToolCalls: TelemetryToolCall[] | null = null;
+  const toolCalls: AssistantCloudRunReportToolCall[] = [];
+  const stepsData: { tool_calls: AssistantCloudRunReportToolCall[] }[] = [];
+  let currentStepToolCalls: AssistantCloudRunReportToolCall[] | null = null;
 
   for (const p of parts) {
     if (p.type === "step-start") {
@@ -624,10 +561,10 @@ function extractModelId(
 
 function buildAiSdkV6Result(
   textParts: string[],
-  toolCalls: TelemetryToolCall[],
+  toolCalls: AssistantCloudRunReportToolCall[],
   totalSteps: number,
   metadata?: Record<string, unknown>,
-  stepsData?: { tool_calls: TelemetryToolCall[] }[],
+  stepsData?: { tool_calls: AssistantCloudRunReportToolCall[] }[],
   usage?: {
     inputTokens?: number;
     outputTokens?: number;
@@ -636,7 +573,9 @@ function buildAiSdkV6Result(
   },
 ): TelemetryData {
   const hasText = textParts.length > 0;
-  const outputText = hasText ? truncateStr(textParts.join("")) : undefined;
+  const outputText = hasText
+    ? truncateRunTelemetryText(textParts.join(""))
+    : undefined;
   const modelId = extractModelId(metadata);
 
   const steps: TelemetryStepData[] | undefined =
@@ -671,46 +610,6 @@ function buildAiSdkV6Result(
   };
 }
 
-type UsageFields = {
-  inputTokens?: number;
-  outputTokens?: number;
-  promptTokens?: number;
-  completionTokens?: number;
-  reasoningTokens?: number;
-  cachedInputTokens?: number;
-};
-
-function normalizeUsage(u: UsageFields):
-  | {
-      inputTokens?: number;
-      outputTokens?: number;
-      reasoningTokens?: number;
-      cachedInputTokens?: number;
-    }
-  | undefined {
-  const input = u.inputTokens ?? u.promptTokens;
-  const output = u.outputTokens ?? u.completionTokens;
-  if (
-    input == null &&
-    output == null &&
-    u.reasoningTokens == null &&
-    u.cachedInputTokens == null
-  ) {
-    return undefined;
-  }
-
-  return {
-    ...(input != null ? { inputTokens: input } : undefined),
-    ...(output != null ? { outputTokens: output } : undefined),
-    ...(u.reasoningTokens != null
-      ? { reasoningTokens: u.reasoningTokens }
-      : undefined),
-    ...(u.cachedInputTokens != null
-      ? { cachedInputTokens: u.cachedInputTokens }
-      : undefined),
-  };
-}
-
 function extractAiSdkV6Usage(metadata?: Record<string, unknown>):
   | {
       inputTokens?: number;
@@ -720,15 +619,15 @@ function extractAiSdkV6Usage(metadata?: Record<string, unknown>):
     }
   | undefined {
   // Try top-level metadata.usage
-  const usage = metadata?.usage as UsageFields | undefined;
+  const usage = metadata?.usage as RunTelemetryUsageInit | undefined;
   if (usage) {
-    const normalized = normalizeUsage(usage);
+    const normalized = normalizeRunTelemetryUsage(usage);
     if (normalized) return normalized;
   }
 
   // Try aggregating from metadata.steps[].usage
   const steps = metadata?.steps as
-    | readonly { usage?: UsageFields }[]
+    | readonly { usage?: RunTelemetryUsageInit }[]
     | undefined;
   if (steps && steps.length > 0) {
     let inputTokens = 0;
@@ -742,7 +641,7 @@ function extractAiSdkV6Usage(metadata?: Record<string, unknown>):
     let hasAny = false;
     for (const s of steps) {
       if (!s.usage) continue;
-      const n = normalizeUsage(s.usage);
+      const n = normalizeRunTelemetryUsage(s.usage);
       if (n) {
         if (n.inputTokens != null) {
           inputTokens += n.inputTokens;
@@ -795,8 +694,8 @@ function extractAiSdkV6<T>(content: T): TelemetryData | null {
 
 function aggregateAiSdkV6RunSteps<T>(stepMessages: T[]): TelemetryData | null {
   const allTextParts: string[] = [];
-  const allToolCalls: TelemetryToolCall[] = [];
-  const allStepsData: { tool_calls: TelemetryToolCall[] }[] = [];
+  const allToolCalls: AssistantCloudRunReportToolCall[] = [];
+  const allStepsData: { tool_calls: AssistantCloudRunReportToolCall[] }[] = [];
   let hasAssistant = false;
   let metadata: Record<string, unknown> | undefined;
   let inputTokens = 0;


### PR DESCRIPTION
## summary

- `assistant-cloud` now owns the run report tool call shape and the serialization behind it: `AssistantCloudRunReportToolCall`, `createRunTelemetryToolCall`, `normalizeRunTelemetryUsage`, and `truncateRunTelemetryText`, in a new `runTelemetry` module.
- both producers of that payload consumed a verbatim copy of the same primitives: `AssistantCloudThreadHistoryAdapter` in core and `extractRunTelemetry` in cloud-ai-sdk each carried their own `MAX_SPAN_CONTENT`, `truncateStr`, `safeStringify`, `BASE64_PATTERN`, `summarizeMcpResult`, and usage normalizer, plus their own re-declaration of a tool call type that `AssistantCloudRuns.ts` already declared privately as `ReportToolCall`. the two copies had already drifted: only cloud-ai-sdk's carried `sampling_calls`.
- both now import from `assistant-cloud`, which both already depend on (core optionally, cloud-ai-sdk hard) and which owns the wire contract, so the "keep in sync with assistant-cloud createRunSchema" comment that appeared in both files now sits next to the type it describes. net 139 added, 308 removed.
- behavior preserving. each caller passes exactly what it passed before, so the emitted report is byte-identical on both paths. one real divergence between them survives on purpose and is filed as #6261 (core omits `tool_source` for static `ai-sdk/v6` tool calls where cloud-ai-sdk sends `"frontend"`); fixing it inside a pure extraction would have hidden a payload change in a refactor.
- core's `assistant-cloud` peer floor moves from `^0.1.31` to `^0.1.42`. core value-imports the new exports, and `onlyUpdatePeerDependentsWhenOutOfRange` in the changeset config means a peer range that still satisfies the new version is never auto-rewritten, so this one has to move by hand. react's is a plain dependency and changesets rewrites it on release.

## test plan

### already verified

- [x] `turbo test --filter=assistant-cloud --filter=@assistant-ui/core --filter=@assistant-ui/cloud-ai-sdk` -> assistant-cloud 82/82, core 1417/1417, cloud-ai-sdk 93/93 on the v7 leg and 93/93 again on the peer-v6 leg, plus `tsc --project tsconfig.peer-v6.json` clean
- [x] `pnpm lint` (oxlint + `oxfmt --check`) clean
- [x] api-surface regenerated: purely additive on `assistant-cloud` (7 new exports, nothing removed); on core and cloud-ai-sdk the only delta is the inlined type's name changing from `ReportToolCall` to `AssistantCloudRunReportToolCall`
- [x] `pnpm -C apps/docs generate:api-reference` -> zero drift
- [x] typecheck baselined with a patch swap: 68 pre-existing errors on `main` across cloud, core, and react, the same 68 after, line-for-line identical, none naming a touched file

### reviewer should verify

- [ ] the public naming on `assistant-cloud`, since its surface is append-only and these four exports are permanent

## notes

- a third inline copy of the same `inputTokens ?? promptTokens` rule lives in `wrapSamplingHandler` (`packages/cloud/src/instrumentMcpSampling.ts`). it emits snake_case directly rather than the camelCase shape, so routing it through `normalizeRunTelemetryUsage` reads worse than leaving it; not touched.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.puBdAdaDA2wJNRvjFH6VUbBnNeVWcDxVazSsVN8wNlPYCfZACwrlg050tv0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

