### PR TITLE
fix(cloud-ai-sdk): load all thread list pages

### DIFF
--- a/.changeset/load-cloud-thread-pages.md
+++ b/.changeset/load-cloud-thread-pages.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: load every Cloud thread list page

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -355,7 +355,7 @@ const myThreads = useThreads({ cloud: myCloud });
 const { messages, sendMessage } = useCloudChat({ threads: myThreads });
 ```
 
-`useThreads` requests up to 100 threads per page and follows Cloud cursors until all matching threads are loaded. With `includeArchived`, active and archived pages load concurrently and the complete list is committed after both finish.
+`useThreads` requests 20 threads per page and follows Cloud cursors until all matching threads are loaded. With `includeArchived`, active and archived pages load concurrently and the complete list is committed after both finish.
 
 **Parameters:**
 

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -355,6 +355,8 @@ const myThreads = useThreads({ cloud: myCloud });
 const { messages, sendMessage } = useCloudChat({ threads: myThreads });
 ```
 
+`useThreads` requests up to 100 threads per page and follows Cloud cursors until all matching threads are loaded. With `includeArchived`, active and archived pages load concurrently and the complete list is committed after both finish.
+
 **Parameters:**
 
 | Parameter | Type | Description |

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -279,12 +279,59 @@ describe("useThreads", () => {
       await result.current.refresh();
     });
 
-    expect(list).toHaveBeenNthCalledWith(1, { is_archived: false });
-    expect(list).toHaveBeenNthCalledWith(2, { is_archived: true });
+    expect(list).toHaveBeenNthCalledWith(1, {
+      is_archived: false,
+      limit: 20,
+    });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      is_archived: true,
+      limit: 20,
+    });
     expect(result.current.threads).toMatchObject([
       { id: "archived", status: "archived" },
       { id: "active", status: "regular" },
     ]);
+  });
+
+  it("loads every page of active threads", async () => {
+    const firstPage = Array.from(
+      { length: 20 },
+      (_, index) =>
+        createThreadListResponse(`Thread ${index}`, `thread-${index}`)
+          .threads[0]!,
+    );
+    const lastThread = createThreadListResponse("Thread 20", "thread-20")
+      .threads[0]!;
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: firstPage })
+      .mockResolvedValueOnce({ threads: [lastThread] });
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result } = renderHook(() => useThreads({ cloud, enabled: false }));
+
+    await act(async () => {
+      expect(await result.current.refresh()).toBe(true);
+    });
+
+    expect(list).toHaveBeenNthCalledWith(1, {
+      is_archived: false,
+      limit: 20,
+    });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      is_archived: false,
+      limit: 20,
+      after: "thread-19",
+    });
+    expect(result.current.threads).toHaveLength(21);
+    expect(result.current.threads.at(-1)?.id).toBe("thread-20");
   });
 
   it("deduplicates threads returned by both archive filters", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -252,16 +252,32 @@ describe("useThreads", () => {
     expect(list).toHaveBeenCalledOnce();
   });
 
-  it("loads active and archived threads when requested", async () => {
-    const active = createThreadListResponse("Active", "active").threads[0]!;
-    const archived = {
-      ...createThreadListResponse("Archived", "archived").threads[0]!,
+  it("loads every active and archived page when requested", async () => {
+    const activePage = Array.from(
+      { length: 100 },
+      (_, index) =>
+        createThreadListResponse(`Active ${index}`, `active-${index}`)
+          .threads[0]!,
+    );
+    const archivedPage = Array.from({ length: 100 }, (_, index) => ({
+      ...createThreadListResponse(`Archived ${index}`, `archived-${index}`)
+        .threads[0]!,
+      is_archived: true,
+    }));
+    const lastArchived = {
+      ...createThreadListResponse("Newest archived", "archived-100")
+        .threads[0]!,
       is_archived: true,
       last_message_at: new Date("2026-02-01T00:00:00.000Z"),
     };
-    const list = vi.fn(async (query?: { is_archived?: boolean }) => ({
-      threads: query?.is_archived ? [archived] : [active],
-    }));
+    const list = vi.fn(
+      async (query?: { is_archived?: boolean; after?: string }) => {
+        if (query?.is_archived) {
+          return { threads: query.after ? [lastArchived] : archivedPage };
+        }
+        return { threads: query?.after ? [] : activePage };
+      },
+    );
     const cloud = {
       threads: {
         list,
@@ -279,33 +295,39 @@ describe("useThreads", () => {
       await result.current.refresh();
     });
 
-    expect(list).toHaveBeenNthCalledWith(1, {
+    expect(list).toHaveBeenCalledWith({
       is_archived: false,
-      limit: 20,
+      limit: 100,
     });
-    expect(list).toHaveBeenNthCalledWith(2, {
+    expect(list).toHaveBeenCalledWith({
       is_archived: true,
-      limit: 20,
+      limit: 100,
     });
-    expect(result.current.threads).toMatchObject([
-      { id: "archived", status: "archived" },
-      { id: "active", status: "regular" },
-    ]);
+    expect(list).toHaveBeenCalledWith({
+      is_archived: false,
+      limit: 100,
+      after: "active-99",
+    });
+    expect(list).toHaveBeenCalledWith({
+      is_archived: true,
+      limit: 100,
+      after: "archived-99",
+    });
+    expect(result.current.threads).toHaveLength(201);
+    expect(result.current.threads[0]).toMatchObject({
+      id: "archived-100",
+      status: "archived",
+    });
   });
 
-  it("loads every page of active threads", async () => {
+  it("stops when thread pagination does not advance", async () => {
     const firstPage = Array.from(
-      { length: 20 },
+      { length: 100 },
       (_, index) =>
         createThreadListResponse(`Thread ${index}`, `thread-${index}`)
           .threads[0]!,
     );
-    const lastThread = createThreadListResponse("Thread 20", "thread-20")
-      .threads[0]!;
-    const list = vi
-      .fn()
-      .mockResolvedValueOnce({ threads: firstPage })
-      .mockResolvedValueOnce({ threads: [lastThread] });
+    const list = vi.fn().mockResolvedValue({ threads: firstPage });
     const cloud = {
       threads: {
         list,
@@ -323,15 +345,16 @@ describe("useThreads", () => {
 
     expect(list).toHaveBeenNthCalledWith(1, {
       is_archived: false,
-      limit: 20,
+      limit: 100,
     });
     expect(list).toHaveBeenNthCalledWith(2, {
       is_archived: false,
-      limit: 20,
-      after: "thread-19",
+      limit: 100,
+      after: "thread-99",
     });
-    expect(result.current.threads).toHaveLength(21);
-    expect(result.current.threads.at(-1)?.id).toBe("thread-20");
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeNull();
+    expect(result.current.threads).toHaveLength(100);
   });
 
   it("deduplicates threads returned by both archive filters", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -254,19 +254,18 @@ describe("useThreads", () => {
 
   it("loads every active and archived page when requested", async () => {
     const activePage = Array.from(
-      { length: 100 },
+      { length: 20 },
       (_, index) =>
         createThreadListResponse(`Active ${index}`, `active-${index}`)
           .threads[0]!,
     );
-    const archivedPage = Array.from({ length: 100 }, (_, index) => ({
+    const archivedPage = Array.from({ length: 20 }, (_, index) => ({
       ...createThreadListResponse(`Archived ${index}`, `archived-${index}`)
         .threads[0]!,
       is_archived: true,
     }));
     const lastArchived = {
-      ...createThreadListResponse("Newest archived", "archived-100")
-        .threads[0]!,
+      ...createThreadListResponse("Newest archived", "archived-20").threads[0]!,
       is_archived: true,
       last_message_at: new Date("2026-02-01T00:00:00.000Z"),
     };
@@ -297,32 +296,32 @@ describe("useThreads", () => {
 
     expect(list).toHaveBeenCalledWith({
       is_archived: false,
-      limit: 100,
+      limit: 20,
     });
     expect(list).toHaveBeenCalledWith({
       is_archived: true,
-      limit: 100,
+      limit: 20,
     });
     expect(list).toHaveBeenCalledWith({
       is_archived: false,
-      limit: 100,
-      after: "active-99",
+      limit: 20,
+      after: "active-19",
     });
     expect(list).toHaveBeenCalledWith({
       is_archived: true,
-      limit: 100,
-      after: "archived-99",
+      limit: 20,
+      after: "archived-19",
     });
-    expect(result.current.threads).toHaveLength(201);
+    expect(result.current.threads).toHaveLength(41);
     expect(result.current.threads[0]).toMatchObject({
-      id: "archived-100",
+      id: "archived-20",
       status: "archived",
     });
   });
 
   it("stops when thread pagination does not advance", async () => {
     const firstPage = Array.from(
-      { length: 100 },
+      { length: 20 },
       (_, index) =>
         createThreadListResponse(`Thread ${index}`, `thread-${index}`)
           .threads[0]!,
@@ -345,16 +344,16 @@ describe("useThreads", () => {
 
     expect(list).toHaveBeenNthCalledWith(1, {
       is_archived: false,
-      limit: 100,
+      limit: 20,
     });
     expect(list).toHaveBeenNthCalledWith(2, {
       is_archived: false,
-      limit: 100,
-      after: "thread-99",
+      limit: 20,
+      after: "thread-19",
     });
     expect(list).toHaveBeenCalledTimes(2);
     expect(result.current.error).toBeNull();
-    expect(result.current.threads).toHaveLength(100);
+    expect(result.current.threads).toHaveLength(20);
   });
 
   it("deduplicates threads returned by both archive filters", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -34,7 +34,7 @@ function toCloudThread(t: {
   };
 }
 
-const CLOUD_THREAD_PAGE_SIZE = 20;
+const CLOUD_THREAD_PAGE_SIZE = 100;
 
 async function listAllThreads(
   cloud: UseThreadsOptions["cloud"],
@@ -54,9 +54,7 @@ async function listAllThreads(
     if (response.threads.length < CLOUD_THREAD_PAGE_SIZE) return threads;
 
     const nextAfter = response.threads.at(-1)?.id;
-    if (!nextAfter || nextAfter === after) {
-      throw new Error("Cloud thread pagination did not advance");
-    }
+    if (!nextAfter || nextAfter === after) return threads;
     after = nextAfter;
   }
 }

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -34,7 +34,7 @@ function toCloudThread(t: {
   };
 }
 
-const CLOUD_THREAD_PAGE_SIZE = 100;
+const CLOUD_THREAD_PAGE_SIZE = 20;
 
 async function listAllThreads(
   cloud: UseThreadsOptions["cloud"],

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -34,6 +34,33 @@ function toCloudThread(t: {
   };
 }
 
+const CLOUD_THREAD_PAGE_SIZE = 20;
+
+async function listAllThreads(
+  cloud: UseThreadsOptions["cloud"],
+  isArchived: boolean,
+) {
+  const threads: Parameters<typeof toCloudThread>[0][] = [];
+  let after: string | undefined;
+
+  while (true) {
+    const response = await cloud.threads.list({
+      is_archived: isArchived,
+      limit: CLOUD_THREAD_PAGE_SIZE,
+      ...(after ? { after } : {}),
+    });
+    threads.push(...response.threads);
+
+    if (response.threads.length < CLOUD_THREAD_PAGE_SIZE) return threads;
+
+    const nextAfter = response.threads.at(-1)?.id;
+    if (!nextAfter || nextAfter === after) {
+      throw new Error("Cloud thread pagination did not advance");
+    }
+    after = nextAfter;
+  }
+}
+
 export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const { cloud, includeArchived = false, enabled = true } = options;
   const includeArchivedRef = useRef(includeArchived);
@@ -140,17 +167,15 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         async (commit) => {
           // Keep includeArchived refreshes atomic; withAction preserves the
           // previous complete list and exposes either request's failure.
-          const responses = includeArchived
+          const threadGroups = includeArchived
             ? await Promise.all([
-                cloud.threads.list({ is_archived: false }),
-                cloud.threads.list({ is_archived: true }),
+                listAllThreads(cloud, false),
+                listAllThreads(cloud, true),
               ])
-            : [await cloud.threads.list({ is_archived: false })];
+            : [await listAllThreads(cloud, false)];
           const nextThreads = Array.from(
             new Map(
-              responses
-                .flatMap((response) => response.threads)
-                .map((thread) => [thread.id, thread] as const),
+              threadGroups.flat().map((thread) => [thread.id, thread] as const),
             ).values(),
             toCloudThread,
           );


### PR DESCRIPTION
## Summary

- follow Cloud thread cursors until each active or archived list is exhausted
- use the established 20-thread page size and safely stop if a cursor does not advance
- keep active and archived refreshes atomic, deduplicate and sort the complete result, and document the loading contract
- cover independent active/archived pagination, exact-page termination, and repeated cursors with a patch changeset

## Why

`useThreads()` previously made one request per archive status. Cloud paginates thread lists, so accounts with more than one page of active or archived threads could never access older conversations through this hook.

The hook exposes a complete thread array rather than a load-more API, so it now follows cursors to completion. It uses the same 20-thread cursor contract as the core Cloud thread-list adapter, while a repeated cursor returns the pages already collected for compatibility with older or self-hosted backends that ignore `after`.

## Testing

- `vitest run` in `packages/cloud-ai-sdk` (95 tests)
- `vitest run --config vitest.peer-v6.config.ts` (95 tests)
- `tsc --noEmit --project tsconfig.peer-v6.json`
- `aui-build` in `packages/cloud-ai-sdk`
- `oxlint packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts`
- `oxfmt --check packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts apps/docs/content/docs/cloud/ai-sdk.mdx`