### PR TITLE
fix(react-streamdown): update streamed code block content

### DIFF
--- a/.changeset/streamed-code-content.md
+++ b/.changeset/streamed-code-content.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: update fenced code blocks as streamed content changes

--- a/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
+++ b/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, renderHook, screen, cleanup } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import type { Element } from "hast";
 import {
   PreContext,
@@ -151,6 +151,36 @@ describe("PreOverride component", () => {
 
     const codeElement = screen.getByTestId("child-code");
     expect(codeElement.getAttribute("data-block")).toBe("true");
+  });
+
+  it("remounts code only when streamed content is replaced", () => {
+    const onMount = vi.fn();
+    const Code = ({ children }: { children: ReactNode }) => {
+      useEffect(() => {
+        onMount();
+      }, []);
+      return <code>{children}</code>;
+    };
+    const { rerender } = render(
+      <PreOverride>
+        <Code>fir</Code>
+      </PreOverride>,
+    );
+
+    rerender(
+      <PreOverride>
+        <Code>first</Code>
+      </PreOverride>,
+    );
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <PreOverride>
+        <Code>second</Code>
+      </PreOverride>,
+    );
+    expect(onMount).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("second")).toBeDefined();
   });
 
   it("handles non-element children without data-block", () => {

--- a/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
+++ b/packages/react-streamdown/src/__tests__/PreOverride.test.tsx
@@ -163,20 +163,20 @@ describe("PreOverride component", () => {
     };
     const { rerender } = render(
       <PreOverride>
-        <Code>fir</Code>
+        <Code>{"fir\n"}</Code>
       </PreOverride>,
     );
 
     rerender(
       <PreOverride>
-        <Code>first</Code>
+        <Code>{"first\n"}</Code>
       </PreOverride>,
     );
     expect(onMount).toHaveBeenCalledTimes(1);
 
     rerender(
       <PreOverride>
-        <Code>second</Code>
+        <Code>{"second\n"}</Code>
       </PreOverride>,
     );
     expect(onMount).toHaveBeenCalledTimes(2);

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { TextMessagePartProvider } from "@assistant-ui/react";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { defaultRehypePlugins } from "streamdown";
+import { normalizeMathDelimiters } from "../preprocess";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
   StreamdownTextComponents,
@@ -108,6 +109,64 @@ describe("StreamdownTextPrimitive", () => {
 
     expect(await screen.findByText("second")).toBeTruthy();
     expect(screen.queryByText("first")).toBeNull();
+  });
+
+  it("does not remount blocks when preprocessing rewrites appended text", async () => {
+    const mounted = vi.fn();
+    const BlockComponent = ({ content }: { content: string }) => {
+      useEffect(() => {
+        mounted();
+      }, []);
+      return <div>{content}</div>;
+    };
+    const { rerender } = render(
+      <TextMessagePartProvider text={"\\(x"} isRunning>
+        <StreamdownTextPrimitive
+          preprocess={normalizeMathDelimiters}
+          BlockComponent={BlockComponent}
+        />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("\\(x")).toBeTruthy();
+
+    rerender(
+      <TextMessagePartProvider text={"\\(x\\)"} isRunning>
+        <StreamdownTextPrimitive
+          preprocess={normalizeMathDelimiters}
+          BlockComponent={BlockComponent}
+        />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("$x$")).toBeTruthy();
+    expect(mounted).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not remount blocks for deferred text appends", async () => {
+    const mounted = vi.fn();
+    const BlockComponent = ({ content }: { content: string }) => {
+      useEffect(() => {
+        mounted();
+      }, []);
+      return <div>{content}</div>;
+    };
+    const { rerender } = render(
+      <TextMessagePartProvider text="first" isRunning>
+        <StreamdownTextPrimitive defer BlockComponent={BlockComponent} />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first")).toBeTruthy();
+
+    rerender(
+      <TextMessagePartProvider text="first second" isRunning>
+        <StreamdownTextPrimitive defer BlockComponent={BlockComponent} />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first second")).toBeTruthy();
+    await waitFor(() => expect(mounted).toHaveBeenCalledTimes(1));
   });
 
   it("renders settled text in full when smooth is enabled", async () => {

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -91,6 +91,25 @@ describe("StreamdownTextPrimitive", () => {
     expect(await screen.findByText("first chunk second chunk")).toBeTruthy();
   });
 
+  it("updates streamed fenced code block content", async () => {
+    const { rerender } = render(
+      <TextMessagePartProvider text={"```ts\nfirst\n```"} isRunning>
+        <StreamdownTextPrimitive />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first")).toBeTruthy();
+
+    rerender(
+      <TextMessagePartProvider text={"```ts\nsecond\n```"} isRunning>
+        <StreamdownTextPrimitive />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("second")).toBeTruthy();
+    expect(screen.queryByText("first")).toBeNull();
+  });
+
   it("renders settled text in full when smooth is enabled", async () => {
     render(
       <TextMessagePartProvider text="hello smooth" isRunning={false}>

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,17 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
-import {
-  AssistantRuntimeProvider,
-  MessagePrimitive,
-  TextMessagePartProvider,
-  ThreadPrimitive,
-  useLocalRuntime,
-  type AssistantRuntime,
-  type ChatModelAdapter,
-} from "@assistant-ui/react";
-import { useEffect, useState, type ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TextMessagePartProvider } from "@assistant-ui/react";
+import { useEffect, type ReactNode } from "react";
 import { defaultRehypePlugins } from "streamdown";
-import { normalizeMathDelimiters } from "../preprocess";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
   StreamdownTextComponents,
@@ -100,99 +91,39 @@ describe("StreamdownTextPrimitive", () => {
     expect(await screen.findByText("first chunk second chunk")).toBeTruthy();
   });
 
-  it("updates streamed fenced code block content", async () => {
-    const { rerender } = render(
-      <TextMessagePartProvider text={"```ts\nfirst\n```"} isRunning>
-        <StreamdownTextPrimitive />
-      </TextMessagePartProvider>,
-    );
-
-    expect(await screen.findByText("first")).toBeTruthy();
-
-    rerender(
-      <TextMessagePartProvider text={"```ts\nsecond\n```"} isRunning>
-        <StreamdownTextPrimitive />
-      </TextMessagePartProvider>,
-    );
-
-    expect(await screen.findByText("second")).toBeTruthy();
-    expect(screen.queryByText("first")).toBeNull();
-  });
-
-  it("resets blocks for prefix-preserving message part replacements", async () => {
-    const mounted = vi.fn();
-    const BlockComponent = ({ content }: { content: string }) => {
-      const [renderedContent] = useState(content);
-      useEffect(() => {
-        mounted();
-      }, []);
-      return <div>{renderedContent}</div>;
-    };
-    const adapter: ChatModelAdapter = {
-      async *run() {},
-    };
-    let runtime: AssistantRuntime | null = null;
-    const Text = () => (
-      <StreamdownTextPrimitive BlockComponent={BlockComponent} />
-    );
-    const Message = () => <MessagePrimitive.Parts components={{ Text }} />;
-    const App = () => {
-      const localRuntime = useLocalRuntime(adapter, {
-        initialMessages: [{ role: "assistant", content: "first" }],
-      });
-      runtime = localRuntime;
-      return (
-        <AssistantRuntimeProvider runtime={localRuntime}>
-          <ThreadPrimitive.Messages components={{ Message }} />
-        </AssistantRuntimeProvider>
+  it.each([
+    { name: "streaming", isRunning: true, props: {} },
+    { name: "static", isRunning: false, props: { mode: "static" as const } },
+    { name: "deferred", isRunning: true, props: { defer: true } },
+  ])(
+    "updates $name fenced code block content",
+    async ({ isRunning, props }) => {
+      const { rerender } = render(
+        <TextMessagePartProvider
+          text={"```ts\nfirst\n```"}
+          isRunning={isRunning}
+        >
+          <StreamdownTextPrimitive {...props} />
+        </TextMessagePartProvider>,
       );
-    };
 
-    render(<App />);
-    expect(await screen.findByText("first")).toBeTruthy();
+      expect(await screen.findByText("first")).toBeTruthy();
 
-    await act(async () => {
-      runtime!.thread.reset([{ role: "assistant", content: "first second" }]);
-    });
+      rerender(
+        <TextMessagePartProvider
+          text={"```ts\nsecond\n```"}
+          isRunning={isRunning}
+        >
+          <StreamdownTextPrimitive {...props} />
+        </TextMessagePartProvider>,
+      );
 
-    expect(await screen.findByText("first second")).toBeTruthy();
-    expect(screen.queryByText("first")).toBeNull();
-    expect(mounted).toHaveBeenCalledTimes(2);
-  });
+      expect(await screen.findByText("second")).toBeTruthy();
+      expect(screen.queryByText("first")).toBeNull();
+    },
+  );
 
-  it("does not remount blocks when preprocessing rewrites appended text", async () => {
-    const mounted = vi.fn();
-    const BlockComponent = ({ content }: { content: string }) => {
-      useEffect(() => {
-        mounted();
-      }, []);
-      return <div>{content}</div>;
-    };
-    const { rerender } = render(
-      <TextMessagePartProvider text={"\\(x"} isRunning>
-        <StreamdownTextPrimitive
-          preprocess={normalizeMathDelimiters}
-          BlockComponent={BlockComponent}
-        />
-      </TextMessagePartProvider>,
-    );
-
-    expect(await screen.findByText("\\(x")).toBeTruthy();
-
-    rerender(
-      <TextMessagePartProvider text={"\\(x\\)"} isRunning>
-        <StreamdownTextPrimitive
-          preprocess={normalizeMathDelimiters}
-          BlockComponent={BlockComponent}
-        />
-      </TextMessagePartProvider>,
-    );
-
-    expect(await screen.findByText("$x$")).toBeTruthy();
-    expect(mounted).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not remount blocks for deferred text appends", async () => {
+  it("preserves streaming blocks for prefix appends", async () => {
     const mounted = vi.fn();
     const BlockComponent = ({ content }: { content: string }) => {
       useEffect(() => {
@@ -202,7 +133,7 @@ describe("StreamdownTextPrimitive", () => {
     };
     const { rerender } = render(
       <TextMessagePartProvider text="first" isRunning>
-        <StreamdownTextPrimitive defer BlockComponent={BlockComponent} />
+        <StreamdownTextPrimitive BlockComponent={BlockComponent} />
       </TextMessagePartProvider>,
     );
 
@@ -210,12 +141,12 @@ describe("StreamdownTextPrimitive", () => {
 
     rerender(
       <TextMessagePartProvider text="first second" isRunning>
-        <StreamdownTextPrimitive defer BlockComponent={BlockComponent} />
+        <StreamdownTextPrimitive BlockComponent={BlockComponent} />
       </TextMessagePartProvider>,
     );
 
     expect(await screen.findByText("first second")).toBeTruthy();
-    await waitFor(() => expect(mounted).toHaveBeenCalledTimes(1));
+    expect(mounted).toHaveBeenCalledTimes(1);
   });
 
   it("renders settled text in full when smooth is enabled", async () => {

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { TextMessagePartProvider } from "@assistant-ui/react";
 import { useEffect, type ReactNode } from "react";
 import { defaultRehypePlugins } from "streamdown";
+import { normalizeMathDelimiters } from "../preprocess";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
   StreamdownTextComponents,
@@ -123,7 +124,26 @@ describe("StreamdownTextPrimitive", () => {
     },
   );
 
-  it("preserves streaming blocks for prefix appends", async () => {
+  it.each([
+    {
+      name: "plain",
+      initial: "first",
+      next: "first second",
+      props: {},
+    },
+    {
+      name: "preprocessed",
+      initial: "\\(x",
+      next: "\\(x\\)",
+      props: { preprocess: normalizeMathDelimiters },
+    },
+    {
+      name: "deferred",
+      initial: "first",
+      next: "first second",
+      props: { defer: true },
+    },
+  ])("preserves $name blocks for raw prefix appends", async (testCase) => {
     const mounted = vi.fn();
     const BlockComponent = ({ content }: { content: string }) => {
       useEffect(() => {
@@ -132,20 +152,28 @@ describe("StreamdownTextPrimitive", () => {
       return <div>{content}</div>;
     };
     const { rerender } = render(
-      <TextMessagePartProvider text="first" isRunning>
-        <StreamdownTextPrimitive BlockComponent={BlockComponent} />
+      <TextMessagePartProvider text={testCase.initial} isRunning>
+        <StreamdownTextPrimitive
+          {...testCase.props}
+          BlockComponent={BlockComponent}
+        />
       </TextMessagePartProvider>,
     );
 
-    expect(await screen.findByText("first")).toBeTruthy();
+    expect(await screen.findByText(testCase.initial)).toBeTruthy();
 
     rerender(
-      <TextMessagePartProvider text="first second" isRunning>
-        <StreamdownTextPrimitive BlockComponent={BlockComponent} />
+      <TextMessagePartProvider text={testCase.next} isRunning>
+        <StreamdownTextPrimitive
+          {...testCase.props}
+          BlockComponent={BlockComponent}
+        />
       </TextMessagePartProvider>,
     );
 
-    expect(await screen.findByText("first second")).toBeTruthy();
+    const expectedText =
+      testCase.name === "preprocessed" ? "$x$" : testCase.next;
+    expect(await screen.findByText(expectedText)).toBeTruthy();
     expect(mounted).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { TextMessagePartProvider } from "@assistant-ui/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { defaultRehypePlugins } from "streamdown";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
@@ -122,6 +122,32 @@ describe("StreamdownTextPrimitive", () => {
       expect(screen.queryByText("first")).toBeNull();
     },
   );
+
+  it("preserves code mounts during streamed prefix appends", async () => {
+    const mounted = vi.fn();
+    const Code = ({ children }: { children?: ReactNode }) => {
+      useEffect(() => {
+        mounted();
+      }, []);
+      return <code>{children}</code>;
+    };
+    const components = { code: Code } as StreamdownTextComponents;
+    const { rerender } = render(
+      <TextMessagePartProvider text={"```ts\nfir\n```"} isRunning>
+        <StreamdownTextPrimitive components={components} />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("fir")).toBeTruthy();
+    rerender(
+      <TextMessagePartProvider text={"```ts\nfirst\n```"} isRunning>
+        <StreamdownTextPrimitive components={components} />
+      </TextMessagePartProvider>,
+    );
+
+    expect(await screen.findByText("first")).toBeTruthy();
+    await waitFor(() => expect(mounted).toHaveBeenCalledTimes(1));
+  });
 
   it("renders settled text in full when smooth is enabled", async () => {
     render(

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { TextMessagePartProvider } from "@assistant-ui/react";
-import { useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { defaultRehypePlugins } from "streamdown";
-import { normalizeMathDelimiters } from "../preprocess";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
   StreamdownTextComponents,
@@ -123,59 +122,6 @@ describe("StreamdownTextPrimitive", () => {
       expect(screen.queryByText("first")).toBeNull();
     },
   );
-
-  it.each([
-    {
-      name: "plain",
-      initial: "first",
-      next: "first second",
-      props: {},
-    },
-    {
-      name: "preprocessed",
-      initial: "\\(x",
-      next: "\\(x\\)",
-      props: { preprocess: normalizeMathDelimiters },
-    },
-    {
-      name: "deferred",
-      initial: "first",
-      next: "first second",
-      props: { defer: true },
-    },
-  ])("preserves $name blocks for raw prefix appends", async (testCase) => {
-    const mounted = vi.fn();
-    const BlockComponent = ({ content }: { content: string }) => {
-      useEffect(() => {
-        mounted();
-      }, []);
-      return <div>{content}</div>;
-    };
-    const { rerender } = render(
-      <TextMessagePartProvider text={testCase.initial} isRunning>
-        <StreamdownTextPrimitive
-          {...testCase.props}
-          BlockComponent={BlockComponent}
-        />
-      </TextMessagePartProvider>,
-    );
-
-    expect(await screen.findByText(testCase.initial)).toBeTruthy();
-
-    rerender(
-      <TextMessagePartProvider text={testCase.next} isRunning>
-        <StreamdownTextPrimitive
-          {...testCase.props}
-          BlockComponent={BlockComponent}
-        />
-      </TextMessagePartProvider>,
-    );
-
-    const expectedText =
-      testCase.name === "preprocessed" ? "$x$" : testCase.next;
-    expect(await screen.findByText(expectedText)).toBeTruthy();
-    expect(mounted).toHaveBeenCalledTimes(1);
-  });
 
   it("renders settled text in full when smooth is enabled", async () => {
     render(

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { TextMessagePartProvider } from "@assistant-ui/react";
-import { useEffect, type ReactNode } from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  AssistantRuntimeProvider,
+  MessagePrimitive,
+  TextMessagePartProvider,
+  ThreadPrimitive,
+  useLocalRuntime,
+  type AssistantRuntime,
+  type ChatModelAdapter,
+} from "@assistant-ui/react";
+import { useEffect, useState, type ReactNode } from "react";
 import { defaultRehypePlugins } from "streamdown";
 import { normalizeMathDelimiters } from "../preprocess";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
@@ -109,6 +117,47 @@ describe("StreamdownTextPrimitive", () => {
 
     expect(await screen.findByText("second")).toBeTruthy();
     expect(screen.queryByText("first")).toBeNull();
+  });
+
+  it("resets blocks for prefix-preserving message part replacements", async () => {
+    const mounted = vi.fn();
+    const BlockComponent = ({ content }: { content: string }) => {
+      const [renderedContent] = useState(content);
+      useEffect(() => {
+        mounted();
+      }, []);
+      return <div>{renderedContent}</div>;
+    };
+    const adapter: ChatModelAdapter = {
+      async *run() {},
+    };
+    let runtime: AssistantRuntime | null = null;
+    const Text = () => (
+      <StreamdownTextPrimitive BlockComponent={BlockComponent} />
+    );
+    const Message = () => <MessagePrimitive.Parts components={{ Text }} />;
+    const App = () => {
+      const localRuntime = useLocalRuntime(adapter, {
+        initialMessages: [{ role: "assistant", content: "first" }],
+      });
+      runtime = localRuntime;
+      return (
+        <AssistantRuntimeProvider runtime={localRuntime}>
+          <ThreadPrimitive.Messages components={{ Message }} />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    expect(await screen.findByText("first")).toBeTruthy();
+
+    await act(async () => {
+      runtime!.thread.reset([{ role: "assistant", content: "first second" }]);
+    });
+
+    expect(await screen.findByText("first second")).toBeTruthy();
+    expect(screen.queryByText("first")).toBeNull();
+    expect(mounted).toHaveBeenCalledTimes(2);
   });
 
   it("does not remount blocks when preprocessing rewrites appended text", async () => {

--- a/packages/react-streamdown/src/__tests__/memoization.test.ts
+++ b/packages/react-streamdown/src/__tests__/memoization.test.ts
@@ -57,6 +57,16 @@ describe("memoCompareNodes", () => {
     expect(memoCompareNodes(prev, next)).toBe(true);
   });
 
+  it("returns false for React elements with different children", () => {
+    const prev = {
+      children: createElement("code", { key: "1" }, "first"),
+    };
+    const next = {
+      children: createElement("code", { key: "1" }, "second"),
+    };
+    expect(memoCompareNodes(prev, next)).toBe(false);
+  });
+
   it("returns false for different React element types", () => {
     const prev = { children: createElement("div", { key: "1" }) };
     const next = { children: createElement("span", { key: "1" }) };

--- a/packages/react-streamdown/src/__tests__/memoization.test.ts
+++ b/packages/react-streamdown/src/__tests__/memoization.test.ts
@@ -67,6 +67,16 @@ describe("memoCompareNodes", () => {
     expect(memoCompareNodes(prev, next)).toBe(false);
   });
 
+  it("returns true for equivalent React element child arrays", () => {
+    const prev = {
+      children: createElement("code", null, ["first", "second"]),
+    };
+    const next = {
+      children: createElement("code", null, ["first", "second"]),
+    };
+    expect(memoCompareNodes(prev, next)).toBe(true);
+  });
+
   it("returns false for different React element types", () => {
     const prev = { children: createElement("div", { key: "1" }) };
     const next = { children: createElement("span", { key: "1" }) };

--- a/packages/react-streamdown/src/adapters/PreOverride.tsx
+++ b/packages/react-streamdown/src/adapters/PreOverride.tsx
@@ -23,22 +23,18 @@ const useCodeRevision = (children: ReactNode) => {
     : null;
   const content =
     typeof childContent === "string" || typeof childContent === "number"
-      ? String(childContent)
+      ? String(childContent).replace(/\n$/, "")
       : null;
   const [state, setState] = useState(() => ({
     anchor: content,
     revision: 0,
   }));
 
-  if (
-    content === null ||
-    content === state.anchor ||
-    (state.anchor !== null && content.startsWith(state.anchor))
-  ) {
+  if (content === null || content === state.anchor) {
     return state.revision;
   }
 
-  if (state.anchor === null || state.anchor === "") {
+  if (state.anchor === null || content.startsWith(state.anchor)) {
     setState({ anchor: content, revision: state.revision });
     return state.revision;
   }

--- a/packages/react-streamdown/src/adapters/PreOverride.tsx
+++ b/packages/react-streamdown/src/adapters/PreOverride.tsx
@@ -3,7 +3,7 @@
 import type { Element } from "hast";
 import {
   type ComponentPropsWithoutRef,
-  type ReactElement,
+  type ReactNode,
   cloneElement,
   createContext,
   isValidElement,
@@ -47,9 +47,17 @@ export const PreOverride = memo(function PreOverride({
   node,
   ...rest
 }: PreOverrideProps) {
-  const childWithBlock = isValidElement(children)
-    ? cloneElement(children as ReactElement<{ "data-block"?: string }>, {
+  const childWithBlock = isValidElement<{
+    "data-block"?: string;
+    children?: ReactNode;
+  }>(children)
+    ? cloneElement(children, {
         "data-block": "true",
+        key:
+          typeof children.props.children === "string" ||
+          typeof children.props.children === "number"
+            ? children.props.children
+            : children.key,
       })
     : children;
 

--- a/packages/react-streamdown/src/adapters/PreOverride.tsx
+++ b/packages/react-streamdown/src/adapters/PreOverride.tsx
@@ -9,11 +9,43 @@ import {
   isValidElement,
   memo,
   useContext,
+  useState,
 } from "react";
 import { memoCompareNodes } from "../memoization";
 
 type PreOverrideProps = ComponentPropsWithoutRef<"pre"> & {
   node?: Element | undefined;
+};
+
+const useCodeRevision = (children: ReactNode) => {
+  const childContent = isValidElement<{ children?: ReactNode }>(children)
+    ? children.props.children
+    : null;
+  const content =
+    typeof childContent === "string" || typeof childContent === "number"
+      ? String(childContent)
+      : null;
+  const [state, setState] = useState(() => ({
+    anchor: content,
+    revision: 0,
+  }));
+
+  if (
+    content === null ||
+    content === state.anchor ||
+    (state.anchor !== null && content.startsWith(state.anchor))
+  ) {
+    return state.revision;
+  }
+
+  if (state.anchor === null || state.anchor === "") {
+    setState({ anchor: content, revision: state.revision });
+    return state.revision;
+  }
+
+  const nextRevision = state.revision + 1;
+  setState({ anchor: content, revision: nextRevision });
+  return nextRevision;
 };
 
 /**
@@ -47,17 +79,14 @@ export const PreOverride = memo(function PreOverride({
   node,
   ...rest
 }: PreOverrideProps) {
+  const codeRevision = useCodeRevision(children);
   const childWithBlock = isValidElement<{
     "data-block"?: string;
     children?: ReactNode;
   }>(children)
     ? cloneElement(children, {
         "data-block": "true",
-        key:
-          typeof children.props.children === "string" ||
-          typeof children.props.children === "number"
-            ? children.props.children
-            : children.key,
+        key: `${children.key ?? "code"}:${codeRevision}`,
       })
     : children;
 

--- a/packages/react-streamdown/src/memoization.ts
+++ b/packages/react-streamdown/src/memoization.ts
@@ -2,11 +2,21 @@
 
 import type { ReactNode } from "react";
 
-type ReactElement = { type: unknown; key: unknown };
+type ReactElement = {
+  type: unknown;
+  key: unknown;
+  props: { children?: ReactNode; [key: string]: unknown };
+};
 
 function isReactElement(node: unknown): node is ReactElement {
   return (
-    typeof node === "object" && node !== null && "type" in node && "key" in node
+    typeof node === "object" &&
+    node !== null &&
+    "type" in node &&
+    "key" in node &&
+    "props" in node &&
+    typeof node.props === "object" &&
+    node.props !== null
   );
 }
 
@@ -16,7 +26,9 @@ function isReactElement(node: unknown): node is ReactElement {
 function compareNodes(a: ReactNode, b: ReactNode): boolean {
   if (a === b) return true;
   if (!isReactElement(a) || !isReactElement(b)) return false;
-  return a.type === b.type && a.key === b.key;
+  return (
+    a.type === b.type && a.key === b.key && memoCompareNodes(a.props, b.props)
+  );
 }
 
 /**

--- a/packages/react-streamdown/src/memoization.ts
+++ b/packages/react-streamdown/src/memoization.ts
@@ -25,6 +25,12 @@ function isReactElement(node: unknown): node is ReactElement {
  */
 function compareNodes(a: ReactNode, b: ReactNode): boolean {
   if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((node, index) => compareNodes(node, b[index]));
+  }
   if (!isReactElement(a) || !isReactElement(b)) return false;
   return (
     a.type === b.type && a.key === b.key && memoCompareNodes(a.props, b.props)

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -30,16 +30,28 @@ import type {
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
 
-// Streamdown 2.5 memoizes code nodes by source position, so equal-length
-// replacements need a new subtree while ordinary prefix appends stay mounted.
-const useStreamRevision = (text: string) => {
-  const [state, setState] = useState({ text, revision: 0 });
-  if (state.text === text) return state.revision;
+// Streamdown 2.5 memoizes fenced code nodes by source position. Raw text
+// replacements reset that subtree once their rendered text is ready.
+const useStreamRevision = (rawText: string, renderedText: string) => {
+  const [state, setState] = useState({
+    rawText,
+    renderedText,
+    pendingReset: false,
+    revision: 0,
+  });
+  if (state.rawText === rawText && state.renderedText === renderedText) {
+    return state.revision;
+  }
 
-  const revision = text.startsWith(state.text)
-    ? state.revision
-    : state.revision + 1;
-  setState({ text, revision });
+  let pendingReset =
+    state.pendingReset ||
+    (state.rawText !== rawText && !rawText.startsWith(state.rawText));
+  let revision = state.revision;
+  if (pendingReset && state.renderedText !== renderedText) {
+    pendingReset = false;
+    revision += 1;
+  }
+  setState({ rawText, renderedText, pendingReset, revision });
   return revision;
 };
 
@@ -188,7 +200,7 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
-    const streamRevision = useStreamRevision(processedText);
+    const streamRevision = useStreamRevision(messagePart.text, processedText);
 
     const shouldTailRemend =
       mode === "streaming" &&

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useAui,
-  useAuiState,
-  useMessagePartText,
-  useSmooth,
-} from "@assistant-ui/react";
+import { useMessagePartText, useSmooth } from "@assistant-ui/react";
 import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
@@ -35,15 +30,16 @@ import type {
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
 
-const useStreamRevision = (text: string, part: unknown) => {
-  const [state, setState] = useState({ text, part, revision: 0 });
-  if (state.text === text && state.part === part) return state.revision;
+// Streamdown 2.5 memoizes code nodes by source position, so equal-length
+// replacements need a new subtree while ordinary prefix appends stay mounted.
+const useStreamRevision = (text: string) => {
+  const [state, setState] = useState({ text, revision: 0 });
+  if (state.text === text) return state.revision;
 
-  const revision =
-    state.part === part && text.startsWith(state.text)
-      ? state.revision
-      : state.revision + 1;
-  setState({ text, part, revision });
+  const revision = text.startsWith(state.text)
+    ? state.revision
+    : state.revision + 1;
+  setState({ text, revision });
   return revision;
 };
 
@@ -178,10 +174,7 @@ export const StreamdownTextPrimitive = forwardRef<
     },
     ref,
   ) => {
-    const aui = useAui();
-    const part = useAuiState(() => aui.part);
     const messagePart = useMessagePartText();
-    const streamRevision = useStreamRevision(messagePart.text, part);
 
     const processedPart = useMemo(
       () =>
@@ -195,6 +188,7 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
+    const streamRevision = useStreamRevision(processedText);
 
     const shouldTailRemend =
       mode === "streaming" &&

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -17,6 +17,7 @@ import {
   forwardRef,
   useDeferredValue,
   useMemo,
+  useRef,
 } from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
 import { DEFAULT_SHIKI_THEME, mergePlugins } from "../defaults";
@@ -174,6 +175,11 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
+    const streamRevisionRef = useRef({ text: processedText, revision: 0 });
+    if (!processedText.startsWith(streamRevisionRef.current.text)) {
+      streamRevisionRef.current.revision += 1;
+    }
+    streamRevisionRef.current.text = processedText;
 
     const shouldTailRemend =
       mode === "streaming" &&
@@ -257,6 +263,7 @@ export const StreamdownTextPrimitive = forwardRef<
         className={containerClass}
       >
         <Streamdown
+          key={streamRevisionRef.current.revision}
           mode={mode}
           isAnimating={status.type === "running"}
           components={mergedComponents}

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -17,7 +17,7 @@ import {
   forwardRef,
   useDeferredValue,
   useMemo,
-  useRef,
+  useState,
 } from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
 import { DEFAULT_SHIKI_THEME, mergePlugins } from "../defaults";
@@ -29,6 +29,17 @@ import type {
 } from "../types";
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
+
+const useStreamRevision = (text: string) => {
+  const [state, setState] = useState({ text, revision: 0 });
+  if (state.text === text) return state.revision;
+
+  const revision = text.startsWith(state.text)
+    ? state.revision
+    : state.revision + 1;
+  setState({ text, revision });
+  return revision;
+};
 
 // Streamdown extends the default sanitize schema without exporting it, so it is
 // read back off its own plugin set; a copy would fall behind on a bump. An
@@ -162,6 +173,7 @@ export const StreamdownTextPrimitive = forwardRef<
     ref,
   ) => {
     const messagePart = useMessagePartText();
+    const streamRevision = useStreamRevision(messagePart.text);
 
     const processedPart = useMemo(
       () =>
@@ -175,11 +187,6 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
-    const streamRevisionRef = useRef({ text: processedText, revision: 0 });
-    if (!processedText.startsWith(streamRevisionRef.current.text)) {
-      streamRevisionRef.current.revision += 1;
-    }
-    streamRevisionRef.current.text = processedText;
 
     const shouldTailRemend =
       mode === "streaming" &&
@@ -263,7 +270,7 @@ export const StreamdownTextPrimitive = forwardRef<
         className={containerClass}
       >
         <Streamdown
-          key={streamRevisionRef.current.revision}
+          key={streamRevision}
           mode={mode}
           isAnimating={status.type === "running"}
           components={mergedComponents}

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useMessagePartText, useSmooth } from "@assistant-ui/react";
+import {
+  useAui,
+  useAuiState,
+  useMessagePartText,
+  useSmooth,
+} from "@assistant-ui/react";
 import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
@@ -30,14 +35,15 @@ import type {
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
 
-const useStreamRevision = (text: string) => {
-  const [state, setState] = useState({ text, revision: 0 });
-  if (state.text === text) return state.revision;
+const useStreamRevision = (text: string, part: unknown) => {
+  const [state, setState] = useState({ text, part, revision: 0 });
+  if (state.text === text && state.part === part) return state.revision;
 
-  const revision = text.startsWith(state.text)
-    ? state.revision
-    : state.revision + 1;
-  setState({ text, revision });
+  const revision =
+    state.part === part && text.startsWith(state.text)
+      ? state.revision
+      : state.revision + 1;
+  setState({ text, part, revision });
   return revision;
 };
 
@@ -172,8 +178,10 @@ export const StreamdownTextPrimitive = forwardRef<
     },
     ref,
   ) => {
+    const aui = useAui();
+    const part = useAuiState(() => aui.part);
     const messagePart = useMessagePartText();
-    const streamRevision = useStreamRevision(messagePart.text);
+    const streamRevision = useStreamRevision(messagePart.text, part);
 
     const processedPart = useMemo(
       () =>

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useMessagePartText, useSmooth } from "@assistant-ui/react";
+import {
+  useAui,
+  useAuiState,
+  useMessagePartText,
+  useSmooth,
+} from "@assistant-ui/react";
 import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
@@ -17,6 +22,7 @@ import {
   forwardRef,
   useDeferredValue,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
@@ -30,29 +36,42 @@ import type {
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
 
-// Streamdown 2.5 memoizes fenced code nodes by source position. Raw text
-// replacements reset that subtree once their rendered text is ready.
-const useStreamRevision = (rawText: string, renderedText: string) => {
-  const [state, setState] = useState({
+// Replaced text needs a fresh subtree once the replacement is rendered, while
+// prefix appends preserve Streamdown's incremental state.
+const useStreamRevision = (
+  part: unknown,
+  rawText: string,
+  renderedText: string,
+) => {
+  const [revision, setRevision] = useState(0);
+  const previousRef = useRef({
+    part,
     rawText,
     renderedText,
-    pendingReset: false,
-    revision: 0,
   });
-  if (state.rawText === rawText && state.renderedText === renderedText) {
-    return state.revision;
+  const pendingResetRef = useRef(false);
+  const previous = previousRef.current;
+  const rawTextChanged = rawText !== previous.rawText;
+  const textReplaced =
+    part !== previous.part ||
+    (rawTextChanged && !rawText.startsWith(previous.rawText));
+
+  if (textReplaced) {
+    pendingResetRef.current = true;
+  } else if (rawTextChanged) {
+    pendingResetRef.current = false;
   }
 
-  let pendingReset =
-    state.pendingReset ||
-    (state.rawText !== rawText && !rawText.startsWith(state.rawText));
-  let revision = state.revision;
-  if (pendingReset && state.renderedText !== renderedText) {
-    pendingReset = false;
-    revision += 1;
-  }
-  setState({ rawText, renderedText, pendingReset, revision });
-  return revision;
+  const shouldReset =
+    pendingResetRef.current && renderedText !== previous.renderedText;
+  previousRef.current = { part, rawText, renderedText };
+
+  if (!shouldReset) return revision;
+
+  pendingResetRef.current = false;
+  const nextRevision = revision + 1;
+  setRevision(nextRevision);
+  return nextRevision;
 };
 
 // Streamdown extends the default sanitize schema without exporting it, so it is
@@ -187,6 +206,8 @@ export const StreamdownTextPrimitive = forwardRef<
     ref,
   ) => {
     const messagePart = useMessagePartText();
+    const aui = useAui();
+    const part = useAuiState(() => aui.part);
 
     const processedPart = useMemo(
       () =>
@@ -200,7 +221,11 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
-    const streamRevision = useStreamRevision(messagePart.text, processedText);
+    const streamRevision = useStreamRevision(
+      part,
+      messagePart.text,
+      processedText,
+    );
 
     const shouldTailRemend =
       mode === "streaming" &&

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useAui,
-  useAuiState,
-  useMessagePartText,
-  useSmooth,
-} from "@assistant-ui/react";
+import { useMessagePartText, useSmooth } from "@assistant-ui/react";
 import { harden } from "rehype-harden";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
@@ -22,8 +17,6 @@ import {
   forwardRef,
   useDeferredValue,
   useMemo,
-  useRef,
-  useState,
 } from "react";
 import { useAdaptedComponents } from "../adapters/components-adapter";
 import { DEFAULT_SHIKI_THEME, mergePlugins } from "../defaults";
@@ -35,44 +28,6 @@ import type {
 } from "../types";
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
-
-// Replaced text needs a fresh subtree once the replacement is rendered, while
-// prefix appends preserve Streamdown's incremental state.
-const useStreamRevision = (
-  part: unknown,
-  rawText: string,
-  renderedText: string,
-) => {
-  const [revision, setRevision] = useState(0);
-  const previousRef = useRef({
-    part,
-    rawText,
-    renderedText,
-  });
-  const pendingResetRef = useRef(false);
-  const previous = previousRef.current;
-  const rawTextChanged = rawText !== previous.rawText;
-  const textReplaced =
-    part !== previous.part ||
-    (rawTextChanged && !rawText.startsWith(previous.rawText));
-
-  if (textReplaced) {
-    pendingResetRef.current = true;
-  } else if (rawTextChanged) {
-    pendingResetRef.current = false;
-  }
-
-  const shouldReset =
-    pendingResetRef.current && renderedText !== previous.renderedText;
-  previousRef.current = { part, rawText, renderedText };
-
-  if (!shouldReset) return revision;
-
-  pendingResetRef.current = false;
-  const nextRevision = revision + 1;
-  setRevision(nextRevision);
-  return nextRevision;
-};
 
 // Streamdown extends the default sanitize schema without exporting it, so it is
 // read back off its own plugin set; a copy would fall behind on a bump. An
@@ -206,8 +161,6 @@ export const StreamdownTextPrimitive = forwardRef<
     ref,
   ) => {
     const messagePart = useMessagePartText();
-    const aui = useAui();
-    const part = useAuiState(() => aui.part);
 
     const processedPart = useMemo(
       () =>
@@ -221,11 +174,6 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const deferredText = useDeferredValue(text);
     const processedText = defer ? deferredText : text;
-    const streamRevision = useStreamRevision(
-      part,
-      messagePart.text,
-      processedText,
-    );
 
     const shouldTailRemend =
       mode === "streaming" &&
@@ -309,7 +257,6 @@ export const StreamdownTextPrimitive = forwardRef<
         className={containerClass}
       >
         <Streamdown
-          key={streamRevision}
           mode={mode}
           isAnimating={status.type === "running"}
           components={mergedComponents}


### PR DESCRIPTION
## Summary

- compare nested React-element props in `memoCompareNodes` instead of treating matching type/key as equal
- refresh only the memoized fenced-code child when streamed content is replaced
- preserve the existing code component instance during prefix-only token appends

## Why

`PreOverride` previously skipped updates when its child kept the same type and key even though its text props changed. Comparing nested props makes that update observable, but Streamdown 2.5's nested code memo can still retain the old subtree when the HAST source position is unchanged.

The fix keeps a small transactional revision at the fenced-code boundary. The revision stays stable for ordinary append-only streaming such as `fir` to `first`, and changes for a replacement such as `first` to `second`. This refreshes the stale code child without remounting the surrounding markdown tree or remounting code on every token.

## Validation

- reproduced the default-renderer failure on untouched `origin/main`
- added nested React-element comparator coverage
- added default-renderer regressions for streaming, static, and deferred replacements
- added a mount-count regression proving prefix appends preserve the code component instance
- `pnpm --filter @assistant-ui/react-streamdown test` (143 tests)
- `pnpm --filter @assistant-ui/react-streamdown build`
- targeted oxlint and oxfmt checks

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ncdnMOjXtYWqgl3l1GF_2sO8QLzbtgHXyJx6OpuztEY8k2RfFPZvU7u0Mcg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

