### PR TITLE
fix(core): tag static ai-sdk/v6 tool calls as frontend

### DIFF
--- a/.changeset/core-run-telemetry-frontend-source.md
+++ b/.changeset/core-run-telemetry-frontend-source.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: tag static ai-sdk/v6 tool calls as frontend in cloud run telemetry

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -188,6 +188,98 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
+  it("reports frontend and MCP sources for ai-sdk/v6 tool calls", () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const formatted = result.current.withFormat({
+      format: "ai-sdk/v6",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message: { id: string }) => message.id,
+    });
+
+    formatted.reportTelemetry([
+      {
+        parentId: null,
+        message: {
+          id: "message-1",
+          role: "assistant",
+          parts: [
+            { type: "step-start" },
+            {
+              type: "tool-search",
+              toolCallId: "static-1",
+              input: { query: "test" },
+              output: { result: "ok" },
+            },
+            {
+              type: "dynamic-tool",
+              toolName: "mcp-search",
+              toolCallId: "dynamic-1",
+              input: { query: "test" },
+              output: { result: "ok" },
+            },
+            { type: "step-start" },
+            {
+              type: "tool-search",
+              toolCallId: "static-2",
+              input: { query: "again" },
+              output: { result: "ok" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(cloud.runs.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool_calls: [
+          expect.objectContaining({
+            tool_call_id: "static-1",
+            tool_source: "frontend",
+          }),
+          expect.objectContaining({
+            tool_call_id: "dynamic-1",
+            tool_source: "mcp",
+          }),
+          expect.objectContaining({
+            tool_call_id: "static-2",
+            tool_source: "frontend",
+          }),
+        ],
+        steps: [
+          {
+            tool_calls: [
+              expect.objectContaining({
+                tool_call_id: "static-1",
+                tool_source: "frontend",
+              }),
+              expect.objectContaining({
+                tool_call_id: "dynamic-1",
+                tool_source: "mcp",
+              }),
+            ],
+          },
+          {
+            tool_calls: [
+              expect.objectContaining({
+                tool_call_id: "static-2",
+                tool_source: "frontend",
+              }),
+            ],
+          },
+        ],
+      }),
+    );
+  });
+
   it("initializes the pinned item instead of the new main thread", async () => {
     mocks.aui = mocks.makeClient(undefined, "new-thread", "thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -503,9 +503,9 @@ function isDynamicToolPart(p: AiSdkV6Part): boolean {
 }
 
 function partToToolCall(p: AiSdkV6Part): AssistantCloudRunReportToolCall {
-  const toolSource: "mcp" | undefined = isDynamicToolPart(p)
+  const toolSource: "mcp" | "frontend" = isDynamicToolPart(p)
     ? "mcp"
-    : undefined;
+    : "frontend";
   return createRunTelemetryToolCall({
     toolName: p.toolName ?? p.type.slice(5),
     toolCallId: p.toolCallId!,


### PR DESCRIPTION
closes #6261

## summary

- cloud run telemetry from the assistant-ui runtime now tags static `ai-sdk/v6` tool calls as `tool_source: "frontend"`, matching `useCloudChat` and the server `createAssistantRun` path
- dynamic-tool parts stay `"mcp"`
- existing persisted rows are unchanged

## test plan

### already verified

- [x] `vitest run src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts` in `@assistant-ui/core` -> 8/8 green

### reviewer should verify

- [ ] report a run through the assistant-ui cloud runtime with a static `tool-*` call and confirm the span lands with `tool_source: "frontend"`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CDXapatB-UVx9hm3-2xq8_KqFwDNBrQhvO5RK6F6QDIVkmHGrfMKlPQYGW4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->