### PR TITLE
fix(react-langgraph): guard stream event branches against malformed chunk.data

### DIFF
--- a/.changeset/langgraph-null-updates-data.md
+++ b/.changeset/langgraph-null-updates-data.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: tolerate updates events whose payload is null or not an object

--- a/.changeset/langgraph-null-updates-data.md
+++ b/.changeset/langgraph-null-updates-data.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-fix: skip malformed stream payloads instead of throwing, and latch tuple mode only after a valid tuple
+fix: skip malformed stream payloads instead of throwing, and latch tuple mode only after a valid tuple, and leave values undefined on a non-object snapshot

--- a/.changeset/langgraph-null-updates-data.md
+++ b/.changeset/langgraph-null-updates-data.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-fix: tolerate updates events whose payload is null or not an object
+fix: skip malformed stream payloads instead of throwing, and latch tuple mode only after a valid tuple

--- a/.changeset/langgraph-null-updates-data.md
+++ b/.changeset/langgraph-null-updates-data.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-fix: skip malformed stream payloads instead of throwing, and latch tuple mode only after a valid tuple, and leave values undefined on a non-object snapshot
+fix: skip malformed stream payloads instead of throwing

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -846,6 +846,7 @@ describe("useLangGraphMessages", {}, () => {
 
   it("keeps streaming after messages events with null payloads", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    onTestFinished(() => warnSpy.mockRestore());
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
       { event: "messages/partial", data: null },
@@ -889,11 +890,11 @@ describe("useLangGraphMessages", {}, () => {
       "Received invalid messages tuple format:",
       null,
     );
-    warnSpy.mockRestore();
   });
 
   it("does not latch the tuple mode on a malformed messages event", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    onTestFinished(() => warnSpy.mockRestore());
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
       { event: "messages", data: null },
@@ -930,7 +931,6 @@ describe("useLangGraphMessages", {}, () => {
     expect(result.current.messages.map((m) => m.content)).toEqual([
       "first second",
     ]);
-    warnSpy.mockRestore();
   });
 
   it("does not replace tuple-accumulated messages with updates snapshots", async () => {

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -775,8 +775,8 @@ describe("useLangGraphMessages", {}, () => {
     });
   });
 
-  it("keeps streaming after an updates event with a null payload", async () => {
-    let capturedUpdates: unknown = "unset";
+  it("keeps streaming after updates events with null or primitive payloads", async () => {
+    const capturedUpdates: unknown[] = [];
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
       { event: "updates", data: null },
@@ -800,7 +800,7 @@ describe("useLangGraphMessages", {}, () => {
         appendMessage: appendLangChainChunk,
         eventHandlers: {
           onUpdates: (updates) => {
-            capturedUpdates = updates;
+            capturedUpdates.push(updates);
           },
         },
       }),
@@ -817,7 +817,75 @@ describe("useLangGraphMessages", {}, () => {
       expect(result.current.messages).toHaveLength(2);
       expect(result.current.messages[1]!.id).toEqual("ai-2");
     });
-    expect(capturedUpdates).toBe("not-an-object");
+    expect(capturedUpdates).toEqual([null, "not-an-object"]);
+  });
+
+  it("keeps the active interrupt when a null updates payload arrives", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "updates", data: { __interrupt__: [{ value: "approve?" }] } },
+      { event: "updates", data: null },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ id: "user-1", type: "human" as const, content: "hi" }],
+        {},
+      );
+    });
+
+    expect(result.current.interrupt).toEqual({ value: "approve?" });
+  });
+
+  it("keeps streaming after messages events with null payloads", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "messages/partial", data: null },
+      { event: "messages", data: null },
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-2",
+            content: "This is a streamed AI response",
+            type: "AIMessageChunk",
+          },
+          { run_attempt: 1 },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human" as const, content: "hi" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[1]!.id).toEqual("ai-2");
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Received invalid messages tuple format:",
+      null,
+    );
+    warnSpy.mockRestore();
   });
 
   it("does not replace tuple-accumulated messages with updates snapshots", async () => {

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -933,6 +933,29 @@ describe("useLangGraphMessages", {}, () => {
     ]);
   });
 
+  it("keeps values undefined on a null values snapshot", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "values", data: null },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ id: "user-1", type: "human" as const, content: "hi" }],
+        {},
+      );
+    });
+
+    expect(result.current.values).toBeUndefined();
+  });
+
   it("does not replace tuple-accumulated messages with updates snapshots", async () => {
     const initialHumanMessage = {
       id: "user-1",

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -775,6 +775,51 @@ describe("useLangGraphMessages", {}, () => {
     });
   });
 
+  it("keeps streaming after an updates event with a null payload", async () => {
+    let capturedUpdates: unknown = "unset";
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "updates", data: null },
+      { event: "updates", data: "not-an-object" },
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-2",
+            content: "This is a streamed AI response",
+            type: "AIMessageChunk",
+          },
+          { run_attempt: 1 },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: {
+          onUpdates: (updates) => {
+            capturedUpdates = updates;
+          },
+        },
+      }),
+    );
+
+    act(() => {
+      result.current.sendMessage(
+        [{ id: "user-1", type: "human" as const, content: "hi" }],
+        {},
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[1]!.id).toEqual("ai-2");
+    });
+    expect(capturedUpdates).toBe("not-an-object");
+  });
+
   it("does not replace tuple-accumulated messages with updates snapshots", async () => {
     const initialHumanMessage = {
       id: "user-1",

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -882,9 +882,54 @@ describe("useLangGraphMessages", {}, () => {
       expect(result.current.messages[1]!.id).toEqual("ai-2");
     });
     expect(warnSpy).toHaveBeenCalledWith(
+      "Received invalid messages payload:",
+      null,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
       "Received invalid messages tuple format:",
       null,
     );
+    warnSpy.mockRestore();
+  });
+
+  it("does not latch the tuple mode on a malformed messages event", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "messages", data: null },
+      {
+        event: "values",
+        data: {
+          messages: [{ id: "ai-1", type: "ai" as const, content: "first" }],
+        },
+      },
+      {
+        event: "values",
+        data: {
+          messages: [
+            { id: "ai-1", type: "ai" as const, content: "first second" },
+          ],
+        },
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ id: "user-1", type: "human" as const, content: "hi" }],
+        {},
+      );
+    });
+
+    expect(result.current.messages.map((m) => m.content)).toEqual([
+      "first second",
+    ]);
     warnSpy.mockRestore();
   });
 

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -933,9 +933,12 @@ describe("useLangGraphMessages", {}, () => {
     ]);
   });
 
-  it("keeps values undefined on a non-object values snapshot", async () => {
+  it("keeps the last valid values snapshot when a malformed one follows", async () => {
+    const capturedValues: unknown[] = [];
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
+      { event: "values", data: null },
+      { event: "values", data: { step: 1 } },
       { event: "values", data: null },
       { event: "values", data: 42 },
     ]);
@@ -944,6 +947,11 @@ describe("useLangGraphMessages", {}, () => {
       useLangGraphMessages({
         stream: mockStreamCallback,
         appendMessage: appendLangChainChunk,
+        eventHandlers: {
+          onValues: (values) => {
+            capturedValues.push(values);
+          },
+        },
       }),
     );
 
@@ -954,7 +962,8 @@ describe("useLangGraphMessages", {}, () => {
       );
     });
 
-    expect(result.current.values).toBeUndefined();
+    expect(result.current.values).toEqual({ step: 1 });
+    expect(capturedValues).toEqual([null, { step: 1 }, null, 42]);
   });
 
   it("does not replace tuple-accumulated messages with updates snapshots", async () => {

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -933,10 +933,11 @@ describe("useLangGraphMessages", {}, () => {
     ]);
   });
 
-  it("keeps values undefined on a null values snapshot", async () => {
+  it("keeps values undefined on a non-object values snapshot", async () => {
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,
       { event: "values", data: null },
+      { event: "values", data: 42 },
     ]);
 
     const { result } = renderHook(() =>

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -124,17 +124,17 @@ const normalizeMessageType = <TMessage>(message: TMessage): TMessage => {
   return message;
 };
 
-const extractMessagesFromUpdates = <TMessage>(data: unknown): TMessage[] => {
-  if (data === null || typeof data !== "object") return [];
-  const record = data as Record<string, unknown>;
+const extractMessagesFromUpdates = <TMessage>(
+  data: Record<string, unknown>,
+): TMessage[] => {
   // { messages: [...] } shape
-  if (Array.isArray(record.messages)) {
-    return (record.messages as TMessage[]).map(normalizeMessageType);
+  if (Array.isArray(data.messages)) {
+    return (data.messages as TMessage[]).map(normalizeMessageType);
   }
 
   // { nodeName: { messages: [...] } } shape
   const messages: TMessage[] = [];
-  for (const value of Object.values(record)) {
+  for (const value of Object.values(data)) {
     if (value && typeof value === "object" && "messages" in value) {
       const nodeMessages = (value as Record<string, unknown>).messages;
       if (Array.isArray(nodeMessages)) {
@@ -314,6 +314,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
           switch (eventType) {
             case LangGraphKnownEventTypes.MessagesPartial:
             case LangGraphKnownEventTypes.MessagesComplete:
+              if (!Array.isArray(chunk.data)) break;
               onMessages?.(chunk.data, config.runConfig);
               setMessagesImmediate(accumulator.addMessages(chunk.data));
               break;
@@ -328,6 +329,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
               } else {
                 invokeEventCallback("onUpdates", onUpdates, chunk.data);
               }
+              if (chunk.data === null || typeof chunk.data !== "object") break;
               const extracted = extractMessagesFromUpdates<TMessage>(
                 chunk.data,
               );
@@ -336,7 +338,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 setMessagesImmediate(accumulator.addMessages(extracted));
               }
               // A subgraph update may set an interrupt but never clear one; the parent's top-level update clears it when the subgraph ends.
-              const updateInterrupt = chunk.data?.__interrupt__?.[0];
+              const updateInterrupt = chunk.data.__interrupt__?.[0];
               if (!eventNamespace || updateInterrupt !== undefined) {
                 onInterrupt?.(updateInterrupt, config.runConfig);
                 setInterrupt(updateInterrupt);
@@ -384,15 +386,16 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
               break;
             case LangGraphKnownEventTypes.Messages: {
               hasTupleMessageEvents = true;
-              const [tupleMessage, tupleMetadata] = (
-                chunk as LangChainMessageTupleEvent
-              ).data;
+              const tupleData = (chunk as LangChainMessageTupleEvent).data;
+              const [tupleMessage, tupleMetadata] = Array.isArray(tupleData)
+                ? tupleData
+                : [];
               const normalizedTupleMessage =
                 normalizeLangGraphTupleMessage(tupleMessage);
               if (!normalizedTupleMessage) {
                 console.warn(
                   "Received invalid messages tuple format:",
-                  tupleMessage,
+                  tupleData,
                 );
                 break;
               }

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -314,7 +314,10 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
           switch (eventType) {
             case LangGraphKnownEventTypes.MessagesPartial:
             case LangGraphKnownEventTypes.MessagesComplete:
-              if (!Array.isArray(chunk.data)) break;
+              if (!Array.isArray(chunk.data)) {
+                console.warn("Received invalid messages payload:", chunk.data);
+                break;
+              }
               onMessages?.(chunk.data, config.runConfig);
               setMessagesImmediate(accumulator.addMessages(chunk.data));
               break;
@@ -385,7 +388,6 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
               }
               break;
             case LangGraphKnownEventTypes.Messages: {
-              hasTupleMessageEvents = true;
               const tupleData = (chunk as LangChainMessageTupleEvent).data;
               const [tupleMessage, tupleMetadata] = Array.isArray(tupleData)
                 ? tupleData
@@ -399,6 +401,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 );
                 break;
               }
+              hasTupleMessageEvents = true;
 
               const tupleMetadataWithNamespace:
                 | LangGraphTupleMetadata

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -358,7 +358,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 );
                 break;
               }
-              setValues(chunk.data as Record<string, unknown>);
+              setValues(chunk.data ?? undefined);
               invokeEventCallback("onValues", onValues, chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -358,12 +358,9 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 );
                 break;
               }
-              setValues(
-                chunk.data !== null && typeof chunk.data === "object"
-                  ? chunk.data
-                  : undefined,
-              );
               invokeEventCallback("onValues", onValues, chunk.data);
+              if (chunk.data === null || typeof chunk.data !== "object") break;
+              setValues(chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;
                 if (hasTupleMessageEvents) {

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -358,7 +358,11 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 );
                 break;
               }
-              setValues(chunk.data ?? undefined);
+              setValues(
+                chunk.data !== null && typeof chunk.data === "object"
+                  ? chunk.data
+                  : undefined,
+              );
               invokeEventCallback("onValues", onValues, chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -124,17 +124,17 @@ const normalizeMessageType = <TMessage>(message: TMessage): TMessage => {
   return message;
 };
 
-const extractMessagesFromUpdates = <TMessage>(
-  data: Record<string, unknown>,
-): TMessage[] => {
+const extractMessagesFromUpdates = <TMessage>(data: unknown): TMessage[] => {
+  if (data === null || typeof data !== "object") return [];
+  const record = data as Record<string, unknown>;
   // { messages: [...] } shape
-  if (Array.isArray(data.messages)) {
-    return (data.messages as TMessage[]).map(normalizeMessageType);
+  if (Array.isArray(record.messages)) {
+    return (record.messages as TMessage[]).map(normalizeMessageType);
   }
 
   // { nodeName: { messages: [...] } } shape
   const messages: TMessage[] = [];
-  for (const value of Object.values(data)) {
+  for (const value of Object.values(record)) {
     if (value && typeof value === "object" && "messages" in value) {
       const nodeMessages = (value as Record<string, unknown>).messages;
       if (Array.isArray(nodeMessages)) {
@@ -336,7 +336,7 @@ const useLangGraphMessagesInternal = <TMessage extends { id?: string }>({
                 setMessagesImmediate(accumulator.addMessages(extracted));
               }
               // A subgraph update may set an interrupt but never clear one; the parent's top-level update clears it when the subgraph ends.
-              const updateInterrupt = chunk.data.__interrupt__?.[0];
+              const updateInterrupt = chunk.data?.__interrupt__?.[0];
               if (!eventNamespace || updateInterrupt !== undefined) {
                 onInterrupt?.(updateInterrupt, config.runConfig);
                 setInterrupt(updateInterrupt);


### PR DESCRIPTION
## What
`useLangGraphMessages` now skips the internal handling of an event whose `data` is null or not the expected shape instead of dereferencing it: `updates` breaks after the `onUpdates` / `onSubgraphUpdates` dispatch when the payload is not an object, `values` breaks after the `onValues` dispatch when the snapshot is not an object, `messages/partial` and `messages/complete` require an array (warning otherwise, like the tuple branch), and the `messages` tuple branch falls into its existing invalid-tuple warning instead of destructuring null. The tuple branch now flips `hasTupleMessageEvents` only after a tuple is actually consumed, so a malformed tuple does not switch later `values` snapshots to the incremental path.

## Why
A user-supplied `stream` (`data` is typed `any`) that yields `{ event: "updates", data: null }` threw `TypeError: Cannot read properties of null (reading 'messages')` inside the event loop, so the run ended and every later event was dropped. The `values` branch already guarded its message extraction; the `updates`, `messages/partial|complete` and `messages` tuple branches had the same unguarded deref, so the fix mirrors that guard at each site rather than catching the error.

## Impact
- Users of `@assistant-ui/react-langgraph` whose custom `stream` (or server) emits a null or malformed payload for one of these events keep receiving later events.
- No output change for well-formed streams.

## Scope & caveats
- Origin: found with a custom `stream` callback, not an observed LangGraph server frame; the guard exists because `stream` is user-supplied and `data` is `any`.
- `onUpdates` / `onSubgraphUpdates` / `onValues` still receive the raw payload unchanged; a non-object update or snapshot is otherwise a no-op, so it neither extracts messages, touches an active interrupt, nor replaces the last valid `values` snapshot.
- Arrays still flow through `Object.values` in the updates extractor as before.
- The sibling langchain converter guard is tracked separately as a follow-up, not in this PR.
- Tests: null and string `updates` payloads followed by a tuple (all raw payloads asserted on `onUpdates`); a null update after an `__interrupt__` keeps the interrupt; null `messages/partial` and `messages` tuple payloads followed by a valid tuple; a null tuple followed by two `values` snapshots still updates an existing message; a valid `values` snapshot survives a following null and primitive payload (all raw payloads asserted on `onValues`). Each fails without the guard.
- Changeset: patch (`@assistant-ui/react-langgraph`).
