### PR TITLE
fix(react-ag-ui): keep developer messages across snapshot import

### DIFF
--- a/.changeset/agui-developer-role.md
+++ b/.changeset/agui-developer-role.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: keep developer messages across snapshot import

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -662,7 +662,7 @@ function toAssistantSnapshotMessage(
 }
 
 function toUserOrSystemSnapshotMessage(
-  role: "user" | "system",
+  role: "user" | "system" | "developer",
   rawMessage: Record<string, unknown>,
 ): CoreThreadMessageLike {
   const messageName = getString(rawMessage, "name");
@@ -670,10 +670,19 @@ function toUserOrSystemSnapshotMessage(
     role === "user" ? toSnapshotAttachments(rawMessage.content) : [];
   return {
     id: getString(rawMessage, "id") ?? generateId(),
-    role,
+    // The internal message model has no developer role; it rides as a system
+    // message with its wire role kept in metadata so the export restores it.
+    role: role === "developer" ? "system" : role,
     content: extractText(rawMessage.content),
     ...(messageName !== undefined ? { name: messageName } : {}),
     ...(attachments.length > 0 ? { attachments } : {}),
+    ...(role === "developer"
+      ? {
+          metadata: {
+            custom: { [AG_UI_METADATA_NAMESPACE]: { role: "developer" } },
+          },
+        }
+      : {}),
   };
 }
 
@@ -939,7 +948,7 @@ export function fromAgUiMessages(
       continue;
     }
 
-    if (role === "user" || role === "system") {
+    if (role === "user" || role === "system" || role === "developer") {
       converted.push(toUserOrSystemSnapshotMessage(role, rawMessage));
     }
   }
@@ -1137,9 +1146,21 @@ export function toAgUiMessages(
     }
 
     if (message.role === "system" || message.role === "developer") {
+      const custom = isObject(message.metadata)
+        ? message.metadata.custom
+        : undefined;
+      const namespaced = isObject(custom)
+        ? custom[AG_UI_METADATA_NAMESPACE]
+        : undefined;
+      const wireRole =
+        message.role === "system" &&
+        isObject(namespaced) &&
+        namespaced.role === "developer"
+          ? ("developer" as const)
+          : message.role;
       converted.push({
         id: message.id,
-        role: message.role,
+        role: wireRole,
         content: extractText(message.content),
         ...(message.name ? { name: message.name } : {}),
       });

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -679,7 +679,11 @@ function toUserOrSystemSnapshotMessage(
     ...(role === "developer"
       ? {
           metadata: {
-            custom: { [AG_UI_METADATA_NAMESPACE]: { role: "developer" } },
+            custom: {
+              [AG_UI_METADATA_NAMESPACE]: {
+                role: "developer",
+              } satisfies AgUiCustomMetadata,
+            },
           },
         }
       : {}),

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -28,6 +28,9 @@ export type AgUiOpaqueReasoning = {
 };
 
 export type AgUiCustomMetadata = {
+  /** Wire role restored on export for messages the internal model cannot
+   * represent (a developer record rides as a system message). */
+  role?: "developer";
   interrupts?: AgUiInterrupt[];
   opaqueReasoning?: AgUiOpaqueReasoning[];
 };

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -50,6 +50,25 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("round-trips a developer message through import and export", () => {
+    const imported = fromAgUiMessages([
+      { id: "d-1", role: "developer", content: "Hidden instruction" },
+      { id: "u-1", role: "user", content: "Hello" },
+    ] as Message[]);
+
+    const developer = imported.find((message) => message.id === "d-1");
+    expect(developer).toMatchObject({ role: "system" });
+
+    const replayed = toAgUiMessages(
+      imported as Parameters<typeof toAgUiMessages>[0],
+    );
+    expect(replayed[0]).toMatchObject({
+      id: "d-1",
+      role: "developer",
+      content: "Hidden instruction",
+    });
+  });
+
   it("keeps system, developer, and reasoning roles and drops unknown ones", () => {
     const result = toAgUiMessages([
       { id: "s-1", role: "system", content: "Be brief" },


### PR DESCRIPTION
## Summary

`fromAgUiMessages` silently drops `role: "developer"` messages: the import loop handles `tool`, `activity`, `assistant`, `reasoning`, and `user | system`, so a developer record matches nothing and falls off the end without a push. The export direction emits developer records fine (`AgUiMessage` declares the arm, and the "keeps system, developer, and reasoning roles" test pins it) — making the loss one-way: a `MESSAGES_SNAPSHOT` or persisted thread containing a developer instruction loses it on import, and because `buildRunInput` re-derives the wire messages from the repository, the instruction is never re-sent to the agent.

Developer records now import as internal `system` messages (the internal model has no developer role) carrying `custom.agui.role: "developer"`, and the export's system branch restores the wire role from that marker — so the instruction renders like a system message and round-trips back to the agent as `role: "developer"`.

## Why

A developer message is standing instruction state for the agent; dropping it on reload means a conversation resumed from a snapshot behaves differently from the live session that produced it — the same live/reload parity gap class as the reasoning-signature work, but for an entire message. Riding as `system` plus a namespaced metadata marker follows the package's established pattern for wire-only state (`custom.agui.interrupts`, `custom.agui.opaqueReasoning`), and the direct `role: "developer"` export path is untouched, so the pinned export test passes unchanged.

## Repro

```ts
const imported = fromAgUiMessages([
  { id: "d-1", role: "developer", content: "Hidden instruction" },
  { id: "u-1", role: "user", content: "Hello" },
]);
// main:  imported contains only the user message — the instruction is gone,
//        and the next run input omits it entirely
// fixed: imported carries it as a system message with the wire role in
//        metadata; toAgUiMessages restores { id: "d-1", role: "developer" }
```

## Validation

- New round-trip regression test: import a developer record, assert it lands as an internal system message, and assert export restores `role: "developer"` with content intact. Fails on `main` (the record vanishes on import) and passes with this change.
- Full `@assistant-ui/react-ag-ui` suite: 438 passed across 14 files — including the pinned export-side test, unchanged. `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.y-mEH0C9FI1H9vIwJimhWEztYrfOC2WE2LhLWnT5gIUfCOd9aemdMCQGq0M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->