### PR TITLE
fix(docs): keep use client in PreviewCode snippets

### DIFF
--- a/apps/docs/components/pages/docs/preview-code.server.test.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PreviewCode } from "./preview-code.server";
+
+const PreviewCodeClient = vi.hoisted(() => () => null);
+
+vi.mock("./preview-code", () => ({
+  PreviewCodeClient,
+}));
+
+type PreviewCodeElement = ReactElement<{
+  code: string;
+  baseCode?: string;
+}>;
+
+async function getPreviewCode(
+  file: string,
+  name: string,
+): Promise<PreviewCodeElement["props"]> {
+  const element = (await PreviewCode({
+    file,
+    name,
+    children: null,
+    base: null,
+  })) as PreviewCodeElement;
+  return element.props;
+}
+
+describe("PreviewCode", () => {
+  it("keeps a leading client directive in the extracted snippet", async () => {
+    const { code, baseCode } = await getPreviewCode(
+      "components/pages/docs/samples/badge",
+      "BadgeAnimatedSample",
+    );
+
+    expect(code.startsWith('"use client";\n\n')).toBe(true);
+    expect(baseCode?.startsWith('"use client";\n\n')).toBe(true);
+    expect(code).toContain('import { useEffect, useState } from "react";');
+    expect(code).toContain("function BadgeAnimatedSample()");
+  });
+
+  it("does not add a client directive to directive-free samples", async () => {
+    const { code } = await getPreviewCode(
+      "components/pages/docs/samples/mermaid",
+      "MermaidSample",
+    );
+
+    expect(code).not.toMatch(/^["']use client["'];?/);
+    expect(code).toContain(
+      'import { renderMermaidSVG } from "beautiful-mermaid";',
+    );
+    expect(code).toContain("function MermaidSample()");
+  });
+});

--- a/apps/docs/components/pages/docs/preview-code.server.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.tsx
@@ -199,6 +199,10 @@ function cleanupImports(imports: string[]): string[] {
     );
 }
 
+function extractUseClientDirective(source: string): string | undefined {
+  return source.match(/^\s*(["'])use client\1;?/)?.[0].trim();
+}
+
 function buildPreviewCode(file: string, name: string): string {
   const filePath = path.join(process.cwd(), `${file}.tsx`);
   try {
@@ -209,10 +213,15 @@ function buildPreviewCode(file: string, name: string): string {
     const allImports = extractImports(source);
     const relevantImports = filterRelevantImports(allImports, cleanedCode);
     const cleanedImports = cleanupImports(relevantImports);
+    const useClientDirective = extractUseClientDirective(source);
+    const previewCode =
+      cleanedImports.length > 0
+        ? `${cleanedImports.join("\n")}\n\n${cleanedCode}`
+        : cleanedCode;
 
-    return cleanedImports.length > 0
-      ? `${cleanedImports.join("\n")}\n\n${cleanedCode}`
-      : cleanedCode;
+    return useClientDirective
+      ? `${useClientDirective}\n\n${previewCode}`
+      : previewCode;
   } catch {
     return `// Error reading file: ${file}`;
   }


### PR DESCRIPTION
closes #6195

## summary

- PreviewCode snippets now keep a leading `"use client"` from the sample source, so copied hook-based samples are valid App Router files
- directive-free samples stay unchanged
- supersedes #6196, which targeted the pre-#6201 `components/docs/` paths

## test plan

### already verified

- [x] `vitest run components/pages/docs/preview-code.server.test.tsx` in `@assistant-ui/docs` -> 2/2 green

### reviewer should verify

- [ ] open a badge PreviewCode on the docs site, copy the BadgeAnimatedSample snippet, and confirm it starts with `"use client";`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2sIn1pgozn1_rJ_gOqQ3U4Comx4Wdy5Zarh5kamFR8wAvvClwnhbgxq6IZg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->