### PR TITLE
fix(core): derive requires-action in the external-store convertMessage path

### DIFF
--- a/.changeset/external-store-convert-message-auto-status.md
+++ b/.changeset/external-store-convert-message-auto-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: derive requires-action for pending and interrupted tool calls in the external-store convertMessage path

--- a/.changeset/external-store-convert-message-auto-status.md
+++ b/.changeset/external-store-convert-message-auto-status.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: derive requires-action for pending and interrupted tool calls in the external-store convertMessage path
+fix: derive requires-action for pending and interrupted tool calls in the external-store convertMessage path; messages with unresolved tool calls now report requires-action instead of complete

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -12,7 +12,12 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import {
+  getAutoStatus,
+  isAutoStatus,
+  isInterruptedToolCall,
+  isPendingToolCall,
+} from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { generateErrorMessageId } from "../../utils/id";
@@ -28,24 +33,6 @@ import type { MessageTiming } from "../../types/message";
 const generatedFallbackMessages = new WeakSet<object>();
 
 export type JoinStrategy = "concat-content" | "none";
-
-type ThreadMessageLikeContentItem = Exclude<
-  ThreadMessageLike["content"],
-  string
->[number];
-
-const isPendingToolCall = (c: ThreadMessageLikeContentItem): boolean =>
-  c.type === "tool-call" && c.result === undefined;
-
-const isInterruptedToolCall = (c: ThreadMessageLikeContentItem): boolean => {
-  if (c.type !== "tool-call" || c.result !== undefined) return false;
-  return (
-    c.interrupt != null ||
-    (c.approval != null &&
-      c.approval.approved === undefined &&
-      c.approval.resolution === undefined)
-  );
-};
 
 export namespace useExternalMessageConverter {
   export type Message =

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -1,5 +1,26 @@
 import type { MessageStatus } from "../../types/message";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import type { ThreadMessageLike } from "./thread-message-like";
+
+type ThreadMessageLikeContentItem = Exclude<
+  ThreadMessageLike["content"],
+  string
+>[number];
+
+export const isPendingToolCall = (c: ThreadMessageLikeContentItem): boolean =>
+  c.type === "tool-call" && c.result === undefined;
+
+export const isInterruptedToolCall = (
+  c: ThreadMessageLikeContentItem,
+): boolean => {
+  if (c.type !== "tool-call" || c.result !== undefined) return false;
+  return (
+    c.interrupt != null ||
+    (c.approval != null &&
+      c.approval.approved === undefined &&
+      c.approval.resolution === undefined)
+  );
+};
 
 const symbolAutoStatus = Symbol("autoStatus");
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -19,7 +19,12 @@ import {
   FALLBACK_ID_PREFIX,
 } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "./thread-message-converter";
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import {
+  getAutoStatus,
+  isAutoStatus,
+  isInterruptedToolCall,
+  isPendingToolCall,
+} from "../../runtime/utils/auto-status";
 import {
   fromThreadMessageLike,
   type ThreadMessageLike,
@@ -279,20 +284,24 @@ export class ExternalStoreThreadRuntimeCore
             if (!store.convertMessage) return m;
 
             const isLast = idx === (store.messages?.length ?? 0) - 1;
-            const autoStatus = getAutoStatus(
-              isLast,
-              isRunning,
-              false,
-              false,
-              undefined,
-            );
+            const getContentAutoStatus = (
+              content: ThreadMessageLike["content"],
+            ) =>
+              getAutoStatus(
+                isLast,
+                isRunning,
+                typeof content !== "string" &&
+                  content.some(isInterruptedToolCall),
+                typeof content !== "string" && content.some(isPendingToolCall),
+                undefined,
+              );
             const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
 
             if (
               cache &&
               (cache.role !== "assistant" ||
                 !isAutoStatus(cache.status) ||
-                cache.status === autoStatus)
+                cache.status === getContentAutoStatus(cache.content))
             ) {
               if (
                 cache.id.startsWith(FALLBACK_ID_PREFIX) &&
@@ -309,7 +318,7 @@ export class ExternalStoreThreadRuntimeCore
             const newMessage = fromThreadMessageLike(
               messageLike,
               fallbackId,
-              autoStatus,
+              getContentAutoStatus(messageLike.content),
             );
             bindExternalStoreMessage(newMessage, m);
             return newMessage;

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1299,6 +1299,17 @@ describe("ExternalStoreThreadRuntimeCore - convertMessage auto status", () => {
     });
   });
 
+  it("reports an interrupt for a human interrupt", () => {
+    const runtime = makeRuntime({
+      role: "assistant",
+      content: [toolCall({ interrupt: { type: "human", payload: {} } })],
+    });
+    expect(runtime.messages[1]!.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+  });
+
   it("reports complete once the tool call has a result", () => {
     const runtime = makeRuntime({
       role: "assistant",
@@ -1354,5 +1365,37 @@ describe("ExternalStoreThreadRuntimeCore - convertMessage auto status", () => {
       }),
     );
     expect(runtime.messages[1]!.status).toMatchObject({ type: "complete" });
+  });
+
+  it("recomputes a cached message's status when the run ends", () => {
+    const pending: ThreadMessageLike = {
+      role: "assistant",
+      content: [toolCall()],
+    };
+    const user: ThreadMessageLike = { role: "user", content: "run it" };
+    const convertMessage = vi.fn((m: ThreadMessageLike) => m);
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        isRunning: true,
+        messages: [user, pending],
+        convertMessage,
+        setMessages: vi.fn(),
+      }),
+    );
+    expect(runtime.messages[1]!.status).toMatchObject({ type: "running" });
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        isRunning: false,
+        messages: [user, pending],
+        convertMessage,
+        setMessages: vi.fn(),
+      }),
+    );
+    expect(runtime.messages[1]!.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
   });
 });

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1291,7 +1291,7 @@ describe("ExternalStoreThreadRuntimeCore - convertMessage auto status", () => {
   it("reports an interrupt for an unresolved approval", () => {
     const runtime = makeRuntime({
       role: "assistant",
-      content: [toolCall({ approval: {} })],
+      content: [toolCall({ approval: { id: "a1" } })],
     });
     expect(runtime.messages[1]!.status).toMatchObject({
       type: "requires-action",

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1258,3 +1258,101 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
     expect(runtime.messages.map(textOf)).toEqual(["id-less", "kept"]);
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - convertMessage auto status", () => {
+  const toolCall = (extra?: Record<string, unknown>) => ({
+    type: "tool-call" as const,
+    toolCallId: "t1",
+    toolName: "search",
+    args: {},
+    argsText: "{}",
+    ...extra,
+  });
+
+  const makeRuntime = (assistant: ThreadMessageLike, isRunning = false) =>
+    new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        isRunning,
+        messages: [{ role: "user", content: "run it" }, assistant],
+        convertMessage: (m: ThreadMessageLike) => m,
+        setMessages: vi.fn(),
+      }),
+    );
+
+  it("reports requires-action for a tool call without a result", () => {
+    const runtime = makeRuntime({ role: "assistant", content: [toolCall()] });
+    expect(runtime.messages[1]!.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+
+  it("reports an interrupt for an unresolved approval", () => {
+    const runtime = makeRuntime({
+      role: "assistant",
+      content: [toolCall({ approval: {} })],
+    });
+    expect(runtime.messages[1]!.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+  });
+
+  it("reports complete once the tool call has a result", () => {
+    const runtime = makeRuntime({
+      role: "assistant",
+      content: [toolCall({ result: "ok" })],
+    });
+    expect(runtime.messages[1]!.status).toMatchObject({ type: "complete" });
+  });
+
+  it("keeps the last message running while a tool call is still pending", () => {
+    const runtime = makeRuntime(
+      { role: "assistant", content: [toolCall()] },
+      true,
+    );
+    expect(runtime.messages[1]!.status).toMatchObject({ type: "running" });
+  });
+
+  it("reuses the converted message until its auto status changes", () => {
+    const pending: ThreadMessageLike = {
+      role: "assistant",
+      content: [toolCall()],
+    };
+    const user: ThreadMessageLike = { role: "user", content: "run it" };
+    const convertMessage = vi.fn((m: ThreadMessageLike) => m);
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        isRunning: false,
+        messages: [user, pending],
+        convertMessage,
+        setMessages: vi.fn(),
+      }),
+    );
+    const first = runtime.messages[1]!;
+    expect(convertMessage).toHaveBeenCalledTimes(2);
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        isRunning: false,
+        messages: [user, pending],
+        convertMessage,
+        setMessages: vi.fn(),
+      }),
+    );
+    expect(runtime.messages[1]).toBe(first);
+    expect(convertMessage).toHaveBeenCalledTimes(2);
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        isRunning: false,
+        messages: [user, { ...pending, content: [toolCall({ result: "ok" })] }],
+        convertMessage,
+        setMessages: vi.fn(),
+      }),
+    );
+    expect(runtime.messages[1]!.status).toMatchObject({ type: "complete" });
+  });
+});


### PR DESCRIPTION
## What
The `store.convertMessage` path of `ExternalStoreThreadRuntimeCore` now derives the `requires-action` status (reason `tool-calls` or `interrupt`) from the converted content, the way `useExternalMessageConverter` already does. The two content helpers move next to `getAutoStatus` and both callers share them.

## Why
The two converter entry points disagree on status. `useExternalMessageConverter` derives the tool-call flags from content, while the core `convertMessage` call hard-codes both to `false`, so an assistant message with an unresolved tool call reports `complete` on the direct path and `requires-action` on the hook path. Closes  https://github.com/assistant-ui/assistant-ui/issues/6323.

## Impact
- Adapters passing `convertMessage` on the store now get `requires-action` for unresolved tool calls and unresolved interrupts/approvals, so HITL and approval UI shows on that path too.
- Messages without pending tool calls, and any message with an explicit `status`, are unchanged.

## Scope & caveats
- The `error` flag is intentionally out of scope: the React converter takes it from its own `metadata.error` option, and `ThreadMessageLike` has no equivalent field to derive it from.
- The cache-hit branch recomputes the status from `cache.content` before comparing; this looks new but only reorders the existing check, since the converter cache is keyed on source message identity and flushed when `convertMessage` changes.
- `message-repository.ts` still calls `getAutoStatus(false, false, false, false)` on purpose: it imports stored messages with no live run context.
- Helpers are module-level exports only, not added to `internal.ts` or any barrel. Additive, nothing removed or reshaped.
- Tests: pending → `tool-calls`, unresolved approval → `interrupt`, result present → `complete`, last + running → `running` wins, cache reuse and status flip on source swap.
- Changeset: patch (`@assistant-ui/core`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BsPeESh24leCOx7etT_oh0ECU-PaBWWyeM1K0UPGSegBRsmubp85Hg22w_Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->