### PR TITLE
fix(react-ink): reset fallback elapsed time per run

### DIFF
--- a/.changeset/react-ink-elapsed-timer.md
+++ b/.changeset/react-ink-elapsed-timer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: reset fallback elapsed time when each run starts

--- a/packages/react-ink/src/primitives/loading/LoadingElapsedTime.test.tsx
+++ b/packages/react-ink/src/primitives/loading/LoadingElapsedTime.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "ink-testing-library";
+
+const h = vi.hoisted(() => ({
+  isRunning: false,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: <T,>(
+      selector: (state: {
+        thread: { isRunning: boolean; messages: never[] };
+      }) => T,
+    ) =>
+      selector({
+        thread: { isRunning: h.isRunning, messages: [] },
+      }),
+  };
+});
+
+import { LoadingElapsedTime } from "./LoadingElapsedTime";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  h.isRunning = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("LoadingElapsedTime", () => {
+  it("starts the fallback timer when each run begins", async () => {
+    const instance = render(<LoadingElapsedTime />);
+
+    vi.setSystemTime(120_000);
+    h.isRunning = true;
+    instance.rerender(<LoadingElapsedTime />);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(instance.lastFrame()).toContain("(0s)");
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(instance.lastFrame()).toContain("(2s)");
+
+    h.isRunning = false;
+    instance.rerender(<LoadingElapsedTime />);
+    vi.setSystemTime(240_000);
+    h.isRunning = true;
+    instance.rerender(<LoadingElapsedTime />);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(instance.lastFrame()).toContain("(0s)");
+  });
+});

--- a/packages/react-ink/src/primitives/loading/LoadingElapsedTime.tsx
+++ b/packages/react-ink/src/primitives/loading/LoadingElapsedTime.tsx
@@ -37,6 +37,9 @@ export const LoadingElapsedTime = ({
   useEffect(() => {
     if (!isRunning) return;
 
+    fallbackStartTimeRef.current = Date.now();
+    setNow(fallbackStartTimeRef.current);
+
     const interval = setInterval(() => {
       setNow(Date.now());
     }, 1000);


### PR DESCRIPTION
## Summary

- reset the local fallback clock whenever a thread transitions into a running state
- preserve runtime stream timing metadata as the preferred start time
- add a regression test covering idle time and repeated runs while the primitive stays mounted

## Why

`LoadingPrimitive.ElapsedTime` initialized its fallback start time only when the component mounted. In standalone layouts that keep the primitive mounted, a later run inherited that old timestamp and could jump from `0s` to minutes elapsed on the first timer update.

## Test plan

- `pnpm test` in `packages/react-ink` (26 files, 256 tests)
- `pnpm lint`
- `pnpm --filter @assistant-ui/react-ink build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TUwIosqbp-JZGAnKScziUwbwAN8-QkJXQrMHB82pupyHDcffS8ZCWSsH5uE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->