### PR TITLE
fix(core): refresh static suggestions on config changes

### DIFF
--- a/.changeset/static-suggestions-refresh.md
+++ b/.changeset/static-suggestions-refresh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: refresh static suggestions when their configuration changes

--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -15,24 +15,19 @@ The Suggestions API allows you to configure a list of suggested prompts that are
 Configure suggestions using the `Suggestions()` API in your runtime provider:
 
 ```tsx
-import { useMemo } from "react";
 import { AuiConfig, Tools, Suggestions } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/ai-sdk";
 
 function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   const runtime = useChatRuntime();
-  const suggestions = useMemo(
-    () => [
-      "What can you help me with?",
-      "Tell me a joke",
-      "Explain quantum computing",
-    ],
-    [],
-  );
 
   const config = AuiConfig({
     tools: Tools({ toolkit: myToolkit }),
-    suggestions: Suggestions(suggestions),
+    suggestions: Suggestions([
+      "What can you help me with?",
+      "Tell me a joke",
+      "Explain quantum computing",
+    ]),
   });
 
   return (

--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -15,19 +15,24 @@ The Suggestions API allows you to configure a list of suggested prompts that are
 Configure suggestions using the `Suggestions()` API in your runtime provider:
 
 ```tsx
+import { useMemo } from "react";
 import { AuiConfig, Tools, Suggestions } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/ai-sdk";
 
 function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   const runtime = useChatRuntime();
-
-  const config = AuiConfig({
-    tools: Tools({ toolkit: myToolkit }),
-    suggestions: Suggestions([
+  const suggestions = useMemo(
+    () => [
       "What can you help me with?",
       "Tell me a joke",
       "Explain quantum computing",
-    ]),
+    ],
+    [],
+  );
+
+  const config = AuiConfig({
+    tools: Tools({ toolkit: myToolkit }),
+    suggestions: Suggestions(suggestions),
   });
 
   return (

--- a/packages/core/src/store/clients/suggestions.test.ts
+++ b/packages/core/src/store/clients/suggestions.test.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { createTapRoot, flushTapSync, useResource } from "@assistant-ui/tap";
+import { describe, expect, it } from "vitest";
+import { Suggestions, type SuggestionConfig } from "./suggestions";
+
+describe("Suggestions", () => {
+  it("updates when the configured suggestions change", () => {
+    let setSuggestions!: (suggestions: SuggestionConfig[]) => void;
+    const root = createTapRoot(function SuggestionsRoot() {
+      const [suggestions, setValue] = useState<SuggestionConfig[]>([
+        "account-a",
+      ]);
+      setSuggestions = setValue;
+      return useResource(Suggestions(suggestions));
+    });
+
+    try {
+      expect(root.getValue().getState().suggestions[0]?.prompt).toBe(
+        "account-a",
+      );
+
+      flushTapSync(() => setSuggestions(["account-b"]));
+
+      expect(root.getValue().getState().suggestions[0]?.prompt).toBe(
+        "account-b",
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+});

--- a/packages/core/src/store/clients/suggestions.ts
+++ b/packages/core/src/store/clients/suggestions.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { resource, withKey } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import { useClientLookup } from "@assistant-ui/store/client";
@@ -40,26 +40,25 @@ const useSuggestionsClient = (
 const useStaticSuggestions = (
   suggestions?: SuggestionConfig[],
 ): ClientOutput<"suggestions"> => {
-  const [state] = useState<SuggestionsState>(() => {
-    const normalizedSuggestions = (suggestions ?? []).map((s) => {
-      if (typeof s === "string") {
+  const state = useMemo<SuggestionsState>(
+    () => ({
+      suggestions: (suggestions ?? []).map((s) => {
+        if (typeof s === "string") {
+          return {
+            title: s,
+            label: "",
+            prompt: s,
+          };
+        }
         return {
-          title: s,
-          label: "",
-          prompt: s,
+          title: s.title,
+          label: s.label,
+          prompt: s.prompt,
         };
-      }
-      return {
-        title: s.title,
-        label: s.label,
-        prompt: s.prompt,
-      };
-    });
-
-    return {
-      suggestions: normalizedSuggestions,
-    };
-  });
+      }),
+    }),
+    [suggestions],
+  );
 
   return useSuggestionsClient(state);
 };


### PR DESCRIPTION
## Summary

- derive normalized static suggestion state from the current configuration
- refresh suggestion clients when account, workspace, or application state changes the configured array
- add a Tap regression test covering an in-place resource update

## Why

`Suggestions()` initialized its state once with `useState`, so later configuration changes were ignored. This contradicted the documented dynamic-suggestions workflow and could leave prompts from a previous application scope visible.

## Test plan

- `pnpm test` in `packages/core` (136 files, 1464 tests)
- `pnpm lint`
- `pnpm --filter @assistant-ui/core build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nplk7mbEEkhaahfq9sEF522UlhPzv0_MFmlmaUZmrteSmkkeWkDZOE02Z9I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->