### PR TITLE
fix(core): derive requires-action in the external-store convertMessage path

### DIFF
--- a/.changeset/external-store-requires-action.md
+++ b/.changeset/external-store-requires-action.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: derive requires-action status for pending and interrupted tool calls in the external-store convertMessage path

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -12,7 +12,12 @@ import {
   fromThreadMessageLike,
   type ThreadMessageLike,
 } from "../../runtime/utils/thread-message-like";
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import {
+  getAutoStatus,
+  isAutoStatus,
+  isInterruptedToolCall,
+  isPendingToolCall,
+} from "../../runtime/utils/auto-status";
 import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { generateErrorMessageId } from "../../utils/id";
@@ -28,24 +33,6 @@ import type { MessageTiming } from "../../types/message";
 const generatedFallbackMessages = new WeakSet<object>();
 
 export type JoinStrategy = "concat-content" | "none";
-
-type ThreadMessageLikeContentItem = Exclude<
-  ThreadMessageLike["content"],
-  string
->[number];
-
-const isPendingToolCall = (c: ThreadMessageLikeContentItem): boolean =>
-  c.type === "tool-call" && c.result === undefined;
-
-const isInterruptedToolCall = (c: ThreadMessageLikeContentItem): boolean => {
-  if (c.type !== "tool-call" || c.result !== undefined) return false;
-  return (
-    c.interrupt != null ||
-    (c.approval != null &&
-      c.approval.approved === undefined &&
-      c.approval.resolution === undefined)
-  );
-};
 
 export namespace useExternalMessageConverter {
   export type Message =

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -39,6 +39,29 @@ const AUTO_STATUS_INTERRUPT = Object.freeze(
 export const isAutoStatus = (status: MessageStatus) =>
   (status as any)[symbolAutoStatus] === true;
 
+type ToolCallStatusPart = {
+  readonly type: string;
+  readonly result?: unknown;
+  readonly interrupt?: unknown;
+  readonly approval?: {
+    readonly approved?: boolean | undefined;
+    readonly resolution?: string | undefined;
+  };
+};
+
+export const isPendingToolCall = (part: ToolCallStatusPart): boolean =>
+  part.type === "tool-call" && part.result === undefined;
+
+export const isInterruptedToolCall = (part: ToolCallStatusPart): boolean => {
+  if (part.type !== "tool-call" || part.result !== undefined) return false;
+  return (
+    part.interrupt != null ||
+    (part.approval != null &&
+      part.approval.approved === undefined &&
+      part.approval.resolution === undefined)
+  );
+};
+
 export const getAutoStatus = (
   isLast: boolean,
   isRunning: boolean,

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -19,7 +19,12 @@ import {
   FALLBACK_ID_PREFIX,
 } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "./thread-message-converter";
-import { getAutoStatus, isAutoStatus } from "../../runtime/utils/auto-status";
+import {
+  getAutoStatus,
+  isAutoStatus,
+  isInterruptedToolCall,
+  isPendingToolCall,
+} from "../../runtime/utils/auto-status";
 import {
   fromThreadMessageLike,
   type ThreadMessageLike,
@@ -279,20 +284,24 @@ export class ExternalStoreThreadRuntimeCore
             if (!store.convertMessage) return m;
 
             const isLast = idx === (store.messages?.length ?? 0) - 1;
-            const autoStatus = getAutoStatus(
-              isLast,
-              isRunning,
-              false,
-              false,
-              undefined,
-            );
+            const contentAutoStatus = (
+              content: ThreadMessageLike["content"] | ThreadMessage["content"],
+            ) =>
+              getAutoStatus(
+                isLast,
+                isRunning,
+                typeof content === "object" &&
+                  content.some(isInterruptedToolCall),
+                typeof content === "object" && content.some(isPendingToolCall),
+                undefined,
+              );
             const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
 
             if (
               cache &&
               (cache.role !== "assistant" ||
                 !isAutoStatus(cache.status) ||
-                cache.status === autoStatus)
+                cache.status === contentAutoStatus(cache.content))
             ) {
               if (
                 cache.id.startsWith(FALLBACK_ID_PREFIX) &&
@@ -309,7 +318,7 @@ export class ExternalStoreThreadRuntimeCore
             const newMessage = fromThreadMessageLike(
               messageLike,
               fallbackId,
-              autoStatus,
+              contentAutoStatus(messageLike.content),
             );
             bindExternalStoreMessage(newMessage, m);
             return newMessage;

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -1258,3 +1258,102 @@ describe("ExternalStoreThreadRuntimeCore - id-less converted messages", () => {
     expect(runtime.messages.map(textOf)).toEqual(["id-less", "kept"]);
   });
 });
+
+describe("ExternalStoreThreadRuntimeCore - convertMessage status derivation", () => {
+  const identity = (m: ThreadMessageLike): ThreadMessageLike => m;
+
+  const toolCallMessage = (part: Record<string, unknown>): ThreadMessageLike =>
+    ({
+      id: "a1",
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "t1",
+          toolName: "search",
+          args: {},
+          argsText: "{}",
+          ...part,
+        },
+      ],
+    }) as ThreadMessageLike;
+
+  const user: ThreadMessageLike = { id: "u1", role: "user", content: "run it" };
+
+  const statusOf = (message: ThreadMessageLike, isRunning = false) => {
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages: [user, message],
+        convertMessage: identity,
+        setMessages: vi.fn(),
+        isRunning,
+      }),
+    );
+    const last = runtime.messages[1]!;
+    if (last.role !== "assistant") throw new Error("expected assistant");
+    return last.status;
+  };
+
+  it("derives requires-action for an unresolved tool call", () => {
+    expect(statusOf(toolCallMessage({}))).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+
+  it("derives requires-action interrupt for an interrupted tool call", () => {
+    expect(
+      statusOf(
+        toolCallMessage({ interrupt: { type: "human", payload: null } }),
+      ),
+    ).toMatchObject({ type: "requires-action", reason: "interrupt" });
+  });
+
+  it("derives requires-action interrupt for an unresolved approval gate", () => {
+    expect(
+      statusOf(toolCallMessage({ approval: { id: "ap-1" } })),
+    ).toMatchObject({ type: "requires-action", reason: "interrupt" });
+  });
+
+  it("keeps complete for a tool call with a result", () => {
+    expect(statusOf(toolCallMessage({ result: "ok" }))).toMatchObject({
+      type: "complete",
+    });
+  });
+
+  it("keeps running while the last message is streaming", () => {
+    expect(statusOf(toolCallMessage({}), true)).toMatchObject({
+      type: "running",
+    });
+  });
+
+  it("recomputes the cached status when the run stops", () => {
+    const messages = [user, toolCallMessage({})];
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({
+        messages,
+        convertMessage: identity,
+        setMessages: vi.fn(),
+        isRunning: true,
+      }),
+    );
+    expect(runtime.messages[1]).toMatchObject({ status: { type: "running" } });
+
+    runtime.__internal_setAdapter(
+      makeStore({
+        messages,
+        convertMessage: identity,
+        setMessages: vi.fn(),
+        isRunning: false,
+      }),
+    );
+    const settled = runtime.messages[1]!;
+    if (settled.role !== "assistant") throw new Error("expected assistant");
+    expect(settled.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6323

## Summary

`useExternalStoreRuntime`'s two converter entry points disagreed on message status: `useExternalMessageConverter` derives `requires-action` (reason `tool-calls` / `interrupt`) from content, while the built-in `store.convertMessage` path hard-coded both `getAutoStatus` content flags to `false`, so an assistant message with an unresolved tool call or an open interrupt/approval gate came out `complete`.

- `isPendingToolCall` / `isInterruptedToolCall` move from `external-message-converter.ts` into the framework-agnostic `runtime/utils/auto-status.ts` (typed structurally so they accept both `ThreadMessageLike` items and converted `ThreadMessage` parts — the shapes are identical); the React converter now imports them, unchanged in behavior.
- The `convertMessage` path in `ExternalStoreThreadRuntimeCore` derives both flags from content: from the fresh conversion's content when converting, and from the cached message's content in the cache-validity check (converted tool-call parts preserve `result`/`interrupt`/`approval`, and the frozen auto-status singletons keep the identity comparison working) — so a cached `running` message correctly flips to `requires-action` when the run stops.

## Why

`requires-action` drives HITL, approval, and interrupt affordances, so the same message rendered different UI depending on which entry point the adapter used. `getAutoStatus` already produces the pending/interrupt statuses when the flags are set; the store path just never passed them.

## Validation

- Six new tests in `src/tests/external-store-thread-runtime-core.test.ts`: pending tool call → `requires-action`/`tool-calls`; interrupt and open approval gate → `requires-action`/`interrupt`; result present → `complete`; last-message streaming → `running`; and cache recomputation when `isRunning` flips. The four `requires-action` assertions fail on `main`; all pass with this change.
- `@assistant-ui/core`: 1440/1443 passing (the 3 failures are pre-existing `AssistantCloudThreadHistoryAdapter` telemetry failures, reproduced identically with this change stashed). `@assistant-ui/react`: 420/420.
- `tsc --noEmit` output is byte-identical to `main`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YR1Ot2pB72CHNjOTI-Vw6khv8l9CmhzvU9_XFFoyaChe2ubsdRNcLRKVzC4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->