### PR TITLE
chore(react): drop unreachable legacy forwarding sources

### DIFF
--- a/.changeset/drop-legacy-forwarders.md
+++ b/.changeset/drop-legacy-forwarders.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+chore: drop unreachable legacy forwarding sources.

--- a/packages/react/src/legacy-runtime/runtime/MessagePartRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/MessagePartRuntime.ts
@@ -1,2 +1,0 @@
-export type { MessagePartState, MessagePartRuntime } from "@assistant-ui/core";
-export { MessagePartRuntimeImpl } from "@assistant-ui/core/internal";

--- a/packages/react/src/legacy-runtime/runtime/MessageRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/MessageRuntime.ts
@@ -1,3 +1,0 @@
-export type { MessageState, MessageRuntime } from "@assistant-ui/core";
-export type { MessageStateBinding } from "@assistant-ui/core/internal";
-export { MessageRuntimeImpl } from "@assistant-ui/core/internal";

--- a/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime/ThreadListRuntime.ts
@@ -1,4 +1,0 @@
-export type { ThreadListState, ThreadListRuntime } from "@assistant-ui/core";
-
-export type { ThreadListRuntimeCoreBinding } from "@assistant-ui/core/internal";
-export { ThreadListRuntimeImpl } from "@assistant-ui/core/internal";


### PR DESCRIPTION
## summary

- deletes three legacy-runtime forwarding files (runtime/MessageRuntime.ts, MessagePartRuntime.ts, ThreadListRuntime.ts) that only re-exported names from @assistant-ui/core and are referenced by nothing: repo-wide greps across every import spelling find zero references, the public barrel exports the same names directly from core, and the package exports map exposes only "." so the removed dist files were never reachable
- no shipped export changes; the barrel is untouched

## test plan

### already verified

- [x] @assistant-ui/react build green (9/9 tasks) and full vitest suite 50 files, 420 tests green (rerun independently)
- [x] post-deletion reference grep: zero hits

no reviewer steps beyond the greps above; source-only deletion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ScMQjORyzz-nsf8psQMV2Btdm_vJxCz_T3fdSWaYr7BoQaN2Jkc3CvzD_XM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->