### PR TITLE
fix(ai-sdk): import external message trees without dropping chat

### DIFF
--- a/.changeset/aisdk-seed-message-repository.md
+++ b/.changeset/aisdk-seed-message-repository.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: import an external AI SDK message tree without disconnecting useChat

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -10,7 +10,7 @@ declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, 
 
 type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
 
-type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ExternalStoreSharedOptions & {
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
     history?: ThreadHistoryAdapter | undefined;
     suggestion?: SuggestionAdapter | undefined;
@@ -20,6 +20,8 @@ type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
   joinStrategy?: JoinStrategy | undefined;
+  messageRepository?: MessageFormatRepository<UI_MESSAGE>;
+  unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
 };
 
 declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKThreadsOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
@@ -539,6 +541,8 @@ type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<
   onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
   onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
+  messageRepository?: AISDKRuntimeAdapter<UI_MESSAGE>["messageRepository"];
+  unstable_onBranchChange?: AISDKRuntimeAdapter["unstable_onBranchChange"];
 };
 
 type ClientError<E extends string> = {

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -2196,7 +2196,7 @@ declare const useAISDKChat: <UI_MESSAGE extends UIMessage = UIMessage>() => UseC
 
 declare const useAISDKError: () => Error | undefined;
 
-declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter) => AssistantRuntime;
+declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter<UI_MESSAGE>) => AssistantRuntime;
 
 declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -10,7 +10,7 @@ declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, 
 
 type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
 
-type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ExternalStoreSharedOptions & {
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
     history?: ThreadHistoryAdapter | undefined;
     suggestion?: SuggestionAdapter | undefined;
@@ -20,6 +20,8 @@ type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
   joinStrategy?: JoinStrategy | undefined;
+  messageRepository?: MessageFormatRepository<UI_MESSAGE>;
+  unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
 };
 
 declare const AISDKThreads: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKThreadsOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
@@ -539,6 +541,8 @@ type ChatThreadOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<
   onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
   onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
+  messageRepository?: AISDKRuntimeAdapter<UI_MESSAGE>["messageRepository"];
+  unstable_onBranchChange?: AISDKRuntimeAdapter["unstable_onBranchChange"];
 };
 
 type ClientError<E extends string> = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -2196,7 +2196,7 @@ declare const useAISDKChat: <UI_MESSAGE extends UIMessage = UIMessage>() => UseC
 
 declare const useAISDKError: () => Error | undefined;
 
-declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter) => AssistantRuntime;
+declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter<UI_MESSAGE>) => AssistantRuntime;
 
 declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
 

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -657,7 +657,7 @@ const runtime = useChatRuntime({
 });
 ```
 
-`unstable_onBranchChange` fires after an explicit `switchToBranch` (for example a BranchPicker click). It complements `setMessages` and does not enable switching by itself.
+`unstable_onBranchChange` fires after an explicit `switchToBranch` (for example a BranchPicker click). It complements `setMessages` and does not enable switching by itself. The callback is unstable and may change without notice.
 
 ## Advanced: useAISDKRuntime
 

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -644,6 +644,21 @@ const runtime = useChatRuntime({
 
 When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`. For streams that should survive a page reload without a custom channel, use the built-in transport-level path instead: see [Resumable streams](/docs/guides/resumable-streams), which reconnects automatically on mount and reports failures via `onResumeError`.
 
+### messageRepository
+
+Import a branch-aware AI SDK message tree into the thread. Live updates still come from `useChat`; this is a seed, not a replacement for that feed. Pass a stable reference and change it only when a new tree should be loaded. Persisted threads that already go through `adapters.history` do not need this.
+
+```tsx
+const runtime = useChatRuntime({
+  messageRepository: storedTree,
+  unstable_onBranchChange: ({ headId }) => {
+    saveSelectedBranch(headId);
+  },
+});
+```
+
+`unstable_onBranchChange` fires after an explicit `switchToBranch` (for example a BranchPicker click). It complements `setMessages` and does not enable switching by itself.
+
 ## Advanced: useAISDKRuntime
 
 When you need direct access to the `useChat` instance (e.g. to share it with non-assistant-ui code), drop down to `useAISDKRuntime`:
@@ -658,7 +673,7 @@ const runtime = useAISDKRuntime(chat);
 
 `useAISDKRuntime` does not provide `cloud` or the higher-level adapter slots; those are part of `useChatRuntime`. If you need both your own `useChat` access AND cloud thread support, you generally want `useChatRuntime` and to read the chat state through assistant-ui hooks instead.
 
-`useAISDKRuntime` accepts `joinStrategy` and `onResume` (see [Runtime options](#runtime-options)) plus one option of its own, `cancelPendingToolCallsOnSend`:
+`useAISDKRuntime` accepts `joinStrategy`, `onResume`, `messageRepository`, and `unstable_onBranchChange` (see [Runtime options](#runtime-options)) plus one option of its own, `cancelPendingToolCallsOnSend`:
 
 ```tsx
 const runtime = useAISDKRuntime(chat, {

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -646,7 +646,7 @@ When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`. Fo
 
 ### messageRepository
 
-Import a branch-aware AI SDK message tree into the thread. Live updates still come from `useChat`; this is a seed, not a replacement for that feed. Pass a stable reference and change it only when a new tree should be loaded. Persisted threads that already go through `adapters.history` do not need this.
+Import a branch-aware AI SDK message tree once, and only when `useChat` is empty. After that seed, live updates come only from `useChat`. Clearing the chat or passing a new object identity does not reload the tree. Persisted threads that already go through `adapters.history` do not need this.
 
 ```tsx
 const runtime = useChatRuntime({

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -789,6 +789,91 @@ describe("useAISDKRuntime", () => {
     );
   });
 
+  it("does not overwrite a nonempty chat with the repository", async () => {
+    const chat = createChatHelpers([
+      { id: "live", role: "user", parts: [{ type: "text", text: "keep me" }] },
+    ]);
+    const messageRepository = {
+      headId: "a1",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "u1",
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: "question" }],
+          },
+        },
+        {
+          parentId: "u1",
+          message: {
+            id: "a1",
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text: "first" }],
+          },
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { messageRepository }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.map((message) => message.id),
+      ).toEqual(["live"]);
+    });
+    expect(chat.messages.map((message: { id: string }) => message.id)).toEqual([
+      "live",
+    ]);
+  });
+
+  it("does not reseed when the repository object identity changes", async () => {
+    const chat = createChatHelpers();
+    const makeRepository = (text: string) => ({
+      headId: "a1",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "u1",
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: "question" }],
+          },
+        },
+        {
+          parentId: "u1",
+          message: {
+            id: "a1",
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text }],
+          },
+        },
+      ],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ repository }) =>
+        useAISDKRuntime(chat, { messageRepository: repository }),
+      { initialProps: { repository: makeRepository("first") } },
+    );
+
+    await waitFor(() => {
+      expect(textOf(result.current.thread.getState().messages.at(-1))).toBe(
+        "first",
+      );
+    });
+    const setMessagesCalls = chat.setMessages.mock.calls.length;
+
+    rerender({ repository: makeRepository("second") });
+
+    expect(textOf(result.current.thread.getState().messages.at(-1))).toBe(
+      "first",
+    );
+    expect(chat.setMessages.mock.calls.length).toBe(setMessagesCalls);
+  });
+
   it("calls adapters.suggestion after settle with messages and signal", async () => {
     const generate = vi.fn().mockResolvedValue([{ prompt: "next" }]);
     const chat = createChatHelpers([

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -7,13 +7,17 @@ import { validateUIMessages } from "ai";
 // Mock only the sibling module that requires AUI store context (not available
 // in isolation). Every other dependency — useExternalStoreRuntime,
 // useToolInvocations, the message converter — runs for real.
-vi.mock("./useExternalHistory", () => ({
-  useExternalHistory: vi.fn(() => ({
-    isLoading: false,
-    deleteMessage: vi.fn().mockResolvedValue(undefined),
-  })),
-  toExportedMessageRepository: vi.fn(),
-}));
+vi.mock("./useExternalHistory", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./useExternalHistory")>();
+  return {
+    ...original,
+    useExternalHistory: vi.fn(() => ({
+      isLoading: false,
+      deleteMessage: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
 
 import { useExternalHistory } from "./useExternalHistory";
 import { useAISDKRuntime } from "./useAISDKRuntime";
@@ -688,6 +692,101 @@ describe("useAISDKRuntime", () => {
     const suggestions = [{ prompt: "tell me a joke" }];
     const { result } = renderHook(() => useAISDKRuntime(chat, { suggestions }));
     expect(result.current.thread.getState().suggestions).toEqual(suggestions);
+  });
+
+  it("imports a message tree without replacing the chat feed", async () => {
+    const chat = createChatHelpers();
+    const onBranchChange = vi.fn();
+    const messageRepository = {
+      headId: "a2",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "u1",
+            role: "user" as const,
+            parts: [{ type: "text" as const, text: "question" }],
+          },
+        },
+        {
+          parentId: "u1",
+          message: {
+            id: "a1",
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text: "first" }],
+          },
+        },
+        {
+          parentId: "u1",
+          message: {
+            id: "a2",
+            role: "assistant" as const,
+            parts: [{ type: "text" as const, text: "second" }],
+          },
+        },
+      ],
+    };
+
+    const { result, rerender } = renderHook(() =>
+      useAISDKRuntime(chat, {
+        messageRepository,
+        unstable_onBranchChange: onBranchChange,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.map((message) => message.id),
+      ).toEqual(["u1", "a2"]);
+    });
+    expect(result.current.thread.getMessageById("a2").getState()).toMatchObject(
+      {
+        branchNumber: 2,
+        branchCount: 2,
+      },
+    );
+    expect(chat.messages.map((message: { id: string }) => message.id)).toEqual([
+      "u1",
+      "a2",
+    ]);
+
+    act(() => {
+      result.current.thread
+        .getMessageById("a2")
+        .switchToBranch({ branchId: "a1" });
+    });
+
+    expect(onBranchChange).toHaveBeenCalledWith({
+      headId: "a1",
+      visibleMessageIds: ["u1", "a1"],
+    });
+    expect(chat.messages.map((message: { id: string }) => message.id)).toEqual([
+      "u1",
+      "a1",
+    ]);
+    expect(chat.messages).not.toEqual([]);
+
+    chat.messages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "question" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "first token" }],
+      },
+    ];
+    rerender();
+
+    await waitFor(() => {
+      expect(textOf(result.current.thread.getState().messages.at(-1))).toBe(
+        "first token",
+      );
+    });
+    expect(result.current.thread.getMessageById("a1").getState()).toMatchObject(
+      {
+        branchNumber: 1,
+        branchCount: 2,
+      },
+    );
   });
 
   it("calls adapters.suggestion after settle with messages and signal", async () => {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -35,7 +35,10 @@ import {
   getExternalStoreMessages,
   pickExternalStoreSharedOptions,
 } from "@assistant-ui/core";
-import { consumeSuggestionResult } from "@assistant-ui/core/internal";
+import {
+  consumeSuggestionResult,
+  MessageRepository,
+} from "@assistant-ui/core/internal";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import { sliceMessagesUntil } from "../utils/sliceMessagesUntil";
 import { toCreateMessage } from "../converters/toCreateMessage";
@@ -70,48 +73,63 @@ const toUIMessage = <UI_MESSAGE extends UIMessage>(
     role: createMessage.role ?? fallbackRole,
   }) as UI_MESSAGE;
 
-export type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
-  adapters?:
-    | (NonNullable<ExternalStoreAdapter["adapters"]> & {
-        history?: ThreadHistoryAdapter | undefined;
-        suggestion?: SuggestionAdapter | undefined;
-      })
-    | undefined;
-  toCreateMessage?: CustomToCreateMessageFunction;
-  /**
-   * Whether to automatically cancel pending interactive tool calls when the user sends a new message.
-   *
-   * When enabled (default), the pending tool calls will be marked as failed with an error message
-   * indicating the user cancelled the tool call by sending a new message.
-   *
-   * @default true
-   */
-  cancelPendingToolCallsOnSend?: boolean | undefined;
-  /**
-   * Called when `runtime.thread.resumeRun(config)` is invoked.
-   *
-   * When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`.
-   * Provide this to bridge resume invocations into a custom replay channel
-   * (for example, an SSE reconnect endpoint keyed by turn id).
-   */
-  onResume?: ExternalStoreAdapter["onResume"];
-  /**
-   * Called when `runtime.thread.resumeToolCall(options)` is invoked for a tool call the in-process tracker does not own.
-   *
-   * When omitted, `resumeToolCall` throws `"Tool call ${toolCallId} is not waiting for resume."`.
-   * Provide this to bridge resume-tool-call invocations into a custom handler.
-   */
-  onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
-  /**
-   * How consecutive assistant messages are rendered.
-   *
-   * `"concat-content"` (the default) merges them into a single thread message.
-   * `"none"` keeps each assistant message as its own thread message, which is
-   * useful when a backend persists proactive or consecutive assistant messages
-   * as separate entries.
-   */
-  joinStrategy?: JoinStrategy | undefined;
-};
+export type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage = UIMessage> =
+  ExternalStoreSharedOptions & {
+    adapters?:
+      | (NonNullable<ExternalStoreAdapter["adapters"]> & {
+          history?: ThreadHistoryAdapter | undefined;
+          suggestion?: SuggestionAdapter | undefined;
+        })
+      | undefined;
+    toCreateMessage?: CustomToCreateMessageFunction;
+    /**
+     * Whether to automatically cancel pending interactive tool calls when the user sends a new message.
+     *
+     * When enabled (default), the pending tool calls will be marked as failed with an error message
+     * indicating the user cancelled the tool call by sending a new message.
+     *
+     * @default true
+     */
+    cancelPendingToolCallsOnSend?: boolean | undefined;
+    /**
+     * Called when `runtime.thread.resumeRun(config)` is invoked.
+     *
+     * When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`.
+     * Provide this to bridge resume invocations into a custom replay channel
+     * (for example, an SSE reconnect endpoint keyed by turn id).
+     */
+    onResume?: ExternalStoreAdapter["onResume"];
+    /**
+     * Called when `runtime.thread.resumeToolCall(options)` is invoked for a tool call the in-process tracker does not own.
+     *
+     * When omitted, `resumeToolCall` throws `"Tool call ${toolCallId} is not waiting for resume."`.
+     * Provide this to bridge resume-tool-call invocations into a custom handler.
+     */
+    onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
+    /**
+     * How consecutive assistant messages are rendered.
+     *
+     * `"concat-content"` (the default) merges them into a single thread message.
+     * `"none"` keeps each assistant message as its own thread message, which is
+     * useful when a backend persists proactive or consecutive assistant messages
+     * as separate entries.
+     */
+    joinStrategy?: JoinStrategy | undefined;
+    /**
+     * A branch-aware AI SDK message tree to import into the thread. Live
+     * updates still come from `useChat`; this is not a replacement for that
+     * feed. Pass a stable reference and change it only when a new tree should
+     * be loaded.
+     */
+    messageRepository?: MessageFormatRepository<UI_MESSAGE>;
+    /**
+     * Called after an explicit `switchToBranch` (for example a BranchPicker
+     * click). Complements `setMessages` and does not enable switching by itself.
+     *
+     * @deprecated This API is still under active development and might change without notice.
+     */
+    unstable_onBranchChange?: ExternalStoreAdapter["unstable_onBranchChange"];
+  };
 
 const EMPTY_SUGGESTIONS: readonly ThreadSuggestion[] = [];
 
@@ -190,7 +208,7 @@ const useGeneratedSuggestions = (
 
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>,
-  adapter: AISDKRuntimeAdapter = {},
+  adapter: AISDKRuntimeAdapter<UI_MESSAGE> = {},
 ) => {
   const {
     adapters,
@@ -199,6 +217,8 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onResume,
     onResumeToolCall,
     joinStrategy,
+    messageRepository,
+    unstable_onBranchChange,
   } = adapter;
   const suggestionAdapter = adapters?.suggestion;
   const contextAdapters = useRuntimeAdapters();
@@ -247,6 +267,17 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       [toolStatuses, messageTiming, optimisticMessageId, chatHelpers.error],
     ),
   });
+
+  const exportedMessageRepository = useMemo(() => {
+    if (!messageRepository) return undefined;
+    const converted = toExportedMessageRepository(
+      AISDKMessageConverter.toThreadMessages as (
+        messages: UI_MESSAGE[],
+      ) => ThreadMessage[],
+      messageRepository,
+    );
+    return converted.messages.length > 0 ? converted : undefined;
+  }, [messageRepository]);
 
   const generatedSuggestions = useGeneratedSuggestions(
     suggestionAdapter,
@@ -329,7 +360,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   const runtime = useExternalStoreRuntime({
     isRunning,
-    messages,
+    ...(exportedMessageRepository && messages.length === 0
+      ? { messageRepository: exportedMessageRepository }
+      : { messages }),
     unstable_enableToolInvocations: true,
     setToolStatuses,
     setMessages: (messages) =>
@@ -515,6 +548,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
     ...(onResume && { onResume }),
     ...(onResumeToolCall && { onResumeToolCall }),
+    ...(unstable_onBranchChange && { unstable_onBranchChange }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,
@@ -524,5 +558,22 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     isLoading,
   });
 
+  const importedMessageRepositoryRef = useRef<
+    MessageFormatRepository<UI_MESSAGE> | undefined
+  >(undefined);
+  const setMessagesRef = useRef(chatHelpers.setMessages);
+  setMessagesRef.current = chatHelpers.setMessages;
+
+  useEffect(() => {
+    if (importedMessageRepositoryRef.current === messageRepository) return;
+    importedMessageRepositoryRef.current = messageRepository;
+    if (!exportedMessageRepository) return;
+    runtime.thread.import(exportedMessageRepository);
+    const tempRepo = new MessageRepository();
+    tempRepo.import(exportedMessageRepository);
+    setMessagesRef.current(
+      tempRepo.getMessages().flatMap(getExternalStoreMessages<UI_MESSAGE>),
+    );
+  }, [exportedMessageRepository, messageRepository, runtime]);
   return runtime;
 };

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -116,10 +116,9 @@ export type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage = UIMessage> =
      */
     joinStrategy?: JoinStrategy | undefined;
     /**
-     * A branch-aware AI SDK message tree to import into the thread. Live
-     * updates still come from `useChat`; this is not a replacement for that
-     * feed. Pass a stable reference and change it only when a new tree should
-     * be loaded.
+     * A branch-aware AI SDK message tree seeded once when `useChat` is empty.
+     * After that seed, live updates come only from `useChat`. A later empty
+     * chat or a new object identity does not reload the tree.
      */
     messageRepository?: MessageFormatRepository<UI_MESSAGE>;
     /**
@@ -358,9 +357,15 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     });
   };
 
+  const hasSeededRepositoryRef = useRef(false);
+  const shouldFeedRepository =
+    exportedMessageRepository != null &&
+    !hasSeededRepositoryRef.current &&
+    messages.length === 0;
+
   const runtime = useExternalStoreRuntime({
     isRunning,
-    ...(exportedMessageRepository && messages.length === 0
+    ...(shouldFeedRepository
       ? { messageRepository: exportedMessageRepository }
       : { messages }),
     unstable_enableToolInvocations: true,
@@ -558,25 +563,22 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     isLoading,
   });
 
-  const importedMessageRepositoryRef = useRef<
-    MessageFormatRepository<UI_MESSAGE> | undefined
-  >(undefined);
   const setMessagesRef = useRef(chatHelpers.setMessages);
   setMessagesRef.current = chatHelpers.setMessages;
 
-  const chatMessageCount = chatHelpers.messages.length;
-
   useEffect(() => {
-    if (importedMessageRepositoryRef.current === messageRepository) return;
-    importedMessageRepositoryRef.current = messageRepository;
+    if (hasSeededRepositoryRef.current) return;
     if (!exportedMessageRepository) return;
-    runtime.thread.import(exportedMessageRepository);
-    if (chatMessageCount > 0) return;
+    if (chatHelpers.messages.length > 0) {
+      hasSeededRepositoryRef.current = true;
+      return;
+    }
     const tempRepo = new MessageRepository();
     tempRepo.import(exportedMessageRepository);
     setMessagesRef.current(
       tempRepo.getMessages().flatMap(getExternalStoreMessages<UI_MESSAGE>),
     );
-  }, [exportedMessageRepository, messageRepository, runtime, chatMessageCount]);
+    hasSeededRepositoryRef.current = true;
+  }, [exportedMessageRepository, chatHelpers.messages.length]);
   return runtime;
 };

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -564,16 +564,19 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const setMessagesRef = useRef(chatHelpers.setMessages);
   setMessagesRef.current = chatHelpers.setMessages;
 
+  const chatMessageCount = chatHelpers.messages.length;
+
   useEffect(() => {
     if (importedMessageRepositoryRef.current === messageRepository) return;
     importedMessageRepositoryRef.current = messageRepository;
     if (!exportedMessageRepository) return;
     runtime.thread.import(exportedMessageRepository);
+    if (chatMessageCount > 0) return;
     const tempRepo = new MessageRepository();
     tempRepo.import(exportedMessageRepository);
     setMessagesRef.current(
       tempRepo.getMessages().flatMap(getExternalStoreMessages<UI_MESSAGE>),
     );
-  }, [exportedMessageRepository, messageRepository, runtime]);
+  }, [exportedMessageRepository, messageRepository, runtime, chatMessageCount]);
   return runtime;
 };

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -45,6 +45,8 @@ export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
        */
       onResumeError?: ((error: unknown) => void) | undefined;
       joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
+      messageRepository?: AISDKRuntimeAdapter<UI_MESSAGE>["messageRepository"];
+      unstable_onBranchChange?: AISDKRuntimeAdapter["unstable_onBranchChange"];
     };
 
 export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
@@ -133,6 +135,8 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
     onResumeToolCall,
     onResumeError,
     joinStrategy,
+    messageRepository,
+    unstable_onBranchChange,
     ...chatInit
   } = options ?? {};
   // peel guard: any shared key left in `chatInit` collapses this to `never`
@@ -149,6 +153,8 @@ export const splitChatThreadOptions = <UI_MESSAGE extends UIMessage>(
     onResumeToolCall,
     onResumeError,
     joinStrategy,
+    messageRepository,
+    unstable_onBranchChange,
     chatInit,
   };
 };
@@ -166,6 +172,8 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     onResumeToolCall,
     onResumeError,
     joinStrategy,
+    messageRepository,
+    unstable_onBranchChange,
     chatInit: chatOptions,
   } = splitChatThreadOptions(options);
 
@@ -200,6 +208,8 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(onResume && { onResume }),
     ...(onResumeToolCall && { onResumeToolCall }),
     ...(joinStrategy && { joinStrategy }),
+    ...(messageRepository && { messageRepository }),
+    ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
 
   if (sourceTransport instanceof AssistantChatTransport) {


### PR DESCRIPTION
closes #6213

## summary

- `useAISDKRuntime` now accepts a branch-aware AI SDK `messageRepository` and `unstable_onBranchChange`.
- the tree is imported into the thread; `useChat` stays the live feed. swapping the two (as in #6275) disconnects streaming and lets `switchToBranch` wipe `chat.messages`.
- empty chat uses the imported tree until `useChat` has a visible path, so a later `messages` sync cannot `resetHead(null)` the siblings.

## test plan

### already verified

- [x] `vitest run src/runtime/useAISDKRuntime.test.ts` in `@assistant-ui/ai-sdk` -> 30/30 green
- [x] `vitest run src/runtime` in `@assistant-ui/ai-sdk` -> 13 files, 99/99 green

### reviewer should verify

- [ ] load a tree with two sibling assistant replies, confirm the branch picker shows 2/2, switch branches, then stream another token and confirm the tree is still there

## notes

- #6275 forwards `messageRepository` in place of `messages`. that is the external-store contract, not this runtime's. this PR is the replacement.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.E4WrORhJe65itPFJzBnxIR_WqqVUet5MhsVCd6VtwaaWHudjMyG9qxa0Bn4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->