### PR TITLE
refactor(core): share the attachment add cancellation machinery

### DIFF
--- a/.changeset/attachment-add-operations.md
+++ b/.changeset/attachment-add-operations.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: share the attachment add cancellation machinery between the composer core and the store client.

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -29,14 +29,13 @@ import type { QueuePlacement } from "../queue/external-thread-queue-adapter";
 import { EMPTY_QUEUE_ITEMS, type QueueItemState } from "../queue/queue-item";
 import { generateId } from "../../utils/id";
 import { notifyEventListeners } from "../../utils/notify-event-listeners";
+import {
+  AttachmentAddOperations,
+  drainAttachmentAdd,
+} from "../utils/attachment-add-operations";
 
 const isAttachmentComplete = (a: Attachment): a is CompleteAttachment =>
   a.status.type === "complete";
-
-type AttachmentAddOperation = {
-  cancelled: boolean;
-  attachmentIds: Set<string>;
-};
 
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
@@ -149,21 +148,14 @@ export abstract class BaseComposerRuntimeCore
   protected _isSending = false;
   private _removedDuringSend = new Set<string>();
   private _sendGeneration = 0;
-  private _attachmentAddOperations = new Set<AttachmentAddOperation>();
+  private _attachmentAddOperations = new AttachmentAddOperations();
 
   private _cancelAttachmentAdd(attachmentId: string) {
-    for (const operation of [...this._attachmentAddOperations]) {
-      if (!operation.attachmentIds.has(attachmentId)) continue;
-      operation.cancelled = true;
-      this._attachmentAddOperations.delete(operation);
-    }
+    this._attachmentAddOperations.cancel(attachmentId);
   }
 
   private _cancelAllAttachmentAdds() {
-    for (const operation of this._attachmentAddOperations) {
-      operation.cancelled = true;
-    }
-    this._attachmentAddOperations.clear();
+    this._attachmentAddOperations.cancelAll();
   }
 
   private _emptyTextAndAttachments() {
@@ -463,16 +455,10 @@ export abstract class BaseComposerRuntimeCore
       throw err;
     }
 
-    const operation: AttachmentAddOperation = {
-      cancelled: false,
-      attachmentIds: new Set(),
-    };
-    const operations = this._attachmentAddOperations;
-    operations.add(operation);
+    const operation = this._attachmentAddOperations.start();
     const upsertAttachment = (a: PendingAttachment) => {
-      if (operation.cancelled) return false;
+      if (!this._attachmentAddOperations.accept(operation, a.id)) return false;
 
-      operation.attachmentIds.add(a.id);
       const idx = this._attachments.findIndex(
         (attachment) => attachment.id === a.id,
       );
@@ -491,18 +477,15 @@ export abstract class BaseComposerRuntimeCore
     };
     let lastAttachment: PendingAttachment | undefined;
     try {
-      const promiseOrGenerator = adapter.add({ file: fileOrAttachment });
-      if (Symbol.asyncIterator in promiseOrGenerator) {
-        for await (const r of promiseOrGenerator) {
-          lastAttachment = r;
-          if (!upsertAttachment(r)) break;
-        }
-      } else {
-        lastAttachment = await promiseOrGenerator;
-        upsertAttachment(lastAttachment);
-      }
+      await drainAttachmentAdd(
+        adapter.add({ file: fileOrAttachment }),
+        (attachment) => {
+          lastAttachment = attachment;
+          return upsertAttachment(attachment);
+        },
+      );
     } catch (e) {
-      if (operation.cancelled) return;
+      if (this._attachmentAddOperations.isCancelled(operation)) return;
       if (lastAttachment) {
         upsertAttachment({
           ...lastAttachment,
@@ -521,10 +504,10 @@ export abstract class BaseComposerRuntimeCore
       );
       throw e;
     } finally {
-      operations.delete(operation);
+      this._attachmentAddOperations.finish(operation);
     }
 
-    if (operation.cancelled) return;
+    if (this._attachmentAddOperations.isCancelled(operation)) return;
     if (
       lastAttachment?.status.type === "incomplete" &&
       lastAttachment.status.reason === "error"

--- a/packages/core/src/runtime/utils/attachment-add-operations.ts
+++ b/packages/core/src/runtime/utils/attachment-add-operations.ts
@@ -1,0 +1,59 @@
+export type AttachmentAddOperation = {
+  cancelled: boolean;
+  attachmentIds: Set<string>;
+};
+
+export class AttachmentAddOperations {
+  private readonly operations = new Set<AttachmentAddOperation>();
+
+  start() {
+    const operation: AttachmentAddOperation = {
+      cancelled: false,
+      attachmentIds: new Set(),
+    };
+    this.operations.add(operation);
+    return operation;
+  }
+
+  accept(operation: AttachmentAddOperation, attachmentId: string) {
+    if (operation.cancelled) return false;
+    operation.attachmentIds.add(attachmentId);
+    return true;
+  }
+
+  finish(operation: AttachmentAddOperation) {
+    this.operations.delete(operation);
+  }
+
+  isCancelled(operation: AttachmentAddOperation) {
+    return operation.cancelled;
+  }
+
+  cancel(attachmentId: string) {
+    for (const operation of [...this.operations]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      this.operations.delete(operation);
+    }
+  }
+
+  cancelAll() {
+    for (const operation of this.operations) {
+      operation.cancelled = true;
+    }
+    this.operations.clear();
+  }
+}
+
+export const drainAttachmentAdd = async <T>(
+  result: Promise<T> | AsyncIterable<T>,
+  accept: (attachment: T) => boolean,
+) => {
+  if (Symbol.asyncIterator in result) {
+    for await (const attachment of result) {
+      if (!accept(attachment)) break;
+    }
+  } else {
+    accept(await result);
+  }
+};

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -44,6 +44,10 @@ import type { ComposerSendOptions } from "../scopes/composer";
 import { fileMatchesAccept } from "../../adapters/attachment";
 import { getThreadMessageText } from "../../utils/text";
 import { resolveToolApprovalResponse } from "../../runtime/utils/resolveToolApprovalResponse";
+import {
+  AttachmentAddOperations,
+  drainAttachmentAdd,
+} from "../../runtime/utils/attachment-add-operations";
 import { toMessagePartStatus } from "../../utils/normalizePartStatus";
 import { ModelContext } from "./model-context-client";
 import { ThreadSuggestions } from "./suggestions";
@@ -420,53 +424,6 @@ type ComposerClientResourceProps = {
   attachmentAdapter?: AttachmentAdapter | undefined;
 };
 
-type AttachmentAddOperation = {
-  cancelled: boolean;
-  attachmentIds: Set<string>;
-};
-
-class AttachmentAddOperations {
-  private readonly operations = new Set<AttachmentAddOperation>();
-
-  start() {
-    const operation: AttachmentAddOperation = {
-      cancelled: false,
-      attachmentIds: new Set(),
-    };
-    this.operations.add(operation);
-    return operation;
-  }
-
-  accept(operation: AttachmentAddOperation, attachmentId: string) {
-    if (operation.cancelled) return false;
-    operation.attachmentIds.add(attachmentId);
-    return true;
-  }
-
-  finish(operation: AttachmentAddOperation) {
-    this.operations.delete(operation);
-  }
-
-  isCancelled(operation: AttachmentAddOperation) {
-    return operation.cancelled;
-  }
-
-  cancel(attachmentId: string) {
-    for (const operation of [...this.operations]) {
-      if (!operation.attachmentIds.has(attachmentId)) continue;
-      operation.cancelled = true;
-      this.operations.delete(operation);
-    }
-  }
-
-  cancelAll() {
-    for (const operation of this.operations) {
-      operation.cancelled = true;
-    }
-    this.operations.clear();
-  }
-}
-
 const useQueueItemClient = ({
   item,
   onMove,
@@ -485,19 +442,6 @@ const useQueueItemClient = ({
 };
 
 const QueueItemClient = resource(useQueueItemClient);
-
-const drainAdapterAdd = async (
-  result: ReturnType<AttachmentAdapter["add"]>,
-  upsert: (attachment: Attachment) => boolean,
-) => {
-  if (Symbol.asyncIterator in result) {
-    for await (const attachment of result) {
-      if (!upsert(attachment)) break;
-    }
-  } else {
-    upsert(await result);
-  }
-};
 
 // State whose setter tracks the latest value in a ref, so imperative
 // call sequences (setText immediately followed by send) observe the write
@@ -672,7 +616,7 @@ const useComposerClientResource = ({
       if (!isCreateAttachment(fileOrAttachment) && attachmentAdapter) {
         const operation = attachmentAddOperations.start();
         try {
-          await drainAdapterAdd(
+          await drainAttachmentAdd(
             attachmentAdapter.add({ file: fileOrAttachment }),
             (attachment) => {
               if (!attachmentAddOperations.accept(operation, attachment.id))


### PR DESCRIPTION
## summary

- the base composer core implemented attachment-add cancellation inline ({ cancelled, attachmentIds } records, cancel-by-attachment scan, cancel-all on reset/clear/send, refusal of yields after cancellation) while the store's external-thread client had the same machinery packaged as a helper
- both now consume one private AttachmentAddOperations class in runtime/utils (no barrel export); each caller keeps its own error-event emission and state-update policy
- behavior identical: cancellation mid-add stops accepting yielded attachments, and a cancelled operation's late results are dropped silently; net minus 9 lines

## test plan

### already verified

- [x] full core vitest suite: 136 files, 1468 tests green with zero assertion changes (rerun independently); no public export changes

### reviewer should verify

- [ ] removing an attachment while its adapter.add generator is mid-stream still discards the remaining yields in both the composer and the store client paths

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DQBv6axz52XZEfLep9kj7OcTCAnmsfpmY5wUzIEDXmRwAx2EAJgcpM2oIfQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->