### PR TITLE
fix(core): keep prepended id-less external-store messages

### DIFF
--- a/.changeset/external-store-positional-fallback-ids.md
+++ b/.changeset/external-store-positional-fallback-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep prepended history when convertMessage returns no id

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -77,6 +77,8 @@ export const hasUpcomingMessage = (
   return isRunning && messages[messages.length - 1]?.role !== "assistant";
 };
 
+const FALLBACK_ID_PREFIX = "__external_store_fallback_";
+
 export class ExternalStoreThreadRuntimeCore
   extends BaseThreadRuntimeCore
   implements ThreadRuntimeCore
@@ -285,19 +287,29 @@ export class ExternalStoreThreadRuntimeCore
               false,
               undefined,
             );
+            const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
 
             if (
               cache &&
               (cache.role !== "assistant" ||
                 !isAutoStatus(cache.status) ||
                 cache.status === autoStatus)
-            )
+            ) {
+              if (
+                cache.id.startsWith(FALLBACK_ID_PREFIX) &&
+                cache.id !== fallbackId
+              ) {
+                const updated = { ...cache, id: fallbackId };
+                bindExternalStoreMessage(updated, m);
+                return updated;
+              }
               return cache;
+            }
 
             const messageLike = store.convertMessage(m, idx);
             const newMessage = fromThreadMessageLike(
               messageLike,
-              idx.toString(),
+              fallbackId,
               autoStatus,
             );
             bindExternalStoreMessage(newMessage, m);

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1155,3 +1155,106 @@ describe("ExternalStoreThreadRuntimeCore - message queue", () => {
     expect(queue.remove).toHaveBeenCalledWith("q1");
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
+  const convertMessage = (m: {
+    role?: "user" | "assistant";
+    text: string;
+  }): ThreadMessageLike => ({
+    role: m.role ?? "user",
+    content: [{ type: "text", text: m.text }],
+  });
+
+  const storeWith = (
+    messages: { role?: "user" | "assistant"; text: string }[],
+    isRunning = false,
+  ) => makeStore({ messages, convertMessage, isRunning });
+
+  const textOf = (message: { content: readonly { type: string }[] }) => {
+    const part = message.content[0];
+    return part && part.type === "text" && "text" in part ? part.text : undefined;
+  };
+
+  it("keeps a prepended history message", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const m0 = { text: "older-user" };
+      const m1 = { text: "newer-user" };
+      const m2 = { role: "assistant" as const, text: "newer-assistant" };
+
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        storeWith([m1, m2]),
+      );
+      expect(runtime.messages).toHaveLength(2);
+
+      runtime.__internal_setAdapter(storeWith([m0, m1, m2]));
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(runtime.messages).toHaveLength(3);
+      expect(runtime.messages.map(textOf)).toEqual([
+        "older-user",
+        "newer-user",
+        "newer-assistant",
+      ]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps the last message id when its host object is replaced while running", () => {
+    const user = { text: "hi" };
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      storeWith([user, { role: "assistant", text: "he" }], true),
+    );
+    const assistantId = runtime.messages[1]!.id;
+
+    runtime.__internal_setAdapter(
+      storeWith([user, { role: "assistant", text: "hel" }], true),
+    );
+    runtime.__internal_setAdapter(
+      storeWith([user, { role: "assistant", text: "hello" }], true),
+    );
+
+    expect(runtime.messages[1]!.id).toBe(assistantId);
+    expect(runtime.getBranches(assistantId)).toEqual([assistantId]);
+    expect(textOf(runtime.messages[1]!)).toBe("hello");
+  });
+
+  it("does not rewrite an explicit host id when the list shifts", () => {
+    const convertWithId = (m: {
+      id?: string;
+      text: string;
+    }): ThreadMessageLike => ({
+      ...(m.id !== undefined ? { id: m.id } : {}),
+      role: "user",
+      content: [{ type: "text", text: m.text }],
+    });
+
+    const explicit = { id: "host-a", text: "kept" };
+    const idLess = { text: "id-less" };
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [explicit],
+        convertMessage: convertWithId,
+      }),
+    );
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages: [idLess, explicit],
+        convertMessage: convertWithId,
+      }),
+    );
+
+    expect(runtime.messages.map((m) => m.id)).toEqual([
+      expect.stringMatching(/^__external_store_fallback_/),
+      "host-a",
+    ]);
+    expect(runtime.messages.map(textOf)).toEqual(["id-less", "kept"]);
+  });
+});
+
+

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1172,7 +1172,9 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
 
   const textOf = (message: { content: readonly { type: string }[] }) => {
     const part = message.content[0];
-    return part && part.type === "text" && "text" in part ? part.text : undefined;
+    return part && part.type === "text" && "text" in part
+      ? part.text
+      : undefined;
   };
 
   it("keeps a prepended history message", () => {
@@ -1256,5 +1258,3 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
     expect(runtime.messages.map(textOf)).toEqual(["id-less", "kept"]);
   });
 });
-
-


### PR DESCRIPTION
closes #6172

## summary

- when `convertMessage` returns no `id`, fallback ids stay positional (`__external_store_fallback_<index>`) so a streaming host that replaces the last message object keeps the same id
- if a cached fallback id no longer matches the current index (load-older prepend), the conversion is re-idded instead of colliding with the new head and getting dropped
- explicit host ids are left alone
- supersedes #6173, which keyed fallback ids on host object identity and would mint a new id on every streaming content swap

## test plan

### already verified

- [x] `vitest run src/tests/external-store-thread-runtime-core.test.ts` in `@assistant-ui/core` -> 55/55 green

### reviewer should verify

- [ ] prepend older history with a stable id-less `convertMessage` and confirm the new message stays in the thread
- [ ] stream an id-less assistant message by replacing the last host object twice while `isRunning` and confirm the id and `getBranches` stay at 1

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.t0RtvtDaKRCrv7cKx9loxuAthK7Zg4BT2kVgJ9QLvCgUo4srff0pcu0hNaQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->