### PR TITLE
fix(react-langchain): do not default a tool message's toolName to ""

### DIFF
--- a/.changeset/langchain-nameless-tool-message.md
+++ b/.changeset/langchain-nameless-tool-message.md
@@ -1,0 +1,15 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+fix: do not default a tool message's `toolName` to an empty string
+
+A tool message that arrives over the LangGraph v2 `messages` stream has no name -- the
+protocol carries none, and the SDK rebuilds it as
+`new ToolMessage({ id, content, tool_call_id })`. Defaulting that absence to `""` produced
+a name that disagrees with every tool call, so `joinExternalMessages` threw
+`Tool call name ... does not match existing tool call ...` during render, on every render
+of a thread holding a completed tool call. `toolName` is optional on the converter's
+`Message` type and the joiner skips its identity check when it is null, so the absence is
+now left intact and the name is taken from the tool call. A result that does carry a
+different name is still rejected.

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AppendMessage } from "@assistant-ui/core";
+import { convertExternalMessages } from "@assistant-ui/core/react";
 import {
   convertLangChainBaseMessage,
   getMessageContent,
@@ -946,5 +947,79 @@ describe("convertLangChainBaseMessage audio transcripts", () => {
       const result = convertLangChainBaseMessage(audioMessage("", audio), {});
       expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
     }
+  });
+});
+
+describe("convertLangChainBaseMessage tool messages", () => {
+  const toolCall = {
+    type: "tool_call",
+    id: "call-1",
+    name: "search",
+    args: { query: "hello" },
+  };
+
+  const aiWithToolCall = (): LangChainBaseMessage =>
+    ({
+      _getType: () => "ai",
+      id: "msg-ai",
+      content: [],
+      tool_calls: [toolCall],
+    }) as LangChainBaseMessage;
+
+  const toolResult = (name?: string): LangChainBaseMessage =>
+    ({
+      _getType: () => "tool",
+      id: "msg-tool",
+      content: "3 results",
+      tool_call_id: "call-1",
+      ...(name !== undefined && { name }),
+    }) as LangChainBaseMessage;
+
+  it("leaves toolName absent when the message has no name", () => {
+    const result = convertLangChainBaseMessage(toolResult(), {});
+
+    expect(result.role).toBe("tool");
+    if (result.role !== "tool") throw new Error("expected a tool message");
+    expect(result.toolName).toBeUndefined();
+  });
+
+  it("keeps the name when the message carries one", () => {
+    const result = convertLangChainBaseMessage(toolResult("search"), {});
+
+    if (result.role !== "tool") throw new Error("expected a tool message");
+    expect(result.toolName).toBe("search");
+  });
+
+  // A tool message that arrives over the LangGraph v2 `messages` stream has no
+  // name: the protocol carries none, and the SDK rebuilds it as
+  // `new ToolMessage({ id, content, tool_call_id })`. Defaulting that absence
+  // to "" used to make `joinExternalMessages` throw
+  // "Tool call name ... does not match existing tool call ...", inside a
+  // render, on every render of a thread holding a completed tool call.
+  it("merges a nameless tool result into its call instead of throwing", () => {
+    const messages = convertExternalMessages(
+      [aiWithToolCall(), toolResult()],
+      (message) => convertLangChainBaseMessage(message, {}),
+      false,
+      {},
+    );
+
+    expect(messages).toHaveLength(1);
+    const part = messages[0]!.content[0]!;
+    expect(part.type).toBe("tool-call");
+    if (part.type !== "tool-call") throw new Error("expected a tool call part");
+    expect(part.toolName).toBe("search");
+    expect(part.result).toBe("3 results");
+  });
+
+  it("still rejects a result naming a different tool", () => {
+    expect(() =>
+      convertExternalMessages(
+        [aiWithToolCall(), toolResult("other_tool")],
+        (message) => convertLangChainBaseMessage(message, {}),
+        false,
+        {},
+      ),
+    ).toThrow(/does not match existing tool call/);
   });
 });

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -990,12 +990,6 @@ describe("convertLangChainBaseMessage tool messages", () => {
     expect(result.toolName).toBe("search");
   });
 
-  // A tool message that arrives over the LangGraph v2 `messages` stream has no
-  // name: the protocol carries none, and the SDK rebuilds it as
-  // `new ToolMessage({ id, content, tool_call_id })`. Defaulting that absence
-  // to "" used to make `joinExternalMessages` throw
-  // "Tool call name ... does not match existing tool call ...", inside a
-  // render, on every render of a thread holding a completed tool call.
   it("merges a nameless tool result into its call instead of throwing", () => {
     const messages = convertExternalMessages(
       [aiWithToolCall(), toolResult()],

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1012,6 +1012,19 @@ describe("convertLangChainBaseMessage tool messages", () => {
     expect(part.result).toBe("3 results");
   });
 
+  it("treats an empty name as no name", () => {
+    const messages = convertExternalMessages(
+      [aiWithToolCall(), toolResult("")],
+      (message) => convertLangChainBaseMessage(message, {}),
+      false,
+      {},
+    );
+
+    const part = messages[0]!.content[0]!;
+    if (part.type !== "tool-call") throw new Error("expected a tool call part");
+    expect(part.toolName).toBe("search");
+  });
+
   it("still rejects a result naming a different tool", () => {
     expect(() =>
       convertExternalMessages(

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -210,14 +210,8 @@ export const convertLangChainBaseMessage = (
     case "tool":
       return {
         role: "tool",
-        // Left absent rather than defaulted to "": `toolName` is optional on
-        // the converter's Message type, and `joinExternalMessages` only checks
-        // it against the tool call's name when it is non-null. A tool message
-        // that arrives over the LangGraph v2 `messages` stream never has a
-        // name -- the protocol has no field for one -- so defaulting to ""
-        // manufactures a name that disagrees with every call and throws. An
-        // empty name is not a name either, so it is normalized to absent
-        // rather than passed through into the same failure.
+        // `joinExternalMessages` only checks the name against the tool call
+        // when it is non-null, so an empty name manufactures a mismatch.
         toolName: message.name || undefined,
         toolCallId: message.tool_call_id ?? "",
         result: message.content,

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -215,8 +215,10 @@ export const convertLangChainBaseMessage = (
         // it against the tool call's name when it is non-null. A tool message
         // that arrives over the LangGraph v2 `messages` stream never has a
         // name -- the protocol has no field for one -- so defaulting to ""
-        // manufactures a name that disagrees with every call and throws.
-        toolName: message.name,
+        // manufactures a name that disagrees with every call and throws. An
+        // empty name is not a name either, so it is normalized to absent
+        // rather than passed through into the same failure.
+        toolName: message.name || undefined,
         toolCallId: message.tool_call_id ?? "",
         result: message.content,
         artifact: message.artifact,

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -210,7 +210,13 @@ export const convertLangChainBaseMessage = (
     case "tool":
       return {
         role: "tool",
-        toolName: message.name ?? "",
+        // Left absent rather than defaulted to "": `toolName` is optional on
+        // the converter's Message type, and `joinExternalMessages` only checks
+        // it against the tool call's name when it is non-null. A tool message
+        // that arrives over the LangGraph v2 `messages` stream never has a
+        // name -- the protocol has no field for one -- so defaulting to ""
+        // manufactures a name that disagrees with every call and throws.
+        toolName: message.name,
         toolCallId: message.tool_call_id ?? "",
         result: message.content,
         artifact: message.artifact,


### PR DESCRIPTION
## The bug

`convertLangChainBaseMessage` defaults a tool message's `toolName` to `""`:

```ts
case "tool":
  return {
    role: "tool",
    toolName: message.name ?? "",
```

`joinExternalMessages` then compares that against the tool call it is merging into:

```ts
if (output.toolName != null) {
  if (toolCall.toolName !== output.toolName)
    throw new Error(
      `Tool call name ${output.toolCallId} ${output.toolName} does not match existing tool call ${toolCall.toolName}`,
    );
}
```

`""` is not `null`, so the check runs and `"" !== "search"` throws. The throw happens
inside `useExternalMessageConverter`, i.e. during render, on **every** render of a thread
that holds a completed tool call — the UI does not recover.

The `null` guard above is deliberate: `toolName` is declared optional on the converter's
own `Message` type (`external-message-converter.ts`), so "unknown name" is a supported
state. Defaulting to `""` is what takes that state away.

## Why every LangGraph tool message hits this

A tool message that arrives over the LangGraph v2 `messages` stream has no name, and cannot
have one:

- the server emits `message-start` with `id`, `role` and `tool_call_id` only — there is no
  name field on the event (`@langchain/langgraph`, `dist/pregel/messages-v2.js`,
  `emitFinalMessage`);
- the client rebuilds it as `new ToolMessage({ id, content, tool_call_id })`
  (`@langchain/langgraph-sdk`, `dist/stream/assembled-to-message.js`, `case "tool"`), and
  the assembler's `extras` carries only `toolCallId`, so there is nothing to supply.

So `message.name` is always `undefined` on the streamed copy, `?? ""` turns that into a
name that disagrees with every call, and `useStreamRuntime` throws as soon as any tool
result arrives. Setting `name` server-side does not help: it survives into `values.messages`
but never onto the stream.

This looks like the same failure reported in the later comments of #1235
(`Tool call name tooluse_… null does not match existing tool call get_data`), which was
read at the time as a LangGraph problem.

## The fix

Leave absent absent — one expression:

```diff
-        toolName: message.name ?? "",
+        toolName: message.name,
```

The name is then taken from the tool **call**, which is where it is actually known, and the
identity check still runs whenever a result does carry a name.

## Tests

Four cases added to `packages/react-langchain/src/convertMessages.test.ts`:

- a nameless tool message converts with `toolName` undefined;
- a named one keeps its name;
- an AI tool call plus a **nameless** result merge into one assistant message whose
  tool-call part has the call's `toolName` and the result — this is the regression, and it
  throws on `main`;
- a result naming a **different** tool still throws, so the fix does not cost the existing
  safety check.

## Repro

Any `useStreamRuntime` app against a LangGraph server whose graph emits a `ToolMessage`.
The error appears the moment the tool result reaches the client.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZlU1Z6eM_yQII-sI0OCXcLNykBk63IK60f8u9L3HNLJvH0EGC-sa4QOx27w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->