### PR TITLE
docs: fix mismatch spelling in interactables guide

### DIFF
--- a/apps/docs/content/docs/tools/interactables.mdx
+++ b/apps/docs/content/docs/tools/interactables.mdx
@@ -663,7 +663,7 @@ aui.interactables.importState(snapshot);
 
 <Callout type="warn">
   If you change a Zod schema after state has been persisted, the loaded snapshot
-  may silently mis-match the new shape. The adapter does a shallow merge, so
+  may silently mismatch the new shape. The adapter does a shallow merge, so
   extra fields are preserved and missing fields keep their initial values, but
   type mismatches are not caught at runtime. To avoid silent corruption, version
   your schema key (e.g. `"taskBoard_v2"`) or namespace it by schema hash


### PR DESCRIPTION
## Summary

- Correct the nonstandard `mis-match` spelling to `mismatch` in the schema evolution warning for interactable state.

## Validation

- `uvx codespell apps/docs/content/docs/tools/interactables.mdx`
- `git diff --check`

## Changeset

Not needed; this only updates the private docs application.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wcQjc8ExrOW5MV8i-YgPhC0m4ZtaWDVqOdxs9BZ6jSOXnjV5sQD00XNfQoY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->