### PR TITLE
fix(create-assistant-ui): propagate termination to the CLI child

### DIFF
--- a/.changeset/tender-snails-signal.md
+++ b/.changeset/tender-snails-signal.md
@@ -2,4 +2,4 @@
 "create-assistant-ui": patch
 ---
 
-fix: propagate termination signals to the spawned CLI
+fix: propagate termination signals to the spawned CLI. cancelling now exits by the signal (130 for `SIGINT`, 143 for `SIGTERM`) instead of reporting success, so a cancelled scaffold no longer looks like a completed one to CI.

--- a/.changeset/tender-snails-signal.md
+++ b/.changeset/tender-snails-signal.md
@@ -1,0 +1,5 @@
+---
+"create-assistant-ui": patch
+---
+
+fix: propagate termination signals to the spawned CLI

--- a/packages/create-assistant-ui/package.json
+++ b/packages/create-assistant-ui/package.json
@@ -25,7 +25,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run"
   },
   "dependencies": {
     "assistant-ui": "workspace:*",
@@ -33,7 +34,8 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
-    "@types/cross-spawn": "^6.0.6"
+    "@types/cross-spawn": "^6.0.6",
+    "vitest": "^4.1.11"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-assistant-ui/src/index.ts
+++ b/packages/create-assistant-ui/src/index.ts
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
 import { main } from "./run";
 
-process.on("SIGINT", () => process.exit(0));
-process.on("SIGTERM", () => process.exit(0));
-
 void main();

--- a/packages/create-assistant-ui/src/run.test.ts
+++ b/packages/create-assistant-ui/src/run.test.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("cross-spawn", async (importOriginal) => ({
+  ...(await importOriginal()),
+  spawn: mocks.spawn,
+}));
+
+import { runSpawn } from "./run";
+
+const createChild = () =>
+  Object.assign(new EventEmitter(), {
+    kill: vi.fn(() => true),
+  });
+
+describe("runSpawn", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards termination signals to the child", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const initialListeners = process.listenerCount("SIGTERM");
+    const result = runSpawn("assistant-ui", ["create"]);
+
+    process.emit("SIGTERM", "SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    child.emit("close", 0, null);
+    await expect(result).rejects.toMatchObject({ signal: "SIGTERM" });
+    expect(process.listenerCount("SIGTERM")).toBe(initialListeners);
+  });
+
+  it("removes signal forwarding after normal completion", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const initialSigintListeners = process.listenerCount("SIGINT");
+    const initialSigtermListeners = process.listenerCount("SIGTERM");
+    const result = runSpawn("assistant-ui", ["create"]);
+
+    child.emit("close", 0, null);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(process.listenerCount("SIGINT")).toBe(initialSigintListeners);
+    expect(process.listenerCount("SIGTERM")).toBe(initialSigtermListeners);
+  });
+});

--- a/packages/create-assistant-ui/src/run.test.ts
+++ b/packages/create-assistant-ui/src/run.test.ts
@@ -126,6 +126,9 @@ describe("main", () => {
     await expect(result).rejects.toThrow("process.exit");
     expect(removeAllListeners).toHaveBeenCalledWith("SIGTERM");
     expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    expect(removeAllListeners.mock.invocationCallOrder[0]).toBeLessThan(
+      kill.mock.invocationCallOrder[0]!,
+    );
     expect(exit).toHaveBeenCalledWith(143);
   });
 

--- a/packages/create-assistant-ui/src/run.test.ts
+++ b/packages/create-assistant-ui/src/run.test.ts
@@ -25,15 +25,57 @@ describe("runSpawn", () => {
   it("forwards termination signals to the child", async () => {
     const child = createChild();
     mocks.spawn.mockReturnValue(child);
+    const existingListeners = new Set(process.listeners("SIGTERM"));
     const initialListeners = process.listenerCount("SIGTERM");
     const result = runSpawn("assistant-ui", ["create"]);
+    const signalHandler = process
+      .listeners("SIGTERM")
+      .find((listener) => !existingListeners.has(listener));
 
-    process.emit("SIGTERM", "SIGTERM");
+    expect(signalHandler).toBeDefined();
+    signalHandler?.();
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
 
     child.emit("close", 0, null);
-    await expect(result).rejects.toMatchObject({ signal: "SIGTERM" });
+    await expect(result).rejects.toMatchObject({
+      signal: "SIGTERM",
+      forwarded: true,
+    });
     expect(process.listenerCount("SIGTERM")).toBe(initialListeners);
+  });
+
+  it("force-stops the child after a repeated termination signal", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const existingListeners = new Set(process.listeners("SIGTERM"));
+    const result = runSpawn("assistant-ui", ["create"]);
+    const signalHandler = process
+      .listeners("SIGTERM")
+      .find((listener) => !existingListeners.has(listener));
+
+    expect(signalHandler).toBeDefined();
+    signalHandler?.();
+    signalHandler?.();
+
+    expect(child.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    await expect(result).rejects.toMatchObject({
+      signal: "SIGTERM",
+      forwarded: true,
+    });
+  });
+
+  it("distinguishes child crash signals from forwarded signals", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const result = runSpawn("assistant-ui", ["create"]);
+
+    child.emit("close", null, "SIGSEGV");
+
+    await expect(result).rejects.toMatchObject({
+      signal: "SIGSEGV",
+      forwarded: false,
+    });
   });
 
   it("removes signal forwarding after normal completion", async () => {

--- a/packages/create-assistant-ui/src/run.test.ts
+++ b/packages/create-assistant-ui/src/run.test.ts
@@ -10,7 +10,7 @@ vi.mock("cross-spawn", async (importOriginal) => ({
   spawn: mocks.spawn,
 }));
 
-import { runSpawn } from "./run";
+import { main, runSpawn } from "./run";
 
 const createChild = () =>
   Object.assign(new EventEmitter(), {
@@ -19,6 +19,7 @@ const createChild = () =>
 
 describe("runSpawn", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -48,6 +49,7 @@ describe("runSpawn", () => {
     const child = createChild();
     mocks.spawn.mockReturnValue(child);
     const existingListeners = new Set(process.listeners("SIGTERM"));
+    const initialListeners = process.listenerCount("SIGTERM");
     const result = runSpawn("assistant-ui", ["create"]);
     const signalHandler = process
       .listeners("SIGTERM")
@@ -63,6 +65,7 @@ describe("runSpawn", () => {
       signal: "SIGTERM",
       forwarded: true,
     });
+    expect(process.listenerCount("SIGTERM")).toBe(initialListeners);
   });
 
   it("distinguishes child crash signals from forwarded signals", async () => {
@@ -90,5 +93,60 @@ describe("runSpawn", () => {
 
     expect(process.listenerCount("SIGINT")).toBe(initialSigintListeners);
     expect(process.listenerCount("SIGTERM")).toBe(initialSigtermListeners);
+  });
+});
+
+describe("main", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("re-raises a signal forwarded to the child", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const existingListeners = new Set(process.listeners("SIGTERM"));
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const removeAllListeners = vi
+      .spyOn(process, "removeAllListeners")
+      .mockReturnValue(process);
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const result = main();
+
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    const signalHandler = process
+      .listeners("SIGTERM")
+      .find((listener) => !existingListeners.has(listener));
+    expect(signalHandler).toBeDefined();
+    signalHandler?.();
+    child.emit("close", null, "SIGTERM");
+
+    await expect(result).rejects.toThrow("process.exit");
+    expect(removeAllListeners).toHaveBeenCalledWith("SIGTERM");
+    expect(kill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    expect(exit).toHaveBeenCalledWith(143);
+  });
+
+  it("does not re-raise a signal received only by the child", async () => {
+    const child = createChild();
+    mocks.spawn.mockReturnValue(child);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const removeAllListeners = vi
+      .spyOn(process, "removeAllListeners")
+      .mockReturnValue(process);
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    const result = main();
+
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    child.emit("close", null, "SIGSEGV");
+
+    await expect(result).rejects.toThrow("process.exit");
+    expect(removeAllListeners).not.toHaveBeenCalled();
+    expect(kill).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(139);
   });
 });

--- a/packages/create-assistant-ui/src/run.ts
+++ b/packages/create-assistant-ui/src/run.ts
@@ -17,10 +17,12 @@ class SpawnExitError extends Error {
 
 class SpawnSignalError extends Error {
   signal: NodeJS.Signals;
+  forwarded: boolean;
 
-  constructor(signal: NodeJS.Signals) {
+  constructor(signal: NodeJS.Signals, forwarded: boolean) {
     super(`Process terminated by ${signal}`);
     this.signal = signal;
+    this.forwarded = forwarded;
   }
 }
 
@@ -32,7 +34,12 @@ export function runSpawn(command: string, args: string[]): Promise<void> {
     let forwardedSignal: NodeJS.Signals | null = null;
 
     const forwardSignal = (signal: NodeJS.Signals) => {
-      if (forwardedSignal !== null) return;
+      if (forwardedSignal !== null) {
+        child.kill("SIGKILL");
+        cleanup();
+        reject(new SpawnSignalError(signal, true));
+        return;
+      }
       forwardedSignal = signal;
       child.kill(signal);
     };
@@ -52,9 +59,12 @@ export function runSpawn(command: string, args: string[]): Promise<void> {
     });
     child.on("close", (code, signal) => {
       cleanup();
-      const terminationSignal = forwardedSignal ?? signal;
-      if (terminationSignal !== null) {
-        reject(new SpawnSignalError(terminationSignal));
+      if (forwardedSignal !== null) {
+        reject(new SpawnSignalError(forwardedSignal, true));
+        return;
+      }
+      if (signal !== null) {
+        reject(new SpawnSignalError(signal, false));
         return;
       }
       if (code !== 0) {
@@ -97,8 +107,10 @@ export async function main(): Promise<void> {
     await runSpawn(process.execPath, [assistantUiBinPath, ...args]);
   } catch (error) {
     if (error instanceof SpawnSignalError) {
-      process.removeAllListeners(error.signal);
-      process.kill(process.pid, error.signal);
+      if (error.forwarded) {
+        process.removeAllListeners(error.signal);
+        process.kill(process.pid, error.signal);
+      }
       process.exit(128 + (constants.signals[error.signal] ?? 0));
     }
 

--- a/packages/create-assistant-ui/src/run.ts
+++ b/packages/create-assistant-ui/src/run.ts
@@ -1,6 +1,7 @@
 import { spawn } from "cross-spawn";
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { constants } from "node:os";
 import path from "node:path";
 
 const require = createRequire(import.meta.url);
@@ -14,14 +15,48 @@ class SpawnExitError extends Error {
   }
 }
 
-function runSpawn(command: string, args: string[]): Promise<void> {
+class SpawnSignalError extends Error {
+  signal: NodeJS.Signals;
+
+  constructor(signal: NodeJS.Signals) {
+    super(`Process terminated by ${signal}`);
+    this.signal = signal;
+  }
+}
+
+export function runSpawn(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: "inherit",
     });
+    let forwardedSignal: NodeJS.Signals | null = null;
 
-    child.on("error", (error) => reject(error));
-    child.on("close", (code) => {
+    const forwardSignal = (signal: NodeJS.Signals) => {
+      if (forwardedSignal !== null) return;
+      forwardedSignal = signal;
+      child.kill(signal);
+    };
+    const onSigint = () => forwardSignal("SIGINT");
+    const onSigterm = () => forwardSignal("SIGTERM");
+    const cleanup = () => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+    };
+
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
+
+    child.on("error", (error) => {
+      cleanup();
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      cleanup();
+      const terminationSignal = forwardedSignal ?? signal;
+      if (terminationSignal !== null) {
+        reject(new SpawnSignalError(terminationSignal));
+        return;
+      }
       if (code !== 0) {
         reject(new SpawnExitError(code || 1));
       } else {
@@ -61,6 +96,12 @@ export async function main(): Promise<void> {
 
     await runSpawn(process.execPath, [assistantUiBinPath, ...args]);
   } catch (error) {
+    if (error instanceof SpawnSignalError) {
+      process.removeAllListeners(error.signal);
+      process.kill(process.pid, error.signal);
+      process.exit(128 + (constants.signals[error.signal] ?? 0));
+    }
+
     if (error instanceof SpawnExitError) {
       process.exit(error.code);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3842,6 +3842,9 @@ importers:
       '@types/cross-spawn':
         specifier: ^6.0.6
         version: 6.0.6
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/eve:
     dependencies:


### PR DESCRIPTION
## Summary

- forward `SIGINT` and `SIGTERM` from the `create-assistant-ui` wrapper to its spawned CLI child
- wait for child settlement, remove temporary signal listeners, and preserve the original signal termination on the wrapper
- add the package test command and focused signal-forwarding coverage
- add a patch changeset for `create-assistant-ui`

## Why

The wrapper previously handled both signals with `process.exit(0)`. When only the wrapper PID was terminated, such as by CI, a container runtime, or another process manager, it reported success while the child remained alive. The child could continue downloading templates or writing into the project directory after cancellation appeared complete.

Signal handling now lives alongside the child process. The first termination signal is forwarded to the child, listeners are cleaned up on every settlement path, and the wrapper re-raises the same signal after the child exits. Normal child exits retain their existing behavior.

## Testing

- `runSpawn` unit suite: 2 tests passed
- `create-assistant-ui` package build passed
- package TypeScript check passed
- process-level probe after the fix: wrapper exited via `SIGTERM`; spawned child was no longer alive
- oxlint and oxfmt checks passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jgTFaNZVs6HobM2Rv6yNJoFuOVC7dYYzWUitP_cERdMkKHkr6HX-Ronb-FQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->