### PR TITLE
test(react): cover post-mount useAdapters bag on the synthesized provider path

### DIFF
--- a/packages/react/src/tests/RemoteThreadListRuntime.adapterProvider.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.adapterProvider.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, render, waitFor } from "@testing-library/react";
-import type { FC, PropsWithChildren } from "react";
+import { useState, type FC, type PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
 import {
   RuntimeAdapterProvider,
@@ -105,6 +105,36 @@ describe("RemoteThreadListAdapter.unstable_Provider", () => {
     await renderAndWaitForBinder(adapter, capture);
 
     expect(capture.adapters?.history).toBe(dummyHistory);
+  });
+
+  it("picks up a post-mount useAdapters bag", async () => {
+    const capture: { adapters: CapturedAdapters } = { adapters: null };
+    const firstHistory: ThreadHistoryAdapter = {
+      load: async () => ({ messages: [] }),
+      append: async () => {},
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      load: async () => ({ messages: [] }),
+      append: async () => {},
+    };
+
+    let bump: (() => void) | undefined;
+    const adapter = makeAdapter({
+      unstable_useAdapters: function useTestAdapters() {
+        const [swapped, setSwapped] = useState(false);
+        bump = () => setSwapped(true);
+        return { history: swapped ? secondHistory : firstHistory };
+      },
+    });
+
+    await renderAndWaitForBinder(adapter, capture);
+    expect(capture.adapters?.history).toBe(firstHistory);
+
+    await act(async () => {
+      bump!();
+    });
+
+    expect(capture.adapters?.history).toBe(secondHistory);
   });
 
   it("picks up a swapped Provider on re-render", async () => {


### PR DESCRIPTION
## what

Adds one regression test: a synthesized `RuntimeAdapterProvider` whose `unstable_useAdapters` bag changes after mount. A state bump inside the adapter hook returns a different history adapter; the test asserts the replacement reaches the thread runtime hook.

## why

#6073 reports that a post-mount bag never reaches the thread runtime on this path. I could not reproduce that — the replacement propagates on main, as do five adjacent variants (key added/removed post-mount, null→non-null, non-null→null, sequential swaps). Details and a repro request are on the issue. What the issue got right is the coverage gap: no test exercised a changed synthesized bag after mount, so nothing would catch a future regression here.

The reported `renders: 3, calls: 2, distinct: 1` is the signature of `useStableRuntimeAdapters` absorbing a fresh-but-shallow-equal bag, which is intended behavior from #6068. A bag that genuinely changes — including a history adapter recreated after an auth refresh, which is a new object identity — propagates today.

## what this test proves

Only that a changed bag reaches the runtime on the synthesized path. It is not a fix, because I found nothing to fix. Mutation-checked at both ends of the seam named in the issue: freezing `useStableRuntimeAdapters` at mount, and breaking the `_AdapterSink` republish, each make this test and only this test fail.

This deliberately does not close #6073 — if the reporter's scenario differs from the ones probed, their repro reopens the chase with this coverage already in place.

## test plan

- `packages/react` 414/414 (50 files), three consecutive runs, no flake
- `packages/core` 1422/1422
- oxlint + oxfmt clean; api-surface regenerated under Node 24, zero drift

Related: #6073


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bPMP3QhyTvU6daNyXv6PeQQoEiVX-sJ6cU8Ysv9lqFtWq-KavPofrefUupA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->