### PR TITLE
fix(ai-sdk): route sends through replacement transports

### DIFF
--- a/.changeset/steady-transports-route.md
+++ b/.changeset/steady-transports-route.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: route immediate sends through replacement chat transports

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -2130,7 +2130,8 @@ type Unstable_InteractableSnapshotEntry = {
 
 type Unsubscribe = () => void;
 
-type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE> & {
+type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
   cloud?: AssistantCloud | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -8,7 +8,9 @@ import { ComponentType, ReactNode } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
-type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
+type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
+};
 
 type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ExternalStoreSharedOptions & {
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -2130,7 +2130,8 @@ type Unstable_InteractableSnapshotEntry = {
 
 type Unsubscribe = () => void;
 
-type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE> & {
+type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
   cloud?: AssistantCloud | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
 };

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -8,7 +8,9 @@ import { ComponentType, ReactNode } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
-type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatThreadOptions<UI_MESSAGE>;
+type AISDKChatOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
+};
 
 type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ExternalStoreSharedOptions & {
   adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -592,6 +592,12 @@ const runtime = useChatRuntime({
 });
 ```
 
+`useChatRuntime` clones `AssistantChatTransport` instances per thread so their
+assistant-ui runtime wiring stays isolated. Subclasses that keep additional
+constructor arguments or instance fields should override `__internal_clone()`
+to preserve that state. Other AI SDK `ChatTransport` implementations are
+shared as-is.
+
 If you need a transport that does not inherit from `AssistantChatTransport`, you forfeit automatic system-message and frontend-tool forwarding; the transport is then a regular AI SDK `ChatTransport` and you control everything explicitly.
 
 ## Runtime options

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -592,11 +592,11 @@ const runtime = useChatRuntime({
 });
 ```
 
-`useChatRuntime` clones `AssistantChatTransport` instances per thread so their
-assistant-ui runtime wiring stays isolated. Subclasses that keep additional
-constructor arguments or instance fields should override `__internal_clone()`
-to preserve that state. Other AI SDK `ChatTransport` implementations are
-shared as-is.
+`useChatRuntime` and `AISDKChat` clone `AssistantChatTransport` instances per
+thread so their assistant-ui runtime wiring stays isolated. Subclasses that
+keep additional constructor arguments or instance fields should override
+`__internal_clone()` to preserve that state. Other AI SDK `ChatTransport`
+implementations are shared as-is.
 
 If you need a transport that does not inherit from `AssistantChatTransport`, you forfeit automatic system-message and frontend-tool forwarding; the transport is then a regular AI SDK `ChatTransport` and you control everything explicitly.
 

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -82,6 +82,7 @@
     "@types/react-dom": "^19.2.4",
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "vitest": "^4.1.10"
   },
   "publishConfig": {

--- a/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/AISDKChat.integration.test.tsx
@@ -1,15 +1,68 @@
 // @vitest-environment jsdom
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { render, waitFor } from "@testing-library/react";
 import { StrictMode } from "react";
 import { AuiConfig, AuiProvider, useAui } from "@assistant-ui/store";
 import { flushTapSync } from "@assistant-ui/tap";
-import { describe, expect, it } from "vitest";
+import type { ChatTransport, UIMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
 import { AISDKChat } from "./AISDKChat";
 import { createCancellableTransport } from "./__tests__/controlled-transport";
 
 describe("AISDKChat React integration", () => {
+  it("routes sends through a replacement transport", async () => {
+    const emptyStream = () =>
+      new ReadableStream({ start: (controller) => controller.close() });
+    const sendA = vi.fn(async () => emptyStream());
+    const sendB = vi.fn(async () => emptyStream());
+    const transportA: ChatTransport<UIMessage> = {
+      sendMessages: sendA,
+      reconnectToStream: vi.fn(),
+    };
+    const transportB: ChatTransport<UIMessage> = {
+      sendMessages: sendB,
+      reconnectToStream: vi.fn(),
+    };
+    let initialClient: ReturnType<typeof useAui> | undefined;
+    let currentClient: ReturnType<typeof useAui> | undefined;
+    const CaptureClient = () => {
+      const aui = useAui();
+      initialClient ??= aui;
+      currentClient = aui;
+      return null;
+    };
+    const SendOnLayout = () => {
+      const aui = useAui();
+      useLayoutEffect(() => {
+        flushTapSync(() => {
+          aui.composer.setText("hello");
+          aui.composer.send();
+        });
+      }, [aui]);
+      return null;
+    };
+    const App = ({
+      transport,
+      send = false,
+    }: {
+      transport: ChatTransport<UIMessage>;
+      send?: boolean;
+    }) => (
+      <AuiProvider config={AuiConfig({ threads: AISDKChat({ transport }) })}>
+        <CaptureClient />
+        {send && <SendOnLayout />}
+      </AuiProvider>
+    );
+
+    const view = render(<App transport={transportA} />);
+    view.rerender(<App transport={transportB} send />);
+
+    await waitFor(() => expect(sendB).toHaveBeenCalledOnce());
+    expect(sendA).not.toHaveBeenCalled();
+    expect(currentClient).toBe(initialClient);
+  });
+
   it("does not treat React provider unmount as client destruction", async () => {
     const { transport, getCancelCount, close } = createCancellableTransport();
     let started = false;

--- a/packages/ai-sdk/src/runtime/AISDKChat.ts
+++ b/packages/ai-sdk/src/runtime/AISDKChat.ts
@@ -2,7 +2,7 @@
 
 import { resource, useResource } from "@assistant-ui/tap";
 import { useState } from "react";
-import { generateId } from "ai";
+import { generateId, type ChatTransport } from "ai";
 import type { UIMessage } from "@ai-sdk/react";
 import {
   RuntimeAdapter,
@@ -11,8 +11,18 @@ import {
 import { attachTransformScopes } from "@assistant-ui/store/client";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
 
-export type AISDKChatOptions<UI_MESSAGE extends UIMessage = UIMessage> =
-  ChatThreadOptions<UI_MESSAGE>;
+export type AISDKChatOptions<UI_MESSAGE extends UIMessage = UIMessage> = Omit<
+  ChatThreadOptions<UI_MESSAGE>,
+  "transport"
+> & {
+  /**
+   * The transport the chat sends through. An `AssistantChatTransport` is
+   * cloned so its assistant-ui runtime wiring stays private to this chat;
+   * subclasses with additional state should override `__internal_clone()`.
+   * Other transport implementations are used as-is.
+   */
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
+};
 
 const useAISDKChat = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: AISDKChatOptions<UI_MESSAGE>,

--- a/packages/ai-sdk/src/runtime/AISDKChat.ts
+++ b/packages/ai-sdk/src/runtime/AISDKChat.ts
@@ -28,6 +28,7 @@ const useAISDKChat = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: AISDKChatOptions<UI_MESSAGE>,
 ) => {
   const [id] = useState(() => options?.id ?? generateId());
+  const { transport, ...chatOptions } = options ?? {};
   // The transport resolves the request id from the thread list item, falling
   // back to the runtime's main item, whose id here is the external store's
   // placeholder constant. The single thread of this entry is the chat itself,
@@ -35,12 +36,20 @@ const useAISDKChat = <UI_MESSAGE extends UIMessage = UIMessage>(
   const [threadListItem] = useState(() => ({
     initialize: async () => ({ remoteId: id, externalId: undefined }),
   }));
-  const runtime = useChatThread(options, {
-    id,
-    isMainThread: true,
-    getThreadListItem: () => threadListItem,
-    stopOnClientDestroy: true,
-  });
+  const runtime = useChatThread(
+    options === undefined
+      ? undefined
+      : {
+          ...chatOptions,
+          ...(transport !== undefined && { transport }),
+        },
+    {
+      id,
+      isMainThread: true,
+      getThreadListItem: () => threadListItem,
+      stopOnClientDestroy: true,
+    },
+  );
   return useResource(RuntimeAdapter(runtime));
 };
 

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
@@ -34,6 +34,18 @@ const createRuntime = (system: string) =>
   }) as AssistantRuntime;
 
 describe("DynamicChatTransport", () => {
+  it("rejects sends without a registered thread context", () => {
+    const dynamicTransport = new DynamicChatTransport(
+      new AssistantChatTransport<UIMessage>(),
+    );
+
+    expect(() =>
+      dynamicTransport.getCurrentTransport("missing-thread"),
+    ).toThrow(
+      'DynamicChatTransport has no registered context for chat "missing-thread"',
+    );
+  });
+
   it("keeps AssistantChatTransport wiring scoped per thread", async () => {
     const bodies: Array<{ id: string; system: string }> = [];
     const createTransport = () =>

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
@@ -40,22 +40,29 @@ describe("DynamicChatTransport", () => {
     );
 
     expect(() =>
-      dynamicTransport.getCurrentTransport("missing-thread"),
+      dynamicTransport.sendMessages(sendMessagesOptions("missing-thread")),
     ).toThrow(
       'DynamicChatTransport has no registered context for chat "missing-thread"',
     );
   });
 
   it("keeps AssistantChatTransport wiring scoped per thread", async () => {
-    const bodies: Array<{ id: string; system: string }> = [];
-    const createTransport = () =>
-      new AssistantChatTransport<UIMessage>({
-        fetch: vi.fn(async (_input, init) => {
-          bodies.push(JSON.parse(String(init?.body)));
-          return emptyStreamResponse();
-        }),
+    const createTransport = () => {
+      const bodies: Array<{ id: string; system: string }> = [];
+      const fetch = vi.fn(async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return emptyStreamResponse();
       });
-    const dynamicTransport = new DynamicChatTransport(createTransport());
+      return {
+        bodies,
+        fetch,
+        transport: new AssistantChatTransport<UIMessage>({
+          fetch,
+        }),
+      };
+    };
+    const initial = createTransport();
+    const dynamicTransport = new DynamicChatTransport(initial.transport);
     const ownerA = {};
     const ownerB = {};
 
@@ -85,13 +92,18 @@ describe("DynamicChatTransport", () => {
     await dynamicTransport.sendMessages(sendMessagesOptions("thread-a"));
     await dynamicTransport.sendMessages(sendMessagesOptions("thread-b"));
 
-    dynamicTransport.setTransport(createTransport());
+    const replacement = createTransport();
+    dynamicTransport.setTransport(replacement.transport);
     await dynamicTransport.sendMessages(sendMessagesOptions("thread-a"));
     await dynamicTransport.sendMessages(sendMessagesOptions("thread-b"));
 
-    expect(bodies).toEqual([
+    expect(initial.fetch).toHaveBeenCalledTimes(2);
+    expect(replacement.fetch).toHaveBeenCalledTimes(2);
+    expect(initial.bodies).toEqual([
       expect.objectContaining({ id: "remote-a", system: "system-a" }),
       expect.objectContaining({ id: "remote-b", system: "system-b" }),
+    ]);
+    expect(replacement.bodies).toEqual([
       expect.objectContaining({ id: "remote-a", system: "system-a" }),
       expect.objectContaining({ id: "remote-b", system: "system-b" }),
     ]);

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
@@ -1,0 +1,90 @@
+import type { AssistantRuntime } from "@assistant-ui/core";
+import type { UIMessage } from "@ai-sdk/react";
+import { describe, expect, it, vi } from "vitest";
+import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import { DynamicChatTransport } from "./DynamicChatTransport";
+
+const emptyStreamResponse = () =>
+  new Response(
+    new ReadableStream({ start: (controller) => controller.close() }),
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+
+const sendMessagesOptions = (chatId: string) => ({
+  trigger: "submit-message" as const,
+  chatId,
+  messageId: undefined,
+  messages: [
+    {
+      id: `message-${chatId}`,
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: "hello" }],
+    },
+  ],
+  abortSignal: undefined,
+});
+
+const createRuntime = (system: string) =>
+  ({
+    thread: {
+      getModelContext: () => ({ system }),
+    },
+  }) as AssistantRuntime;
+
+describe("DynamicChatTransport", () => {
+  it("keeps AssistantChatTransport wiring scoped per thread", async () => {
+    const bodies: Array<{ id: string; system: string }> = [];
+    const createTransport = () =>
+      new AssistantChatTransport<UIMessage>({
+        fetch: vi.fn(async (_input, init) => {
+          bodies.push(JSON.parse(String(init?.body)));
+          return emptyStreamResponse();
+        }),
+      });
+    const dynamicTransport = new DynamicChatTransport(createTransport());
+    const ownerA = {};
+    const ownerB = {};
+
+    dynamicTransport.setThreadContext(
+      "thread-a",
+      ownerA,
+      createRuntime("system-a"),
+      () => ({
+        initialize: async () => ({
+          remoteId: "remote-a",
+          externalId: undefined,
+        }),
+      }),
+    );
+    dynamicTransport.setThreadContext(
+      "thread-b",
+      ownerB,
+      createRuntime("system-b"),
+      () => ({
+        initialize: async () => ({
+          remoteId: "remote-b",
+          externalId: undefined,
+        }),
+      }),
+    );
+
+    await dynamicTransport.sendMessages(sendMessagesOptions("thread-a"));
+    await dynamicTransport.sendMessages(sendMessagesOptions("thread-b"));
+
+    dynamicTransport.setTransport(createTransport());
+    await dynamicTransport.sendMessages(sendMessagesOptions("thread-a"));
+    await dynamicTransport.sendMessages(sendMessagesOptions("thread-b"));
+
+    expect(bodies).toEqual([
+      expect.objectContaining({ id: "remote-a", system: "system-a" }),
+      expect.objectContaining({ id: "remote-b", system: "system-b" }),
+      expect.objectContaining({ id: "remote-a", system: "system-a" }),
+      expect.objectContaining({ id: "remote-b", system: "system-b" }),
+    ]);
+    expect(dynamicTransport.getCurrentTransport("thread-a")).not.toBe(
+      dynamicTransport.getCurrentTransport("thread-b"),
+    );
+  });
+});

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
@@ -111,4 +111,40 @@ describe("DynamicChatTransport", () => {
       dynamicTransport.getCurrentTransport("thread-b"),
     );
   });
+
+  it("defers replacement clones until a thread uses the transport", async () => {
+    const clone = vi.spyOn(
+      AssistantChatTransport.prototype,
+      "__internal_clone",
+    );
+    const dynamicTransport = new DynamicChatTransport(
+      new AssistantChatTransport<UIMessage>(),
+    );
+    dynamicTransport.setThreadContext(
+      "thread-a",
+      {},
+      createRuntime("system-a"),
+      () => ({
+        initialize: async () => ({
+          remoteId: "remote-a",
+          externalId: undefined,
+        }),
+      }),
+    );
+    clone.mockClear();
+
+    for (let index = 0; index < 10; index++) {
+      dynamicTransport.setTransport(
+        new AssistantChatTransport<UIMessage>({
+          fetch: async () => emptyStreamResponse(),
+        }),
+      );
+    }
+
+    expect(clone).not.toHaveBeenCalled();
+
+    await dynamicTransport.sendMessages(sendMessagesOptions("thread-a"));
+
+    expect(clone).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.test.ts
@@ -1,6 +1,6 @@
 import type { AssistantRuntime } from "@assistant-ui/core";
 import type { UIMessage } from "@ai-sdk/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import { DynamicChatTransport } from "./DynamicChatTransport";
 
@@ -34,6 +34,10 @@ const createRuntime = (system: string) =>
   }) as AssistantRuntime;
 
 describe("DynamicChatTransport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("rejects sends without a registered thread context", () => {
     const dynamicTransport = new DynamicChatTransport(
       new AssistantChatTransport<UIMessage>(),

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -26,6 +26,7 @@ export class DynamicChatTransport<
   UI_MESSAGE extends UIMessage,
 > implements ChatTransport<UI_MESSAGE> {
   private readonly listeners = new Set<() => void>();
+  private hasPendingNotification = false;
   private runtime: AssistantRuntime | undefined;
   private getThreadListItem:
     | (() => InitializableThreadListItem | undefined)
@@ -53,8 +54,14 @@ export class DynamicChatTransport<
     this.transport = transport;
     this.wireTransport();
     if (previousStorage !== getResumableStorage(transport)) {
-      for (const listener of this.listeners) listener();
+      this.hasPendingNotification = true;
     }
+  }
+
+  public flushTransportChange() {
+    if (!this.hasPendingNotification) return;
+    this.hasPendingNotification = false;
+    for (const listener of this.listeners) listener();
   }
 
   public setRuntime(runtime: AssistantRuntime) {

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -39,7 +39,7 @@ export class DynamicChatTransport<
     (options) => this.getTransport(options.chatId).reconnectToStream(options);
 
   public readonly getCurrentTransport = (chatId: string) =>
-    this.getTransport(chatId);
+    this.threadContexts.get(chatId)?.transport ?? this.transport;
 
   public readonly subscribe = (listener: () => void) => {
     this.listeners.add(listener);

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -5,33 +5,27 @@ import {
   AssistantChatTransport,
   type InitializableThreadListItem,
 } from "../transport/AssistantChatTransport";
+import { getResumableAdapter } from "./getResumableAdapter";
 
-const getResumableStorage = <UI_MESSAGE extends UIMessage>(
-  transport: ChatTransport<UI_MESSAGE>,
-) => {
-  if (transport instanceof AssistantChatTransport) {
-    return transport.getResumableAdapter()?.storage;
-  }
-  const getAdapter = (
-    transport as {
-      getResumableAdapter?: () => { storage?: unknown } | undefined;
-    }
-  ).getResumableAdapter;
-  return typeof getAdapter === "function"
-    ? getAdapter.call(transport)?.storage
-    : undefined;
+type ThreadTransportContext<UI_MESSAGE extends UIMessage> = {
+  owner: object;
+  transport: ChatTransport<UI_MESSAGE>;
+  runtime?: AssistantRuntime | undefined;
+  getThreadListItem?:
+    | (() => InitializableThreadListItem | undefined)
+    | undefined;
 };
 
 export class DynamicChatTransport<
   UI_MESSAGE extends UIMessage,
 > implements ChatTransport<UI_MESSAGE> {
   private readonly listeners = new Set<() => void>();
+  private readonly threadContexts = new Map<
+    string,
+    ThreadTransportContext<UI_MESSAGE>
+  >();
   private hasPendingNotification = false;
-  private runtime: AssistantRuntime | undefined;
   private transport: ChatTransport<UI_MESSAGE>;
-  private getThreadListItem:
-    | (() => InitializableThreadListItem | undefined)
-    | undefined;
 
   constructor(transport: ChatTransport<UI_MESSAGE>) {
     this.transport = transport;
@@ -39,12 +33,13 @@ export class DynamicChatTransport<
 
   public readonly sendMessages: ChatTransport<UI_MESSAGE>["sendMessages"] = (
     options,
-  ) => this.transport.sendMessages(options);
+  ) => this.getTransport(options.chatId).sendMessages(options);
 
   public readonly reconnectToStream: ChatTransport<UI_MESSAGE>["reconnectToStream"] =
-    (options) => this.transport.reconnectToStream(options);
+    (options) => this.getTransport(options.chatId).reconnectToStream(options);
 
-  public readonly getCurrentTransport = () => this.transport;
+  public readonly getCurrentTransport = (chatId: string) =>
+    this.getTransport(chatId);
 
   public readonly subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -53,11 +48,14 @@ export class DynamicChatTransport<
 
   public setTransport(transport: ChatTransport<UI_MESSAGE>) {
     if (this.transport === transport) return;
-    const previousStorage = getResumableStorage(this.transport);
     this.transport = transport;
-    this.wireTransport();
-    if (previousStorage !== getResumableStorage(transport)) {
-      this.hasPendingNotification = true;
+    for (const context of this.threadContexts.values()) {
+      const previousStorage = getResumableAdapter(context.transport)?.storage;
+      context.transport = this.createThreadTransport(transport);
+      this.wireTransport(context);
+      if (previousStorage !== getResumableAdapter(context.transport)?.storage) {
+        this.hasPendingNotification = true;
+      }
     }
   }
 
@@ -67,23 +65,51 @@ export class DynamicChatTransport<
     for (const listener of this.listeners) listener();
   }
 
-  public setRuntime(runtime: AssistantRuntime) {
-    this.runtime = runtime;
-    this.wireTransport();
+  public registerThread(chatId: string, owner: object) {
+    const existing = this.threadContexts.get(chatId);
+    if (existing?.owner === owner) return;
+    this.threadContexts.set(chatId, {
+      owner,
+      transport: this.createThreadTransport(this.transport),
+    });
   }
 
-  public setGetThreadListItem(
+  public setThreadContext(
+    chatId: string,
+    owner: object,
+    runtime: AssistantRuntime,
     getThreadListItem: () => InitializableThreadListItem | undefined,
   ) {
-    this.getThreadListItem = getThreadListItem;
-    this.wireTransport();
+    this.registerThread(chatId, owner);
+    const context = this.threadContexts.get(chatId)!;
+    context.runtime = runtime;
+    context.getThreadListItem = getThreadListItem;
+    this.wireTransport(context);
   }
 
-  private wireTransport() {
-    if (!(this.transport instanceof AssistantChatTransport)) return;
-    if (this.runtime) this.transport.setRuntime(this.runtime);
-    if (this.getThreadListItem) {
-      this.transport.__internal_setGetThreadListItem(this.getThreadListItem);
+  public unregisterThread(chatId: string, owner: object) {
+    if (this.threadContexts.get(chatId)?.owner === owner) {
+      this.threadContexts.delete(chatId);
+    }
+  }
+
+  private getTransport(chatId: string) {
+    return this.threadContexts.get(chatId)?.transport ?? this.transport;
+  }
+
+  private createThreadTransport(transport: ChatTransport<UI_MESSAGE>) {
+    return transport instanceof AssistantChatTransport
+      ? transport.__internal_clone()
+      : transport;
+  }
+
+  private wireTransport(context: ThreadTransportContext<UI_MESSAGE>) {
+    if (!(context.transport instanceof AssistantChatTransport)) return;
+    if (context.runtime) context.transport.setRuntime(context.runtime);
+    if (context.getThreadListItem) {
+      context.transport.__internal_setGetThreadListItem(
+        context.getThreadListItem,
+      );
     }
   }
 }

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -1,0 +1,79 @@
+import type { AssistantRuntime } from "@assistant-ui/core";
+import type { UIMessage } from "@ai-sdk/react";
+import type { ChatTransport } from "ai";
+import {
+  AssistantChatTransport,
+  type InitializableThreadListItem,
+} from "../transport/AssistantChatTransport";
+
+const getResumableStorage = <UI_MESSAGE extends UIMessage>(
+  transport: ChatTransport<UI_MESSAGE>,
+) => {
+  if (transport instanceof AssistantChatTransport) {
+    return transport.getResumableAdapter()?.storage;
+  }
+  const getAdapter = (
+    transport as {
+      getResumableAdapter?: () => { storage?: unknown } | undefined;
+    }
+  ).getResumableAdapter;
+  return typeof getAdapter === "function"
+    ? getAdapter.call(transport)?.storage
+    : undefined;
+};
+
+export class DynamicChatTransport<
+  UI_MESSAGE extends UIMessage,
+> implements ChatTransport<UI_MESSAGE> {
+  private readonly listeners = new Set<() => void>();
+  private runtime: AssistantRuntime | undefined;
+  private getThreadListItem:
+    | (() => InitializableThreadListItem | undefined)
+    | undefined;
+
+  constructor(private transport: ChatTransport<UI_MESSAGE>) {}
+
+  public readonly sendMessages: ChatTransport<UI_MESSAGE>["sendMessages"] = (
+    options,
+  ) => this.transport.sendMessages(options);
+
+  public readonly reconnectToStream: ChatTransport<UI_MESSAGE>["reconnectToStream"] =
+    (options) => this.transport.reconnectToStream(options);
+
+  public readonly getCurrentTransport = () => this.transport;
+
+  public readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  public setTransport(transport: ChatTransport<UI_MESSAGE>) {
+    if (this.transport === transport) return;
+    const previousStorage = getResumableStorage(this.transport);
+    this.transport = transport;
+    this.wireTransport();
+    if (previousStorage !== getResumableStorage(transport)) {
+      for (const listener of this.listeners) listener();
+    }
+  }
+
+  public setRuntime(runtime: AssistantRuntime) {
+    this.runtime = runtime;
+    this.wireTransport();
+  }
+
+  public setGetThreadListItem(
+    getThreadListItem: () => InitializableThreadListItem | undefined,
+  ) {
+    this.getThreadListItem = getThreadListItem;
+    this.wireTransport();
+  }
+
+  private wireTransport() {
+    if (!(this.transport instanceof AssistantChatTransport)) return;
+    if (this.runtime) this.transport.setRuntime(this.runtime);
+    if (this.getThreadListItem) {
+      this.transport.__internal_setGetThreadListItem(this.getThreadListItem);
+    }
+  }
+}

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -17,6 +17,11 @@ type ThreadTransportContext<UI_MESSAGE extends UIMessage> = {
     | undefined;
 };
 
+type ThreadTransportBinding = {
+  runtime: AssistantRuntime;
+  getThreadListItem: () => InitializableThreadListItem | undefined;
+};
+
 export class DynamicChatTransport<
   UI_MESSAGE extends UIMessage,
 > implements ChatTransport<UI_MESSAGE> {
@@ -43,6 +48,26 @@ export class DynamicChatTransport<
     this.getThreadTransport(this.threadContexts.get(chatId)) ?? this.transport;
 
   public readonly getCurrentSourceTransport = () => this.transport;
+
+  public createThreadProxy(
+    owner: object,
+    getBinding: () => ThreadTransportBinding,
+  ): ChatTransport<UI_MESSAGE> {
+    return {
+      sendMessages: (options) =>
+        this.getOrCreateBoundTransport(
+          options.chatId,
+          owner,
+          getBinding,
+        ).sendMessages(options),
+      reconnectToStream: (options) =>
+        this.getOrCreateBoundTransport(
+          options.chatId,
+          owner,
+          getBinding,
+        ).reconnectToStream(options),
+    };
+  }
 
   public readonly subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -78,11 +103,10 @@ export class DynamicChatTransport<
     runtime: AssistantRuntime,
     getThreadListItem: () => InitializableThreadListItem | undefined,
   ) {
-    this.registerThread(chatId, owner);
-    const context = this.threadContexts.get(chatId)!;
-    context.runtime = runtime;
-    context.getThreadListItem = getThreadListItem;
-    this.getThreadTransport(context);
+    this.getBoundTransport(chatId, owner, {
+      runtime,
+      getThreadListItem,
+    });
   }
 
   public unregisterThread(chatId: string, owner: object) {
@@ -99,6 +123,29 @@ export class DynamicChatTransport<
       );
     }
     return this.getThreadTransport(context)!;
+  }
+
+  private getBoundTransport(
+    chatId: string,
+    owner: object,
+    binding: ThreadTransportBinding,
+  ) {
+    this.registerThread(chatId, owner);
+    const context = this.threadContexts.get(chatId)!;
+    context.runtime = binding.runtime;
+    context.getThreadListItem = binding.getThreadListItem;
+    return this.getThreadTransport(context)!;
+  }
+
+  private getOrCreateBoundTransport(
+    chatId: string,
+    owner: object,
+    getBinding: () => ThreadTransportBinding,
+  ) {
+    const context = this.threadContexts.get(chatId);
+    return context?.owner === owner
+      ? this.getThreadTransport(context)!
+      : this.getBoundTransport(chatId, owner, getBinding());
   }
 
   private getThreadTransport(

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -9,7 +9,8 @@ import { getResumableAdapter } from "./getResumableAdapter";
 
 type ThreadTransportContext<UI_MESSAGE extends UIMessage> = {
   owner: object;
-  transport: ChatTransport<UI_MESSAGE>;
+  sourceTransport?: ChatTransport<UI_MESSAGE> | undefined;
+  transport?: ChatTransport<UI_MESSAGE> | undefined;
   runtime?: AssistantRuntime | undefined;
   getThreadListItem?:
     | (() => InitializableThreadListItem | undefined)
@@ -39,7 +40,9 @@ export class DynamicChatTransport<
     (options) => this.getTransport(options.chatId).reconnectToStream(options);
 
   public readonly getCurrentTransport = (chatId: string) =>
-    this.threadContexts.get(chatId)?.transport ?? this.transport;
+    this.getThreadTransport(this.threadContexts.get(chatId)) ?? this.transport;
+
+  public readonly getCurrentSourceTransport = () => this.transport;
 
   public readonly subscribe = (listener: () => void) => {
     this.listeners.add(listener);
@@ -48,14 +51,10 @@ export class DynamicChatTransport<
 
   public setTransport(transport: ChatTransport<UI_MESSAGE>) {
     if (this.transport === transport) return;
+    const previousStorage = getResumableAdapter(this.transport)?.storage;
     this.transport = transport;
-    for (const context of this.threadContexts.values()) {
-      const previousStorage = getResumableAdapter(context.transport)?.storage;
-      context.transport = this.createThreadTransport(transport);
-      this.wireTransport(context);
-      if (previousStorage !== getResumableAdapter(context.transport)?.storage) {
-        this.hasPendingNotification = true;
-      }
+    if (previousStorage !== getResumableAdapter(transport)?.storage) {
+      this.hasPendingNotification = true;
     }
   }
 
@@ -70,7 +69,6 @@ export class DynamicChatTransport<
     if (existing?.owner === owner) return;
     this.threadContexts.set(chatId, {
       owner,
-      transport: this.createThreadTransport(this.transport),
     });
   }
 
@@ -84,7 +82,7 @@ export class DynamicChatTransport<
     const context = this.threadContexts.get(chatId)!;
     context.runtime = runtime;
     context.getThreadListItem = getThreadListItem;
-    this.wireTransport(context);
+    this.getThreadTransport(context);
   }
 
   public unregisterThread(chatId: string, owner: object) {
@@ -100,7 +98,19 @@ export class DynamicChatTransport<
         `DynamicChatTransport has no registered context for chat "${chatId}"`,
       );
     }
-    return context.transport;
+    return this.getThreadTransport(context)!;
+  }
+
+  private getThreadTransport(
+    context: ThreadTransportContext<UI_MESSAGE> | undefined,
+  ) {
+    if (!context) return undefined;
+    if (context.sourceTransport !== this.transport) {
+      context.sourceTransport = this.transport;
+      context.transport = this.createThreadTransport(this.transport);
+    }
+    this.wireTransport(context, context.transport!);
+    return context.transport!;
   }
 
   private createThreadTransport(transport: ChatTransport<UI_MESSAGE>) {
@@ -109,13 +119,14 @@ export class DynamicChatTransport<
       : transport;
   }
 
-  private wireTransport(context: ThreadTransportContext<UI_MESSAGE>) {
-    if (!(context.transport instanceof AssistantChatTransport)) return;
-    if (context.runtime) context.transport.setRuntime(context.runtime);
+  private wireTransport(
+    context: ThreadTransportContext<UI_MESSAGE>,
+    transport: ChatTransport<UI_MESSAGE>,
+  ) {
+    if (!(transport instanceof AssistantChatTransport)) return;
+    if (context.runtime) transport.setRuntime(context.runtime);
     if (context.getThreadListItem) {
-      context.transport.__internal_setGetThreadListItem(
-        context.getThreadListItem,
-      );
+      transport.__internal_setGetThreadListItem(context.getThreadListItem);
     }
   }
 }

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -94,7 +94,13 @@ export class DynamicChatTransport<
   }
 
   private getTransport(chatId: string) {
-    return this.threadContexts.get(chatId)?.transport ?? this.transport;
+    const context = this.threadContexts.get(chatId);
+    if (!context) {
+      throw new Error(
+        `DynamicChatTransport has no registered context for chat "${chatId}"`,
+      );
+    }
+    return context.transport;
   }
 
   private createThreadTransport(transport: ChatTransport<UI_MESSAGE>) {

--- a/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/DynamicChatTransport.ts
@@ -28,11 +28,14 @@ export class DynamicChatTransport<
   private readonly listeners = new Set<() => void>();
   private hasPendingNotification = false;
   private runtime: AssistantRuntime | undefined;
+  private transport: ChatTransport<UI_MESSAGE>;
   private getThreadListItem:
     | (() => InitializableThreadListItem | undefined)
     | undefined;
 
-  constructor(private transport: ChatTransport<UI_MESSAGE>) {}
+  constructor(transport: ChatTransport<UI_MESSAGE>) {
+    this.transport = transport;
+  }
 
   public readonly sendMessages: ChatTransport<UI_MESSAGE>["sendMessages"] = (
     options,

--- a/packages/ai-sdk/src/runtime/getResumableAdapter.ts
+++ b/packages/ai-sdk/src/runtime/getResumableAdapter.ts
@@ -1,0 +1,16 @@
+import type { UIMessage } from "@ai-sdk/react";
+import type { ChatTransport } from "ai";
+import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import type { AssistantChatResumableOptions } from "../transport/resumable";
+
+export const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
+  transport: ChatTransport<UI_MESSAGE>,
+): AssistantChatResumableOptions | undefined => {
+  if (transport instanceof AssistantChatTransport) {
+    return transport.getResumableAdapter();
+  }
+  const candidate = (transport as { getResumableAdapter?: () => unknown })
+    .getResumableAdapter;
+  if (typeof candidate !== "function") return undefined;
+  return candidate.call(transport) as AssistantChatResumableOptions | undefined;
+};

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
 import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
@@ -192,5 +192,59 @@ describe("useChatRuntime integration", () => {
     expect(transport.getCurrentTransport("suspended-thread")).toBe(
       sourceTransport,
     );
+  });
+
+  it("uses the latest thread list item getter after host rerenders", async () => {
+    const bodies: Array<{ id: string }> = [];
+    const sourceTransport = new AssistantChatTransport<UIMessage>({
+      fetch: vi.fn(async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          new ReadableStream({ start: (controller) => controller.close() }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    });
+    const transport = new DynamicChatTransport(sourceTransport);
+    const { rerender } = renderHook(
+      ({ remoteId }: { remoteId: string }) =>
+        useChatThread(
+          { transport },
+          {
+            id: "stable-thread",
+            isMainThread: true,
+            getThreadListItem: () => ({
+              initialize: async () => ({
+                remoteId,
+                externalId: undefined,
+              }),
+            }),
+          },
+        ),
+      { initialProps: { remoteId: "remote-a" } },
+    );
+    const send = () =>
+      transport.sendMessages({
+        trigger: "submit-message",
+        chatId: "stable-thread",
+        messageId: undefined,
+        messages: [
+          {
+            id: "message-id",
+            role: "user",
+            parts: [{ type: "text", text: "hello" }],
+          },
+        ],
+        abortSignal: undefined,
+      });
+
+    await send();
+    rerender({ remoteId: "remote-b" });
+    await send();
+
+    expect(bodies).toEqual([
+      expect.objectContaining({ id: "remote-a" }),
+      expect.objectContaining({ id: "remote-b" }),
+    ]);
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
-import type { UIMessage } from "ai";
+import type { ChatTransport, UIMessage } from "ai";
 import { StrictMode, useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import { useChatRuntime } from "./useChatRuntime";
 
@@ -63,5 +64,38 @@ describe("useChatRuntime integration", () => {
         "Hello from the server",
       );
     });
+  });
+
+  it("routes sends through a replacement transport", async () => {
+    const createEmptyStream = () =>
+      new ReadableStream({ start: (controller) => controller.close() });
+    const sendA = vi.fn(async () => createEmptyStream());
+    const sendB = vi.fn(async () => createEmptyStream());
+    const transportA: ChatTransport<UIMessage> = {
+      sendMessages: sendA,
+      reconnectToStream: vi.fn(),
+    };
+    const transportB: ChatTransport<UIMessage> = {
+      sendMessages: sendB,
+      reconnectToStream: vi.fn(),
+    };
+    let runtime: AssistantRuntime | undefined;
+    const App = ({ transport }: { transport: ChatTransport<UIMessage> }) => {
+      runtime = useChatRuntime({ transport });
+      return <AssistantRuntimeProvider runtime={runtime} />;
+    };
+
+    const view = render(<App transport={transportA} />);
+    view.rerender(<App transport={transportB} />);
+
+    await act(async () => {
+      await runtime!.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    expect(sendB).toHaveBeenCalledOnce();
+    expect(sendA).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
 
-import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { AssistantRuntime } from "@assistant-ui/core";
-import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import {
+  AssistantRuntimeProvider,
+  RuntimeAdapterProvider,
+} from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import { useTapHost } from "@assistant-ui/tap";
 import type { ChatTransport, UIMessage } from "ai";
@@ -10,6 +19,7 @@ import { createRoot } from "react-dom/client";
 import {
   StrictMode,
   Suspense,
+  type ReactNode,
   useEffect,
   useLayoutEffect,
   useState,
@@ -252,8 +262,8 @@ describe("useChatRuntime integration", () => {
     );
   });
 
-  it("uses the latest thread list item getter after host rerenders", async () => {
-    const bodies: Array<{ id: string }> = [];
+  it("routes runtime sends through a wired clone with the latest thread item", async () => {
+    const bodies: Array<{ id: string; system: string }> = [];
     const sourceTransport = new AssistantChatTransport<UIMessage>({
       fetch: vi.fn(async (_input, init) => {
         bodies.push(JSON.parse(String(init?.body)));
@@ -264,7 +274,18 @@ describe("useChatRuntime integration", () => {
       }),
     });
     const transport = new DynamicChatTransport(sourceTransport);
-    const { rerender } = renderHook(
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RuntimeAdapterProvider
+        adapters={{
+          modelContext: {
+            getModelContext: () => ({ system: "system prompt" }),
+          },
+        }}
+      >
+        {children}
+      </RuntimeAdapterProvider>
+    );
+    const { result, rerender } = renderHook(
       ({ remoteId }: { remoteId: string }) =>
         useChatThread(
           { transport },
@@ -279,30 +300,24 @@ describe("useChatRuntime integration", () => {
             }),
           },
         ),
-      { initialProps: { remoteId: "remote-a" } },
+      { initialProps: { remoteId: "remote-a" }, wrapper },
     );
-    const send = () =>
-      transport.sendMessages({
-        trigger: "submit-message",
-        chatId: "stable-thread",
-        messageId: undefined,
-        messages: [
-          {
-            id: "message-id",
-            role: "user",
-            parts: [{ type: "text", text: "hello" }],
-          },
-        ],
-        abortSignal: undefined,
+    const send = async () => {
+      await act(async () => {
+        await result.current.thread.append({
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        });
       });
+    };
 
     await send();
     rerender({ remoteId: "remote-b" });
     await send();
 
     expect(bodies).toEqual([
-      expect.objectContaining({ id: "remote-a" }),
-      expect.objectContaining({ id: "remote-b" }),
+      expect.objectContaining({ id: "remote-a", system: "system prompt" }),
+      expect.objectContaining({ id: "remote-b", system: "system prompt" }),
     ]);
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import type { ChatTransport, UIMessage } from "ai";
-import { StrictMode, useState } from "react";
+import { StrictMode, useLayoutEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import { useChatRuntime } from "./useChatRuntime";
@@ -79,23 +79,34 @@ describe("useChatRuntime integration", () => {
       sendMessages: sendB,
       reconnectToStream: vi.fn(),
     };
-    let runtime: AssistantRuntime | undefined;
-    const App = ({ transport }: { transport: ChatTransport<UIMessage> }) => {
-      runtime = useChatRuntime({ transport });
-      return <AssistantRuntimeProvider runtime={runtime} />;
+    const SendOnLayout = ({ runtime }: { runtime: AssistantRuntime }) => {
+      useLayoutEffect(() => {
+        void runtime.thread.append({
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        });
+      }, [runtime]);
+      return null;
+    };
+    const App = ({
+      transport,
+      send = false,
+    }: {
+      transport: ChatTransport<UIMessage>;
+      send?: boolean;
+    }) => {
+      const runtime = useChatRuntime({ transport });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {send && <SendOnLayout runtime={runtime} />}
+        </AssistantRuntimeProvider>
+      );
     };
 
     const view = render(<App transport={transportA} />);
-    view.rerender(<App transport={transportB} />);
+    view.rerender(<App transport={transportB} send />);
 
-    await act(async () => {
-      await runtime!.thread.append({
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-      });
-    });
-
-    expect(sendB).toHaveBeenCalledOnce();
+    await waitFor(() => expect(sendB).toHaveBeenCalledOnce());
     expect(sendA).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -119,6 +119,38 @@ describe("useChatRuntime integration", () => {
     expect(sendA).not.toHaveBeenCalled();
   });
 
+  it("routes sends triggered during the initial layout commit", async () => {
+    const send = vi.fn(
+      async () =>
+        new ReadableStream({ start: (controller) => controller.close() }),
+    );
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages: send,
+      reconnectToStream: vi.fn(),
+    };
+    const SendOnLayout = ({ runtime }: { runtime: AssistantRuntime }) => {
+      useLayoutEffect(() => {
+        void runtime.thread.append({
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        });
+      }, [runtime]);
+      return null;
+    };
+    const App = () => {
+      const runtime = useChatRuntime({ transport });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <SendOnLayout runtime={runtime} />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+
+    await waitFor(() => expect(send).toHaveBeenCalledOnce());
+  });
+
   it("keeps AssistantChatTransport wired through StrictMode effect replay", () => {
     const sourceTransport = new AssistantChatTransport<UIMessage>({
       api: "/api/chat",

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -4,11 +4,14 @@ import { render, screen, waitFor } from "@testing-library/react";
 import type { AssistantRuntime } from "@assistant-ui/core";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
+import { useTapHost } from "@assistant-ui/tap";
 import type { ChatTransport, UIMessage } from "ai";
-import { StrictMode, useLayoutEffect, useState } from "react";
+import { StrictMode, useEffect, useLayoutEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import { DynamicChatTransport } from "./DynamicChatTransport";
 import { useChatRuntime } from "./useChatRuntime";
+import { useChatThread } from "./useChatThread";
 
 const messages: UIMessage[] = [
   {
@@ -108,5 +111,49 @@ describe("useChatRuntime integration", () => {
 
     await waitFor(() => expect(sendB).toHaveBeenCalledOnce());
     expect(sendA).not.toHaveBeenCalled();
+  });
+
+  it("keeps AssistantChatTransport wired through StrictMode effect replay", () => {
+    const sourceTransport = new AssistantChatTransport<UIMessage>({
+      api: "/api/chat",
+    });
+    const transport = new DynamicChatTransport(sourceTransport);
+    const wiredDuringEffectSetup: boolean[] = [];
+    const Probe = ({ effects }: { effects: () => void }) => {
+      useEffect(effects);
+      useEffect(() => {
+        try {
+          wiredDuringEffectSetup.push(
+            transport.getCurrentTransport("strict-mode-thread") !==
+              sourceTransport,
+          );
+        } catch {
+          wiredDuringEffectSetup.push(false);
+        }
+      }, []);
+      return null;
+    };
+
+    const App = () => {
+      const { effects } = useTapHost(function ChatThreadResource() {
+        return useChatThread(
+          { transport },
+          {
+            id: "strict-mode-thread",
+            isMainThread: true,
+            getThreadListItem: () => undefined,
+          },
+        );
+      });
+      return <Probe effects={effects} />;
+    };
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+
+    expect(wiredDuringEffectSetup).toEqual([true, true]);
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -6,6 +6,7 @@ import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import { useTapHost } from "@assistant-ui/tap";
 import type { ChatTransport, UIMessage } from "ai";
+import { createRoot } from "react-dom/client";
 import {
   StrictMode,
   Suspense,
@@ -128,12 +129,17 @@ describe("useChatRuntime integration", () => {
       sendMessages: send,
       reconnectToStream: vi.fn(),
     };
+    let resolveLayout!: () => void;
+    const layoutCommitted = new Promise<void>((resolve) => {
+      resolveLayout = resolve;
+    });
     const SendOnLayout = ({ runtime }: { runtime: AssistantRuntime }) => {
       useLayoutEffect(() => {
-        void runtime.thread.append({
+        runtime.thread.append({
           role: "user",
           content: [{ type: "text", text: "hello" }],
         });
+        resolveLayout();
       }, [runtime]);
       return null;
     };
@@ -145,10 +151,30 @@ describe("useChatRuntime integration", () => {
         </AssistantRuntimeProvider>
       );
     };
+    const actEnvironment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+    const container = document.createElement("div");
+    const root = createRoot(container);
 
-    render(<App />);
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+    document.body.append(container);
+    try {
+      root.render(<App />);
+      await layoutCommitted;
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    await waitFor(() => expect(send).toHaveBeenCalledOnce());
+      expect(send).toHaveBeenCalledOnce();
+    } finally {
+      root.unmount();
+      container.remove();
+      if (previousActEnvironment === undefined) {
+        delete actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+      } else {
+        actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      }
+    }
   });
 
   it("keeps AssistantChatTransport wired through StrictMode effect replay", () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.integration.test.tsx
@@ -6,7 +6,13 @@ import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import { useAuiState } from "@assistant-ui/store";
 import { useTapHost } from "@assistant-ui/tap";
 import type { ChatTransport, UIMessage } from "ai";
-import { StrictMode, useEffect, useLayoutEffect, useState } from "react";
+import {
+  StrictMode,
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import { DynamicChatTransport } from "./DynamicChatTransport";
@@ -155,5 +161,36 @@ describe("useChatRuntime integration", () => {
     );
 
     expect(wiredDuringEffectSetup).toEqual([true, true]);
+  });
+
+  it("does not publish transport contexts from suspended renders", () => {
+    const sourceTransport = new AssistantChatTransport<UIMessage>({
+      api: "/api/chat",
+    });
+    const transport = new DynamicChatTransport(sourceTransport);
+    const pending = new Promise<never>(() => {});
+    const SuspendedThread = () => {
+      useTapHost(function ChatThreadResource() {
+        return useChatThread(
+          { transport },
+          {
+            id: "suspended-thread",
+            isMainThread: true,
+            getThreadListItem: () => undefined,
+          },
+        );
+      });
+      throw pending;
+    };
+
+    render(
+      <Suspense fallback={null}>
+        <SuspendedThread />
+      </Suspense>,
+    );
+
+    expect(transport.getCurrentTransport("suspended-thread")).toBe(
+      sourceTransport,
+    );
   });
 });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -1,9 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatTransport, UIMessage } from "ai";
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -384,49 +382,6 @@ describe("useChatRuntime", () => {
     rerender({ transport: transportB });
 
     await waitFor(() => expect(resumeStream).toHaveBeenCalledTimes(1));
-  });
-
-  it("routes immediate sends through a replacement transport", async () => {
-    const sendA = vi.fn().mockResolvedValue(new ReadableStream());
-    const sendB = vi.fn().mockResolvedValue(new ReadableStream());
-    const transportA = {
-      sendMessages: sendA,
-      reconnectToStream: vi.fn(),
-    };
-    const transportB = {
-      sendMessages: sendB,
-      reconnectToStream: vi.fn(),
-    };
-    let activeTransport: ChatTransport<UIMessage> | undefined;
-    mocks.useChat.mockImplementation(
-      ({ transport }: { transport: ChatTransport<UIMessage> }) => {
-        activeTransport = transport;
-        return { resumeStream: vi.fn(), status: "ready" };
-      },
-    );
-
-    const { rerender } = renderHook(
-      ({
-        transport,
-        send,
-      }: {
-        transport: ChatTransport<UIMessage>;
-        send: boolean;
-      }) => {
-        useChatRuntime({ transport });
-        useLayoutEffect(() => {
-          if (send) {
-            void activeTransport?.sendMessages(sendMessagesOptions as never);
-          }
-        }, [send]);
-      },
-      { initialProps: { transport: transportA, send: false } },
-    );
-
-    rerender({ transport: transportB, send: true });
-
-    await waitFor(() => expect(sendB).toHaveBeenCalledOnce());
-    expect(sendA).not.toHaveBeenCalled();
   });
 
   it("does not clear a newer stream id when an older resume fails", async () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -3,7 +3,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChatTransport } from "ai";
+import type { ChatTransport, UIMessage } from "ai";
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -397,20 +397,26 @@ describe("useChatRuntime", () => {
       sendMessages: sendB,
       reconnectToStream: vi.fn(),
     };
-    let activeTransport: ChatTransport | undefined;
+    let activeTransport: ChatTransport<UIMessage> | undefined;
     mocks.useChat.mockImplementation(
-      ({ transport }: { transport: ChatTransport }) => {
+      ({ transport }: { transport: ChatTransport<UIMessage> }) => {
         activeTransport = transport;
         return { resumeStream: vi.fn(), status: "ready" };
       },
     );
 
     const { rerender } = renderHook(
-      ({ transport, send }: { transport: ChatTransport; send: boolean }) => {
+      ({
+        transport,
+        send,
+      }: {
+        transport: ChatTransport<UIMessage>;
+        send: boolean;
+      }) => {
         useChatRuntime({ transport });
         useLayoutEffect(() => {
           if (send) {
-            void activeTransport?.sendMessages(sendMessagesOptions);
+            void activeTransport?.sendMessages(sendMessagesOptions as never);
           }
         }, [send]);
       },

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatTransport } from "ai";
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -382,6 +384,43 @@ describe("useChatRuntime", () => {
     rerender({ transport: transportB });
 
     await waitFor(() => expect(resumeStream).toHaveBeenCalledTimes(1));
+  });
+
+  it("routes immediate sends through a replacement transport", async () => {
+    const sendA = vi.fn().mockResolvedValue(new ReadableStream());
+    const sendB = vi.fn().mockResolvedValue(new ReadableStream());
+    const transportA = {
+      sendMessages: sendA,
+      reconnectToStream: vi.fn(),
+    };
+    const transportB = {
+      sendMessages: sendB,
+      reconnectToStream: vi.fn(),
+    };
+    let activeTransport: ChatTransport | undefined;
+    mocks.useChat.mockImplementation(
+      ({ transport }: { transport: ChatTransport }) => {
+        activeTransport = transport;
+        return { resumeStream: vi.fn(), status: "ready" };
+      },
+    );
+
+    const { rerender } = renderHook(
+      ({ transport, send }: { transport: ChatTransport; send: boolean }) => {
+        useChatRuntime({ transport });
+        useLayoutEffect(() => {
+          if (send) {
+            void activeTransport?.sendMessages(sendMessagesOptions);
+          }
+        }, [send]);
+      },
+      { initialProps: { transport: transportA, send: false } },
+    );
+
+    rerender({ transport: transportB, send: true });
+
+    await waitFor(() => expect(sendB).toHaveBeenCalledOnce());
+    expect(sendA).not.toHaveBeenCalled();
   });
 
   it("does not clear a newer stream id when an older resume fails", async () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ChatTransport, UIMessage } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -89,11 +90,52 @@ const sendMessagesOptions = {
 describe("useChatRuntime", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.useAISDKRuntime.mockImplementation(() => mocks.runtime);
     mocks.state.isLoadingHistory = false;
     mocks.state.threadId = "thread-id";
     mocks.state.mainThreadId = "thread-id";
     mocks.subscribers.clear();
     window.sessionStorage.clear();
+  });
+
+  it("refreshes AssistantChatTransport wiring when the runtime changes", async () => {
+    const bodies: Array<{ system: string }> = [];
+    const transport = new AssistantChatTransport({
+      fetch: vi.fn(async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          new ReadableStream({ start: (controller) => controller.close() }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    });
+    const createRuntime = (system: string) => ({
+      thread: {
+        getState: () => ({ isLoading: false }),
+        getModelContext: () => ({ system }),
+        subscribe: () => () => {},
+      },
+      threads: { mainItem: undefined },
+    });
+    let currentRuntime = createRuntime("system-a");
+    mocks.useAISDKRuntime.mockImplementation(() => currentRuntime);
+    mocks.useChat.mockReturnValue({
+      resumeStream: vi.fn(),
+      status: "ready",
+    });
+    const { rerender } = renderHook(() => useChatRuntime({ transport }));
+    const dynamicTransport = mocks.useChat.mock.lastCall?.[0]
+      .transport as ChatTransport<UIMessage>;
+
+    await dynamicTransport.sendMessages(sendMessagesOptions as never);
+    currentRuntime = createRuntime("system-b");
+    rerender();
+    await dynamicTransport.sendMessages(sendMessagesOptions as never);
+
+    expect(bodies).toEqual([
+      expect.objectContaining({ system: "system-a" }),
+      expect.objectContaining({ system: "system-b" }),
+    ]);
   });
 
   it("forwards a defined chat update throttle to useChat", () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.test.ts
@@ -103,13 +103,13 @@ describe("useChatRuntime", () => {
     });
 
     renderHook(() => useChatRuntime({ throttle: 50 }));
-    renderHook(() => useChatRuntime({ throttle: undefined }));
-
-    expect(mocks.useChat).toHaveBeenNthCalledWith(
-      1,
+    expect(mocks.useChat).toHaveBeenLastCalledWith(
       expect.objectContaining({ throttle: 50 }),
     );
-    expect(mocks.useChat.mock.calls[1]?.[0]).not.toHaveProperty("throttle");
+
+    mocks.useChat.mockClear();
+    renderHook(() => useChatRuntime({ throttle: undefined }));
+    expect(mocks.useChat.mock.lastCall?.[0]).not.toHaveProperty("throttle");
   });
 
   it("waits for external history to load before resuming a stream", async () => {

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -8,6 +8,10 @@ import {
   useRemoteThreadListRuntime,
 } from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
+import type { ChatTransport } from "ai";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import { DynamicChatTransport } from "./DynamicChatTransport";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
@@ -15,6 +19,24 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     cloud?: AssistantCloud | undefined;
     onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+const useDynamicChatTransport = <UI_MESSAGE extends UIMessage>(
+  transport: ChatTransport<UI_MESSAGE> | undefined,
+): ChatTransport<UI_MESSAGE> => {
+  const fallback = useMemo(() => new AssistantChatTransport<UI_MESSAGE>(), []);
+  const [dynamicTransport] = useState(
+    () => new DynamicChatTransport(transport ?? fallback),
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    dynamicTransport.setTransport(transport ?? fallback);
+  }, [dynamicTransport, fallback, transport]);
+
+  return dynamicTransport;
+};
 
 const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: ChatThreadOptions<UI_MESSAGE>,
@@ -38,9 +60,10 @@ export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   ...options
 }: UseChatRuntimeOptions<UI_MESSAGE> = {}): AssistantRuntime => {
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
+  const transport = useDynamicChatTransport(options.transport);
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
-      return useChatThreadRuntime(options);
+      return useChatThreadRuntime({ ...options, transport });
     },
     adapter: cloudAdapter,
     allowNesting: true,

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -9,7 +9,7 @@ import {
 } from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { ChatTransport } from "ai";
-import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useInsertionEffect, useMemo, useState } from "react";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
 import { DynamicChatTransport } from "./DynamicChatTransport";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
@@ -20,9 +20,6 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };
 
-const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useLayoutEffect;
-
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage>(
   transport: ChatTransport<UI_MESSAGE> | undefined,
 ): ChatTransport<UI_MESSAGE> => {
@@ -31,9 +28,12 @@ const useDynamicChatTransport = <UI_MESSAGE extends UIMessage>(
     () => new DynamicChatTransport(transport ?? fallback),
   );
 
-  useIsomorphicLayoutEffect(() => {
+  useInsertionEffect(() => {
     dynamicTransport.setTransport(transport ?? fallback);
   }, [dynamicTransport, fallback, transport]);
+  useEffect(() => {
+    dynamicTransport.flushTransportChange();
+  }, [dynamicTransport, transport]);
 
   return dynamicTransport;
 };

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -9,10 +9,10 @@ import {
 } from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import type { ChatTransport } from "ai";
-import { useEffect, useInsertionEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { AssistantChatTransport } from "../transport/AssistantChatTransport";
-import { DynamicChatTransport } from "./DynamicChatTransport";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
+import { useDynamicChatTransport } from "./useDynamicChatTransport";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
@@ -25,24 +25,6 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
     cloud?: AssistantCloud | undefined;
     onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };
-
-const useDynamicChatTransport = <UI_MESSAGE extends UIMessage>(
-  transport: ChatTransport<UI_MESSAGE> | undefined,
-): ChatTransport<UI_MESSAGE> => {
-  const fallback = useMemo(() => new AssistantChatTransport<UI_MESSAGE>(), []);
-  const [dynamicTransport] = useState(
-    () => new DynamicChatTransport(transport ?? fallback),
-  );
-
-  useInsertionEffect(() => {
-    dynamicTransport.setTransport(transport ?? fallback);
-  }, [dynamicTransport, fallback, transport]);
-  useEffect(() => {
-    dynamicTransport.flushTransportChange();
-  }, [dynamicTransport, transport]);
-
-  return dynamicTransport;
-};
 
 const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   options?: ChatThreadOptions<UI_MESSAGE>,
@@ -66,7 +48,8 @@ export const useChatRuntime = <UI_MESSAGE extends UIMessage = UIMessage>({
   ...options
 }: UseChatRuntimeOptions<UI_MESSAGE> = {}): AssistantRuntime => {
   const cloudAdapter = useCloudThreadListAdapter({ cloud });
-  const transport = useDynamicChatTransport(options.transport);
+  const fallback = useMemo(() => new AssistantChatTransport<UI_MESSAGE>(), []);
+  const transport = useDynamicChatTransport(options.transport ?? fallback);
   return useRemoteThreadListRuntime({
     runtimeHook: function RuntimeHook() {
       return useChatThreadRuntime({ ...options, transport });

--- a/packages/ai-sdk/src/runtime/useChatRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useChatRuntime.ts
@@ -15,7 +15,13 @@ import { DynamicChatTransport } from "./DynamicChatTransport";
 import { useChatThread, type ChatThreadOptions } from "./useChatThread";
 
 export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
-  ChatThreadOptions<UI_MESSAGE> & {
+  Omit<ChatThreadOptions<UI_MESSAGE>, "transport"> & {
+    /**
+     * The transport threads send through. `AssistantChatTransport` instances
+     * are cloned per thread through `__internal_clone()` so their assistant-ui
+     * wiring remains isolated. Other transport instances are shared as-is.
+     */
+    transport?: ChatTransport<UI_MESSAGE> | undefined;
     cloud?: AssistantCloud | undefined;
     onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   };

--- a/packages/ai-sdk/src/runtime/useChatThread.binding.test.tsx
+++ b/packages/ai-sdk/src/runtime/useChatThread.binding.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { Suspense } from "react";
+import { render } from "@testing-library/react";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import type { ChatTransport, UIMessage } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantChatTransport } from "../transport/AssistantChatTransport";
+import { DynamicChatTransport } from "./DynamicChatTransport";
+
+const mocks = vi.hoisted(() => ({
+  system: "",
+  useAISDKRuntime: vi.fn(),
+  useChat: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@ai-sdk/react")>()),
+  useChat: mocks.useChat,
+}));
+
+vi.mock("./useAISDKRuntime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useAISDKRuntime")>()),
+  useAISDKRuntime: mocks.useAISDKRuntime,
+}));
+
+import { useChatThread } from "./useChatThread";
+
+const createRuntime = (system: string) =>
+  ({
+    thread: {
+      getModelContext: () => ({ system }),
+      getState: () => ({ isLoading: false }),
+      subscribe: () => () => {},
+    },
+  }) as AssistantRuntime;
+
+describe("useChatThread transport binding", () => {
+  beforeEach(() => {
+    mocks.system = "";
+    mocks.useAISDKRuntime.mockReset();
+    mocks.useChat.mockReset();
+    mocks.useAISDKRuntime.mockImplementation(() => createRuntime(mocks.system));
+    mocks.useChat.mockImplementation(({ id, transport }) => ({
+      id,
+      transport,
+      messages: [],
+      status: "ready",
+      error: undefined,
+      stop: vi.fn(async () => {}),
+    }));
+  });
+
+  it("keeps fallback wiring on committed values after an abandoned render", async () => {
+    const bodies: Array<{ id: string; system: string }> = [];
+    const sourceTransport = new AssistantChatTransport<UIMessage>({
+      fetch: vi.fn(async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          new ReadableStream({ start: (controller) => controller.close() }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    });
+    const transport = new DynamicChatTransport(sourceTransport);
+    const pending = new Promise<never>(() => {});
+    let committedProxy: ChatTransport<UIMessage> | undefined;
+
+    const App = ({
+      system,
+      remoteId,
+      suspend = false,
+    }: {
+      system: string;
+      remoteId: string;
+      suspend?: boolean;
+    }) => {
+      mocks.system = system;
+      useChatThread(
+        { transport },
+        {
+          id: "thread-id",
+          isMainThread: true,
+          getThreadListItem: () => ({
+            initialize: async () => ({
+              remoteId,
+              externalId: undefined,
+            }),
+          }),
+        },
+      );
+      const proxy = mocks.useChat.mock.lastCall?.[0].transport as
+        | ChatTransport<UIMessage>
+        | undefined;
+      if (!suspend) committedProxy = proxy;
+      if (suspend) throw pending;
+      return null;
+    };
+
+    const view = render(
+      <Suspense fallback={null}>
+        <App system="committed-system" remoteId="committed-remote" />
+      </Suspense>,
+    );
+
+    transport.registerThread("thread-id", {});
+    view.rerender(
+      <Suspense fallback={null}>
+        <App system="discarded-system" remoteId="discarded-remote" suspend />
+      </Suspense>,
+    );
+
+    await committedProxy!.sendMessages({
+      trigger: "submit-message",
+      chatId: "thread-id",
+      messageId: undefined,
+      messages: [
+        {
+          id: "message-id",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        },
+      ],
+      abortSignal: undefined,
+    });
+
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        id: "committed-remote",
+        system: "committed-system",
+      }),
+    ]);
+  });
+});

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -11,15 +11,12 @@ import {
   type AISDKRuntimeAdapter,
   type CustomToCreateMessageFunction,
 } from "./useAISDKRuntime";
-import type { ChatInit, ChatTransport } from "ai";
+import type { ChatInit } from "ai";
 import {
   AssistantChatTransport,
   type InitializableThreadListItem,
 } from "../transport/AssistantChatTransport";
-import type {
-  AssistantChatResumableOptions,
-  ResumableClientStorage,
-} from "../transport/resumable";
+import type { ResumableClientStorage } from "../transport/resumable";
 import {
   useCallback,
   useEffect,
@@ -29,6 +26,7 @@ import {
 } from "react";
 import { useResourceCleanup } from "./useResourceCleanup";
 import { DynamicChatTransport } from "./DynamicChatTransport";
+import { getResumableAdapter } from "./getResumableAdapter";
 
 export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> &
@@ -61,18 +59,6 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
    * from the instance.
    */
   chat?: Chat<UI_MESSAGE> | undefined;
-};
-
-const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
-  transport: ChatTransport<UI_MESSAGE>,
-): AssistantChatResumableOptions | undefined => {
-  if (transport instanceof AssistantChatTransport) {
-    return transport.getResumableAdapter();
-  }
-  const candidate = (transport as { getResumableAdapter?: () => unknown })
-    .getResumableAdapter;
-  if (typeof candidate !== "function") return undefined;
-  return candidate.call(transport) as AssistantChatResumableOptions | undefined;
 };
 
 const getNoPendingStreamId = () => null;
@@ -165,6 +151,10 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
   const transport = transportOptions ?? defaultTransport;
+  const transportContextOwner = useMemo(() => ({}), []);
+  if (transport instanceof DynamicChatTransport) {
+    transport.registerThread(id, transportContextOwner);
+  }
   const subscribeToTransport = useCallback(
     (callback: () => void) =>
       transport instanceof DynamicChatTransport
@@ -175,9 +165,9 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const getSourceTransport = useCallback(
     () =>
       transport instanceof DynamicChatTransport
-        ? transport.getCurrentTransport()
+        ? transport.getCurrentTransport(id)
         : transport,
-    [transport],
+    [id, transport],
   );
   const sourceTransport = useSyncExternalStore(
     subscribeToTransport,
@@ -209,12 +199,23 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   });
 
   if (transport instanceof DynamicChatTransport) {
-    transport.setRuntime(runtime);
-    transport.setGetThreadListItem(getThreadListItem);
+    transport.setThreadContext(
+      id,
+      transportContextOwner,
+      runtime,
+      getThreadListItem,
+    );
   } else if (sourceTransport instanceof AssistantChatTransport) {
     sourceTransport.setRuntime(runtime);
     sourceTransport.__internal_setGetThreadListItem(getThreadListItem);
   }
+  useEffect(
+    () =>
+      transport instanceof DynamicChatTransport
+        ? () => transport.unregisterThread(id, transportContextOwner)
+        : undefined,
+    [id, transport, transportContextOwner],
+  );
 
   const subscribeToRuntime = useCallback(
     (callback: () => void) => runtime.thread.subscribe(callback),

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -187,10 +187,28 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     getSourceTransport,
   );
 
+  const transportBindingRef = useRef<{
+    runtime: AssistantRuntime;
+    getThreadListItem: () => InitializableThreadListItem | undefined;
+  } | null>(null);
+  const chatTransport = useMemo(
+    () =>
+      transport instanceof DynamicChatTransport
+        ? transport.createThreadProxy(transportContextOwner, () => {
+            const binding = transportBindingRef.current;
+            if (!binding) {
+              throw new Error("Chat transport used before runtime setup");
+            }
+            return binding;
+          })
+        : transport,
+    [transport, transportContextOwner],
+  );
+
   const chat = useChat({
     ...chatOptions,
     id,
-    transport,
+    transport: chatTransport,
     ...(throttle !== undefined && { throttle }),
     ...(externalChat !== undefined && { chat: externalChat }),
   });
@@ -209,6 +227,10 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
+  transportBindingRef.current = {
+    runtime,
+    getThreadListItem: getCurrentThreadListItem,
+  };
 
   const registerTransportContext = useEffectEvent(
     (dynamicTransport: DynamicChatTransport<UI_MESSAGE>, chatId: string) => {

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -66,9 +66,7 @@ const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
 ): ChatTransport<UI_MESSAGE> => {
   const transportRef = useRef<ChatTransport<UI_MESSAGE>>(transport);
-  useEffect(() => {
-    transportRef.current = transport;
-  });
+  transportRef.current = transport;
   const dynamicTransport = useMemo(
     () =>
       new Proxy(transportRef.current, {

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -193,7 +193,8 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   );
 
   const transportBindingRef = useRef<ChatThreadTransportBinding | null>(null);
-  // The proxy captures this mount-local fallback; shared updates publish only during commit.
+  // This is null when useMemo runs, so the proxy pins its mount render's binding. The fallback
+  // serves only pre-commit sends; after insertion effects, transportBindingRef is authoritative.
   let initialTransportBinding: ChatThreadTransportBinding | null = null;
   const chatTransport = useMemo(
     () =>

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -29,6 +29,7 @@ import {
 import { useResourceCleanup } from "./useResourceCleanup";
 import { DynamicChatTransport } from "./DynamicChatTransport";
 import { getResumableAdapter } from "./getResumableAdapter";
+import { useDynamicChatTransport } from "./useDynamicChatTransport";
 
 export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> &
@@ -152,7 +153,11 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   } = env;
 
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
-  const transport = transportOptions ?? defaultTransport;
+  const configuredTransport = transportOptions ?? defaultTransport;
+  const transport = useDynamicChatTransport(
+    configuredTransport,
+    externalChat === undefined,
+  );
   const transportContextOwner = useMemo(() => ({}), []);
   const getThreadListItemRef = useRef(getThreadListItem);
   useInsertionEffect(() => {
@@ -224,10 +229,12 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
 
   if (
     !(transport instanceof DynamicChatTransport) &&
-    transport instanceof AssistantChatTransport
+    configuredTransport instanceof AssistantChatTransport
   ) {
-    transport.setRuntime(runtime);
-    transport.__internal_setGetThreadListItem(getCurrentThreadListItem);
+    configuredTransport.setRuntime(runtime);
+    configuredTransport.__internal_setGetThreadListItem(
+      getCurrentThreadListItem,
+    );
   }
 
   const subscribeToRuntime = useCallback(

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -23,12 +23,12 @@ import type {
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
 } from "react";
 import { useResourceCleanup } from "./useResourceCleanup";
+import { DynamicChatTransport } from "./DynamicChatTransport";
 
 export type ChatThreadOptions<UI_MESSAGE extends UIMessage = UIMessage> =
   ChatInit<UI_MESSAGE> &
@@ -61,32 +61,6 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
    * from the instance.
    */
   chat?: Chat<UI_MESSAGE> | undefined;
-};
-
-const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useLayoutEffect;
-
-const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
-  transport: ChatTransport<UI_MESSAGE>,
-): ChatTransport<UI_MESSAGE> => {
-  const transportRef = useRef<ChatTransport<UI_MESSAGE>>(transport);
-  useIsomorphicLayoutEffect(() => {
-    transportRef.current = transport;
-  }, [transport]);
-  const dynamicTransport = useMemo(
-    () =>
-      new Proxy(transportRef.current, {
-        get(_, prop) {
-          const res =
-            transportRef.current[prop as keyof ChatTransport<UI_MESSAGE>];
-          return typeof res === "function"
-            ? res.bind(transportRef.current)
-            : res;
-        },
-      }),
-    [],
-  );
-  return dynamicTransport;
 };
 
 const getResumableAdapter = <UI_MESSAGE extends UIMessage>(
@@ -190,8 +164,26 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   } = env;
 
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
-  const sourceTransport = transportOptions ?? defaultTransport;
-  const transport = useDynamicChatTransport(sourceTransport);
+  const transport = transportOptions ?? defaultTransport;
+  const subscribeToTransport = useCallback(
+    (callback: () => void) =>
+      transport instanceof DynamicChatTransport
+        ? transport.subscribe(callback)
+        : () => {},
+    [transport],
+  );
+  const getSourceTransport = useCallback(
+    () =>
+      transport instanceof DynamicChatTransport
+        ? transport.getCurrentTransport()
+        : transport,
+    [transport],
+  );
+  const sourceTransport = useSyncExternalStore(
+    subscribeToTransport,
+    getSourceTransport,
+    getSourceTransport,
+  );
 
   const chat = useChat({
     ...chatOptions,
@@ -216,7 +208,10 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
 
-  if (sourceTransport instanceof AssistantChatTransport) {
+  if (transport instanceof DynamicChatTransport) {
+    transport.setRuntime(runtime);
+    transport.setGetThreadListItem(getThreadListItem);
+  } else if (sourceTransport instanceof AssistantChatTransport) {
     sourceTransport.setRuntime(runtime);
     sourceTransport.__internal_setGetThreadListItem(getThreadListItem);
   }

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -154,6 +154,14 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
   const transport = transportOptions ?? defaultTransport;
   const transportContextOwner = useMemo(() => ({}), []);
+  const getThreadListItemRef = useRef(getThreadListItem);
+  useInsertionEffect(() => {
+    getThreadListItemRef.current = getThreadListItem;
+  }, [getThreadListItem]);
+  const getCurrentThreadListItem = useCallback(
+    () => getThreadListItemRef.current(),
+    [],
+  );
   const subscribeToTransport = useCallback(
     (callback: () => void) =>
       transport instanceof DynamicChatTransport
@@ -203,7 +211,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
         chatId,
         transportContextOwner,
         runtime,
-        getThreadListItem,
+        getCurrentThreadListItem,
       );
       return () =>
         dynamicTransport.unregisterThread(chatId, transportContextOwner);
@@ -219,7 +227,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     sourceTransport instanceof AssistantChatTransport
   ) {
     sourceTransport.setRuntime(runtime);
-    sourceTransport.__internal_setGetThreadListItem(getThreadListItem);
+    sourceTransport.__internal_setGetThreadListItem(getCurrentThreadListItem);
   }
 
   const subscribeToRuntime = useCallback(

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -227,11 +227,19 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
-  // The proxy reads this only for a first send before insertion effects; owner-matched committed contexts bypass it.
-  transportBindingRef.current = {
-    runtime,
-    getThreadListItem: getCurrentThreadListItem,
-  };
+  // An abandoned mount cannot expose this ref or its proxy; updates publish only during commit.
+  if (!transportBindingRef.current) {
+    transportBindingRef.current = {
+      runtime,
+      getThreadListItem: getCurrentThreadListItem,
+    };
+  }
+  useInsertionEffect(() => {
+    transportBindingRef.current = {
+      runtime,
+      getThreadListItem: getCurrentThreadListItem,
+    };
+  }, [runtime, getCurrentThreadListItem]);
 
   const registerTransportContext = useEffectEvent(
     (dynamicTransport: DynamicChatTransport<UI_MESSAGE>, chatId: string) => {

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -152,6 +152,12 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
   const transport = transportOptions ?? defaultTransport;
   const transportContextOwner = useMemo(() => ({}), []);
+  const getThreadListItemRef = useRef(getThreadListItem);
+  getThreadListItemRef.current = getThreadListItem;
+  const getCurrentThreadListItem = useCallback(
+    () => getThreadListItemRef.current(),
+    [],
+  );
   if (transport instanceof DynamicChatTransport) {
     transport.registerThread(id, transportContextOwner);
   }
@@ -197,25 +203,29 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
+  const runtimeRef = useRef(runtime);
+  runtimeRef.current = runtime;
 
-  if (transport instanceof DynamicChatTransport) {
+  const registerTransportContext = useCallback(() => {
+    if (!(transport instanceof DynamicChatTransport)) return undefined;
     transport.setThreadContext(
       id,
       transportContextOwner,
-      runtime,
-      getThreadListItem,
+      runtimeRef.current,
+      getCurrentThreadListItem,
     );
-  } else if (sourceTransport instanceof AssistantChatTransport) {
+    return () => transport.unregisterThread(id, transportContextOwner);
+  }, [getCurrentThreadListItem, id, transport, transportContextOwner]);
+
+  registerTransportContext();
+  if (
+    !(transport instanceof DynamicChatTransport) &&
+    sourceTransport instanceof AssistantChatTransport
+  ) {
     sourceTransport.setRuntime(runtime);
-    sourceTransport.__internal_setGetThreadListItem(getThreadListItem);
+    sourceTransport.__internal_setGetThreadListItem(getCurrentThreadListItem);
   }
-  useEffect(
-    () =>
-      transport instanceof DynamicChatTransport
-        ? () => transport.unregisterThread(id, transportContextOwner)
-        : undefined,
-    [id, transport, transportContextOwner],
-  );
+  useEffect(registerTransportContext, [registerTransportContext]);
 
   const subscribeToRuntime = useCallback(
     (callback: () => void) => runtime.thread.subscribe(callback),

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -64,6 +64,11 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
   chat?: Chat<UI_MESSAGE> | undefined;
 };
 
+type ChatThreadTransportBinding = {
+  runtime: AssistantRuntime;
+  getThreadListItem: () => InitializableThreadListItem | undefined;
+};
+
 const getNoPendingStreamId = () => null;
 
 const resumedStreamIdsByStorage = new WeakMap<
@@ -187,22 +192,22 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     getSourceTransport,
   );
 
-  const transportBindingRef = useRef<{
-    runtime: AssistantRuntime;
-    getThreadListItem: () => InitializableThreadListItem | undefined;
-  } | null>(null);
+  const transportBindingRef = useRef<ChatThreadTransportBinding | null>(null);
+  // The proxy captures this mount-local fallback; shared updates publish only during commit.
+  let initialTransportBinding: ChatThreadTransportBinding | null = null;
   const chatTransport = useMemo(
     () =>
       transport instanceof DynamicChatTransport
         ? transport.createThreadProxy(transportContextOwner, () => {
-            const binding = transportBindingRef.current;
+            const binding =
+              transportBindingRef.current ?? initialTransportBinding;
             if (!binding) {
               throw new Error("Chat transport used before runtime setup");
             }
             return binding;
           })
         : transport,
-    [transport, transportContextOwner],
+    [initialTransportBinding, transport, transportContextOwner],
   );
 
   const chat = useChat({
@@ -227,13 +232,10 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
-  // An abandoned mount cannot expose this ref or its proxy; updates publish only during commit.
-  if (!transportBindingRef.current) {
-    transportBindingRef.current = {
-      runtime,
-      getThreadListItem: getCurrentThreadListItem,
-    };
-  }
+  initialTransportBinding = {
+    runtime,
+    getThreadListItem: getCurrentThreadListItem,
+  };
   useInsertionEffect(() => {
     transportBindingRef.current = {
       runtime,

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -227,6 +227,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
+  // The proxy reads this only for a first send before insertion effects; owner-matched committed contexts bypass it.
   transportBindingRef.current = {
     runtime,
     getThreadListItem: getCurrentThreadListItem,

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -63,11 +63,14 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
   chat?: Chat<UI_MESSAGE> | undefined;
 };
 
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
 ): ChatTransport<UI_MESSAGE> => {
   const transportRef = useRef<ChatTransport<UI_MESSAGE>>(transport);
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     transportRef.current = transport;
   }, [transport]);
   const dynamicTransport = useMemo(

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -172,9 +172,9 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const getSourceTransport = useCallback(
     () =>
       transport instanceof DynamicChatTransport
-        ? transport.getCurrentTransport(id)
+        ? transport.getCurrentSourceTransport()
         : transport,
-    [id, transport],
+    [transport],
   );
   const sourceTransport = useSyncExternalStore(
     subscribeToTransport,
@@ -220,14 +220,14 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   useInsertionEffect(() => {
     if (!(transport instanceof DynamicChatTransport)) return undefined;
     return registerTransportContext(transport, id);
-  }, [id, transport, transportContextOwner]);
+  }, [id, runtime, transport, transportContextOwner]);
 
   if (
     !(transport instanceof DynamicChatTransport) &&
-    sourceTransport instanceof AssistantChatTransport
+    transport instanceof AssistantChatTransport
   ) {
-    sourceTransport.setRuntime(runtime);
-    sourceTransport.__internal_setGetThreadListItem(getCurrentThreadListItem);
+    transport.setRuntime(runtime);
+    transport.__internal_setGetThreadListItem(getCurrentThreadListItem);
   }
 
   const subscribeToRuntime = useCallback(
@@ -248,6 +248,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     () => getResumableAdapter(sourceTransport)?.storage,
     [sourceTransport],
   );
+
   const subscribeToResumableStorage = useCallback(
     (callback: () => void) =>
       isMainThread

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -20,6 +20,8 @@ import type { ResumableClientStorage } from "../transport/resumable";
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
+  useInsertionEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
@@ -152,15 +154,6 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
   const transport = transportOptions ?? defaultTransport;
   const transportContextOwner = useMemo(() => ({}), []);
-  const getThreadListItemRef = useRef(getThreadListItem);
-  getThreadListItemRef.current = getThreadListItem;
-  const getCurrentThreadListItem = useCallback(
-    () => getThreadListItemRef.current(),
-    [],
-  );
-  if (transport instanceof DynamicChatTransport) {
-    transport.registerThread(id, transportContextOwner);
-  }
   const subscribeToTransport = useCallback(
     (callback: () => void) =>
       transport instanceof DynamicChatTransport
@@ -203,29 +196,31 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(messageRepository && { messageRepository }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
-  const runtimeRef = useRef(runtime);
-  runtimeRef.current = runtime;
 
-  const registerTransportContext = useCallback(() => {
+  const registerTransportContext = useEffectEvent(
+    (dynamicTransport: DynamicChatTransport<UI_MESSAGE>, chatId: string) => {
+      dynamicTransport.setThreadContext(
+        chatId,
+        transportContextOwner,
+        runtime,
+        getThreadListItem,
+      );
+      return () =>
+        dynamicTransport.unregisterThread(chatId, transportContextOwner);
+    },
+  );
+  useInsertionEffect(() => {
     if (!(transport instanceof DynamicChatTransport)) return undefined;
-    transport.setThreadContext(
-      id,
-      transportContextOwner,
-      runtimeRef.current,
-      getCurrentThreadListItem,
-    );
-    return () => transport.unregisterThread(id, transportContextOwner);
-  }, [getCurrentThreadListItem, id, transport, transportContextOwner]);
+    return registerTransportContext(transport, id);
+  }, [id, transport, transportContextOwner]);
 
-  registerTransportContext();
   if (
     !(transport instanceof DynamicChatTransport) &&
     sourceTransport instanceof AssistantChatTransport
   ) {
     sourceTransport.setRuntime(runtime);
-    sourceTransport.__internal_setGetThreadListItem(getCurrentThreadListItem);
+    sourceTransport.__internal_setGetThreadListItem(getThreadListItem);
   }
-  useEffect(registerTransportContext, [registerTransportContext]);
 
   const subscribeToRuntime = useCallback(
     (callback: () => void) => runtime.thread.subscribe(callback),

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -23,6 +23,7 @@ import type {
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
@@ -66,7 +67,9 @@ const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
   transport: ChatTransport<UI_MESSAGE>,
 ): ChatTransport<UI_MESSAGE> => {
   const transportRef = useRef<ChatTransport<UI_MESSAGE>>(transport);
-  transportRef.current = transport;
+  useLayoutEffect(() => {
+    transportRef.current = transport;
+  }, [transport]);
   const dynamicTransport = useMemo(
     () =>
       new Proxy(transportRef.current, {

--- a/packages/ai-sdk/src/runtime/useDynamicChatTransport.ts
+++ b/packages/ai-sdk/src/runtime/useDynamicChatTransport.ts
@@ -1,0 +1,26 @@
+import type { UIMessage } from "@ai-sdk/react";
+import type { ChatTransport } from "ai";
+import { useEffect, useInsertionEffect, useState } from "react";
+import { DynamicChatTransport } from "./DynamicChatTransport";
+
+export const useDynamicChatTransport = <UI_MESSAGE extends UIMessage>(
+  transport: ChatTransport<UI_MESSAGE>,
+  enabled = true,
+): ChatTransport<UI_MESSAGE> => {
+  const [dynamicTransport] = useState(() =>
+    transport instanceof DynamicChatTransport
+      ? transport
+      : new DynamicChatTransport(transport),
+  );
+
+  useInsertionEffect(() => {
+    if (!enabled || dynamicTransport === transport) return;
+    dynamicTransport.setTransport(transport);
+  }, [dynamicTransport, enabled, transport]);
+  useEffect(() => {
+    if (!enabled || dynamicTransport === transport) return;
+    dynamicTransport.flushTransportChange();
+  }, [dynamicTransport, enabled, transport]);
+
+  return enabled ? dynamicTransport : transport;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3611,6 +3611,9 @@ importers:
       react:
         specifier: ^19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- keep one stable transport at the React boundary while forwarding requests to the latest committed transport
- clone and wire `AssistantChatTransport` instances per mounted thread so remote IDs and model context cannot cross threads
- refresh resumable state when the replacement uses different storage
- defer per-thread replacement clones until the thread next sends or reconnects
- cover the real remote-thread/tap host path, `AISDKChat`, and multi-thread wiring with regressions

## Why

The default `useChatRuntime()` thread runs inside a tap resource. Changing the transport prop rerenders the outer React hook, but it does not by itself rerender that hosted resource. The previous proxy lived inside the resource and advanced in a passive effect, so requests made after an account, provider, or endpoint switch could still use the previous transport and its credentials or configuration.

The forwarding transport now updates at the outer committed React boundary. It routes each chat ID through thread-scoped transport wiring, delegates sends immediately, and notifies hosted resources when resumable storage changes. `AISDKChat` resources use the same forwarding transport, but Tap publishes source replacements during its passive commit; a send between the host commit and that flush can still use the previous source. Externally owned `AISDKThreads` chats retain their direct per-thread transport wiring.

## Testing

- `pnpm --filter @assistant-ui/ai-sdk test` (27 files, 263 tests)
- `pnpm --filter @assistant-ui/ai-sdk test:react-compiler`
- `pnpm --filter @assistant-ui/ai-sdk build`
- focused `erasableSyntaxOnly` type check for the new runtime modules
- oxfmt and oxlint on all changed AI SDK runtime files

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AN1oryKrxekXDwcBi2z_JHwOGQExp8w9UmZVfcpYDgLF7YZxLi-VSqpYcIg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

