### PR TITLE
refactor(cloud): provide thread title generation from assistant-cloud

### DIFF
--- a/.changeset/cloud-thread-title.md
+++ b/.changeset/cloud-thread-title.md
@@ -1,0 +1,6 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+refactor: provide thread title generation from assistant-cloud; cloud-ai-sdk keeps only the format-specific half.

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -540,8 +540,19 @@ declare function createSamplingCollector(): {
   reset: () => void;
 };
 
+declare function generateThreadTitle(cloud: AssistantCloud, options: {
+  threadId: string;
+  messages: readonly {
+    role: string;
+    content: readonly {
+      type: "text";
+      text: string;
+    }[];
+  }[];
+}): Promise<string | null>;
+
 declare namespace entry_root_exports {
-  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, normalizeRunTelemetryUsage, truncateRunTelemetryText, wrapSamplingHandler };
+  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, generateThreadTitle, normalizeRunTelemetryUsage, truncateRunTelemetryText, wrapSamplingHandler };
 }
 
 declare function normalizeRunTelemetryUsage(usage: RunTelemetryUsageInit): RunTelemetryUsage | undefined;

--- a/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
+++ b/packages/cloud-ai-sdk/src/threads/generateThreadTitle.ts
@@ -1,4 +1,7 @@
-import type { AssistantCloud } from "assistant-cloud";
+import {
+  generateThreadTitle as generateCloudThreadTitle,
+  type AssistantCloud,
+} from "assistant-cloud";
 import { MESSAGE_FORMAT } from "../chat/MessagePersistence";
 
 export async function generateThreadTitle(
@@ -47,29 +50,8 @@ export async function generateThreadTitle(
 
   if (convertedMessages.length === 0) return null;
 
-  const stream = await cloud.runs.stream({
-    thread_id: threadId,
-    assistant_id: "system/thread_title",
+  return generateCloudThreadTitle(cloud, {
+    threadId,
     messages: convertedMessages,
   });
-
-  let title = "";
-  const reader = stream.getReader();
-  try {
-    while (true) {
-      const { done, value: chunk } = await reader.read();
-      if (done) break;
-      if (chunk.type === "text-delta") {
-        title += chunk.textDelta;
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  if (title) {
-    await cloud.threads.update(threadId, { title });
-  }
-
-  return title || null;
 }

--- a/packages/cloud/src/generateThreadTitle.test.ts
+++ b/packages/cloud/src/generateThreadTitle.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "./AssistantCloud";
+import { generateThreadTitle } from "./generateThreadTitle";
+
+const titleStream = (...chunks: { type: string; textDelta?: string }[]) =>
+  new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+
+const createCloud = (stream: ReadableStream<unknown>) => {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const run = vi.fn().mockResolvedValue(stream);
+  const cloud = {
+    threads: { update },
+    runs: { stream: run },
+  } as unknown as AssistantCloud;
+  return { cloud, update, run };
+};
+
+describe("generateThreadTitle", () => {
+  it("accumulates text deltas and updates the thread title", async () => {
+    const { cloud, run, update } = createCloud(
+      titleStream(
+        { type: "text-delta", textDelta: "Weather " },
+        { type: "text-delta", textDelta: "chat" },
+      ),
+    );
+
+    await expect(
+      generateThreadTitle(cloud, {
+        threadId: "thread-1",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "What is the weather today?" }],
+          },
+        ],
+      }),
+    ).resolves.toBe("Weather chat");
+
+    expect(run).toHaveBeenCalledExactlyOnceWith({
+      thread_id: "thread-1",
+      assistant_id: "system/thread_title",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "What is the weather today?" }],
+        },
+      ],
+    });
+    expect(update).toHaveBeenCalledExactlyOnceWith("thread-1", {
+      title: "Weather chat",
+    });
+  });
+
+  it("returns null without updating when the stream has no text", async () => {
+    const { cloud, update } = createCloud(titleStream());
+
+    await expect(
+      generateThreadTitle(cloud, {
+        threadId: "thread-1",
+        messages: [],
+      }),
+    ).resolves.toBeNull();
+
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/src/generateThreadTitle.ts
+++ b/packages/cloud/src/generateThreadTitle.ts
@@ -1,0 +1,38 @@
+import type { AssistantCloud } from "./AssistantCloud";
+
+export async function generateThreadTitle(
+  cloud: AssistantCloud,
+  options: {
+    threadId: string;
+    messages: readonly {
+      role: string;
+      content: readonly { type: "text"; text: string }[];
+    }[];
+  },
+): Promise<string | null> {
+  const stream = await cloud.runs.stream({
+    thread_id: options.threadId,
+    assistant_id: "system/thread_title",
+    messages: options.messages,
+  });
+
+  let title = "";
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value: chunk } = await reader.read();
+      if (done) break;
+      if (chunk.type === "text-delta") {
+        title += chunk.textDelta;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (title) {
+    await cloud.threads.update(options.threadId, { title });
+  }
+
+  return title || null;
+}

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -2,6 +2,7 @@ export type { CloudMessage } from "./AssistantCloudThreadMessages";
 export type { AssistantCloudTelemetryConfig } from "./AssistantCloudAPI";
 export { CloudAPIError } from "./AssistantCloudAPI";
 export { CloudResponseError } from "./cloudResponse";
+export { generateThreadTitle } from "./generateThreadTitle";
 export type { AssistantCloudRunReport } from "./AssistantCloudRuns";
 export {
   createRunTelemetryToolCall,


### PR DESCRIPTION
## summary

- assistant-cloud now exports `generateThreadTitle(cloud, { threadId, messages })`: the generic half of thread-title generation (runs.stream against system/thread_title, text-delta accumulation, threads.update, title-or-null return), moved byte-faithfully from cloud-ai-sdk
- cloud-ai-sdk's generateThreadTitle keeps its signature and only the ai-sdk half (message list retry, chronological reverse, ai-sdk/v6 format filter, text extraction) and delegates the rest; this mirrors how the run-telemetry serializers already sank into assistant-cloud
- scope note: this helper serves the promise-shaped cloud-ai-sdk path only; core's ThreadListAdapter.generateTitle contract is stream-shaped (returns an AssistantStream consumed incrementally) and is deliberately not covered here
- new colocated test in packages/cloud covers stream accumulation, the update call when a title is produced, and the null path

## test plan

### already verified

- [x] assistant-cloud build green; packages/cloud vitest 14 files, 99 tests; packages/cloud-ai-sdk vitest 13 files, 94 tests (both rerun independently)

### reviewer should verify

- [ ] a new cloud thread on the cloud-ai-sdk path still receives a generated title after the first exchange