### PR TITLE
fix(react-ag-ui): keep tool follow-up text on its assistant message

### DIFF
--- a/.changeset/fix-agui-follow-up-duplication.md
+++ b/.changeset/fix-agui-follow-up-duplication.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-fix(react-ag-ui): keep tool follow-up text on its assistant message
+fix: keep tool follow-up text on its assistant message

--- a/.changeset/fix-agui-follow-up-duplication.md
+++ b/.changeset/fix-agui-follow-up-duplication.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix(react-ag-ui): keep tool follow-up text on its assistant message

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1187,7 +1187,13 @@ export class AgUiThreadRuntimeCore {
     ) => {
       if (startNewMessage && assistantMessageId !== undefined) {
         applyUpdate({ status: { type: "complete", reason: "unknown" } });
+        const previousId = assistantMessageId;
         assistantMessageId = undefined;
+        if (this.tryGetMessage(previousId)) {
+          const created = this.insertAssistantPlaceholder(previousId);
+          assistantMessageId = created;
+          this.markPendingAssistantHistory(created, previousId);
+        }
       }
       const placeholder = ensureAssistant(true);
       if (placeholder === serverId) return;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1181,32 +1181,44 @@ export class AgUiThreadRuntimeCore {
       }
     };
 
+    const adoptServerMessageId = (
+      serverId: string,
+      startNewMessage: boolean,
+    ) => {
+      if (startNewMessage && assistantMessageId !== undefined) {
+        applyUpdate({ status: { type: "complete", reason: "unknown" } });
+        assistantMessageId = undefined;
+      }
+      const placeholder = ensureAssistant(true);
+      if (placeholder === serverId) return;
+      const reassigned = this.reassignAssistantId(placeholder, serverId);
+      // A collision drops the placeholder before revealing the existing
+      // server message as the current head. Only messages introduced during
+      // this run can replace the placeholder; regeneration must not rewrite
+      // a previous branch when the server incorrectly reuses its id.
+      const adoptsVisibleCollision =
+        !reassigned &&
+        !runStartMessageIds.has(serverId) &&
+        this.repository.headId === serverId;
+      if (reassigned || adoptsVisibleCollision) {
+        assistantMessageId = serverId;
+        if (adoptsVisibleCollision) {
+          const parentId = this.tryGetMessage(serverId)?.parentId ?? null;
+          this.markPendingAssistantHistory(serverId, parentId);
+        }
+      } else {
+        assistantCollided = true;
+      }
+    };
+
     const aggregator = new RunAggregator({
       showThinking: this.showThinking,
       logger: this.logger,
       emit: applyUpdate,
       onServerMessageId: (serverId) => {
-        const placeholder = ensureAssistant(true);
-        if (placeholder === serverId) return;
-        const reassigned = this.reassignAssistantId(placeholder, serverId);
-        // A collision drops the placeholder before revealing the existing
-        // server message as the current head. Only messages introduced during
-        // this run can replace the placeholder; regeneration must not rewrite
-        // a previous branch when the server incorrectly reuses its id.
-        const adoptsVisibleCollision =
-          !reassigned &&
-          !runStartMessageIds.has(serverId) &&
-          this.repository.headId === serverId;
-        if (reassigned || adoptsVisibleCollision) {
-          assistantMessageId = serverId;
-          if (adoptsVisibleCollision) {
-            const parentId = this.tryGetMessage(serverId)?.parentId ?? null;
-            this.markPendingAssistantHistory(serverId, parentId);
-          }
-        } else {
-          assistantCollided = true;
-        }
+        adoptServerMessageId(serverId, false);
       },
+      onTextMessageStart: (serverId) => adoptServerMessageId(serverId, true),
     });
     const dispatch = (event: AgUiEvent) =>
       this.handleEvent(aggregator, event, assistantMessageId);

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -66,6 +66,7 @@ export type RunAggregatorOptions = {
   logger: Logger;
   emit: Emit;
   onServerMessageId?: (messageId: string) => void;
+  onTextMessageStart?: (messageId: string) => void;
 };
 
 /**
@@ -83,6 +84,9 @@ export class RunAggregator {
   private readonly showThinking: boolean;
   private readonly logger: Logger;
   private readonly onServerMessageId: ((messageId: string) => void) | undefined;
+  private readonly onTextMessageStart:
+    | ((messageId: string) => void)
+    | undefined;
 
   private status: ChatModelRunResult["status"] | undefined;
   private interrupts: AgUiInterrupt[] | undefined;
@@ -109,6 +113,7 @@ export class RunAggregator {
   )[] = [];
   private textPartCounter = 0;
   private serverMessageIdReported = false;
+  private lastTextMessageId: string | undefined;
 
   private streamStartTime: number | undefined;
   private firstTokenTime: number | undefined;
@@ -119,6 +124,7 @@ export class RunAggregator {
     this.showThinking = options.showThinking;
     this.logger = options.logger;
     this.onServerMessageId = options.onServerMessageId;
+    this.onTextMessageStart = options.onTextMessageStart;
   }
 
   hasToolCall(toolCallId: string): boolean {
@@ -128,22 +134,10 @@ export class RunAggregator {
   handle(event: AgUiEvent): void {
     switch (event.type) {
       case "RUN_STARTED": {
-        this.clearTextParts();
-        this.reasoningParts.clear();
-        this.reasoningSignatures.clear();
-        this.reasoningMessageIds.clear();
-        this.anonymousReasoningKeys.clear();
-        this.activeReasoningKey = undefined;
-        this.reasoningPartCounter = 0;
-        this.toolCalls.clear();
-        this.a2uiBuckets.clear();
-        this.a2uiToolCallIds.clear();
-        this.lastResolvedToolCallId = undefined;
-        this.partOrder.length = 0;
-        this.textPartCounter = 0;
-        this.activeTextMessageId = undefined;
+        this.resetMessageParts();
         this.interrupts = undefined;
         this.serverMessageIdReported = false;
+        this.lastTextMessageId = undefined;
         this.streamStartTime = Date.now();
         this.firstTokenTime = undefined;
         this.totalChunks = 0;
@@ -187,8 +181,18 @@ export class RunAggregator {
       }
 
       case "TEXT_MESSAGE_START": {
+        if (
+          event.messageId &&
+          this.lastTextMessageId !== undefined &&
+          this.lastTextMessageId !== event.messageId &&
+          this.onTextMessageStart
+        ) {
+          this.resetMessageParts();
+          this.onTextMessageStart(event.messageId);
+        }
         this.reportServerMessageId(event.messageId);
         const id = this.startTextMessage(event.messageId);
+        if (event.messageId) this.lastTextMessageId = event.messageId;
         if (id) {
           this.markTextPartTouched(id);
         }
@@ -198,10 +202,20 @@ export class RunAggregator {
       case "TEXT_MESSAGE_CONTENT":
       case "TEXT_MESSAGE_CHUNK": {
         const incomingId = "messageId" in event ? event.messageId : undefined;
+        if (
+          incomingId &&
+          this.lastTextMessageId !== undefined &&
+          this.lastTextMessageId !== incomingId &&
+          this.onTextMessageStart
+        ) {
+          this.resetMessageParts();
+          this.onTextMessageStart(incomingId);
+        }
         this.reportServerMessageId(incomingId);
         if (!event.delta) break;
         this.recordFirstToken();
         const id = this.resolveTextMessageId(incomingId);
+        if (incomingId) this.lastTextMessageId = incomingId;
         this.appendText(id, event.delta);
         this.totalChunks++;
         this.emit();
@@ -446,6 +460,23 @@ export class RunAggregator {
 
   private clearTextParts(): void {
     this.textParts.clear();
+  }
+
+  private resetMessageParts(): void {
+    this.clearTextParts();
+    this.reasoningParts.clear();
+    this.reasoningSignatures.clear();
+    this.reasoningMessageIds.clear();
+    this.anonymousReasoningKeys.clear();
+    this.activeReasoningKey = undefined;
+    this.reasoningPartCounter = 0;
+    this.toolCalls.clear();
+    this.a2uiBuckets.clear();
+    this.a2uiToolCallIds.clear();
+    this.lastResolvedToolCallId = undefined;
+    this.partOrder.length = 0;
+    this.textPartCounter = 0;
+    this.activeTextMessageId = undefined;
   }
 
   private generateTextKey(): string {

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -196,10 +196,10 @@ export class RunAggregator {
         const incomingId = "messageId" in event ? event.messageId : undefined;
         this.beginDistinctTextMessage(incomingId);
         this.reportServerMessageId(incomingId);
+        if (incomingId) this.lastTextMessageId = incomingId;
         if (!event.delta) break;
         this.recordFirstToken();
         const id = this.resolveTextMessageId(incomingId);
-        if (incomingId) this.lastTextMessageId = incomingId;
         this.appendText(id, event.delta);
         this.totalChunks++;
         this.emit();
@@ -437,7 +437,11 @@ export class RunAggregator {
   }
 
   private reportServerMessageId(messageId: string | undefined): void {
-    if (this.serverMessageIdReported || !messageId) return;
+    if (!messageId) return;
+    if (this.lastTextMessageId === undefined) {
+      this.lastTextMessageId = messageId;
+    }
+    if (this.serverMessageIdReported) return;
     this.serverMessageIdReported = true;
     this.onServerMessageId?.(messageId);
   }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -181,15 +181,7 @@ export class RunAggregator {
       }
 
       case "TEXT_MESSAGE_START": {
-        if (
-          event.messageId &&
-          this.lastTextMessageId !== undefined &&
-          this.lastTextMessageId !== event.messageId &&
-          this.onTextMessageStart
-        ) {
-          this.resetMessageParts();
-          this.onTextMessageStart(event.messageId);
-        }
+        this.beginDistinctTextMessage(event.messageId);
         this.reportServerMessageId(event.messageId);
         const id = this.startTextMessage(event.messageId);
         if (event.messageId) this.lastTextMessageId = event.messageId;
@@ -202,15 +194,7 @@ export class RunAggregator {
       case "TEXT_MESSAGE_CONTENT":
       case "TEXT_MESSAGE_CHUNK": {
         const incomingId = "messageId" in event ? event.messageId : undefined;
-        if (
-          incomingId &&
-          this.lastTextMessageId !== undefined &&
-          this.lastTextMessageId !== incomingId &&
-          this.onTextMessageStart
-        ) {
-          this.resetMessageParts();
-          this.onTextMessageStart(incomingId);
-        }
+        this.beginDistinctTextMessage(incomingId);
         this.reportServerMessageId(incomingId);
         if (!event.delta) break;
         this.recordFirstToken();
@@ -477,6 +461,19 @@ export class RunAggregator {
     this.partOrder.length = 0;
     this.textPartCounter = 0;
     this.activeTextMessageId = undefined;
+  }
+
+  private beginDistinctTextMessage(messageId: string | undefined): void {
+    if (
+      !messageId ||
+      this.lastTextMessageId === undefined ||
+      this.lastTextMessageId === messageId ||
+      !this.onTextMessageStart
+    ) {
+      return;
+    }
+    this.resetMessageParts();
+    this.onTextMessageStart(messageId);
   }
 
   private generateTextKey(): string {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -212,6 +212,106 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("keeps tool follow-up text on its own assistant message", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: "assistant-1" },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "get_weather",
+            parentMessageId: "assistant-1",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: { type: "TOOL_CALL_ARGS", toolCallId: "call-1", delta: "{}" },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "tool-1",
+            toolCallId: "call-1",
+            content: "Beijing: 26C",
+            role: "tool",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: "assistant-1" },
+        });
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: "assistant-2" },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: "assistant-2",
+            delta: "Beijing: 26C",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: "assistant-2" },
+        });
+        subscriber.onMessagesSnapshotEvent?.({
+          event: {
+            type: "MESSAGES_SNAPSHOT",
+            messages: [
+              { id: "user-1", role: "user", content: "Weather?" },
+              {
+                id: "assistant-1",
+                role: "assistant",
+                content: "",
+                toolCalls: [
+                  {
+                    id: "call-1",
+                    type: "function",
+                    function: { name: "get_weather", arguments: "{}" },
+                  },
+                ],
+              },
+              {
+                id: "tool-1",
+                role: "tool",
+                toolCallId: "call-1",
+                content: "Beijing: 26C",
+              },
+              { id: "assistant-2", role: "assistant", content: "Beijing: 26C" },
+            ],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistants = core
+      .getMessages()
+      .filter(
+        (message) => message.role === "assistant",
+      ) as ThreadAssistantMessage[];
+    expect(assistants).toHaveLength(2);
+    expect(
+      assistants[0]?.content.filter((part) => part.type === "text"),
+    ).toEqual([]);
+    expect(assistants[0]?.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "call-1",
+        result: "Beijing: 26C",
+      }),
+    );
+    expect(assistants[1]?.content).toEqual([
+      { type: "text", text: "Beijing: 26C" },
+    ]);
+  });
+
   it("imports tool role messages from snapshots as assistant tool-call results", async () => {
     const agent = {
       runAgent: vi.fn(async (_input, subscriber) => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -296,7 +296,10 @@ describe("AGUIThreadRuntimeCore", () => {
       .filter(
         (message) => message.role === "assistant",
       ) as ThreadAssistantMessage[];
-    expect(assistants).toHaveLength(2);
+    expect(assistants.map((message) => message.id)).toEqual([
+      "assistant-1",
+      "assistant-2",
+    ]);
     expect(
       assistants[0]?.content.filter((part) => part.type === "text"),
     ).toEqual([]);
@@ -310,6 +313,96 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(assistants[1]?.content).toEqual([
       { type: "text", text: "Beijing: 26C" },
     ]);
+    expect(
+      core
+        .getMessageRepository()
+        .messages.find((item) => item.message.id === "assistant-2")?.parentId,
+    ).toBe("assistant-1");
+  });
+
+  it("keeps the tool assistant on the head path before a snapshot", async () => {
+    let midRunIds: string[] | undefined;
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: "assistant-1" },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "get_weather",
+            parentMessageId: "assistant-1",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: { type: "TOOL_CALL_ARGS", toolCallId: "call-1", delta: "{}" },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "tool-1",
+            toolCallId: "call-1",
+            content: "Beijing: 26C",
+            role: "tool",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: "assistant-1" },
+        });
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: "assistant-2" },
+        });
+        midRunIds = core.getMessages().map((message) => message.id);
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: "assistant-2",
+            delta: "Beijing: 26C",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: "assistant-2" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    expect(midRunIds?.slice(-2)).toEqual(["assistant-1", "assistant-2"]);
+    const messages = core.getMessages();
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+    const assistants = messages.filter(
+      (message) => message.role === "assistant",
+    ) as ThreadAssistantMessage[];
+    expect(assistants.map((message) => message.id)).toEqual([
+      "assistant-1",
+      "assistant-2",
+    ]);
+    expect(assistants[0]?.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "call-1",
+        result: "Beijing: 26C",
+      }),
+    );
+    expect(assistants[1]?.content).toEqual([
+      { type: "text", text: "Beijing: 26C" },
+    ]);
+    expect(
+      core
+        .getMessageRepository()
+        .messages.find((item) => item.message.id === "assistant-2")?.parentId,
+    ).toBe("assistant-1");
   });
 
   it("imports tool role messages from snapshots as assistant tool-call results", async () => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -322,6 +322,7 @@ describe("AGUIThreadRuntimeCore", () => {
 
   it("keeps the tool assistant on the head path before a snapshot", async () => {
     let midRunIds: string[] | undefined;
+    let midRunTool: ThreadAssistantMessage | undefined;
     const agent = {
       runAgent: vi.fn(async (_input, subscriber) => {
         subscriber.onTextMessageStartEvent?.({
@@ -357,6 +358,11 @@ describe("AGUIThreadRuntimeCore", () => {
           event: { type: "TEXT_MESSAGE_START", messageId: "assistant-2" },
         });
         midRunIds = core.getMessages().map((message) => message.id);
+        midRunTool = core
+          .getMessages()
+          .find((message) => message.id === "assistant-1") as
+          | ThreadAssistantMessage
+          | undefined;
         subscriber.onTextMessageContentEvent?.({
           event: {
             type: "TEXT_MESSAGE_CONTENT",
@@ -375,6 +381,13 @@ describe("AGUIThreadRuntimeCore", () => {
     await core.append(createAppendMessage());
 
     expect(midRunIds?.slice(-2)).toEqual(["assistant-1", "assistant-2"]);
+    expect(midRunTool?.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "call-1",
+        result: "Beijing: 26C",
+      }),
+    );
     const messages = core.getMessages();
     expect(messages.map((message) => message.role)).toEqual([
       "user",
@@ -403,6 +416,73 @@ describe("AGUIThreadRuntimeCore", () => {
         .getMessageRepository()
         .messages.find((item) => item.message.id === "assistant-2")?.parentId,
     ).toBe("assistant-1");
+  });
+
+  it("splits follow-up text when the run opens with a tool call", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "get_weather",
+            parentMessageId: "assistant-1",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: { type: "TOOL_CALL_ARGS", toolCallId: "call-1", delta: "{}" },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "tool-1",
+            toolCallId: "call-1",
+            content: "Beijing: 26C",
+            role: "tool",
+          },
+        });
+        subscriber.onTextMessageStartEvent?.({
+          event: { type: "TEXT_MESSAGE_START", messageId: "assistant-2" },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: "assistant-2",
+            delta: "Beijing: 26C",
+          },
+        });
+        subscriber.onTextMessageEndEvent?.({
+          event: { type: "TEXT_MESSAGE_END", messageId: "assistant-2" },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const assistants = core
+      .getMessages()
+      .filter(
+        (message) => message.role === "assistant",
+      ) as ThreadAssistantMessage[];
+    expect(assistants.map((message) => message.id)).toEqual([
+      "assistant-1",
+      "assistant-2",
+    ]);
+    expect(assistants[0]?.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolCallId: "call-1",
+        result: "Beijing: 26C",
+      }),
+    );
+    expect(assistants[1]?.content).toEqual([
+      { type: "text", text: "Beijing: 26C" },
+    ]);
   });
 
   it("imports tool role messages from snapshots as assistant tool-call results", async () => {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -21,12 +21,14 @@ describe("RunAggregator", () => {
   const createAggregator = (
     showThinking: boolean,
     onServerMessageId?: (id: string) => void,
+    onTextMessageStart?: (id: string) => void,
   ) =>
     new RunAggregator({
       showThinking,
       logger: makeLogger(),
       emit: (update) => results.push(update),
       ...(onServerMessageId ? { onServerMessageId } : {}),
+      ...(onTextMessageStart ? { onTextMessageStart } : {}),
     });
 
   it("streams text content", () => {
@@ -1386,6 +1388,61 @@ describe("RunAggregator", () => {
 
     expect(onServerMessageId).toHaveBeenCalledTimes(1);
     expect(onServerMessageId).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("notifies onTextMessageStart and drops prior parts for a later text id", () => {
+    const onTextMessageStart = vi.fn();
+    const aggregator = createAggregator(false, undefined, onTextMessageStart);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "call-1",
+      toolCallName: "get_weather",
+      parentMessageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_END",
+      toolCallId: "call-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-2",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "srv-2",
+      delta: "Beijing: 26C",
+    } as AgUiEvent);
+
+    expect(onTextMessageStart).toHaveBeenCalledTimes(1);
+    expect(onTextMessageStart).toHaveBeenCalledWith("srv-2");
+    const last = results.at(-1);
+    expect(last?.content).toEqual([{ type: "text", text: "Beijing: 26C" }]);
+  });
+
+  it("splits on TEXT_MESSAGE_CONTENT when START omitted the later id", () => {
+    const onTextMessageStart = vi.fn();
+    const aggregator = createAggregator(false, undefined, onTextMessageStart);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "srv-2",
+      delta: "follow-up",
+    } as AgUiEvent);
+
+    expect(onTextMessageStart).toHaveBeenCalledWith("srv-2");
+    const last = results.at(-1);
+    expect(last?.content).toEqual([{ type: "text", text: "follow-up" }]);
   });
 
   it("re-arms server messageId reporting across runs", () => {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1445,6 +1445,59 @@ describe("RunAggregator", () => {
     expect(last?.content).toEqual([{ type: "text", text: "follow-up" }]);
   });
 
+  it("records a later CHUNK id even when the opening frame has no delta", () => {
+    const onTextMessageStart = vi.fn();
+    const aggregator = createAggregator(false, undefined, onTextMessageStart);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CHUNK",
+      messageId: "srv-2",
+      delta: "",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CHUNK",
+      messageId: "srv-2",
+      delta: "follow-up",
+    } as AgUiEvent);
+
+    expect(onTextMessageStart).toHaveBeenCalledTimes(1);
+    expect(onTextMessageStart).toHaveBeenCalledWith("srv-2");
+    const last = results.at(-1);
+    expect(last?.content).toEqual([{ type: "text", text: "follow-up" }]);
+  });
+
+  it("splits after a tool-only first message", () => {
+    const onTextMessageStart = vi.fn();
+    const aggregator = createAggregator(false, undefined, onTextMessageStart);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "call-1",
+      toolCallName: "get_weather",
+      parentMessageId: "srv-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "srv-2",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "srv-2",
+      delta: "follow-up",
+    } as AgUiEvent);
+
+    expect(onTextMessageStart).toHaveBeenCalledTimes(1);
+    expect(onTextMessageStart).toHaveBeenCalledWith("srv-2");
+    const last = results.at(-1);
+    expect(last?.content).toEqual([{ type: "text", text: "follow-up" }]);
+  });
+
   it("re-arms server messageId reporting across runs", () => {
     const onServerMessageId = vi.fn();
     const aggregator = createAggregator(false, onServerMessageId);


### PR DESCRIPTION
closes #6298

## summary

- after a tool call, a later AG-UI assistant text id stays on its own message instead of also painting onto the tool-call bubble
- a new text id completes the current assistant and inserts the next one as its child, so the tool call stays on the head path while streaming and when the run has no snapshot

## test plan

### already verified

- [x] `pnpm exec vitest run test/ag-ui-thread-runtime-core.spec.ts test/run-aggregator.spec.ts` in `@assistant-ui/react-ag-ui` -> 208/208 green
- [x] `pnpm exec vitest run test/branch-flows.spec.ts` -> 17/17 green

### reviewer should verify

- [ ] send a MAF AG-UI turn that does a tool call then follow-up text and confirm the follow-up appears once, on the second assistant, and the tool bubble stays visible while it streams

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wOFJvYmo01d0kiTq-0DF4yKecZkZguq24PaQP_GEwz0JBMM-2zN8duy-szE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->