### PR TITLE
fix(core): derive requires-action when importing messages into the repository

### DIFF
--- a/.changeset/message-repository-import-auto-status.md
+++ b/.changeset/message-repository-import-auto-status.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: derive requires-action for pending and interrupted tool calls when importing messages into the repository
+fix: derive requires-action for pending and interrupted tool calls when importing messages into the repository, and resume local runs after approving an imported pending approval

--- a/.changeset/message-repository-import-auto-status.md
+++ b/.changeset/message-repository-import-auto-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: derive requires-action for pending and interrupted tool calls when importing messages into the repository

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2452,6 +2452,7 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   deleteMessage(messageId: string): Promise<void>;
   resumeRun(_param4: ResumeRunConfig): Promise<void>;
   exportExternalState(): any;
+  import(data: ExportedMessageRepository): void;
   importExternalState(): void;
   unstable_notifySessionReset(): void;
   startRun(_param5: StartRunConfig, runCallback?: ChatModelAdapter["run"]): Promise<void>;

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -91,12 +91,10 @@ export const getContentAutoStatus = (
   content: ThreadMessageLike["content"],
   isLast: boolean,
   isRunning: boolean,
-  error?: ReadonlyJSONValue,
 ): MessageStatus =>
   getAutoStatus(
     isLast,
     isRunning,
     typeof content !== "string" && content.some(isInterruptedToolCall),
     typeof content !== "string" && content.some(isPendingToolCall),
-    error,
   );

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -86,3 +86,17 @@ export const getAutoStatus = (
         ? AUTO_STATUS_PENDING
         : AUTO_STATUS_COMPLETE;
 };
+
+export const getContentAutoStatus = (
+  content: ThreadMessageLike["content"],
+  isLast: boolean,
+  isRunning: boolean,
+  error?: ReadonlyJSONValue,
+): MessageStatus =>
+  getAutoStatus(
+    isLast,
+    isRunning,
+    typeof content !== "string" && content.some(isInterruptedToolCall),
+    typeof content !== "string" && content.some(isPendingToolCall),
+    error,
+  );

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -2,7 +2,7 @@ import type { ThreadMessage } from "../../types/message";
 import type { RunConfig } from "../../types/message";
 import { generateId } from "../../utils/id";
 import type { ThreadMessageLike } from "./thread-message-like";
-import { getAutoStatus } from "./auto-status";
+import { getContentAutoStatus } from "./auto-status";
 import { fromThreadMessageLike } from "./thread-message-like";
 
 export type ExportedMessageRepositoryItem = {
@@ -28,7 +28,7 @@ export const ExportedMessageRepository = {
       fromThreadMessageLike(
         m,
         generateId(),
-        getAutoStatus(false, false, false, false, undefined),
+        getContentAutoStatus(m.content, false, false),
       ),
     );
 
@@ -47,7 +47,6 @@ export const ExportedMessageRepository = {
     }[],
     options?: { headId?: string | null },
   ): ExportedMessageRepository => {
-    const fallbackStatus = getAutoStatus(false, false, false, false, undefined);
     return {
       ...(options?.headId !== undefined
         ? { headId: options.headId }
@@ -60,7 +59,11 @@ export const ExportedMessageRepository = {
         }
         return {
           parentId,
-          message: fromThreadMessageLike(message, message.id, fallbackStatus),
+          message: fromThreadMessageLike(
+            message,
+            message.id,
+            getContentAutoStatus(message.content, false, false),
+          ),
         };
       }),
     };

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -20,10 +20,8 @@ import {
 } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "./thread-message-converter";
 import {
-  getAutoStatus,
+  getContentAutoStatus,
   isAutoStatus,
-  isInterruptedToolCall,
-  isPendingToolCall,
 } from "../../runtime/utils/auto-status";
 import {
   fromThreadMessageLike,
@@ -351,24 +349,14 @@ export class ExternalStoreThreadRuntimeCore
             if (!store.convertMessage) return m;
 
             const isLast = idx === (store.messages?.length ?? 0) - 1;
-            const getContentAutoStatus = (
-              content: ThreadMessageLike["content"],
-            ) =>
-              getAutoStatus(
-                isLast,
-                isRunning,
-                typeof content !== "string" &&
-                  content.some(isInterruptedToolCall),
-                typeof content !== "string" && content.some(isPendingToolCall),
-                undefined,
-              );
             const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
 
             if (
               cache &&
               (cache.role !== "assistant" ||
                 !isAutoStatus(cache.status) ||
-                cache.status === getContentAutoStatus(cache.content))
+                cache.status ===
+                  getContentAutoStatus(cache.content, isLast, isRunning))
             ) {
               if (
                 cache.id.startsWith(FALLBACK_ID_PREFIX) &&
@@ -385,7 +373,7 @@ export class ExternalStoreThreadRuntimeCore
             const newMessage = fromThreadMessageLike(
               messageLike,
               fallbackId,
-              getContentAutoStatus(messageLike.content),
+              getContentAutoStatus(messageLike.content, isLast, isRunning),
             );
             bindExternalStoreMessage(newMessage, m);
             return newMessage;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -2130,6 +2130,28 @@ describe("LocalThreadRuntimeCore imported approvals", () => {
     expect(thread.messages.at(-1)?.status?.type).toBe("complete");
   });
 
+  it("completes an imported interrupt that has nothing left to act on", () => {
+    const { thread } = createImportedThread([
+      { role: "user", content: [{ type: "text", text: "send an email" }] },
+      {
+        role: "assistant",
+        status: { type: "requires-action", reason: "interrupt" },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-send_email",
+            toolName: "send_email",
+            args: {},
+            argsText: "{}",
+            result: { sent: true },
+          },
+        ],
+      } as ThreadMessageLike,
+    ]);
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
+
   it("resumes the run after adding a result to an imported resultless tool call", async () => {
     const { thread, runs } = createImportedThread(pausedOnApproval(undefined));
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -2108,6 +2108,28 @@ describe("LocalThreadRuntimeCore imported approvals", () => {
     expect(thread.messages.at(-1)?.status?.type).toBe("complete");
   });
 
+  it("normalizes a serialized approval pause that lost its auto-status marker", async () => {
+    const { thread, runs } = createImportedThread([]);
+    thread.import(
+      JSON.parse(
+        JSON.stringify(
+          ExportedMessageRepository.fromArray(pausedOnApproval({ id: "a1" })),
+        ),
+      ),
+    );
+
+    expect(thread.messages.at(-1)?.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
+
   it("resumes the run after adding a result to an imported resultless tool call", async () => {
     const { thread, runs } = createImportedThread(pausedOnApproval(undefined));
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -7,7 +7,10 @@ import type {
 } from "../../runtime/utils/chat-model-adapter";
 import type { AppendMessage } from "../../types/message";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
-import type { ExportedMessageRepositoryItem } from "../../runtime/utils/message-repository";
+import {
+  ExportedMessageRepository,
+  type ExportedMessageRepositoryItem,
+} from "../../runtime/utils/message-repository";
 import type { ThreadMessageLike } from "../../runtime/utils/thread-message-like";
 import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
 import { isMessageNotSentError } from "../../types/error";
@@ -2026,7 +2029,10 @@ describe("LocalThreadRuntimeCore imported approvals", () => {
     },
   ];
 
-  const createImportedThread = (initialMessages: ThreadMessageLike[]) => {
+  const createImportedThread = (
+    initialMessages: ThreadMessageLike[],
+    history?: LocalRuntimeOptionsBase["adapters"]["history"],
+  ) => {
     const runs: ChatModelRunOptions[] = [];
     const core = new LocalRuntimeCore(
       {
@@ -2037,6 +2043,7 @@ describe("LocalThreadRuntimeCore imported approvals", () => {
               return { content: [{ type: "text", text: "done" }] };
             },
           },
+          ...(history !== undefined && { history }),
         },
         unstable_humanToolNames: ["send_email"],
       },
@@ -2073,5 +2080,52 @@ describe("LocalThreadRuntimeCore imported approvals", () => {
       type: "requires-action",
       reason: "interrupt",
     });
+  });
+
+  it("resumes the run after approving an approval restored by the history adapter", async () => {
+    const { thread, runs } = createImportedThread([], {
+      async load() {
+        return ExportedMessageRepository.fromArray(
+          pausedOnApproval({ id: "a1" }),
+        );
+      },
+      async append() {},
+      async update() {},
+    });
+
+    thread.__internal_load();
+    await flush();
+
+    expect(thread.messages.at(-1)?.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
+
+  it("resumes the run after adding a result to an imported resultless tool call", async () => {
+    const { thread, runs } = createImportedThread(pausedOnApproval(undefined));
+
+    expect(thread.messages.at(-1)?.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+
+    thread.addToolResult({
+      messageId: thread.messages.at(-1)!.id,
+      toolCallId: "call-send_email",
+      toolName: "send_email",
+      result: { sent: true },
+      isError: false,
+    });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
   });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -8,6 +8,7 @@ import type {
 import type { AppendMessage } from "../../types/message";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
 import type { ExportedMessageRepositoryItem } from "../../runtime/utils/message-repository";
+import type { ThreadMessageLike } from "../../runtime/utils/thread-message-like";
 import type { ThreadSuggestion } from "../../runtime/interfaces/thread-runtime-core";
 import { isMessageNotSentError } from "../../types/error";
 
@@ -2000,5 +2001,77 @@ describe("LocalRuntimeCore composer.canCancel", () => {
 
     expect(thread.composer.canCancel).toBe(true);
     thread.cancelRun();
+  });
+});
+
+describe("LocalThreadRuntimeCore imported approvals", () => {
+  const pausedOnApproval = (
+    approval: { id: string } | undefined,
+    extra: Record<string, unknown> = {},
+  ): ThreadMessageLike[] => [
+    { role: "user", content: [{ type: "text", text: "send an email" }] },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-send_email",
+          toolName: "send_email",
+          args: {},
+          argsText: "{}",
+          ...(approval !== undefined ? { approval } : {}),
+          ...extra,
+        },
+      ],
+    },
+  ];
+
+  const createImportedThread = (initialMessages: ThreadMessageLike[]) => {
+    const runs: ChatModelRunOptions[] = [];
+    const core = new LocalRuntimeCore(
+      {
+        adapters: {
+          chatModel: {
+            async run(options) {
+              runs.push(options);
+              return { content: [{ type: "text", text: "done" }] };
+            },
+          },
+        },
+        unstable_humanToolNames: ["send_email"],
+      },
+      initialMessages,
+    );
+    return { thread: core.threads.getMainThreadRuntimeCore(), runs };
+  };
+
+  it("resumes the run after approving an imported pending approval", async () => {
+    const { thread, runs } = createImportedThread(
+      pausedOnApproval({ id: "a1" }),
+    );
+
+    expect(thread.messages.at(-1)?.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
+
+  it("keeps the interrupt reason for an imported interrupted tool call", () => {
+    const { thread } = createImportedThread(
+      pausedOnApproval(undefined, {
+        interrupt: { type: "human", payload: { question: "which one?" } },
+      }),
+    );
+
+    expect(thread.messages.at(-1)?.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
   });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -54,6 +54,8 @@ class AbortError extends Error {
 // `shouldContinue` resumes only on `tool-calls` and `resumeToolCall` throws, so
 // an imported `interrupt` with no interrupt payload would be stranded here.
 // Provenance cannot gate it: a repository that went through JSON has no marker.
+// The replacement stays content-derived, so a message with nothing resultless
+// left to act on lands on `complete` rather than an unactionable pause.
 const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
   if (
     message.role !== "assistant" ||
@@ -65,7 +67,17 @@ const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
     )
   )
     return message;
-  return { ...message, status: getAutoStatus(false, false, false, true) };
+  return {
+    ...message,
+    status: getAutoStatus(
+      false,
+      false,
+      false,
+      message.content.some(
+        (c) => c.type === "tool-call" && c.result === undefined,
+      ),
+    ),
+  };
 };
 
 const withLocalPauseReasons = (

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -66,6 +66,16 @@ const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
   return { ...message, status: getAutoStatus(false, false, false, true) };
 };
 
+const withLocalPauseReasons = (
+  data: ExportedMessageRepository,
+): ExportedMessageRepository => ({
+  ...data,
+  messages: data.messages.map((item) => ({
+    ...item,
+    message: withLocalPauseReason(item.message),
+  })),
+});
+
 export class LocalThreadRuntimeCore
   extends BaseThreadRuntimeCore
   implements ThreadRuntimeCore
@@ -289,7 +299,7 @@ export class LocalThreadRuntimeCore
     this._loadPromise = promise
       .then((repo) => {
         if (!repo) return;
-        this.repository.import(repo);
+        this.repository.import(withLocalPauseReasons(repo));
         if (repo.messages.length > 0) {
           this.ensureInitialized();
         }
@@ -452,13 +462,7 @@ export class LocalThreadRuntimeCore
   }
 
   public override import(data: ExportedMessageRepository) {
-    super.import({
-      ...data,
-      messages: data.messages.map((item) => ({
-        ...item,
-        message: withLocalPauseReason(item.message),
-      })),
-    });
+    super.import(withLocalPauseReasons(data));
   }
 
   public importExternalState(): void {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -5,7 +5,7 @@ import type {
   ChatModelRunResult,
 } from "../../runtime/utils/chat-model-adapter";
 import { shouldContinue } from "./should-continue";
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import { getAutoStatus } from "../../runtime/utils/auto-status";
 import type { ExportedMessageRepository } from "../../runtime/utils/message-repository";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
 import { consumeSuggestionResult } from "../../adapters/suggestion";
@@ -56,7 +56,6 @@ const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
     message.role !== "assistant" ||
     message.status.type !== "requires-action" ||
     message.status.reason !== "interrupt" ||
-    !isAutoStatus(message.status) ||
     message.content.some(
       (c) =>
         c.type === "tool-call" && c.result === undefined && c.interrupt != null,

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -5,6 +5,8 @@ import type {
   ChatModelRunResult,
 } from "../../runtime/utils/chat-model-adapter";
 import { shouldContinue } from "./should-continue";
+import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import type { ExportedMessageRepository } from "../../runtime/utils/message-repository";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
 import { consumeSuggestionResult } from "../../adapters/suggestion";
 import type {
@@ -21,7 +23,7 @@ import type {
   AppendMessage,
   ThreadAssistantMessage,
 } from "../../types/message";
-import type { RunConfig } from "../../types/message";
+import type { RunConfig, ThreadMessage } from "../../types/message";
 import { MessageNotSentError, toAssistantError } from "../../types/error";
 import type { ModelContextProvider } from "../../model-context/types";
 import {
@@ -48,6 +50,21 @@ class AbortError extends Error {
     this.detach = detach;
   }
 }
+
+const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
+  if (
+    message.role !== "assistant" ||
+    message.status.type !== "requires-action" ||
+    message.status.reason !== "interrupt" ||
+    !isAutoStatus(message.status) ||
+    message.content.some(
+      (c) =>
+        c.type === "tool-call" && c.result === undefined && c.interrupt != null,
+    )
+  )
+    return message;
+  return { ...message, status: getAutoStatus(false, false, false, true) };
+};
 
 export class LocalThreadRuntimeCore
   extends BaseThreadRuntimeCore
@@ -432,6 +449,16 @@ export class LocalThreadRuntimeCore
 
   public exportExternalState(): any {
     throw new Error("Runtime does not support exporting external states.");
+  }
+
+  public override import(data: ExportedMessageRepository) {
+    super.import({
+      ...data,
+      messages: data.messages.map((item) => ({
+        ...item,
+        message: withLocalPauseReason(item.message),
+      })),
+    });
   }
 
   public importExternalState(): void {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -51,6 +51,9 @@ class AbortError extends Error {
   }
 }
 
+// `shouldContinue` resumes only on `tool-calls` and `resumeToolCall` throws, so
+// an imported `interrupt` with no interrupt payload would be stranded here.
+// Provenance cannot gate it: a repository that went through JSON has no marker.
 const withLocalPauseReason = (message: ThreadMessage): ThreadMessage => {
   if (
     message.role !== "assistant" ||

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -610,6 +610,27 @@ describe("MessageRepository", () => {
       });
     });
 
+    it("fromArray reports requires-action with reason tool-calls for a resultless tool call", () => {
+      const result = ExportedMessageRepository.fromArray([
+        {
+          ...pendingToolCall,
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "t1",
+              toolName: "search",
+              args: {},
+              argsText: "{}",
+            },
+          ],
+        },
+      ]);
+      expect(result.messages[0]!.message.status).toMatchObject({
+        type: "requires-action",
+        reason: "tool-calls",
+      });
+    });
+
     it("keeps complete for a resolved tool call", () => {
       const result = ExportedMessageRepository.fromArray([
         {

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -576,6 +576,62 @@ describe("MessageRepository", () => {
     });
   });
 
+  describe("ExportedMessageRepository auto status", () => {
+    const pendingToolCall: ThreadMessageLike = {
+      id: "a1",
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "t1",
+          toolName: "search",
+          args: {},
+          argsText: "{}",
+          approval: {},
+        },
+      ],
+    };
+
+    it("fromArray reports requires-action for an unresolved approval", () => {
+      const result = ExportedMessageRepository.fromArray([pendingToolCall]);
+      expect(result.messages[0]!.message.status).toMatchObject({
+        type: "requires-action",
+        reason: "interrupt",
+      });
+    });
+
+    it("fromBranchableArray reports requires-action for an unresolved approval", () => {
+      const result = ExportedMessageRepository.fromBranchableArray([
+        { message: pendingToolCall, parentId: null },
+      ]);
+      expect(result.messages[0]!.message.status).toMatchObject({
+        type: "requires-action",
+        reason: "interrupt",
+      });
+    });
+
+    it("keeps complete for a resolved tool call", () => {
+      const result = ExportedMessageRepository.fromArray([
+        {
+          ...pendingToolCall,
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "t1",
+              toolName: "search",
+              args: {},
+              argsText: "{}",
+              result: "ok",
+            },
+          ],
+        },
+      ]);
+      expect(result.messages[0]!.message.status).toMatchObject({
+        type: "complete",
+      });
+    });
+  });
+
   describe("ExportedMessageRepository.fromBranchableArray", () => {
     it("should create a branching tree structure", () => {
       const items = [

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -587,7 +587,7 @@ describe("MessageRepository", () => {
           toolName: "search",
           args: {},
           argsText: "{}",
-          approval: {},
+          approval: { id: "a1" },
         },
       ],
     };


### PR DESCRIPTION
## What
`ExportedMessageRepository.fromArray` and `fromBranchableArray` derive `requires-action` from message content through a new `getContentAutoStatus` helper (wrapping the shared predicates from #6324), and the local runtime normalizes an imported approval pause to the `tool-calls` reason it uses for live runs, so `respondToToolApproval` resumes the run instead of stalling.

## Why
`useLocalRuntime({ initialMessages })` goes through `fromArray`, which called `getAutoStatus(false, false, false, false)`, so a restored assistant message paused on a tool approval came back `complete`: its tool part rendered as finished and `respondToToolApproval` threw at the `requires-action` guard. Fixing the derivation alone moved the symptom: the shared predicate classifies an unresolved approval as `interrupt` (that is the react converter's long-standing contract, and `ui/tool-fallback.tsx` keys on it), but the local runtime's `shouldContinue` only resumes on `tool-calls`, so the approval was recorded and the run never restarted. The second half surfaced while tracing the runtime path during review; it only bites in the local runtime because that is the one consumer that gates on the reason and has no interrupt concept at all.

## Impact
- Imported messages with an unresolved tool call or approval carry `requires-action`, matching their live-run status.
- In the local runtime, an imported approval pause is `requires-action` / `tool-calls`; approving it runs the model again and the message reaches `complete`. A real interrupt (`c.interrupt != null`) keeps `interrupt`.
- External-store, react-pi and react-opencode imports keep the `interrupt` reason for approvals, unchanged from today.
- `external-store-thread-runtime-core.ts` now calls the shared `getContentAutoStatus` instead of an inline copy (no behavior change; `isLast` / `isRunning` still flow from the call site).

## Scope & caveats
- The normalization runs in `LocalThreadRuntimeCore.import()` and on the history adapter's `load()` path (`__internal_load` bypasses `import()` on purpose, so it applies the same helper), covering `initialMessages`, `reset()`, `import()`, and a `ThreadHistoryAdapter` that builds its result with `fromArray`. The rewrite is content-derived: `interrupt` is kept only when a resultless tool call carries an `interrupt` payload; any other `requires-action` / `interrupt` on an imported message becomes `tool-calls`, regardless of where the status came from, so a repository that went through JSON still resumes. In the local runtime a payload-less `interrupt` has no consumer (`resumeToolCall` throws, and both resume paths gate on `tool-calls`), so keeping it would only strand the message.
- A resultless tool call with no approval and no interrupt now imports as `requires-action` / `tool-calls` where it was `complete`, so its part renders as unfinished and a later `addToolResult` resumes. That matches post-#6324 external-store behavior and is what a restored pending call should do; it is covered by its own test.
- `getContentAutoStatus` is a module-level export only, not added to `internal.ts` or any barrel.
- Tests: `fromArray` / `fromBranchableArray` with an unresolved approval, a resolved result, and a resultless call; local runtime imports a paused approval (via `initialMessages`, via a history adapter `load()`, and after a JSON round-trip), approves it, and asserts the adapter runs and the message completes; an imported resultless call resumes via `addToolResult`; an imported real interrupt keeps its reason.
- Changeset: patch (`@assistant-ui/core`).
