### PR TITLE
refactor: fold executing-tool running into the external-store runtime

### DIFF
--- a/.changeset/executing-tools-running-fold.md
+++ b/.changeset/executing-tools-running-fold.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/eve": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor: derive executing-tool running state inside the external-store runtime; adapters now pass raw provider isRunning.

--- a/.changeset/executing-tools-running-fold.md
+++ b/.changeset/executing-tools-running-fold.md
@@ -9,3 +9,4 @@
 ---
 
 refactor: derive executing-tool running state inside the external-store runtime; adapters now pass raw provider isRunning.
+the assistant transport runtime enables tool invocations too, so it now keeps the thread running while a client tool executes instead of reporting idle.

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -236,10 +236,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
-  const isRunning =
-    chatHelpers.status === "submitted" ||
-    chatHelpers.status === "streaming" ||
-    hasExecutingTools;
+  const providerIsRunning =
+    chatHelpers.status === "submitted" || chatHelpers.status === "streaming";
+  const isRunning = providerIsRunning || hasExecutingTools;
 
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 
@@ -364,7 +363,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     messages.length === 0;
 
   const runtime = useExternalStoreRuntime({
-    isRunning,
+    isRunning: providerIsRunning,
     ...(shouldFeedRepository
       ? { messageRepository: exportedMessageRepository }
       : { messages }),

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -40,7 +40,10 @@ import {
   MessageRepository,
 } from "../../runtime/utils/message-repository";
 import { generateId } from "../../utils/id";
-import { ToolInvocationTracker } from "../tool-invocations/ToolInvocationTracker";
+import {
+  ToolInvocationTracker,
+  type ToolExecutionStatus,
+} from "../tool-invocations/ToolInvocationTracker";
 import { EMPTY_QUEUE_ITEMS } from "../../store/scopes/queue-item";
 import type { QuoteInfo } from "../../types/quote";
 import {
@@ -111,7 +114,10 @@ export class ExternalStoreThreadRuntimeCore
   }
   // Unlike `isLoading`: pass `undefined` through to preserve the `getThreadState` fallback.
   public get isRunning(): boolean | undefined {
-    return this._store.isRunning;
+    if (!this._store.unstable_enableToolInvocations) {
+      return this._store.isRunning;
+    }
+    return this._getEffectiveIsRunning(this._store);
   }
 
   protected override _getBaseMessages(): readonly ThreadMessage[] {
@@ -154,6 +160,22 @@ export class ExternalStoreThreadRuntimeCore
    * snapshot — only when `adapter.unstable_enableToolInvocations === true`.
    */
   private _toolInvocations: ToolInvocationTracker | null = null;
+  private _toolStatuses: ReadonlyMap<string, ToolExecutionStatus> = new Map();
+  private _effectiveIsRunning = false;
+
+  private _hasExecutingTools(store: ExternalStoreAdapter<any>): boolean {
+    return (
+      store.unstable_enableToolInvocations === true &&
+      this._toolInvocations !== null &&
+      [...this._toolStatuses.values()].some(
+        (status) => status.type === "executing",
+      )
+    );
+  }
+
+  private _getEffectiveIsRunning(store: ExternalStoreAdapter<any>): boolean {
+    return (store.isRunning ?? false) || this._hasExecutingTools(store);
+  }
 
   public override beginEdit(messageId: string) {
     if (!this._store.onEdit)
@@ -173,12 +195,17 @@ export class ExternalStoreThreadRuntimeCore
   public __internal_setAdapter(store: ExternalStoreAdapter<any>) {
     if (this._store === store) return;
 
-    const isRunning = store.isRunning ?? false;
+    this._updateStoreSnapshot(store);
+  }
+
+  private _updateStoreSnapshot(store: ExternalStoreAdapter<any>) {
+    const previousIsRunning = this._effectiveIsRunning;
     this.isDisabled = store.isDisabled ?? false;
     this.isSendDisabled = store.isSendDisabled ?? false;
 
     const oldStore = this._store as ExternalStoreAdapter<any> | undefined;
     this._store = store;
+    const isRunning = this._getEffectiveIsRunning(store);
     if (oldStore?.queue !== store.queue) {
       this._transformedQueue = undefined;
       store.queue?.__internal_setDispatchTransform?.((message) => {
@@ -230,7 +257,8 @@ export class ExternalStoreThreadRuntimeCore
       if (
         oldStore &&
         oldStore.isRunning === store.isRunning &&
-        oldStore.messageRepository === store.messageRepository
+        oldStore.messageRepository === store.messageRepository &&
+        previousIsRunning === isRunning
       ) {
         this._notifySubscribers();
         return;
@@ -265,7 +293,8 @@ export class ExternalStoreThreadRuntimeCore
           this._converter = new ThreadMessageConverter();
         } else if (
           oldStore.isRunning === store.isRunning &&
-          oldStore.messages === store.messages
+          oldStore.messages === store.messages &&
+          previousIsRunning === isRunning
         ) {
           this._notifySubscribers();
           // no conversion update
@@ -344,8 +373,9 @@ export class ExternalStoreThreadRuntimeCore
     // Common logic for both paths
     if (messages.length > 0) this.ensureInitialized();
 
-    if ((oldStore?.isRunning ?? false) !== (store.isRunning ?? false)) {
-      if (store.isRunning) {
+    this._effectiveIsRunning = isRunning;
+    if (previousIsRunning !== isRunning) {
+      if (isRunning) {
         this._notifyEventSubscribers("runStart", {});
       } else {
         this._notifyEventSubscribers("runEnd", {});
@@ -391,6 +421,7 @@ export class ExternalStoreThreadRuntimeCore
       if (this._toolInvocations) {
         this._toolInvocations.reset();
         this._toolInvocations = null;
+        this._toolStatuses = new Map();
         this._store.setToolStatuses?.({});
       }
       return;
@@ -434,7 +465,15 @@ export class ExternalStoreThreadRuntimeCore
             }
           },
           onStatusesChange: (statuses) => {
-            this._store.setToolStatuses?.(Object.fromEntries(statuses));
+            const hadExecutingTools = this._hasExecutingTools(this._store);
+            this._toolStatuses = statuses;
+            try {
+              this._store.setToolStatuses?.(Object.fromEntries(statuses));
+            } finally {
+              if (hadExecutingTools !== this._hasExecutingTools(this._store)) {
+                this._updateStoreSnapshot(this._store);
+              }
+            }
           },
         },
       );
@@ -442,7 +481,7 @@ export class ExternalStoreThreadRuntimeCore
 
     this._toolInvocations.setState({
       messages: this._messages,
-      isRunning: this._store.isRunning ?? false,
+      isRunning: this._getEffectiveIsRunning(this._store),
       ...(this._store.isLoading !== undefined && {
         isLoading: this._store.isLoading,
       }),
@@ -486,7 +525,7 @@ export class ExternalStoreThreadRuntimeCore
       throw new Error("Runtime does not support switching branches.");
 
     // Silently ignore branch switches while running
-    if (this._store.isRunning) {
+    if (this._getEffectiveIsRunning(this._store)) {
       return;
     }
 
@@ -558,7 +597,7 @@ export class ExternalStoreThreadRuntimeCore
       // Buffering does not start a run, so the tool-abort below must wait
       // until the queue flushes. By then the prior run (and its tools) has
       // settled.
-      if (message.steer ?? this._store.isRunning ?? false)
+      if (message.steer ?? this._getEffectiveIsRunning(this._store))
         this._store.queue.steer(message);
       else this._store.queue.enqueue(message);
       return;
@@ -600,7 +639,7 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.setMessages)
       throw new Error("Runtime does not support deleting messages.");
 
-    if (this._store.isRunning) {
+    if (this._getEffectiveIsRunning(this._store)) {
       await this._toolInvocations?.abort();
     }
 

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -114,10 +114,8 @@ export class ExternalStoreThreadRuntimeCore
   }
   // Unlike `isLoading`: pass `undefined` through to preserve the `getThreadState` fallback.
   public get isRunning(): boolean | undefined {
-    if (!this._store.unstable_enableToolInvocations) {
-      return this._store.isRunning;
-    }
-    return this._getEffectiveIsRunning(this._store);
+    if (this._hasExecutingTools(this._store)) return true;
+    return this._store.isRunning;
   }
 
   protected override _getBaseMessages(): readonly ThreadMessage[] {
@@ -162,15 +160,44 @@ export class ExternalStoreThreadRuntimeCore
   private _toolInvocations: ToolInvocationTracker | null = null;
   private _toolStatuses: ReadonlyMap<string, ToolExecutionStatus> = new Map();
   private _effectiveIsRunning = false;
+  private _inTrackerUpdate = false;
+  private _pendingRunningRefresh = false;
+
+  /**
+   * Tracker mutations initiated by this class (setState, reset) can publish
+   * status changes synchronously. Re-entering the snapshot pipeline from
+   * inside them would feed the tracker a stale snapshot and consume the
+   * restore arming a reset just installed, so the running refresh is
+   * deferred until the mutation returns and stays off the tracker.
+   */
+  private _runTrackerUpdate(fn: () => void): void {
+    this._inTrackerUpdate = true;
+    try {
+      fn();
+    } finally {
+      this._inTrackerUpdate = false;
+    }
+    if (this._pendingRunningRefresh) {
+      this._pendingRunningRefresh = false;
+      this._refreshEffectiveIsRunning();
+    }
+  }
+
+  private _refreshEffectiveIsRunning(): void {
+    const isRunning = this._getEffectiveIsRunning(this._store);
+    if (this._effectiveIsRunning === isRunning) return;
+    this._effectiveIsRunning = isRunning;
+    this._notifyEventSubscribers(isRunning ? "runStart" : "runEnd", {});
+    this._notifySubscribers();
+  }
 
   private _hasExecutingTools(store: ExternalStoreAdapter<any>): boolean {
-    return (
-      store.unstable_enableToolInvocations === true &&
-      this._toolInvocations !== null &&
-      [...this._toolStatuses.values()].some(
-        (status) => status.type === "executing",
-      )
-    );
+    if (store.unstable_enableToolInvocations !== true) return false;
+    if (this._toolInvocations === null) return false;
+    for (const status of this._toolStatuses.values()) {
+      if (status.type === "executing") return true;
+    }
+    return false;
   }
 
   private _getEffectiveIsRunning(store: ExternalStoreAdapter<any>): boolean {
@@ -402,7 +429,7 @@ export class ExternalStoreThreadRuntimeCore
 
     this._messages = this.repository.getMessages();
 
-    this._driveToolInvocations();
+    this._runTrackerUpdate(() => this._driveToolInvocations());
 
     this._notifySubscribers();
   }
@@ -471,7 +498,11 @@ export class ExternalStoreThreadRuntimeCore
               this._store.setToolStatuses?.(Object.fromEntries(statuses));
             } finally {
               if (hadExecutingTools !== this._hasExecutingTools(this._store)) {
-                this._updateStoreSnapshot(this._store);
+                if (this._inTrackerUpdate) {
+                  this._pendingRunningRefresh = true;
+                } else {
+                  this._updateStoreSnapshot(this._store);
+                }
               }
             }
           },
@@ -705,7 +736,7 @@ export class ExternalStoreThreadRuntimeCore
     // back here via __internal_setAdapter. The tracker publishes the
     // cleared status map itself, so adapter-side statuses reset only when
     // the tracker is the source of truth.
-    this._toolInvocations?.reset();
+    this._runTrackerUpdate(() => this._toolInvocations?.reset());
 
     this._store.onLoadExternalState(state);
   }
@@ -716,7 +747,7 @@ export class ExternalStoreThreadRuntimeCore
    * without run-cancel semantics (`onCancel`, composer draft restoration).
    */
   public unstable_notifySessionReset(): void {
-    this._toolInvocations?.reset();
+    this._runTrackerUpdate(() => this._toolInvocations?.reset());
     this._store.queue?.__internal_notifyCancelled?.();
   }
 

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -802,6 +802,83 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
   });
 
   describe("tool callbacks", () => {
+    it("keeps the runtime running until an executing client tool settles", async () => {
+      let resolveTool!: (value: { forecast: string }) => void;
+      const execute = vi.fn(
+        () =>
+          new Promise<{ forecast: string }>((resolve) => {
+            resolveTool = resolve;
+          }),
+      );
+      const core = new ExternalStoreThreadRuntimeCore(
+        {
+          getModelContext: () => ({
+            tools: {
+              weatherSearch: {
+                parameters: { type: "object", properties: {} },
+                execute,
+              },
+            },
+          }),
+        },
+        createBaseAdapter({
+          unstable_enableToolInvocations: true,
+          isRunning: false,
+        }),
+      );
+      const onRunEnd = vi.fn();
+      const onUpdate = vi.fn();
+      core.unstable_on("runEnd", onRunEnd);
+      core.subscribe(onUpdate);
+
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          unstable_enableToolInvocations: true,
+          isRunning: false,
+          messages: [
+            {
+              ...createAssistantMessage("a1"),
+              status: { type: "requires-action", reason: "tool-calls" },
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "tc1",
+                  toolName: "weatherSearch",
+                  args: { city: "London" },
+                  argsText: '{"city":"London"}',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      await vi.waitFor(() => expect(core.isRunning).toBe(true));
+      expect(onRunEnd).not.toHaveBeenCalled();
+
+      onUpdate.mockClear();
+      resolveTool({ forecast: "sunny" });
+
+      await vi.waitFor(() => expect(core.isRunning).toBe(false));
+      expect(onRunEnd).toHaveBeenCalledOnce();
+      expect(onUpdate).toHaveBeenCalled();
+    });
+
+    it("mirrors the adapter running value when tool invocations are disabled", () => {
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter(),
+      );
+
+      expect(core.isRunning).toBeUndefined();
+
+      core.__internal_setAdapter(createBaseAdapter({ isRunning: false }));
+      expect(core.isRunning).toBe(false);
+
+      core.__internal_setAdapter(createBaseAdapter({ isRunning: true }));
+      expect(core.isRunning).toBe(true);
+    });
+
     it("handles rejected automatic tool result callbacks", async () => {
       const error = new Error("tool result failed");
       const consoleError = vi

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -937,6 +937,33 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
 
       expect(core.isRunning).toBe(false);
       expect(onRunEnd).toHaveBeenCalledOnce();
+
+      execute.mockClear();
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          unstable_enableToolInvocations: true,
+          isRunning: false,
+          messages: [
+            {
+              ...createAssistantMessage("a2"),
+              status: { type: "requires-action", reason: "tool-calls" },
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "tc2",
+                  toolName: "weatherSearch",
+                  args: { city: "Paris" },
+                  argsText: '{"city":"Paris"}',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(execute).not.toHaveBeenCalled();
+      expect(core.isRunning).toBe(false);
     });
 
     it("handles rejected automatic tool result callbacks", async () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -879,6 +879,66 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(core.isRunning).toBe(true);
     });
 
+    it("passes an undefined adapter running value through when no tool is executing", () => {
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({ unstable_enableToolInvocations: true }),
+      );
+
+      expect(core.isRunning).toBeUndefined();
+    });
+
+    it("stops running when the session resets during a tool execution", async () => {
+      const execute = vi.fn(() => new Promise<never>(() => {}));
+      const core = new ExternalStoreThreadRuntimeCore(
+        {
+          getModelContext: () => ({
+            tools: {
+              weatherSearch: {
+                parameters: { type: "object", properties: {} },
+                execute,
+              },
+            },
+          }),
+        },
+        createBaseAdapter({
+          unstable_enableToolInvocations: true,
+          isRunning: false,
+        }),
+      );
+      const onRunEnd = vi.fn();
+      core.unstable_on("runEnd", onRunEnd);
+
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          unstable_enableToolInvocations: true,
+          isRunning: false,
+          messages: [
+            {
+              ...createAssistantMessage("a1"),
+              status: { type: "requires-action", reason: "tool-calls" },
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "tc1",
+                  toolName: "weatherSearch",
+                  args: { city: "London" },
+                  argsText: '{"city":"London"}',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      await vi.waitFor(() => expect(core.isRunning).toBe(true));
+
+      core.unstable_notifySessionReset();
+
+      expect(core.isRunning).toBe(false);
+      expect(onRunEnd).toHaveBeenCalledOnce();
+    });
+
     it("handles rejected automatic tool result callbacks", async () => {
       const error = new Error("tool result failed");
       const consoleError = vi

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -200,10 +200,9 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const hasExecutingTools = Object.values(toolStatuses).some(
     (status) => status?.type === "executing",
   );
-  const isRunning =
-    agent.status === "submitted" ||
-    agent.status === "streaming" ||
-    hasExecutingTools;
+  const providerIsRunning =
+    agent.status === "submitted" || agent.status === "streaming";
+  const isRunning = providerIsRunning || hasExecutingTools;
 
   const convertedMessages = useMemo(() => {
     const createdAtByMessageId = createdAtByMessageIdRef.current;
@@ -340,7 +339,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
     messages,
-    isRunning,
+    isRunning: providerIsRunning,
     extras,
     unstable_enableToolInvocations: true,
     setToolStatuses,

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -228,7 +228,7 @@ export function useAgUiRuntime(
         isLoading: core.isLoading,
         messageRepository: core.getMessageRepository(),
         state: core.getState(),
-        isRunning,
+        isRunning: core.isRunning(),
         extras: agUiExtras.provide({
           interrupts:
             core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -443,7 +443,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
-    isRunning: effectiveIsRunning,
+    isRunning,
     isLoading: isLoadingThread,
     messages: threadMessages,
     unstable_enableToolInvocations: true,

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -409,7 +409,7 @@ const useStreamThreadRuntime = (
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
-    isRunning: effectiveIsRunning,
+    isRunning: stream.isLoading,
     isLoading: stream.isThreadLoading,
     messages: threadMessages,
     adapters,

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -700,7 +700,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
-    isRunning: effectiveIsRunning,
+    isRunning,
     isLoading: isLoadingThread,
     messages: threadMessages,
     unstable_enableToolInvocations: true,


### PR DESCRIPTION
## summary

- the external-store runtime now derives "a client tool is still executing" from its embedded ToolInvocationTracker and ORs it into the thread's running state: the isRunning getter, the optimistic assistant placeholder, runStart/runEnd edges, steer/branch/delete gating, and the tracker's own snapshot all use the effective value
- a tracker status change alone drives the refresh: async settles re-run the snapshot pipeline, while status flips published from inside a core-initiated tracker mutation (setState, reset) defer to a light running refresh so a reset's restore arming is never consumed by a stale snapshot
- the isRunning getter passes an undefined adapter value through when no tool is executing, preserving the trailing-assistant-message fallback in getThreadState
- the six adapters that hand-derived the overlay (ai-sdk, eve, react-ag-ui, react-google-adk, react-langchain, react-langgraph) now pass raw provider running to the store; their local overlay stays only where it feeds adapter-local streaming timing and cancel gating
- the assistant transport runtime also enables tool invocations and previously reported idle while a client tool executed; it now inherits the same running semantics from core
- with unstable_enableToolInvocations off the code path is unchanged

## test plan

### already verified

- [x] core external-store, tool-invocations, and the extended contract tests (undefined passthrough, session reset during execution, restore arming survives into the next snapshot): all green
- [x] full vitest suites: ai-sdk 254, eve 136, react-ag-ui 465, react-google-adk 323, react-langchain 117, react-langgraph 290, all green

### reviewer should verify

- [ ] with a client-side tool still executing after the provider stream settles, the thread keeps reporting running (cancel stays available) and run-end fires once when the tool finishes