### PR TITLE
fix(react-mcp): refresh connections after connector changes

### DIFF
--- a/.changeset/tidy-lions-refresh.md
+++ b/.changeset/tidy-lions-refresh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: refresh MCP connections when connector settings change

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -161,7 +161,6 @@ describe("McpManagerResource server ids", () => {
         McpManagerResource({
           connectors: [currentConnector],
           storage: McpMemoryStorage(),
-          autoConnect: false,
         }),
       );
     });
@@ -170,7 +169,9 @@ describe("McpManagerResource server ids", () => {
     });
 
     try {
-      await root.getValue().connector({ index: 0 }).connect();
+      await vi.waitFor(() =>
+        expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledOnce(),
+      );
       const firstTransport = mocks.StreamableHTTPClientTransport.mock
         .instances[0] as { close: ReturnType<typeof vi.fn> };
 
@@ -185,18 +186,78 @@ describe("McpManagerResource server ids", () => {
 
       await vi.waitFor(() => {
         expect(firstTransport.close).toHaveBeenCalledOnce();
-        expect(
-          root.getValue().connector({ index: 0 }).getState(),
-        ).toMatchObject({
-          url: "https://other.example.com/docs/mcp",
-          connectionState: "disconnected",
-        });
+        expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledTimes(2);
       });
 
-      await root.getValue().connector({ index: 0 }).connect();
       expect(mocks.StreamableHTTPClientTransport).toHaveBeenLastCalledWith(
         new URL("https://other.example.com/docs/mcp"),
       );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("keeps a connection across equivalent and cosmetic connector updates", async () => {
+    mocks.StreamableHTTPClientTransport.mockClear();
+    let rerenderEquivalent = () => {};
+    let updatePresentation = () => {};
+    const DynamicManager = resource(function useDynamicManager() {
+      const [, setVersion] = useState(0);
+      const [presentation, setPresentation] = useState({
+        name: "Docs",
+        icon: "docs.svg",
+      });
+      rerenderEquivalent = () => setVersion((version) => version + 1);
+      updatePresentation = () =>
+        setPresentation({ name: "Documentation", icon: "book.svg" });
+
+      return useResource(
+        McpManagerResource({
+          connectors: [
+            defineConnector({
+              id: "docs",
+              name: presentation.name,
+              icon: presentation.icon,
+              url: "https://example.com/docs/mcp",
+              auth: { type: "none" },
+            }),
+          ],
+          storage: McpCustomStorage({
+            loadCustomServers: vi.fn(async () => []),
+            saveCustomServers: vi.fn(async () => {}),
+            loadAuthState: vi.fn(async () => null),
+            saveAuthState: vi.fn(async () => {}),
+            clearAuthState: vi.fn(async () => {}),
+          }),
+          autoConnect: false,
+        }),
+      );
+    });
+    const root = createTapRoot(function Root() {
+      return useResource(DynamicManager());
+    });
+
+    try {
+      await root.getValue().connector({ index: 0 }).connect();
+      const transport = mocks.StreamableHTTPClientTransport.mock
+        .instances[0] as { close: ReturnType<typeof vi.fn> };
+
+      rerenderEquivalent();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledOnce();
+      expect(transport.close).not.toHaveBeenCalled();
+
+      updatePresentation();
+      await vi.waitFor(() =>
+        expect(
+          root.getValue().connector({ index: 0 }).getState(),
+        ).toMatchObject({
+          name: "Documentation",
+          icon: "book.svg",
+        }),
+      );
+      expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledOnce();
+      expect(transport.close).not.toHaveBeenCalled();
     } finally {
       root.unmount();
     }

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -167,6 +167,7 @@ describe("McpManagerResource server ids", () => {
     const root = createTapRoot(function Root() {
       return useResource(DynamicManager());
     });
+    let resolveFirstClose = () => {};
 
     try {
       await vi.waitFor(() =>
@@ -174,6 +175,12 @@ describe("McpManagerResource server ids", () => {
       );
       const firstTransport = mocks.StreamableHTTPClientTransport.mock
         .instances[0] as { close: ReturnType<typeof vi.fn> };
+      firstTransport.close.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstClose = resolve;
+          }),
+      );
 
       updateConnector(
         defineConnector({
@@ -184,15 +191,21 @@ describe("McpManagerResource server ids", () => {
         }),
       );
 
-      await vi.waitFor(() => {
-        expect(firstTransport.close).toHaveBeenCalledOnce();
-        expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledTimes(2);
-      });
+      await vi.waitFor(() =>
+        expect(firstTransport.close).toHaveBeenCalledOnce(),
+      );
+      expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledOnce();
+
+      resolveFirstClose();
+      await vi.waitFor(() =>
+        expect(mocks.StreamableHTTPClientTransport).toHaveBeenCalledTimes(2),
+      );
 
       expect(mocks.StreamableHTTPClientTransport).toHaveBeenLastCalledWith(
         new URL("https://other.example.com/docs/mcp"),
       );
     } finally {
+      resolveFirstClose();
       root.unmount();
     }
   });

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -147,6 +147,60 @@ describe("McpManagerResource server ids", () => {
       root.unmount();
     }
   });
+
+  it("replaces a connected transport when connector settings change", async () => {
+    mocks.StreamableHTTPClientTransport.mockClear();
+    let updateConnector = (_connector: MCPConnector) => {};
+    const DynamicManager = resource(function useDynamicManager() {
+      const [currentConnector, setCurrentConnector] = useState(
+        connector("docs"),
+      );
+      updateConnector = setCurrentConnector;
+
+      return useResource(
+        McpManagerResource({
+          connectors: [currentConnector],
+          storage: McpMemoryStorage(),
+          autoConnect: false,
+        }),
+      );
+    });
+    const root = createTapRoot(function Root() {
+      return useResource(DynamicManager());
+    });
+
+    try {
+      await root.getValue().connector({ index: 0 }).connect();
+      const firstTransport = mocks.StreamableHTTPClientTransport.mock
+        .instances[0] as { close: ReturnType<typeof vi.fn> };
+
+      updateConnector(
+        defineConnector({
+          id: "docs",
+          name: "Docs",
+          url: "https://other.example.com/docs/mcp",
+          auth: { type: "none" },
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(firstTransport.close).toHaveBeenCalledOnce();
+        expect(
+          root.getValue().connector({ index: 0 }).getState(),
+        ).toMatchObject({
+          url: "https://other.example.com/docs/mcp",
+          connectionState: "disconnected",
+        });
+      });
+
+      await root.getValue().connector({ index: 0 }).connect();
+      expect(mocks.StreamableHTTPClientTransport).toHaveBeenLastCalledWith(
+        new URL("https://other.example.com/docs/mcp"),
+      );
+    } finally {
+      root.unmount();
+    }
+  });
 });
 
 describe("McpManagerResource storage failures", () => {

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -85,11 +85,9 @@ const getConnectionDependencies = (
         : [auth.type];
 
   return [
-    props.kind,
     props.url,
     ...authDependencies,
     props.redirectUri,
-    props.connectionTimeout,
     props.cache?.defaultTtlMs,
     props.elicitation,
   ];
@@ -106,21 +104,20 @@ const McpServerSlot = resource(function useMcpServerSlot(
   props: McpServerResourceProps,
 ): ClientOutput<"mcpServer"> {
   const dependencies = getConnectionDependencies(props);
-  const connectionRef = useRef({ dependencies, generation: 0 });
-  if (
-    !areConnectionDependenciesEqual(
-      connectionRef.current.dependencies,
+  const [connection, setConnection] = useState({ dependencies, generation: 0 });
+  let currentConnection = connection;
+  if (!areConnectionDependenciesEqual(connection.dependencies, dependencies)) {
+    currentConnection = {
       dependencies,
-    )
-  ) {
-    connectionRef.current = {
-      dependencies,
-      generation: connectionRef.current.generation + 1,
+      generation: connection.generation + 1,
     };
+    setConnection(currentConnection);
   }
 
+  // Storage resources do not expose a stable scope identity and may return a
+  // fresh client on ordinary renders, so storage changes cannot key remounts.
   return useResource(
-    withKey(connectionRef.current.generation, McpServerResource(props)),
+    withKey(currentConnection.generation, McpServerResource(props)),
   );
 });
 

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -9,7 +9,10 @@ import {
 import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import { ModelContext } from "@assistant-ui/core/store";
 import type { Tool } from "assistant-stream";
-import { McpServerResource } from "./McpServerResource";
+import {
+  McpServerResource,
+  type McpServerResourceProps,
+} from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
 import type { MCPStorage, MCPStorageElement } from "./storage/types";
 import { assertUniqueServerIds } from "../utils/serverId";
@@ -60,6 +63,66 @@ const persistCustomServers = async (
     reportCustomStorageFailure("save", error);
   }
 };
+
+const getConnectionDependencies = (
+  props: McpServerResourceProps,
+): readonly unknown[] => {
+  const auth = props.auth;
+  const authDependencies =
+    auth.type === "bearer"
+      ? [auth.type, auth.token]
+      : auth.type === "oauth"
+        ? [
+            auth.type,
+            auth.scopes?.length,
+            ...(auth.scopes ?? []),
+            auth.authorizationEndpoint,
+            auth.tokenEndpoint,
+            auth.registrationEndpoint,
+            auth.clientId,
+            auth.clientSecret,
+          ]
+        : [auth.type];
+
+  return [
+    props.kind,
+    props.url,
+    ...authDependencies,
+    props.redirectUri,
+    props.connectionTimeout,
+    props.cache?.defaultTtlMs,
+    props.elicitation,
+  ];
+};
+
+const areConnectionDependenciesEqual = (
+  left: readonly unknown[],
+  right: readonly unknown[],
+) =>
+  left.length === right.length &&
+  left.every((value, index) => Object.is(value, right[index]));
+
+const McpServerSlot = resource(function useMcpServerSlot(
+  props: McpServerResourceProps,
+): ClientOutput<"mcpServer"> {
+  const dependencies = getConnectionDependencies(props);
+  const connectionRef = useRef({ dependencies, generation: 0 });
+  if (
+    !areConnectionDependenciesEqual(
+      connectionRef.current.dependencies,
+      dependencies,
+    )
+  ) {
+    connectionRef.current = {
+      dependencies,
+      generation: connectionRef.current.generation + 1,
+    };
+  }
+
+  return useResource(
+    withKey(connectionRef.current.generation, McpServerResource(props)),
+  );
+});
 
 const useMcpManagerResource = (
   props: McpManagerResourceProps,
@@ -141,7 +204,7 @@ const useMcpManagerResource = (
     const connectorElements = connectors.map((c) =>
       withKey(
         c.id,
-        McpServerResource({
+        McpServerSlot({
           id: c.id,
           kind: "connector",
           name: c.name,
@@ -165,7 +228,7 @@ const useMcpManagerResource = (
     const customElements = customServers.map((s) =>
       withKey(
         s.id,
-        McpServerResource({
+        McpServerSlot({
           id: s.id,
           kind: "custom",
           name: s.name,

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -9,10 +9,7 @@ import {
 import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import { ModelContext } from "@assistant-ui/core/store";
 import type { Tool } from "assistant-stream";
-import {
-  McpServerResource,
-  type McpServerResourceProps,
-} from "./McpServerResource";
+import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
 import type { MCPStorage, MCPStorageElement } from "./storage/types";
 import { assertUniqueServerIds } from "../utils/serverId";
@@ -63,63 +60,6 @@ const persistCustomServers = async (
     reportCustomStorageFailure("save", error);
   }
 };
-
-const getConnectionDependencies = (
-  props: McpServerResourceProps,
-): readonly unknown[] => {
-  const auth = props.auth;
-  const authDependencies =
-    auth.type === "bearer"
-      ? [auth.type, auth.token]
-      : auth.type === "oauth"
-        ? [
-            auth.type,
-            auth.scopes?.length,
-            ...(auth.scopes ?? []),
-            auth.authorizationEndpoint,
-            auth.tokenEndpoint,
-            auth.registrationEndpoint,
-            auth.clientId,
-            auth.clientSecret,
-          ]
-        : [auth.type];
-
-  return [
-    props.url,
-    ...authDependencies,
-    props.redirectUri,
-    props.cache?.defaultTtlMs,
-    props.elicitation,
-  ];
-};
-
-const areConnectionDependenciesEqual = (
-  left: readonly unknown[],
-  right: readonly unknown[],
-) =>
-  left.length === right.length &&
-  left.every((value, index) => Object.is(value, right[index]));
-
-const McpServerSlot = resource(function useMcpServerSlot(
-  props: McpServerResourceProps,
-): ClientOutput<"mcpServer"> {
-  const dependencies = getConnectionDependencies(props);
-  const [connection, setConnection] = useState({ dependencies, generation: 0 });
-  let currentConnection = connection;
-  if (!areConnectionDependenciesEqual(connection.dependencies, dependencies)) {
-    currentConnection = {
-      dependencies,
-      generation: connection.generation + 1,
-    };
-    setConnection(currentConnection);
-  }
-
-  // Storage resources do not expose a stable scope identity and may return a
-  // fresh client on ordinary renders, so storage changes cannot key remounts.
-  return useResource(
-    withKey(currentConnection.generation, McpServerResource(props)),
-  );
-});
 
 const useMcpManagerResource = (
   props: McpManagerResourceProps,
@@ -201,7 +141,7 @@ const useMcpManagerResource = (
     const connectorElements = connectors.map((c) =>
       withKey(
         c.id,
-        McpServerSlot({
+        McpServerResource({
           id: c.id,
           kind: "connector",
           name: c.name,
@@ -225,7 +165,7 @@ const useMcpManagerResource = (
     const customElements = customServers.map((s) =>
       withKey(
         s.id,
-        McpServerSlot({
+        McpServerResource({
           id: s.id,
           kind: "custom",
           name: s.name,

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -1,6 +1,6 @@
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, resource, useResource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MCPAuthConfig } from "../mcp-scope";
 import type { MCPStorage } from "./storage/types";
@@ -443,6 +443,47 @@ describe("McpServerResource connectionTimeout", () => {
 
 describe("McpServerResource connection lifecycle", () => {
   beforeEach(resetMocks);
+
+  it("replaces direct resource connections when the server id changes", async () => {
+    const storage = createStorage();
+    let updateId = (_id: string) => {};
+    const DynamicServer = resource(function useDynamicServer() {
+      const [id, setId] = useState("docs");
+      updateId = setId;
+      return useResource(
+        McpServerResource({
+          id,
+          kind: "connector",
+          name: "Docs",
+          url: "https://example.com/mcp",
+          auth: { type: "none" },
+          storage,
+          redirectUri: "https://example.com/callback",
+          autoConnect: true,
+          onRemove: vi.fn(async () => {}),
+        }),
+      );
+    });
+    const root = createTapRoot(function Root() {
+      return useResource(DynamicServer());
+    });
+
+    try {
+      await waitForResourceUpdate(() => mocks.transports.length === 1);
+      const firstTransport = mocks.transports[0];
+
+      updateId("internal-docs");
+
+      await waitForResourceUpdate(
+        () =>
+          firstTransport.close.mock.calls.length === 1 &&
+          mocks.transports.length === 2,
+      );
+      expect(root.getValue().getState().id).toBe("internal-docs");
+    } finally {
+      root.unmount();
+    }
+  });
 
   it("closes a pending connection when the resource unmounts", async () => {
     let resolveConnect!: () => void;

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -41,6 +41,10 @@ export type McpServerResourceProps = {
   onRemove: () => Promise<void>;
 };
 
+type McpServerResourceInstanceProps = McpServerResourceProps & {
+  transportCloseQueueRef: { current: Promise<void> };
+};
+
 const getConnectionDependencies = (
   props: McpServerResourceProps,
 ): readonly unknown[] => {
@@ -78,7 +82,7 @@ const areConnectionDependenciesEqual = (
   left.every((value, index) => Object.is(value, right[index]));
 
 const useMcpServerResourceInstance = (
-  props: McpServerResourceProps,
+  props: McpServerResourceInstanceProps,
 ): ClientOutput<"mcpServer"> => {
   assertValidServerId(props.id);
   const [connectionState, setConnectionState] =
@@ -95,7 +99,6 @@ const useMcpServerResourceInstance = (
   const pendingTransportRef = useRef<StreamableHTTPClientTransport | null>(
     null,
   );
-  const transportCloseQueueRef = useRef(Promise.resolve());
   const connectionGenerationRef = useRef(0);
   const elicitationResolversRef = useRef(
     new Map<
@@ -124,10 +127,10 @@ const useMcpServerResourceInstance = (
   const closeQueuedTransports = (
     transports: StreamableHTTPClientTransport[],
   ): Promise<void> => {
-    const task = transportCloseQueueRef.current.then(async () => {
+    const task = props.transportCloseQueueRef.current.then(async () => {
       await Promise.all(transports.map(closeTransportSafely));
     });
-    transportCloseQueueRef.current = task;
+    props.transportCloseQueueRef.current = task;
     return task;
   };
 
@@ -168,7 +171,7 @@ const useMcpServerResourceInstance = (
     }
   };
 
-  const closeTransports = async () => {
+  const detachTransports = () => {
     cancelPendingElicitations();
     const pendingTransport = pendingTransportRef.current;
     const activeTransport = transportRef.current;
@@ -176,13 +179,18 @@ const useMcpServerResourceInstance = (
     transportRef.current = null;
     clientRef.current = null;
 
-    const transports = new Set(
-      [pendingTransport, activeTransport].filter(
-        (transport): transport is StreamableHTTPClientTransport =>
-          transport !== null,
+    return [
+      ...new Set(
+        [pendingTransport, activeTransport].filter(
+          (transport): transport is StreamableHTTPClientTransport =>
+            transport !== null,
+        ),
       ),
-    );
-    await closeQueuedTransports([...transports]);
+    ];
+  };
+
+  const closeTransports = async () => {
+    await closeQueuedTransports(detachTransports());
   };
 
   const isCurrentConnection = (generation: number) =>
@@ -535,6 +543,7 @@ const useMcpServerResourceInstance = (
 
   // Auto-connect on mount when usable auth exists.
   useEffect(() => {
+    const transportCloseQueueRef = props.transportCloseQueueRef;
     const previousDisposal = pendingDisposalRef.current;
     if (previousDisposal) previousDisposal.cancelled = true;
     const pendingDisposal = { cancelled: false };
@@ -545,14 +554,15 @@ const useMcpServerResourceInstance = (
     return () => {
       mountedRef.current = false;
       signal.cancelled = true;
-      // Defer disposal so StrictMode can replay setup before closing the transport.
-      queueMicrotask(() => {
+      const task = transportCloseQueueRef.current.then(async () => {
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
         if (pendingDisposal.cancelled) return;
         connectionGenerationRef.current += 1;
-        void closeTransports();
+        await Promise.all(detachTransports().map(closeTransportSafely));
       });
+      transportCloseQueueRef.current = task;
     };
-  }, []);
+  }, [props.transportCloseQueueRef]);
 
   const state = useMemo<MCPServerState>(
     () => ({
@@ -681,6 +691,7 @@ const McpServerResourceInstance = resource(useMcpServerResourceInstance);
 export const McpServerResource = resource(function useMcpServerResource(
   props: McpServerResourceProps,
 ): ClientOutput<"mcpServer"> {
+  const transportCloseQueueRef = useRef(Promise.resolve());
   const dependencies = getConnectionDependencies(props);
   const [connection, setConnection] = useState({ dependencies, generation: 0 });
   let currentConnection = connection;
@@ -695,6 +706,9 @@ export const McpServerResource = resource(function useMcpServerResource(
   // Storage resources do not expose a stable scope identity and may return a
   // fresh client on ordinary renders, so storage changes cannot key remounts.
   return useResource(
-    withKey(currentConnection.generation, McpServerResourceInstance(props)),
+    withKey(
+      currentConnection.generation,
+      McpServerResourceInstance({ ...props, transportCloseQueueRef }),
+    ),
   );
 });

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useEffectEvent } from "react";
-import { resource } from "@assistant-ui/tap";
+import { resource, useResource, withKey } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
 import {
   Client,
@@ -41,7 +41,43 @@ export type McpServerResourceProps = {
   onRemove: () => Promise<void>;
 };
 
-const useMcpServerResource = (
+const getConnectionDependencies = (
+  props: McpServerResourceProps,
+): readonly unknown[] => {
+  const auth = props.auth;
+  const authDependencies =
+    auth.type === "bearer"
+      ? [auth.type, auth.token]
+      : auth.type === "oauth"
+        ? [
+            auth.type,
+            auth.scopes?.length,
+            ...(auth.scopes ?? []),
+            auth.authorizationEndpoint,
+            auth.tokenEndpoint,
+            auth.registrationEndpoint,
+            auth.clientId,
+            auth.clientSecret,
+          ]
+        : [auth.type];
+
+  return [
+    props.url,
+    ...authDependencies,
+    props.redirectUri,
+    props.cache?.defaultTtlMs,
+    props.elicitation,
+  ];
+};
+
+const areConnectionDependenciesEqual = (
+  left: readonly unknown[],
+  right: readonly unknown[],
+) =>
+  left.length === right.length &&
+  left.every((value, index) => Object.is(value, right[index]));
+
+const useMcpServerResourceInstance = (
   props: McpServerResourceProps,
 ): ClientOutput<"mcpServer"> => {
   assertValidServerId(props.id);
@@ -640,4 +676,25 @@ const useMcpServerResource = (
   };
 };
 
-export const McpServerResource = resource(useMcpServerResource);
+const McpServerResourceInstance = resource(useMcpServerResourceInstance);
+
+export const McpServerResource = resource(function useMcpServerResource(
+  props: McpServerResourceProps,
+): ClientOutput<"mcpServer"> {
+  const dependencies = getConnectionDependencies(props);
+  const [connection, setConnection] = useState({ dependencies, generation: 0 });
+  let currentConnection = connection;
+  if (!areConnectionDependenciesEqual(connection.dependencies, dependencies)) {
+    currentConnection = {
+      dependencies,
+      generation: connection.generation + 1,
+    };
+    setConnection(currentConnection);
+  }
+
+  // Storage resources do not expose a stable scope identity and may return a
+  // fresh client on ordinary renders, so storage changes cannot key remounts.
+  return useResource(
+    withKey(currentConnection.generation, McpServerResourceInstance(props)),
+  );
+});

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -66,11 +66,12 @@ const getConnectionDependencies = (
         : [auth.type];
 
   return [
+    props.id,
     props.url,
     ...authDependencies,
     props.redirectUri,
     props.cache?.defaultTtlMs,
-    props.elicitation,
+    props.elicitation !== false,
   ];
 };
 


### PR DESCRIPTION
## Summary

- remount the underlying MCP server resource when transport- or client-construction settings change under the same server ID
- close the previous transport while preserving the stable public server lookup ID
- keep equivalent inline connectors and cosmetic name/icon changes connected
- add a patch changeset for `@assistant-ui/react-mcp`

## Why

`McpManagerResource` keys connector resources only by connector ID. When an app rerenders the same connector ID with a new URL or authentication configuration, the resource state reflects the new props but its existing client and transport remain connected to the previous endpoint. The UI can therefore show endpoint B while tool and resource calls still travel through endpoint A.

The server slot keeps the public ID stable but gives connection resources an internal generation. URL, authentication, OAuth redirect, cache, and elicitation changes advance that generation, disposing the old resource and transport. Name, icon, kind, and connection timeout updates do not reconnect because they are not captured by a live transport or client.

Storage is deliberately excluded from the generation key. Current storage resources do not expose a stable scope identity and may return a new client object on an ordinary render, so object identity would reconnect continuously. Supporting storage-scope replacement needs a separate keyed storage lifecycle rather than treating each returned object as a new connection scope.

The slot uses React state adjustment during render rather than mutating a ref. `pnpm check:resource-memo` confirms that its constructed resource argument passes the repository React Compiler memoization audit.

## Testing

- `@assistant-ui/react-mcp` suite: 132 tests passed
- `@assistant-ui/react-mcp` package build passed
- `pnpm check:resource-memo` passed
- oxlint and oxfmt checks passed

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.r0nCGUd0w-uj5vZ9_7ldEcy20GqJZ4IwDPzjplZgy4EqEa7T8VSJxsxd7jc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->