### PR TITLE
fix(react-a2a): load a history adapter that arrives after the first load

### DIFF
--- a/.changeset/a2a-late-history-load.md
+++ b/.changeset/a2a-late-history-load.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: load a history adapter that arrives after the first load

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -150,6 +150,95 @@ describe("A2AThreadRuntimeCore", () => {
     });
   }
 
+  describe("late history loading", () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    function createLateHistory() {
+      const user = createHistoryMessage("user", "user", "Question");
+      return {
+        user,
+        history: {
+          load: vi.fn().mockResolvedValue({
+            headId: user.id,
+            messages: [{ parentId: null, message: user }],
+          }),
+          append: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+    }
+
+    it("loads history when the adapter arrives after the first load", async () => {
+      const client = createMockClient();
+      const core = createCore(client);
+      const { user, history } = createLateHistory();
+
+      await core.__internal_load();
+      expect(history.load).not.toHaveBeenCalled();
+      expect(core.getMessages()).toEqual([]);
+
+      core.updateOptions({ client, history });
+      await flush();
+
+      expect(history.load).toHaveBeenCalledOnce();
+      expect(core.getMessages().map((message) => message.id)).toEqual([
+        user.id,
+      ]);
+      expect(core.isLoading).toBe(false);
+    });
+
+    it("fetches the agent card once across the early load and the late history load", async () => {
+      const agentCard = { name: "Agent", url: "https://agent.example" };
+      const client = createMockClient({
+        getAgentCard: vi.fn().mockResolvedValue(agentCard),
+      });
+      const core = createCore(client);
+      const { history } = createLateHistory();
+
+      await core.__internal_load();
+      expect(core.getAgentCard()).toEqual(agentCard);
+
+      core.updateOptions({ client, history });
+      await flush();
+
+      expect(client.getAgentCard).toHaveBeenCalledOnce();
+      expect(history.load).toHaveBeenCalledOnce();
+    });
+
+    it("does not load late history over a thread that already has messages", async () => {
+      const client = createMockClient();
+      const core = createCore(client);
+      const { history } = createLateHistory();
+
+      await core.__internal_load();
+      await core.append({
+        ...createUserAppendMessage("Typed"),
+        startRun: false,
+      } as AppendMessage);
+      expect(core.getMessages()).toHaveLength(1);
+
+      core.updateOptions({ client, history });
+      await flush();
+
+      expect(history.load).not.toHaveBeenCalled();
+      expect(core.getMessages()).toHaveLength(1);
+    });
+
+    it("does not reload when the adapter is replaced after a completed load", async () => {
+      const client = createMockClient();
+      const { history } = createLateHistory();
+      const core = createCore(client, { history });
+      const replacement = createLateHistory().history;
+
+      await core.__internal_load();
+      expect(history.load).toHaveBeenCalledOnce();
+
+      core.updateOptions({ client, history: replacement });
+      await flush();
+
+      expect(replacement.load).not.toHaveBeenCalled();
+    });
+  });
+
   // --- Basic state ---
 
   describe("initial state", () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -110,6 +110,8 @@ export class A2AThreadRuntimeCore {
   private readonly recordedHistoryIds = new Set<string>();
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
+  private _loadRequested = false;
+  private _agentCardPromise: Promise<void> | undefined;
 
   constructor(options: A2AThreadRuntimeCoreOptions) {
     this.client = options.client;
@@ -129,7 +131,18 @@ export class A2AThreadRuntimeCore {
     this.onError = options.onError;
     this.onCancel = options.onCancel;
     this.onArtifactComplete = options.onArtifactComplete;
+    const previousHistory = this.history;
     this.history = options.history;
+
+    if (
+      this._loadRequested &&
+      !this._loadPromise &&
+      !previousHistory &&
+      options.history &&
+      this.repository.getMessages().length === 0
+    ) {
+      void this.__internal_load();
+    }
   }
 
   attachRuntime(runtime: AssistantRuntime) {
@@ -236,18 +249,24 @@ export class A2AThreadRuntimeCore {
   }
 
   __internal_load(): Promise<void> {
+    this._loadRequested = true;
+    this._agentCardPromise ??= this.client
+      .getAgentCard()
+      .then((agentCard) => {
+        this.agentCardValue = agentCard;
+        this.notifyUpdate();
+      })
+      .catch(() => undefined);
+
     if (this._loadPromise) return this._loadPromise;
+    if (!this.history) return this._agentCardPromise;
 
     this._isLoading = true;
 
-    const historyPromise = this.history?.load() ?? Promise.resolve(null);
-    const agentCardPromise = this.client.getAgentCard().catch(() => undefined);
+    const historyPromise = this.history.load();
 
-    this._loadPromise = Promise.all([historyPromise, agentCardPromise])
-      .then(([repo, agentCard]) => {
-        if (agentCard) {
-          this.agentCardValue = agentCard;
-        }
+    this._loadPromise = Promise.all([historyPromise, this._agentCardPromise])
+      .then(([repo]) => {
         if (repo) {
           this.applyExternalMessageRepository(repo);
         }


### PR DESCRIPTION
## What
`A2AThreadRuntimeCore` no longer caches `_loadPromise` when there is no history adapter yet, and the agent card fetch moves to its own once-only promise. When `updateOptions` delivers the first adapter to a thread with no messages after a load was requested, the history load runs then without refetching the card.

## Why
`useA2ARuntime` calls `__internal_load` once on mount, but the adapter comes from `options.adapters?.history ?? useRuntimeAdapters()?.history` on every render, so a cloud-provided adapter that lands one render later was stored and never read. This is the exact defect #6013 fixed in core, and its review named this site. Part of #6277.

## Impact
- A2A threads mounted before their history adapter resolves now show the saved history instead of an empty thread.
- `getAgentCard()` becomes available as soon as the card resolves instead of after the history load settles.

## Scope & caveats
- This is not the keyed reload from #5481: only the undefined to adapter transition on an empty thread triggers a load, replacing an adapter after a load never does. Same carve-out as #6013.
- The AG-UI half of #6277 follows as a separate PR. It is held back briefly because removing the same accidental mount `isLoading` pulse there exposed a core tracker gap (a same-named frontend tool runs on an approval-gated call), and that core fix lands first.
- `isLoading` is no longer `true` during a no-history agent card fetch. That aligns with core, where `isLoading` means the history load, and there is no history to load in that state.
- The card promise's `then` assigns without a truthiness guard because `getAgentCard` resolves `A2AAgentCard`, never `undefined`; the `catch` keeps a failed fetch silent as before.
- No `.catch` on the retrigger: the load body already routes errors to `onError` and resolves.
- Tests: late adapter loads, agent card fetched once across early and late loads, late adapter ignored when messages exist, replacement adapter ignored after a completed load.
- Additive only, private fields; no exports changed.
- Changeset: patch (`@assistant-ui/react-a2a`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.F092nYGE7IF6LcsYLov3LyHfVCF5N_sOAKqRDbnhskFx-yVWmHppZ-lzG98?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->