### PR TITLE
fix(react-langgraph): tolerate messages without content

### DIFF
--- a/.changeset/langgraph-contentless-ai.md
+++ b/.changeset/langgraph-contentless-ai.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: tolerate messages without content in the converter and accumulator

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -41,6 +41,34 @@ const aiChunk = (
   tool_call_chunks: toolCallChunks,
 });
 
+describe("appendLangChainChunk content-less chunks", () => {
+  it("accumulates text after a tool-call-only first chunk", () => {
+    const first = append(undefined, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      tool_call_chunks: [
+        { id: "call-1", name: "search", args: "{}", index: 0 },
+      ],
+    } as unknown as LangChainMessageChunk);
+
+    const merged = append(first, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: "hello",
+    } as unknown as LangChainMessageChunk);
+
+    expect(
+      Array.isArray(merged.content)
+        ? merged.content.some(
+            (part) =>
+              (part as { type?: string; text?: string }).type === "text" &&
+              (part as { text?: string }).text === "hello",
+          )
+        : merged.content === "hello",
+    ).toBe(true);
+  });
+});
+
 describe("appendLangChainChunk tool_call id merging", () => {
   it("merges chunk arriving with real id into entry that started with empty id", () => {
     let acc: AiMessage | undefined;

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -57,15 +57,10 @@ describe("appendLangChainChunk content-less chunks", () => {
       content: "hello",
     } as unknown as LangChainMessageChunk);
 
-    expect(
-      Array.isArray(merged.content)
-        ? merged.content.some(
-            (part) =>
-              (part as { type?: string; text?: string }).type === "text" &&
-              (part as { text?: string }).text === "hello",
-          )
-        : merged.content === "hello",
-    ).toBe(true);
+    expect(merged.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(merged.tool_calls).toEqual([
+      expect.objectContaining({ id: "call-1", name: "search" }),
+    ]);
   });
 });
 

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -57,6 +57,8 @@ describe("appendLangChainChunk content-less chunks", () => {
       content: "hello",
     } as unknown as LangChainMessageChunk);
 
+    expect(first.content).toEqual([]);
+
     expect(merged.content).toEqual([{ type: "text", text: "hello" }]);
     expect(merged.tool_calls).toEqual([
       expect.objectContaining({ id: "call-1", name: "search" }),

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -83,6 +83,7 @@ export const appendLangChainChunk = (
     const toolCalls = (curr.tool_call_chunks ?? []).map(chunkToToolCall);
     return {
       ...curr,
+      content: curr.content ?? [],
       type: curr.type.replace("MessageChunk", "").toLowerCase(),
       tool_call_chunks: undefined,
       ...(toolCalls.length > 0 && { tool_calls: toolCalls }),

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -92,7 +92,7 @@ export const appendLangChainChunk = (
   const newContent =
     typeof prev.content === "string"
       ? [{ type: "text" as const, text: prev.content }]
-      : [...prev.content];
+      : [...(prev.content ?? [])];
 
   if (typeof curr?.content === "string") {
     const lastIndex = newContent.length - 1;

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -36,7 +36,15 @@ describe("convertLangChainMessages content-less messages", () => {
     } as unknown as LangChainMessage);
 
     expect(result.role).toBe("assistant");
-    expect(result.content.some((part) => part.type === "tool-call")).toBe(true);
+    expect(result.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "search",
+        args: { q: 1 },
+        argsText: '{"q":1}',
+      },
+    ]);
   });
 
   it("converts a human message without content", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -27,6 +27,29 @@ const convertLangChainMessages = (
     ) => ConvertResult
   )(message, metadata);
 
+describe("convertLangChainMessages content-less messages", () => {
+  it("converts an ai message without content", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      tool_calls: [{ id: "call-1", name: "search", args: { q: 1 } }],
+    } as unknown as LangChainMessage);
+
+    expect(result.role).toBe("assistant");
+    expect(result.content.some((part) => part.type === "tool-call")).toBe(true);
+  });
+
+  it("converts a human message without content", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "h-1",
+    } as unknown as LangChainMessage);
+
+    expect(result.role).toBe("user");
+    expect(result.content).toEqual([]);
+  });
+});
+
 describe("convertLangChainMessages metadata", () => {
   it("passes additional_kwargs.metadata to system message", () => {
     const result = convertLangChainMessages({

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -126,6 +126,7 @@ const contentToParts = (
   metadata: LangGraphMessageConverterMetadata,
   messageId: string | undefined,
 ) => {
+  if (content == null) return [];
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
   return content
@@ -357,7 +358,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       const normalizedContent =
         typeof message.content === "string"
           ? [{ type: "text" as const, text: message.content }]
-          : message.content;
+          : (message.content ?? []);
 
       const allContent = [
         message.additional_kwargs?.reasoning,


### PR DESCRIPTION
## Summary

An `ai` message whose `content` is `undefined` crashed the converter pipeline and blanked the entire thread. This PR fixes it at the source and hardens the readers:

- **Root cause** (`appendLangChainChunk`): the first-chunk branch built the accumulated message as `{ ...curr, ... } as LangChainMessage`, where `curr.content` is optional on `LangChainMessageChunk` — so a tool-call-only first chunk minted an `ai` message with `content: undefined`, violating the `ai` variant's declared `content` type (hidden by the `as` cast). The accumulator now normalizes `content: curr.content ?? []` at construction.
- **Defensive guards** kept in the readers, since server-sent payloads (`values` events) are a separate path that can also omit `content`:
  - `appendLangChainChunk`: spread `prev.content ?? []` when merging onto a previous message without content.
  - `contentToParts`: return `[]` for nullish content.
  - `convertLangChainMessages`: normalize missing `ai` content to `[]` before iteration.

## Why

A LangGraph node that responds with only tool calls (no text) emits `AIMessageChunk`s without `content`. The accumulated message then flowed into `convertLangChainMessages`, which threw (`normalizedContent is not iterable`, `content.map` of undefined, `prev.content is not iterable`), taking down the whole message list render — one contentless message blanked the thread. The repo's converter guideline is that converters must not throw on undefined or missing fields from non-spec provider payloads.

## Validation

- Regression tests fail on `main` with the exact errors above and pass with this change; assertions pin the exact merged content, the surviving tool call, and the exact converted tool-call part (per review).
- Full `@assistant-ui/react-langgraph` suite: 293/293 passing.
- Pre-existing `tsc` errors in `useLangGraphRuntime.test.tsx` reproduce identically without this change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Gbi9YlvnUKoEeBnYeApZuBT4Qp2NV-w2CkXMGlc7RGdU6v873ZvtV0yWI-o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->