### PR TITLE
refactor(react-pi): use the shared assistant-stream SSE decoder

### DIFF
--- a/.changeset/pi-sse-decoder.md
+++ b/.changeset/pi-sse-decoder.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+refactor: parse pi event streams with the shared assistant-stream SSE decoder.

--- a/packages/react-pi/package.json
+++ b/packages/react-pi/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@assistant-ui/core": "^0.3.15",
     "@assistant-ui/store": "^0.3.10",
+    "assistant-stream": "^0.3.39",
     "@standard-schema/spec": "^1.1.0"
   },
   "peerDependencies": {

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -290,7 +290,7 @@ export const openPiEventStream = (
         }
         validateEventStreamContentType(response);
 
-        const sseDecoder = new SSEEventDecoder();
+        const sseDecoder = createSseDecoder();
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
         const handleFrame = (frame: { event?: string; data: string }) => {
@@ -339,9 +339,6 @@ export const openPiEventStream = (
             const { value, done } = result;
             if (done) {
               shouldCancel = false;
-              for (const frame of sseDecoder.push(textDecoder.decode())) {
-                handleFrame(frame);
-              }
               break;
             }
             const chunk = textDecoder.decode(value, { stream: true });

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -6,9 +6,9 @@
  * format and reconnection live here.
  *
  * Two pieces:
- * - `createSseDecoder()` — a pure, incremental SSE frame parser. Feed it text
- *   chunks (which may split a frame mid-line); it returns the complete frames so
- *   far. This is the unit-tested core, with no network or browser dependency.
+ * - `createSseDecoder()` — an incremental SSE frame parser wrapping
+ *   assistant-stream's `SSEEventDecoder`. Feed it text chunks (which may split
+ *   a frame mid-line); it returns the complete frames so far.
  * - `openPiEventStream()` — a `fetch` + `ReadableStream` loop that feeds the
  *   decoder and emits parsed `PiAnyClientEvent`s. Snapshot-first reconnect: the
  *   server re-sends a `snapshot` on every (re)connect, so a dropped stream
@@ -17,6 +17,7 @@
  *
  * Browser-safe: imports no `@earendil-works/pi-*`.
  */
+import { SSEEventDecoder } from "assistant-stream/utils";
 import { isRecord } from "@assistant-ui/core/internal";
 import { isKnownPiClientEventType } from "../eventTypes";
 import type { PiAnyClientEvent } from "../types";
@@ -39,86 +40,18 @@ export interface SseFrame {
 
 /**
  * Incremental SSE frame parser. `push(chunk)` returns every frame completed by
- * that chunk; partial trailing data is buffered until its terminating blank
- * line arrives. Handles LF, CRLF, and CR line endings, `:`-comment heartbeats,
- * and multi-line `data:`.
+ * that chunk; partial trailing data is buffered by the shared decoder until its
+ * terminating blank line arrives.
  */
 export const createSseDecoder = () => {
-  let buffer = "";
-  let skipNextLineFeed = false;
-  let dataLines: string[] = [];
-  let eventName: string | undefined;
-  let lastId: string | undefined;
-
-  const resetFrame = () => {
-    dataLines = [];
-    eventName = undefined;
-  };
-
-  const handleLine = (line: string, out: SseFrame[]) => {
-    if (line === "") {
-      // Blank line dispatches the frame. A frame with no data lines (e.g. a
-      // lone `:` heartbeat followed by a blank line) is discarded.
-      if (dataLines.length === 0) {
-        resetFrame();
-        return;
-      }
-      const frame: SseFrame = { data: dataLines.join("\n") };
-      if (eventName !== undefined) frame.event = eventName;
-      if (lastId !== undefined) frame.id = lastId;
-      out.push(frame);
-      resetFrame();
-      return;
-    }
-    // Comment line (used for keep-alive); ignore.
-    if (line.startsWith(":")) return;
-
-    const colon = line.indexOf(":");
-    const field = colon === -1 ? line : line.slice(0, colon);
-    let value = colon === -1 ? "" : line.slice(colon + 1);
-    if (value.startsWith(" ")) value = value.slice(1);
-
-    switch (field) {
-      case "data":
-        dataLines.push(value);
-        break;
-      case "event":
-        eventName = value;
-        break;
-      case "id":
-        lastId = value;
-        break;
-      // `retry:` is ignored — reconnect cadence is owned by openPiEventStream.
-    }
-  };
-
+  const decoder = new SSEEventDecoder();
   return {
     push(chunk: string): SseFrame[] {
-      const out: SseFrame[] = [];
-      let lineStart = 0;
-
-      for (let index = 0; index < chunk.length; index++) {
-        const character = chunk[index]!;
-
-        if (skipNextLineFeed) {
-          skipNextLineFeed = false;
-          if (character === "\n") {
-            lineStart = index + 1;
-            continue;
-          }
-        }
-
-        if (character === "\n" || character === "\r") {
-          buffer += chunk.slice(lineStart, index);
-          handleLine(buffer, out);
-          buffer = "";
-          skipNextLineFeed = character === "\r";
-          lineStart = index + 1;
-        }
-      }
-
-      buffer += chunk.slice(lineStart);
-      return out;
+      return decoder.push(chunk).map(({ data, event, id }) => ({
+        ...(event === undefined ? {} : { event }),
+        data,
+        ...(id === undefined ? {} : { id }),
+      }));
     },
   };
 };
@@ -357,9 +290,30 @@ export const openPiEventStream = (
         }
         validateEventStreamContentType(response);
 
-        const decoder = createSseDecoder();
+        const sseDecoder = new SSEEventDecoder();
         const reader = response.body.getReader();
         const textDecoder = new TextDecoder();
+        const handleFrame = (frame: { event?: string; data: string }) => {
+          if (frame.event === "ping" || frame.data === "") return;
+          let parsed: PiAnyClientEvent;
+          try {
+            parsed = parseEventStreamPayload(frame.data, expectedThreadId);
+          } catch (error) {
+            if (error instanceof InvalidKnownEventStreamPayloadError) {
+              needsSnapshotRecovery = true;
+              throw error;
+            }
+            reportError(error);
+            return;
+          }
+          if (
+            requestUrl === snapshotRecoveryUrl &&
+            parsed.type === "snapshot"
+          ) {
+            needsSnapshotRecovery = false;
+          }
+          if (!closed) emitEvent(parsed);
+        };
 
         let shouldCancel = true;
         let cancelPromise: Promise<void> | undefined;
@@ -385,29 +339,14 @@ export const openPiEventStream = (
             const { value, done } = result;
             if (done) {
               shouldCancel = false;
+              for (const frame of sseDecoder.push(textDecoder.decode())) {
+                handleFrame(frame);
+              }
               break;
             }
             const chunk = textDecoder.decode(value, { stream: true });
-            for (const frame of decoder.push(chunk)) {
-              if (frame.event === "ping" || frame.data === "") continue;
-              let parsed: PiAnyClientEvent;
-              try {
-                parsed = parseEventStreamPayload(frame.data, expectedThreadId);
-              } catch (error) {
-                if (error instanceof InvalidKnownEventStreamPayloadError) {
-                  needsSnapshotRecovery = true;
-                  throw error;
-                }
-                reportError(error);
-                continue;
-              }
-              if (
-                requestUrl === snapshotRecoveryUrl &&
-                parsed.type === "snapshot"
-              ) {
-                needsSnapshotRecovery = false;
-              }
-              if (!closed) emitEvent(parsed);
+            for (const frame of sseDecoder.push(chunk)) {
+              handleFrame(frame);
             }
           }
         } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4775,6 +4775,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
+      assistant-stream:
+        specifier: ^0.3.39
+        version: link:../assistant-stream
     devDependencies:
       '@assistant-ui/react':
         specifier: workspace:*


### PR DESCRIPTION
## summary

- react-pi's client hand-rolled a full SSE line parser (field/colon split, comment heartbeats, CRLF/CR handling, multi-line data); it now wraps assistant-stream's SSEEventDecoder, the same decoder react-a2a and react-google-adk already use
- `createSseDecoder` keeps its exported shape (SseFrame frames), so `openPiEventStream` and every consumer are unchanged; pi-only concerns stay local (ping filtering, payload and thread validation, snapshot-first reconnect, cancellation)
- adds the first-party `assistant-stream@^0.3.39` dependency (same specifier react-a2a carries) with the lockfile regenerated

## test plan

### already verified

- [x] full react-pi vitest suite: 13 files, 216 tests green, including the decoder edge-case fixtures (CRLF splits, comment lines, multi-line data)

### reviewer should verify

- [ ] a live pi event stream still decodes and reconnects (snapshot replaces state after a dropped connection)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kdBaYxGKZ_jA7XDiykzG6I3EsBkcAWF7jAlNtObLBfeLvKj8JDWZNT77vd4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->