### PR TITLE
fix(core): roll back failed frame registrations

### DIFF
--- a/.changeset/assistant-frame-registration-rollback.md
+++ b/.changeset/assistant-frame-registration-rollback.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: roll back AssistantFrame providers when registration fails
+fix: roll back AssistantFrame providers on registration, release, and disposal failures

--- a/.changeset/assistant-frame-registration-rollback.md
+++ b/.changeset/assistant-frame-registration-rollback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: roll back AssistantFrame providers when registration fails

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -365,6 +365,40 @@ describe("AssistantFrameProvider", () => {
     ).not.toThrow();
   });
 
+  it("keeps an existing registration when the same provider fails to register again", async () => {
+    const execute = vi.fn(async () => "result");
+    const firstUnsubscribe = vi.fn();
+    let subscriptionCount = 0;
+    const provider = {
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute } },
+      }),
+      subscribe: () => {
+        subscriptionCount += 1;
+        if (subscriptionCount === 1) return firstUnsubscribe;
+        throw new Error("second subscribe failed");
+      },
+    };
+    const releaseFirst = AssistantFrameProvider.addModelContextProvider(
+      provider,
+      "https://parent.example",
+    );
+
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        provider,
+        "https://parent.example",
+      ),
+    ).toThrow("second subscribe failed");
+    expect(firstUnsubscribe).not.toHaveBeenCalled();
+
+    dispatchToolCall("https://parent.example");
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+    releaseFirst();
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+  });
+
   it("releases a subscription when the initial broadcast fails", () => {
     const unsubscribe = vi.fn();
     expect(() =>

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -338,6 +338,33 @@ describe("AssistantFrameProvider", () => {
     );
   });
 
+  it("rolls back a provider when registration fails", () => {
+    const execute = vi.fn(async () => "result");
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        {
+          getModelContext: () => ({
+            tools: { sensitiveTool: { execute } },
+          }),
+          subscribe: () => {
+            throw new Error("subscribe failed");
+          },
+        },
+        "https://first.example",
+      ),
+    ).toThrow("subscribe failed");
+
+    dispatchToolCall("https://first.example");
+    expect(execute).not.toHaveBeenCalled();
+
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        { getModelContext: () => ({}) },
+        "https://second.example",
+      ),
+    ).not.toThrow();
+  });
+
   it("resets the origin policy after every provider unsubscribes", () => {
     const unsubscribe = AssistantFrameProvider.addModelContextProvider(
       { getModelContext: () => ({}) },

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -388,6 +388,27 @@ describe("AssistantFrameProvider", () => {
     ).not.toThrow();
   });
 
+  it("reports rollback cleanup failures without replacing the original error", () => {
+    const contextError = new Error("context failed");
+    const unsubscribeError = new Error("unsubscribe failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider({
+        getModelContext: () => {
+          throw contextError;
+        },
+        subscribe: () => () => {
+          throw unsubscribeError;
+        },
+      }),
+    ).toThrow(contextError);
+
+    expect(consoleError).toHaveBeenCalledWith(unsubscribeError);
+  });
+
   it("cleans up provider state when its unsubscribe throws", () => {
     const unsubscribe = vi.fn(() => {
       throw new Error("unsubscribe failed");
@@ -408,6 +429,34 @@ describe("AssistantFrameProvider", () => {
         "https://second.example",
       ),
     ).not.toThrow();
+  });
+
+  it("finishes disposal when a provider unsubscribe throws", () => {
+    const error = new Error("unsubscribe failed");
+    const firstUnsubscribe = vi.fn(() => {
+      throw error;
+    });
+    const secondUnsubscribe = vi.fn();
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({}),
+      subscribe: () => firstUnsubscribe,
+    });
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({}),
+      subscribe: () => secondUnsubscribe,
+    });
+
+    expect(() => AssistantFrameProvider.dispose()).toThrow(error);
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    expect(secondUnsubscribe).toHaveBeenCalledOnce();
+
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        { getModelContext: () => ({}) },
+        "https://new.example",
+      ),
+    ).not.toThrow();
+    expect(window.addEventListener).toHaveBeenCalledTimes(2);
   });
 
   it("resets the origin policy after every provider unsubscribes", () => {

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -365,6 +365,51 @@ describe("AssistantFrameProvider", () => {
     ).not.toThrow();
   });
 
+  it("releases a subscription when the initial broadcast fails", () => {
+    const unsubscribe = vi.fn();
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        {
+          getModelContext: () => {
+            throw new Error("context failed");
+          },
+          subscribe: () => unsubscribe,
+        },
+        "https://first.example",
+      ),
+    ).toThrow("context failed");
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        { getModelContext: () => ({}) },
+        "https://second.example",
+      ),
+    ).not.toThrow();
+  });
+
+  it("cleans up provider state when its unsubscribe throws", () => {
+    const unsubscribe = vi.fn(() => {
+      throw new Error("unsubscribe failed");
+    });
+    const release = AssistantFrameProvider.addModelContextProvider(
+      {
+        getModelContext: () => ({}),
+        subscribe: () => unsubscribe,
+      },
+      "https://first.example",
+    );
+
+    expect(release).toThrow("unsubscribe failed");
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider(
+        { getModelContext: () => ({}) },
+        "https://second.example",
+      ),
+    ).not.toThrow();
+  });
+
   it("resets the origin policy after every provider unsubscribes", () => {
     const unsubscribe = AssistantFrameProvider.addModelContextProvider(
       { getModelContext: () => ({}) },

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -399,6 +399,29 @@ describe("AssistantFrameProvider", () => {
     expect(firstUnsubscribe).toHaveBeenCalledOnce();
   });
 
+  it("merges a provider registered more than once only once", () => {
+    const provider = {
+      getModelContext: () => ({ system: "shared system" }),
+    };
+
+    AssistantFrameProvider.addModelContextProvider(provider);
+    AssistantFrameProvider.addModelContextProvider(provider);
+
+    expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: {
+          type: "model-context-update",
+          context: {
+            system: "shared system",
+            tools: {},
+          },
+        },
+      },
+      "*",
+    );
+  });
+
   it("releases a subscription when the initial broadcast fails", () => {
     const unsubscribe = vi.fn();
     expect(() =>

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -228,10 +228,14 @@ export class AssistantFrameProvider {
       // Rollback failures must not replace the registration error.
       try {
         unsubscribe?.();
-      } catch {}
+      } catch (unsubscribeError) {
+        console.error(unsubscribeError);
+      }
       try {
         instance.broadcastUpdate();
-      } catch {}
+      } catch (broadcastError) {
+        console.error(broadcastError);
+      }
       throw error;
     }
 
@@ -252,6 +256,7 @@ export class AssistantFrameProvider {
         instance.broadcastUpdate();
       } catch (error) {
         if (!unsubscribeFailed) throw error;
+        console.error(error);
       }
       if (unsubscribeFailed) throw unsubscribeError;
     };
@@ -262,20 +267,40 @@ export class AssistantFrameProvider {
       const instance = AssistantFrameProvider._instance;
       window.removeEventListener("message", instance.handleMessage);
 
-      instance._providerUnsubscribes.forEach((unsubscribe) => unsubscribe?.());
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      const runCleanup = (cleanup: () => void) => {
+        try {
+          cleanup();
+        } catch (error) {
+          if (cleanupFailed) {
+            console.error(error);
+          } else {
+            cleanupFailed = true;
+            cleanupError = error;
+          }
+        }
+      };
+
+      instance._providerUnsubscribes.forEach((unsubscribe) => {
+        if (unsubscribe) runCleanup(unsubscribe);
+      });
       instance._providerUnsubscribes.clear();
       instance._providers.clear();
       instance._activeToolCalls.forEach(({ abortController, event }, id) => {
-        abortController.abort();
-        instance.sendMessage(event, {
-          type: "tool-result",
-          id,
-          error: "AssistantFrameProvider has been disposed",
+        runCleanup(() => {
+          abortController.abort();
+          instance.sendMessage(event, {
+            type: "tool-result",
+            id,
+            error: "AssistantFrameProvider has been disposed",
+          });
         });
       });
       instance._activeToolCalls.clear();
 
       AssistantFrameProvider._instance = null;
+      if (cleanupFailed) throw cleanupError;
     }
   }
 }

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -191,6 +191,20 @@ export class AssistantFrameProvider {
     }
   }
 
+  private removeProvider(
+    provider: ModelContextProvider,
+    origin: string,
+  ): Unsubscribe | undefined {
+    this._providers.delete(provider);
+    const unsubscribe = this._providerUnsubscribes.get(provider);
+    this._providerUnsubscribes.delete(provider);
+    if (origin !== "*") {
+      this._strictRegistrations -= 1;
+      if (this._strictRegistrations === 0) this._targetOrigin = "*";
+    }
+    return unsubscribe;
+  }
+
   static addModelContextProvider(
     provider: ModelContextProvider,
     targetOrigin?: string,
@@ -200,21 +214,18 @@ export class AssistantFrameProvider {
     instance._providers.add(provider);
     if (origin !== "*") instance._strictRegistrations += 1;
 
-    let unsubscribe: Unsubscribe | undefined;
     try {
-      unsubscribe = provider.subscribe?.(() => instance.broadcastUpdate());
+      const unsubscribe = provider.subscribe?.(() =>
+        instance.broadcastUpdate(),
+      );
       if (unsubscribe) {
         instance._providerUnsubscribes.set(provider, unsubscribe);
       }
 
       instance.broadcastUpdate();
     } catch (error) {
-      instance._providers.delete(provider);
-      instance._providerUnsubscribes.delete(provider);
-      if (origin !== "*") {
-        instance._strictRegistrations -= 1;
-        if (instance._strictRegistrations === 0) instance._targetOrigin = "*";
-      }
+      const unsubscribe = instance.removeProvider(provider, origin);
+      // Rollback failures must not replace the registration error.
       try {
         unsubscribe?.();
       } catch {}
@@ -228,14 +239,21 @@ export class AssistantFrameProvider {
     return () => {
       if (released) return;
       released = true;
-      instance._providers.delete(provider);
-      instance._providerUnsubscribes.get(provider)?.();
-      instance._providerUnsubscribes.delete(provider);
-      if (origin !== "*") {
-        instance._strictRegistrations -= 1;
-        if (instance._strictRegistrations === 0) instance._targetOrigin = "*";
+      const unsubscribe = instance.removeProvider(provider, origin);
+      let unsubscribeFailed = false;
+      let unsubscribeError: unknown;
+      try {
+        unsubscribe?.();
+      } catch (error) {
+        unsubscribeFailed = true;
+        unsubscribeError = error;
       }
-      instance.broadcastUpdate();
+      try {
+        instance.broadcastUpdate();
+      } catch (error) {
+        if (!unsubscribeFailed) throw error;
+      }
+      if (unsubscribeFailed) throw unsubscribeError;
     };
   }
 

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -157,7 +157,7 @@ export class AssistantFrameProvider {
   }
 
   private getModelContext(): ModelContext {
-    const contexts = Array.from(this._providers.values()).map((p) =>
+    const contexts = Array.from(new Set(this._providers.values())).map((p) =>
       p.getModelContext(),
     );
 

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -32,11 +32,8 @@ const serializeModelContext = (
 export class AssistantFrameProvider {
   private static _instance: AssistantFrameProvider | null = null;
 
-  private _providers = new Set<ModelContextProvider>();
-  private _providerUnsubscribes = new Map<
-    ModelContextProvider,
-    Unsubscribe | undefined
-  >();
+  private _providers = new Map<symbol, ModelContextProvider>();
+  private _providerUnsubscribes = new Map<symbol, Unsubscribe | undefined>();
   private _activeToolCalls = new Map<
     string,
     { abortController: AbortController; event: MessageEvent }
@@ -160,7 +157,7 @@ export class AssistantFrameProvider {
   }
 
   private getModelContext(): ModelContext {
-    const contexts = Array.from(this._providers).map((p) =>
+    const contexts = Array.from(this._providers.values()).map((p) =>
       p.getModelContext(),
     );
 
@@ -191,13 +188,10 @@ export class AssistantFrameProvider {
     }
   }
 
-  private removeProvider(
-    provider: ModelContextProvider,
-    origin: string,
-  ): Unsubscribe | undefined {
-    this._providers.delete(provider);
-    const unsubscribe = this._providerUnsubscribes.get(provider);
-    this._providerUnsubscribes.delete(provider);
+  private removeProvider(id: symbol, origin: string): Unsubscribe | undefined {
+    this._providers.delete(id);
+    const unsubscribe = this._providerUnsubscribes.get(id);
+    this._providerUnsubscribes.delete(id);
     if (origin !== "*") {
       this._strictRegistrations -= 1;
       if (this._strictRegistrations === 0) this._targetOrigin = "*";
@@ -211,7 +205,8 @@ export class AssistantFrameProvider {
   ): Unsubscribe {
     const origin = targetOrigin ?? "*";
     const instance = AssistantFrameProvider.getInstance(origin);
-    instance._providers.add(provider);
+    const id = Symbol();
+    instance._providers.set(id, provider);
     if (origin !== "*") instance._strictRegistrations += 1;
 
     try {
@@ -219,12 +214,12 @@ export class AssistantFrameProvider {
         instance.broadcastUpdate(),
       );
       if (unsubscribe) {
-        instance._providerUnsubscribes.set(provider, unsubscribe);
+        instance._providerUnsubscribes.set(id, unsubscribe);
       }
 
       instance.broadcastUpdate();
     } catch (error) {
-      const unsubscribe = instance.removeProvider(provider, origin);
+      const unsubscribe = instance.removeProvider(id, origin);
       // Rollback failures must not replace the registration error.
       try {
         unsubscribe?.();
@@ -243,7 +238,7 @@ export class AssistantFrameProvider {
     return () => {
       if (released) return;
       released = true;
-      const unsubscribe = instance.removeProvider(provider, origin);
+      const unsubscribe = instance.removeProvider(id, origin);
       let unsubscribeFailed = false;
       let unsubscribeError: unknown;
       try {

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -200,12 +200,29 @@ export class AssistantFrameProvider {
     instance._providers.add(provider);
     if (origin !== "*") instance._strictRegistrations += 1;
 
-    const unsubscribe = provider.subscribe?.(() => instance.broadcastUpdate());
-    if (unsubscribe) {
-      instance._providerUnsubscribes.set(provider, unsubscribe);
-    }
+    let unsubscribe: Unsubscribe | undefined;
+    try {
+      unsubscribe = provider.subscribe?.(() => instance.broadcastUpdate());
+      if (unsubscribe) {
+        instance._providerUnsubscribes.set(provider, unsubscribe);
+      }
 
-    instance.broadcastUpdate();
+      instance.broadcastUpdate();
+    } catch (error) {
+      instance._providers.delete(provider);
+      instance._providerUnsubscribes.delete(provider);
+      if (origin !== "*") {
+        instance._strictRegistrations -= 1;
+        if (instance._strictRegistrations === 0) instance._targetOrigin = "*";
+      }
+      try {
+        unsubscribe?.();
+      } catch {}
+      try {
+        instance.broadcastUpdate();
+      } catch {}
+      throw error;
+    }
 
     let released = false;
     return () => {


### PR DESCRIPTION
## Summary

- roll back only the failed AssistantFrame provider registration when subscription or initial broadcasting fails
- track repeated registrations of the same provider independently while preserving deduplicated context merging
- clean provider and strict-origin state before invoking user teardown callbacks
- finish singleton disposal even when one or more provider teardowns fail
- preserve the first lifecycle error and report secondary cleanup failures

## Why

`addModelContextProvider()` inserted a provider and updated the singleton origin policy before calling user-controlled lifecycle code. If `subscribe()`, context serialization, or a later unsubscribe threw, cleanup could stop midway. The failed provider or its strict origin then remained active, so tools could still execute and later providers from another valid origin could be rejected.

Provider bookkeeping was also keyed by provider object. Registering the same provider twice and failing the second registration could therefore remove the first successful registration and its cleanup callback. Registrations are now keyed independently, matching the composite provider pattern, while context merging still deduplicates repeated provider objects as before.

`dispose()` had the same failure mode: one throwing unsubscribe stopped cleanup after the window listener was removed but before the singleton was reset. Later registrations then reused a dead provider instance.

The lifecycle paths now remove only their own internal state first, continue all cleanup, reset the singleton, and then rethrow the first error. Secondary failures are logged following the existing `CompositeContextProvider` precedent.

## Minimal reproduction

A user-reachable registration failure is a tool using a Zod v3 parameters schema. Frame serialization calls `toJSONSchema()`, which rejects that schema after the provider has already been inserted:

```ts
import { z } from "zod/v3";

AssistantFrameProvider.addModelContextProvider({
  getModelContext: () => ({
    tools: {
      legacyTool: {
        parameters: z.object({ query: z.string() }),
        execute: async () => "ok",
      },
    },
  }),
});
```

Before this fix, the call throws but `legacyTool` remains executable through frame messages and a strict `targetOrigin` remains pinned. The tests also reproduce direct `subscribe()`, duplicate registration, initial broadcast, release, and disposal failures.

## Testing

- `vitest run src/model-context/frame/provider.test.ts` (20 tests)
- `aui-build`