### PR TITLE
ci: validate built declarations strictly

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -11,6 +11,8 @@ on:
       - "templates/**"
       - "scripts/generate-api-surface.mjs"
       - "scripts/check-api-surface.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-built-declarations.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -27,6 +29,8 @@ on:
       - "templates/**"
       - "scripts/generate-api-surface.mjs"
       - "scripts/check-api-surface.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-built-declarations.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -146,6 +150,17 @@ jobs:
             # Push to main: Check API surface for packages changed in last commit
             pnpm run api-surface:check -- --skip-build --filter="...[HEAD^1]"
           fi
+
+      - name: Check built declarations
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm run declarations:check -- --filter="...[origin/${{ github.base_ref }}]"
+          else
+            pnpm run declarations:check -- --filter="...[HEAD^1]"
+          fi
+
+      - name: Test built declaration checker
+        run: pnpm run declarations:test
 
       - name: Test API surface generator
         run: pnpm run api-surface:test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*'",
     "api-surface:check": "node scripts/check-api-surface.mjs",
     "api-surface:test": "node --test scripts/generate-api-surface.test.mjs",
+    "declarations:check": "node scripts/check-built-declarations.mjs",
+    "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",
     "check:resource-memo": "node packages/x-buildutils/check-resource-memoization.mjs",
     "lint:fix": "pnpm exec oxlint --fix && pnpm exec oxfmt",

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { optionArgs, optionValues } from "./lib/script-options.mjs";
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function posixPath(file) {
+  return file.replaceAll("\\", "/");
+}
+
+function collectTypeTargets(value) {
+  if (!value || typeof value !== "object") return [];
+  if (typeof value.types === "string") return [value.types];
+  return Object.values(value).flatMap(collectTypeTargets);
+}
+
+function declarationFilesForTarget(packageDir, typePath) {
+  if (!typePath.includes("*")) {
+    const file = path.resolve(packageDir, typePath);
+    if (!existsSync(file)) {
+      throw new Error(
+        `Missing declaration file ${typePath}. Run the package build first.`,
+      );
+    }
+    return [file];
+  }
+
+  if (typePath.split("*").length !== 2) {
+    throw new Error(
+      `Only one wildcard is supported in declaration path ${typePath}.`,
+    );
+  }
+
+  const [prefix, suffix] = typePath.split("*");
+  const files = readdirSync(packageDir, {
+    recursive: true,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(entry.parentPath ?? entry.path, entry.name))
+    .filter((file) => {
+      const relative = `./${posixPath(path.relative(packageDir, file))}`;
+      return relative.startsWith(prefix) && relative.endsWith(suffix);
+    })
+    .sort();
+
+  if (files.length === 0) {
+    throw new Error(
+      `No declaration files matched ${typePath}. Run the package build first.`,
+    );
+  }
+  return files;
+}
+
+export function collectDeclarationEntries(packageDir, pkg) {
+  const entries = [];
+  if (pkg.exports && typeof pkg.exports === "object") {
+    for (const [exportPath, exportValue] of Object.entries(pkg.exports)) {
+      for (const typePath of collectTypeTargets(exportValue)) {
+        for (const file of declarationFilesForTarget(packageDir, typePath)) {
+          entries.push({ exportPath, file });
+        }
+      }
+    }
+  }
+
+  if (entries.length === 0 && typeof pkg.types === "string") {
+    for (const file of declarationFilesForTarget(packageDir, pkg.types)) {
+      entries.push({ exportPath: ".", file });
+    }
+  }
+
+  return entries.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+export function createDeclarationProbe(packageDir, pkg) {
+  const entries = collectDeclarationEntries(packageDir, pkg);
+  if (entries.length === 0) return null;
+
+  const tempDir = mkdtempSync(path.join(packageDir, ".strict-libcheck-"));
+  const paths = {};
+  const imports = [];
+  for (const [index, entry] of entries.entries()) {
+    const alias = `__assistant_ui_strict_libcheck_${index}__`;
+    paths[alias] = [posixPath(path.relative(tempDir, entry.file))];
+    imports.push(`import "${alias}";`);
+  }
+
+  writeFileSync(path.join(tempDir, "probe.ts"), `${imports.join("\n")}\n`);
+  writeFileSync(
+    path.join(tempDir, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        extends: "../tsconfig.json",
+        compilerOptions: {
+          composite: false,
+          incremental: false,
+          noEmit: true,
+          paths,
+          skipLibCheck: false,
+        },
+        files: ["probe.ts"],
+        include: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  return {
+    configPath: path.join(tempDir, "tsconfig.json"),
+    entries,
+    remove() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function collectPackages(repoRoot, filteredPackageNames) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  return readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
+    .filter(existsSync)
+    .map((packageJsonPath) => ({
+      packageDir: path.dirname(packageJsonPath),
+      pkg: readJson(packageJsonPath),
+    }))
+    .filter(({ pkg }) => !pkg.private)
+    .filter(
+      ({ pkg }) => !filteredPackageNames || filteredPackageNames.has(pkg.name),
+    )
+    .sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
+}
+
+function collectTurboFilteredPackageNames(repoRoot, filters) {
+  if (filters.length === 0) return null;
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "turbo",
+      "ls",
+      ...optionArgs("--filter", filters),
+      "--output=json",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to list filtered packages:\n${result.stdout}${result.stderr}`,
+    );
+  }
+
+  const jsonStart = result.stdout.indexOf("{");
+  if (jsonStart === -1) {
+    throw new Error(`Turbo did not return JSON output:\n${result.stdout}`);
+  }
+  const output = JSON.parse(result.stdout.slice(jsonStart));
+  return new Set(output.packages.items.map((item) => item.name));
+}
+
+function checkPackage(repoRoot, packageDir, pkg) {
+  const probe = createDeclarationProbe(packageDir, pkg);
+  if (!probe) return 0;
+
+  try {
+    console.log(
+      `Checking ${pkg.name} (${probe.entries.length} declaration entries)`,
+    );
+    const result = spawnSync(
+      "pnpm",
+      ["exec", "tsc", "--project", probe.configPath, "--pretty", "false"],
+      { cwd: repoRoot, stdio: "inherit" },
+    );
+    return result.status ?? 1;
+  } finally {
+    probe.remove();
+  }
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const filters = optionValues(process.argv.slice(2), "--filter");
+  const filteredPackageNames = collectTurboFilteredPackageNames(
+    repoRoot,
+    filters,
+  );
+  const packages = collectPackages(repoRoot, filteredPackageNames);
+  for (const { packageDir, pkg } of packages) {
+    const status = checkPackage(repoRoot, packageDir, pkg);
+    if (status !== 0) {
+      process.exitCode = status;
+      return;
+    }
+  }
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main();
+}

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  collectDeclarationEntries,
+  createDeclarationProbe,
+} from "./check-built-declarations.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function createFixture(declaration) {
+  const packageDir = mkdtempSync(path.join(tmpdir(), "aui-libcheck-"));
+  mkdirSync(path.join(packageDir, "dist"));
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "fixture-package",
+      type: "module",
+      exports: { ".": { types: "./dist/index.d.ts" } },
+    }),
+  );
+  writeFileSync(
+    path.join(packageDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        strict: true,
+      },
+    }),
+  );
+  writeFileSync(path.join(packageDir, "dist/index.d.ts"), declaration);
+  return packageDir;
+}
+
+function runProbe(packageDir) {
+  const pkg = JSON.parse(
+    readFileSync(path.join(packageDir, "package.json"), "utf8"),
+  );
+  const probe = createDeclarationProbe(packageDir, pkg);
+  assert.ok(probe);
+  try {
+    return spawnSync(
+      "pnpm",
+      ["exec", "tsc", "--project", probe.configPath, "--pretty", "false"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+  } finally {
+    probe.remove();
+  }
+}
+
+test("accepts internally consistent built declarations", () => {
+  const packageDir = createFixture("export interface PresentType {}\n");
+  try {
+    const result = runProbe(packageDir);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("rejects dangling types in built declarations", () => {
+  const packageDir = createFixture(
+    "export declare const broken: MissingType;\n",
+  );
+  try {
+    const result = runProbe(packageDir);
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stdout + result.stderr,
+      /Cannot find name 'MissingType'/,
+    );
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("expands wildcard declaration exports", () => {
+  const packageDir = createFixture("export {};\n");
+  mkdirSync(path.join(packageDir, "dist/features"));
+  writeFileSync(
+    path.join(packageDir, "dist/features/alpha.d.ts"),
+    "export {};\n",
+  );
+  writeFileSync(
+    path.join(packageDir, "dist/features/beta.d.ts"),
+    "export {};\n",
+  );
+  try {
+    const entries = collectDeclarationEntries(packageDir, {
+      exports: {
+        "./features/*": { types: "./dist/features/*.d.ts" },
+      },
+    });
+    assert.deepEqual(
+      entries.map((entry) => path.basename(entry.file)),
+      ["alpha.d.ts", "beta.d.ts"],
+    );
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- type-check every selected package built declaration entry with skipLibCheck disabled
- reuse the changed-package Turbo filter in the existing code-quality workflow
- add deterministic fixtures proving valid declarations pass and dangling built types fail

## Why

The API-surface check tracks intended public exports, but it does not validate the internal consistency of every declaration file that is shipped. A removed internal type can therefore leave an exported declaration dangling without failing CI.

The new probe maps each published declaration entry into a temporary TypeScript project that extends the package configuration and runs with skipLibCheck disabled after the package build.

## Testing

- pnpm run declarations:test
- pnpm run declarations:check -- --filter=@assistant-ui/core
- pnpm run api-surface:test
- pnpm lint (0 errors; 122 existing warnings)

Closes #5979

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Bpj-CshkyzBbp4lnrCTiFyfRhcbD-8F81KwR-CWEV6vtZWT4g6S-LeAjniM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->