### PR TITLE
refactor(core): share the remote thread list empty state and seeding

### DIFF
--- a/.changeset/remote-thread-seed.md
+++ b/.changeset/remote-thread-seed.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: share the remote thread list empty state and local thread seeding.

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -13,10 +13,10 @@ import {
   useClientResource,
 } from "@assistant-ui/store/client";
 import { isDevelopment, useThreadSelectionEvents } from "../../store/internal";
-import { generateId } from "../../utils/id";
 import { OptimisticState } from "../../runtimes/remote-thread-list/optimistic-state";
 import {
   classifyThreads,
+  createEmptyRemoteThreadState,
   createThreadMappingId,
   getThreadData,
   normalizeCursor,
@@ -24,8 +24,8 @@ import {
   type RemoteThreadData,
   type RemoteThreadState,
   preserveMidLoadTransitions,
+  seedNewThread,
   statusSnapshot,
-  LOCAL_THREAD_ID_PREFIX,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadInitializeResponse,
@@ -43,16 +43,7 @@ import { AdaptedRemoteThread } from "./AdaptedRemoteThread";
 
 const RESOLVED_PROMISE = Promise.resolve();
 
-const EMPTY_LIST: RemoteThreadState = {
-  isLoading: true,
-  isLoadingMore: false,
-  cursor: undefined,
-  newThreadId: undefined,
-  threadIds: [],
-  archivedThreadIds: [],
-  threadIdMap: {},
-  threadData: {},
-};
+const EMPTY_LIST = createEmptyRemoteThreadState();
 
 export type RemoteThreadListProps = {
   /**
@@ -100,39 +91,6 @@ const applyTitleStream = async (
   for await (const result of messageStream) {
     await onTitle(result.parts.filter((part) => part.type === "text")[0]?.text);
   }
-};
-
-const seedNewThread = (
-  state: RemoteThreadState,
-): { id: string; state: RemoteThreadState } => {
-  let id: string;
-  do {
-    id = `${LOCAL_THREAD_ID_PREFIX}${generateId()}`;
-  } while (state.threadIdMap[id]);
-  const mappingId = createThreadMappingId(id);
-  return {
-    id,
-    state: {
-      ...state,
-      newThreadId: id,
-      threadIdMap: {
-        ...state.threadIdMap,
-        [id]: mappingId,
-      },
-      threadData: {
-        ...state.threadData,
-        [mappingId]: {
-          status: "new",
-          id,
-          remoteId: undefined,
-          externalId: undefined,
-          title: undefined,
-          custom: undefined,
-          localOrigin: true,
-        },
-      },
-    },
-  };
 };
 
 const useThreadListItemClient = (props: {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1,5 +1,4 @@
 import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
-import { generateId } from "../../utils/id";
 import { BaseSubscribable } from "../../subscribable/subscribable";
 import { OptimisticState } from "../../runtimes/remote-thread-list/optimistic-state";
 import { EMPTY_THREAD_CORE } from "../../runtimes/remote-thread-list/empty-thread-core";
@@ -9,13 +8,14 @@ import type {
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import {
   classifyThreads,
+  createEmptyRemoteThreadState,
   createThreadMappingId,
   getThreadData,
   normalizeCursor,
   updateStatusReducer,
   preserveMidLoadTransitions,
+  seedNewThread,
   statusSnapshot,
-  LOCAL_THREAD_ID_PREFIX,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
 import type {
   RemoteThreadListAdapter,
@@ -52,48 +52,7 @@ const threadStatusError = (
     `Thread "${threadIdOrRemoteId}" has status "${status}", so it cannot ${action}.`,
   );
 
-const EMPTY_REMOTE_STATE: RemoteThreadState = {
-  isLoading: true,
-  isLoadingMore: false,
-  cursor: undefined,
-  newThreadId: undefined,
-  threadIds: [],
-  archivedThreadIds: [],
-  threadIdMap: {},
-  threadData: {},
-};
-
-const addNewThread = (state: RemoteThreadState) => {
-  let id: string;
-  do {
-    id = `${LOCAL_THREAD_ID_PREFIX}${generateId()}`;
-  } while (state.threadIdMap[id]);
-
-  const mappingId = createThreadMappingId(id);
-  return {
-    id,
-    state: {
-      ...state,
-      newThreadId: id,
-      threadIdMap: {
-        ...state.threadIdMap,
-        [id]: mappingId,
-      },
-      threadData: {
-        ...state.threadData,
-        [mappingId]: {
-          status: "new",
-          id,
-          remoteId: undefined,
-          externalId: undefined,
-          title: undefined,
-          custom: undefined,
-          localOrigin: true,
-        } satisfies RemoteThreadData,
-      },
-    },
-  };
-};
+const EMPTY_REMOTE_STATE = createEmptyRemoteThreadState();
 
 export class RemoteThreadListThreadListRuntimeCore
   extends BaseSubscribable
@@ -443,7 +402,7 @@ export class RemoteThreadListThreadListRuntimeCore
       if (preservedDraft !== undefined) {
         this._mainThreadId = preservedDraft;
       } else {
-        const seeded = addNewThread(nextState);
+        const seeded = seedNewThread(nextState);
         this._mainThreadId = seeded.id;
         nextState = seeded.state;
       }
@@ -768,7 +727,7 @@ export class RemoteThreadListThreadListRuntimeCore
     const state = this._state.baseValue;
     let id: string | undefined = this._state.value.newThreadId;
     if (id === undefined) {
-      const next = addNewThread(state);
+      const next = seedNewThread(state);
       id = next.id;
       this._state.update(next.state);
     }

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  createEmptyRemoteThreadState,
+  createThreadMappingId,
+  seedNewThread,
+} from "./remote-thread-state";
+
+describe("remote thread state", () => {
+  it("creates an empty state", () => {
+    expect(createEmptyRemoteThreadState()).toEqual({
+      isLoading: true,
+      isLoadingMore: false,
+      cursor: undefined,
+      newThreadId: undefined,
+      threadIds: [],
+      archivedThreadIds: [],
+      threadIdMap: {},
+      threadData: {},
+    });
+  });
+
+  it("seeds unique local threads with matching mapping ids", () => {
+    const first = seedNewThread(createEmptyRemoteThreadState());
+    const second = seedNewThread(first.state);
+
+    expect(second.id).not.toBe(first.id);
+    expect(first.state.newThreadId).toBe(first.id);
+    expect(second.state.newThreadId).toBe(second.id);
+    expect(first.state.threadIdMap[first.id]).toBe(
+      createThreadMappingId(first.id),
+    );
+    expect(second.state.threadIdMap[second.id]).toBe(
+      createThreadMappingId(second.id),
+    );
+    expect(Object.keys(second.state.threadData)).toEqual([first.id, second.id]);
+  });
+});

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -2,6 +2,7 @@ import type {
   RemoteThreadInitializeResponse,
   RemoteThreadMetadata,
 } from "./types";
+import { generateId } from "../../utils/id";
 
 export type RemoteThreadData =
   | {
@@ -101,6 +102,50 @@ export type RemoteThreadState = {
   readonly archivedThreadIds: readonly string[];
   readonly threadIdMap: Readonly<Record<string, THREAD_MAPPING_ID>>;
   readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
+};
+
+export const createEmptyRemoteThreadState = (): RemoteThreadState => ({
+  isLoading: true,
+  isLoadingMore: false,
+  cursor: undefined,
+  newThreadId: undefined,
+  threadIds: [],
+  archivedThreadIds: [],
+  threadIdMap: {},
+  threadData: {},
+});
+
+export const seedNewThread = (
+  state: RemoteThreadState,
+): { id: string; state: RemoteThreadState } => {
+  let id: string;
+  do {
+    id = `${LOCAL_THREAD_ID_PREFIX}${generateId()}`;
+  } while (state.threadIdMap[id]);
+  const mappingId = createThreadMappingId(id);
+  return {
+    id,
+    state: {
+      ...state,
+      newThreadId: id,
+      threadIdMap: {
+        ...state.threadIdMap,
+        [id]: mappingId,
+      },
+      threadData: {
+        ...state.threadData,
+        [mappingId]: {
+          status: "new",
+          id,
+          remoteId: undefined,
+          externalId: undefined,
+          title: undefined,
+          custom: undefined,
+          localOrigin: true,
+        } satisfies RemoteThreadData,
+      },
+    },
+  };
 };
 
 // A list() response predating a mid-flight local transition (a thread


### PR DESCRIPTION
## summary

- the legacy remote thread-list core and the tap client defined byte-equivalent initial RemoteThreadState objects and the same new-local-thread seeding (unique LOCAL_THREAD_ID_PREFIX id generation, mapping id, "new" thread data entry)
- both now call createEmptyRemoteThreadState and seedNewThread from the shared remote-thread-state.ts module they already import reducers from; internal-only exports, no package-barrel changes
- new colocated test covers id uniqueness across seeds and the seeded state shape

## test plan

### already verified

- [x] full core vitest suite: 137 files, 1470 tests green (rerun independently); no public export changes

### reviewer should verify

- [ ] creating a new thread before the remote list loads still lands one "new" entry visible in both the legacy runtime and the tap client paths

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hDVE5CSLWIdUAUl99nbPFxLui4d767QNlIu7qk6D24hlxT-oXfnNMHbxI9o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->