### PR TITLE
fix(ui): render kit shimmer trigger labels as single nodes

### DIFF
--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -195,18 +195,12 @@ function ReasoningTrigger({
       />
       <span
         data-slot="reasoning-trigger-label"
-        className="aui-reasoning-trigger-label-wrapper relative inline-block leading-none tabular-nums"
+        className={cn(
+          "aui-reasoning-trigger-label-wrapper relative inline-block leading-none tabular-nums",
+          active && "shimmer motion-reduce:animate-none",
+        )}
       >
-        <span>Reasoning{durationText}</span>
-        {active ? (
-          <span
-            aria-hidden
-            data-slot="reasoning-trigger-shimmer"
-            className="aui-reasoning-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
-          >
-            Reasoning{durationText}
-          </span>
-        ) : null}
+        Reasoning{durationText}
       </span>
       <ChevronDownIcon
         data-slot="reasoning-trigger-chevron"

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -196,7 +196,7 @@ function ReasoningTrigger({
       <span
         data-slot="reasoning-trigger-label"
         className={cn(
-          "aui-reasoning-trigger-label-wrapper relative inline-block leading-none tabular-nums",
+          "aui-reasoning-trigger-label-wrapper inline-block leading-none tabular-nums",
           active && "shimmer motion-reduce:animate-none",
         )}
       >

--- a/packages/ui/src/components/assistant-ui/shimmer-labels.test.tsx
+++ b/packages/ui/src/components/assistant-ui/shimmer-labels.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Reasoning } from "./reasoning";
+import { ToolFallback } from "./tool-fallback";
+import { ToolGroup } from "./tool-group";
+
+const cases: Record<string, { element: ReactElement; text: string }> = {
+  "reasoning trigger": {
+    element: (
+      <Reasoning.Root>
+        <Reasoning.Trigger active duration={3} />
+      </Reasoning.Root>
+    ),
+    text: "Reasoning (3s)",
+  },
+  "tool-fallback trigger": {
+    element: (
+      <ToolFallback.Root>
+        <ToolFallback.Trigger toolName="Search" status={{ type: "running" }} />
+      </ToolFallback.Root>
+    ),
+    text: "Search",
+  },
+  "tool-group trigger": {
+    element: (
+      <ToolGroup.Root>
+        <ToolGroup.Trigger count={3} active />
+      </ToolGroup.Root>
+    ),
+    text: "3 tool calls",
+  },
+};
+
+afterEach(cleanup);
+
+describe("shimmer labels", () => {
+  it.each(Object.entries(cases))(
+    "%s keeps shimmer text outside aria-hidden subtrees",
+    (_name, { element }) => {
+      const { container } = render(element);
+      const shimmerLabels = container.querySelectorAll(".shimmer");
+
+      expect(shimmerLabels.length).toBeGreaterThan(0);
+      for (const shimmerLabel of shimmerLabels) {
+        expect(shimmerLabel.closest('[aria-hidden="true"]')).toBeNull();
+      }
+    },
+  );
+
+  it.each(Object.entries(cases))(
+    "%s renders its active shimmer label's text exactly once",
+    (_name, { element, text }) => {
+      const { getAllByText } = render(element);
+
+      expect(getAllByText(text)).toHaveLength(1);
+    },
+  );
+});

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -161,7 +161,7 @@ function ToolFallbackTrigger({
       <span
         data-slot="tool-fallback-trigger-label"
         className={cn(
-          "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
+          "aui-tool-fallback-trigger-label-wrapper inline-block text-start leading-none",
           isCancelled && "text-muted-foreground line-through",
           isRunning && "shimmer motion-reduce:animate-none",
         )}

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -163,20 +163,10 @@ function ToolFallbackTrigger({
         className={cn(
           "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
           isCancelled && "text-muted-foreground line-through",
+          isRunning && "shimmer motion-reduce:animate-none",
         )}
       >
-        <span>
-          {label}: <b>{toolName}</b>
-        </span>
-        {isRunning && (
-          <span
-            aria-hidden
-            data-slot="tool-fallback-trigger-shimmer"
-            className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
-          >
-            {label}: <b>{toolName}</b>
-          </span>
-        )}
+        {label}: <b>{toolName}</b>
       </span>
       <ToolFallbackDuration />
       <ChevronDownIcon

--- a/packages/ui/src/components/assistant-ui/tool-group.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-group.tsx
@@ -124,7 +124,7 @@ function ToolGroupTrigger({
       <span
         data-slot="tool-group-trigger-label"
         className={cn(
-          "aui-tool-group-trigger-label-wrapper relative inline-block text-start text-xs leading-none font-medium",
+          "aui-tool-group-trigger-label-wrapper inline-block text-start text-xs leading-none font-medium",
           "group-data-[variant=ghost]/tool-group-root:font-normal",
           "group-data-[variant=outline]/tool-group-root:grow",
           "group-data-[variant=muted]/tool-group-root:grow",

--- a/packages/ui/src/components/assistant-ui/tool-group.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-group.tsx
@@ -124,22 +124,14 @@ function ToolGroupTrigger({
       <span
         data-slot="tool-group-trigger-label"
         className={cn(
-          "aui-tool-group-trigger-label-wrapper relative inline-block text-start leading-none font-medium",
+          "aui-tool-group-trigger-label-wrapper relative inline-block text-start text-xs leading-none font-medium",
           "group-data-[variant=ghost]/tool-group-root:font-normal",
           "group-data-[variant=outline]/tool-group-root:grow",
           "group-data-[variant=muted]/tool-group-root:grow",
+          active && "shimmer motion-reduce:animate-none",
         )}
       >
-        <span className="text-xs">{label}</span>
-        {active && (
-          <span
-            aria-hidden
-            data-slot="tool-group-trigger-shimmer"
-            className="aui-tool-group-trigger-shimmer shimmer pointer-events-none absolute inset-0 text-xs motion-reduce:animate-none"
-          >
-            {label}
-          </span>
-        )}
+        {label}
       </span>
       <ChevronDownIcon
         data-slot="tool-group-trigger-chevron"

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -161,7 +161,7 @@ function ToolFallbackTrigger({
       <span
         data-slot="tool-fallback-trigger-label"
         className={cn(
-          "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
+          "aui-tool-fallback-trigger-label-wrapper inline-block text-start leading-none",
           isCancelled && "text-muted-foreground line-through",
           isRunning && "shimmer motion-reduce:animate-none",
         )}

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -163,20 +163,10 @@ function ToolFallbackTrigger({
         className={cn(
           "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
           isCancelled && "text-muted-foreground line-through",
+          isRunning && "shimmer motion-reduce:animate-none",
         )}
       >
-        <span>
-          {label}: <b>{toolName}</b>
-        </span>
-        {isRunning && (
-          <span
-            aria-hidden
-            data-slot="tool-fallback-trigger-shimmer"
-            className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
-          >
-            {label}: <b>{toolName}</b>
-          </span>
-        )}
+        {label}: <b>{toolName}</b>
       </span>
       <ToolFallbackDuration />
       <ChevronDownIcon


### PR DESCRIPTION
## summary

- the reasoning, tool-fallback, and tool-group collapsible triggers rendered their label twice: a visible span plus an aria-hidden absolutely positioned shimmer overlay with the same text, so selecting and copying yielded doubled text ("Reasoning (3s)Reasoning (3s)")
- this is the same defect family #5810 fixed in the elements tree with the single-node shimmer doctrine; the kit tree was never swept. tw-shimmer's gradient base is currentColor, so one node paints both the base ink and the sweep
- each trigger now toggles the shimmer class on its single visible label node; the aria-hidden overlay (and its aui-*-trigger-shimmer class hook) is removed
- new shimmer-labels.test.tsx extends the #5810 assertions to the kit: shimmer never inside aria-hidden, and the label text renders exactly once while active
- templates/minimal's tool-fallback.tsx copy is synced byte-equal (reasoning and tool-group have no minimal copies; tool-fallback is not in the sync OVERRIDES list)
- @assistant-ui/ui is private, so no changeset

## test plan

### already verified

- [x] packages/ui vitest: 9 files, 362 tests green including the 6 new regression assertions
- [x] cmp kit tool-fallback.tsx vs templates/minimal copy: byte-identical

### reviewer should verify

- [ ] while reasoning streams, select and copy the trigger label: the clipboard contains the label text exactly once, and the shimmer sweep still animates

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ng7fBSIL0KO5Nb8WIgteRkGPz9NqCbFmljxTZFMJoobMoomhRvt-HoVGaXg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->