### PR TITLE
fix(react-ag-ui, react-a2a): apply runtime options after commit

### DIFF
--- a/.changeset/runtime-options-after-commit.md
+++ b/.changeset/runtime-options-after-commit.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-a2a": patch
+---
+
+fix: apply runtime options after commit

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -62,6 +62,69 @@ afterEach(() => {
 });
 
 describe("useA2ARuntime", () => {
+  const createHistory = () => ({
+    load: vi.fn().mockResolvedValue({
+      headId: "restored",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "restored",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "hello" }],
+            createdAt: new Date(0),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+    }),
+    append: vi.fn().mockResolvedValue(undefined),
+  });
+
+  it("loads a history adapter that arrives on a later render", async () => {
+    const { client } = createMockClient();
+    const history = createHistory();
+    const { result, rerender } = renderHook(
+      ({ history }: { history?: ReturnType<typeof createHistory> }) =>
+        useA2ARuntime({ client, adapters: history ? { history } : {} }),
+      { initialProps: {} },
+    );
+
+    await waitFor(() =>
+      expect(result.current.thread.getState().isLoading).toBe(false),
+    );
+    expect(history.load).not.toHaveBeenCalled();
+
+    rerender({ history });
+
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.map((m) => m.id),
+      ).toEqual(["restored"]),
+    );
+    expect(history.load).toHaveBeenCalledOnce();
+  });
+
+  it("loads history through a swapped client's core", async () => {
+    const first = createMockClient();
+    const second = createMockClient();
+    const history = createHistory();
+    const { result, rerender } = renderHook(
+      ({ client }) => useA2ARuntime({ client, adapters: { history } }),
+      { initialProps: { client: first.client } },
+    );
+
+    await waitFor(() => expect(history.load).toHaveBeenCalledOnce());
+
+    rerender({ client: second.client });
+
+    await waitFor(() => expect(second.getAgentCard).toHaveBeenCalledOnce());
+    await waitFor(() => expect(history.load).toHaveBeenCalledTimes(2));
+    expect(result.current.thread.getState().messages.map((m) => m.id)).toEqual([
+      "restored",
+    ]);
+  });
+
   it("switches provided clients and aborts the previous client run", async () => {
     const first = createMockClient(true);
     const second = createMockClient();

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -72,16 +72,7 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
     });
   }, [managedClientOptionsKey, options.client, resolveHeaders]);
 
-  const core = useMemo(
-    () =>
-      new A2AThreadRuntimeCore({
-        client,
-        notifyUpdate,
-      }),
-    [client, notifyUpdate],
-  );
-
-  core.updateOptions({
+  const coreOptions = {
     client,
     contextId: options.contextId,
     configuration: options.configuration,
@@ -91,6 +82,22 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       onArtifactComplete: options.onArtifactComplete,
     }),
     ...(historyAdapter && { history: historyAdapter }),
+  };
+  const coreOptionsRef = useRef(coreOptions);
+  coreOptionsRef.current = coreOptions;
+
+  const core = useMemo(
+    () =>
+      new A2AThreadRuntimeCore({
+        ...coreOptionsRef.current,
+        client,
+        notifyUpdate,
+      }),
+    [client, notifyUpdate],
+  );
+
+  useEffect(() => {
+    core.updateOptions(coreOptions);
   });
 
   // Thread list

--- a/packages/react-ag-ui/src/useAgUiRuntime.history.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.history.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ThreadHistoryAdapter } from "@assistant-ui/core";
+import type { HttpAgent } from "@ag-ui/client";
+import { useAgUiRuntime } from "./useAgUiRuntime";
+
+const agent = { runAgent: vi.fn(), abortRun: vi.fn() } as unknown as HttpAgent;
+
+function createHistory(): ThreadHistoryAdapter {
+  return {
+    load: vi.fn().mockResolvedValue({
+      headId: "restored",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "restored",
+            role: "user" as const,
+            content: [{ type: "text" as const, text: "hello" }],
+            createdAt: new Date(0),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+    }),
+    append: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useAgUiRuntime history", () => {
+  it("loads a history adapter that arrives on a later render", async () => {
+    const history = createHistory();
+    const { result, rerender } = renderHook(
+      ({ history }: { history?: ThreadHistoryAdapter }) =>
+        useAgUiRuntime({ agent, adapters: history ? { history } : {} }),
+      { initialProps: {} },
+    );
+
+    await waitFor(() =>
+      expect(result.current.thread.getState().isLoading).toBe(false),
+    );
+    expect(history.load).not.toHaveBeenCalled();
+    expect(result.current.thread.getState().messages).toEqual([]);
+
+    rerender({ history });
+
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.map((m) => m.id),
+      ).toEqual(["restored"]),
+    );
+    expect(history.load).toHaveBeenCalledOnce();
+  });
+
+  it("loads once when the adapter is present from the first render", async () => {
+    const history = createHistory();
+    const { result, rerender } = renderHook(() =>
+      useAgUiRuntime({ agent, adapters: { history } }),
+    );
+
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.map((m) => m.id),
+      ).toEqual(["restored"]),
+    );
+    rerender();
+    rerender();
+    expect(history.load).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -81,14 +81,16 @@ export function useAgUiRuntime(
   }
 
   const core = coreRef.current;
-  core.updateOptions({
-    agent: options.agent,
-    logger,
-    showThinking: options.showThinking ?? true,
-    autoCancelPendingToolCalls: options.autoCancelPendingToolCalls,
-    ...(options.onError && { onError: options.onError }),
-    ...(options.onCancel && { onCancel: options.onCancel }),
-    ...(historyAdapter && { history: historyAdapter }),
+  useEffect(() => {
+    core.updateOptions({
+      agent: options.agent,
+      logger,
+      showThinking: options.showThinking ?? true,
+      autoCancelPendingToolCalls: options.autoCancelPendingToolCalls,
+      ...(options.onError && { onError: options.onError }),
+      ...(options.onCancel && { onCancel: options.onCancel }),
+      ...(historyAdapter && { history: historyAdapter }),
+    });
   });
 
   const [toolStatuses, setToolStatuses] = useState<


### PR DESCRIPTION
## What
`useAgUiRuntime` and `useA2ARuntime` now apply `core.updateOptions(...)` in a deps-less `useEffect` instead of the render body, declared ahead of the `__internal_load` effect. `useA2ARuntime` also seeds a freshly memoized core with the full option set rather than only `client`.

## Why
Cubic flagged on #6286 that the late-history retrigger inside `updateOptions` (#6278 for A2A, #6286 for AG-UI) starts `history.load()` during render, so a render React discards can still kick off a load. Core already writes options post-commit in `useLocalRuntime.ts:53-55`; this brings both adapter hooks in line. Closes #6308.

## Impact
- No output change: nothing in either hook reads option fields during render, and every consumer of options (runs, callbacks, history) fires after commit.
- Option writes and the history retrigger now run only for committed renders.

## Scope & caveats
- Rebased on main after #6286 landed; diff is the two hooks, two hook-level tests, and one changeset.
- Deps-less effect is deliberate: it keeps today's per-render write semantics and matches the core precedent exactly.
- `coreOptionsRef.current = coreOptions` during render in `useA2ARuntime` mirrors the existing `headersRef` pattern in the same file; the memoized constructor reads it so a client swap does not produce a bare core for one commit.
- `updateOptions` bodies in both cores are untouched; the A2A `lastOptionsContextId` guard still applies under effect timing.
- Tests: late adapter on a later render (both hooks), single load with the adapter present from mount (AG-UI), history load through a swapped client's core (A2A). Not covered: a discarded concurrent render, which jsdom cannot reproduce deterministically.
- Additive only, no exports changed.
- Changeset: patch (`@assistant-ui/react-ag-ui`, `@assistant-ui/react-a2a`).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.B-rmrhf8FP_eHbivzMye8ZfBGUxEMq38z1S6Cfh_AuD9DZexXnrXmAUAxl4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->