### PR TITLE
fix(react-a2a): keep the server-assigned contextId across re-renders

### DIFF
--- a/.changeset/a2a-context-id.md
+++ b/.changeset/a2a-context-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: keep the server-assigned contextId across re-renders

--- a/.changeset/a2a-context-id.md
+++ b/.changeset/a2a-context-id.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-a2a": patch
 ---
 
-fix: keep the server-assigned contextId across re-renders
+fix: keep the server-assigned contextId across re-renders. switching threads aborts the in-flight run and fires onCancel

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -424,17 +424,14 @@ describe("A2AThreadRuntimeCore", () => {
       });
       const history = {
         load: vi.fn().mockResolvedValue({ messages: [] }),
-        append: vi.fn(),
+        append: vi.fn().mockResolvedValue(undefined),
       };
-      const client = createMockClient({ streamMessage });
-      const core = new A2AThreadRuntimeCore({
-        client,
-        notifyUpdate: notifyUpdate as unknown as () => void,
-        history,
-      } as never);
+      const core = createCore({ streamMessage }, { history });
 
       const run = core.append(createUserAppendMessage("First"));
-      await Promise.resolve();
+      await vi.waitFor(() => {
+        expect(streamMessage).toHaveBeenCalledTimes(1);
+      });
       history.append.mockClear();
 
       core.applyExternalMessages([]);

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -405,11 +405,32 @@ describe("A2AThreadRuntimeCore", () => {
       });
 
       await core.append(createUserAppendMessage("First"));
+      core.resetContext();
       core.applyExternalMessages([]);
       await core.append(createUserAppendMessage("Fresh thread"));
 
       const secondSend = streamMessage.mock.calls[1]?.[0];
       expect(secondSend?.contextId).toBeUndefined();
+    });
+
+    it("keeps the contextId across a bare external apply", async () => {
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed", "Answer");
+      });
+      const client = createMockClient({ streamMessage });
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+      });
+
+      await core.append(createUserAppendMessage("First"));
+      // Branch switches, deletes, and cancel resyncs route through
+      // applyExternalMessages without a thread switch.
+      core.applyExternalMessages(core.getMessages());
+      await core.append(createUserAppendMessage("Second"));
+
+      const secondSend = streamMessage.mock.calls[1]?.[0];
+      expect(secondSend?.contextId).toBe("ctx-1");
     });
 
     it("applies a changed contextId option", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -405,12 +405,50 @@ describe("A2AThreadRuntimeCore", () => {
       });
 
       await core.append(createUserAppendMessage("First"));
-      core.resetContext();
       core.applyExternalMessages([]);
+      core.resetContext();
       await core.append(createUserAppendMessage("Fresh thread"));
 
       const secondSend = streamMessage.mock.calls[1]?.[0];
       expect(secondSend?.contextId).toBeUndefined();
+    });
+
+    it("does not persist a partial message when switching away mid-run", async () => {
+      let releaseStream!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("working");
+        await gate;
+      });
+      const history = {
+        load: vi.fn().mockResolvedValue({ messages: [] }),
+        append: vi.fn(),
+      };
+      const client = createMockClient({ streamMessage });
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+        history,
+      } as never);
+
+      const run = core.append(createUserAppendMessage("First"));
+      await Promise.resolve();
+      history.append.mockClear();
+
+      core.applyExternalMessages([]);
+      core.resetContext();
+      releaseStream();
+      await run.catch(() => {});
+
+      const cancelledAppend = history.append.mock.calls.find((call) => {
+        const entry = call[0] as
+          | { message?: { status?: { reason?: string } } }
+          | undefined;
+        return entry?.message?.status?.reason === "cancelled";
+      });
+      expect(cancelledAppend).toBeUndefined();
     });
 
     it("keeps the contextId across a bare external apply", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -386,12 +386,30 @@ describe("A2AThreadRuntimeCore", () => {
 
       // useA2ARuntime re-applies its options on every render, including the
       // renders triggered by the stream's own notifyUpdate calls.
-      core.updateOptions({ client, contextId: undefined } as never);
+      core.updateOptions({ client, contextId: undefined });
 
       await core.append(createUserAppendMessage("Second"));
 
       const secondSend = streamMessage.mock.calls[1]?.[0];
       expect(secondSend?.contextId).toBe("ctx-1");
+    });
+
+    it("resets the contextId when the thread is switched", async () => {
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed", "Answer");
+      });
+      const client = createMockClient({ streamMessage });
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+      });
+
+      await core.append(createUserAppendMessage("First"));
+      core.applyExternalMessages([]);
+      await core.append(createUserAppendMessage("Fresh thread"));
+
+      const secondSend = streamMessage.mock.calls[1]?.[0];
+      expect(secondSend?.contextId).toBeUndefined();
     });
 
     it("applies a changed contextId option", async () => {
@@ -405,7 +423,7 @@ describe("A2AThreadRuntimeCore", () => {
       });
 
       await core.append(createUserAppendMessage("First"));
-      core.updateOptions({ client, contextId: "ctx-override" } as never);
+      core.updateOptions({ client, contextId: "ctx-override" });
       await core.append(createUserAppendMessage("Second"));
 
       const secondSend = streamMessage.mock.calls[1]?.[0];

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -371,6 +371,48 @@ describe("A2AThreadRuntimeCore", () => {
     });
   });
 
+  describe("updateOptions", () => {
+    it("keeps the server-assigned contextId across re-renders", async () => {
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed", "Answer");
+      });
+      const client = createMockClient({ streamMessage });
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+      });
+
+      await core.append(createUserAppendMessage("First"));
+
+      // useA2ARuntime re-applies its options on every render, including the
+      // renders triggered by the stream's own notifyUpdate calls.
+      core.updateOptions({ client, contextId: undefined } as never);
+
+      await core.append(createUserAppendMessage("Second"));
+
+      const secondSend = streamMessage.mock.calls[1]?.[0];
+      expect(secondSend?.contextId).toBe("ctx-1");
+    });
+
+    it("applies a changed contextId option", async () => {
+      const streamMessage = vi.fn().mockImplementation(async function* () {
+        yield statusUpdateEvent("completed", "Answer");
+      });
+      const client = createMockClient({ streamMessage });
+      const core = new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate: notifyUpdate as unknown as () => void,
+      });
+
+      await core.append(createUserAppendMessage("First"));
+      core.updateOptions({ client, contextId: "ctx-override" } as never);
+      await core.append(createUserAppendMessage("Second"));
+
+      const secondSend = streamMessage.mock.calls[1]?.[0];
+      expect(secondSend?.contextId).toBe("ctx-override");
+    });
+  });
+
   // --- Edit & Reload ---
 
   describe("edit", () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -142,6 +142,16 @@ export class A2AThreadRuntimeCore {
     this.history = options.history;
   }
 
+  /** Thread-boundary reset: applyExternalMessages alone also serves branch
+   * switches, deletes, and cancel resyncs, which must keep the live context. */
+  resetContext(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this.contextId = this.lastOptionsContextId;
+  }
+
   attachRuntime(runtime: AssistantRuntime) {
     this.runtime = runtime;
   }
@@ -361,9 +371,6 @@ export class A2AThreadRuntimeCore {
       this.recordedHistoryIds.add(message.id);
     }
     this.currentTask = undefined;
-    // An external apply is a thread boundary; the next conversation must not
-    // inherit the previous thread's server-assigned context.
-    this.contextId = this.lastOptionsContextId;
     this.currentArtifacts = [];
     this.notifyUpdate();
   }

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -111,9 +111,12 @@ export class A2AThreadRuntimeCore {
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
 
+  private lastOptionsContextId: string | undefined;
+
   constructor(options: A2AThreadRuntimeCoreOptions) {
     this.client = options.client;
     this.contextId = options.contextId;
+    this.lastOptionsContextId = options.contextId;
     this.configuration = options.configuration;
     this.onError = options.onError;
     this.onCancel = options.onCancel;
@@ -124,7 +127,14 @@ export class A2AThreadRuntimeCore {
 
   updateOptions(options: Omit<A2AThreadRuntimeCoreOptions, "notifyUpdate">) {
     this.client = options.client;
-    this.contextId = options.contextId;
+    // The hook re-applies options on every render, including renders caused
+    // by this core's own notifyUpdate. The option only seeds the context: a
+    // re-render with the same value must not clobber a server-assigned
+    // contextId learned from the stream.
+    if (options.contextId !== this.lastOptionsContextId) {
+      this.contextId = options.contextId;
+      this.lastOptionsContextId = options.contextId;
+    }
     this.configuration = options.configuration;
     this.onError = options.onError;
     this.onCancel = options.onCancel;

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -145,11 +145,17 @@ export class A2AThreadRuntimeCore {
   /** Thread-boundary reset: applyExternalMessages alone also serves branch
    * switches, deletes, and cancel resyncs, which must keep the live context. */
   resetContext(): void {
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
-    }
+    // Restore the seed before aborting: an onCancel callback that starts a
+    // new run must not pick up the old thread's context, and its controller
+    // must not be discarded.
+    const controller = this.abortController;
     this.contextId = this.lastOptionsContextId;
+    if (controller) {
+      controller.abort();
+      if (this.abortController === controller) {
+        this.abortController = null;
+      }
+    }
   }
 
   attachRuntime(runtime: AssistantRuntime) {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -361,6 +361,9 @@ export class A2AThreadRuntimeCore {
       this.recordedHistoryIds.add(message.id);
     }
     this.currentTask = undefined;
+    // An external apply is a thread boundary; the next conversation must not
+    // inherit the previous thread's server-assigned context.
+    this.contextId = this.lastOptionsContextId;
     this.currentArtifacts = [];
     this.notifyUpdate();
   }

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -104,15 +104,18 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       onSwitchToNewThread: onSwitchToNewThread
         ? async () => {
             await onSwitchToNewThread();
-            core.resetContext();
+            // Apply first so the abort inside resetContext finds an already
+            // cleared repository and cannot persist the old thread's partial
+            // assistant message.
             core.applyExternalMessages([]);
+            core.resetContext();
           }
         : undefined,
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
             const result = await onSwitchToThread(threadId);
-            core.resetContext();
             core.applyExternalMessages(result.messages);
+            core.resetContext();
           }
         : undefined,
     };

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -104,12 +104,14 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       onSwitchToNewThread: onSwitchToNewThread
         ? async () => {
             await onSwitchToNewThread();
+            core.resetContext();
             core.applyExternalMessages([]);
           }
         : undefined,
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
             const result = await onSwitchToThread(threadId);
+            core.resetContext();
             core.applyExternalMessages(result.messages);
           }
         : undefined,


### PR DESCRIPTION
## Summary

`useA2ARuntime` calls `core.updateOptions({...})` in the render body on every render, and `updateOptions` unconditionally wrote `this.contextId = options.contextId`. But the core *learns* the real context from the server: `handleStatusUpdate` and `handleTaskSnapshot` assign the streamed `contextId` and then call `notifyUpdate()` — which triggers a re-render — which re-applies the options — which reverts `contextId` to the (usually `undefined`) prop. From turn 2 onward the outgoing `A2AMessage` carries no `contextId`, so the agent sees a fresh conversation context while the surviving `taskId` points at the old one — worst on the `input_required` / `auth_required` resume path, where continuity is the whole point.

`updateOptions` now applies `options.contextId` only when the option value itself changed since the last call (the option is documented as the *initial* context), so render-driven re-application preserves the server-assigned value while a deliberately changed prop still wins.

## Why

The clobber is structural: the very act of learning the contextId (notify → render → updateOptions) is what erased it, so no A2A conversation could retain server-assigned context past its first turn. Change-detection keeps both documented behaviors: the option seeds the context, and an app that intentionally re-points the thread at a different context still can.

## Repro

```ts
// stream assigns contextId "ctx-1" during turn 1; the hook re-renders and
// re-applies { contextId: undefined }
await core.append(first);
core.updateOptions({ client, contextId: undefined }); // ← every render does this
await core.append(second);
// main:  second streamMessage call has no contextId — new conversation context
// fixed: second call carries contextId "ctx-1"
```

## Validation

- Two regression tests: a re-render with an unchanged option preserves the server-assigned `contextId` on the next send (fails on `main` — the send loses it), and a *changed* `contextId` option still applies (passes before and after, pinning the override path).
- Full `@assistant-ui/react-a2a` suite: 246 passed across 4 files, `tsc --noEmit` clean.

### Review round 1

- Valid and blocking (both reviewers): suppressing the render clobber also removed the only reset of `contextId` on thread switches, so thread A's server context would have leaked into thread B's first message. `finalizeExternalApply` — the shared boundary for thread switches and history loads, which already resets `currentTask`/`currentArtifacts` — now also resets `contextId` to the option seed. Regression test added for the exact leak sequence (learn `ctx-1` → `applyExternalMessages([])` → next send carries no contextId); it fails on the previous commit and passes now, and the round-trip continuity test still passes since no apply boundary occurs mid-conversation.
- Dropped the `as never` casts on the test's `updateOptions` calls per review — the argument satisfies the signature directly, so the tests now break if it changes.

### Review round 2

Both reviewers were right that round 1 over-corrected: `applyExternalMessages` also serves branch switches, deletes, and cancel resyncs (all routed through `setMessages`), so resetting in `finalizeExternalApply` would have wiped the live context on the most common interactions — stopping a run, branch navigation. The reset now lives on an internal `resetContext()` called from the two real thread-boundary wrappers in `useA2ARuntime` (`onSwitchToNewThread` / `onSwitchToThread`), and it aborts any in-flight run first so a late event from the old thread's stream cannot re-leak its context (the second reviewer's race). Tests updated: the thread-switch regression drives the new seam, and a companion test pins that a bare `applyExternalMessages` — the branch/cancel shape — keeps the learned context.

### Review round 3

- Valid (claude): resetting before the apply let the abort listener persist the old thread's partial assistant message into history (and potentially into the *new* thread's adapter, depending on render timing). The wrappers now apply first — the abort then finds a cleared repository and the persist no-ops — with a regression test pinning that a mid-run switch never `history.append`s a cancelled partial. The unconditional `onCancel` callback still fires for the genuinely cancelled in-flight run, which is accurate reporting.
- Valid (cubic P2): `resetContext` now restores the seed *before* aborting, so an `onCancel` callback that immediately starts a new run cannot pick up the old context, and the controller slot is cleared only if it still belongs to the aborted run.
- On cubic's P3 (hook-wiring coverage): the ordering contract is pinned at the core level in the exact wrapper sequence; the wrapper bodies themselves are two-line pass-throughs exercised by `useA2ARuntime.test.tsx`'s existing thread-list path.
