### PR TITLE
ci: make every workflow uses entry visible to ratchet

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -41,4 +41,4 @@ jobs:
       - name: Update API reference pages
         run: pnpm -C apps/docs generate:api-reference
 
-      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # ratchet:autofix-ci/action@v1.3.4

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check changeset bump types against package versions
         id: check
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -22,15 +22,15 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6.0.10
 
       - name: Setup node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 24
           cache: "pnpm"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create version PR
         id: changesets
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # ratchet:changesets/action@v2.1.1
         with:
           commit-message: "chore: update versions"
           pr-title: "chore: update versions"
@@ -50,7 +50,7 @@ jobs:
       - name: Detect release packages
         id: release_plan
         if: steps.changesets.outputs.has-changesets == 'false'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             const { execFileSync } = require("node:child_process");
@@ -125,7 +125,7 @@ jobs:
 
       - name: Trigger npm publish
         if: steps.changesets.outputs.has-changesets == 'false' && steps.release_plan.outputs.hasReleasePackages == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             await github.rest.repos.createDispatchEvent({

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -296,7 +296,7 @@ jobs:
     # and 6 and node-redis; both legs need a live server or their suites skip.
     services:
       redis:
-        image: redis:8-alpine
+        image: redis:8-alpine # ratchet:exclude
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Resolve release commit SHA
         id: release-sha
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             const dispatchReleaseShaRaw = context.payload?.client_payload?.releaseSha;
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Cancel older queued/waiting runs
         continue-on-error: true
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             const owner = context.repo.owner;
@@ -211,7 +211,7 @@ jobs:
     steps:
 
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_SHA }}
@@ -258,7 +258,7 @@ jobs:
 
       - name: Resolve publish targets
         id: targets
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             const fs = require("node:fs");
@@ -409,7 +409,7 @@ jobs:
 
       - name: Write release summary
         if: steps.targets.outputs.targetCount != '0'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         env:
           TARGETS_JSON: ${{ steps.targets.outputs.targetsJson }}
         with:
@@ -679,16 +679,16 @@ jobs:
     steps:
 
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_SHA }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # ratchet:pnpm/action-setup@v6.0.10
 
       - name: Setup node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 24
           # No cache - hardened against cache poisoning for sensitive publish operations
@@ -701,7 +701,7 @@ jobs:
         # exchange after this pre-flight call within the same job, causing
         # "OIDC publish authorize: Invalid token" on every package.
         if: false
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         env:
           TARGETS_JSON: ${{ needs.summary.outputs.targets_json }}
         with:
@@ -800,7 +800,7 @@ jobs:
 
       - name: Publish to npm and create GitHub releases
         id: changesets-publish
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # ratchet:changesets/action@v2.1.1
         with:
           publish-script: pnpm ci:publish
           create-github-releases: true

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Resolve release commit SHA
         id: release-sha
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0
         with:
           script: |
             const dispatchReleaseShaRaw = context.payload?.client_payload?.releaseSha;
@@ -103,7 +103,7 @@ jobs:
       DEFAULT_BRANCH: ${{ needs.approve.outputs.default_branch }}
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ env.RELEASE_SHA }}
@@ -232,14 +232,14 @@ jobs:
       VERSION: ${{ needs.summary.outputs.version }}
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
           fetch-depth: 1
           fetch-tags: true
           ref: ${{ env.RELEASE_SHA }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # ratchet:astral-sh/setup-uv@v10.0.1
         with:
           # No cache - hardened against cache poisoning for sensitive publish operations
           enable-cache: false
@@ -268,7 +268,7 @@ jobs:
       # PyPI trusted publishing requires this workflow filename and the
       # `pypi publish` environment to match the project's trusted-publisher config.
       - name: Publish to PyPI via OIDC
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # ratchet:pypa/gh-action-pypi-publish@v1.14.2
         with:
           packages-dir: ${{ env.PYTHON_PACKAGE_DIR }}/dist
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -36,10 +36,10 @@ jobs:
         working-directory: python/${{ matrix.package }}
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # ratchet:astral-sh/setup-uv@v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/traction.yaml
+++ b/.github/workflows/traction.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v7.0.0
         with:
           node-version: 24
 


### PR DESCRIPTION
## summary

- `ratchet update` only touches a `uses:` entry whose trailing comment carries a `ratchet:owner/repo@version` marker. 27 entries across seven workflows carried a plain `# vX` comment instead, so ratchet silently skipped them and they sat outside the update path entirely. this gives all 75 `uses:` entries in the 13 workflows a marker.
- nothing eroded these. the markers were added piecemeal by whichever PR happened to touch a file (#4608, #4713, #4836, #4850, #4977, #5104), and `changeset.yaml`, `npm-publish.yaml`, `pypi-publish.yaml`, `python-tests.yaml` and `traction.yaml` have never contained one in any commit (`git log -S'ratchet:' -- <file>` returns nothing for each). #6304 carried a wrong guess at the cause and has been corrected.
- the redis service image in `code-quality.yaml` gets `# ratchet:exclude`. it is a deliberately floating tag, and without the annotation every `ratchet update` run repins it to a digest.
- no SHA moves. this is a comment-only change: 27 `uses:` lines plus the one `image:` line.

## test plan

### already verified

- [x] checked each of the eight distinct `owner/repo@version` pairs against `gh api repos/OWNER/REPO/commits/vX` before writing the marker -> all eight resolve to the SHA already in the file, so no marker names a version its SHA is not
- [x] compared the removed and added 40-character SHA multisets in the diff -> 27 vs 27, identical
- [x] counted changed lines that are not `uses:` lines -> 0 (the `image:` line is the separate hunk above)
- [x] `ratchet update .github/workflows/*.yaml .github/workflows/*.yml` on the result -> zero bytes changed, which both proves the markers are now seen and confirms every action is already on its latest release
- [x] parsed all 13 workflows with the `yaml` library -> every file parses, job counts intact, and `uses:` count equals marker count in each

### reviewer should verify

- [ ] nothing beyond CI: the workflows in this diff are release and publish paths (`npm-publish`, `pypi-publish`, `traction`) that cannot run without a release tag, so their diffs are worth an extra read even though they are comment-only

## notes

- nothing prevents a future hand-written `uses:` from omitting a marker and dropping back out of coverage. `ratchet lint` does not catch it, since it reports unpinned refs and these lines are pinned; catching it needs a small assertion that every `uses:` contains `# ratchet:`. left out as its own decision rather than bundled here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.WIU86ueZr5V0xeQrZlSv2-llsVxm5hMwk8x7dzotgVYqbWCIeTu5_oiIq24?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->