### PR TITLE
fix(core): keep prepended id-less messages in the external message converter

### DIFF
--- a/.changeset/converter-fallback-ids.md
+++ b/.changeset/converter-fallback-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep prepended id-less messages in the external message converter

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -54,6 +54,37 @@ const renderConverter = (initialProps: Props = {}) =>
   );
 
 describe("useExternalMessageConverter", () => {
+  it("refreshes positional fallback ids when an id-less message is prepended", () => {
+    const idlessConvert: useExternalMessageConverter.Callback<TestMessage> = (
+      message,
+    ) => ({
+      role: message.role,
+      content: [{ type: "text", text: message.text }],
+    });
+
+    const older: TestMessage = { id: "u0", role: "user", text: "older" };
+    const newer: TestMessage = { id: "u1", role: "user", text: "newer" };
+
+    const { result, rerender } = renderHook(
+      ({ messages }: { messages: TestMessage[] }) =>
+        useExternalMessageConverter<TestMessage>({
+          callback: idlessConvert,
+          messages,
+          isRunning: false,
+          metadata: EMPTY,
+        }),
+      { initialProps: { messages: [newer] } },
+    );
+
+    rerender({ messages: [older, newer] });
+
+    const ids = result.current.map((message) => message.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(
+      result.current.map((message) => (message.content[0] as any).text),
+    ).toEqual(["older", "newer"]);
+  });
+
   it("reuses converted messages across rerenders when inputs are unchanged", () => {
     const { result, rerender } = renderConverter();
 

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -117,6 +117,14 @@ describe("useExternalMessageConverter", () => {
 
     rerender({ messages: [older, explicit] });
 
+    // The caller-supplied id survives untouched — at the cost of colliding
+    // with the id minted for the prepended message, since the caller chose an
+    // id inside the reserved fallback namespace. The full list makes that
+    // trade-off explicit.
+    expect(result.current.map((message) => message.id)).toEqual([
+      "__external_store_fallback_0",
+      "__external_store_fallback_0",
+    ]);
     const explicitOut = result.current.find(
       (message) => (message.content[0] as any).text === "kept",
     );

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -88,6 +88,41 @@ describe("useExternalMessageConverter", () => {
     ).toEqual(["older", "newer"]);
   });
 
+  it("never rewrites a caller-supplied id that matches the generated shape", () => {
+    const explicitConvert: useExternalMessageConverter.Callback<TestMessage> = (
+      message,
+    ) => ({
+      role: message.role,
+      id: message.id === "explicit" ? "__external_store_fallback_0" : undefined,
+      content: [{ type: "text", text: message.text }],
+    });
+
+    const explicit: TestMessage = {
+      id: "explicit",
+      role: "user",
+      text: "kept",
+    };
+    const older: TestMessage = { id: "u0", role: "user", text: "older" };
+
+    const { result, rerender } = renderHook(
+      ({ messages }: { messages: TestMessage[] }) =>
+        useExternalMessageConverter<TestMessage>({
+          callback: explicitConvert,
+          messages,
+          isRunning: false,
+          metadata: EMPTY,
+        }),
+      { initialProps: { messages: [explicit] } },
+    );
+
+    rerender({ messages: [older, explicit] });
+
+    const explicitOut = result.current.find(
+      (message) => (message.content[0] as any).text === "kept",
+    );
+    expect(explicitOut?.id).toBe("__external_store_fallback_0");
+  });
+
   it("reuses converted messages across rerenders when inputs are unchanged", () => {
     const { result, rerender } = renderConverter();
 

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -79,7 +79,10 @@ describe("useExternalMessageConverter", () => {
     rerender({ messages: [older, newer] });
 
     const ids = result.current.map((message) => message.id);
-    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([
+      "__external_store_fallback_0",
+      "__external_store_fallback_1",
+    ]);
     expect(
       result.current.map((message) => (message.content[0] as any).text),
     ).toEqual(["older", "newer"]);

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -8,10 +8,6 @@ import {
   bindExternalStoreMessage,
   FALLBACK_ID_PREFIX,
 } from "../../runtime/utils/external-store-message";
-
-// Generatedness is tracked by identity, not by id shape: a caller-supplied id
-// that happens to match the generated pattern must never be rewritten.
-const generatedFallbackMessages = new WeakSet<object>();
 import {
   fromThreadMessageLike,
   type ThreadMessageLike,
@@ -26,6 +22,10 @@ import type {
   ToolCallMessagePart,
 } from "../../types/message";
 import type { MessageTiming } from "../../types/message";
+
+// Generatedness is tracked by identity, not by id shape: a caller-supplied id
+// that happens to match the generated pattern must never be rewritten.
+const generatedFallbackMessages = new WeakSet<object>();
 
 export type JoinStrategy = "concat-content" | "none";
 

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -6,12 +6,13 @@ import {
   getExternalStoreMessages,
   symbolInnerMessage,
   bindExternalStoreMessage,
+  FALLBACK_ID_PREFIX,
+  isGeneratedFallbackId,
 } from "../../runtime/utils/external-store-message";
 import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
-import { FALLBACK_ID_PREFIX } from "../../runtimes/external-store/external-store-thread-runtime-core";
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -413,7 +414,7 @@ export const convertExternalMessages = <T extends WeakKey>(
     );
     const newMessage = fromThreadMessageLike(
       joined,
-      idx.toString(),
+      `${FALLBACK_ID_PREFIX}${idx}`,
       autoStatus,
     );
     bindExternalStoreMessage(newMessage, message.inputs);
@@ -536,10 +537,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
             // A positional fallback id goes stale when messages are prepended
             // or reordered; serving it unchanged makes two messages collide on
             // one id and the dedup downstream drops one of them.
-            if (
-              cache.id.startsWith(FALLBACK_ID_PREFIX) &&
-              cache.id !== fallbackId
-            ) {
+            if (isGeneratedFallbackId(cache.id) && cache.id !== fallbackId) {
               const updated = { ...cache, id: fallbackId };
               bindExternalStoreMessage(updated, message.inputs);
               return updated;

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -11,6 +11,7 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
+import { FALLBACK_ID_PREFIX } from "../../runtimes/external-store/external-store-thread-runtime-core";
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -522,6 +523,8 @@ export const useExternalMessageConverter = <T extends WeakKey>({
           isLast ? state.metadata.error : undefined,
         );
 
+        const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
+
         if (
           cache &&
           (cache.role !== "assistant" ||
@@ -530,13 +533,24 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         ) {
           const inputs = getExternalStoreMessages<T>(cache);
           if (shallowArrayEqual(inputs, message.inputs)) {
+            // A positional fallback id goes stale when messages are prepended
+            // or reordered; serving it unchanged makes two messages collide on
+            // one id and the dedup downstream drops one of them.
+            if (
+              cache.id.startsWith(FALLBACK_ID_PREFIX) &&
+              cache.id !== fallbackId
+            ) {
+              const updated = { ...cache, id: fallbackId };
+              bindExternalStoreMessage(updated, message.inputs);
+              return updated;
+            }
             return cache;
           }
         }
 
         const newMessage = fromThreadMessageLike(
           joined,
-          idx.toString(),
+          fallbackId,
           autoStatus,
         );
         bindExternalStoreMessage(newMessage, message.inputs);

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -7,8 +7,11 @@ import {
   symbolInnerMessage,
   bindExternalStoreMessage,
   FALLBACK_ID_PREFIX,
-  isGeneratedFallbackId,
 } from "../../runtime/utils/external-store-message";
+
+// Generatedness is tracked by identity, not by id shape: a caller-supplied id
+// that happens to match the generated pattern must never be rewritten.
+const generatedFallbackMessages = new WeakSet<object>();
 import {
   fromThreadMessageLike,
   type ThreadMessageLike,
@@ -537,8 +540,12 @@ export const useExternalMessageConverter = <T extends WeakKey>({
             // A positional fallback id goes stale when messages are prepended
             // or reordered; serving it unchanged makes two messages collide on
             // one id and the dedup downstream drops one of them.
-            if (isGeneratedFallbackId(cache.id) && cache.id !== fallbackId) {
+            if (
+              generatedFallbackMessages.has(cache) &&
+              cache.id !== fallbackId
+            ) {
               const updated = { ...cache, id: fallbackId };
+              generatedFallbackMessages.add(updated);
               bindExternalStoreMessage(updated, message.inputs);
               return updated;
             }
@@ -551,6 +558,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
           fallbackId,
           autoStatus,
         );
+        if (joined.id == null) generatedFallbackMessages.add(newMessage);
         bindExternalStoreMessage(newMessage, message.inputs);
         return newMessage;
       },

--- a/packages/core/src/runtime/utils/external-store-message.ts
+++ b/packages/core/src/runtime/utils/external-store-message.ts
@@ -42,3 +42,11 @@ export const getExternalStoreMessages = <T>(
   container[symbolInnerMessages] = [value];
   return container[symbolInnerMessages];
 };
+
+export const FALLBACK_ID_PREFIX = "__external_store_fallback_";
+
+/** True for ids this package generated positionally (prefix + index) — a
+ * caller-supplied id that merely resembles the prefix is left untouched. */
+export const isGeneratedFallbackId = (id: string): boolean =>
+  id.startsWith(FALLBACK_ID_PREFIX) &&
+  /^\d+$/.test(id.slice(FALLBACK_ID_PREFIX.length));

--- a/packages/core/src/runtime/utils/external-store-message.ts
+++ b/packages/core/src/runtime/utils/external-store-message.ts
@@ -44,9 +44,3 @@ export const getExternalStoreMessages = <T>(
 };
 
 export const FALLBACK_ID_PREFIX = "__external_store_fallback_";
-
-/** True for ids this package generated positionally (prefix + index) — a
- * caller-supplied id that merely resembles the prefix is left untouched. */
-export const isGeneratedFallbackId = (id: string): boolean =>
-  id.startsWith(FALLBACK_ID_PREFIX) &&
-  /^\d+$/.test(id.slice(FALLBACK_ID_PREFIX.length));

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -16,6 +16,7 @@ import type {
 import {
   getExternalStoreMessages,
   bindExternalStoreMessage,
+  FALLBACK_ID_PREFIX,
 } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "./thread-message-converter";
 import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
@@ -76,8 +77,6 @@ export const hasUpcomingMessage = (
 ) => {
   return isRunning && messages[messages.length - 1]?.role !== "assistant";
 };
-
-export const FALLBACK_ID_PREFIX = "__external_store_fallback_";
 
 export class ExternalStoreThreadRuntimeCore
   extends BaseThreadRuntimeCore

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -77,7 +77,7 @@ export const hasUpcomingMessage = (
   return isRunning && messages[messages.length - 1]?.role !== "assistant";
 };
 
-const FALLBACK_ID_PREFIX = "__external_store_fallback_";
+export const FALLBACK_ID_PREFIX = "__external_store_fallback_";
 
 export class ExternalStoreThreadRuntimeCore
   extends BaseThreadRuntimeCore


### PR DESCRIPTION
## Summary

`useExternalMessageConverter` mints a *positional* fallback id (`idx.toString()`) for any converted message whose source has no `id`, and its cache returns the previously converted message without ever refreshing that id. When a message is prepended (history load, pagination), every retained message keeps its old positional id while the new chunk at index 0 mints id `"0"` — two messages now collide on one id, and `ExternalStoreThreadRuntimeCore`'s duplicate-id guard silently drops the prepended message with only a console warning.

This is the exact defect #6271 fixed in `ExternalStoreThreadRuntimeCore`'s own conversion path (`FALLBACK_ID_PREFIX` plus an id-rewrite on cache hits) — but that fix never reached the converter hook, which is what `react-langgraph`, `react-langchain`, `react-google-adk`, and `ai-sdk` consume. The same fix shape is now mirrored here: fallback ids carry the shared prefix, and a cache hit whose fallback id no longer matches the message's current index is re-issued at the right id instead of served stale.

## Why

Same reasoning that landed #6271, one layer up: positional ids are only valid for the position they were minted at, so a cache keyed on message identity must not preserve them across reordering. Reusing the exported `FALLBACK_ID_PREFIX` keeps the two conversion paths recognizably one pattern; messages that carry a real id are untouched (the rewrite is gated on the prefix).

## Repro

```ts
// convertMessage returns messages without ids
render(useExternalMessageConverter({ messages: [newer], ... }));
rerender({ messages: [older, newer] }); // history prepend
// main:  both outputs carry id "0" → the downstream dedup drops one message
// fixed: ids stay unique and both messages render
```

## Validation

- New regression test: prepending an id-less message must leave all output ids unique with both messages present, in order. Fails on `main` (duplicate id, one message effectively lost) and passes with this change.
- Full `@assistant-ui/core` suite: 1420 passed; the 3 remaining failures (cloud telemetry/persistence specs) fail identically on `main` before this change and are untouched. `tsc --noEmit` error count unchanged.

### Review round 1

All four findings taken:

- `convertExternalMessages` (the `toThreadMessages` half of the pair) now mints the same prefixed fallback id, so the two conversion paths agree again for id-less messages and switching paths no longer remounts them.
- The rewrite is gated on `isGeneratedFallbackId` — prefix **plus** an all-digit suffix — so a pathological caller id that merely resembles the prefix (e.g. `__external_store_fallback_custom`) is never reclassified. This is strictly tighter than the check #6271 landed in the runtime core.
- `FALLBACK_ID_PREFIX` (and the new helper) moved to `runtime/utils/external-store-message.ts` next to `bindExternalStoreMessage`, fixing the backwards react-layer → runtime-core import both reviewers flagged; the runtime core imports it from there.
- The regression test asserts the exact expected ids instead of mere uniqueness.

### Review round 2

- Taken to its conclusion: shape-based classification could still rewrite a caller id byte-identical to a generated one (`__external_store_fallback_0`). Generatedness is now tracked by object identity — a module-level `WeakSet` populated only when the converter itself mints the id — so caller-supplied ids are never rewritten no matter what they look like. The shape helper became dead and was removed. New test pins the byte-identical case surviving a prepend. (Preserving such an id can collide with a freshly minted positional one — a hazard that exists only for callers minting ids inside the reserved fallback namespace, and which the downstream duplicate-id guard then resolves. Round 3 makes this trade-off explicit in the test.)

### Review round 3

- The `WeakSet` declaration moved below the import block (it had been spliced mid-imports).
- Per both reviewers, the byte-identical-id test now asserts the *full* id list, making the deliberate trade-off visible: the caller-supplied id survives untouched at the cost of colliding with the minted positional id — a hazard reachable only when a caller mints ids inside the reserved `__external_store_fallback_*` namespace. The round-2 note above was reworded accordingly (it had mischaracterized this as pre-existing behavior).
