### PR TITLE
ci: fail built-declaration checks only on shipped dts

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -11,6 +11,8 @@ on:
       - "templates/**"
       - "scripts/generate-api-surface.mjs"
       - "scripts/check-api-surface.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-built-declarations.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -27,6 +29,8 @@ on:
       - "templates/**"
       - "scripts/generate-api-surface.mjs"
       - "scripts/check-api-surface.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-built-declarations.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -146,6 +150,17 @@ jobs:
             # Push to main: Check API surface for packages changed in last commit
             pnpm run api-surface:check -- --skip-build --filter="...[HEAD^1]"
           fi
+
+      - name: Check built declarations
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm run declarations:check -- --filter="...[origin/${{ github.base_ref }}]"
+          else
+            pnpm run declarations:check -- --filter="...[HEAD^1]"
+          fi
+
+      - name: Test built declaration checker
+        run: pnpm run declarations:test
 
       - name: Test API surface generator
         run: pnpm run api-surface:test

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ packages/react-devtools/src/styles/panel.generated.ts
 # turbo
 .turbo
 .api-surface-tmp/
+.strict-libcheck-*/
 
 # python
 __pycache__/

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*'",
     "api-surface:check": "node scripts/check-api-surface.mjs",
     "api-surface:test": "node --test scripts/generate-api-surface.test.mjs",
+    "declarations:check": "node scripts/check-built-declarations.mjs",
+    "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",
     "check:resource-memo": "node packages/x-buildutils/check-resource-memoization.mjs",
     "lint:fix": "pnpm exec oxlint --fix && pnpm exec oxfmt",

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -152,7 +152,7 @@ export function parseTscErrorFiles(output) {
 export function parseUnanchoredTscErrors(output) {
   return output
     .split("\n")
-    .filter((line) => /error TS\d+:/.test(line) && !TSC_ERROR.test(line));
+    .filter((line) => /^\s*error TS\d+:/.test(line) && !TSC_ERROR.test(line));
 }
 
 export function isOwnDeclarationFile(packageDir, file, cwd) {
@@ -264,6 +264,10 @@ function checkPackage(repoRoot, packageDir, pkg) {
       unanchoredLines,
     });
     if (gate === "pass") return 0;
+    if (gate === "spawn-failed") {
+      process.stdout.write(`${result.error ?? gate}\n`);
+      return 1;
+    }
     if (gate === "own-errors") {
       const ownFiles = new Set(own);
       const lines = output.split("\n").filter((line) => {

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -220,7 +221,13 @@ function collectTurboFilteredPackageNames(repoRoot, filters) {
 }
 
 function checkPackage(repoRoot, packageDir, pkg) {
-  const probe = createDeclarationProbe(packageDir, pkg);
+  let probe;
+  try {
+    probe = createDeclarationProbe(packageDir, pkg);
+  } catch (error) {
+    console.error(`${pkg.name}: ${error.message}`);
+    return 1;
+  }
   if (!probe) return 0;
 
   try {
@@ -259,6 +266,15 @@ function checkPackage(repoRoot, packageDir, pkg) {
   }
 }
 
+export function isExecutedAsMain(metaUrl, argv1) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(fileURLToPath(metaUrl)) === realpathSync(argv1);
+  } catch {
+    return false;
+  }
+}
+
 function main() {
   const repoRoot = process.cwd();
   const filters = optionValues(process.argv.slice(2), "--filter");
@@ -279,9 +295,6 @@ function main() {
   if (failed) process.exitCode = 1;
 }
 
-if (
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
-) {
+if (isExecutedAsMain(import.meta.url, process.argv[1])) {
   main();
 }

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { optionArgs, optionValues } from "./lib/script-options.mjs";
+
+const TSC_ERROR = /^(.+)\(\d+,\d+\): error TS\d+:/;
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function posixPath(file) {
+  return file.replaceAll("\\", "/");
+}
+
+function spawnTsc(repoRoot, args) {
+  const local = path.join(repoRoot, "node_modules", ".bin", "tsc");
+  return spawnSync(existsSync(local) ? local : "tsc", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+function collectTypeTargets(value) {
+  if (!value || typeof value !== "object") return [];
+  if (typeof value.types === "string") return [value.types];
+  return Object.values(value).flatMap(collectTypeTargets);
+}
+
+function declarationFilesForTarget(packageDir, typePath) {
+  if (!typePath.includes("*")) {
+    const file = path.resolve(packageDir, typePath);
+    if (!existsSync(file)) {
+      throw new Error(
+        `Missing declaration file ${typePath}. Run the package build first.`,
+      );
+    }
+    return [file];
+  }
+
+  if (typePath.split("*").length !== 2) {
+    throw new Error(
+      `Only one wildcard is supported in declaration path ${typePath}.`,
+    );
+  }
+
+  const [prefix, suffix] = typePath.split("*");
+  const dir = path.resolve(packageDir, prefix);
+  if (!existsSync(dir)) {
+    throw new Error(
+      `No declaration files matched ${typePath}. Run the package build first.`,
+    );
+  }
+
+  const files = readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(suffix))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+
+  if (files.length === 0) {
+    throw new Error(
+      `No declaration files matched ${typePath}. Run the package build first.`,
+    );
+  }
+  return files;
+}
+
+export function collectDeclarationEntries(packageDir, pkg) {
+  const entries = [];
+  if (pkg.exports && typeof pkg.exports === "object") {
+    for (const [exportPath, exportValue] of Object.entries(pkg.exports)) {
+      for (const typePath of collectTypeTargets(exportValue)) {
+        for (const file of declarationFilesForTarget(packageDir, typePath)) {
+          entries.push({ exportPath, file });
+        }
+      }
+    }
+  }
+
+  if (entries.length === 0 && typeof pkg.types === "string") {
+    for (const file of declarationFilesForTarget(packageDir, pkg.types)) {
+      entries.push({ exportPath: ".", file });
+    }
+  }
+
+  return entries.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+export function createDeclarationProbe(packageDir, pkg) {
+  const entries = collectDeclarationEntries(packageDir, pkg);
+  if (entries.length === 0) return null;
+
+  const tempDir = mkdtempSync(path.join(packageDir, ".strict-libcheck-"));
+  const paths = {};
+  const imports = [];
+  for (const [index, entry] of entries.entries()) {
+    const alias = `__assistant_ui_strict_libcheck_${index}__`;
+    paths[alias] = [posixPath(path.relative(tempDir, entry.file))];
+    imports.push(`import "${alias}";`);
+  }
+
+  writeFileSync(path.join(tempDir, "probe.ts"), `${imports.join("\n")}\n`);
+  writeFileSync(
+    path.join(tempDir, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        extends: "../tsconfig.json",
+        compilerOptions: {
+          composite: false,
+          incremental: false,
+          noEmit: true,
+          paths,
+          skipLibCheck: false,
+        },
+        files: ["probe.ts"],
+        include: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  return {
+    configPath: path.join(tempDir, "tsconfig.json"),
+    entries,
+    remove() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export function parseTscErrorFiles(output) {
+  const files = [];
+  for (const line of output.split("\n")) {
+    const match = TSC_ERROR.exec(line);
+    if (match) files.push(match[1]);
+  }
+  return files;
+}
+
+export function isOwnDeclarationFile(packageDir, file, cwd) {
+  const resolved = path.resolve(cwd, file);
+  const root = path.resolve(packageDir);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    return false;
+  }
+  return !resolved.split(path.sep).includes("node_modules");
+}
+
+export function ownDeclarationDiagnostics(packageDir, output, cwd) {
+  return parseTscErrorFiles(output).filter((file) =>
+    isOwnDeclarationFile(packageDir, file, cwd),
+  );
+}
+
+function collectPackages(repoRoot, filteredPackageNames) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  return readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
+    .filter(existsSync)
+    .map((packageJsonPath) => ({
+      packageDir: path.dirname(packageJsonPath),
+      pkg: readJson(packageJsonPath),
+    }))
+    .filter(({ pkg }) => !pkg.private)
+    .filter(
+      ({ pkg }) => !filteredPackageNames || filteredPackageNames.has(pkg.name),
+    )
+    .sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
+}
+
+function collectTurboFilteredPackageNames(repoRoot, filters) {
+  if (filters.length === 0) return null;
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "turbo",
+      "ls",
+      ...optionArgs("--filter", filters),
+      "--output=json",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to list filtered packages:\n${result.stdout}${result.stderr}`,
+    );
+  }
+
+  const jsonStart = result.stdout.indexOf("{");
+  if (jsonStart === -1) {
+    throw new Error(`Turbo did not return JSON output:\n${result.stdout}`);
+  }
+  const output = JSON.parse(result.stdout.slice(jsonStart));
+  return new Set(output.packages.items.map((item) => item.name));
+}
+
+function checkPackage(repoRoot, packageDir, pkg) {
+  const probe = createDeclarationProbe(packageDir, pkg);
+  if (!probe) return 0;
+
+  try {
+    console.log(
+      `Checking ${pkg.name} (${probe.entries.length} declaration entries)`,
+    );
+    const result = spawnTsc(repoRoot, [
+      "--project",
+      probe.configPath,
+      "--pretty",
+      "false",
+    ]);
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    const own = ownDeclarationDiagnostics(packageDir, output, repoRoot);
+    if (own.length === 0) return 0;
+    const ownFiles = new Set(own);
+    const lines = output.split("\n").filter((line) => {
+      const match = TSC_ERROR.exec(line);
+      return match !== null && ownFiles.has(match[1]);
+    });
+    process.stdout.write(`${lines.join("\n")}\n`);
+    return 1;
+  } finally {
+    probe.remove();
+  }
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const filters = optionValues(process.argv.slice(2), "--filter");
+  const filteredPackageNames = collectTurboFilteredPackageNames(
+    repoRoot,
+    filters,
+  );
+  const packages = collectPackages(repoRoot, filteredPackageNames);
+  if (packages.length === 0) {
+    console.log("No public packages matched the filter.");
+    return;
+  }
+
+  let failed = false;
+  for (const { packageDir, pkg } of packages) {
+    if (checkPackage(repoRoot, packageDir, pkg) !== 0) failed = true;
+  }
+  if (failed) process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main();
+}

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -149,6 +149,12 @@ export function parseTscErrorFiles(output) {
   return files;
 }
 
+export function parseUnanchoredTscErrors(output) {
+  return output
+    .split("\n")
+    .filter((line) => /error TS\d+:/.test(line) && !TSC_ERROR.test(line));
+}
+
 export function isOwnDeclarationFile(packageDir, file, cwd) {
   const resolved = path.resolve(cwd, file);
   const root = path.resolve(packageDir);
@@ -169,10 +175,16 @@ export function declarationGateResult({
   status,
   ownFiles,
   parsedFiles,
+  unanchoredLines = [],
 }) {
   if (spawnError || status == null) return "spawn-failed";
   if (ownFiles.length > 0) return "own-errors";
-  if (status !== 0 && parsedFiles.length === 0) return "unparsed-failure";
+  if (
+    status !== 0 &&
+    (parsedFiles.length === 0 || unanchoredLines.length > 0)
+  ) {
+    return "unparsed-failure";
+  }
   return "pass";
 }
 
@@ -242,12 +254,14 @@ function checkPackage(repoRoot, packageDir, pkg) {
     ]);
     const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     const parsedFiles = parseTscErrorFiles(output);
+    const unanchoredLines = parseUnanchoredTscErrors(output);
     const own = ownDeclarationDiagnostics(packageDir, output, repoRoot);
     const gate = declarationGateResult({
       spawnError: result.error,
       status: result.status,
       ownFiles: own,
       parsedFiles,
+      unanchoredLines,
     });
     if (gate === "pass") return 0;
     if (gate === "own-errors") {

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -163,6 +163,18 @@ export function ownDeclarationDiagnostics(packageDir, output, cwd) {
   );
 }
 
+export function declarationGateResult({
+  spawnError,
+  status,
+  ownFiles,
+  parsedFiles,
+}) {
+  if (spawnError || status == null) return "spawn-failed";
+  if (ownFiles.length > 0) return "own-errors";
+  if (status !== 0 && parsedFiles.length === 0) return "unparsed-failure";
+  return "pass";
+}
+
 function collectPackages(repoRoot, filteredPackageNames) {
   const packagesRoot = path.join(repoRoot, "packages");
   return readdirSync(packagesRoot, { withFileTypes: true })
@@ -222,14 +234,25 @@ function checkPackage(repoRoot, packageDir, pkg) {
       "false",
     ]);
     const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    const parsedFiles = parseTscErrorFiles(output);
     const own = ownDeclarationDiagnostics(packageDir, output, repoRoot);
-    if (own.length === 0) return 0;
-    const ownFiles = new Set(own);
-    const lines = output.split("\n").filter((line) => {
-      const match = TSC_ERROR.exec(line);
-      return match !== null && ownFiles.has(match[1]);
+    const gate = declarationGateResult({
+      spawnError: result.error,
+      status: result.status,
+      ownFiles: own,
+      parsedFiles,
     });
-    process.stdout.write(`${lines.join("\n")}\n`);
+    if (gate === "pass") return 0;
+    if (gate === "own-errors") {
+      const ownFiles = new Set(own);
+      const lines = output.split("\n").filter((line) => {
+        const match = TSC_ERROR.exec(line);
+        return match !== null && ownFiles.has(match[1]);
+      });
+      process.stdout.write(`${lines.join("\n")}\n`);
+      return 1;
+    }
+    process.stdout.write(output || `${gate}\n`);
     return 1;
   } finally {
     probe.remove();

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -168,6 +168,18 @@ test("fails when tsc cannot spawn or reports no file-anchored errors", () => {
     }),
     "pass",
   );
+  assert.equal(
+    declarationGateResult({
+      spawnError: undefined,
+      status: 2,
+      ownFiles: [],
+      parsedFiles: ["node_modules/dep/index.d.ts"],
+      unanchoredLines: [
+        "error TS2688: Cannot find type definition file for 'browser-process'.",
+      ],
+    }),
+    "unparsed-failure",
+  );
 });
 
 test("treats symlink-equivalent paths as the main module", () => {

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  collectDeclarationEntries,
+  createDeclarationProbe,
+  isOwnDeclarationFile,
+  ownDeclarationDiagnostics,
+} from "./check-built-declarations.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function createFixture(declaration) {
+  const packageDir = mkdtempSync(path.join(tmpdir(), "aui-libcheck-"));
+  mkdirSync(path.join(packageDir, "dist"));
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: "fixture-package",
+      type: "module",
+      exports: { ".": { types: "./dist/index.d.ts" } },
+    }),
+  );
+  writeFileSync(
+    path.join(packageDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        strict: true,
+      },
+    }),
+  );
+  writeFileSync(path.join(packageDir, "dist/index.d.ts"), declaration);
+  return packageDir;
+}
+
+function runProbe(packageDir) {
+  const pkg = JSON.parse(
+    readFileSync(path.join(packageDir, "package.json"), "utf8"),
+  );
+  const probe = createDeclarationProbe(packageDir, pkg);
+  assert.ok(probe);
+  try {
+    const local = path.join(repoRoot, "node_modules", ".bin", "tsc");
+    return spawnSync(
+      existsSync(local) ? local : "tsc",
+      ["--project", probe.configPath, "--pretty", "false"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+  } finally {
+    probe.remove();
+  }
+}
+
+test("accepts internally consistent built declarations", () => {
+  const packageDir = createFixture("export interface PresentType {}\n");
+  try {
+    const result = runProbe(packageDir);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("rejects dangling types in built declarations", () => {
+  const packageDir = createFixture(
+    "export declare const broken: MissingType;\n",
+  );
+  try {
+    const result = runProbe(packageDir);
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stdout + result.stderr,
+      /Cannot find name 'MissingType'/,
+    );
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});
+
+test("ignores declaration errors outside the package", () => {
+  const packageDir = path.join(repoRoot, "packages", "core");
+  const output = [
+    "node_modules/.pnpm/@types+node@26.2.0/node_modules/@types/node/globals.d.ts(3,13): error TS2451: Cannot redeclare block-scoped variable 'process'.",
+    "packages/x-buildutils/types/browser-process/index.d.ts(6,15): error TS2451: Cannot redeclare block-scoped variable 'process'.",
+    "node_modules/.pnpm/@radix-ui+primitive@1.1.7/node_modules/@radix-ui/primitive/dist/index.d.mts(18,36): error TS2304: Cannot find name 'setImmediate'.",
+  ].join("\n");
+  assert.deepEqual(ownDeclarationDiagnostics(packageDir, output, repoRoot), []);
+  assert.equal(
+    isOwnDeclarationFile(packageDir, "packages/core/dist/index.d.ts", repoRoot),
+    true,
+  );
+});
+
+test("keeps dangling types from the package dist", () => {
+  const packageDir = path.join(repoRoot, "packages", "core");
+  const output =
+    "packages/core/dist/index.d.ts(12,14): error TS2304: Cannot find name 'MissingType'.";
+  assert.deepEqual(ownDeclarationDiagnostics(packageDir, output, repoRoot), [
+    "packages/core/dist/index.d.ts",
+  ]);
+});
+
+test("expands a single-directory wildcard types target", () => {
+  const packageDir = createFixture("export {};\n");
+  mkdirSync(path.join(packageDir, "dist/features"));
+  writeFileSync(
+    path.join(packageDir, "dist/features/alpha.d.ts"),
+    "export {};\n",
+  );
+  writeFileSync(
+    path.join(packageDir, "dist/features/beta.d.ts"),
+    "export {};\n",
+  );
+  try {
+    const entries = collectDeclarationEntries(packageDir, {
+      exports: {
+        "./features/*": { types: "./dist/features/*.d.ts" },
+      },
+    });
+    assert.deepEqual(
+      entries.map((entry) => path.basename(entry.file)),
+      ["alpha.d.ts", "beta.d.ts"],
+    );
+  } finally {
+    rmSync(packageDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -18,6 +18,7 @@ import {
   isExecutedAsMain,
   isOwnDeclarationFile,
   ownDeclarationDiagnostics,
+  parseUnanchoredTscErrors,
 } from "./check-built-declarations.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -179,6 +180,19 @@ test("fails when tsc cannot spawn or reports no file-anchored errors", () => {
       ],
     }),
     "unparsed-failure",
+  );
+});
+
+test("keeps only unanchored tsc error lines", () => {
+  assert.deepEqual(
+    parseUnanchoredTscErrors(
+      [
+        "error TS2688: Cannot find type definition file for 'browser-process'.",
+        "node_modules/dep/index.d.ts(1,1): error TS2307: Cannot find module 'x'.",
+        "  Type 'X' is not assignable to type 'Y'.",
+      ].join("\n"),
+    ),
+    ["error TS2688: Cannot find type definition file for 'browser-process'."],
   );
 });
 

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -14,6 +14,7 @@ import test from "node:test";
 import {
   collectDeclarationEntries,
   createDeclarationProbe,
+  declarationGateResult,
   isOwnDeclarationFile,
   ownDeclarationDiagnostics,
 } from "./check-built-declarations.mjs";
@@ -136,4 +137,34 @@ test("expands a single-directory wildcard types target", () => {
   } finally {
     rmSync(packageDir, { recursive: true, force: true });
   }
+});
+
+test("fails when tsc cannot spawn or reports no file-anchored errors", () => {
+  assert.equal(
+    declarationGateResult({
+      spawnError: new Error("ENOENT"),
+      status: null,
+      ownFiles: [],
+      parsedFiles: [],
+    }),
+    "spawn-failed",
+  );
+  assert.equal(
+    declarationGateResult({
+      spawnError: undefined,
+      status: 1,
+      ownFiles: [],
+      parsedFiles: [],
+    }),
+    "unparsed-failure",
+  );
+  assert.equal(
+    declarationGateResult({
+      spawnError: undefined,
+      status: 2,
+      ownFiles: [],
+      parsedFiles: ["node_modules/dep/index.d.ts"],
+    }),
+    "pass",
+  );
 });

--- a/scripts/check-built-declarations.test.mjs
+++ b/scripts/check-built-declarations.test.mjs
@@ -15,6 +15,7 @@ import {
   collectDeclarationEntries,
   createDeclarationProbe,
   declarationGateResult,
+  isExecutedAsMain,
   isOwnDeclarationFile,
   ownDeclarationDiagnostics,
 } from "./check-built-declarations.mjs";
@@ -167,4 +168,17 @@ test("fails when tsc cannot spawn or reports no file-anchored errors", () => {
     }),
     "pass",
   );
+});
+
+test("treats symlink-equivalent paths as the main module", () => {
+  const script = path.join(import.meta.dirname, "check-built-declarations.mjs");
+  assert.equal(isExecutedAsMain(import.meta.url, script), false);
+  assert.equal(
+    isExecutedAsMain(
+      import.meta.resolve("./check-built-declarations.mjs"),
+      script,
+    ),
+    true,
+  );
+  assert.equal(isExecutedAsMain(import.meta.url, undefined), false);
 });


### PR DESCRIPTION
closes #5979

## summary

- after building, type-check each published declaration entry with `skipLibCheck: false`
- fail only on diagnostics whose file lives under the package and outside `node_modules`, so dangling internal types still fail and dependency `.d.ts` errors do not
- reuse the changed-package turbo filter in the existing code-quality job

#6287 tried the same gate without that filter and went red on `assistant-stream` / `react` for errors inside radix and `@types/node`.

## test plan

### already verified

- [x] `node --test scripts/check-built-declarations.test.mjs` -> 5/5 green (consistent dts pass, dangling name fails, node_modules diagnostics ignored, own dist kept, single-directory wildcard)
- [x] probe on built `@assistant-ui/core` / `assistant-stream` / `@assistant-ui/react`: core has 0 tsc errors; stream and react have 2 raw errors each, 0 own errors, gate would pass

### reviewer should verify

- [ ] a PR that only changes scripts still runs `declarations:test` in Build Changed Packages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.N33Kg8NNpbO04QEGzsHv7SyTKXjKrramrHkQp-Etx0Vs5epeQM9WYKk2CJI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->