### PR TITLE
fix(assistant-stream): skip settled tool calls in unstable_runPendingTools

### DIFF
--- a/.changeset/run-pending-tools-skip-settled.md
+++ b/.changeset/run-pending-tools-skip-settled.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: unstable_runPendingTools no longer re-executes tool calls that already have a result

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -131,6 +131,41 @@ describe("unstable_runPendingTools", () => {
     });
   });
 
+  it("skips tool calls that carry a result without a state", async () => {
+    const execute = vi.fn<NonNullable<Tool["execute"]>>(async () => "fresh");
+    const message: AssistantMessage = {
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "settled",
+          toolName: "echo",
+          args: {},
+          result: "stored",
+        } as ToolCallPart,
+      ],
+      content: [],
+      metadata: {
+        unstable_state: {},
+        unstable_data: [],
+        unstable_annotations: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    const settled = await unstable_runPendingTools(
+      message,
+      { echo: { parameters: { type: "object", properties: {} }, execute } },
+      new AbortController().signal,
+      async () => {},
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(settled).toBe(message);
+  });
+
   it("removes the abort listener after tool execution settles", async () => {
     const abortController = new AbortController();
     const addEventListener = vi.spyOn(

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -76,6 +76,61 @@ describe("unstable_runPendingTools", () => {
     expect(part.result).toBe(NO_RESULT);
   });
 
+  it("skips tool calls that already have a result", async () => {
+    const execute = vi.fn<NonNullable<Tool["execute"]>>(async () => "fresh");
+    const message: AssistantMessage = {
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "settled",
+          toolName: "echo",
+          argsText: '{"n":1}',
+          args: { n: 1 },
+          status: { type: "complete", reason: "stop" },
+          state: "result",
+          result: "stored",
+          artifact: { kept: true },
+          isError: false,
+        },
+        {
+          type: "tool-call",
+          toolCallId: "pending",
+          toolName: "echo",
+          argsText: '{"n":2}',
+          args: { n: 2 },
+          status: { type: "requires-action", reason: "tool-call-result" },
+          state: "call",
+        },
+      ],
+      content: [],
+      metadata: {
+        unstable_state: {},
+        unstable_data: [],
+        unstable_annotations: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    const settled = await unstable_runPendingTools(
+      message,
+      { echo: { parameters: { type: "object", properties: {} }, execute } },
+      new AbortController().signal,
+      async () => {},
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0]).toEqual({ n: 2 });
+    expect(settled.parts[0]).toBe(message.parts[0]);
+    expect(settled.parts[1]).toMatchObject({
+      toolCallId: "pending",
+      state: "result",
+      result: "fresh",
+    });
+  });
+
   it("removes the abort listener after tool execution settles", async () => {
     const abortController = new AbortController();
     const addEventListener = vi.spyOn(

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -7,7 +7,7 @@ import type {
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { ToolResponse } from "./ToolResponse";
 import { ToolExecutionStream } from "./ToolExecutionStream";
-import type { AssistantMessage } from "../utils/types";
+import type { AssistantMessage, ToolCallPart } from "../utils/types";
 import type { ReadonlyJSONObject, ReadonlyJSONValue } from "../../utils";
 
 const TOOL_EXECUTION_ID = Symbol.for("assistant-stream.tool-execution-id");
@@ -201,6 +201,13 @@ function getToolStreamResponse(
   tools?.[context.toolName]?.streamCall?.(reader, executionContext);
 }
 
+const isPendingToolCall = (
+  part: AssistantMessage["parts"][number],
+): part is ToolCallPart =>
+  part.type === "tool-call" &&
+  part.state !== "result" &&
+  part.result === undefined;
+
 export async function unstable_runPendingTools(
   message: AssistantMessage,
   tools: Record<string, Tool> | undefined,
@@ -208,7 +215,7 @@ export async function unstable_runPendingTools(
   human: (toolCallId: string, payload: unknown) => Promise<unknown>,
 ) {
   const toolCallPromises = message.parts
-    .filter((part) => part.type === "tool-call" && part.state !== "result")
+    .filter(isPendingToolCall)
     .map(async (part) => {
       const promiseOrUndefined = getToolResponse(
         tools,
@@ -248,7 +255,7 @@ export async function unstable_runPendingTools(
   );
 
   const updatedParts = message.parts.map((p) => {
-    if (p.type === "tool-call") {
+    if (isPendingToolCall(p)) {
       const toolResponse = toolCallResultsById[p.toolCallId];
       if (toolResponse) {
         return {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -208,7 +208,7 @@ export async function unstable_runPendingTools(
   human: (toolCallId: string, payload: unknown) => Promise<unknown>,
 ) {
   const toolCallPromises = message.parts
-    .filter((part) => part.type === "tool-call")
+    .filter((part) => part.type === "tool-call" && part.state !== "result")
     .map(async (part) => {
       const promiseOrUndefined = getToolResponse(
         tools,


### PR DESCRIPTION
## What
`unstable_runPendingTools` now skips tool-call parts that are already settled (`state === "result"` or a present `result`). Only unsettled calls are executed and merged back; settled parts are returned untouched, and the merge
step uses the same predicate so a settled part can never be rewritten.

## Why
The pending filter only checked `type === "tool-call"`, so replaying a resumed or persisted message re-ran tools that already had a result and replaced the stored one.

## Impact
- Callers replaying persisted messages: settled tools no longer execute again, and their stored results survive.
- Messages with only unsettled calls: no output change.

## Scope & caveats
- Settled means `state === "result" || result !== undefined`, the same predicate `toGenericMessages.ts:156` already uses, so `state`-less persisted parts are covered too.
- `partial-call` parts are deliberately still executed, matching the accumulator's requires-action shape (`assistant-message-accumulator.ts:599-602`); this PR only stops re-running settled calls.
- Duplicate `toolCallId`s within one message are invalid input; the merge guard keeps settled parts immune even then, but nothing else about that case changes.
- The streaming path (`toolResultStream` / `ToolExecutionStream`) is untouched; it never sees settled parts.
- Tests: two regression tests in the existing suite (settled part preserved by identity with a pending sibling resolved; `result`-without-`state` part skipped); both fail on main.
- Additive only, no exports touched.
- Changeset: patch (`assistant-stream`).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.acp5pFJs2CAAMAFtzR-kV9YzzfWFZcUni55o3InZlSmC1IH0deEfFRTtjbQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->