### PR TITLE
fix(react-pi): deliver the first message of a brand-new thread

### DIFF
--- a/.changeset/pi-first-message.md
+++ b/.changeset/pi-first-message.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: deliver the first message of a brand-new thread

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AssistantRuntimeProvider,
+  ExportedMessageRepository,
+} from "@assistant-ui/react";
+import type { AssistantRuntime } from "@assistant-ui/react";
+import type { PiClient, PiThreadSnapshot } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./ThreadController", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./ThreadController")>();
+
+  class PiThreadController {
+    getState = () => createPiThreadState("t-new");
+    getProjectedMessages = () => [];
+    getMessageRepository = () => ExportedMessageRepository.fromArray([]);
+    getVersion = () => 0;
+    subscribe = () => () => {};
+    subscribeMetadata = () => () => {};
+    subscribeMessages = () => () => {};
+    connect = () => () => {};
+    load = vi.fn().mockResolvedValue(undefined);
+    refresh = vi.fn().mockResolvedValue(undefined);
+    sendMessage = mocks.sendMessage;
+    cancel = vi.fn().mockResolvedValue(undefined);
+    clearQueue = vi.fn().mockResolvedValue({ steering: [], followUp: [] });
+    setModel = vi.fn().mockResolvedValue(undefined);
+    setThinkingLevel = vi.fn().mockResolvedValue(undefined);
+    respondToToolApproval = vi.fn().mockResolvedValue(undefined);
+    resumeToolCall = vi.fn().mockResolvedValue(undefined);
+    respondToHostUiRequest = vi.fn().mockResolvedValue(undefined);
+    dispose = vi.fn();
+  }
+
+  return { ...original, PiThreadController };
+});
+
+import { createPiThreadState } from "./threadState";
+import { usePiRuntime } from "./usePiRuntime";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const snapshot: PiThreadSnapshot = {
+  metadata: { id: "srv-1", status: "idle" },
+  messages: [],
+} as unknown as PiThreadSnapshot;
+
+const createClient = () => {
+  const createThread = vi.fn().mockResolvedValue(snapshot);
+  const client = {
+    listThreads: vi.fn().mockResolvedValue([]),
+    createThread,
+    getThread: vi.fn().mockResolvedValue(snapshot),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PiClient;
+  return { client, createThread };
+};
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  vi.clearAllMocks();
+});
+
+describe("usePiRuntime new-thread first message", () => {
+  it("delivers the first message of a brand-new thread", async () => {
+    const { client, createThread } = createClient();
+    let runtime!: AssistantRuntime;
+
+    const Harness = () => {
+      runtime = usePiRuntime({ client });
+      return createElement(AssistantRuntimeProvider, { runtime }, null);
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root!.render(createElement(Harness));
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      await runtime.thread.append("hello pi");
+    });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(createThread).toHaveBeenCalledTimes(1);
+
+    const createdWithMessage =
+      createThread.mock.calls[0]?.[0]?.initialMessage !== undefined;
+    const sentViaController = mocks.sendMessage.mock.calls.length > 0;
+    expect(createdWithMessage || sentViaController).toBe(true);
+  });
+});

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -54,8 +54,12 @@ const snapshot: PiThreadSnapshot = {
   messages: [],
 } as unknown as PiThreadSnapshot;
 
-const createClient = () => {
-  const createThread = vi.fn().mockResolvedValue(snapshot);
+const createClient = (
+  createThreadImpl: (options?: {
+    initialMessage?: unknown;
+  }) => Promise<PiThreadSnapshot> = () => Promise.resolve(snapshot),
+) => {
+  const createThread = vi.fn(createThreadImpl);
   const client = {
     listThreads: vi.fn().mockResolvedValue([]),
     createThread,
@@ -65,6 +69,13 @@ const createClient = () => {
   } as unknown as PiClient;
   return { client, createThread };
 };
+
+const sentTexts = () =>
+  mocks.sendMessage.mock.calls.map((call) => {
+    const content = (call[0] as { content: readonly { text?: string }[] })
+      .content;
+    return content.map((part) => part.text).join("");
+  });
 
 let root: Root | undefined;
 
@@ -97,10 +108,49 @@ describe("usePiRuntime new-thread first message", () => {
     await act(async () => {});
 
     expect(createThread).toHaveBeenCalledTimes(1);
+    // The core initializes before onNew runs, so the atomic path cannot see
+    // the message; delivery must happen exactly once via the live thread.
+    expect(createThread.mock.calls[0]?.[0]?.initialMessage).toBeUndefined();
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(sentTexts()).toEqual(["hello pi"]);
+  });
 
-    const createdWithMessage =
-      createThread.mock.calls[0]?.[0]?.initialMessage !== undefined;
-    const sentViaController = mocks.sendMessage.mock.calls.length > 0;
-    expect(createdWithMessage || sentViaController).toBe(true);
+  it("delivers both messages when a second send lands during initialization", async () => {
+    let resolveCreate!: (value: PiThreadSnapshot) => void;
+    const { client, createThread } = createClient(
+      () =>
+        new Promise<PiThreadSnapshot>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    let runtime!: AssistantRuntime;
+
+    const Harness = () => {
+      runtime = usePiRuntime({ client });
+      return createElement(AssistantRuntimeProvider, { runtime }, null);
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => {
+      root!.render(createElement(Harness));
+    });
+    await act(async () => {});
+
+    let first!: Promise<void> | void;
+    let second!: Promise<void> | void;
+    await act(async () => {
+      first = runtime.thread.append("message A");
+      second = runtime.thread.append("message B");
+    });
+
+    await act(async () => {
+      resolveCreate(snapshot);
+      await Promise.all([first, second]);
+    });
+    await act(async () => {});
+
+    expect(createThread).toHaveBeenCalledTimes(1);
+    expect(createThread.mock.calls[0]?.[0]?.initialMessage).toBeUndefined();
+    expect(sentTexts().sort()).toEqual(["message A", "message B"]);
   });
 });

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -151,6 +151,6 @@ describe("usePiRuntime new-thread first message", () => {
 
     expect(createThread).toHaveBeenCalledTimes(1);
     expect(createThread.mock.calls[0]?.[0]?.initialMessage).toBeUndefined();
-    expect(sentTexts().sort()).toEqual(["message A", "message B"]);
+    expect(sentTexts()).toEqual(["message A", "message B"]);
   });
 });

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -366,6 +366,7 @@ const useNewPiThreadStore = (
   options: PiRuntimeOptions,
   enabled: boolean,
   pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
+  consumedInitialMessagesRef: { current: WeakSet<PiSendMessageInput> },
 ): ExternalStoreAdapter<ThreadMessage> => {
   const aui = useAui();
   const {
@@ -379,6 +380,7 @@ const useNewPiThreadStore = (
   const [optimisticMessages, setOptimisticMessages] = useState<
     readonly ThreadMessageLike[]
   >([]);
+  const optimisticMessageIndexRef = useRef(0);
   const optimisticRepository = useMemo(
     () => ExportedMessageRepository.fromArray(optimisticMessages),
     [optimisticMessages],
@@ -399,7 +401,7 @@ const useNewPiThreadStore = (
         if (!enabled) return NOOP_ON_NEW();
         const optimistic = toOptimisticThreadMessage(
           message,
-          optimisticMessages.length,
+          optimisticMessageIndexRef.current++,
         );
         const initialMessage = buildPiSendInput(message, undefined);
         pendingInitialMessageRef.current = initialMessage;
@@ -408,15 +410,22 @@ const useNewPiThreadStore = (
           const { remoteId, externalId } =
             await aui.threadListItem.initialize();
           if (pendingInitialMessageRef.current === initialMessage) {
+            pendingInitialMessageRef.current = undefined;
+          }
+          if (consumedInitialMessagesRef.current.has(initialMessage)) {
+            consumedInitialMessagesRef.current.delete(initialMessage);
+          } else {
             // The core starts thread initialization before dispatching onNew,
             // so adapter.initialize has usually already run and created the
-            // thread without the message; deliver it to the live thread.
-            pendingInitialMessageRef.current = undefined;
+            // thread without this message (or another send overwrote the
+            // single handoff slot); deliver it to the live thread.
             await getController(registry, externalId ?? remoteId).sendMessage(
               message,
             );
           }
-          setOptimisticMessages([]);
+          setOptimisticMessages((messages) =>
+            messages.filter((candidate) => candidate !== optimistic),
+          );
         } catch (error) {
           if (pendingInitialMessageRef.current === initialMessage) {
             pendingInitialMessageRef.current = undefined;
@@ -432,9 +441,9 @@ const useNewPiThreadStore = (
     [
       aui,
       enabled,
-      optimisticMessages.length,
       optimisticRepository,
       pendingInitialMessageRef,
+      consumedInitialMessagesRef,
       registry,
       adapters,
       isDisabled,
@@ -452,6 +461,7 @@ const useRuntimeHook = (
   registry: PiControllerRegistry,
   options: PiRuntimeOptions,
   pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
+  consumedInitialMessagesRef: { current: WeakSet<PiSendMessageInput> },
 ) => {
   const threadListItem = useAuiState((state) => state.threadListItem);
   const isMainThread = useAuiState(
@@ -474,6 +484,7 @@ const useRuntimeHook = (
     options,
     threadListItem.status === "new",
     pendingInitialMessageRef,
+    consumedInitialMessagesRef,
   );
 
   // One runtime whose store CONTENT switches between the new-thread and
@@ -518,6 +529,9 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
   const pendingInitialMessageRef = useRef<PiSendMessageInput | undefined>(
     undefined,
   );
+  const consumedInitialMessagesRef = useRef<WeakSet<PiSendMessageInput>>(
+    new WeakSet(),
+  );
 
   useEffect(() => () => registry.dispose(), [registry]);
 
@@ -549,6 +563,9 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       initialize: async () => {
         const initialMessage = pendingInitialMessageRef.current;
         pendingInitialMessageRef.current = undefined;
+        if (initialMessage) {
+          consumedInitialMessagesRef.current.add(initialMessage);
+        }
         const snapshot = await client.createThread({
           ...(options.workspacePath !== undefined
             ? { workspacePath: options.workspacePath }
@@ -578,6 +595,7 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       options.workspacePath,
       options.includeArchived,
       pendingInitialMessageRef,
+      consumedInitialMessagesRef,
     ],
   );
 
@@ -593,7 +611,12 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       : {}),
     runtimeHook: () => {
       // oxlint-disable-next-line react-hooks/rules-of-hooks -- runtimeHook is invoked by useRemoteThreadListRuntime at the correct hook position
-      return useRuntimeHook(registry, options, pendingInitialMessageRef);
+      return useRuntimeHook(
+        registry,
+        options,
+        pendingInitialMessageRef,
+        consumedInitialMessagesRef,
+      );
     },
   });
 };

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -93,9 +93,6 @@ export const NOOP_CONTROLLER: PiThreadControllerLike = {
   dispose: () => {},
 };
 
-const NOOP_ON_NEW = () =>
-  Promise.reject(new Error("Pi thread is still initializing"));
-
 const reportPiCallbackError = (callbackError: unknown) => {
   console.error("[react-pi] onError callback threw an error", callbackError);
 };
@@ -395,7 +392,6 @@ const useNewPiThreadStore = (
       extras: EMPTY_RUNTIME_EXTRAS,
       ...(adapters ? { adapters } : {}),
       onNew: async (message) => {
-        if (!enabled) return NOOP_ON_NEW();
         const optimistic = toOptimisticThreadMessage(
           message,
           optimisticMessageIndexRef.current++,

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -362,6 +362,7 @@ const toOptimisticThreadMessage = (
 });
 
 const useNewPiThreadStore = (
+  registry: PiControllerRegistry,
   options: PiRuntimeOptions,
   enabled: boolean,
   pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
@@ -404,7 +405,17 @@ const useNewPiThreadStore = (
         pendingInitialMessageRef.current = initialMessage;
         setOptimisticMessages((messages) => [...messages, optimistic]);
         try {
-          await aui.threadListItem.initialize();
+          const { remoteId, externalId } =
+            await aui.threadListItem.initialize();
+          if (pendingInitialMessageRef.current === initialMessage) {
+            // The core starts thread initialization before dispatching onNew,
+            // so adapter.initialize has usually already run and created the
+            // thread without the message; deliver it to the live thread.
+            pendingInitialMessageRef.current = undefined;
+            await getController(registry, externalId ?? remoteId).sendMessage(
+              message,
+            );
+          }
           setOptimisticMessages([]);
         } catch (error) {
           if (pendingInitialMessageRef.current === initialMessage) {
@@ -424,6 +435,7 @@ const useNewPiThreadStore = (
       optimisticMessages.length,
       optimisticRepository,
       pendingInitialMessageRef,
+      registry,
       adapters,
       isDisabled,
       isSendDisabled,
@@ -458,6 +470,7 @@ const useRuntimeHook = (
     options,
   );
   const newThreadStore = useNewPiThreadStore(
+    registry,
     options,
     threadListItem.status === "new",
     pendingInitialMessageRef,

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -25,14 +25,13 @@ import {
 } from "react";
 import {
   appendMessageParts,
-  buildPiSendInput,
   PiThreadController,
   type PiThreadControllerLike,
 } from "./ThreadController";
 import { piQueueItemId } from "../queueIds";
 import { splitHostUiRequests, type PiInterruptAnswer } from "./hostUi";
 import { createPiThreadState, type PiThreadState } from "./threadState";
-import type { PiClient, PiSendMessageInput, PiThreadMetadata } from "../types";
+import type { PiClient, PiThreadMetadata } from "../types";
 import { piExtras } from "./piExtras";
 import type { PiRuntimeExtrasInternal, PiRuntimeOptions } from "./runtimeTypes";
 
@@ -365,8 +364,6 @@ const useNewPiThreadStore = (
   registry: PiControllerRegistry,
   options: PiRuntimeOptions,
   enabled: boolean,
-  pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
-  consumedInitialMessagesRef: { current: WeakSet<PiSendMessageInput> },
 ): ExternalStoreAdapter<ThreadMessage> => {
   const aui = useAui();
   const {
@@ -403,33 +400,20 @@ const useNewPiThreadStore = (
           message,
           optimisticMessageIndexRef.current++,
         );
-        const initialMessage = buildPiSendInput(message, undefined);
-        pendingInitialMessageRef.current = initialMessage;
         setOptimisticMessages((messages) => [...messages, optimistic]);
         try {
+          // The core starts thread initialization before dispatching onNew,
+          // so adapter.initialize has already created the thread empty;
+          // deliver the message to the live thread.
           const { remoteId, externalId } =
             await aui.threadListItem.initialize();
-          if (pendingInitialMessageRef.current === initialMessage) {
-            pendingInitialMessageRef.current = undefined;
-          }
-          if (consumedInitialMessagesRef.current.has(initialMessage)) {
-            consumedInitialMessagesRef.current.delete(initialMessage);
-          } else {
-            // The core starts thread initialization before dispatching onNew,
-            // so adapter.initialize has usually already run and created the
-            // thread without this message (or another send overwrote the
-            // single handoff slot); deliver it to the live thread.
-            await getController(registry, externalId ?? remoteId).sendMessage(
-              message,
-            );
-          }
+          await getController(registry, externalId ?? remoteId).sendMessage(
+            message,
+          );
           setOptimisticMessages((messages) =>
             messages.filter((candidate) => candidate !== optimistic),
           );
         } catch (error) {
-          if (pendingInitialMessageRef.current === initialMessage) {
-            pendingInitialMessageRef.current = undefined;
-          }
           setOptimisticMessages((messages) =>
             messages.filter((message) => message !== optimistic),
           );
@@ -442,8 +426,6 @@ const useNewPiThreadStore = (
       aui,
       enabled,
       optimisticRepository,
-      pendingInitialMessageRef,
-      consumedInitialMessagesRef,
       registry,
       adapters,
       isDisabled,
@@ -460,8 +442,6 @@ const useNewPiThreadStore = (
 const useRuntimeHook = (
   registry: PiControllerRegistry,
   options: PiRuntimeOptions,
-  pendingInitialMessageRef: { current: PiSendMessageInput | undefined },
-  consumedInitialMessagesRef: { current: WeakSet<PiSendMessageInput> },
 ) => {
   const threadListItem = useAuiState((state) => state.threadListItem);
   const isMainThread = useAuiState(
@@ -483,8 +463,6 @@ const useRuntimeHook = (
     registry,
     options,
     threadListItem.status === "new",
-    pendingInitialMessageRef,
-    consumedInitialMessagesRef,
   );
 
   // One runtime whose store CONTENT switches between the new-thread and
@@ -526,12 +504,6 @@ const mapThreadMetadata = (metadata: PiThreadMetadata) => ({
 export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
   const { client } = options;
   const registry = useMemo(() => createRegistry(client), [client]);
-  const pendingInitialMessageRef = useRef<PiSendMessageInput | undefined>(
-    undefined,
-  );
-  const consumedInitialMessagesRef = useRef<WeakSet<PiSendMessageInput>>(
-    new WeakSet(),
-  );
 
   useEffect(() => () => registry.dispose(), [registry]);
 
@@ -561,16 +533,10 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
         await client.deleteThread?.(remoteId);
       },
       initialize: async () => {
-        const initialMessage = pendingInitialMessageRef.current;
-        pendingInitialMessageRef.current = undefined;
-        if (initialMessage) {
-          consumedInitialMessagesRef.current.add(initialMessage);
-        }
         const snapshot = await client.createThread({
           ...(options.workspacePath !== undefined
             ? { workspacePath: options.workspacePath }
             : {}),
-          ...(initialMessage ? { initialMessage } : {}),
         });
         return {
           remoteId: snapshot.metadata.id,
@@ -590,13 +556,7 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
         return mapThreadMetadata(snapshot.metadata);
       },
     }),
-    [
-      client,
-      options.workspacePath,
-      options.includeArchived,
-      pendingInitialMessageRef,
-      consumedInitialMessagesRef,
-    ],
+    [client, options.workspacePath, options.includeArchived],
   );
 
   return useRemoteThreadListRuntime({
@@ -611,12 +571,7 @@ export const usePiRuntime = (options: PiRuntimeOptions): AssistantRuntime => {
       : {}),
     runtimeHook: () => {
       // oxlint-disable-next-line react-hooks/rules-of-hooks -- runtimeHook is invoked by useRemoteThreadListRuntime at the correct hook position
-      return useRuntimeHook(
-        registry,
-        options,
-        pendingInitialMessageRef,
-        consumedInitialMessagesRef,
-      );
+      return useRuntimeHook(registry, options);
     },
   });
 };


### PR DESCRIPTION
Closes #6265

## Summary

The first message sent on a brand-new Pi thread is silently dropped. `useNewPiThreadStore.onNew` stashes the message in `pendingInitialMessageRef` and awaits `threadListItem.initialize()`, expecting `adapter.initialize` to pick it up and pass it to `client.createThread({ initialMessage })`. But the external-store core starts thread initialization *before* dispatching `onNew` (`ensureInitialized()` / `_getInitializePromise()` run first, and `OptimisticState.optimisticUpdate` invokes `adapter.initialize` synchronously — an ordering the core pins with its own test, "dispatches an append without waiting for thread initialization"). So `adapter.initialize` reads the ref while it is still `undefined`, creates an empty thread, `onNew`'s await joins the already-in-flight initialization, the optimistic copy is erased, and the message goes nowhere — no error, no send.

After `initialize()` resolves, `onNew` now checks whether its message is still in the ref: if so, the thread was created without it, and the message is delivered to the live thread through the same `controller.sendMessage` path ordinary sends use. The atomic `createThread({ initialMessage })` path stays intact for any ordering where the adapter runs after the ref is set.

## Why

Data loss on the most common interaction there is: typing the first message of a new conversation. The runtime shows the optimistic message briefly, then erases it when initialization settles, and the agent never receives anything.

## Repro

Reproduced with an integration test that runs the real `useRemoteThreadListRuntime` + external-store core (only the thread controller and Pi client are stubbed): appending to a fresh runtime's new main thread ends with `createThread` called **without** `initialMessage` and `sendMessage` never called — the message is unreachable. With this change the same flow delivers it via `sendMessage`.

## Validation

- New `usePiRuntime.newThread.test.tsx` integration test asserting the first append reaches the server by either path (atomic `createThread` payload or a follow-up `sendMessage`). Fails on `main` (neither happens) and passes with this change.
- Full `@assistant-ui/react-pi` suite: 214 passed across 13 files; the package's pre-existing `tsc` error count (5, all in untouched test files) is unchanged.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pAQAshWtf4_MPQIyYQVsJaToCOtVQcJT_rXCXU8kt33weyuYr4IgcyMXRa4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

### Review round 1

Both reviewers converged on two findings, both valid and both fixed:

- **Single-slot handoff dropped the first of two sends during initialization.** Consumption is now tracked per message (a `WeakSet` the adapter marks when it atomically consumes a message), so each `onNew` continuation delivers its own message via the live thread whenever the adapter did not consume it — overwriting the handoff slot no longer loses anything. Success cleanup also removes only that send's optimistic message instead of clearing the whole list. The new two-sends-during-initialization test exposed a third latent bug in the same store: optimistic ids were derived from a stale `optimisticMessages.length` closure, so two in-flight sends collided on the same id and crashed the message repository — ids now come from a monotonic counter (the pattern `react-opencode`'s new-thread store already uses).
- **Weak test oracle.** The OR-disjunction is replaced with route-exact assertions: `createThread` receives no `initialMessage`, `sendMessage` fires exactly once with the exact payload; the second test pins both interleaved sends arriving with no duplicates.

### Review round 2

- Accepted both reviewers' conclusion that the atomic `createThread({ initialMessage })` handoff is unreachable: the external-store core starts `initialize()` before dispatching `onNew`, so the handoff slot is always empty when the adapter reads it. The ref, the `WeakSet`, and the adapter-side pickup are removed entirely — `onNew` now awaits initialization and delivers through the live thread unconditionally, which is the single delivery path the tests pin.
- The two-send test now asserts delivery order (`["message A", "message B"]`) instead of sorting it away, since A takes the live-send path and B lands in the follow-up queue — an inversion would reorder the conversation.

