### PR TITLE
fix(ai-sdk): preserve external message repository branches

### DIFF
--- a/.changeset/ai-sdk-external-message-repository.md
+++ b/.changeset/ai-sdk-external-message-repository.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: preserve externally owned message branches in the AI SDK runtime

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -11,6 +11,8 @@ declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, 
 type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
 
 type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+  messageRepository?: ExternalStoreAdapter["messageRepository"];
+  unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
     history?: ThreadHistoryAdapter | undefined;
     suggestion?: SuggestionAdapter | undefined;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -11,6 +11,8 @@ declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, 
 type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
 
 type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+  messageRepository?: ExternalStoreAdapter["messageRepository"];
+  unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
     history?: ThreadHistoryAdapter | undefined;
     suggestion?: SuggestionAdapter | undefined;

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -3,6 +3,10 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { validateUIMessages } from "ai";
+import type {
+  ExportedMessageRepository,
+  ThreadMessage,
+} from "@assistant-ui/core";
 
 // Mock only the sibling module that requires AUI store context (not available
 // in isolation). Every other dependency — useExternalStoreRuntime,
@@ -69,6 +73,31 @@ const textOf = (message: any): string =>
     .filter((part: any) => part.type === "text")
     .map((part: any) => part.text)
     .join("|");
+
+const createRepositoryMessage = (
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): ThreadMessage =>
+  ({
+    id,
+    role,
+    createdAt: new Date(),
+    content: [{ type: "text", text }],
+    metadata: { custom: {} },
+    ...(role === "user"
+      ? { attachments: [] }
+      : {
+          status: { type: "complete", reason: "stop" },
+          metadata: {
+            unstable_state: null,
+            unstable_annotations: [],
+            unstable_data: [],
+            steps: [],
+            custom: {},
+          },
+        }),
+  }) as ThreadMessage;
 
 describe("useAISDKRuntime", () => {
   beforeEach(() => {
@@ -688,6 +717,56 @@ describe("useAISDKRuntime", () => {
     const suggestions = [{ prompt: "tell me a joke" }];
     const { result } = renderHook(() => useAISDKRuntime(chat, { suggestions }));
     expect(result.current.thread.getState().suggestions).toEqual(suggestions);
+  });
+
+  it("uses an external message repository and forwards branch changes", () => {
+    const chat = createChatHelpers();
+    const onBranchChange = vi.fn();
+    const messageRepository = {
+      headId: "a2",
+      messages: [
+        {
+          parentId: null,
+          message: createRepositoryMessage("u1", "user", "question"),
+        },
+        {
+          parentId: "u1",
+          message: createRepositoryMessage("a1", "assistant", "first"),
+        },
+        {
+          parentId: "u1",
+          message: createRepositoryMessage("a2", "assistant", "second"),
+        },
+      ],
+    } satisfies ExportedMessageRepository;
+
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, {
+        messageRepository,
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    expect(
+      result.current.thread.getState().messages.map((message) => message.id),
+    ).toEqual(["u1", "a2"]);
+    expect(result.current.thread.getMessageById("a2").getState()).toMatchObject(
+      {
+        branchNumber: 2,
+        branchCount: 2,
+      },
+    );
+
+    act(() => {
+      result.current.thread
+        .getMessageById("a2")
+        .switchToBranch({ branchId: "a1" });
+    });
+
+    expect(onBranchChange).toHaveBeenCalledWith({
+      headId: "a1",
+      visibleMessageIds: ["u1", "a1"],
+    });
   });
 
   it("calls adapters.suggestion after settle with messages and signal", async () => {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -71,6 +71,8 @@ const toUIMessage = <UI_MESSAGE extends UIMessage>(
   }) as UI_MESSAGE;
 
 export type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+  messageRepository?: ExternalStoreAdapter["messageRepository"];
+  unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
   adapters?:
     | (NonNullable<ExternalStoreAdapter["adapters"]> & {
         history?: ThreadHistoryAdapter | undefined;
@@ -199,6 +201,8 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onResume,
     onResumeToolCall,
     joinStrategy,
+    messageRepository,
+    unstable_onBranchChange,
   } = adapter;
   const suggestionAdapter = adapters?.suggestion;
   const contextAdapters = useRuntimeAdapters();
@@ -329,7 +333,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   const runtime = useExternalStoreRuntime({
     isRunning,
-    messages,
+    ...(messageRepository ? { messageRepository } : { messages }),
     unstable_enableToolInvocations: true,
     setToolStatuses,
     setMessages: (messages) =>
@@ -515,6 +519,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
     ...(onResume && { onResume }),
     ...(onResumeToolCall && { onResumeToolCall }),
+    ...(unstable_onBranchChange && { unstable_onBranchChange }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,


### PR DESCRIPTION
Closes #6213

## Summary

- expose `messageRepository` and `unstable_onBranchChange` on `AISDKRuntimeAdapter`
- make the external repository authoritative when it is provided, while preserving the existing converted-message path by default
- add a regression test for sibling branches and the canonical branch-change callback
- update generated API surfaces and add a patch changeset

## Root cause

`useAISDKRuntime` always supplied the flat output of `AISDKMessageConverter.useThreadMessages` to `useExternalStoreRuntime`. The external-store core therefore reconstructed parentage from array order, even when the application already owned a branch-aware `ExportedMessageRepository`. `AISDKRuntimeAdapter` also omitted the existing `unstable_onBranchChange` callback, so the owner could not persist an explicit branch switch.

## Verification

The regression test failed before the fix with an empty runtime branch (`expected [u1, a2], received []`) and passes after the repository is forwarded.

- `pnpm --filter @assistant-ui/ai-sdk test` — 25 files, 250 tests passed
- `pnpm --filter @assistant-ui/ai-sdk build` — passed
- `pnpm --filter @assistant-ui/react-ai-sdk build` — passed
- `pnpm exec oxlint packages/ai-sdk/src/runtime/useAISDKRuntime.ts packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts` — passed
- filtered API surface generation and check for `@assistant-ui/ai-sdk` and `@assistant-ui/react-ai-sdk` — passed

## Risk and compatibility

Existing callers are unchanged: when `messageRepository` is absent, the runtime still uses converted AI SDK messages. When it is present, the repository follows the existing external-store contract and becomes the source of branch parent/head state. The branch callback remains optional and only observes explicit branch switches.

## AI assistance

Codex assisted with repository analysis, implementation, and test drafting. The diff and verification results were reviewed and executed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9m0r0i6wlp6g7C0TAB-bY9IV46zZnDAQGy42tmW2SmKqZZbSS2FnQDJOsRo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->