### PR TITLE
fix(react-pi): deliver snapshots to late shared-stream subscribers

### DIFF
--- a/.changeset/late-pi-snapshots.md
+++ b/.changeset/late-pi-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: deliver current thread state to late shared-stream subscribers

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1132,6 +1132,7 @@ interface PiCustomMessage {
 interface PiEventStreamOptions {
   url: string;
   onEvent: (event: PiAnyClientEvent) => void;
+  onConnect?: () => void;
   onError?: (error: unknown) => void;
   fetchImpl?: typeof fetch;
   headers?: Record<string, string>;

--- a/packages/react-pi/README.md
+++ b/packages/react-pi/README.md
@@ -215,6 +215,9 @@ degrade rather than crash.
 - Every (re)connect is **snapshot-first**: the server re-sends an authoritative
   `snapshot` event, then live events apply on top. There is no event replay in the
   MVP; the snapshot is authoritative.
+- Browser subscribers share the long-lived SSE connection. A subscriber joining
+  late receives the current snapshot first; when the cached snapshot is behind,
+  one short-lived snapshot request is shared by all subscribers waiting for it.
 - Cold/historical threads load via a **read-only session-file snapshot** — opening
   a thread to read it does **not** spin up a live `AgentSession`. A live runtime is
   created only when you send, cancel, change model/thinking, answer host UI, or

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -505,6 +505,45 @@ describe("openPiEventStream", () => {
     expect(errors).toHaveLength(1);
   });
 
+  it("notifies each successful connection before its events", async () => {
+    let calls = 0;
+    const onConnect = vi.fn();
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        );
+      }
+      return sseResponse([
+        sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+      ]);
+    }) as unknown as typeof fetch;
+
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onConnect,
+        onEvent: () => {
+          close();
+          resolve();
+        },
+      });
+    });
+
+    expect(onConnect).toHaveBeenCalledTimes(2);
+  });
+
   it("releases a completed response body before reconnecting", async () => {
     const body = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -128,6 +128,8 @@ export interface PiEventStreamOptions {
   url: string;
   /** Called with each decoded `PiClientEvent`. */
   onEvent: (event: PiAnyClientEvent) => void;
+  /** Called after each successful SSE response is opened, before events. */
+  onConnect?: () => void;
   /** Non-fatal stream errors (network drop, bad JSON, reconnect-delay failures).
    * The loop reconnects after each; surface these for logging, not control flow. */
   onError?: (error: unknown) => void;
@@ -305,6 +307,7 @@ export const openPiEventStream = (
   const {
     url,
     onEvent,
+    onConnect,
     onError,
     fetchImpl = fetch,
     headers,
@@ -338,6 +341,20 @@ export const openPiEventStream = (
       reportEventCallbackError(callbackError);
     }
   };
+  const reportConnectCallbackError = (callbackError: unknown) => {
+    console.error(
+      "[react-pi] onConnect callback threw an error",
+      callbackError,
+    );
+  };
+  const emitConnect = () => {
+    if (!onConnect) return;
+    try {
+      void Promise.resolve(onConnect()).catch(reportConnectCallbackError);
+    } catch (callbackError) {
+      reportConnectCallbackError(callbackError);
+    }
+  };
 
   const run = async () => {
     while (!closed) {
@@ -356,6 +373,7 @@ export const openPiEventStream = (
           throw new Error(`Pi event stream failed: HTTP ${response.status}`);
         }
         validateEventStreamContentType(response);
+        emitConnect();
 
         const decoder = createSseDecoder();
         const reader = response.body.getReader();

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -582,13 +582,13 @@ describe("createPiHttpClient", () => {
       threadId: "t1",
       seq: 4,
     } satisfies PiAnyClientEvent;
-    const staleError = {
+    const outOfBandError = {
       type: "error",
       threadId: "t1",
-      seq: 2,
-      error: "stale failure",
+      seq: 0,
+      error: "subscription failed",
     } satisfies PiAnyClientEvent;
-    for (const event of [staleError, agentEnd]) {
+    for (const event of [outOfBandError, agentEnd]) {
       streamControllers[0]!.enqueue(
         new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
       );
@@ -608,7 +608,7 @@ describe("createPiHttpClient", () => {
     await vi.waitFor(() => expect(firstEvents).toHaveLength(5));
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
     await vi.waitFor(() =>
-      expect(thirdEvents).toEqual([currentSnapshot, agentEnd]),
+      expect(thirdEvents).toEqual([currentSnapshot, outOfBandError, agentEnd]),
     );
 
     const fourthEvents: PiAnyClientEvent[] = [];
@@ -739,6 +739,82 @@ describe("createPiHttpClient", () => {
     unsubscribeSeventh();
     unsubscribeEighth();
     unsubscribeNinth();
+  });
+
+  it("caps stale snapshot retries after a server sequence reset", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      streamCloseDelayMs: 0,
+    });
+    const send = (
+      controller: ReadableStreamDefaultController<Uint8Array>,
+      event: PiAnyClientEvent,
+    ) => {
+      controller.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    };
+    const snapshotAt = (seq: number) =>
+      ({
+        type: "snapshot",
+        threadId: "t1",
+        seq,
+        snapshot,
+      }) satisfies PiAnyClientEvent;
+
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(streamControllers[0]!, snapshotAt(50));
+    send(streamControllers[0]!, {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 51,
+    });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    const resetSnapshot = snapshotAt(1);
+    send(streamControllers[0]!, resetSnapshot);
+    send(streamControllers[1]!, resetSnapshot);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    send(streamControllers[2]!, resetSnapshot);
+
+    await vi.waitFor(() => expect(lateEvents).toEqual([resetSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    const nextEvents: PiAnyClientEvent[] = [];
+    const unsubscribeNext = client.subscribe("t1", (event) => {
+      nextEvents.push(event);
+    });
+    await vi.waitFor(() => expect(nextEvents).toEqual([resetSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    unsubscribeFirst();
+    unsubscribeLate();
+    unsubscribeNext();
   });
 
   it("falls back to live events when a snapshot refresh fails", async () => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -70,6 +70,7 @@ const openSharedSse = () => {
   ) as unknown as typeof fetch;
   const client = createPiHttpClient({
     fetchImpl,
+    reconnectDelay: () => Promise.resolve(),
     streamCloseDelayMs: 0,
   });
   const send = (index: number, event: PiAnyClientEvent) => {
@@ -77,7 +78,10 @@ const openSharedSse = () => {
       new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
     );
   };
-  return { client, fetchImpl, send };
+  const close = (index: number) => {
+    controllers[index]!.close();
+  };
+  return { client, fetchImpl, send, close };
 };
 
 const snapshotAt = (
@@ -785,6 +789,49 @@ describe("createPiHttpClient", () => {
     });
     await vi.waitFor(() => expect(cachedEvents).toEqual([newerHelperSnapshot]));
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    unsubscribeFirst();
+    unsubscribeLate();
+    unsubscribeCached();
+  });
+
+  it("rebases the cache when the main stream reconnects", async () => {
+    const { client, fetchImpl, send, close } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+    const preReconnectSnapshot = snapshotAt(50);
+    send(1, preReconnectSnapshot);
+    await vi.waitFor(() => expect(lateEvents).toEqual([preReconnectSnapshot]));
+
+    close(0);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    const reconnectSnapshot = snapshotAt(1, "running");
+    send(2, reconnectSnapshot);
+    await vi.waitFor(() =>
+      expect(firstEvents.at(-1)).toEqual(reconnectSnapshot),
+    );
+    await vi.waitFor(() =>
+      expect(lateEvents).toEqual([preReconnectSnapshot, reconnectSnapshot]),
+    );
+
+    const cachedEvents: PiAnyClientEvent[] = [];
+    const unsubscribeCached = client.subscribe("t1", (event) => {
+      cachedEvents.push(event);
+    });
+    await vi.waitFor(() => expect(cachedEvents).toEqual([reconnectSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
 
     unsubscribeFirst();
     unsubscribeLate();

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -756,7 +756,7 @@ describe("createPiHttpClient", () => {
     unsubscribeNinth();
   });
 
-  it("keeps the highest-sequence snapshot when a delayed main snapshot is older", async () => {
+  it("delivers a delayed older main snapshot only to listeners behind it", async () => {
     const { client, fetchImpl, send } = openSharedSse();
     const firstEvents: PiAnyClientEvent[] = [];
     const unsubscribeFirst = client.subscribe("t1", (event) => {
@@ -777,11 +777,16 @@ describe("createPiHttpClient", () => {
     send(1, newerHelperSnapshot);
     await vi.waitFor(() => expect(lateEvents).toEqual([newerHelperSnapshot]));
 
-    send(0, snapshotAt(3, "running"));
-    expect(firstEvents).toEqual([
-      snapshotAt(1),
-      { type: "agent_start", threadId: "t1", seq: 2 },
-    ]);
+    const delayedMainSnapshot = snapshotAt(3, "running");
+    send(0, delayedMainSnapshot);
+    await vi.waitFor(() =>
+      expect(firstEvents).toEqual([
+        snapshotAt(1),
+        { type: "agent_start", threadId: "t1", seq: 2 },
+        delayedMainSnapshot,
+      ]),
+    );
+    expect(lateEvents).toEqual([newerHelperSnapshot]);
 
     const cachedEvents: PiAnyClientEvent[] = [];
     const unsubscribeCached = client.subscribe("t1", (event) => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -588,11 +588,18 @@ describe("createPiHttpClient", () => {
       seq: 0,
       error: "subscription failed",
     } satisfies PiAnyClientEvent;
-    for (const event of [outOfBandError, agentEnd]) {
+    const staleError = {
+      type: "error",
+      threadId: "t1",
+      seq: 2,
+      error: "stale failure",
+    } satisfies PiAnyClientEvent;
+    for (const event of [outOfBandError, staleError, agentEnd]) {
       streamControllers[0]!.enqueue(
         new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
       );
     }
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(6));
     const currentSnapshot = {
       type: "snapshot",
       threadId: "t1",
@@ -605,7 +612,6 @@ describe("createPiHttpClient", () => {
     streamControllers[1]!.enqueue(
       new TextEncoder().encode(`data: ${JSON.stringify(currentSnapshot)}\n\n`),
     );
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(5));
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
     await vi.waitFor(() =>
       expect(thirdEvents).toEqual([currentSnapshot, outOfBandError, agentEnd]),

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -752,6 +752,45 @@ describe("createPiHttpClient", () => {
     unsubscribeNinth();
   });
 
+  it("keeps the highest-sequence snapshot when a delayed main snapshot is older", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    const newerHelperSnapshot = snapshotAt(4, "idle");
+    send(1, newerHelperSnapshot);
+    await vi.waitFor(() => expect(lateEvents).toEqual([newerHelperSnapshot]));
+
+    send(0, snapshotAt(3, "running"));
+    expect(firstEvents).toEqual([
+      snapshotAt(1),
+      { type: "agent_start", threadId: "t1", seq: 2 },
+    ]);
+
+    const cachedEvents: PiAnyClientEvent[] = [];
+    const unsubscribeCached = client.subscribe("t1", (event) => {
+      cachedEvents.push(event);
+    });
+    await vi.waitFor(() => expect(cachedEvents).toEqual([newerHelperSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    unsubscribeFirst();
+    unsubscribeLate();
+    unsubscribeCached();
+  });
+
   it("caps stale snapshot retries after a server sequence reset", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     const fetchImpl = vi.fn(

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -615,7 +615,9 @@ describe("createPiHttpClient", () => {
     send(0, outOfBandError);
     send(0, staleError);
     send(0, agentEnd);
-    await vi.waitFor(() => expect(firstEvents.length).toBeGreaterThanOrEqual(5));
+    await vi.waitFor(() =>
+      expect(firstEvents.length).toBeGreaterThanOrEqual(5),
+    );
     const refreshed = snapshotAt(2, "running");
     send(1, refreshed);
 

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -637,11 +637,108 @@ describe("createPiHttpClient", () => {
     await vi.waitFor(() => expect(fifthEvents).toEqual([latestSnapshot]));
     expect(fetchImpl).toHaveBeenCalledTimes(3);
 
+    const send = (
+      controller: ReadableStreamDefaultController<Uint8Array>,
+      event: PiAnyClientEvent,
+    ) => {
+      controller.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    };
+    const snapshotAt = (seq: number, status: "idle" | "running") =>
+      ({
+        type: "snapshot",
+        threadId: "t1",
+        seq,
+        snapshot: {
+          metadata: { id: "t1", status, messageCount: 1 },
+          messages: [messageStart.message],
+        },
+      }) satisfies PiAnyClientEvent;
+
+    const eventBeforeSharedLoad = {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 5,
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, eventBeforeSharedLoad);
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(6));
+
+    const sixthEvents: PiAnyClientEvent[] = [];
+    const unsubscribeSixth = client.subscribe("t1", (event) => {
+      sixthEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(4));
+
+    const eventDuringSharedLoad = {
+      type: "agent_end",
+      threadId: "t1",
+      seq: 6,
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, eventDuringSharedLoad);
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(7));
+
+    const seventhEvents: PiAnyClientEvent[] = [];
+    const unsubscribeSeventh = client.subscribe("t1", (event) => {
+      seventhEvents.push(event);
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+
+    const snapshotBeforeSeventhJoin = snapshotAt(5, "running");
+    send(streamControllers[3]!, snapshotBeforeSeventhJoin);
+    await vi.waitFor(() =>
+      expect(sixthEvents).toEqual([
+        snapshotBeforeSeventhJoin,
+        eventDuringSharedLoad,
+      ]),
+    );
+    expect(seventhEvents).toEqual([]);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(5));
+
+    const snapshotForSeventh = snapshotAt(6, "idle");
+    send(streamControllers[4]!, snapshotForSeventh);
+    await vi.waitFor(() => expect(seventhEvents).toEqual([snapshotForSeventh]));
+
+    const eventBeforeNewerMainSnapshot = {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 7,
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, eventBeforeNewerMainSnapshot);
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(8));
+
+    const eighthEvents: PiAnyClientEvent[] = [];
+    const unsubscribeEighth = client.subscribe("t1", (event) => {
+      eighthEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(6));
+
+    const newerMainSnapshot = snapshotAt(8, "idle");
+    send(streamControllers[0]!, newerMainSnapshot);
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(9));
+
+    const olderHelperSnapshot = snapshotAt(7, "running");
+    send(streamControllers[5]!, olderHelperSnapshot);
+    await vi.waitFor(() =>
+      expect(eighthEvents).toEqual([olderHelperSnapshot, newerMainSnapshot]),
+    );
+
+    const ninthEvents: PiAnyClientEvent[] = [];
+    const unsubscribeNinth = client.subscribe("t1", (event) => {
+      ninthEvents.push(event);
+    });
+    await vi.waitFor(() => expect(ninthEvents).toEqual([newerMainSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
+
     unsubscribeFirst();
     unsubscribeSecond();
     unsubscribeThird();
     unsubscribeFourth();
     unsubscribeFifth();
+    unsubscribeSixth();
+    unsubscribeSeventh();
+    unsubscribeEighth();
+    unsubscribeNinth();
   });
 
   it("falls back to live events when a snapshot refresh fails", async () => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -582,9 +582,17 @@ describe("createPiHttpClient", () => {
       threadId: "t1",
       seq: 4,
     } satisfies PiAnyClientEvent;
-    streamControllers[0]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(agentEnd)}\n\n`),
-    );
+    const staleError = {
+      type: "error",
+      threadId: "t1",
+      seq: 2,
+      error: "stale failure",
+    } satisfies PiAnyClientEvent;
+    for (const event of [staleError, agentEnd]) {
+      streamControllers[0]!.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    }
     const currentSnapshot = {
       type: "snapshot",
       threadId: "t1",
@@ -597,15 +605,149 @@ describe("createPiHttpClient", () => {
     streamControllers[1]!.enqueue(
       new TextEncoder().encode(`data: ${JSON.stringify(currentSnapshot)}\n\n`),
     );
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(4));
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(5));
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
     await vi.waitFor(() =>
       expect(thirdEvents).toEqual([currentSnapshot, agentEnd]),
     );
 
+    const fourthEvents: PiAnyClientEvent[] = [];
+    const fifthEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFourth = client.subscribe("t1", (event) => {
+      fourthEvents.push(event);
+    });
+    const unsubscribeFifth = client.subscribe("t1", (event) => {
+      fifthEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+
+    const latestSnapshot = {
+      type: "snapshot",
+      threadId: "t1",
+      seq: 4,
+      snapshot: {
+        metadata: { id: "t1", status: "idle", messageCount: 1 },
+        messages: [messageStart.message],
+      },
+    } satisfies PiAnyClientEvent;
+    streamControllers[2]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(latestSnapshot)}\n\n`),
+    );
+    await vi.waitFor(() => expect(fourthEvents).toEqual([latestSnapshot]));
+    await vi.waitFor(() => expect(fifthEvents).toEqual([latestSnapshot]));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
     unsubscribeFirst();
     unsubscribeSecond();
     unsubscribeThird();
+    unsubscribeFourth();
+    unsubscribeFifth();
+  });
+
+  it("falls back to live events when a snapshot refresh fails", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      streamCloseDelayMs: 0,
+    });
+
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    const send = (
+      controller: ReadableStreamDefaultController<Uint8Array>,
+      event: PiAnyClientEvent,
+    ) => {
+      controller.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    };
+    send(streamControllers[0]!, {
+      type: "snapshot",
+      threadId: "t1",
+      seq: 1,
+      snapshot,
+    });
+    send(streamControllers[0]!, {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 2,
+    });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    const liveEvent = {
+      type: "agent_end",
+      threadId: "t1",
+      seq: 3,
+    } satisfies PiAnyClientEvent;
+    const snapshotError = {
+      type: "error",
+      threadId: "t1",
+      seq: 0,
+      error: "snapshot unavailable",
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, liveEvent);
+    send(streamControllers[1]!, snapshotError);
+    await vi.waitFor(() =>
+      expect(lateEvents).toEqual([snapshotError, liveEvent]),
+    );
+
+    const nextLiveEvent = {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 4,
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, nextLiveEvent);
+    await vi.waitFor(() =>
+      expect(lateEvents).toEqual([snapshotError, liveEvent, nextLiveEvent]),
+    );
+
+    const timeoutEvents: PiAnyClientEvent[] = [];
+    let unsubscribeTimeout = () => {};
+    vi.useFakeTimers();
+    try {
+      unsubscribeTimeout = client.subscribe("t1", (event) => {
+        timeoutEvents.push(event);
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+      await vi.advanceTimersByTimeAsync(10_000);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const postTimeoutEvent = {
+      type: "agent_end",
+      threadId: "t1",
+      seq: 5,
+    } satisfies PiAnyClientEvent;
+    send(streamControllers[0]!, postTimeoutEvent);
+    await vi.waitFor(() => expect(timeoutEvents).toEqual([postTimeoutEvent]));
+
+    unsubscribeFirst();
+    unsubscribeLate();
+    unsubscribeTimeout();
   });
 
   it("can subscribe to live events without an initial snapshot", async () => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -838,6 +838,41 @@ describe("createPiHttpClient", () => {
     unsubscribeCached();
   });
 
+  it("flushes pending listeners when a reconnect reports an error instead of a snapshot", async () => {
+    const { client, fetchImpl, send, close } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    close(0);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    const openFailure = {
+      type: "error",
+      threadId: "t1",
+      seq: 0,
+      error: "session open failed",
+    } satisfies PiAnyClientEvent;
+    send(2, openFailure);
+
+    await vi.waitFor(() => expect(lateEvents).toEqual([openFailure]));
+    expect(firstEvents.at(-1)).toEqual(openFailure);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    unsubscribeFirst();
+    unsubscribeLate();
+  });
+
   it("caps stale snapshot retries after a server sequence reset", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     const fetchImpl = vi.fn(

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -530,30 +530,44 @@ describe("createPiHttpClient", () => {
     );
     await vi.waitFor(() => expect(firstEvents).toEqual([initialSnapshot]));
 
+    const replayTasks: (() => void)[] = [];
+    const queueMicrotaskSpy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((task) => replayTasks.push(task));
     const secondEvents: PiAnyClientEvent[] = [];
     const unsubscribeSecond = client.subscribe("t1", (event) => {
       secondEvents.push(event);
     });
 
-    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(replayTasks).toHaveLength(1);
+    queueMicrotaskSpy.mockRestore();
 
     const agentStart = {
       type: "agent_start",
       threadId: "t1",
       seq: 2,
     } satisfies PiAnyClientEvent;
+    streamControllers[0]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(agentStart)}\n\n`),
+    );
+    await vi.waitFor(() =>
+      expect(firstEvents).toEqual([initialSnapshot, agentStart]),
+    );
+    expect(secondEvents).toEqual([]);
+
+    replayTasks[0]!();
+    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
     const messageStart = {
       type: "message_start",
       threadId: "t1",
       seq: 3,
       message: { role: "user", content: "hello", timestamp: 1 },
     } satisfies PiAnyClientEvent;
-    for (const event of [agentStart, messageStart]) {
-      streamControllers[0]!.enqueue(
-        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
-      );
-    }
+    streamControllers[0]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(messageStart)}\n\n`),
+    );
     await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
 

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -492,14 +492,14 @@ describe("createPiHttpClient", () => {
     );
   });
 
-  it("replays current state to late snapshot subscribers", async () => {
-    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+  it("delivers authoritative state to late snapshot subscribers", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     const fetchImpl = vi.fn(
       async () =>
         new Response(
           new ReadableStream<Uint8Array>({
             start(controller) {
-              streamController = controller;
+              streamControllers.push(controller);
             },
           }),
           {
@@ -519,21 +519,16 @@ describe("createPiHttpClient", () => {
     });
 
     await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
-    for (const event of [
-      { type: "snapshot", threadId: "t1", seq: 1, snapshot },
-      { type: "agent_start", threadId: "t1", seq: 2 },
-      {
-        type: "message_start",
-        threadId: "t1",
-        seq: 3,
-        message: { role: "user", content: "hello", timestamp: 1 },
-      },
-    ] satisfies PiAnyClientEvent[]) {
-      streamController.enqueue(
-        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
-      );
-    }
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
+    const initialSnapshot = {
+      type: "snapshot",
+      threadId: "t1",
+      seq: 1,
+      snapshot,
+    } satisfies PiAnyClientEvent;
+    streamControllers[0]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(initialSnapshot)}\n\n`),
+    );
+    await vi.waitFor(() => expect(firstEvents).toEqual([initialSnapshot]));
 
     const secondEvents: PiAnyClientEvent[] = [];
     const unsubscribeSecond = client.subscribe("t1", (event) => {
@@ -543,32 +538,56 @@ describe("createPiHttpClient", () => {
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
     expect(fetchImpl).toHaveBeenCalledTimes(1);
 
-    streamController.enqueue(
-      new TextEncoder().encode(
-        `data: ${JSON.stringify({
-          type: "agent_end",
-          threadId: "t1",
-          seq: 4,
-        })}\n\n`,
-      ),
-    );
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(4));
+    const agentStart = {
+      type: "agent_start",
+      threadId: "t1",
+      seq: 2,
+    } satisfies PiAnyClientEvent;
+    const messageStart = {
+      type: "message_start",
+      threadId: "t1",
+      seq: 3,
+      message: { role: "user", content: "hello", timestamp: 1 },
+    } satisfies PiAnyClientEvent;
+    for (const event of [agentStart, messageStart]) {
+      streamControllers[0]!.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    }
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
     await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
 
     const thirdEvents: PiAnyClientEvent[] = [];
     const unsubscribeThird = client.subscribe("t1", (event) => {
       thirdEvents.push(event);
     });
-    await vi.waitFor(() => expect(thirdEvents).toHaveLength(1));
-    expect(thirdEvents[0]).toMatchObject({
-      type: "snapshot",
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+
+    const agentEnd = {
+      type: "agent_end",
       threadId: "t1",
       seq: 4,
+    } satisfies PiAnyClientEvent;
+    streamControllers[0]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(agentEnd)}\n\n`),
+    );
+    const currentSnapshot = {
+      type: "snapshot",
+      threadId: "t1",
+      seq: 3,
       snapshot: {
-        metadata: { id: "t1", status: "idle", messageCount: 1 },
-        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        metadata: { id: "t1", status: "running", messageCount: 1 },
+        messages: [messageStart.message],
       },
-    });
+    } satisfies PiAnyClientEvent;
+    streamControllers[1]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(currentSnapshot)}\n\n`),
+    );
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(4));
+    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    await vi.waitFor(() =>
+      expect(thirdEvents).toEqual([currentSnapshot, agentEnd]),
+    );
 
     unsubscribeFirst();
     unsubscribeSecond();

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -492,6 +492,89 @@ describe("createPiHttpClient", () => {
     );
   });
 
+  it("replays current state to late snapshot subscribers", async () => {
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        ),
+    ) as unknown as typeof fetch;
+    const client = createPiHttpClient({
+      fetchImpl,
+      streamCloseDelayMs: 0,
+    });
+
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    for (const event of [
+      { type: "snapshot", threadId: "t1", seq: 1, snapshot },
+      { type: "agent_start", threadId: "t1", seq: 2 },
+      {
+        type: "message_start",
+        threadId: "t1",
+        seq: 3,
+        message: { role: "user", content: "hello", timestamp: 1 },
+      },
+    ] satisfies PiAnyClientEvent[]) {
+      streamController.enqueue(
+        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+      );
+    }
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
+
+    const secondEvents: PiAnyClientEvent[] = [];
+    const unsubscribeSecond = client.subscribe("t1", (event) => {
+      secondEvents.push(event);
+    });
+
+    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    streamController.enqueue(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify({
+          type: "agent_end",
+          threadId: "t1",
+          seq: 4,
+        })}\n\n`,
+      ),
+    );
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(4));
+    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+
+    const thirdEvents: PiAnyClientEvent[] = [];
+    const unsubscribeThird = client.subscribe("t1", (event) => {
+      thirdEvents.push(event);
+    });
+    await vi.waitFor(() => expect(thirdEvents).toHaveLength(1));
+    expect(thirdEvents[0]).toMatchObject({
+      type: "snapshot",
+      threadId: "t1",
+      seq: 4,
+      snapshot: {
+        metadata: { id: "t1", status: "idle", messageCount: 1 },
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      },
+    });
+
+    unsubscribeFirst();
+    unsubscribeSecond();
+    unsubscribeThird();
+  });
+
   it("can subscribe to live events without an initial snapshot", async () => {
     const { fn, calls } = fakeFetch(() => new Response(null, { status: 204 }));
     const client = createPiHttpClient({

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -52,6 +52,49 @@ const snapshot: PiThreadSnapshot = {
   messages: [],
 };
 
+const openSharedSse = () => {
+  const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+  const fetchImpl = vi.fn(
+    async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controllers.push(controller);
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        },
+      ),
+  ) as unknown as typeof fetch;
+  const client = createPiHttpClient({
+    fetchImpl,
+    streamCloseDelayMs: 0,
+  });
+  const send = (index: number, event: PiAnyClientEvent) => {
+    controllers[index]!.enqueue(
+      new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
+    );
+  };
+  return { client, fetchImpl, send };
+};
+
+const snapshotAt = (
+  seq: number,
+  status: "idle" | "running" = "idle",
+  messages: PiThreadSnapshot["messages"] = [],
+) =>
+  ({
+    type: "snapshot",
+    threadId: "t1",
+    seq,
+    snapshot: {
+      metadata: { id: "t1", status, messageCount: messages.length },
+      messages,
+    },
+  }) satisfies PiAnyClientEvent;
+
 describe("createPiHttpClient", () => {
   it("lists threads with workspace + archived query params", async () => {
     const threads: PiThreadMetadata[] = [{ id: "t1", status: "idle" }];
@@ -492,51 +535,25 @@ describe("createPiHttpClient", () => {
     );
   });
 
-  it("delivers authoritative state to late snapshot subscribers", async () => {
-    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
-    const fetchImpl = vi.fn(
-      async () =>
-        new Response(
-          new ReadableStream<Uint8Array>({
-            start(controller) {
-              streamControllers.push(controller);
-            },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "text/event-stream" },
-          },
-        ),
-    ) as unknown as typeof fetch;
-    const client = createPiHttpClient({
-      fetchImpl,
-      streamCloseDelayMs: 0,
-    });
-
+  it("replays a current cached snapshot to a late subscriber", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
     const firstEvents: PiAnyClientEvent[] = [];
     const unsubscribeFirst = client.subscribe("t1", (event) => {
       firstEvents.push(event);
     });
 
     await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
-    const initialSnapshot = {
-      type: "snapshot",
-      threadId: "t1",
-      seq: 1,
-      snapshot,
-    } satisfies PiAnyClientEvent;
-    streamControllers[0]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(initialSnapshot)}\n\n`),
-    );
+    const initialSnapshot = snapshotAt(1);
+    send(0, initialSnapshot);
     await vi.waitFor(() => expect(firstEvents).toEqual([initialSnapshot]));
 
     const replayTasks: (() => void)[] = [];
     const queueMicrotaskSpy = vi
       .spyOn(globalThis, "queueMicrotask")
       .mockImplementation((task) => replayTasks.push(task));
-    const secondEvents: PiAnyClientEvent[] = [];
-    const unsubscribeSecond = client.subscribe("t1", (event) => {
-      secondEvents.push(event);
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
     });
 
     expect(replayTasks).toHaveLength(1);
@@ -547,41 +564,37 @@ describe("createPiHttpClient", () => {
       threadId: "t1",
       seq: 2,
     } satisfies PiAnyClientEvent;
-    streamControllers[0]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(agentStart)}\n\n`),
-    );
+    send(0, agentStart);
     await vi.waitFor(() =>
       expect(firstEvents).toEqual([initialSnapshot, agentStart]),
     );
-    expect(secondEvents).toEqual([]);
+    expect(lateEvents).toEqual([]);
 
     replayTasks[0]!();
-    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    await vi.waitFor(() => expect(lateEvents).toEqual(firstEvents));
     expect(fetchImpl).toHaveBeenCalledTimes(1);
 
-    const messageStart = {
-      type: "message_start",
-      threadId: "t1",
-      seq: 3,
-      message: { role: "user", content: "hello", timestamp: 1 },
-    } satisfies PiAnyClientEvent;
-    streamControllers[0]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(messageStart)}\n\n`),
-    );
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
-    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    unsubscribeFirst();
+    unsubscribeLate();
+  });
 
-    const thirdEvents: PiAnyClientEvent[] = [];
-    const unsubscribeThird = client.subscribe("t1", (event) => {
-      thirdEvents.push(event);
+  it("shares one snapshot refresh and keeps out-of-band errors", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+
+    const lateEvents: PiAnyClientEvent[] = [];
+    const unsubscribeLate = client.subscribe("t1", (event) => {
+      lateEvents.push(event);
     });
     await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
 
-    const agentEnd = {
-      type: "agent_end",
-      threadId: "t1",
-      seq: 4,
-    } satisfies PiAnyClientEvent;
     const outOfBandError = {
       type: "error",
       threadId: "t1",
@@ -591,107 +604,93 @@ describe("createPiHttpClient", () => {
     const staleError = {
       type: "error",
       threadId: "t1",
-      seq: 2,
+      seq: 1,
       error: "stale failure",
     } satisfies PiAnyClientEvent;
-    for (const event of [outOfBandError, staleError, agentEnd]) {
-      streamControllers[0]!.enqueue(
-        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
-      );
-    }
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(6));
-    const currentSnapshot = {
-      type: "snapshot",
+    const agentEnd = {
+      type: "agent_end",
       threadId: "t1",
       seq: 3,
-      snapshot: {
-        metadata: { id: "t1", status: "running", messageCount: 1 },
-        messages: [messageStart.message],
-      },
     } satisfies PiAnyClientEvent;
-    streamControllers[1]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(currentSnapshot)}\n\n`),
-    );
-    await vi.waitFor(() => expect(secondEvents).toEqual(firstEvents));
+    send(0, outOfBandError);
+    send(0, staleError);
+    send(0, agentEnd);
+    await vi.waitFor(() => expect(firstEvents.length).toBeGreaterThanOrEqual(5));
+    const refreshed = snapshotAt(2, "running");
+    send(1, refreshed);
+
     await vi.waitFor(() =>
-      expect(thirdEvents).toEqual([currentSnapshot, outOfBandError, agentEnd]),
+      expect(lateEvents).toEqual([refreshed, outOfBandError, agentEnd]),
     );
 
-    const fourthEvents: PiAnyClientEvent[] = [];
-    const fifthEvents: PiAnyClientEvent[] = [];
-    const unsubscribeFourth = client.subscribe("t1", (event) => {
-      fourthEvents.push(event);
+    unsubscribeFirst();
+    unsubscribeLate();
+  });
+
+  it("dedupes concurrent stale-snapshot refreshes", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
     });
-    const unsubscribeFifth = client.subscribe("t1", (event) => {
-      fifthEvents.push(event);
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
+    const secondEvents: PiAnyClientEvent[] = [];
+    const thirdEvents: PiAnyClientEvent[] = [];
+    const unsubscribeSecond = client.subscribe("t1", (event) => {
+      secondEvents.push(event);
     });
-    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+    const unsubscribeThird = client.subscribe("t1", (event) => {
+      thirdEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
 
-    const latestSnapshot = {
-      type: "snapshot",
-      threadId: "t1",
-      seq: 4,
-      snapshot: {
-        metadata: { id: "t1", status: "idle", messageCount: 1 },
-        messages: [messageStart.message],
-      },
-    } satisfies PiAnyClientEvent;
-    streamControllers[2]!.enqueue(
-      new TextEncoder().encode(`data: ${JSON.stringify(latestSnapshot)}\n\n`),
-    );
-    await vi.waitFor(() => expect(fourthEvents).toEqual([latestSnapshot]));
-    await vi.waitFor(() => expect(fifthEvents).toEqual([latestSnapshot]));
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const refreshed = snapshotAt(2);
+    send(1, refreshed);
+    await vi.waitFor(() => expect(secondEvents).toEqual([refreshed]));
+    await vi.waitFor(() => expect(thirdEvents).toEqual([refreshed]));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
 
-    const send = (
-      controller: ReadableStreamDefaultController<Uint8Array>,
-      event: PiAnyClientEvent,
-    ) => {
-      controller.enqueue(
-        new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`),
-      );
-    };
-    const snapshotAt = (seq: number, status: "idle" | "running") =>
-      ({
-        type: "snapshot",
-        threadId: "t1",
-        seq,
-        snapshot: {
-          metadata: { id: "t1", status, messageCount: 1 },
-          messages: [messageStart.message],
-        },
-      }) satisfies PiAnyClientEvent;
+    unsubscribeFirst();
+    unsubscribeSecond();
+    unsubscribeThird();
+  });
 
-    const eventBeforeSharedLoad = {
-      type: "agent_start",
-      threadId: "t1",
-      seq: 5,
-    } satisfies PiAnyClientEvent;
-    send(streamControllers[0]!, eventBeforeSharedLoad);
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(6));
+  it("starts a follow-up refresh when a listener joins after the helper snapshot", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
 
     const sixthEvents: PiAnyClientEvent[] = [];
     const unsubscribeSixth = client.subscribe("t1", (event) => {
       sixthEvents.push(event);
     });
-    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(4));
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
 
     const eventDuringSharedLoad = {
       type: "agent_end",
       threadId: "t1",
-      seq: 6,
+      seq: 3,
     } satisfies PiAnyClientEvent;
-    send(streamControllers[0]!, eventDuringSharedLoad);
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(7));
+    send(0, eventDuringSharedLoad);
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(3));
 
     const seventhEvents: PiAnyClientEvent[] = [];
     const unsubscribeSeventh = client.subscribe("t1", (event) => {
       seventhEvents.push(event);
     });
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
 
-    const snapshotBeforeSeventhJoin = snapshotAt(5, "running");
-    send(streamControllers[3]!, snapshotBeforeSeventhJoin);
+    const snapshotBeforeSeventhJoin = snapshotAt(2, "running");
+    send(1, snapshotBeforeSeventhJoin);
     await vi.waitFor(() =>
       expect(sixthEvents).toEqual([
         snapshotBeforeSeventhJoin,
@@ -699,32 +698,42 @@ describe("createPiHttpClient", () => {
       ]),
     );
     expect(seventhEvents).toEqual([]);
-    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(5));
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
 
-    const snapshotForSeventh = snapshotAt(6, "idle");
-    send(streamControllers[4]!, snapshotForSeventh);
+    const snapshotForSeventh = snapshotAt(3, "idle");
+    send(2, snapshotForSeventh);
     await vi.waitFor(() => expect(seventhEvents).toEqual([snapshotForSeventh]));
 
-    const eventBeforeNewerMainSnapshot = {
-      type: "agent_start",
-      threadId: "t1",
-      seq: 7,
-    } satisfies PiAnyClientEvent;
-    send(streamControllers[0]!, eventBeforeNewerMainSnapshot);
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(8));
+    unsubscribeFirst();
+    unsubscribeSixth();
+    unsubscribeSeventh();
+  });
+
+  it("keeps the highest-sequence snapshot when the main stream overtakes a helper", async () => {
+    const { client, fetchImpl, send } = openSharedSse();
+    const firstEvents: PiAnyClientEvent[] = [];
+    const unsubscribeFirst = client.subscribe("t1", (event) => {
+      firstEvents.push(event);
+    });
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+    send(0, snapshotAt(1));
+    send(0, { type: "agent_start", threadId: "t1", seq: 2 });
+    await vi.waitFor(() => expect(firstEvents).toHaveLength(2));
 
     const eighthEvents: PiAnyClientEvent[] = [];
     const unsubscribeEighth = client.subscribe("t1", (event) => {
       eighthEvents.push(event);
     });
-    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(6));
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
 
-    const newerMainSnapshot = snapshotAt(8, "idle");
-    send(streamControllers[0]!, newerMainSnapshot);
-    await vi.waitFor(() => expect(firstEvents).toHaveLength(9));
+    const newerMainSnapshot = snapshotAt(4, "idle");
+    send(0, newerMainSnapshot);
+    await vi.waitFor(() =>
+      expect(firstEvents.at(-1)).toEqual(newerMainSnapshot),
+    );
 
-    const olderHelperSnapshot = snapshotAt(7, "running");
-    send(streamControllers[5]!, olderHelperSnapshot);
+    const olderHelperSnapshot = snapshotAt(3, "running");
+    send(1, olderHelperSnapshot);
     await vi.waitFor(() =>
       expect(eighthEvents).toEqual([olderHelperSnapshot, newerMainSnapshot]),
     );
@@ -734,15 +743,9 @@ describe("createPiHttpClient", () => {
       ninthEvents.push(event);
     });
     await vi.waitFor(() => expect(ninthEvents).toEqual([newerMainSnapshot]));
-    expect(fetchImpl).toHaveBeenCalledTimes(6);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
 
     unsubscribeFirst();
-    unsubscribeSecond();
-    unsubscribeThird();
-    unsubscribeFourth();
-    unsubscribeFifth();
-    unsubscribeSixth();
-    unsubscribeSeventh();
     unsubscribeEighth();
     unsubscribeNinth();
   });

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -57,6 +57,7 @@ type SharedSnapshotLoad = {
 type SharedStream = {
   listeners: Set<PiEventListener>;
   pendingEvents: Map<PiEventListener, PendingSnapshotEvents>;
+  snapshotSeqs: Map<PiEventListener, number>;
   snapshotEvent: PiSnapshotEvent | undefined;
   hasEventsSinceSnapshot: boolean;
   latestSeq: number;
@@ -76,6 +77,17 @@ const notifyListener = (listener: PiEventListener, event: PiClientEvent) => {
   } catch (error) {
     console.error("[react-pi] Listener threw an error", error);
   }
+};
+
+const deliverEvent = (
+  stream: SharedStream,
+  listener: PiEventListener,
+  event: PiClientEvent,
+) => {
+  if (event.type === "snapshot") {
+    stream.snapshotSeqs.set(listener, event.seq);
+  }
+  notifyListener(listener, event);
 };
 
 const applyCachedSnapshot = (
@@ -108,14 +120,14 @@ const deliverPendingSnapshots = (
     const pending = stream.pendingEvents.get(listener);
     if (!pending || !stream.listeners.has(listener)) continue;
     stream.pendingEvents.delete(listener);
-    notifyListener(listener, snapshotEvent);
+    deliverEvent(stream, listener, snapshotEvent);
     for (const event of pending.events) {
       if (!stream.listeners.has(listener)) break;
       if (
         (event.type === "error" && event.seq === 0) ||
         event.seq > snapshotEvent.seq
       ) {
-        notifyListener(listener, event);
+        deliverEvent(stream, listener, event);
       }
     }
   }
@@ -130,7 +142,7 @@ const flushStrandedPendingListeners = (stream: SharedStream) => {
     if (!stream.listeners.has(listener)) continue;
     for (const event of pending.events) {
       if (!stream.listeners.has(listener)) break;
-      notifyListener(listener, event);
+      deliverEvent(stream, listener, event);
     }
   }
 };
@@ -396,6 +408,7 @@ export const createPiHttpClient = (
         const createdStream: SharedStream = {
           listeners,
           pendingEvents,
+          snapshotSeqs: new Map(),
           snapshotEvent: undefined,
           hasEventsSinceSnapshot: false,
           latestSeq: 0,
@@ -428,23 +441,24 @@ export const createPiHttpClient = (
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
               let rebasePending = false;
+              let rebaseSnapshot = false;
               if (clientEvent.type === "snapshot") {
                 const fromReconnect = createdStream.awaitingLiveSnapshot;
                 const isLiveReset =
                   createdStream.liveSnapshotSeq > 0 &&
                   clientEvent.seq < createdStream.liveSnapshotSeq;
                 createdStream.awaitingLiveSnapshot = false;
+                rebaseSnapshot = fromReconnect || isLiveReset;
                 if (
-                  !applyCachedSnapshot(
+                  applyCachedSnapshot(
                     createdStream,
                     clientEvent,
-                    fromReconnect || isLiveReset,
+                    rebaseSnapshot,
                   )
                 ) {
-                  return;
+                  createdStream.liveSnapshotSeq = clientEvent.seq;
+                  rebasePending = fromReconnect;
                 }
-                createdStream.liveSnapshotSeq = clientEvent.seq;
-                rebasePending = fromReconnect;
               } else {
                 createdStream.latestSeq = Math.max(
                   createdStream.latestSeq,
@@ -461,8 +475,13 @@ export const createPiHttpClient = (
                 const pending = pendingEvents.get(listener);
                 if (pending) {
                   pending.events.push(clientEvent);
-                } else {
-                  notifyListener(listener, clientEvent);
+                } else if (
+                  clientEvent.type !== "snapshot" ||
+                  rebaseSnapshot ||
+                  (createdStream.snapshotSeqs.get(listener) ?? 0) <
+                    clientEvent.seq
+                ) {
+                  deliverEvent(createdStream, listener, clientEvent);
                 }
               }
               if (rebasePending && clientEvent.type === "snapshot") {
@@ -506,14 +525,14 @@ export const createPiHttpClient = (
           stream.pendingEvents.delete(pendingListener);
           applyCachedSnapshot(stream, snapshotEvent);
 
-          notifyListener(pendingListener, snapshotEvent);
+          deliverEvent(stream, pendingListener, snapshotEvent);
           for (const event of pending.events) {
             if (!stream.listeners.has(pendingListener)) break;
             if (
               (event.type === "error" && event.seq === 0) ||
               event.seq > snapshotEvent.seq
             ) {
-              notifyListener(pendingListener, event);
+              deliverEvent(stream, pendingListener, event);
             }
           }
         };
@@ -525,10 +544,10 @@ export const createPiHttpClient = (
           const pending = stream.pendingEvents.get(pendingListener);
           stream.pendingEvents.delete(pendingListener);
           if (!stream.listeners.has(pendingListener)) return;
-          if (errorEvent) notifyListener(pendingListener, errorEvent);
+          if (errorEvent) deliverEvent(stream, pendingListener, errorEvent);
           for (const event of pending?.events ?? []) {
             if (!stream.listeners.has(pendingListener)) break;
-            notifyListener(pendingListener, event);
+            deliverEvent(stream, pendingListener, event);
           }
         };
 
@@ -622,6 +641,7 @@ export const createPiHttpClient = (
         if (!current) return;
         current.listeners.delete(listener);
         current.pendingEvents.delete(listener);
+        current.snapshotSeqs.delete(listener);
         const snapshotLoad = current.snapshotLoad;
         if (snapshotLoad?.listeners.delete(listener)) {
           if (snapshotLoad.listeners.size === 0) {

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -29,13 +29,6 @@
 import { isRecord } from "@assistant-ui/core/internal";
 import { openPiEventStream } from "./eventSource";
 import { isThreadMetadata, isThreadSnapshot } from "./validation";
-import { isKnownPiClientEventType } from "../eventTypes";
-import { piQueueItemId } from "../queueIds";
-import {
-  createPiThreadState,
-  reducePiThreadState,
-  type PiThreadState,
-} from "../runtime/threadState";
 import type {
   PiClient,
   PiClientEvent,
@@ -47,12 +40,14 @@ import type {
   PiThreadSnapshot,
 } from "../types";
 
+type PiSnapshotEvent = Extract<PiClientEvent, { type: "snapshot" }>;
+
 type SharedStream = {
   listeners: Set<(event: PiClientEvent) => void>;
   pendingEvents: Map<(event: PiClientEvent) => void, PiClientEvent[]>;
-  replayEvents: PiClientEvent[];
-  replayState: PiThreadState | undefined;
-  canCompactReplay: boolean;
+  snapshotEvent: PiSnapshotEvent | undefined;
+  hasEventsSinceSnapshot: boolean;
+  snapshotLoads: Map<(event: PiClientEvent) => void, () => void>;
   close: () => void;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
 };
@@ -65,82 +60,6 @@ const notifyListener = (
     listener(event);
   } catch (error) {
     console.error("[react-pi] Listener threw an error", error);
-  }
-};
-
-const snapshotEventFromState = (state: PiThreadState): PiClientEvent => {
-  const {
-    queuedMessages: _queuedMessages,
-    contextUsage: _contextUsage,
-    messageCount: _messageCount,
-    ...metadata
-  } = state.metadata;
-  const queuedMessages = [
-    ...state.queue.steering.map((content, index) => ({
-      id: piQueueItemId("steer", index),
-      mode: "steer" as const,
-      content,
-    })),
-    ...state.queue.followUp.map((content, index) => ({
-      id: piQueueItemId("followUp", index),
-      mode: "followUp" as const,
-      content,
-    })),
-  ];
-
-  return {
-    type: "snapshot",
-    threadId: state.threadId,
-    seq: state.lastSeq,
-    snapshot: {
-      metadata: {
-        ...metadata,
-        messageCount: state.messages.length,
-        ...(queuedMessages.length > 0 ? { queuedMessages } : {}),
-        ...(state.contextUsage !== undefined
-          ? { contextUsage: state.contextUsage }
-          : {}),
-      },
-      messages: [...state.messages],
-      ...(state.hostUiRequests.length > 0
-        ? { hostUiRequests: state.hostUiRequests }
-        : {}),
-      ...(state.readiness !== undefined ? { readiness: state.readiness } : {}),
-      ...(state.lastError !== undefined ? { lastError: state.lastError } : {}),
-    },
-  };
-};
-
-const updateReplay = (stream: SharedStream, event: PiClientEvent) => {
-  if (!stream.replayState) return;
-
-  if (event.type === "snapshot") {
-    stream.replayState = reducePiThreadState(
-      createPiThreadState(event.threadId),
-      event,
-    );
-    stream.replayEvents = [event];
-    stream.canCompactReplay = true;
-    return;
-  }
-
-  if (stream.replayEvents.length === 0) return;
-  stream.replayState = reducePiThreadState(stream.replayState, event);
-  stream.replayEvents.push(event);
-
-  if (
-    !isKnownPiClientEventType(event.type) ||
-    (event.type === "entry_appended" && event.entry.type !== "custom")
-  ) {
-    stream.canCompactReplay = false;
-  }
-
-  if (
-    stream.canCompactReplay &&
-    event.type === "agent_end" &&
-    event.willRetry !== true
-  ) {
-    stream.replayEvents = [snapshotEventFromState(stream.replayState)];
   }
 };
 
@@ -395,6 +314,9 @@ export const createPiHttpClient = (
       const streamKey = `${base}:${threadId}:${
         includeSnapshot ? "snapshot" : "live"
       }`;
+      const eventsUrl = `${threadUrl(threadId)}/events${
+        includeSnapshot ? "" : "?snapshot=false"
+      }`;
       let stream = streams.get(streamKey);
       if (!stream) {
         const listeners = new Set<(event: PiClientEvent) => void>();
@@ -402,17 +324,12 @@ export const createPiHttpClient = (
           (event: PiClientEvent) => void,
           PiClientEvent[]
         >();
-        const eventsUrl = `${threadUrl(threadId)}/events${
-          includeSnapshot ? "" : "?snapshot=false"
-        }`;
         const createdStream: SharedStream = {
           listeners,
           pendingEvents,
-          replayEvents: [],
-          replayState: includeSnapshot
-            ? createPiThreadState(threadId)
-            : undefined,
-          canCompactReplay: true,
+          snapshotEvent: undefined,
+          hasEventsSinceSnapshot: false,
+          snapshotLoads: new Map(),
           closeTimer: undefined,
           close: openPiEventStream({
             url: eventsUrl,
@@ -426,7 +343,12 @@ export const createPiHttpClient = (
             ...(onStreamError ? { onError: onStreamError } : {}),
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
-              updateReplay(createdStream, clientEvent);
+              if (clientEvent.type === "snapshot") {
+                createdStream.snapshotEvent = clientEvent;
+                createdStream.hasEventsSinceSnapshot = false;
+              } else if (createdStream.snapshotEvent) {
+                createdStream.hasEventsSinceSnapshot = true;
+              }
               for (const listener of [...listeners]) {
                 const pending = pendingEvents.get(listener);
                 if (pending) {
@@ -447,23 +369,60 @@ export const createPiHttpClient = (
 
       const isNewListener = !stream.listeners.has(listener);
       stream.listeners.add(listener);
-      if (isNewListener && includeSnapshot && stream.replayEvents.length > 0) {
-        const replayEvents = [...stream.replayEvents];
+      if (isNewListener && includeSnapshot && stream.snapshotEvent) {
         const pendingEvents: PiClientEvent[] = [];
         stream.pendingEvents.set(listener, pendingEvents);
-        queueMicrotask(() => {
+
+        const finishSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
           if (
             !stream.listeners.has(listener) ||
             stream.pendingEvents.get(listener) !== pendingEvents
           ) {
             return;
           }
+
+          stream.snapshotLoads.get(listener)?.();
+          stream.snapshotLoads.delete(listener);
           stream.pendingEvents.delete(listener);
-          for (const event of [...replayEvents, ...pendingEvents]) {
-            if (!stream.listeners.has(listener)) break;
-            notifyListener(listener, event);
+          if (
+            !pendingEvents.some(
+              (event) =>
+                event.type !== "error" && event.seq > snapshotEvent.seq,
+            )
+          ) {
+            stream.snapshotEvent = snapshotEvent;
+            stream.hasEventsSinceSnapshot = false;
           }
-        });
+
+          notifyListener(listener, snapshotEvent);
+          for (const event of pendingEvents) {
+            if (!stream.listeners.has(listener)) break;
+            if (event.type === "error" || event.seq > snapshotEvent.seq) {
+              notifyListener(listener, event);
+            }
+          }
+        };
+
+        if (!stream.hasEventsSinceSnapshot) {
+          const snapshotEvent = stream.snapshotEvent;
+          queueMicrotask(() => finishSnapshotLoad(snapshotEvent));
+        } else {
+          let closeSnapshotStream = () => {};
+          closeSnapshotStream = openPiEventStream({
+            url: eventsUrl,
+            expectedThreadId: threadId,
+            fetchImpl,
+            ...(headers ? { headers } : {}),
+            ...(reconnectDelay ? { reconnectDelay } : {}),
+            ...(onStreamError ? { onError: onStreamError } : {}),
+            onEvent: (event) => {
+              if (event.type !== "snapshot") return;
+              closeSnapshotStream();
+              finishSnapshotLoad(event as PiSnapshotEvent);
+            },
+          });
+          stream.snapshotLoads.set(listener, closeSnapshotStream);
+        }
       }
 
       return () => {
@@ -471,6 +430,8 @@ export const createPiHttpClient = (
         if (!current) return;
         current.listeners.delete(listener);
         current.pendingEvents.delete(listener);
+        current.snapshotLoads.get(listener)?.();
+        current.snapshotLoads.delete(listener);
         if (current.listeners.size > 0 || current.closeTimer) return;
         if (streamCloseDelayMs <= 0) {
           current.close();

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -41,21 +41,28 @@ import type {
 } from "../types";
 
 type PiSnapshotEvent = Extract<PiClientEvent, { type: "snapshot" }>;
+type PiEventListener = (event: PiClientEvent) => void;
+
+type SharedSnapshotLoad = {
+  listeners: Set<PiEventListener>;
+  close: () => void;
+  timeout: ReturnType<typeof setTimeout> | undefined;
+};
 
 type SharedStream = {
-  listeners: Set<(event: PiClientEvent) => void>;
-  pendingEvents: Map<(event: PiClientEvent) => void, PiClientEvent[]>;
+  listeners: Set<PiEventListener>;
+  pendingEvents: Map<PiEventListener, PiClientEvent[]>;
   snapshotEvent: PiSnapshotEvent | undefined;
   hasEventsSinceSnapshot: boolean;
-  snapshotLoads: Map<(event: PiClientEvent) => void, () => void>;
+  latestSeq: number;
+  snapshotLoad: SharedSnapshotLoad | undefined;
   close: () => void;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
 };
 
-const notifyListener = (
-  listener: (event: PiClientEvent) => void,
-  event: PiClientEvent,
-) => {
+const SNAPSHOT_LOAD_TIMEOUT_MS = 10_000;
+
+const notifyListener = (listener: PiEventListener, event: PiClientEvent) => {
   try {
     listener(event);
   } catch (error) {
@@ -319,17 +326,15 @@ export const createPiHttpClient = (
       }`;
       let stream = streams.get(streamKey);
       if (!stream) {
-        const listeners = new Set<(event: PiClientEvent) => void>();
-        const pendingEvents = new Map<
-          (event: PiClientEvent) => void,
-          PiClientEvent[]
-        >();
+        const listeners = new Set<PiEventListener>();
+        const pendingEvents = new Map<PiEventListener, PiClientEvent[]>();
         const createdStream: SharedStream = {
           listeners,
           pendingEvents,
           snapshotEvent: undefined,
           hasEventsSinceSnapshot: false,
-          snapshotLoads: new Map(),
+          latestSeq: 0,
+          snapshotLoad: undefined,
           closeTimer: undefined,
           close: openPiEventStream({
             url: eventsUrl,
@@ -343,10 +348,18 @@ export const createPiHttpClient = (
             ...(onStreamError ? { onError: onStreamError } : {}),
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
+              createdStream.latestSeq = Math.max(
+                createdStream.latestSeq,
+                clientEvent.seq,
+              );
               if (clientEvent.type === "snapshot") {
                 createdStream.snapshotEvent = clientEvent;
-                createdStream.hasEventsSinceSnapshot = false;
-              } else if (createdStream.snapshotEvent) {
+                createdStream.hasEventsSinceSnapshot =
+                  createdStream.latestSeq > clientEvent.seq;
+              } else if (
+                createdStream.snapshotEvent &&
+                clientEvent.seq > createdStream.snapshotEvent.seq
+              ) {
                 createdStream.hasEventsSinceSnapshot = true;
               }
               for (const listener of [...listeners]) {
@@ -370,45 +383,78 @@ export const createPiHttpClient = (
       const isNewListener = !stream.listeners.has(listener);
       stream.listeners.add(listener);
       if (isNewListener && includeSnapshot && stream.snapshotEvent) {
-        const pendingEvents: PiClientEvent[] = [];
-        stream.pendingEvents.set(listener, pendingEvents);
+        stream.pendingEvents.set(listener, []);
 
-        const finishSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
-          if (
-            !stream.listeners.has(listener) ||
-            stream.pendingEvents.get(listener) !== pendingEvents
-          ) {
+        const finishSnapshotLoad = (
+          pendingListener: PiEventListener,
+          snapshotEvent: PiSnapshotEvent,
+        ) => {
+          const pendingEvents = stream.pendingEvents.get(pendingListener);
+          if (!pendingEvents || !stream.listeners.has(pendingListener)) {
             return;
           }
 
-          stream.snapshotLoads.get(listener)?.();
-          stream.snapshotLoads.delete(listener);
-          stream.pendingEvents.delete(listener);
-          if (
-            !pendingEvents.some(
-              (event) =>
-                event.type !== "error" && event.seq > snapshotEvent.seq,
-            )
-          ) {
-            stream.snapshotEvent = snapshotEvent;
-            stream.hasEventsSinceSnapshot = false;
-          }
+          stream.pendingEvents.delete(pendingListener);
+          stream.snapshotEvent = snapshotEvent;
+          stream.hasEventsSinceSnapshot = stream.latestSeq > snapshotEvent.seq;
 
-          notifyListener(listener, snapshotEvent);
+          notifyListener(pendingListener, snapshotEvent);
           for (const event of pendingEvents) {
-            if (!stream.listeners.has(listener)) break;
-            if (event.type === "error" || event.seq > snapshotEvent.seq) {
-              notifyListener(listener, event);
+            if (!stream.listeners.has(pendingListener)) break;
+            if (event.seq > snapshotEvent.seq) {
+              notifyListener(pendingListener, event);
             }
+          }
+        };
+
+        const stopSnapshotLoad = () => {
+          const snapshotLoad = stream.snapshotLoad;
+          if (!snapshotLoad) return undefined;
+          stream.snapshotLoad = undefined;
+          if (snapshotLoad.timeout) clearTimeout(snapshotLoad.timeout);
+          snapshotLoad.close();
+          return snapshotLoad;
+        };
+
+        const failSnapshotLoad = (errorEvent?: PiClientEvent) => {
+          const snapshotLoad = stopSnapshotLoad();
+          if (!snapshotLoad) return;
+          for (const pendingListener of snapshotLoad.listeners) {
+            const events = stream.pendingEvents.get(pendingListener);
+            stream.pendingEvents.delete(pendingListener);
+            if (!stream.listeners.has(pendingListener)) continue;
+            if (errorEvent) notifyListener(pendingListener, errorEvent);
+            for (const event of events ?? []) {
+              if (!stream.listeners.has(pendingListener)) break;
+              notifyListener(pendingListener, event);
+            }
+          }
+        };
+
+        const finishSharedSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
+          const snapshotLoad = stopSnapshotLoad();
+          if (!snapshotLoad) return;
+          for (const pendingListener of snapshotLoad.listeners) {
+            finishSnapshotLoad(pendingListener, snapshotEvent);
           }
         };
 
         if (!stream.hasEventsSinceSnapshot) {
           const snapshotEvent = stream.snapshotEvent;
-          queueMicrotask(() => finishSnapshotLoad(snapshotEvent));
+          queueMicrotask(() => finishSnapshotLoad(listener, snapshotEvent));
+        } else if (stream.snapshotLoad) {
+          stream.snapshotLoad.listeners.add(listener);
         } else {
-          let closeSnapshotStream = () => {};
-          closeSnapshotStream = openPiEventStream({
+          const snapshotLoad: SharedSnapshotLoad = {
+            listeners: new Set([listener]),
+            close: () => {},
+            timeout: undefined,
+          };
+          stream.snapshotLoad = snapshotLoad;
+          snapshotLoad.timeout = setTimeout(() => {
+            if (stream.snapshotLoad === snapshotLoad) failSnapshotLoad();
+          }, SNAPSHOT_LOAD_TIMEOUT_MS);
+          snapshotLoad.close = openPiEventStream({
             url: eventsUrl,
             expectedThreadId: threadId,
             fetchImpl,
@@ -416,12 +462,14 @@ export const createPiHttpClient = (
             ...(reconnectDelay ? { reconnectDelay } : {}),
             ...(onStreamError ? { onError: onStreamError } : {}),
             onEvent: (event) => {
-              if (event.type !== "snapshot") return;
-              closeSnapshotStream();
-              finishSnapshotLoad(event as PiSnapshotEvent);
+              if (stream.snapshotLoad !== snapshotLoad) return;
+              if (event.type === "snapshot") {
+                finishSharedSnapshotLoad(event as PiSnapshotEvent);
+              } else if (event.type === "error") {
+                failSnapshotLoad(event as PiClientEvent);
+              }
             },
           });
-          stream.snapshotLoads.set(listener, closeSnapshotStream);
         }
       }
 
@@ -430,8 +478,14 @@ export const createPiHttpClient = (
         if (!current) return;
         current.listeners.delete(listener);
         current.pendingEvents.delete(listener);
-        current.snapshotLoads.get(listener)?.();
-        current.snapshotLoads.delete(listener);
+        const snapshotLoad = current.snapshotLoad;
+        if (snapshotLoad?.listeners.delete(listener)) {
+          if (snapshotLoad.listeners.size === 0) {
+            current.snapshotLoad = undefined;
+            if (snapshotLoad.timeout) clearTimeout(snapshotLoad.timeout);
+            snapshotLoad.close();
+          }
+        }
         if (current.listeners.size > 0 || current.closeTimer) return;
         if (streamCloseDelayMs <= 0) {
           current.close();

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -42,6 +42,10 @@ import type {
 
 type PiSnapshotEvent = Extract<PiClientEvent, { type: "snapshot" }>;
 type PiEventListener = (event: PiClientEvent) => void;
+type PendingSnapshotEvents = {
+  events: PiClientEvent[];
+  joinSeq: number;
+};
 
 type SharedSnapshotLoad = {
   listeners: Set<PiEventListener>;
@@ -51,7 +55,7 @@ type SharedSnapshotLoad = {
 
 type SharedStream = {
   listeners: Set<PiEventListener>;
-  pendingEvents: Map<PiEventListener, PiClientEvent[]>;
+  pendingEvents: Map<PiEventListener, PendingSnapshotEvents>;
   snapshotEvent: PiSnapshotEvent | undefined;
   hasEventsSinceSnapshot: boolean;
   latestSeq: number;
@@ -365,7 +369,7 @@ export const createPiHttpClient = (
               for (const listener of [...listeners]) {
                 const pending = pendingEvents.get(listener);
                 if (pending) {
-                  pending.push(clientEvent);
+                  pending.events.push(clientEvent);
                 } else {
                   notifyListener(listener, clientEvent);
                 }
@@ -383,23 +387,36 @@ export const createPiHttpClient = (
       const isNewListener = !stream.listeners.has(listener);
       stream.listeners.add(listener);
       if (isNewListener && includeSnapshot && stream.snapshotEvent) {
-        stream.pendingEvents.set(listener, []);
+        stream.pendingEvents.set(listener, {
+          events: [],
+          joinSeq: stream.latestSeq,
+        });
+
+        const commitSnapshot = (snapshotEvent: PiSnapshotEvent) => {
+          if (
+            !stream.snapshotEvent ||
+            snapshotEvent.seq >= stream.snapshotEvent.seq
+          ) {
+            stream.snapshotEvent = snapshotEvent;
+          }
+          stream.hasEventsSinceSnapshot =
+            stream.latestSeq > stream.snapshotEvent.seq;
+        };
 
         const finishSnapshotLoad = (
           pendingListener: PiEventListener,
           snapshotEvent: PiSnapshotEvent,
         ) => {
-          const pendingEvents = stream.pendingEvents.get(pendingListener);
-          if (!pendingEvents || !stream.listeners.has(pendingListener)) {
+          const pending = stream.pendingEvents.get(pendingListener);
+          if (!pending || !stream.listeners.has(pendingListener)) {
             return;
           }
 
           stream.pendingEvents.delete(pendingListener);
-          stream.snapshotEvent = snapshotEvent;
-          stream.hasEventsSinceSnapshot = stream.latestSeq > snapshotEvent.seq;
+          commitSnapshot(snapshotEvent);
 
           notifyListener(pendingListener, snapshotEvent);
-          for (const event of pendingEvents) {
+          for (const event of pending.events) {
             if (!stream.listeners.has(pendingListener)) break;
             if (event.seq > snapshotEvent.seq) {
               notifyListener(pendingListener, event);
@@ -420,33 +437,29 @@ export const createPiHttpClient = (
           const snapshotLoad = stopSnapshotLoad();
           if (!snapshotLoad) return;
           for (const pendingListener of snapshotLoad.listeners) {
-            const events = stream.pendingEvents.get(pendingListener);
+            const pending = stream.pendingEvents.get(pendingListener);
             stream.pendingEvents.delete(pendingListener);
             if (!stream.listeners.has(pendingListener)) continue;
             if (errorEvent) notifyListener(pendingListener, errorEvent);
-            for (const event of events ?? []) {
+            for (const event of pending?.events ?? []) {
               if (!stream.listeners.has(pendingListener)) break;
               notifyListener(pendingListener, event);
             }
           }
         };
 
-        const finishSharedSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
-          const snapshotLoad = stopSnapshotLoad();
-          if (!snapshotLoad) return;
-          for (const pendingListener of snapshotLoad.listeners) {
-            finishSnapshotLoad(pendingListener, snapshotEvent);
+        const startSnapshotLoad = (
+          pendingListeners: Iterable<PiEventListener>,
+        ) => {
+          if (stream.snapshotLoad) {
+            for (const pendingListener of pendingListeners) {
+              stream.snapshotLoad.listeners.add(pendingListener);
+            }
+            return;
           }
-        };
 
-        if (!stream.hasEventsSinceSnapshot) {
-          const snapshotEvent = stream.snapshotEvent;
-          queueMicrotask(() => finishSnapshotLoad(listener, snapshotEvent));
-        } else if (stream.snapshotLoad) {
-          stream.snapshotLoad.listeners.add(listener);
-        } else {
           const snapshotLoad: SharedSnapshotLoad = {
-            listeners: new Set([listener]),
+            listeners: new Set(pendingListeners),
             close: () => {},
             timeout: undefined,
           };
@@ -470,6 +483,31 @@ export const createPiHttpClient = (
               }
             },
           });
+        };
+
+        const finishSharedSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
+          const snapshotLoad = stopSnapshotLoad();
+          if (!snapshotLoad) return;
+          commitSnapshot(snapshotEvent);
+          const retryListeners: PiEventListener[] = [];
+          for (const pendingListener of snapshotLoad.listeners) {
+            const pending = stream.pendingEvents.get(pendingListener);
+            if (pending && snapshotEvent.seq < pending.joinSeq) {
+              retryListeners.push(pendingListener);
+            } else {
+              finishSnapshotLoad(pendingListener, snapshotEvent);
+            }
+          }
+          if (retryListeners.length > 0) {
+            startSnapshotLoad(retryListeners);
+          }
+        };
+
+        if (!stream.hasEventsSinceSnapshot) {
+          const snapshotEvent = stream.snapshotEvent;
+          queueMicrotask(() => finishSnapshotLoad(listener, snapshotEvent));
+        } else {
+          startSnapshotLoad([listener]);
         }
       }
 

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -121,6 +121,20 @@ const deliverPendingSnapshots = (
   }
 };
 
+const flushStrandedPendingListeners = (stream: SharedStream) => {
+  for (const listener of [...stream.pendingEvents.keys()]) {
+    if (stream.snapshotLoad?.listeners.has(listener)) continue;
+    const pending = stream.pendingEvents.get(listener);
+    if (!pending) continue;
+    stream.pendingEvents.delete(listener);
+    if (!stream.listeners.has(listener)) continue;
+    for (const event of pending.events) {
+      if (!stream.listeners.has(listener)) break;
+      notifyListener(listener, event);
+    }
+  }
+};
+
 export interface PiHttpClientOptions {
   /** Base path/URL of the route layer. Default: `/api/pi`. */
   baseUrl?: string;
@@ -453,6 +467,13 @@ export const createPiHttpClient = (
               }
               if (rebasePending && clientEvent.type === "snapshot") {
                 deliverPendingSnapshots(createdStream, clientEvent);
+              } else if (
+                createdStream.awaitingLiveSnapshot &&
+                clientEvent.type === "error" &&
+                clientEvent.seq === 0
+              ) {
+                createdStream.awaitingLiveSnapshot = false;
+                flushStrandedPendingListeners(createdStream);
               }
             },
           }),

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -60,6 +60,7 @@ type SharedStream = {
   snapshotEvent: PiSnapshotEvent | undefined;
   hasEventsSinceSnapshot: boolean;
   latestSeq: number;
+  liveSnapshotSeq: number;
   snapshotLoad: SharedSnapshotLoad | undefined;
   close: () => void;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -74,6 +75,28 @@ const notifyListener = (listener: PiEventListener, event: PiClientEvent) => {
   } catch (error) {
     console.error("[react-pi] Listener threw an error", error);
   }
+};
+
+const applyCachedSnapshot = (
+  stream: SharedStream,
+  snapshotEvent: PiSnapshotEvent,
+  replace = false,
+): boolean => {
+  if (
+    !replace &&
+    stream.snapshotEvent &&
+    snapshotEvent.seq < stream.snapshotEvent.seq
+  ) {
+    stream.latestSeq = Math.max(stream.latestSeq, snapshotEvent.seq);
+    stream.hasEventsSinceSnapshot = stream.latestSeq > stream.snapshotEvent.seq;
+    return false;
+  }
+  stream.latestSeq = replace
+    ? snapshotEvent.seq
+    : Math.max(stream.latestSeq, snapshotEvent.seq);
+  stream.snapshotEvent = snapshotEvent;
+  stream.hasEventsSinceSnapshot = stream.latestSeq > snapshotEvent.seq;
+  return true;
 };
 
 export interface PiHttpClientOptions {
@@ -340,6 +363,7 @@ export const createPiHttpClient = (
           snapshotEvent: undefined,
           hasEventsSinceSnapshot: false,
           latestSeq: 0,
+          liveSnapshotSeq: 0,
           snapshotLoad: undefined,
           closeTimer: undefined,
           close: openPiEventStream({
@@ -355,9 +379,15 @@ export const createPiHttpClient = (
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
               if (clientEvent.type === "snapshot") {
-                createdStream.latestSeq = clientEvent.seq;
-                createdStream.snapshotEvent = clientEvent;
-                createdStream.hasEventsSinceSnapshot = false;
+                const isLiveReset =
+                  createdStream.liveSnapshotSeq > 0 &&
+                  clientEvent.seq < createdStream.liveSnapshotSeq;
+                if (
+                  !applyCachedSnapshot(createdStream, clientEvent, isLiveReset)
+                ) {
+                  return;
+                }
+                createdStream.liveSnapshotSeq = clientEvent.seq;
               } else {
                 createdStream.latestSeq = Math.max(
                   createdStream.latestSeq,
@@ -397,17 +427,6 @@ export const createPiHttpClient = (
           snapshotRetries: 0,
         });
 
-        const commitSnapshot = (snapshotEvent: PiSnapshotEvent) => {
-          if (
-            !stream.snapshotEvent ||
-            snapshotEvent.seq >= stream.snapshotEvent.seq
-          ) {
-            stream.snapshotEvent = snapshotEvent;
-          }
-          stream.hasEventsSinceSnapshot =
-            stream.latestSeq > stream.snapshotEvent.seq;
-        };
-
         const finishSnapshotLoad = (
           pendingListener: PiEventListener,
           snapshotEvent: PiSnapshotEvent,
@@ -418,7 +437,7 @@ export const createPiHttpClient = (
           }
 
           stream.pendingEvents.delete(pendingListener);
-          commitSnapshot(snapshotEvent);
+          applyCachedSnapshot(stream, snapshotEvent);
 
           notifyListener(pendingListener, snapshotEvent);
           for (const event of pending.events) {
@@ -503,7 +522,7 @@ export const createPiHttpClient = (
         const finishSharedSnapshotLoad = (snapshotEvent: PiSnapshotEvent) => {
           const snapshotLoad = stopSnapshotLoad();
           if (!snapshotLoad) return;
-          commitSnapshot(snapshotEvent);
+          applyCachedSnapshot(stream, snapshotEvent);
           const retryListeners: PiEventListener[] = [];
           for (const pendingListener of snapshotLoad.listeners) {
             const pending = stream.pendingEvents.get(pendingListener);

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -29,6 +29,13 @@
 import { isRecord } from "@assistant-ui/core/internal";
 import { openPiEventStream } from "./eventSource";
 import { isThreadMetadata, isThreadSnapshot } from "./validation";
+import { isKnownPiClientEventType } from "../eventTypes";
+import { piQueueItemId } from "../queueIds";
+import {
+  createPiThreadState,
+  reducePiThreadState,
+  type PiThreadState,
+} from "../runtime/threadState";
 import type {
   PiClient,
   PiClientEvent,
@@ -42,8 +49,99 @@ import type {
 
 type SharedStream = {
   listeners: Set<(event: PiClientEvent) => void>;
+  pendingEvents: Map<(event: PiClientEvent) => void, PiClientEvent[]>;
+  replayEvents: PiClientEvent[];
+  replayState: PiThreadState | undefined;
+  canCompactReplay: boolean;
   close: () => void;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
+};
+
+const notifyListener = (
+  listener: (event: PiClientEvent) => void,
+  event: PiClientEvent,
+) => {
+  try {
+    listener(event);
+  } catch (error) {
+    console.error("[react-pi] Listener threw an error", error);
+  }
+};
+
+const snapshotEventFromState = (state: PiThreadState): PiClientEvent => {
+  const {
+    queuedMessages: _queuedMessages,
+    contextUsage: _contextUsage,
+    messageCount: _messageCount,
+    ...metadata
+  } = state.metadata;
+  const queuedMessages = [
+    ...state.queue.steering.map((content, index) => ({
+      id: piQueueItemId("steer", index),
+      mode: "steer" as const,
+      content,
+    })),
+    ...state.queue.followUp.map((content, index) => ({
+      id: piQueueItemId("followUp", index),
+      mode: "followUp" as const,
+      content,
+    })),
+  ];
+
+  return {
+    type: "snapshot",
+    threadId: state.threadId,
+    seq: state.lastSeq,
+    snapshot: {
+      metadata: {
+        ...metadata,
+        messageCount: state.messages.length,
+        ...(queuedMessages.length > 0 ? { queuedMessages } : {}),
+        ...(state.contextUsage !== undefined
+          ? { contextUsage: state.contextUsage }
+          : {}),
+      },
+      messages: [...state.messages],
+      ...(state.hostUiRequests.length > 0
+        ? { hostUiRequests: state.hostUiRequests }
+        : {}),
+      ...(state.readiness !== undefined ? { readiness: state.readiness } : {}),
+      ...(state.lastError !== undefined ? { lastError: state.lastError } : {}),
+    },
+  };
+};
+
+const updateReplay = (stream: SharedStream, event: PiClientEvent) => {
+  if (!stream.replayState) return;
+
+  if (event.type === "snapshot") {
+    stream.replayState = reducePiThreadState(
+      createPiThreadState(event.threadId),
+      event,
+    );
+    stream.replayEvents = [event];
+    stream.canCompactReplay = true;
+    return;
+  }
+
+  if (stream.replayEvents.length === 0) return;
+  stream.replayState = reducePiThreadState(stream.replayState, event);
+  stream.replayEvents.push(event);
+
+  if (
+    !isKnownPiClientEventType(event.type) ||
+    (event.type === "entry_appended" && event.entry.type !== "custom")
+  ) {
+    stream.canCompactReplay = false;
+  }
+
+  if (
+    stream.canCompactReplay &&
+    event.type === "agent_end" &&
+    event.willRetry !== true
+  ) {
+    stream.replayEvents = [snapshotEventFromState(stream.replayState)];
+  }
 };
 
 export interface PiHttpClientOptions {
@@ -300,11 +398,21 @@ export const createPiHttpClient = (
       let stream = streams.get(streamKey);
       if (!stream) {
         const listeners = new Set<(event: PiClientEvent) => void>();
+        const pendingEvents = new Map<
+          (event: PiClientEvent) => void,
+          PiClientEvent[]
+        >();
         const eventsUrl = `${threadUrl(threadId)}/events${
           includeSnapshot ? "" : "?snapshot=false"
         }`;
-        stream = {
+        const createdStream: SharedStream = {
           listeners,
+          pendingEvents,
+          replayEvents: [],
+          replayState: includeSnapshot
+            ? createPiThreadState(threadId)
+            : undefined,
+          canCompactReplay: true,
           closeTimer: undefined,
           close: openPiEventStream({
             url: eventsUrl,
@@ -317,28 +425,52 @@ export const createPiHttpClient = (
             ...(reconnectDelay ? { reconnectDelay } : {}),
             ...(onStreamError ? { onError: onStreamError } : {}),
             onEvent: (event) => {
+              const clientEvent = event as PiClientEvent;
+              updateReplay(createdStream, clientEvent);
               for (const listener of [...listeners]) {
-                try {
-                  listener(event as PiClientEvent);
-                } catch (error) {
-                  console.error("[react-pi] Listener threw an error", error);
+                const pending = pendingEvents.get(listener);
+                if (pending) {
+                  pending.push(clientEvent);
+                } else {
+                  notifyListener(listener, clientEvent);
                 }
               }
             },
           }),
         };
+        stream = createdStream;
         streams.set(streamKey, stream);
       } else if (stream.closeTimer) {
         clearTimeout(stream.closeTimer);
         stream.closeTimer = undefined;
       }
 
+      const isNewListener = !stream.listeners.has(listener);
       stream.listeners.add(listener);
+      if (isNewListener && includeSnapshot && stream.replayEvents.length > 0) {
+        const replayEvents = [...stream.replayEvents];
+        const pendingEvents: PiClientEvent[] = [];
+        stream.pendingEvents.set(listener, pendingEvents);
+        queueMicrotask(() => {
+          if (
+            !stream.listeners.has(listener) ||
+            stream.pendingEvents.get(listener) !== pendingEvents
+          ) {
+            return;
+          }
+          stream.pendingEvents.delete(listener);
+          for (const event of [...replayEvents, ...pendingEvents]) {
+            if (!stream.listeners.has(listener)) break;
+            notifyListener(listener, event);
+          }
+        });
+      }
 
       return () => {
         const current = streams.get(streamKey);
         if (!current) return;
         current.listeners.delete(listener);
+        current.pendingEvents.delete(listener);
         if (current.listeners.size > 0 || current.closeTimer) return;
         if (streamCloseDelayMs <= 0) {
           current.close();

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -61,6 +61,7 @@ type SharedStream = {
   hasEventsSinceSnapshot: boolean;
   latestSeq: number;
   liveSnapshotSeq: number;
+  awaitingLiveSnapshot: boolean;
   snapshotLoad: SharedSnapshotLoad | undefined;
   close: () => void;
   closeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -97,6 +98,27 @@ const applyCachedSnapshot = (
   stream.snapshotEvent = snapshotEvent;
   stream.hasEventsSinceSnapshot = stream.latestSeq > snapshotEvent.seq;
   return true;
+};
+
+const deliverPendingSnapshots = (
+  stream: SharedStream,
+  snapshotEvent: PiSnapshotEvent,
+) => {
+  for (const listener of [...stream.pendingEvents.keys()]) {
+    const pending = stream.pendingEvents.get(listener);
+    if (!pending || !stream.listeners.has(listener)) continue;
+    stream.pendingEvents.delete(listener);
+    notifyListener(listener, snapshotEvent);
+    for (const event of pending.events) {
+      if (!stream.listeners.has(listener)) break;
+      if (
+        (event.type === "error" && event.seq === 0) ||
+        event.seq > snapshotEvent.seq
+      ) {
+        notifyListener(listener, event);
+      }
+    }
+  }
 };
 
 export interface PiHttpClientOptions {
@@ -364,6 +386,7 @@ export const createPiHttpClient = (
           hasEventsSinceSnapshot: false,
           latestSeq: 0,
           liveSnapshotSeq: 0,
+          awaitingLiveSnapshot: false,
           snapshotLoad: undefined,
           closeTimer: undefined,
           close: openPiEventStream({
@@ -376,18 +399,38 @@ export const createPiHttpClient = (
             ...(headers ? { headers } : {}),
             ...(reconnectDelay ? { reconnectDelay } : {}),
             ...(onStreamError ? { onError: onStreamError } : {}),
+            onConnect: () => {
+              createdStream.awaitingLiveSnapshot = true;
+              const snapshotLoad = createdStream.snapshotLoad;
+              if (snapshotLoad) {
+                createdStream.snapshotLoad = undefined;
+                clearTimeout(snapshotLoad.timeout);
+                snapshotLoad.close();
+              }
+              for (const pending of createdStream.pendingEvents.values()) {
+                pending.events = [];
+              }
+            },
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
+              let rebasePending = false;
               if (clientEvent.type === "snapshot") {
+                const fromReconnect = createdStream.awaitingLiveSnapshot;
                 const isLiveReset =
                   createdStream.liveSnapshotSeq > 0 &&
                   clientEvent.seq < createdStream.liveSnapshotSeq;
+                createdStream.awaitingLiveSnapshot = false;
                 if (
-                  !applyCachedSnapshot(createdStream, clientEvent, isLiveReset)
+                  !applyCachedSnapshot(
+                    createdStream,
+                    clientEvent,
+                    fromReconnect || isLiveReset,
+                  )
                 ) {
                   return;
                 }
                 createdStream.liveSnapshotSeq = clientEvent.seq;
+                rebasePending = fromReconnect;
               } else {
                 createdStream.latestSeq = Math.max(
                   createdStream.latestSeq,
@@ -407,6 +450,9 @@ export const createPiHttpClient = (
                 } else {
                   notifyListener(listener, clientEvent);
                 }
+              }
+              if (rebasePending && clientEvent.type === "snapshot") {
+                deliverPendingSnapshots(createdStream, clientEvent);
               }
             },
           }),

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -478,7 +478,7 @@ export const createPiHttpClient = (
                 } else if (
                   clientEvent.type !== "snapshot" ||
                   rebaseSnapshot ||
-                  (createdStream.snapshotSeqs.get(listener) ?? 0) <
+                  (createdStream.snapshotSeqs.get(listener) ?? -1) <
                     clientEvent.seq
                 ) {
                   deliverEvent(createdStream, listener, clientEvent);

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -45,6 +45,7 @@ type PiEventListener = (event: PiClientEvent) => void;
 type PendingSnapshotEvents = {
   events: PiClientEvent[];
   joinSeq: number;
+  snapshotRetries: number;
 };
 
 type SharedSnapshotLoad = {
@@ -65,6 +66,7 @@ type SharedStream = {
 };
 
 const SNAPSHOT_LOAD_TIMEOUT_MS = 10_000;
+const MAX_SNAPSHOT_RETRIES = 1;
 
 const notifyListener = (listener: PiEventListener, event: PiClientEvent) => {
   try {
@@ -331,7 +333,7 @@ export const createPiHttpClient = (
       let stream = streams.get(streamKey);
       if (!stream) {
         const listeners = new Set<PiEventListener>();
-        const pendingEvents = new Map<PiEventListener, PiClientEvent[]>();
+        const pendingEvents = new Map<PiEventListener, PendingSnapshotEvents>();
         const createdStream: SharedStream = {
           listeners,
           pendingEvents,
@@ -352,19 +354,21 @@ export const createPiHttpClient = (
             ...(onStreamError ? { onError: onStreamError } : {}),
             onEvent: (event) => {
               const clientEvent = event as PiClientEvent;
-              createdStream.latestSeq = Math.max(
-                createdStream.latestSeq,
-                clientEvent.seq,
-              );
               if (clientEvent.type === "snapshot") {
+                createdStream.latestSeq = clientEvent.seq;
                 createdStream.snapshotEvent = clientEvent;
-                createdStream.hasEventsSinceSnapshot =
-                  createdStream.latestSeq > clientEvent.seq;
-              } else if (
-                createdStream.snapshotEvent &&
-                clientEvent.seq > createdStream.snapshotEvent.seq
-              ) {
-                createdStream.hasEventsSinceSnapshot = true;
+                createdStream.hasEventsSinceSnapshot = false;
+              } else {
+                createdStream.latestSeq = Math.max(
+                  createdStream.latestSeq,
+                  clientEvent.seq,
+                );
+                if (
+                  createdStream.snapshotEvent &&
+                  clientEvent.seq > createdStream.snapshotEvent.seq
+                ) {
+                  createdStream.hasEventsSinceSnapshot = true;
+                }
               }
               for (const listener of [...listeners]) {
                 const pending = pendingEvents.get(listener);
@@ -390,6 +394,7 @@ export const createPiHttpClient = (
         stream.pendingEvents.set(listener, {
           events: [],
           joinSeq: stream.latestSeq,
+          snapshotRetries: 0,
         });
 
         const commitSnapshot = (snapshotEvent: PiSnapshotEvent) => {
@@ -418,9 +423,23 @@ export const createPiHttpClient = (
           notifyListener(pendingListener, snapshotEvent);
           for (const event of pending.events) {
             if (!stream.listeners.has(pendingListener)) break;
-            if (event.seq > snapshotEvent.seq) {
+            if (event.type === "error" || event.seq > snapshotEvent.seq) {
               notifyListener(pendingListener, event);
             }
+          }
+        };
+
+        const flushPendingEvents = (
+          pendingListener: PiEventListener,
+          errorEvent?: PiClientEvent,
+        ) => {
+          const pending = stream.pendingEvents.get(pendingListener);
+          stream.pendingEvents.delete(pendingListener);
+          if (!stream.listeners.has(pendingListener)) return;
+          if (errorEvent) notifyListener(pendingListener, errorEvent);
+          for (const event of pending?.events ?? []) {
+            if (!stream.listeners.has(pendingListener)) break;
+            notifyListener(pendingListener, event);
           }
         };
 
@@ -437,14 +456,7 @@ export const createPiHttpClient = (
           const snapshotLoad = stopSnapshotLoad();
           if (!snapshotLoad) return;
           for (const pendingListener of snapshotLoad.listeners) {
-            const pending = stream.pendingEvents.get(pendingListener);
-            stream.pendingEvents.delete(pendingListener);
-            if (!stream.listeners.has(pendingListener)) continue;
-            if (errorEvent) notifyListener(pendingListener, errorEvent);
-            for (const event of pending?.events ?? []) {
-              if (!stream.listeners.has(pendingListener)) break;
-              notifyListener(pendingListener, event);
-            }
+            flushPendingEvents(pendingListener, errorEvent);
           }
         };
 
@@ -493,7 +505,12 @@ export const createPiHttpClient = (
           for (const pendingListener of snapshotLoad.listeners) {
             const pending = stream.pendingEvents.get(pendingListener);
             if (pending && snapshotEvent.seq < pending.joinSeq) {
-              retryListeners.push(pendingListener);
+              if (pending.snapshotRetries < MAX_SNAPSHOT_RETRIES) {
+                pending.snapshotRetries += 1;
+                retryListeners.push(pendingListener);
+              } else {
+                flushPendingEvents(pendingListener);
+              }
             } else {
               finishSnapshotLoad(pendingListener, snapshotEvent);
             }

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -423,7 +423,10 @@ export const createPiHttpClient = (
           notifyListener(pendingListener, snapshotEvent);
           for (const event of pending.events) {
             if (!stream.listeners.has(pendingListener)) break;
-            if (event.type === "error" || event.seq > snapshotEvent.seq) {
+            if (
+              (event.type === "error" && event.seq === 0) ||
+              event.seq > snapshotEvent.seq
+            ) {
               notifyListener(pendingListener, event);
             }
           }


### PR DESCRIPTION
## Summary

- replay the cached authoritative snapshot when a subscriber joins before any newer live event
- share bounded snapshot refreshes when the cached snapshot is stale
- buffer events per listener and reject snapshots older than that listener's join sequence
- rebase sequence tracking on authoritative main-stream snapshots and fall back to live delivery after one stale refresh retry
- preserve out-of-band errors while filtering stale buffered events

## Why

`PiClient.subscribe()` is snapshot-first by default, but the HTTP client multiplexes listeners onto one long-lived SSE connection. Only listeners present when that connection opened received its initial snapshot; a later raw `PiClient` subscriber could start without thread state.

The long-lived connection remains shared. A late subscriber uses the cached server snapshot when it is current, or joins one short-lived shared request for an authoritative sequence-stamped snapshot. If a listener joins an in-flight refresh after its snapshot was captured, that listener keeps its buffer and rolls into one shared follow-up request rather than silently missing intervening events.

A main-stream snapshot is authoritative and rebases sequence tracking after server restarts. Each waiting listener gets at most one stale-snapshot retry before returning to live delivery, preventing a restarted server from causing an unbounded refresh loop.

## Validation

- reproduced the public-client bug with a controlled SSE stream: the first subscriber received the snapshot while the second received zero events
- covered cached delivery with an event racing the replay microtask
- covered concurrent stale-snapshot refresh and a listener joining after the helper snapshot boundary
- covered highest-sequence cache retention when the main stream overtakes a helper response
- covered server sequence resets, bounded retries, out-of-band errors, refresh failures, and timeout fallback
- `pnpm --filter @assistant-ui/react-pi test` (219 tests)
- `pnpm --filter @assistant-ui/react-pi build`
- targeted oxlint and oxfmt checks

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-1VhnAFZsApsF6Yv9BkV2Qba6NWn2q4KbreS8ToSGp8B5n618WOSMthpS_o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->