### PR TITLE
fix(ui): satisfy React hooks lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,6 +87,20 @@
     },
     {
       "files": [
+        "packages/ui/src/components/assistant-ui/attachment.tsx",
+        "packages/ui/src/components/assistant-ui/attachment.radix.tsx",
+        "packages/ui/src/components/assistant-ui/file.tsx",
+        "packages/ui/src/components/assistant-ui/image.tsx",
+        "packages/ui/src/components/assistant-ui/reasoning.tsx"
+      ],
+      "rules": {
+        "react/refs": "error",
+        "react/set-state-in-effect": "error",
+        "react/static-components": "error"
+      }
+    },
+    {
+      "files": [
         "packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx",
         "packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx",
         "packages/react/src/unstable/**",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -91,7 +91,8 @@
         "packages/ui/src/components/assistant-ui/attachment.radix.tsx",
         "packages/ui/src/components/assistant-ui/file.tsx",
         "packages/ui/src/components/assistant-ui/image.tsx",
-        "packages/ui/src/components/assistant-ui/reasoning.tsx"
+        "packages/ui/src/components/assistant-ui/reasoning.tsx",
+        "templates/minimal/components/assistant-ui/attachment.tsx"
       ],
       "rules": {
         "react/refs": "error",

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type PropsWithChildren, useEffect, useState, type FC } from "react";
+import {
+  type PropsWithChildren,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type FC,
+} from "react";
 import {
   XIcon,
   PlusIcon,
@@ -36,24 +42,47 @@ import {
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  type PropsWithChildren,
-  useEffect,
-  useMemo,
-  useState,
-  type FC,
-} from "react";
+import { type PropsWithChildren, useEffect, useState, type FC } from "react";
 import {
   XIcon,
   PlusIcon,
@@ -43,17 +37,19 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { cn } from "@/lib/utils";
 
 const useFileSrc = (file: File | undefined) => {
-  const src = useMemo(
-    () => (file ? URL.createObjectURL(file) : undefined),
-    [file],
-  );
+  const [src, setSrc] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!src) return;
-    return () => URL.revokeObjectURL(src);
-  }, [src]);
+    if (!file) return;
 
-  return src;
+    const objectUrl = URL.createObjectURL(file);
+    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
+    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [file]);
+
+  return file ? src : undefined;
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -2,9 +2,9 @@
 
 import {
   type PropsWithChildren,
+  useEffect,
   useMemo,
   useState,
-  useSyncExternalStore,
   type FC,
 } from "react";
 import {
@@ -42,47 +42,18 @@ import {
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
-type FileSrcStore = {
-  subscribe: (onStoreChange: () => void) => () => void;
-  getSnapshot: () => string | undefined;
-};
-
-const emptyFileSrcStore: FileSrcStore = {
-  subscribe: () => () => {},
-  getSnapshot: () => undefined,
-};
-
-const createFileSrcStore = (file: File | undefined): FileSrcStore => {
-  if (!file) return emptyFileSrcStore;
-
-  let objectUrl: string | undefined;
-  let subscriberCount = 0;
-
-  return {
-    subscribe: (onStoreChange: () => void) => {
-      subscriberCount += 1;
-      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
-      onStoreChange();
-
-      return () => {
-        subscriberCount -= 1;
-        if (subscriberCount === 0 && objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-          objectUrl = undefined;
-        }
-      };
-    },
-    getSnapshot: () => objectUrl,
-  };
-};
-
 const useFileSrc = (file: File | undefined) => {
-  const store = useMemo(() => createFileSrcStore(file), [file]);
-  return useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    emptyFileSrcStore.getSnapshot,
+  const src = useMemo(
+    () => (file ? URL.createObjectURL(file) : undefined),
+    [file],
   );
+
+  useEffect(() => {
+    if (!src) return;
+    return () => URL.revokeObjectURL(src);
+  }, [src]);
+
+  return src;
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type PropsWithChildren, useEffect, useState, type FC } from "react";
+import {
+  type PropsWithChildren,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type FC,
+} from "react";
 import {
   XIcon,
   PlusIcon,
@@ -36,26 +42,47 @@ import {
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) return;
-
-    const objectUrl = URL.createObjectURL(file);
-    let isActive = true;
-    // The active setup publishes the URL after StrictMode's simulated cleanup.
-    queueMicrotask(() => {
-      if (isActive) setSrc(objectUrl);
-    });
-
-    return () => {
-      isActive = false;
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return file ? src : undefined;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -43,10 +43,16 @@ const useFileSrc = (file: File | undefined) => {
     if (!file) return;
 
     const objectUrl = URL.createObjectURL(file);
-    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
-    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+    let isActive = true;
+    // The active setup publishes the URL after StrictMode's simulated cleanup.
+    queueMicrotask(() => {
+      if (isActive) setSrc(objectUrl);
+    });
 
-    return () => URL.revokeObjectURL(objectUrl);
+    return () => {
+      isActive = false;
+      URL.revokeObjectURL(objectUrl);
+    };
   }, [file]);
 
   return file ? src : undefined;

--- a/packages/ui/src/components/assistant-ui/attachment.test.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import {
   cloneElement,
   isValidElement,
+  StrictMode,
   type PropsWithChildren,
   type ReactElement,
   type ReactNode,
@@ -117,7 +118,11 @@ afterEach(() => {
 describe("ComposerAttachments", () => {
   it("replaces and revokes object URLs when the file changes", async () => {
     mocks.file = new File(["first"], "first.png", { type: "image/png" });
-    const { rerender, unmount } = render(<ComposerAttachments />);
+    const { rerender, unmount } = render(
+      <StrictMode>
+        <ComposerAttachments />
+      </StrictMode>,
+    );
 
     const getImage = () =>
       document.querySelector<HTMLImageElement>('img[alt="Attachment preview"]');
@@ -126,6 +131,7 @@ describe("ComposerAttachments", () => {
       expect(element?.src).toContain("blob:test-");
     });
     const firstSrc = getImage()!.src;
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith(firstSrc);
     const initialUrls = vi
       .mocked(URL.createObjectURL)
       .mock.results.map(({ value }) => value);
@@ -133,9 +139,14 @@ describe("ComposerAttachments", () => {
     mocks.file = new File(["second"], "second.png", {
       type: "image/png",
     });
-    rerender(<ComposerAttachments />);
+    rerender(
+      <StrictMode>
+        <ComposerAttachments />
+      </StrictMode>,
+    );
 
     await waitFor(() => expect(getImage()?.src).not.toBe(firstSrc));
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith(getImage()!.src);
     for (const url of initialUrls) {
       expect(URL.revokeObjectURL).toHaveBeenCalledWith(url);
     }

--- a/packages/ui/src/components/assistant-ui/attachment.test.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import {
+  cloneElement,
+  isValidElement,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ComposerAttachments } from "./attachment";
+
+const mocks = vi.hoisted(() => ({
+  file: undefined as File | undefined,
+}));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@assistant-ui/react")>();
+  const Passthrough = ({ children }: PropsWithChildren) => children;
+
+  return {
+    ...original,
+    useAui: () => ({ attachment: { source: "message" } }),
+    useAuiState: (
+      selector: (state: {
+        attachment: {
+          type: "image";
+          file?: File;
+          content: never[];
+          status: { type: "complete" };
+        };
+      }) => unknown,
+    ) =>
+      selector({
+        attachment: {
+          type: "image",
+          ...(mocks.file ? { file: mocks.file } : {}),
+          content: [],
+          status: { type: "complete" },
+        },
+      }),
+    AttachmentPrimitive: {
+      ...original.AttachmentPrimitive,
+      Root: Passthrough,
+      Name: () => null,
+    },
+    ComposerPrimitive: {
+      ...original.ComposerPrimitive,
+      Attachments: ({ children }: { children: () => ReactNode }) => children(),
+    },
+  };
+});
+
+vi.mock("@/components/ui/tooltip", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/components/ui/tooltip")>();
+  const Passthrough = ({ children }: PropsWithChildren) => children;
+
+  return {
+    ...original,
+    Tooltip: Passthrough,
+    TooltipContent: Passthrough,
+    TooltipProvider: Passthrough,
+    TooltipTrigger: ({
+      children,
+      render: trigger,
+    }: PropsWithChildren<{ render?: ReactElement }>) =>
+      isValidElement(trigger)
+        ? cloneElement(trigger, undefined, children)
+        : children,
+  };
+});
+
+vi.mock("@/components/ui/dialog", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/components/ui/dialog")>();
+  const Passthrough = ({ children }: PropsWithChildren) => children;
+
+  return {
+    ...original,
+    Dialog: Passthrough,
+    DialogContent: () => null,
+    DialogTitle: Passthrough,
+    DialogTrigger: ({ render: trigger }: { render?: ReactElement }) => trigger,
+  };
+});
+
+vi.mock("@/components/ui/avatar", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/components/ui/avatar")>();
+  const Passthrough = ({ children }: PropsWithChildren) => children;
+
+  return {
+    ...original,
+    Avatar: Passthrough,
+    AvatarFallback: Passthrough,
+    AvatarImage: (props: React.ComponentProps<"img">) => <img {...props} />,
+  };
+});
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+beforeEach(() => {
+  let nextUrl = 1;
+  mocks.file = undefined;
+  URL.createObjectURL = vi.fn(() => `blob:test-${nextUrl++}`);
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+describe("ComposerAttachments", () => {
+  it("replaces and revokes object URLs when the file changes", async () => {
+    mocks.file = new File(["first"], "first.png", { type: "image/png" });
+    const { rerender, unmount } = render(<ComposerAttachments />);
+
+    const getImage = () =>
+      document.querySelector<HTMLImageElement>('img[alt="Attachment preview"]');
+    await waitFor(() => {
+      const element = getImage();
+      expect(element?.src).toContain("blob:test-");
+    });
+    const firstSrc = getImage()!.src;
+    const initialUrls = vi
+      .mocked(URL.createObjectURL)
+      .mock.results.map(({ value }) => value);
+
+    mocks.file = new File(["second"], "second.png", {
+      type: "image/png",
+    });
+    rerender(<ComposerAttachments />);
+
+    await waitFor(() => expect(getImage()?.src).not.toBe(firstSrc));
+    for (const url of initialUrls) {
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(url);
+    }
+
+    unmount();
+
+    for (const { value: url } of vi.mocked(URL.createObjectURL).mock.results) {
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(url);
+    }
+  });
+});

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -2,8 +2,9 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
+  useMemo,
   useState,
+  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -38,24 +39,47 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -3,7 +3,6 @@
 import {
   type PropsWithChildren,
   useEffect,
-  useMemo,
   useState,
   type FC,
   isValidElement,
@@ -40,17 +39,19 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { cn } from "@/lib/utils";
 
 const useFileSrc = (file: File | undefined) => {
-  const src = useMemo(
-    () => (file ? URL.createObjectURL(file) : undefined),
-    [file],
-  );
+  const [src, setSrc] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!src) return;
-    return () => URL.revokeObjectURL(src);
-  }, [src]);
+    if (!file) return;
 
-  return src;
+    const objectUrl = URL.createObjectURL(file);
+    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
+    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [file]);
+
+  return file ? src : undefined;
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -2,8 +2,9 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
+  useMemo,
   useState,
+  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -38,26 +39,47 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) return;
-
-    const objectUrl = URL.createObjectURL(file);
-    let isActive = true;
-    // The active setup publishes the URL after StrictMode's simulated cleanup.
-    queueMicrotask(() => {
-      if (isActive) setSrc(objectUrl);
-    });
-
-    return () => {
-      isActive = false;
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return file ? src : undefined;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -2,9 +2,9 @@
 
 import {
   type PropsWithChildren,
+  useEffect,
   useMemo,
   useState,
-  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -39,47 +39,18 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
-type FileSrcStore = {
-  subscribe: (onStoreChange: () => void) => () => void;
-  getSnapshot: () => string | undefined;
-};
-
-const emptyFileSrcStore: FileSrcStore = {
-  subscribe: () => () => {},
-  getSnapshot: () => undefined,
-};
-
-const createFileSrcStore = (file: File | undefined): FileSrcStore => {
-  if (!file) return emptyFileSrcStore;
-
-  let objectUrl: string | undefined;
-  let subscriberCount = 0;
-
-  return {
-    subscribe: (onStoreChange: () => void) => {
-      subscriberCount += 1;
-      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
-      onStoreChange();
-
-      return () => {
-        subscriberCount -= 1;
-        if (subscriberCount === 0 && objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-          objectUrl = undefined;
-        }
-      };
-    },
-    getSnapshot: () => objectUrl,
-  };
-};
-
 const useFileSrc = (file: File | undefined) => {
-  const store = useMemo(() => createFileSrcStore(file), [file]);
-  return useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    emptyFileSrcStore.getSnapshot,
+  const src = useMemo(
+    () => (file ? URL.createObjectURL(file) : undefined),
+    [file],
   );
+
+  useEffect(() => {
+    if (!src) return;
+    return () => URL.revokeObjectURL(src);
+  }, [src]);
+
+  return src;
 };
 
 const useAttachmentSrc = () => {

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -45,10 +45,16 @@ const useFileSrc = (file: File | undefined) => {
     if (!file) return;
 
     const objectUrl = URL.createObjectURL(file);
-    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
-    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+    let isActive = true;
+    // The active setup publishes the URL after StrictMode's simulated cleanup.
+    queueMicrotask(() => {
+      if (isActive) setSrc(objectUrl);
+    });
 
-    return () => URL.revokeObjectURL(objectUrl);
+    return () => {
+      isActive = false;
+      URL.revokeObjectURL(objectUrl);
+    };
   }, [file]);
 
   return file ? src : undefined;

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -36,27 +36,29 @@ const fileVariants = cva(
   },
 );
 
-function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
+const mimeTypeIcons = {
+  file: FileIcon,
+  image: ImageIcon,
+  text: FileTextIcon,
+  json: BracesIcon,
+  audio: MusicIcon,
+  video: VideoIcon,
+} as const;
+
+type MimeTypeIconName = keyof typeof mimeTypeIcons;
+
+function getMimeTypeIconName(mimeType: string): MimeTypeIconName {
   const type = mimeType.toLowerCase();
-  if (type.startsWith("image/")) {
-    return ImageIcon;
-  }
-  if (type === "application/pdf") {
-    return FileTextIcon;
-  }
-  if (type === "application/json") {
-    return BracesIcon;
-  }
-  if (type.startsWith("text/")) {
-    return FileTextIcon;
-  }
-  if (type.startsWith("audio/")) {
-    return MusicIcon;
-  }
-  if (type.startsWith("video/")) {
-    return VideoIcon;
-  }
-  return FileIcon;
+  if (type.startsWith("image/")) return "image";
+  if (type === "application/json") return "json";
+  if (type === "application/pdf" || type.startsWith("text/")) return "text";
+  if (type.startsWith("audio/")) return "audio";
+  if (type.startsWith("video/")) return "video";
+  return "file";
+}
+
+function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
+  return mimeTypeIcons[getMimeTypeIconName(mimeType)];
 }
 
 export type FileDataKind = "data-uri" | "url" | "base64" | "id";
@@ -122,7 +124,8 @@ function FileIconDisplay({
   children,
   ...props
 }: FileIconDisplayProps) {
-  const IconComponent = mimeType ? getMimeTypeIcon(mimeType) : FileIcon;
+  const iconName = mimeType ? getMimeTypeIconName(mimeType) : "file";
+  const IconComponent = mimeTypeIcons[iconName];
 
   return (
     <span

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -8,7 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ImageMessagePart } from "@assistant-ui/react";
 
-import { ImageActions } from "./image";
+import { ImageActions, ImageZoom } from "./image";
 
 class FakeClipboardItem {
   constructor(public readonly items: Record<string, Blob>) {}
@@ -162,5 +162,23 @@ describe("ImageActions regeneration", () => {
     } finally {
       process.off("unhandledRejection", onUnhandledRejection);
     }
+  });
+});
+
+describe("ImageZoom", () => {
+  it("opens and closes the portal from user interaction", () => {
+    render(
+      <ImageZoom src="https://example.com/image.png">
+        <span>Preview</span>
+      </ImageZoom>,
+    );
+
+    expect(screen.queryByLabelText("Close zoomed image")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Click to zoom image"));
+    expect(screen.getByLabelText("Close zoomed image")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByLabelText("Close zoomed image")).toBeNull();
   });
 });

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -254,12 +254,7 @@ type ImageZoomProps = PropsWithChildren<{
 }>;
 
 function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
-  const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   const handleOpen = () => setIsOpen(true);
   const handleClose = () => setIsOpen(false);
@@ -294,8 +289,7 @@ function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
       >
         {children}
       </div>
-      {isMounted &&
-        isOpen &&
+      {isOpen &&
         createPortal(
           <div
             data-slot="image-zoom-overlay"

--- a/packages/ui/src/components/assistant-ui/reasoning.test.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ReasoningRoot } from "./reasoning";
+
+vi.mock("@assistant-ui/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/react")>()),
+  useScrollLock: () => () => {},
+}));
+
+vi.mock("@/components/assistant-ui/markdown-text", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/components/assistant-ui/markdown-text")
+  >()),
+  MarkdownText: ({ children }: React.PropsWithChildren) => children,
+}));
+
+afterEach(cleanup);
+
+const openState = (container: HTMLElement) =>
+  container
+    .querySelector('[data-slot="reasoning-root"]')
+    ?.hasAttribute("data-open");
+
+describe("ReasoningRoot", () => {
+  it("keeps the initial defaultOpen value when the prop changes", () => {
+    const { container, rerender } = render(
+      <ReasoningRoot defaultOpen>Reasoning</ReasoningRoot>,
+    );
+
+    expect(openState(container)).toBe(true);
+
+    rerender(<ReasoningRoot defaultOpen={false}>Reasoning</ReasoningRoot>);
+
+    expect(openState(container)).toBe(true);
+  });
+
+  it("opens temporarily while streaming", () => {
+    const { container, rerender } = render(
+      <ReasoningRoot streaming={false}>Reasoning</ReasoningRoot>,
+    );
+
+    expect(openState(container)).toBe(false);
+
+    rerender(<ReasoningRoot streaming>Reasoning</ReasoningRoot>);
+    expect(openState(container)).toBe(true);
+
+    rerender(<ReasoningRoot streaming={false}>Reasoning</ReasoningRoot>);
+    expect(openState(container)).toBe(false);
+  });
+});

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -74,14 +74,14 @@ function ReasoningRoot({
   ...props
 }: ReasoningRootProps) {
   const collapsibleRef = useRef<HTMLDivElement>(null);
-  const initialOpenRef = useRef(defaultOpen);
+  const [initialOpen] = useState(defaultOpen);
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
 
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled
     ? controlledOpen
-    : (userOpen ?? (streaming || initialOpenRef.current));
+    : (userOpen ?? (streaming || initialOpen));
   const isPreview = streaming === true && isOpen;
 
   const prevStreamingRef = useRef(streaming);
@@ -90,10 +90,10 @@ function ReasoningRoot({
     prevStreamingRef.current = streaming;
     // A streaming transition only animates the panel when the resting state
     // is collapsed; with `defaultOpen` the disclosure stays open across it.
-    if (!isControlled && userOpen === null && !initialOpenRef.current) {
+    if (!isControlled && userOpen === null && !initialOpen) {
       lockScroll();
     }
-  }, [streaming, isControlled, userOpen, lockScroll]);
+  }, [streaming, isControlled, userOpen, initialOpen, lockScroll]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -2,8 +2,9 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
+  useMemo,
   useState,
+  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -38,24 +39,47 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -3,7 +3,6 @@
 import {
   type PropsWithChildren,
   useEffect,
-  useMemo,
   useState,
   type FC,
   isValidElement,
@@ -40,17 +39,19 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { cn } from "@/lib/utils";
 
 const useFileSrc = (file: File | undefined) => {
-  const src = useMemo(
-    () => (file ? URL.createObjectURL(file) : undefined),
-    [file],
-  );
+  const [src, setSrc] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!src) return;
-    return () => URL.revokeObjectURL(src);
-  }, [src]);
+    if (!file) return;
 
-  return src;
+    const objectUrl = URL.createObjectURL(file);
+    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
+    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [file]);
+
+  return file ? src : undefined;
 };
 
 const useAttachmentSrc = () => {

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -2,8 +2,9 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
+  useMemo,
   useState,
+  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -38,26 +39,47 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
+type FileSrcStore = {
+  subscribe: (onStoreChange: () => void) => () => void;
+  getSnapshot: () => string | undefined;
+};
+
+const emptyFileSrcStore: FileSrcStore = {
+  subscribe: () => () => {},
+  getSnapshot: () => undefined,
+};
+
+const createFileSrcStore = (file: File | undefined): FileSrcStore => {
+  if (!file) return emptyFileSrcStore;
+
+  let objectUrl: string | undefined;
+  let subscriberCount = 0;
+
+  return {
+    subscribe: (onStoreChange: () => void) => {
+      subscriberCount += 1;
+      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
+      onStoreChange();
+
+      return () => {
+        subscriberCount -= 1;
+        if (subscriberCount === 0 && objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = undefined;
+        }
+      };
+    },
+    getSnapshot: () => objectUrl,
+  };
+};
+
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) return;
-
-    const objectUrl = URL.createObjectURL(file);
-    let isActive = true;
-    // The active setup publishes the URL after StrictMode's simulated cleanup.
-    queueMicrotask(() => {
-      if (isActive) setSrc(objectUrl);
-    });
-
-    return () => {
-      isActive = false;
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return file ? src : undefined;
+  const store = useMemo(() => createFileSrcStore(file), [file]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    emptyFileSrcStore.getSnapshot,
+  );
 };
 
 const useAttachmentSrc = () => {

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -2,9 +2,9 @@
 
 import {
   type PropsWithChildren,
+  useEffect,
   useMemo,
   useState,
-  useSyncExternalStore,
   type FC,
   isValidElement,
 } from "react";
@@ -39,47 +39,18 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { cn } from "@/lib/utils";
 
-type FileSrcStore = {
-  subscribe: (onStoreChange: () => void) => () => void;
-  getSnapshot: () => string | undefined;
-};
-
-const emptyFileSrcStore: FileSrcStore = {
-  subscribe: () => () => {},
-  getSnapshot: () => undefined,
-};
-
-const createFileSrcStore = (file: File | undefined): FileSrcStore => {
-  if (!file) return emptyFileSrcStore;
-
-  let objectUrl: string | undefined;
-  let subscriberCount = 0;
-
-  return {
-    subscribe: (onStoreChange: () => void) => {
-      subscriberCount += 1;
-      if (subscriberCount === 1) objectUrl = URL.createObjectURL(file);
-      onStoreChange();
-
-      return () => {
-        subscriberCount -= 1;
-        if (subscriberCount === 0 && objectUrl) {
-          URL.revokeObjectURL(objectUrl);
-          objectUrl = undefined;
-        }
-      };
-    },
-    getSnapshot: () => objectUrl,
-  };
-};
-
 const useFileSrc = (file: File | undefined) => {
-  const store = useMemo(() => createFileSrcStore(file), [file]);
-  return useSyncExternalStore(
-    store.subscribe,
-    store.getSnapshot,
-    emptyFileSrcStore.getSnapshot,
+  const src = useMemo(
+    () => (file ? URL.createObjectURL(file) : undefined),
+    [file],
   );
+
+  useEffect(() => {
+    if (!src) return;
+    return () => URL.revokeObjectURL(src);
+  }, [src]);
+
+  return src;
 };
 
 const useAttachmentSrc = () => {

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -45,10 +45,16 @@ const useFileSrc = (file: File | undefined) => {
     if (!file) return;
 
     const objectUrl = URL.createObjectURL(file);
-    // oxlint-disable-next-line react/set-state-in-effect -- StrictMode cleanup requires publishing a fresh URL from each effect setup.
-    setSrc(objectUrl); // eslint-disable-line react-hooks/set-state-in-effect
+    let isActive = true;
+    // The active setup publishes the URL after StrictMode's simulated cleanup.
+    queueMicrotask(() => {
+      if (isActive) setSrc(objectUrl);
+    });
 
-    return () => URL.revokeObjectURL(objectUrl);
+    return () => {
+      isActive = false;
+      URL.revokeObjectURL(objectUrl);
+    };
   }, [file]);
 
   return file ? src : undefined;


### PR DESCRIPTION
## Summary

- fix the React Hooks refs, set-state-in-effect, and static-components findings in the generated assistant-ui components from the reporter's reproduction
- add focused behavior tests for attachment object URL cleanup, image zoom portals, and reasoning open state
- enforce these three rules as errors for the affected registry sources and the synced minimal attachment copy
- sync the attachment fix into the minimal template

## Why

Newer React Hooks ESLint configurations flag code copied from the assistant-ui registry. The four reproduced Hook findings come from our generated component source, so consumers should not need to downgrade them to warnings.

The separate react/prop-types reports are not part of this change. The registry components are TypeScript, and that rule depends on the consumer's ESLint configuration.

Validated against a preserved local clone of the reporter's reproduction at commit 8292082caeeef70729155777526ab82efbf127a5. The three React Hooks rule families report no findings in the five affected source files after this change.

## Implementation

- manage attachment object URLs through a useSyncExternalStore subscription lifecycle, so allocation and revocation happen after commit, StrictMode receives a live replacement URL, and file changes never expose the previous revoked URL
- remove the redundant mounted-state effect from ImageZoom; the portal can only open after client interaction
- capture ReasoningRoot's initial defaultOpen value in state instead of reading a ref during render
- resolve file icon names before JSX so React sees statically declared component references

## Scope

The lint override is intentionally limited to the files fixed here plus the synced minimal attachment copy. Enabling these rules across every registry component currently exposes additional findings outside the submitted reproduction, including context display, Mermaid, number roll, composer trigger, and voice components. The broader set-state-in-effect cleanup is already tracked in #6311; this PR keeps the reporter fix reviewable and makes these corrected files non-regressing.

## Testing

- reporter ESLint configuration against the five affected source files: zero React Hooks findings
- attachment lifecycle test under React StrictMode verifies the live preview URL is not revoked
- repository Oxlint: passes
- UI test suite: 366 passed, 15 skipped
- changed-file Oxfmt check: passes
- template sync check: passes
- lint-staged checks: passes

No changeset is needed because @assistant-ui/ui and the registry templates are private.

Closes #6362
Related to #6311