### PR TITLE
chore(docs): upgrade the Learn course project to current versions

### DIFF
--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/shared/project/package.json
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/shared/project/package.json
@@ -8,24 +8,24 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ai-sdk/openai": "4.0.14",
-    "@assistant-ui/next": "0.0.11",
-    "@assistant-ui/react": "0.14.27",
+    "@ai-sdk/openai": "4.0.47",
     "@assistant-ui/ai-sdk": "0.0.2",
-    "ai": "7.0.28",
-    "assistant-stream": "0.3.26",
-    "lucide-react": "1.24.0",
-    "next": "16.2.10",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
+    "@assistant-ui/next": "0.0.17",
+    "@assistant-ui/react": "0.15.16",
+    "ai": "7.0.79",
+    "assistant-stream": "0.3.39",
+    "lucide-react": "1.34.0",
+    "next": "16.3.2",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "4.3.2",
-    "@types/node": "26.1.1",
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3",
-    "tailwindcss": "4.3.2",
+    "@tailwindcss/postcss": "4.3.3",
+    "@types/node": "26.3.0",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.5",
+    "tailwindcss": "4.3.3",
     "typescript": "7.0.2"
   }
 }

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S6/project/lib/browser-thread-list-adapter.tsx
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/stages/S6/project/lib/browser-thread-list-adapter.tsx
@@ -68,7 +68,7 @@ function createHistoryProvider(prefix: string) {
     const aui = useAui();
     const history = useMemo<ThreadHistoryAdapter>(() => {
       const key = () => {
-        const remoteId = aui.threadListItem().getState().remoteId;
+        const remoteId = aui.threadListItem.getState().remoteId;
         return `${prefix}messages:${remoteId ?? "new"}`;
       };
       const load: ThreadHistoryAdapter["load"] = async () =>


### PR DESCRIPTION
## summary

- the Learn course's project fixture (`apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/shared/project/package.json`) pins exact versions, which taze skips by design, so `pnpm deps:update` has never touched it since the course landed in #5496. it had drifted far enough to stop working: on the old pins `next build` dies with `Next.js build worker exited with code: 1`, and `tsc` reports 9 errors, 3 of them in the course's own source, because `@assistant-ui/react@0.14.27` pulls a nested `@assistant-ui/core` that does not typecheck against the top-level one `@assistant-ui/ai-sdk` resolves.
- all 17 pins move to current, the notable one being `@assistant-ui/react` 0.14.27 to 0.15.16. `next` and `@assistant-ui/next` have to move together: `@assistant-ui/next@0.0.13` and earlier break under `next` 16.3, where turbopack applies the `withAui` loader to its own generated worker shim (fixed in 0.0.14, #5571).
- `lib/browser-thread-list-adapter.tsx` switches to `aui.threadListItem.getState()`. 0.15 turned nullary scope accessors into properties and deprecated the call form, and this is teaching material, so it should show the current idiom. no stage uses an API 0.15 dropped.
- `@assistant-ui/ai-sdk` moves back into alphabetical order in the dependency block; #6224 inserted it out of place, and every other manifest in the repo is sorted.

`package.json` is the whole dependency change; the one line in `browser-thread-list-adapter.tsx` is the only code the upgrade required.

## test plan

### already verified

- [x] expanded every stage the way `stage-source.ts` does (cumulative overlay by `previousStageId`, the `normalizePreviewImports` rewrite, `next.config.tools.ts` from S3 on) and ran `npm run build` in each -> S0 through S7 all build
- [x] `npx tsc --noEmit` on the expanded S7 -> zero errors in the course's own source (the two remaining are `@ai-sdk/provider` needing `@types/json-schema`, present on the old pins too, and never reached through `npm run build` since Next writes `skipLibCheck: true` into the tsconfig itself)
- [x] the same expansion on the old pins for a baseline -> `next build` fails and `tsc` reports 9 errors, so this PR takes the fixture from broken to building
- [x] `pnpm -C apps/docs exec tsc --noEmit` -> 0 errors
- [x] `pnpm -C apps/docs test` -> 38 files, 228 tests green (covers `registry.test.ts`, `stage-source.test.ts`, `preview-agent.test.ts`)
- [x] `pnpm lint` -> oxlint clean, oxfmt reports all files correctly formatted

### reviewer should verify

- [ ] walk the Learn preview at `/learn/preview/S7` and confirm the thread, weather tool, notepad, thread list, and branch controls still render and behave

## notes

- no changeset: `apps/docs` is `private: true`.
- this closes out the first bucket in #6304 (exact pins the update pipeline cannot see). the other 8, in `examples/with-expo`, still wait on the `minimumReleaseAge` window that blocked `expo install --fix` in #6305.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AR89FqX3ZFolrcngGorHAxIGjD8yMzghbQVQZOL1CwsA8XGtQLQ90FSE97M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->