### PR TITLE
fix(cloud-ai-sdk): apply chat options after commit

### DIFF
--- a/.changeset/cloud-chat-options-after-commit.md
+++ b/.changeset/cloud-chat-options-after-commit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: keep committed Cloud chat options active across interrupted renders

--- a/packages/cloud-ai-sdk/src/__tests__/contract/persistence.test.ts
+++ b/packages/cloud-ai-sdk/src/__tests__/contract/persistence.test.ts
@@ -33,7 +33,7 @@ function createCore() {
     onSyncError: undefined,
   };
 
-  return new CloudChatCore({} as never, refs);
+  return new CloudChatCore({} as never, refs, {} as never);
 }
 
 describe("Contract: Persistence", () => {
@@ -111,7 +111,7 @@ describe("Contract: Persistence", () => {
       onSyncError,
     };
 
-    new CloudChatCore({} as never, refs);
+    new CloudChatCore({} as never, refs, {} as never);
 
     expect(MessagePersistenceMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
+++ b/packages/cloud-ai-sdk/src/__tests__/contract/threadLifecycle.test.ts
@@ -47,7 +47,7 @@ function createCore() {
     onSyncError: undefined,
   };
 
-  const core = new CloudChatCore(cloud, refs);
+  const core = new CloudChatCore(cloud, refs, {} as never);
   return { core, createThread, selectThread, refresh, generateTitle };
 }
 

--- a/packages/cloud-ai-sdk/src/__tests__/contract/titlePolicy.test.ts
+++ b/packages/cloud-ai-sdk/src/__tests__/contract/titlePolicy.test.ts
@@ -32,7 +32,7 @@ function createCore() {
     onSyncError: undefined,
   };
 
-  const core = new CloudChatCore({} as never, refs);
+  const core = new CloudChatCore({} as never, refs, {} as never);
   return { core, generateTitle };
 }
 

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -32,6 +32,15 @@ export class ChatRegistry {
     return this.chatByKey.get(chatKey);
   }
 
+  register(
+    chatKey: string,
+    threadId: string | null,
+    chat: Chat<UIMessage>,
+  ): void {
+    this.chatByKey.set(chatKey, chat);
+    this.getOrCreateMeta(chatKey, threadId);
+  }
+
   getMeta(chatKey: string): ChatMeta | undefined {
     return this.metaByKey.get(chatKey);
   }

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
+import { createElement, startTransition, Suspense } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { useChatRegistry } from "./useChatRegistry";
 
@@ -141,5 +142,62 @@ describe("useChatRegistry", () => {
     rerender();
 
     expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("does not register chats from abandoned renders", () => {
+    const scope = {};
+    const pending = new Promise<never>(() => {});
+    const createChat = vi.fn().mockImplementation((chatKey: string) => ({
+      id: chatKey,
+      messages: [],
+      source: "committed fallback",
+    }));
+
+    const Probe = ({
+      threadId,
+      source,
+      suspend,
+    }: {
+      threadId: string;
+      source: string;
+      suspend: boolean;
+    }) => {
+      const { activeChat } = useChatRegistry({
+        scope,
+        threadId,
+        createChat: createChat as never,
+        createRenderChat: ((chatKey: string) => ({
+          id: chatKey,
+          messages: [],
+          source,
+        })) as never,
+      });
+      if (suspend) throw pending;
+      return createElement(
+        "span",
+        null,
+        (activeChat as unknown as { source: string }).source,
+      );
+    };
+    const renderProbe = (threadId: string, source: string, suspend: boolean) =>
+      createElement(
+        Suspense,
+        { fallback: null },
+        createElement(Probe, { threadId, source, suspend }),
+      );
+
+    const view = render(renderProbe("thread-a", "account-a", false));
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(renderProbe("thread-b", "abandoned", true));
+      });
+    });
+
+    expect(view.container.textContent).toBe("account-a");
+
+    view.rerender(renderProbe("thread-b", "committed", false));
+
+    expect(view.container.textContent).toBe("committed");
   });
 });

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -14,6 +14,9 @@ type UseChatRegistryOptions = {
   scope: object;
   threadId: string | null;
   createChat: (chatKey: string, registry: ChatRegistry) => Chat<UIMessage>;
+  createRenderChat?:
+    | ((chatKey: string, registry: ChatRegistry) => Chat<UIMessage>)
+    | undefined;
 };
 
 function createRegistry(
@@ -28,6 +31,7 @@ export function useChatRegistry({
   scope,
   threadId,
   createChat,
+  createRenderChat = createChat,
 }: UseChatRegistryOptions): {
   registry: ChatRegistry;
   activeChat: Chat<UIMessage>;
@@ -46,7 +50,15 @@ export function useChatRegistry({
     ? (registry.getChatKeyForThread(threadId) ?? threadId)
     : freshSession.key;
 
-  const activeChat = registry.getOrCreate(activeChatKey, threadId);
+  const activeChat = useMemo(
+    () =>
+      registry.get(activeChatKey) ?? createRenderChat(activeChatKey, registry),
+    [activeChatKey, createRenderChat, registry],
+  );
+
+  useEffect(() => {
+    registry.register(activeChatKey, threadId, activeChat);
+  }, [activeChat, activeChatKey, registry, threadId]);
 
   const committedRegistryRef = useRef(registry);
   useEffect(() => {

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useInsertionEffect, useMemo, useRef } from "react";
 import type { Chat } from "@ai-sdk/react";
 import type { UIMessage } from "@ai-sdk/react";
 import { ChatRegistry } from "./ChatRegistry";
@@ -53,7 +53,7 @@ export function useChatRegistry({
   const activeChat =
     registry.get(activeChatKey) ?? createRenderChat(activeChatKey, registry);
 
-  useEffect(() => {
+  useInsertionEffect(() => {
     registry.register(activeChatKey, threadId, activeChat);
   }, [activeChat, activeChatKey, registry, threadId]);
 

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -50,11 +50,8 @@ export function useChatRegistry({
     ? (registry.getChatKeyForThread(threadId) ?? threadId)
     : freshSession.key;
 
-  const activeChat = useMemo(
-    () =>
-      registry.get(activeChatKey) ?? createRenderChat(activeChatKey, registry),
-    [activeChatKey, createRenderChat, registry],
-  );
+  const activeChat =
+    registry.get(activeChatKey) ?? createRenderChat(activeChatKey, registry);
 
   useEffect(() => {
     registry.register(activeChatKey, threadId, activeChat);

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, render, renderHook } from "@testing-library/react";
-import { createElement, Suspense } from "react";
+import { createElement, startTransition, Suspense } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UseThreadsResult } from "../types";
 import { CloudChatCore } from "../core/CloudChatCore";
 import { ChatRegistry } from "./ChatRegistry";
 import { useCloudChat } from "./useCloudChat";
+import { useCloudChatCore } from "./useCloudChatCore";
 
 function createThreads(
   cloud: unknown,
@@ -101,6 +102,79 @@ describe("useCloudChat thread switching", () => {
     view.rerender(renderProbe(threadsA, false));
 
     expect(stopAll).not.toHaveBeenCalled();
+  });
+
+  it("keeps committed options active when an options update suspends", async () => {
+    const cloud = {
+      threads: {
+        create: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
+      },
+    };
+    const threadsA = createThreads(cloud, null);
+    const threadsB = createThreads(cloud, null);
+    const transportA = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn().mockResolvedValue(null),
+    };
+    const transportB = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn().mockResolvedValue(null),
+    };
+    const pending = new Promise<never>(() => {});
+    let core: CloudChatCore | undefined;
+
+    const Probe = ({
+      label,
+      threads,
+      transport,
+      suspend,
+    }: {
+      label: string;
+      threads: UseThreadsResult;
+      transport: typeof transportA;
+      suspend: boolean;
+    }) => {
+      const currentCore = useCloudChatCore(cloud as never, {
+        threads,
+        chatConfig: {},
+        transport: transport as never,
+      });
+      core ??= currentCore;
+      if (suspend) throw pending;
+      return createElement("span", null, label);
+    };
+    const renderProbe = (
+      label: string,
+      threads: UseThreadsResult,
+      transport: typeof transportA,
+      suspend: boolean,
+    ) =>
+      createElement(
+        Suspense,
+        { fallback: null },
+        createElement(Probe, { label, threads, transport, suspend }),
+      );
+
+    const view = render(renderProbe("account-a", threadsA, transportA, false));
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(renderProbe("account-b", threadsB, transportB, true));
+      });
+    });
+
+    expect(view.container.textContent).toBe("account-a");
+
+    const registry = new ChatRegistry(() => ({}) as never);
+    await core
+      ?.createTransport("transport-chat", registry)
+      .reconnectToStream({} as never);
+    await core?.ensureThreadId("thread-chat", registry);
+
+    expect(transportA.reconnectToStream).toHaveBeenCalledOnce();
+    expect(transportB.reconnectToStream).not.toHaveBeenCalled();
+    expect(threadsA.selectThread).toHaveBeenCalledWith("thread-1");
+    expect(threadsB.selectThread).not.toHaveBeenCalled();
   });
 
   it("retries an interrupted history load when switching back to a thread", () => {

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
 import { act, render, renderHook } from "@testing-library/react";
-import { createElement, startTransition, Suspense } from "react";
+import {
+  createElement,
+  startTransition,
+  Suspense,
+  useLayoutEffect,
+} from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UseThreadsResult } from "../types";
 import { CloudChatCore } from "../core/CloudChatCore";
@@ -175,6 +180,58 @@ describe("useCloudChat thread switching", () => {
     expect(transportB.reconnectToStream).not.toHaveBeenCalled();
     expect(threadsA.selectThread).toHaveBeenCalledWith("thread-1");
     expect(threadsB.selectThread).not.toHaveBeenCalled();
+  });
+
+  it("applies a committed transport before any effect in the same commit", async () => {
+    const cloud = {
+      threads: {
+        create: vi.fn().mockResolvedValue({ thread_id: "thread-1" }),
+      },
+    };
+    const threads = createThreads(cloud, null);
+    const transportA = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn().mockResolvedValue(null),
+    };
+    const transportB = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn().mockResolvedValue(null),
+    };
+    const registry = new ChatRegistry(() => ({}) as never);
+
+    const Probe = ({
+      transport,
+      reconnect,
+    }: {
+      transport: typeof transportA;
+      reconnect: boolean;
+    }) => {
+      const core = useCloudChatCore(cloud as never, {
+        threads,
+        chatConfig: {},
+        transport: transport as never,
+      });
+      useLayoutEffect(() => {
+        if (!reconnect) return;
+        void core
+          .createTransport("transport-chat", registry)
+          .reconnectToStream({} as never);
+      });
+      return null;
+    };
+
+    const view = render(
+      createElement(Probe, { transport: transportA, reconnect: false }),
+    );
+
+    await act(async () => {
+      view.rerender(
+        createElement(Probe, { transport: transportB, reconnect: true }),
+      );
+    });
+
+    expect(transportB.reconnectToStream).toHaveBeenCalledOnce();
+    expect(transportA.reconnectToStream).not.toHaveBeenCalled();
   });
 
   it("retries an interrupted history load when switching back to a thread", () => {

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -50,10 +50,16 @@ export function useCloudChat(
       core.createChat(chatKey, registry),
     [core],
   );
+  const createRenderChat = useCallback(
+    (chatKey: string, registry: ChatRegistry) =>
+      core.createChat(chatKey, registry, chatConfig),
+    [chatConfig, core],
+  );
   const { registry, activeChat } = useChatRegistry({
     scope: threads.cloud,
     threadId: threads.threadId,
     createChat,
+    createRenderChat,
   });
 
   useThreadMessageLoader(threads.threadId, registry, core);

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -37,14 +37,6 @@ export function useCloudChatCore(
     return new CloudChatCore(cloud, latestState.options, latestState.transport);
   }, [cloud]);
 
-  // The only hook that runs before descendant layout effects: a parent's
-  // useLayoutEffect fires after its children's, and useEffect leaves a
-  // pre-passive window in which the core still answers with the previous
-  // options and transport.
-  useInsertionEffect(() => {
-    core.updateOptions(currentOptions, currentTransport);
-  });
-
   // Track component lifetime for safe async operations
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -53,7 +45,15 @@ export function useCloudChatCore(
       mountedRef.current = false;
     };
   }, []);
-  core.mountedRef = mountedRef;
+
+  // The only hook that runs before descendant layout effects: a parent's
+  // useLayoutEffect fires after its children's, and useEffect leaves a
+  // pre-passive window in which the core still answers with the previous
+  // options and transport.
+  useInsertionEffect(() => {
+    core.mountedRef = mountedRef;
+    core.updateOptions(currentOptions, currentTransport);
+  });
 
   return core;
 }

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -23,23 +23,20 @@ export function useCloudChatCore(
     new DefaultChatTransport({}),
   );
   const currentTransport = transport ?? fallbackTransport.current;
-  const initialStateRef = useRef({
+  const latestStateRef = useRef({
     options: currentOptions,
     transport: currentTransport,
   });
-  initialStateRef.current = {
+  latestStateRef.current = {
     options: currentOptions,
     transport: currentTransport,
   };
 
   const core = useMemo(() => {
-    const initialState = initialStateRef.current;
-    const nextCore = new CloudChatCore(cloud, initialState.options);
-    nextCore.updateOptions(initialState.options, initialState.transport);
-    return nextCore;
+    const latestState = latestStateRef.current;
+    return new CloudChatCore(cloud, latestState.options, latestState.transport);
   }, [cloud]);
 
-  core.setChatCreationConfig(chatConfig);
   useEffect(() => {
     core.updateOptions(currentOptions, currentTransport);
   });

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -18,15 +18,31 @@ export function useCloudChatCore(
 ): CloudChatCore {
   const { threads, chatConfig, onSyncError, transport } = options;
   const currentOptions = { threads, chatConfig, onSyncError };
-  const currentOptionsRef = useRef(currentOptions);
-  currentOptionsRef.current = currentOptions;
 
-  const core = useMemo(
-    () => new CloudChatCore(cloud, currentOptionsRef.current),
-    [cloud],
+  const fallbackTransport = useRef<ChatTransport<UIMessage>>(
+    new DefaultChatTransport({}),
   );
+  const currentTransport = transport ?? fallbackTransport.current;
+  const initialStateRef = useRef({
+    options: currentOptions,
+    transport: currentTransport,
+  });
+  initialStateRef.current = {
+    options: currentOptions,
+    transport: currentTransport,
+  };
 
-  core.options = currentOptions;
+  const core = useMemo(() => {
+    const initialState = initialStateRef.current;
+    const nextCore = new CloudChatCore(cloud, initialState.options);
+    nextCore.updateOptions(initialState.options, initialState.transport);
+    return nextCore;
+  }, [cloud]);
+
+  core.setChatCreationConfig(chatConfig);
+  useEffect(() => {
+    core.updateOptions(currentOptions, currentTransport);
+  });
 
   // Track component lifetime for safe async operations
   const mountedRef = useRef(true);
@@ -37,11 +53,6 @@ export function useCloudChatCore(
     };
   }, []);
   core.mountedRef = mountedRef;
-
-  const fallbackTransport = useRef<ChatTransport<UIMessage>>(
-    new DefaultChatTransport({}),
-  );
-  core.baseTransport = transport ?? fallbackTransport.current;
 
   return core;
 }

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useInsertionEffect, useMemo, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ChatTransport } from "ai";
 import { DefaultChatTransport } from "ai";
@@ -37,7 +37,11 @@ export function useCloudChatCore(
     return new CloudChatCore(cloud, latestState.options, latestState.transport);
   }, [cloud]);
 
-  useEffect(() => {
+  // The only hook that runs before descendant layout effects: a parent's
+  // useLayoutEffect fires after its children's, and useEffect leaves a
+  // pre-passive window in which the core still answers with the previous
+  // options and transport.
+  useInsertionEffect(() => {
     core.updateOptions(currentOptions, currentTransport);
   });
 

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -57,7 +57,7 @@ function createCore(overrides?: {
     onSyncError: onSyncError as ((error: Error) => void) | undefined,
   };
 
-  const core = new CloudChatCore({} as never, refs);
+  const core = new CloudChatCore({} as never, refs, {} as never);
   return core;
 }
 
@@ -95,8 +95,13 @@ describe("CloudChatCore", () => {
     const currentMessages = [{ id: "current" }];
     const core = createCore({ chatConfig: { messages: initialMessages } });
 
-    core.setChatCreationConfig({ messages: currentMessages } as never);
-    core.createChat("chat-1", {} as never);
+    core.createChat(
+      "chat-1",
+      {} as never,
+      {
+        messages: currentMessages,
+      } as never,
+    );
 
     expect(chatOptionsRef.current?.messages).toBe(currentMessages);
   });

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -90,6 +90,17 @@ describe("CloudChatCore", () => {
     expect(result).toBe(completion);
   });
 
+  it("uses the current render config when creating a chat", () => {
+    const initialMessages = [{ id: "initial" }];
+    const currentMessages = [{ id: "current" }];
+    const core = createCore({ chatConfig: { messages: initialMessages } });
+
+    core.setChatCreationConfig({ messages: currentMessages } as never);
+    core.createChat("chat-1", {} as never);
+
+    expect(chatOptionsRef.current?.messages).toBe(currentMessages);
+  });
+
   it("preserves synchronous finish callback failures", () => {
     const error = new Error("finish failed");
     const onFinish = vi.fn(() => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -31,15 +31,18 @@ export class CloudChatCore {
   readonly telemetryReporter: CloudTelemetryReporter;
 
   options: CloudChatCoreOptions;
-  private chatCreationConfig: CloudChatConfig;
   /** Set by the React wrapper. */
   mountedRef: { current: boolean } = { current: true };
-  baseTransport!: ChatTransport<UIMessage>;
+  private baseTransport: ChatTransport<UIMessage>;
 
-  constructor(cloud: AssistantCloud, options: CloudChatCoreOptions) {
+  constructor(
+    cloud: AssistantCloud,
+    options: CloudChatCoreOptions,
+    baseTransport: ChatTransport<UIMessage>,
+  ) {
     this.cloud = cloud;
     this.options = options;
-    this.chatCreationConfig = options.chatConfig;
+    this.baseTransport = baseTransport;
     this.persistence = new MessagePersistence(
       cloud,
       this.handleSyncError.bind(this),
@@ -47,10 +50,6 @@ export class CloudChatCore {
     this.sessionManager = new ThreadSessionManager();
     this.titlePolicy = new TitlePolicy();
     this.telemetryReporter = new CloudTelemetryReporter(cloud);
-  }
-
-  setChatCreationConfig(chatConfig: CloudChatConfig): void {
-    this.chatCreationConfig = chatConfig;
   }
 
   updateOptions(
@@ -191,7 +190,11 @@ export class CloudChatCore {
     };
   }
 
-  createChat(chatKey: string, registry: ChatRegistry): Chat<UIMessage> {
+  createChat(
+    chatKey: string,
+    registry: ChatRegistry,
+    chatConfig: CloudChatConfig = this.options.chatConfig,
+  ): Chat<UIMessage> {
     const {
       onFinish: _onFinish,
       onData: _onData,
@@ -200,7 +203,7 @@ export class CloudChatCore {
       sendAutomaticallyWhen: _sendAutomaticallyWhen,
       id: _id,
       ...chatInit
-    } = this.chatCreationConfig;
+    } = chatConfig;
 
     return new Chat<UIMessage>({
       ...chatInit,

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -30,16 +30,16 @@ export class CloudChatCore {
   readonly titlePolicy: TitlePolicy;
   readonly telemetryReporter: CloudTelemetryReporter;
 
-  /** Updated by the React wrapper each render. */
   options: CloudChatCoreOptions;
+  private chatCreationConfig: CloudChatConfig;
   /** Set by the React wrapper. */
   mountedRef: { current: boolean } = { current: true };
-  /** Set by the React wrapper. */
   baseTransport!: ChatTransport<UIMessage>;
 
   constructor(cloud: AssistantCloud, options: CloudChatCoreOptions) {
     this.cloud = cloud;
     this.options = options;
+    this.chatCreationConfig = options.chatConfig;
     this.persistence = new MessagePersistence(
       cloud,
       this.handleSyncError.bind(this),
@@ -47,6 +47,18 @@ export class CloudChatCore {
     this.sessionManager = new ThreadSessionManager();
     this.titlePolicy = new TitlePolicy();
     this.telemetryReporter = new CloudTelemetryReporter(cloud);
+  }
+
+  setChatCreationConfig(chatConfig: CloudChatConfig): void {
+    this.chatCreationConfig = chatConfig;
+  }
+
+  updateOptions(
+    options: CloudChatCoreOptions,
+    baseTransport: ChatTransport<UIMessage>,
+  ): void {
+    this.options = options;
+    this.baseTransport = baseTransport;
   }
 
   async ensureThreadId(
@@ -188,7 +200,7 @@ export class CloudChatCore {
       sendAutomaticallyWhen: _sendAutomaticallyWhen,
       id: _id,
       ...chatInit
-    } = this.options.chatConfig;
+    } = this.chatCreationConfig;
 
     return new Chat<UIMessage>({
       ...chatInit,


### PR DESCRIPTION
## Summary

- apply long-lived Cloud chat options and transports only after React commits a render
- keep chats created during render provisional until that render commits
- create render-time chats from the current static AI SDK config while async paths use committed config
- cover abandoned option and chat-registration transitions with Suspense regression tests

## Why

`useCloudChatCore()` mutated its shared `CloudChatCore` during render. If an account, workspace, thread adapter, or transport update suspended and React abandoned that render, the previously committed UI still used the same core after it had already been redirected to the uncommitted options.

Chat creation had the same exposure: `useChatRegistry()` stored a newly created chat during render, so an abandoned thread transition could leave a chat configured from options that never committed.

The live core now receives options and transport from a commit effect. Render-created chats remain local to that render and enter the registry only after commit. Chats created later by asynchronous history paths use the committed configuration.

## Minimal reproduction

The regression tests render account A, start a transition to account B that suspends, and then exercise the still-committed runtime. Before the fix:

- the shared core used B's thread adapter and transport while A remained visible
- a chat created for B remained cached even after React abandoned B's render

After the fix, A remains active and a later committed render creates its chat from its own configuration.

## Commit timing

The option update intentionally occurs in a passive commit effect, matching the other runtime commit-safety fixes in the repository. A synchronous callback fired from another effect in the same commit can observe the previous transport until this effect runs; normal user events after the commit observe the latest transport. This ordering tradeoff avoids exposing committed runtime state to abandoned renders.

## Testing

- `vitest run src/chat/useChatRegistry.test.ts src/chat/useCloudChat.switch.test.ts src/core/CloudChatCore.test.ts` (15 tests)
- `vitest run src/__tests__/contract/persistence.test.ts src/__tests__/contract/titlePolicy.test.ts src/__tests__/contract/threadLifecycle.test.ts` (18 tests)
- `aui-build`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iA-gJiyo33guUGzrX9KFu-vkJ5ft9GFKjRlpgyy_gUm9Gbzt7-cSfy3fLFE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->