### PR TITLE
fix(ui): handle image regeneration failures

### DIFF
--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -147,6 +147,10 @@ describe("ImageActions regeneration", () => {
 
       fireEvent.click(screen.getByLabelText("Regenerate image"));
 
+      expect(
+        (screen.getByLabelText("Regenerate image") as HTMLButtonElement)
+          .disabled,
+      ).toBe(true);
       await waitFor(() =>
         expect(
           (screen.getByLabelText("Regenerate image") as HTMLButtonElement)

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -124,3 +124,39 @@ describe("ImageActions data URI handling", () => {
     expect(blob.type).toBe("image/png");
   });
 });
+
+describe("ImageActions regeneration", () => {
+  it("handles rejected regeneration callbacks", async () => {
+    const rejection = new Error("regeneration failed");
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const part = {
+        type: "image",
+        image: "data:image/png;base64,aGVsbG8=",
+        prompt: "hello",
+      } as ImageMessagePart;
+      render(
+        <ImageActions
+          part={part}
+          onRegenerate={() => Promise.reject(rejection)}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText("Regenerate image"));
+
+      await waitFor(() =>
+        expect(
+          (screen.getByLabelText("Regenerate image") as HTMLButtonElement)
+            .disabled,
+        ).toBe(false),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+});

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -383,6 +383,7 @@ function RegenerateButton({
         setIsRegenerating(true);
         try {
           await onRegenerate();
+        } catch {
         } finally {
           setIsRegenerating(false);
         }


### PR DESCRIPTION
## Summary

- contain rejected async image regeneration callbacks
- always restore the regenerate button after callback failure
- add regression coverage for global unhandled rejections

## Why

`ImageActions` allows `onRegenerate` to return a promise, but the click handler previously allowed rejected promises to escape as global `unhandledRejection` events. This could surface framework-level error reporting for a consumer-managed generation failure even though the button correctly reset its loading state.

The action now contains the rejection, consistent with the neighboring asynchronous image actions, while leaving error presentation to the consumer callback.

## Testing

- `pnpm --filter @assistant-ui/ui test`
- `pnpm --filter @assistant-ui/ui... --if-present build`
- `pnpm exec oxfmt --check packages/ui/src/components/assistant-ui/image.tsx packages/ui/src/components/assistant-ui/image.test.tsx`
- `pnpm exec oxlint packages/ui/src/components/assistant-ui/image.tsx packages/ui/src/components/assistant-ui/image.test.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ia7OgPk3mof6KpkkB78EkSzvQZqGqpGZBmozQZNyKudgvm-seBFb_2-taP8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->