### PR TITLE
fix(assistant-stream): keep partial args parseable inside a unicode escape

### DIFF
--- a/.changeset/partial-json-unicode-escape.md
+++ b/.changeset/partial-json-unicode-escape.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: keep partial tool args parseable while a `\uXXXX` escape is still streaming

--- a/packages/assistant-stream/src/utils/json/fix-json.ts
+++ b/packages/assistant-stream/src/utils/json/fix-json.ts
@@ -28,6 +28,7 @@ type State =
   | "FINISH"
   | "INSIDE_STRING"
   | "INSIDE_STRING_ESCAPE"
+  | "INSIDE_STRING_UNICODE_ESCAPE"
   | "INSIDE_LITERAL"
   | "INSIDE_NUMBER"
   | "INSIDE_OBJECT_START"
@@ -65,6 +66,7 @@ export function fixJson(input: string): [string, string[]] {
   const stack: State[] = ["ROOT"];
   let lastValidIndex = -1;
   let literalStart: number | null = null;
+  let unicodeEscapeDigits = 0;
   const path: string[] = [];
   let currentKey: string | undefined;
 
@@ -335,10 +337,33 @@ export function fixJson(input: string): [string, string[]] {
 
       case "INSIDE_STRING_ESCAPE": {
         stack.pop();
+        const parent = stack[stack.length - 1];
 
-        if (stack[stack.length - 1] === "INSIDE_STRING") {
+        if (char === "u") {
+          stack.push("INSIDE_STRING_UNICODE_ESCAPE");
+          unicodeEscapeDigits = 0;
+        } else if (parent === "INSIDE_STRING") {
           lastValidIndex = i;
-        } else if (stack[stack.length - 1] === "INSIDE_OBJECT_KEY") {
+        }
+
+        if (parent === "INSIDE_OBJECT_KEY") {
+          currentKey += char;
+        }
+
+        break;
+      }
+
+      case "INSIDE_STRING_UNICODE_ESCAPE": {
+        unicodeEscapeDigits++;
+        const complete = unicodeEscapeDigits === 4;
+        if (complete) stack.pop();
+        const parent = stack[stack.length - (complete ? 1 : 2)];
+
+        if (complete && parent === "INSIDE_STRING") {
+          lastValidIndex = i;
+        }
+
+        if (parent === "INSIDE_OBJECT_KEY") {
           currentKey += char;
         }
 

--- a/packages/assistant-stream/src/utils/json/fix-json.ts
+++ b/packages/assistant-stream/src/utils/json/fix-json.ts
@@ -62,6 +62,8 @@ type State =
 // Example input: '{"foo":'
 // Example output: ['{}', []]
 
+const HEX_DIGIT = /[0-9a-fA-F]/;
+
 export function fixJson(input: string): [string, string[]] {
   const stack: State[] = ["ROOT"];
   let lastValidIndex = -1;
@@ -356,7 +358,8 @@ export function fixJson(input: string): [string, string[]] {
       case "INSIDE_STRING_UNICODE_ESCAPE": {
         const parent = stack[stack.length - 2];
 
-        if (!/[0-9a-fA-F]/.test(char)) {
+        // The pop guarantees the re-read lands outside this state, so the scan stays linear.
+        if (!HEX_DIGIT.test(char)) {
           stack.pop();
           i--;
           break;

--- a/packages/assistant-stream/src/utils/json/fix-json.ts
+++ b/packages/assistant-stream/src/utils/json/fix-json.ts
@@ -354,13 +354,20 @@ export function fixJson(input: string): [string, string[]] {
       }
 
       case "INSIDE_STRING_UNICODE_ESCAPE": {
-        unicodeEscapeDigits++;
-        const complete = unicodeEscapeDigits === 4;
-        if (complete) stack.pop();
-        const parent = stack[stack.length - (complete ? 1 : 2)];
+        const parent = stack[stack.length - 2];
 
-        if (complete && parent === "INSIDE_STRING") {
-          lastValidIndex = i;
+        if (!/[0-9a-fA-F]/.test(char)) {
+          stack.pop();
+          i--;
+          break;
+        }
+
+        unicodeEscapeDigits++;
+        if (unicodeEscapeDigits === 4) {
+          stack.pop();
+          if (parent === "INSIDE_STRING") {
+            lastValidIndex = i;
+          }
         }
 
         if (parent === "INSIDE_OBJECT_KEY") {

--- a/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
+++ b/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
@@ -239,3 +239,44 @@ describe("parsePartialJsonObject and getPartialJsonObjectFieldState", () => {
     });
   });
 });
+
+describe("parsePartialJsonObject inside a unicode escape", () => {
+  const full = `{"a":"x\\uD83D\\uDE00y"}`;
+
+  it("returns an object for every prefix of a string containing a surrogate-pair escape", () => {
+    for (let cut = 0; cut <= full.length; cut++) {
+      expect(
+        parsePartialJsonObject(full.slice(0, cut)),
+        `cut=${cut}`,
+      ).toBeDefined();
+    }
+  });
+
+  it("omits the unfinished escape from the partial value", () => {
+    expect(parsePartialJsonObject(`{"a":"x\\u`)).toMatchObject({ a: "x" });
+    expect(parsePartialJsonObject(`{"a":"x\\uD8`)).toMatchObject({ a: "x" });
+    expect(parsePartialJsonObject(`{"a":"x\\uD83D\\uDE0`)).toMatchObject({
+      a: "x\uD83D",
+    });
+    expect(parsePartialJsonObject(`{"a":"x\\uD83D\\uDE00y`)).toMatchObject({
+      a: "x😀y",
+    });
+  });
+
+  it("keeps the partial path through an escape cut inside a value", () => {
+    const args = parsePartialJsonObject(`{"a":"x\\uD8`)!;
+    expect(getPartialJsonObjectFieldState(args, ["a"])).toBe("partial");
+  });
+
+  it("handles an escape cut inside an object key", () => {
+    expect(Object.keys(parsePartialJsonObject(`{"\\u00e9`)!)).toEqual([]);
+    expect(parsePartialJsonObject(`{"\\u00e9":1`)).toMatchObject({ é: 1 });
+    expect(parsePartialJsonObject(`{"\\u00e9":"v`)).toMatchObject({ é: "v" });
+  });
+
+  it("leaves single-char escapes unchanged", () => {
+    expect(parsePartialJsonObject(`{"a":"x\\n`)).toMatchObject({ a: "x\n" });
+    expect(parsePartialJsonObject(`{"a":"x\\`)).toMatchObject({ a: "x" });
+    expect(parsePartialJsonObject(`{"a":"x\\"`)).toMatchObject({ a: 'x"' });
+  });
+});

--- a/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
+++ b/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
@@ -274,6 +274,12 @@ describe("parsePartialJsonObject inside a unicode escape", () => {
     expect(parsePartialJsonObject(`{"\\u00e9":"v`)).toMatchObject({ é: "v" });
   });
 
+  it("keeps malformed escapes unparseable", () => {
+    expect(parsePartialJsonObject(`{"a":"\\uZZ`)).toBeUndefined();
+    expect(parsePartialJsonObject(`{"a":"\\u"}`)).toBeUndefined();
+    expect(parsePartialJsonObject(`{"a":"\\u12"}`)).toBeUndefined();
+  });
+
   it("leaves single-char escapes unchanged", () => {
     expect(parsePartialJsonObject(`{"a":"x\\n`)).toMatchObject({ a: "x\n" });
     expect(parsePartialJsonObject(`{"a":"x\\`)).toMatchObject({ a: "x" });


### PR DESCRIPTION
## What

`fixJson` now tracks a `\uXXXX` escape as its own state and only marks the input valid once all four hex chars have arrived. Before, the escape state popped after one char, so a prefix cut inside the escape (`{"a":"\uD8`) was closed as `"\uD8"`, which is invalid JSON.

## Why

Providers commonly ASCII-escape tool args, so emoji and CJK arrive as `\uXXXX` pairs rather than raw characters. Slicing `{"a":"😀"}` at every length shows the problem: 8 of the 21 cuts return `undefined` from `parsePartialJsonObject`, every one of them landing inside an escape. In a streaming tool-args UI that reads as the args object vanishing and reappearing on those ticks.

The raw form `{"a":"😀"}` is unaffected either way; only the escaped encoding trips this.

## Impact

- Partial args that end inside a unicode escape now parse, with the unfinished escape omitted from the value until it completes.
- No change for complete inputs, single-char escapes, or any prefix that already parsed.

## Scope & caveats

- A completed high surrogate whose low half has not arrived yet (`\uD83D`) is emitted as is, same as today; holding it back is a cosmetic one-tick blip and out of scope.
- Non-hex chars after `\u` end the escape and are reprocessed as string chars, so malformed escapes still return `undefined` as on main, non-throwing as before.
- Escapes inside object keys keep accumulating raw text into `currentKey`; the key is only decoded once it closes, so a half key never reaches `JSON.parse`.
- No finalization closer is needed for the new state: `lastValidIndex` stays before the backslash, so the existing `"` closer yields valid JSON.
- The rewind on a non-hex char pops first, so the re-read lands outside this state and the scan stays linear at one rewind per escape.
- Additive only, `fixJson` internals; no wire types or exports touched.
- Changeset: patch (`assistant-stream`).

## Verification

Both implementations were run side by side over every prefix of a corpus, comparing three properties: nothing that parsed before stops parsing, values agree wherever both parse, and neither throws.

Hand-written corpus (surrogate pairs, CJK, malformed escapes, escapes in keys, trailing backslash):

```
TOTAL 367   REGRESSIONS 0   IMPROVEMENTS 32   VALUE-MISMATCHES 0
```

400 generated documents, each in raw-unicode and ASCII-escaped encodings:

```
TOTAL PREFIXES 55465  (threw: 0)
REGRESSIONS 0
IMPROVEMENTS 1664
VALUE-MISMATCHES 0
```

- `pnpm --filter assistant-stream test`: 499 passed, 20 skipped when merged onto current main
- `tsc --noEmit -p packages/assistant-stream/tsconfig.json`: 0 errors, unchanged from main
- New tests: every prefix of a surrogate-pair string, mid-escape values, partial path through an escape, escapes in keys, malformed escapes still unparseable, single-char escapes unchanged

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FS7lk5989tqAeFYrouE8ab7f7pIJj1EHqMNAlmGBQ5MzRVchXHsI4epPSx0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->