### PR TITLE
fix(react): re-assert the top-anchor pin after a layout-induced scroll clamp

### DIFF
--- a/.changeset/webkit-top-anchor-pin.md
+++ b/.changeset/webkit-top-anchor-pin.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: re-assert the top-anchor pin after a layout-induced scroll clamp on WebKit

--- a/.changeset/webkit-top-anchor-pin.md
+++ b/.changeset/webkit-top-anchor-pin.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: re-assert the top-anchor pin after a layout-induced scroll clamp on WebKit
+fix: restore the pre-clamp viewport position after a layout-induced scroll clamp on WebKit

--- a/packages/react/src/primitives/thread/topAnchor/createReserveObservers.ts
+++ b/packages/react/src/primitives/thread/topAnchor/createReserveObservers.ts
@@ -1,8 +1,16 @@
 "use client";
 
-export const createReserveObservers = (onChange: () => void) => {
-  const resizeObserver = new ResizeObserver(onChange);
-  const mutationObserver = new MutationObserver(onChange);
+export type ReserveObserverChange =
+  | { type: "resize" }
+  | { type: "mutation"; records: readonly MutationRecord[] };
+
+export const createReserveObservers = (
+  onChange: (change: ReserveObserverChange) => void,
+) => {
+  const resizeObserver = new ResizeObserver(() => onChange({ type: "resize" }));
+  const mutationObserver = new MutationObserver((records) =>
+    onChange({ type: "mutation", records }),
+  );
 
   let observedViewport: HTMLElement | null = null;
   let observedAnchor: HTMLElement | null = null;

--- a/packages/react/src/primitives/thread/topAnchor/createReserveObservers.ts
+++ b/packages/react/src/primitives/thread/topAnchor/createReserveObservers.ts
@@ -1,16 +1,8 @@
 "use client";
 
-export type ReserveObserverChange =
-  | { type: "resize" }
-  | { type: "mutation"; records: readonly MutationRecord[] };
-
-export const createReserveObservers = (
-  onChange: (change: ReserveObserverChange) => void,
-) => {
-  const resizeObserver = new ResizeObserver(() => onChange({ type: "resize" }));
-  const mutationObserver = new MutationObserver((records) =>
-    onChange({ type: "mutation", records }),
-  );
+export const createReserveObservers = (onChange: () => void) => {
+  const resizeObserver = new ResizeObserver(onChange);
+  const mutationObserver = new MutationObserver(onChange);
 
   let observedViewport: HTMLElement | null = null;
   let observedAnchor: HTMLElement | null = null;

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -331,7 +331,7 @@ describe("mountTopAnchorReserve", () => {
     expect(reserve.style.height).toBe("0px");
   });
 
-  it("re-pins after a layout-induced scroll clamp", () => {
+  const mountPinnedViewport = () => {
     const viewport = document.createElement("div");
     const anchor = document.createElement("div");
     const target = document.createElement("div");
@@ -365,17 +365,14 @@ describe("mountTopAnchorReserve", () => {
     viewport.scrollTop = 220;
     viewport.dispatchEvent(new Event("scroll"));
 
-    defineReadonlyNumber(viewport, "scrollHeight", 500);
+    return { viewport, anchor, target, store, setState };
+  };
+
+  it("restores the pre-clamp position after an unattributed scrollTop drop", () => {
+    const { viewport } = mountPinnedViewport();
+
     viewport.scrollTop = 100;
     viewport.dispatchEvent(new Event("scroll"));
-
-    setState({
-      turnAnchor: "top",
-      element: { viewport, anchor, target },
-      targetConfig: numericClamp,
-      topAnchorTurn: activeTopAnchorTurn,
-    });
-    vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
@@ -385,40 +382,12 @@ describe("mountTopAnchorReserve", () => {
     });
   });
 
-  it("does not re-pin after the user scrolls away", () => {
-    const viewport = document.createElement("div");
-    const anchor = document.createElement("div");
-    const target = document.createElement("div");
-    document.body.append(target);
+  it("leaves a wheel-attributed upward scroll alone", () => {
+    const { viewport, setState, anchor, target } = mountPinnedViewport();
 
-    defineReadonlyNumber(viewport, "offsetTop", 0);
-    defineReadonlyNumber(viewport, "clientHeight", 400);
-    defineReadonlyNumber(viewport, "scrollHeight", 560);
-    defineReadonlyNumber(anchor, "offsetTop", 220);
-    defineReadonlyNumber(anchor, "offsetHeight", 64);
-    anchor.dataset.messageId = "msg-1";
-    viewport.scrollTo = vi.fn();
-
-    const { store, setState } = makeStore({
-      turnAnchor: "top",
-      element: { viewport, anchor, target },
-      targetConfig: numericClamp,
-      topAnchorTurn: activeTopAnchorTurn,
-    });
-
-    mountTopAnchorReserve(store);
-    vi.runOnlyPendingTimers();
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-
-    viewport.scrollTop = 220;
-    viewport.dispatchEvent(new Event("scroll"));
-
+    viewport.dispatchEvent(new Event("wheel"));
     viewport.scrollTop = 100;
     viewport.dispatchEvent(new Event("scroll"));
-
-    defineReadonlyNumber(viewport, "scrollHeight", 500);
     setState({
       turnAnchor: "top",
       element: { viewport, anchor, target },
@@ -431,34 +400,45 @@ describe("mountTopAnchorReserve", () => {
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
   });
 
-  it("pins the next turn normally after a user scroll released the previous pin", () => {
-    const viewport = document.createElement("div");
-    const anchor = document.createElement("div");
-    const target = document.createElement("div");
-    document.body.append(target);
+  it("leaves a keyboard-attributed upward scroll alone", () => {
+    const { viewport, setState, anchor, target } = mountPinnedViewport();
 
-    defineReadonlyNumber(viewport, "offsetTop", 0);
-    defineReadonlyNumber(viewport, "clientHeight", 400);
-    defineReadonlyNumber(viewport, "scrollHeight", 560);
-    defineReadonlyNumber(anchor, "offsetTop", 220);
-    defineReadonlyNumber(anchor, "offsetHeight", 64);
-    anchor.dataset.messageId = "msg-1";
-    viewport.scrollTo = vi.fn();
-
-    const { store, setState } = makeStore({
+    viewport.dispatchEvent(new Event("keydown"));
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+    setState({
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
       topAnchorTurn: activeTopAnchorTurn,
     });
-
-    mountTopAnchorReserve(store);
     vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
-    viewport.scrollTop = 220;
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves upward scrolls alone while a pointer drag is held", () => {
+    const { viewport } = mountPinnedViewport();
+
+    viewport.dispatchEvent(new Event("pointerdown"));
+    viewport.scrollTop = 180;
     viewport.dispatchEvent(new Event("scroll"));
-    viewport.dispatchEvent(new Event("wheel"));
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+    window.dispatchEvent(new Event("pointerup"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the next turn normally after a clamp restore", () => {
+    const { viewport, setState } = mountPinnedViewport();
+
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
 
     const nextAnchor = document.createElement("div");
     const nextTarget = document.createElement("div");
@@ -476,7 +456,7 @@ describe("mountTopAnchorReserve", () => {
     vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(3);
     expect(viewport.scrollTo).toHaveBeenLastCalledWith({
       top: 480,
       behavior: "smooth",

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -331,6 +331,158 @@ describe("mountTopAnchorReserve", () => {
     expect(reserve.style.height).toBe("0px");
   });
 
+  it("re-pins after a layout-induced scroll clamp", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    document.body.append(target);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    anchor.dataset.messageId = "msg-1";
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
+      top: 220,
+      behavior: "smooth",
+    });
+
+    viewport.scrollTop = 220;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    defineReadonlyNumber(viewport, "scrollHeight", 500);
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
+      top: 220,
+      behavior: "instant",
+    });
+  });
+
+  it("does not re-pin after the user scrolls away", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    document.body.append(target);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    anchor.dataset.messageId = "msg-1";
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+
+    viewport.scrollTop = 220;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+
+    defineReadonlyNumber(viewport, "scrollHeight", 500);
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the next turn normally after a user scroll released the previous pin", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    document.body.append(target);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    anchor.dataset.messageId = "msg-1";
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    viewport.scrollTop = 220;
+    viewport.dispatchEvent(new Event("scroll"));
+    viewport.dispatchEvent(new Event("wheel"));
+
+    const nextAnchor = document.createElement("div");
+    const nextTarget = document.createElement("div");
+    document.body.append(nextTarget);
+    defineReadonlyNumber(nextAnchor, "offsetTop", 480);
+    defineReadonlyNumber(nextAnchor, "offsetHeight", 64);
+    nextAnchor.dataset.messageId = "msg-2";
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: nextAnchor, target: nextTarget },
+      targetConfig: numericClamp,
+      topAnchorTurn: { anchorId: "user-2", targetId: "assistant-2" },
+    });
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
+      top: 480,
+      behavior: "smooth",
+    });
+  });
+
   it("does not repeat the smooth top-anchor scroll for the same message", () => {
     const viewport = document.createElement("div");
     const anchor = document.createElement("div");

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -7,6 +7,10 @@ import {
 } from "./mountTopAnchorReserve";
 
 class ResizeObserverMock {
+  static callbacks: (() => void)[] = [];
+  constructor(callback: () => void) {
+    ResizeObserverMock.callbacks.push(callback);
+  }
   observe = vi.fn();
   disconnect = vi.fn();
 }
@@ -48,6 +52,7 @@ const activeTopAnchorTurn = { anchorId: "user-1", targetId: "assistant-1" };
 describe("mountTopAnchorReserve", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    ResizeObserverMock.callbacks = [];
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     vi.stubGlobal("MutationObserver", MutationObserverMock);
   });
@@ -365,14 +370,24 @@ describe("mountTopAnchorReserve", () => {
     viewport.scrollTop = 220;
     viewport.dispatchEvent(new Event("scroll"));
 
-    return { viewport, anchor, target, store, setState };
+    // The wrapped observer callback marks an observed layout change and is
+    // what arms the restore gate in the real flow.
+    const armLayoutChange = () => {
+      ResizeObserverMock.callbacks.at(-1)!();
+    };
+
+    return { viewport, anchor, target, store, setState, armLayoutChange };
   };
 
-  it("restores the pre-clamp position after an unattributed scrollTop drop", () => {
-    const { viewport } = mountPinnedViewport();
+  it("restores the pre-clamp position after a layout-adjacent unattributed drop", () => {
+    const { viewport, armLayoutChange } = mountPinnedViewport();
 
-    viewport.scrollTop = 100;
+    armLayoutChange();
+    defineReadonlyNumber(viewport, "scrollHeight", 460);
+    viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
@@ -382,12 +397,13 @@ describe("mountTopAnchorReserve", () => {
     });
   });
 
-  it("leaves a wheel-attributed upward scroll alone", () => {
+  it("does not restore when no layout change was observed", () => {
     const { viewport, setState, anchor, target } = mountPinnedViewport();
 
-    viewport.dispatchEvent(new Event("wheel"));
-    viewport.scrollTop = 100;
+    defineReadonlyNumber(viewport, "scrollHeight", 460);
+    viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
     setState({
       turnAnchor: "top",
       element: { viewport, anchor, target },
@@ -400,18 +416,61 @@ describe("mountTopAnchorReserve", () => {
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves a keyboard-attributed upward scroll alone", () => {
-    const { viewport, setState, anchor, target } = mountPinnedViewport();
+  it("is a no-op when the browser already preserved the anchor-relative position", () => {
+    const { viewport, anchor, armLayoutChange } = mountPinnedViewport();
 
-    viewport.dispatchEvent(new Event("keydown"));
+    armLayoutChange();
+    defineReadonlyNumber(anchor, "offsetTop", 100);
     viewport.scrollTop = 100;
     viewport.dispatchEvent(new Event("scroll"));
-    setState({
-      turnAnchor: "top",
-      element: { viewport, anchor, target },
-      targetConfig: numericClamp,
-      topAnchorTurn: activeTopAnchorTurn,
-    });
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores at most once per anchor turn", () => {
+    const { viewport, armLayoutChange } = mountPinnedViewport();
+
+    armLayoutChange();
+    viewport.scrollTop = 60;
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+
+    viewport.scrollTop = 220;
+    viewport.dispatchEvent(new Event("scroll"));
+    armLayoutChange();
+    viewport.scrollTop = 60;
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves a wheel-attributed upward scroll alone", () => {
+    const { viewport, armLayoutChange } = mountPinnedViewport();
+
+    armLayoutChange();
+    viewport.dispatchEvent(new Event("wheel"));
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a scroll-key-attributed upward scroll alone", () => {
+    const { viewport, armLayoutChange } = mountPinnedViewport();
+
+    armLayoutChange();
+    viewport.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    viewport.scrollTop = 100;
+    viewport.dispatchEvent(new Event("scroll"));
     vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
@@ -419,8 +478,9 @@ describe("mountTopAnchorReserve", () => {
   });
 
   it("leaves upward scrolls alone while a pointer drag is held", () => {
-    const { viewport } = mountPinnedViewport();
+    const { viewport, armLayoutChange } = mountPinnedViewport();
 
+    armLayoutChange();
     viewport.dispatchEvent(new Event("pointerdown"));
     viewport.scrollTop = 180;
     viewport.dispatchEvent(new Event("scroll"));
@@ -428,17 +488,17 @@ describe("mountTopAnchorReserve", () => {
     viewport.dispatchEvent(new Event("scroll"));
     window.dispatchEvent(new Event("pointerup"));
     vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
   });
 
-  it("pins the next turn normally after a clamp restore", () => {
-    const { viewport, setState } = mountPinnedViewport();
+  it("drops a pending restore when the anchor changes before it applies", () => {
+    const { viewport, setState, armLayoutChange } = mountPinnedViewport();
 
-    viewport.scrollTop = 100;
+    armLayoutChange();
+    viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
 
     const nextAnchor = document.createElement("div");
     const nextTarget = document.createElement("div");
@@ -455,8 +515,9 @@ describe("mountTopAnchorReserve", () => {
     });
     vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
+    vi.runOnlyPendingTimers();
 
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(3);
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
     expect(viewport.scrollTo).toHaveBeenLastCalledWith({
       top: 480,
       behavior: "smooth",

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -479,6 +479,65 @@ describe("mountTopAnchorReserve", () => {
     });
   });
 
+  it("does not use the replacement fallback after wheel intent", () => {
+    const { viewport, notifyReplacement } = mountPinnedViewport();
+
+    viewport.dispatchEvent(new WheelEvent("wheel"));
+    viewport.scrollTop = 60;
+    notifyReplacement();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use the replacement fallback after focus movement", () => {
+    const { viewport, notifyReplacement } = mountPinnedViewport();
+
+    viewport.dispatchEvent(new FocusEvent("focusin"));
+    viewport.scrollTop = 60;
+    notifyReplacement();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat caret movement in an editable child as scroll intent", () => {
+    const { viewport, notifyReplacement } = mountPinnedViewport();
+    const textarea = document.createElement("textarea");
+    viewport.append(textarea);
+
+    textarea.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+    );
+    viewport.scrollTop = 60;
+    notifyReplacement();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a gesture veto an exact range clamp", () => {
+    const { viewport, notifyReplacement, setNaturalScrollHeight } =
+      mountPinnedViewport();
+
+    viewport.dispatchEvent(new WheelEvent("wheel"));
+    setNaturalScrollHeight(400);
+    viewport.scrollTop = 60;
+    notifyReplacement();
+    viewport.dispatchEvent(new Event("scroll"));
+    setNaturalScrollHeight(560);
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
+      top: 220,
+      behavior: "instant",
+    });
+  });
+
   it("does not restore an upward scroll beside an ordinary content mutation", () => {
     const { viewport, notifyCharacterData } = mountPinnedViewport();
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -431,6 +431,15 @@ describe("mountTopAnchorReserve", () => {
             removedNodes: { length: 1 },
           } as MutationRecord,
         ]),
+      notifyMixedReplacement: () =>
+        MutationObserverMock.callbacks.at(-1)!([
+          {
+            type: "childList",
+            addedNodes: { length: 1 },
+            removedNodes: { length: 1 },
+          } as MutationRecord,
+          { type: "characterData" } as MutationRecord,
+        ]),
       setNaturalScrollHeight: (height: number) => {
         naturalScrollHeight = height;
       },
@@ -554,6 +563,17 @@ describe("mountTopAnchorReserve", () => {
 
     viewport.scrollTop = 100;
     notifySeparateChildChanges();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat a mixed mutation batch as a replacement", () => {
+    const { viewport, notifyMixedReplacement } = mountPinnedViewport();
+
+    viewport.scrollTop = 100;
+    notifyMixedReplacement();
     viewport.dispatchEvent(new Event("scroll"));
     vi.runOnlyPendingTimers();
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -16,10 +16,6 @@ class ResizeObserverMock {
 }
 
 class MutationObserverMock {
-  static callbacks: ((records: MutationRecord[]) => void)[] = [];
-  constructor(callback: (records: MutationRecord[]) => void) {
-    MutationObserverMock.callbacks.push(callback);
-  }
   observe = vi.fn();
   disconnect = vi.fn();
 }
@@ -57,10 +53,8 @@ describe("mountTopAnchorReserve", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     ResizeObserverMock.callbacks = [];
-    MutationObserverMock.callbacks = [];
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     vi.stubGlobal("MutationObserver", MutationObserverMock);
-    vi.stubGlobal("CSS", { supports: vi.fn(() => false) });
   });
 
   afterEach(() => {
@@ -406,40 +400,6 @@ describe("mountTopAnchorReserve", () => {
       setState,
       unmount,
       notifyLayout: () => ResizeObserverMock.callbacks.at(-1)!(),
-      notifyReplacement: () =>
-        MutationObserverMock.callbacks.at(-1)!([
-          {
-            type: "childList",
-            addedNodes: { length: 1 },
-            removedNodes: { length: 1 },
-          } as MutationRecord,
-        ]),
-      notifyCharacterData: () =>
-        MutationObserverMock.callbacks.at(-1)!([
-          { type: "characterData" } as MutationRecord,
-        ]),
-      notifySeparateChildChanges: () =>
-        MutationObserverMock.callbacks.at(-1)!([
-          {
-            type: "childList",
-            addedNodes: { length: 1 },
-            removedNodes: { length: 0 },
-          } as MutationRecord,
-          {
-            type: "childList",
-            addedNodes: { length: 0 },
-            removedNodes: { length: 1 },
-          } as MutationRecord,
-        ]),
-      notifyMixedReplacement: () =>
-        MutationObserverMock.callbacks.at(-1)!([
-          {
-            type: "childList",
-            addedNodes: { length: 1 },
-            removedNodes: { length: 1 },
-          } as MutationRecord,
-          { type: "characterData" } as MutationRecord,
-        ]),
       setNaturalScrollHeight: (height: number) => {
         naturalScrollHeight = height;
       },
@@ -462,131 +422,29 @@ describe("mountTopAnchorReserve", () => {
     });
   });
 
-  it("does not restore a reachable programmatic upward scroll", () => {
-    const { viewport, notifyLayout } = mountPinnedViewport();
+  it("does not undo a reachable scrollIntoView movement", () => {
+    const { viewport, target, notifyLayout } = mountPinnedViewport();
+    target.scrollIntoView = vi.fn(() => {
+      viewport.scrollTop = 100;
+      viewport.dispatchEvent(new Event("scroll"));
+    });
 
+    target.scrollIntoView();
     notifyLayout();
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not undo reachable focus scrolling", () => {
+    const { viewport, target, notifyLayout } = mountPinnedViewport();
+    const input = document.createElement("input");
+    target.append(input);
+
+    input.focus();
     viewport.scrollTop = 100;
     viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("restores a transient replacement clamp after the range has recovered", () => {
-    const { viewport, notifyReplacement } = mountPinnedViewport();
-
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
-    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
-      top: 220,
-      behavior: "instant",
-    });
-  });
-
-  it("does not use the replacement fallback after wheel intent", () => {
-    const { viewport, notifyReplacement } = mountPinnedViewport();
-
-    viewport.dispatchEvent(new WheelEvent("wheel"));
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not use the replacement fallback after focus movement", () => {
-    const { viewport, notifyReplacement } = mountPinnedViewport();
-
-    viewport.dispatchEvent(new FocusEvent("focusin"));
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not treat caret movement in an editable child as scroll intent", () => {
-    const { viewport, notifyReplacement } = mountPinnedViewport();
-    const textarea = document.createElement("textarea");
-    viewport.append(textarea);
-
-    textarea.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
-    );
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not let a gesture veto an exact range clamp", () => {
-    const { viewport, notifyReplacement, setNaturalScrollHeight } =
-      mountPinnedViewport();
-
-    viewport.dispatchEvent(new WheelEvent("wheel"));
-    setNaturalScrollHeight(400);
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    setNaturalScrollHeight(560);
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
-    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
-      top: 220,
-      behavior: "instant",
-    });
-  });
-
-  it("does not restore an upward scroll beside an ordinary content mutation", () => {
-    const { viewport, notifyCharacterData } = mountPinnedViewport();
-
-    viewport.scrollTop = 100;
-    notifyCharacterData();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not combine separate child mutations into a replacement", () => {
-    const { viewport, notifySeparateChildChanges } = mountPinnedViewport();
-
-    viewport.scrollTop = 100;
-    notifySeparateChildChanges();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not treat a mixed mutation batch as a replacement", () => {
-    const { viewport, notifyMixedReplacement } = mountPinnedViewport();
-
-    viewport.scrollTop = 100;
-    notifyMixedReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("leaves replacement scrolling to browsers with native scroll anchoring", () => {
-    vi.mocked(CSS.supports).mockReturnValue(true);
-    const { viewport, notifyReplacement } = mountPinnedViewport();
-
-    viewport.scrollTop = 60;
-    notifyReplacement();
-    viewport.dispatchEvent(new Event("scroll"));
+    notifyLayout();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -16,6 +16,10 @@ class ResizeObserverMock {
 }
 
 class MutationObserverMock {
+  static callbacks: ((records: MutationRecord[]) => void)[] = [];
+  constructor(callback: (records: MutationRecord[]) => void) {
+    MutationObserverMock.callbacks.push(callback);
+  }
   observe = vi.fn();
   disconnect = vi.fn();
 }
@@ -53,8 +57,10 @@ describe("mountTopAnchorReserve", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     ResizeObserverMock.callbacks = [];
+    MutationObserverMock.callbacks = [];
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     vi.stubGlobal("MutationObserver", MutationObserverMock);
+    vi.stubGlobal("CSS", { supports: vi.fn(() => false) });
   });
 
   afterEach(() => {
@@ -340,11 +346,25 @@ describe("mountTopAnchorReserve", () => {
     const viewport = document.createElement("div");
     const anchor = document.createElement("div");
     const target = document.createElement("div");
-    document.body.append(target);
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    let naturalScrollHeight = 560;
 
     defineReadonlyNumber(viewport, "offsetTop", 0);
     defineReadonlyNumber(viewport, "clientHeight", 400);
-    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    Object.defineProperty(viewport, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        const reserve = document.querySelector<HTMLElement>(
+          "[data-aui-top-anchor-reserve]",
+        );
+        return (
+          naturalScrollHeight + Number.parseFloat(reserve?.style.height || "0")
+        );
+      },
+    });
     defineReadonlyNumber(anchor, "offsetTop", 220);
     defineReadonlyNumber(anchor, "offsetHeight", 64);
     anchor.dataset.messageId = "msg-1";
@@ -357,8 +377,16 @@ describe("mountTopAnchorReserve", () => {
       topAnchorTurn: activeTopAnchorTurn,
     });
 
-    mountTopAnchorReserve(store);
+    const unmount = mountTopAnchorReserve(store);
     vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector<HTMLElement>(
+      "[data-aui-top-anchor-reserve]",
+    )!;
+    Object.defineProperty(reserve, "offsetHeight", {
+      configurable: true,
+      get: () => Number.parseFloat(reserve.style.height || "0"),
+    });
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
@@ -370,24 +398,52 @@ describe("mountTopAnchorReserve", () => {
     viewport.scrollTop = 220;
     viewport.dispatchEvent(new Event("scroll"));
 
-    // The wrapped observer callback marks an observed layout change and is
-    // what arms the restore gate in the real flow.
-    const armLayoutChange = () => {
-      ResizeObserverMock.callbacks.at(-1)!();
+    return {
+      viewport,
+      anchor,
+      target,
+      store,
+      setState,
+      unmount,
+      notifyLayout: () => ResizeObserverMock.callbacks.at(-1)!(),
+      notifyReplacement: () =>
+        MutationObserverMock.callbacks.at(-1)!([
+          {
+            type: "childList",
+            addedNodes: { length: 1 },
+            removedNodes: { length: 1 },
+          } as MutationRecord,
+        ]),
+      notifyCharacterData: () =>
+        MutationObserverMock.callbacks.at(-1)!([
+          { type: "characterData" } as MutationRecord,
+        ]),
+      notifySeparateChildChanges: () =>
+        MutationObserverMock.callbacks.at(-1)!([
+          {
+            type: "childList",
+            addedNodes: { length: 1 },
+            removedNodes: { length: 0 },
+          } as MutationRecord,
+          {
+            type: "childList",
+            addedNodes: { length: 0 },
+            removedNodes: { length: 1 },
+          } as MutationRecord,
+        ]),
+      setNaturalScrollHeight: (height: number) => {
+        naturalScrollHeight = height;
+      },
     };
-
-    return { viewport, anchor, target, store, setState, armLayoutChange };
   };
 
-  it("restores the pre-clamp position after a layout-adjacent unattributed drop", () => {
-    const { viewport, armLayoutChange } = mountPinnedViewport();
+  it("restores the pre-clamp position when the old offset becomes unreachable", () => {
+    const { viewport, setNaturalScrollHeight } = mountPinnedViewport();
 
-    armLayoutChange();
-    defineReadonlyNumber(viewport, "scrollHeight", 460);
+    setNaturalScrollHeight(400);
     viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
-    defineReadonlyNumber(viewport, "scrollHeight", 560);
-    vi.runOnlyPendingTimers();
+    setNaturalScrollHeight(560);
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
@@ -397,108 +453,118 @@ describe("mountTopAnchorReserve", () => {
     });
   });
 
-  it("does not restore when no layout change was observed", () => {
-    const { viewport, setState, anchor, target } = mountPinnedViewport();
+  it("does not restore a reachable programmatic upward scroll", () => {
+    const { viewport, notifyLayout } = mountPinnedViewport();
 
-    defineReadonlyNumber(viewport, "scrollHeight", 460);
-    viewport.scrollTop = 60;
+    notifyLayout();
+    viewport.scrollTop = 100;
     viewport.dispatchEvent(new Event("scroll"));
-    defineReadonlyNumber(viewport, "scrollHeight", 560);
-    setState({
-      turnAnchor: "top",
-      element: { viewport, anchor, target },
-      targetConfig: numericClamp,
-      topAnchorTurn: activeTopAnchorTurn,
-    });
-    vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op when the browser already preserved the anchor-relative position", () => {
-    const { viewport, anchor, armLayoutChange } = mountPinnedViewport();
+  it("restores a transient replacement clamp after the range has recovered", () => {
+    const { viewport, notifyReplacement } = mountPinnedViewport();
 
-    armLayoutChange();
-    defineReadonlyNumber(anchor, "offsetTop", 100);
-    viewport.scrollTop = 100;
+    viewport.scrollTop = 60;
+    notifyReplacement();
     viewport.dispatchEvent(new Event("scroll"));
     vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
+    expect(viewport.scrollTo).toHaveBeenLastCalledWith({
+      top: 220,
+      behavior: "instant",
+    });
+  });
+
+  it("does not restore an upward scroll beside an ordinary content mutation", () => {
+    const { viewport, notifyCharacterData } = mountPinnedViewport();
+
+    viewport.scrollTop = 100;
+    notifyCharacterData();
+    viewport.dispatchEvent(new Event("scroll"));
     vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not combine separate child mutations into a replacement", () => {
+    const { viewport, notifySeparateChildChanges } = mountPinnedViewport();
+
+    viewport.scrollTop = 100;
+    notifySeparateChildChanges();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves replacement scrolling to browsers with native scroll anchoring", () => {
+    vi.mocked(CSS.supports).mockReturnValue(true);
+    const { viewport, notifyReplacement } = mountPinnedViewport();
+
+    viewport.scrollTop = 60;
+    notifyReplacement();
+    viewport.dispatchEvent(new Event("scroll"));
+    vi.runOnlyPendingTimers();
+
+    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restore an out-of-range movement that did not land at the maximum", () => {
+    const { viewport, setNaturalScrollHeight, notifyLayout } =
+      mountPinnedViewport();
+
+    setNaturalScrollHeight(400);
+    viewport.scrollTop = 40;
+    viewport.dispatchEvent(new Event("scroll"));
+    setNaturalScrollHeight(560);
+    notifyLayout();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
   });
 
   it("restores at most once per anchor turn", () => {
-    const { viewport, armLayoutChange } = mountPinnedViewport();
+    const { viewport, setNaturalScrollHeight, notifyLayout } =
+      mountPinnedViewport();
 
-    armLayoutChange();
+    setNaturalScrollHeight(400);
     viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
+    setNaturalScrollHeight(560);
     vi.runOnlyPendingTimers();
     expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
 
     viewport.scrollTop = 220;
     viewport.dispatchEvent(new Event("scroll"));
-    armLayoutChange();
+    setNaturalScrollHeight(400);
     viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
+    setNaturalScrollHeight(560);
+    notifyLayout();
     vi.runOnlyPendingTimers();
 
     expect(viewport.scrollTo).toHaveBeenCalledTimes(2);
   });
 
-  it("leaves a wheel-attributed upward scroll alone", () => {
-    const { viewport, armLayoutChange } = mountPinnedViewport();
+  it("drops a pending restore across an anchor-gap thread transition", () => {
+    const { viewport, setState, setNaturalScrollHeight } =
+      mountPinnedViewport();
 
-    armLayoutChange();
-    viewport.dispatchEvent(new Event("wheel"));
-    viewport.scrollTop = 100;
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("leaves a scroll-key-attributed upward scroll alone", () => {
-    const { viewport, armLayoutChange } = mountPinnedViewport();
-
-    armLayoutChange();
-    viewport.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
-    viewport.scrollTop = 100;
-    viewport.dispatchEvent(new Event("scroll"));
-    vi.runOnlyPendingTimers();
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("leaves upward scrolls alone while a pointer drag is held", () => {
-    const { viewport, armLayoutChange } = mountPinnedViewport();
-
-    armLayoutChange();
-    viewport.dispatchEvent(new Event("pointerdown"));
-    viewport.scrollTop = 180;
-    viewport.dispatchEvent(new Event("scroll"));
-    viewport.scrollTop = 100;
-    viewport.dispatchEvent(new Event("scroll"));
-    window.dispatchEvent(new Event("pointerup"));
-    vi.runOnlyPendingTimers();
-    vi.runOnlyPendingTimers();
-
-    expect(viewport.scrollTo).toHaveBeenCalledTimes(1);
-  });
-
-  it("drops a pending restore when the anchor changes before it applies", () => {
-    const { viewport, setState, armLayoutChange } = mountPinnedViewport();
-
-    armLayoutChange();
+    setNaturalScrollHeight(400);
     viewport.scrollTop = 60;
     viewport.dispatchEvent(new Event("scroll"));
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: null, target: null },
+      targetConfig: null,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+    vi.runOnlyPendingTimers();
 
     const nextAnchor = document.createElement("div");
     const nextTarget = document.createElement("div");
@@ -513,7 +579,7 @@ describe("mountTopAnchorReserve", () => {
       targetConfig: numericClamp,
       topAnchorTurn: { anchorId: "user-2", targetId: "assistant-2" },
     });
-    vi.runOnlyPendingTimers();
+    setNaturalScrollHeight(560);
     vi.runOnlyPendingTimers();
     vi.runOnlyPendingTimers();
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -59,6 +59,17 @@ const createFrameScheduler = (fn: () => void) => {
 
 const USER_GESTURE_WINDOW_MS = 500;
 const SCROLL_TRAIN_GAP_MS = 150;
+const LAYOUT_CHANGE_WINDOW_MS = 400;
+
+const SCROLL_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+]);
 
 export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
@@ -68,23 +79,35 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   // subtree swapped for its final rendering) makes the browser clamp
   // scrollTop synchronously, before the reserve can grow to compensate;
   // WebKit lays such states out where Chromium happens not to, which turned
-  // the clamp into a permanently broken pin. The clamp is undone by
-  // restoring the pre-clamp position once the reserve has settled. A
-  // scrollTop decrease is attributed to the user — and left alone — while a
-  // scroll gesture is held or recent, or while an uninterrupted scroll train
-  // started by one is still running (touch momentum outlives its input
-  // events). The upward restore and the downward smooth pin never match the
-  // "unattributed decrease" trigger, so the mechanism cannot feed itself.
+  // the clamp into a permanently broken pin. The transient state is not
+  // observable afterwards (the swap completes within the same task), so the
+  // clamp is detected as a scrollTop decrease that no user gesture accounts
+  // for, and bounded by three gates: it must closely follow an observed
+  // layout change, it fires at most once per anchor turn, and the
+  // correction restores the anchor-relative position rather than the raw
+  // offset — so a browser that already compensated (scroll anchoring)
+  // yields a no-op instead of a fight.
   let listenedViewport: HTMLElement | null = null;
   let lastScrollTop = 0;
   let lastScrollAt = -Infinity;
   let lastGestureAt = -Infinity;
+  let lastLayoutChangeAt = -Infinity;
   let gestureHeld = false;
   let userScrollTrain = false;
   let restoreScrollTop: number | null = null;
+  let restoredThisTurn = false;
+  let lastAppliedTarget: number | null = null;
+
+  const clearRestore = () => {
+    restoreScrollTop = null;
+    lastAppliedTarget = null;
+  };
 
   const onGesture = () => {
     lastGestureAt = performance.now();
+  };
+  const onKeyDown = (event: Event) => {
+    if (SCROLL_KEYS.has((event as KeyboardEvent).key)) onGesture();
   };
   const onGestureStart = () => {
     lastGestureAt = performance.now();
@@ -112,7 +135,11 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
         restoreScrollTop = null;
       } else {
         userScrollTrain = false;
-        if (scrollTop < lastScrollTop) {
+        if (
+          scrollTop < lastScrollTop &&
+          !restoredThisTurn &&
+          now - lastLayoutChangeAt < LAYOUT_CHANGE_WINDOW_MS
+        ) {
           restoreScrollTop ??= lastScrollTop;
           scheduler.schedule();
         }
@@ -128,7 +155,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     if (listenedViewport) {
       listenedViewport.removeEventListener("scroll", handleScroll);
       listenedViewport.removeEventListener("wheel", onGesture);
-      listenedViewport.removeEventListener("keydown", onGesture);
+      listenedViewport.removeEventListener("keydown", onKeyDown);
       listenedViewport.removeEventListener("touchstart", onGestureStart);
       listenedViewport.removeEventListener("pointerdown", onGestureStart);
       window.removeEventListener("touchend", onGestureEnd);
@@ -139,11 +166,12 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     listenedViewport = viewport;
     gestureHeld = false;
     userScrollTrain = false;
-    restoreScrollTop = null;
+    restoredThisTurn = false;
+    clearRestore();
     if (viewport) {
       viewport.addEventListener("scroll", handleScroll, { passive: true });
       viewport.addEventListener("wheel", onGesture, { passive: true });
-      viewport.addEventListener("keydown", onGesture, { passive: true });
+      viewport.addEventListener("keydown", onKeyDown, { passive: true });
       viewport.addEventListener("touchstart", onGestureStart, {
         passive: true,
       });
@@ -169,6 +197,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
 
     if (state.turnAnchor !== "top" || !viewport) {
       observers.disconnect();
+      clearRestore();
       if (reserve) {
         setReserveHeight(reserve, 0);
         reserve.remove();
@@ -181,6 +210,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       // trailing turn (followed at most by pending user messages), so reaching
       // here means the anchor gap is transient and the next run is imminent.
       observers.disconnect();
+      clearRestore();
       if (
         reserve?.parentElement &&
         reserve.parentElement.lastElementChild !== reserve
@@ -192,6 +222,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
 
     if (!anchor || !target || !clamp) {
       observers.disconnect();
+      clearRestore();
       if (reserve) {
         setReserveHeight(reserve, 0);
         reserve.remove();
@@ -220,28 +251,41 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       return;
     }
 
-    if (restoreScrollTop !== null) {
-      const top = restoreScrollTop;
-      restoreScrollTop = null;
-      viewport.scrollTo({ top, behavior: "instant" });
-    }
-
     const anchorId = getAnchorId(anchor);
-    if (anchorId !== undefined && lastScrolledAnchorId === anchorId) return;
-
     const targetScrollTop = snapScrollTop(
       computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
     );
 
-    if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
-      viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
+    if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
+      restoreScrollTop = null;
+      restoredThisTurn = false;
+      if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
+        viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
+      }
+      if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
+    } else if (restoreScrollTop !== null && lastAppliedTarget !== null) {
+      // Restore the anchor-relative position: if content above the anchor
+      // changed height and the browser already adjusted scrollTop to match
+      // (scroll anchoring), the desired offset equals the current one and
+      // this is a no-op.
+      const desired = snapScrollTop(
+        restoreScrollTop + (targetScrollTop - lastAppliedTarget),
+      );
+      restoreScrollTop = null;
+      if (Math.abs(viewport.scrollTop - desired) > 1) {
+        restoredThisTurn = true;
+        viewport.scrollTo({ top: desired, behavior: "instant" });
+      }
     }
 
-    if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
+    lastAppliedTarget = targetScrollTop;
   }
 
   const scheduler = createFrameScheduler(apply);
-  const observers = createReserveObservers(scheduler.schedule);
+  const observers = createReserveObservers(() => {
+    lastLayoutChangeAt = performance.now();
+    scheduler.schedule();
+  });
 
   scheduler.schedule();
   const unsubscribe = store.subscribe(scheduler.schedule);

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -101,6 +101,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   const clearRestore = () => {
     restoreScrollTop = null;
     lastAppliedTarget = null;
+    lastLayoutChangeAt = -Infinity;
   };
 
   const onGesture = () => {
@@ -259,6 +260,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
       restoreScrollTop = null;
       restoredThisTurn = false;
+      lastLayoutChangeAt = -Infinity;
       if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
         viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
       }

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -61,10 +61,71 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
   let lastScrolledAnchorId: string | undefined;
 
+  // The browser clamps scrollTop synchronously when a transient layout state
+  // (e.g. a streamed subtree being swapped for its final render) shrinks
+  // scrollHeight below the pinned position; the reserve can only compensate a
+  // frame later. Track whether the user has taken over scrolling so the pin
+  // can be re-asserted after such layout-induced shifts without ever fighting
+  // a user scroll.
+  let userTookOver = false;
+  let pinScrollTarget: number | null = null;
+  let listenedViewport: HTMLElement | null = null;
+  let lastScrollTop = 0;
+  let lastScrollHeight = 0;
+
+  const releasePin = () => {
+    userTookOver = true;
+    pinScrollTarget = null;
+  };
+
+  const handleScroll = () => {
+    const viewport = listenedViewport;
+    if (!viewport) return;
+    const { scrollTop, scrollHeight } = viewport;
+    const stableHeight = scrollHeight === lastScrollHeight;
+
+    if (pinScrollTarget !== null) {
+      if (Math.abs(scrollTop - pinScrollTarget) <= 1) {
+        pinScrollTarget = null;
+      } else if (stableHeight) {
+        const approaching =
+          Math.abs(pinScrollTarget - scrollTop) <
+          Math.abs(pinScrollTarget - lastScrollTop);
+        if (!approaching) releasePin();
+      }
+    } else if (stableHeight && scrollTop !== lastScrollTop) {
+      releasePin();
+    }
+
+    lastScrollTop = scrollTop;
+    lastScrollHeight = scrollHeight;
+  };
+
+  const listenViewport = (viewport: HTMLElement | null) => {
+    if (listenedViewport === viewport) return;
+    if (listenedViewport) {
+      listenedViewport.removeEventListener("scroll", handleScroll);
+      listenedViewport.removeEventListener("wheel", releasePin);
+      listenedViewport.removeEventListener("touchstart", releasePin);
+      listenedViewport.removeEventListener("pointerdown", releasePin);
+    }
+    listenedViewport = viewport;
+    if (viewport) {
+      viewport.addEventListener("scroll", handleScroll, { passive: true });
+      viewport.addEventListener("wheel", releasePin, { passive: true });
+      viewport.addEventListener("touchstart", releasePin, { passive: true });
+      viewport.addEventListener("pointerdown", releasePin, { passive: true });
+      lastScrollTop = viewport.scrollTop;
+      lastScrollHeight = viewport.scrollHeight;
+    }
+  };
+
   function apply() {
     const state = store.getState();
     const { viewport, anchor, target } = state.element;
     const clamp = state.targetConfig;
+
+    listenViewport(state.turnAnchor === "top" ? viewport : null);
 
     if (state.turnAnchor !== "top" || !viewport) {
       observers.disconnect();
@@ -120,17 +181,26 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     }
 
     const anchorId = getAnchorId(anchor);
-    if (anchorId !== undefined && lastScrolledAnchorId === anchorId) return;
-
     const targetScrollTop = snapScrollTop(
       computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
     );
+    const atTarget = Math.abs(viewport.scrollTop - targetScrollTop) <= 1;
+    if (pinScrollTarget !== null && atTarget) pinScrollTarget = null;
 
-    if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
-      viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
+    if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
+      userTookOver = false;
+      if (!atTarget) {
+        pinScrollTarget = targetScrollTop;
+        viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
+      }
+      if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
+      return;
     }
 
-    if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
+    if (!userTookOver && pinScrollTarget === null && !atTarget) {
+      pinScrollTarget = targetScrollTop;
+      viewport.scrollTo({ top: targetScrollTop, behavior: "instant" });
+    }
   }
 
   const scheduler = createFrameScheduler(apply);
@@ -143,6 +213,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     scheduler.cancel();
     unsubscribe();
     observers.disconnect();
+    listenViewport(null);
     reserve?.remove();
   };
 };

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -57,66 +57,106 @@ const createFrameScheduler = (fn: () => void) => {
   };
 };
 
+const USER_GESTURE_WINDOW_MS = 500;
+const SCROLL_TRAIN_GAP_MS = 150;
+
 export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
   let lastScrolledAnchorId: string | undefined;
 
-  // The browser clamps scrollTop synchronously when a transient layout state
-  // (e.g. a streamed subtree being swapped for its final render) shrinks
-  // scrollHeight below the pinned position; the reserve can only compensate a
-  // frame later. Track whether the user has taken over scrolling so the pin
-  // can be re-asserted after such layout-induced shifts without ever fighting
-  // a user scroll.
-  let userTookOver = false;
-  let pinScrollTarget: number | null = null;
+  // A transient layout state that shrinks scrollHeight (e.g. a streamed
+  // subtree swapped for its final rendering) makes the browser clamp
+  // scrollTop synchronously, before the reserve can grow to compensate;
+  // WebKit lays such states out where Chromium happens not to, which turned
+  // the clamp into a permanently broken pin. The clamp is undone by
+  // restoring the pre-clamp position once the reserve has settled. A
+  // scrollTop decrease is attributed to the user — and left alone — while a
+  // scroll gesture is held or recent, or while an uninterrupted scroll train
+  // started by one is still running (touch momentum outlives its input
+  // events). The upward restore and the downward smooth pin never match the
+  // "unattributed decrease" trigger, so the mechanism cannot feed itself.
   let listenedViewport: HTMLElement | null = null;
   let lastScrollTop = 0;
-  let lastScrollHeight = 0;
+  let lastScrollAt = -Infinity;
+  let lastGestureAt = -Infinity;
+  let gestureHeld = false;
+  let userScrollTrain = false;
+  let restoreScrollTop: number | null = null;
 
-  const releasePin = () => {
-    userTookOver = true;
-    pinScrollTarget = null;
+  const onGesture = () => {
+    lastGestureAt = performance.now();
+  };
+  const onGestureStart = () => {
+    lastGestureAt = performance.now();
+    gestureHeld = true;
+  };
+  const onGestureEnd = () => {
+    lastGestureAt = performance.now();
+    gestureHeld = false;
   };
 
   const handleScroll = () => {
     const viewport = listenedViewport;
     if (!viewport) return;
-    const { scrollTop, scrollHeight } = viewport;
-    const stableHeight = scrollHeight === lastScrollHeight;
+    const now = performance.now();
+    const scrollTop = viewport.scrollTop;
 
-    if (pinScrollTarget !== null) {
-      if (Math.abs(scrollTop - pinScrollTarget) <= 1) {
-        pinScrollTarget = null;
-      } else if (stableHeight) {
-        const approaching =
-          Math.abs(pinScrollTarget - scrollTop) <
-          Math.abs(pinScrollTarget - lastScrollTop);
-        if (!approaching) releasePin();
+    if (scrollTop !== lastScrollTop) {
+      const userAttributed =
+        gestureHeld ||
+        now - lastGestureAt < USER_GESTURE_WINDOW_MS ||
+        (userScrollTrain && now - lastScrollAt < SCROLL_TRAIN_GAP_MS);
+
+      if (userAttributed) {
+        userScrollTrain = true;
+        restoreScrollTop = null;
+      } else {
+        userScrollTrain = false;
+        if (scrollTop < lastScrollTop) {
+          restoreScrollTop ??= lastScrollTop;
+          scheduler.schedule();
+        }
       }
-    } else if (stableHeight && scrollTop !== lastScrollTop) {
-      releasePin();
     }
 
+    lastScrollAt = now;
     lastScrollTop = scrollTop;
-    lastScrollHeight = scrollHeight;
   };
 
   const listenViewport = (viewport: HTMLElement | null) => {
     if (listenedViewport === viewport) return;
     if (listenedViewport) {
       listenedViewport.removeEventListener("scroll", handleScroll);
-      listenedViewport.removeEventListener("wheel", releasePin);
-      listenedViewport.removeEventListener("touchstart", releasePin);
-      listenedViewport.removeEventListener("pointerdown", releasePin);
+      listenedViewport.removeEventListener("wheel", onGesture);
+      listenedViewport.removeEventListener("keydown", onGesture);
+      listenedViewport.removeEventListener("touchstart", onGestureStart);
+      listenedViewport.removeEventListener("pointerdown", onGestureStart);
+      window.removeEventListener("touchend", onGestureEnd);
+      window.removeEventListener("touchcancel", onGestureEnd);
+      window.removeEventListener("pointerup", onGestureEnd);
+      window.removeEventListener("pointercancel", onGestureEnd);
     }
     listenedViewport = viewport;
+    gestureHeld = false;
+    userScrollTrain = false;
+    restoreScrollTop = null;
     if (viewport) {
       viewport.addEventListener("scroll", handleScroll, { passive: true });
-      viewport.addEventListener("wheel", releasePin, { passive: true });
-      viewport.addEventListener("touchstart", releasePin, { passive: true });
-      viewport.addEventListener("pointerdown", releasePin, { passive: true });
+      viewport.addEventListener("wheel", onGesture, { passive: true });
+      viewport.addEventListener("keydown", onGesture, { passive: true });
+      viewport.addEventListener("touchstart", onGestureStart, {
+        passive: true,
+      });
+      viewport.addEventListener("pointerdown", onGestureStart, {
+        passive: true,
+      });
+      window.addEventListener("touchend", onGestureEnd, { passive: true });
+      window.addEventListener("touchcancel", onGestureEnd, { passive: true });
+      window.addEventListener("pointerup", onGestureEnd, { passive: true });
+      window.addEventListener("pointercancel", onGestureEnd, {
+        passive: true,
+      });
       lastScrollTop = viewport.scrollTop;
-      lastScrollHeight = viewport.scrollHeight;
     }
   };
 
@@ -180,27 +220,24 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       return;
     }
 
+    if (restoreScrollTop !== null) {
+      const top = restoreScrollTop;
+      restoreScrollTop = null;
+      viewport.scrollTo({ top, behavior: "instant" });
+    }
+
     const anchorId = getAnchorId(anchor);
+    if (anchorId !== undefined && lastScrolledAnchorId === anchorId) return;
+
     const targetScrollTop = snapScrollTop(
       computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
     );
-    const atTarget = Math.abs(viewport.scrollTop - targetScrollTop) <= 1;
-    if (pinScrollTarget !== null && atTarget) pinScrollTarget = null;
 
-    if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
-      userTookOver = false;
-      if (!atTarget) {
-        pinScrollTarget = targetScrollTop;
-        viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
-      }
-      if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
-      return;
+    if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
+      viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
     }
 
-    if (!userTookOver && pinScrollTarget === null && !atTarget) {
-      pinScrollTarget = targetScrollTop;
-      viewport.scrollTo({ top: targetScrollTop, behavior: "instant" });
-    }
+    if (anchorId !== undefined) lastScrolledAnchorId = anchorId;
   }
 
   const scheduler = createFrameScheduler(apply);

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -177,12 +177,14 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   };
 
   const recordPinnedReplacement = (records: readonly MutationRecord[]) => {
-    const replacedContent = records.some(
-      (record) =>
-        record.type === "childList" &&
-        record.addedNodes.length > 0 &&
-        record.removedNodes.length > 0,
-    );
+    const replacedContent =
+      records.length > 0 &&
+      records.every(
+        (record) =>
+          record.type === "childList" &&
+          record.addedNodes.length > 0 &&
+          record.removedNodes.length > 0,
+      );
     pendingPinnedReplacement ||= replacedContent && wasPinnedAtLastScroll();
   };
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -142,6 +142,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     const clamp = state.targetConfig;
     if (
       state.turnAnchor !== "top" ||
+      !viewport ||
       viewport !== listenedViewport ||
       !anchor ||
       !clamp ||

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -4,7 +4,10 @@ import {
   computeTopAnchorReserve,
   computeTopAnchorTargetScrollTop,
 } from "./computeTopAnchorSlack";
-import { createReserveObservers } from "./createReserveObservers";
+import {
+  createReserveObservers,
+  type ReserveObserverChange,
+} from "./createReserveObservers";
 import {
   createReserveElement,
   getAnchorId,
@@ -57,43 +60,12 @@ const createFrameScheduler = (fn: () => void) => {
   };
 };
 
-const USER_GESTURE_WINDOW_MS = 500;
-const SCROLL_TRAIN_GAP_MS = 150;
-const LAYOUT_CHANGE_WINDOW_MS = 400;
-
-const SCROLL_KEYS = new Set([
-  "ArrowUp",
-  "ArrowDown",
-  "PageUp",
-  "PageDown",
-  "Home",
-  "End",
-  " ",
-]);
-
 export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
   let lastScrolledAnchorId: string | undefined;
 
-  // A transient layout state that shrinks scrollHeight (e.g. a streamed
-  // subtree swapped for its final rendering) makes the browser clamp
-  // scrollTop synchronously, before the reserve can grow to compensate;
-  // WebKit lays such states out where Chromium happens not to, which turned
-  // the clamp into a permanently broken pin. The transient state is not
-  // observable afterwards (the swap completes within the same task), so the
-  // clamp is detected as a scrollTop decrease that no user gesture accounts
-  // for, and bounded by three gates: it must closely follow an observed
-  // layout change, it fires at most once per anchor turn, and the
-  // correction restores the anchor-relative position rather than the raw
-  // offset — so a browser that already compensated (scroll anchoring)
-  // yields a no-op instead of a fight.
   let listenedViewport: HTMLElement | null = null;
   let lastScrollTop = 0;
-  let lastScrollAt = -Infinity;
-  let lastGestureAt = -Infinity;
-  let lastLayoutChangeAt = -Infinity;
-  let gestureHeld = false;
-  let userScrollTrain = false;
   let restoreScrollTop: number | null = null;
   let restoredThisTurn = false;
   let lastAppliedTarget: number | null = null;
@@ -101,53 +73,31 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   const clearRestore = () => {
     restoreScrollTop = null;
     lastAppliedTarget = null;
-    lastLayoutChangeAt = -Infinity;
   };
 
-  const onGesture = () => {
-    lastGestureAt = performance.now();
-  };
-  const onKeyDown = (event: Event) => {
-    if (SCROLL_KEYS.has((event as KeyboardEvent).key)) onGesture();
-  };
-  const onGestureStart = () => {
-    lastGestureAt = performance.now();
-    gestureHeld = true;
-  };
-  const onGestureEnd = () => {
-    lastGestureAt = performance.now();
-    gestureHeld = false;
-  };
+  const wasPinnedAtLastScroll = () =>
+    lastAppliedTarget !== null &&
+    Math.abs(lastScrollTop - lastAppliedTarget) <= 1;
 
   const handleScroll = () => {
     const viewport = listenedViewport;
     if (!viewport) return;
-    const now = performance.now();
     const scrollTop = viewport.scrollTop;
+    const maxScrollTop = Math.max(
+      0,
+      viewport.scrollHeight - viewport.clientHeight,
+    );
+    // A range clamp starts beyond the new maximum and lands on it.
+    const isRangeClamp =
+      scrollTop < lastScrollTop &&
+      lastScrollTop > maxScrollTop + 1 &&
+      Math.abs(scrollTop - maxScrollTop) <= 1;
 
-    if (scrollTop !== lastScrollTop) {
-      const userAttributed =
-        gestureHeld ||
-        now - lastGestureAt < USER_GESTURE_WINDOW_MS ||
-        (userScrollTrain && now - lastScrollAt < SCROLL_TRAIN_GAP_MS);
-
-      if (userAttributed) {
-        userScrollTrain = true;
-        restoreScrollTop = null;
-      } else {
-        userScrollTrain = false;
-        if (
-          scrollTop < lastScrollTop &&
-          !restoredThisTurn &&
-          now - lastLayoutChangeAt < LAYOUT_CHANGE_WINDOW_MS
-        ) {
-          restoreScrollTop ??= lastScrollTop;
-          scheduler.schedule();
-        }
-      }
+    if (isRangeClamp && wasPinnedAtLastScroll() && !restoredThisTurn) {
+      restoreScrollTop ??= lastScrollTop;
+      scheduler.schedule();
     }
 
-    lastScrollAt = now;
     lastScrollTop = scrollTop;
   };
 
@@ -155,38 +105,73 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     if (listenedViewport === viewport) return;
     if (listenedViewport) {
       listenedViewport.removeEventListener("scroll", handleScroll);
-      listenedViewport.removeEventListener("wheel", onGesture);
-      listenedViewport.removeEventListener("keydown", onKeyDown);
-      listenedViewport.removeEventListener("touchstart", onGestureStart);
-      listenedViewport.removeEventListener("pointerdown", onGestureStart);
-      window.removeEventListener("touchend", onGestureEnd);
-      window.removeEventListener("touchcancel", onGestureEnd);
-      window.removeEventListener("pointerup", onGestureEnd);
-      window.removeEventListener("pointercancel", onGestureEnd);
     }
     listenedViewport = viewport;
-    gestureHeld = false;
-    userScrollTrain = false;
     restoredThisTurn = false;
     clearRestore();
     if (viewport) {
       viewport.addEventListener("scroll", handleScroll, { passive: true });
-      viewport.addEventListener("wheel", onGesture, { passive: true });
-      viewport.addEventListener("keydown", onKeyDown, { passive: true });
-      viewport.addEventListener("touchstart", onGestureStart, {
-        passive: true,
-      });
-      viewport.addEventListener("pointerdown", onGestureStart, {
-        passive: true,
-      });
-      window.addEventListener("touchend", onGestureEnd, { passive: true });
-      window.addEventListener("touchcancel", onGestureEnd, { passive: true });
-      window.addEventListener("pointerup", onGestureEnd, { passive: true });
-      window.addEventListener("pointercancel", onGestureEnd, {
-        passive: true,
-      });
       lastScrollTop = viewport.scrollTop;
     }
+  };
+
+  const captureTransientReplacementClamp = (
+    records: readonly MutationRecord[],
+  ) => {
+    // Safari 26 can report a same-task replacement only after the scroll range
+    // has recovered, so the exact range-clamp signature is no longer visible.
+    if (
+      restoredThisTurn ||
+      restoreScrollTop !== null ||
+      !wasPinnedAtLastScroll() ||
+      (typeof CSS !== "undefined" && CSS.supports("overflow-anchor", "auto"))
+    ) {
+      return;
+    }
+
+    const replacedContent = records.some(
+      (record) =>
+        record.type === "childList" &&
+        record.addedNodes.length > 0 &&
+        record.removedNodes.length > 0,
+    );
+    if (!replacedContent) return;
+
+    const state = store.getState();
+    const { viewport, anchor } = state.element;
+    const clamp = state.targetConfig;
+    if (
+      state.turnAnchor !== "top" ||
+      viewport !== listenedViewport ||
+      !anchor ||
+      !clamp ||
+      viewport.scrollTop >= lastScrollTop
+    ) {
+      return;
+    }
+
+    const maxScrollTop = Math.max(
+      0,
+      viewport.scrollHeight - viewport.clientHeight,
+    );
+    const targetScrollTop = snapScrollTop(
+      computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
+    );
+    const rangeRecovered = lastScrollTop <= maxScrollTop + 1;
+    const targetUnchanged =
+      lastAppliedTarget !== null &&
+      Math.abs(targetScrollTop - lastAppliedTarget) <= 1;
+
+    if (rangeRecovered && targetUnchanged) {
+      restoreScrollTop = lastScrollTop;
+    }
+  };
+
+  const handleObservedChange = (change: ReserveObserverChange) => {
+    if (change.type === "mutation") {
+      captureTransientReplacementClamp(change.records);
+    }
+    scheduler.schedule();
   };
 
   function apply() {
@@ -260,7 +245,6 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
       restoreScrollTop = null;
       restoredThisTurn = false;
-      lastLayoutChangeAt = -Infinity;
       if (Math.abs(viewport.scrollTop - targetScrollTop) > 1) {
         viewport.scrollTo({ top: targetScrollTop, behavior: "smooth" });
       }
@@ -274,8 +258,8 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
         restoreScrollTop + (targetScrollTop - lastAppliedTarget),
       );
       restoreScrollTop = null;
+      restoredThisTurn = true;
       if (Math.abs(viewport.scrollTop - desired) > 1) {
-        restoredThisTurn = true;
         viewport.scrollTo({ top: desired, behavior: "instant" });
       }
     }
@@ -284,10 +268,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   }
 
   const scheduler = createFrameScheduler(apply);
-  const observers = createReserveObservers(() => {
-    lastLayoutChangeAt = performance.now();
-    scheduler.schedule();
-  });
+  const observers = createReserveObservers(handleObservedChange);
 
   scheduler.schedule();
   const unsubscribe = store.subscribe(scheduler.schedule);

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -4,10 +4,7 @@ import {
   computeTopAnchorReserve,
   computeTopAnchorTargetScrollTop,
 } from "./computeTopAnchorSlack";
-import {
-  createReserveObservers,
-  type ReserveObserverChange,
-} from "./createReserveObservers";
+import { createReserveObservers } from "./createReserveObservers";
 import {
   createReserveElement,
   getAnchorId,
@@ -60,17 +57,6 @@ const createFrameScheduler = (fn: () => void) => {
   };
 };
 
-const FALLBACK_SCROLL_INTENT_WINDOW_MS = 500;
-const SCROLL_KEYS = new Set([
-  "ArrowUp",
-  "ArrowDown",
-  "PageUp",
-  "PageDown",
-  "Home",
-  "End",
-  " ",
-]);
-
 export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
   let lastScrolledAnchorId: string | undefined;
@@ -80,13 +66,10 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let restoreScrollTop: number | null = null;
   let restoredThisTurn = false;
   let lastAppliedTarget: number | null = null;
-  let pendingPinnedReplacement = false;
-  let lastFallbackScrollIntentAt = -Infinity;
 
   const clearRestore = () => {
     restoreScrollTop = null;
     lastAppliedTarget = null;
-    pendingPinnedReplacement = false;
   };
 
   const wasPinnedAtLastScroll = () =>
@@ -115,84 +98,18 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     lastScrollTop = scrollTop;
   };
 
-  const recordFallbackScrollIntent = () => {
-    lastFallbackScrollIntentAt = performance.now();
-  };
-
-  const handleFallbackKeyDown = (event: Event) => {
-    const keyboardEvent = event as KeyboardEvent;
-    const target = keyboardEvent.target;
-    if (
-      !SCROLL_KEYS.has(keyboardEvent.key) ||
-      (target instanceof HTMLElement &&
-        (target.isContentEditable || target.closest("input, textarea")))
-    ) {
-      return;
-    }
-    recordFallbackScrollIntent();
-  };
-
   const listenViewport = (viewport: HTMLElement | null) => {
     if (listenedViewport === viewport) return;
     if (listenedViewport) {
       listenedViewport.removeEventListener("scroll", handleScroll);
-      listenedViewport.removeEventListener("wheel", recordFallbackScrollIntent);
-      listenedViewport.removeEventListener(
-        "touchstart",
-        recordFallbackScrollIntent,
-      );
-      listenedViewport.removeEventListener(
-        "touchmove",
-        recordFallbackScrollIntent,
-      );
-      listenedViewport.removeEventListener("keydown", handleFallbackKeyDown);
-      listenedViewport.removeEventListener(
-        "focusin",
-        recordFallbackScrollIntent,
-      );
     }
     listenedViewport = viewport;
     restoredThisTurn = false;
-    lastFallbackScrollIntentAt = -Infinity;
     clearRestore();
     if (viewport) {
       viewport.addEventListener("scroll", handleScroll, { passive: true });
-      viewport.addEventListener("wheel", recordFallbackScrollIntent, {
-        passive: true,
-      });
-      viewport.addEventListener("touchstart", recordFallbackScrollIntent, {
-        passive: true,
-      });
-      viewport.addEventListener("touchmove", recordFallbackScrollIntent, {
-        passive: true,
-      });
-      viewport.addEventListener("keydown", handleFallbackKeyDown, {
-        passive: true,
-      });
-      viewport.addEventListener("focusin", recordFallbackScrollIntent, {
-        passive: true,
-      });
       lastScrollTop = viewport.scrollTop;
     }
-  };
-
-  const recordPinnedReplacement = (records: readonly MutationRecord[]) => {
-    const replacedContent =
-      records.length > 0 &&
-      records.every(
-        (record) =>
-          record.type === "childList" &&
-          record.addedNodes.length > 0 &&
-          record.removedNodes.length > 0,
-      );
-    pendingPinnedReplacement ||= replacedContent && wasPinnedAtLastScroll();
-  };
-
-  const handleObservedChange = (change: ReserveObserverChange) => {
-    if (change.type === "mutation") {
-      recordPinnedReplacement(change.records);
-    }
-    scheduler.schedule();
   };
 
   function apply() {
@@ -263,29 +180,6 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
     );
 
-    // Safari 26 can expose a same-task replacement only after the scroll range
-    // has recovered, so the exact range-clamp signature is no longer visible.
-    if (pendingPinnedReplacement) {
-      pendingPinnedReplacement = false;
-      const maxScrollTop = Math.max(
-        0,
-        viewport.scrollHeight - viewport.clientHeight,
-      );
-      const fallbackAllowed =
-        !restoredThisTurn &&
-        restoreScrollTop === null &&
-        lastAppliedTarget !== null &&
-        viewport.scrollTop < lastAppliedTarget &&
-        lastAppliedTarget <= maxScrollTop + 1 &&
-        Math.abs(targetScrollTop - lastAppliedTarget) <= 1 &&
-        performance.now() - lastFallbackScrollIntentAt >=
-          FALLBACK_SCROLL_INTENT_WINDOW_MS &&
-        (typeof CSS === "undefined" ||
-          !CSS.supports("overflow-anchor", "auto"));
-
-      if (fallbackAllowed) restoreScrollTop = lastAppliedTarget;
-    }
-
     if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
       restoreScrollTop = null;
       restoredThisTurn = false;
@@ -312,7 +206,7 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   }
 
   const scheduler = createFrameScheduler(apply);
-  const observers = createReserveObservers(handleObservedChange);
+  const observers = createReserveObservers(scheduler.schedule);
 
   scheduler.schedule();
   const unsubscribe = store.subscribe(scheduler.schedule);

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -60,6 +60,17 @@ const createFrameScheduler = (fn: () => void) => {
   };
 };
 
+const FALLBACK_SCROLL_INTENT_WINDOW_MS = 500;
+const SCROLL_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+]);
+
 export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let reserve: HTMLElement | null = null;
   let lastScrolledAnchorId: string | undefined;
@@ -69,10 +80,13 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
   let restoreScrollTop: number | null = null;
   let restoredThisTurn = false;
   let lastAppliedTarget: number | null = null;
+  let pendingPinnedReplacement = false;
+  let lastFallbackScrollIntentAt = -Infinity;
 
   const clearRestore = () => {
     restoreScrollTop = null;
     lastAppliedTarget = null;
+    pendingPinnedReplacement = false;
   };
 
   const wasPinnedAtLastScroll = () =>
@@ -101,76 +115,80 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     lastScrollTop = scrollTop;
   };
 
+  const recordFallbackScrollIntent = () => {
+    lastFallbackScrollIntentAt = performance.now();
+  };
+
+  const handleFallbackKeyDown = (event: Event) => {
+    const keyboardEvent = event as KeyboardEvent;
+    const target = keyboardEvent.target;
+    if (
+      !SCROLL_KEYS.has(keyboardEvent.key) ||
+      (target instanceof HTMLElement &&
+        (target.isContentEditable || target.closest("input, textarea")))
+    ) {
+      return;
+    }
+    recordFallbackScrollIntent();
+  };
+
   const listenViewport = (viewport: HTMLElement | null) => {
     if (listenedViewport === viewport) return;
     if (listenedViewport) {
       listenedViewport.removeEventListener("scroll", handleScroll);
+      listenedViewport.removeEventListener("wheel", recordFallbackScrollIntent);
+      listenedViewport.removeEventListener(
+        "touchstart",
+        recordFallbackScrollIntent,
+      );
+      listenedViewport.removeEventListener(
+        "touchmove",
+        recordFallbackScrollIntent,
+      );
+      listenedViewport.removeEventListener("keydown", handleFallbackKeyDown);
+      listenedViewport.removeEventListener(
+        "focusin",
+        recordFallbackScrollIntent,
+      );
     }
     listenedViewport = viewport;
     restoredThisTurn = false;
+    lastFallbackScrollIntentAt = -Infinity;
     clearRestore();
     if (viewport) {
       viewport.addEventListener("scroll", handleScroll, { passive: true });
+      viewport.addEventListener("wheel", recordFallbackScrollIntent, {
+        passive: true,
+      });
+      viewport.addEventListener("touchstart", recordFallbackScrollIntent, {
+        passive: true,
+      });
+      viewport.addEventListener("touchmove", recordFallbackScrollIntent, {
+        passive: true,
+      });
+      viewport.addEventListener("keydown", handleFallbackKeyDown, {
+        passive: true,
+      });
+      viewport.addEventListener("focusin", recordFallbackScrollIntent, {
+        passive: true,
+      });
       lastScrollTop = viewport.scrollTop;
     }
   };
 
-  const captureTransientReplacementClamp = (
-    records: readonly MutationRecord[],
-  ) => {
-    // Safari 26 can report a same-task replacement only after the scroll range
-    // has recovered, so the exact range-clamp signature is no longer visible.
-    if (
-      restoredThisTurn ||
-      restoreScrollTop !== null ||
-      !wasPinnedAtLastScroll() ||
-      (typeof CSS !== "undefined" && CSS.supports("overflow-anchor", "auto"))
-    ) {
-      return;
-    }
-
+  const recordPinnedReplacement = (records: readonly MutationRecord[]) => {
     const replacedContent = records.some(
       (record) =>
         record.type === "childList" &&
         record.addedNodes.length > 0 &&
         record.removedNodes.length > 0,
     );
-    if (!replacedContent) return;
-
-    const state = store.getState();
-    const { viewport, anchor } = state.element;
-    const clamp = state.targetConfig;
-    if (
-      state.turnAnchor !== "top" ||
-      !viewport ||
-      viewport !== listenedViewport ||
-      !anchor ||
-      !clamp ||
-      viewport.scrollTop >= lastScrollTop
-    ) {
-      return;
-    }
-
-    const maxScrollTop = Math.max(
-      0,
-      viewport.scrollHeight - viewport.clientHeight,
-    );
-    const targetScrollTop = snapScrollTop(
-      computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
-    );
-    const rangeRecovered = lastScrollTop <= maxScrollTop + 1;
-    const targetUnchanged =
-      lastAppliedTarget !== null &&
-      Math.abs(targetScrollTop - lastAppliedTarget) <= 1;
-
-    if (rangeRecovered && targetUnchanged) {
-      restoreScrollTop = lastScrollTop;
-    }
+    pendingPinnedReplacement ||= replacedContent && wasPinnedAtLastScroll();
   };
 
   const handleObservedChange = (change: ReserveObserverChange) => {
     if (change.type === "mutation") {
-      captureTransientReplacementClamp(change.records);
+      recordPinnedReplacement(change.records);
     }
     scheduler.schedule();
   };
@@ -242,6 +260,29 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     const targetScrollTop = snapScrollTop(
       computeTopAnchorTargetScrollTop({ viewport, anchor, ...clamp }),
     );
+
+    // Safari 26 can expose a same-task replacement only after the scroll range
+    // has recovered, so the exact range-clamp signature is no longer visible.
+    if (pendingPinnedReplacement) {
+      pendingPinnedReplacement = false;
+      const maxScrollTop = Math.max(
+        0,
+        viewport.scrollHeight - viewport.clientHeight,
+      );
+      const fallbackAllowed =
+        !restoredThisTurn &&
+        restoreScrollTop === null &&
+        lastAppliedTarget !== null &&
+        viewport.scrollTop < lastAppliedTarget &&
+        lastAppliedTarget <= maxScrollTop + 1 &&
+        Math.abs(targetScrollTop - lastAppliedTarget) <= 1 &&
+        performance.now() - lastFallbackScrollIntentAt >=
+          FALLBACK_SCROLL_INTENT_WINDOW_MS &&
+        (typeof CSS === "undefined" ||
+          !CSS.supports("overflow-anchor", "auto"));
+
+      if (fallbackAllowed) restoreScrollTop = lastAppliedTarget;
+    }
 
     if (anchorId === undefined || anchorId !== lastScrolledAnchorId) {
       restoreScrollTop = null;


### PR DESCRIPTION
Fixes #6315

## Problem

With `turnAnchor="top"`, transient content shrink can reduce Safari's scroll range while the viewport is pinned. Safari clamps `scrollTop` to the temporary maximum and can leave the user message above its pinned position after the content and reserve settle.

## Root cause

The reserve is recalculated on the next animation frame, after the browser has already clamped the viewport. Earlier versions of this patch classified generic upward movement as a clamp, which could also undo `scrollIntoView()`, focus scrolling, or another reachable programmatic scroll.

## Change

- Track scroll changes only while top anchoring is active.
- Capture a clamp only when the previous pinned offset is outside the current scroll range and the browser lands at that range's exact maximum.
- Restore the captured position relative to the current top-anchor target, at most once per anchor turn.
- Clear pending restoration when the viewport, anchor mode, or anchor lifecycle changes.
- Do not infer a clamp after the range has already recovered. A forced-layout same-task decrease is indistinguishable from a reachable host scroll after the fact, while an ordinary same-task remove/add without an intermediate layout read does not clamp on Safari 26.2.

## Verification

- `pnpm --filter @assistant-ui/react exec vitest run src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts --maxWorkers=4` (13 tests, no type errors)
- `pnpm --filter @assistant-ui/react exec vitest run --maxWorkers=2` (50 files, 426 tests, no type errors)
- `pnpm --filter with-tap-runtime exec tsc --noEmit`
- `pnpm --filter @assistant-ui/react build`
- Focused `oxlint`, `oxfmt`, and `git diff --check`

Coverage includes an exact range clamp, reachable `scrollIntoView()` and focus scrolling, an out-of-range movement that does not land at the maximum, once-per-turn behavior, and anchor-gap cleanup.

A self-reporting Safari 26.2 browser probe also checked the event geometry:

- A shrink retained for one rendering update changed the viewport from `scrollTop=220` to `60` and emitted the scroll event while `maxScrollTop=60`; the exact predicate matches.
- Same-task style shrink/regrow and DOM remove/add replacement without an intermediate layout read emitted no clamp event and retained `scrollTop=220`.
- Forcing layout while temporarily shrunken and then recovering in the same task emitted `scrollTop=60` after `maxScrollTop` returned to `220`. This deliberately unsupported shape cannot be distinguished from a host scroll by the later event.

All required GitHub checks, including package/app builds, tests, bundle size, Claude, Cubic, and Rupic, pass on the final commit.

## Public surface

`@assistant-ui/react` internal behavior only. No exports, docs, or templates change. Includes a patch changeset.