### PR TITLE
fix(assistant-stream): guard TextStreamController.close() after consumer cancel

### DIFF
--- a/.changeset/text-stream-close-after-cancel.md
+++ b/.changeset/text-stream-close-after-cancel.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: TextStreamController.close() no longer throws after the consumer cancels

--- a/packages/assistant-stream/src/core/modules/text.test.ts
+++ b/packages/assistant-stream/src/core/modules/text.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createTextStreamController } from "./text";
+import { createAssistantStream } from "./assistant-stream";
+import { createTextStreamController, type TextStreamController } from "./text";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -21,5 +22,31 @@ describe("TextStreamController", () => {
     expect(() => controller.append("late")).not.toThrow();
     expect(error).toHaveBeenCalledOnce();
     error.mockRestore();
+  });
+});
+
+describe("TextStreamController after consumer cancel", () => {
+  it("closes without throwing", async () => {
+    const [stream, controller] = createTextStreamController();
+    await stream.cancel();
+    expect(() => controller.close()).not.toThrow();
+  });
+
+  it("closes without throwing with strict: false", async () => {
+    const [stream, controller] = createTextStreamController({ strict: false });
+    await stream.cancel();
+    expect(() => controller.close()).not.toThrow();
+  });
+
+  it("closes a text part without throwing after the reader cancels", async () => {
+    let part!: TextStreamController;
+    const stream = createAssistantStream((controller) => {
+      part = controller.addTextPart();
+      part.append("hello");
+    });
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel("consumer stopped");
+    expect(() => part.close()).not.toThrow();
   });
 });

--- a/packages/assistant-stream/src/core/modules/text.ts
+++ b/packages/assistant-stream/src/core/modules/text.ts
@@ -1,5 +1,6 @@
 import type { AssistantStream } from "../AssistantStream";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
+import { closeIfOpen, enqueueIfOpen } from "../utils/stream/controller-guards";
 import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 
 export type TextStreamController = {
@@ -49,11 +50,11 @@ class TextStreamControllerImpl implements TextStreamController {
   close() {
     if (this._isClosed) return;
     this._isClosed = true;
-    this._controller.enqueue({
+    enqueueIfOpen(this._controller, {
       type: "part-finish",
       path: [],
     });
-    this._controller.close();
+    closeIfOpen(this._controller);
   }
 }
 

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -4,6 +4,7 @@ import { NO_RESULT, type ToolResponseLike } from "../tool/ToolResponse";
 import type { ReadonlyJSONValue } from "../../utils/json/json-value";
 import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 import { createTextStream, type TextStreamController } from "./text";
+import { closeIfOpen, enqueueIfOpen } from "../utils/stream/controller-guards";
 
 export type ToolCallStreamController = {
   argsText: TextStreamController;
@@ -18,17 +19,6 @@ export type ToolCallStreamController = {
 
 class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _isClosed = false;
-
-  // enqueue() throwing TypeError is the portable termination signal for
-  // ReadableStream controllers; after the consumer cancels, writes are
-  // intentionally discarded instead of surfacing as unhandled rejections.
-  private _enqueue(chunk: AssistantStreamChunk) {
-    try {
-      this._controller.enqueue(chunk);
-    } catch (error) {
-      if (!(error instanceof TypeError)) throw error;
-    }
-  }
 
   private _mergeTask: Promise<void>;
   private _controller: ReadableStreamDefaultController<AssistantStreamChunk>;
@@ -50,19 +40,19 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
           switch (chunk.type) {
             case "text-delta":
               hasArgsText = true;
-              this._enqueue(chunk);
+              enqueueIfOpen(this._controller, chunk);
               break;
 
             case "part-finish":
               if (!hasArgsText) {
                 // if no argsText was provided, assume empty object
-                this._enqueue({
+                enqueueIfOpen(this._controller, {
                   type: "text-delta",
                   textDelta: "{}",
                   path: [],
                 });
               }
-              this._enqueue({
+              enqueueIfOpen(this._controller, {
                 type: "tool-call-args-text-finish",
                 path: [],
               });
@@ -90,7 +80,7 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
     // indistinguishable from one that never finished.
     const result = response.result;
 
-    this._enqueue({
+    enqueueIfOpen(this._controller, {
       type: "result",
       path: [],
       ...(response.artifact !== undefined
@@ -115,15 +105,11 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
     this._argsTextController.close();
     await this._mergeTask;
 
-    this._enqueue({
+    enqueueIfOpen(this._controller, {
       type: "part-finish",
       path: [],
     });
-    try {
-      this._controller.close();
-    } catch (error) {
-      if (!(error instanceof TypeError)) throw error;
-    }
+    closeIfOpen(this._controller);
   }
 }
 

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -5,6 +5,7 @@ import {
   AssistantMetaTransformStream,
 } from "../utils/stream/AssistantMetaTransformStream";
 import { PipeableTransformStream } from "../utils/stream/PipeableTransformStream";
+import { enqueueIfOpen } from "../utils/stream/controller-guards";
 import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
@@ -104,18 +105,6 @@ const withExecutionId = <T extends object>(
     enumerable: true,
   });
   return result;
-};
-
-const enqueueIfOpen = (
-  controller: TransformStreamDefaultController<AssistantStreamChunk>,
-  chunk: AssistantStreamChunk,
-) => {
-  try {
-    controller.enqueue(chunk);
-  } catch (error) {
-    // enqueue() throwing TypeError is the portable termination signal for TransformStream controllers.
-    if (!(error instanceof TypeError)) throw error;
-  }
 };
 
 export class ToolExecutionStream extends PipeableTransformStream<

--- a/packages/assistant-stream/src/core/utils/stream/controller-guards.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/controller-guards.test.ts
@@ -16,10 +16,12 @@ const cancelledController = () => {
 
 describe("controller guards", () => {
   it("swallows enqueue on a cancelled controller", () => {
+    expect(() => cancelledController().enqueue(chunk)).toThrow(TypeError);
     expect(() => enqueueIfOpen(cancelledController(), chunk)).not.toThrow();
   });
 
   it("swallows close on a cancelled controller", () => {
+    expect(() => cancelledController().close()).toThrow(TypeError);
     expect(() => closeIfOpen(cancelledController())).not.toThrow();
   });
 

--- a/packages/assistant-stream/src/core/utils/stream/controller-guards.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/controller-guards.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
+import { closeIfOpen, enqueueIfOpen } from "./controller-guards";
+
+const chunk: AssistantStreamChunk = { type: "part-finish", path: [] };
+
+const cancelledController = () => {
+  let controller!: ReadableStreamDefaultController<AssistantStreamChunk>;
+  void new ReadableStream<AssistantStreamChunk>({
+    start(c) {
+      controller = c;
+    },
+  }).cancel();
+  return controller;
+};
+
+describe("controller guards", () => {
+  it("swallows enqueue on a cancelled controller", () => {
+    expect(() => enqueueIfOpen(cancelledController(), chunk)).not.toThrow();
+  });
+
+  it("swallows close on a cancelled controller", () => {
+    expect(() => closeIfOpen(cancelledController())).not.toThrow();
+  });
+
+  it("rethrows errors that are not the closed-controller signal", () => {
+    const boom = new Error("boom");
+    expect(() =>
+      enqueueIfOpen(
+        {
+          enqueue() {
+            throw boom;
+          },
+        },
+        chunk,
+      ),
+    ).toThrow(boom);
+    expect(() =>
+      closeIfOpen({
+        close() {
+          throw boom;
+        },
+      }),
+    ).toThrow(boom);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/controller-guards.ts
+++ b/packages/assistant-stream/src/core/utils/stream/controller-guards.ts
@@ -1,0 +1,24 @@
+import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
+
+// A controller throws TypeError once its stream is closed or cancelled; that
+// is the only portable signal a producer gets that the consumer went away.
+const isClosedControllerError = (error: unknown) => error instanceof TypeError;
+
+export const enqueueIfOpen = (
+  controller: { enqueue(chunk: AssistantStreamChunk): void },
+  chunk: AssistantStreamChunk,
+) => {
+  try {
+    controller.enqueue(chunk);
+  } catch (error) {
+    if (!isClosedControllerError(error)) throw error;
+  }
+};
+
+export const closeIfOpen = (controller: { close(): void }) => {
+  try {
+    controller.close();
+  } catch (error) {
+    if (!isClosedControllerError(error)) throw error;
+  }
+};


### PR DESCRIPTION
## What
`TextStreamController.close()` no longer throws when the consumer has already cancelled the stream. The try/catch that tool-call and ToolExecutionStream each carried inline now lives in one internal `enqueueIfOpen` / `closeIfOpen` helper, and all four sites use it.

## Impact
- Producers closing a text or reasoning part after the consumer cancelled no longer get an uncaught TypeError.
- No wire or output change; the cancelled consumer observes nothing either way.
- tool-call and ToolExecutionStream behavior is unchanged, the refactor is a 1:1 swap onto the shared helper.

## Scope & caveats
- Strict `append()` after close still throws on purpose: appending to a closed part is a producer bug, closing a part whose consumer left is not (existing test pins it).
- Non-strict `append()` keeps its warn-once drop and is not folded into the helper: it swallows every error type, so folding would change behavior.
- The helper swallows `TypeError` only and rethrows everything else, identical to the inline copies it replaces.
- The helper is internal, not exported from the barrel. Additive only, no exports removed or reshaped.
- Tests: close after cancel in strict and non-strict mode, close of an `addTextPart` part after reader cancel, and the helper's swallow/rethrow split; existing tool-call and ToolExecutionStream cancellation tests cover the dedupe.
- Changeset: patch (`assistant-stream`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yZ_qK2K3KmMVeAGqP8iTtQi3iU-a7JxRCAjgquHFRMEEWLw3y8-BgQNcYo0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->