### PR TITLE
fix(ui): satisfy react-hooks refs and static-components rules

### DIFF
--- a/packages/ui/src/components/assistant-ui/file.test.tsx
+++ b/packages/ui/src/components/assistant-ui/file.test.tsx
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cleanup, render, screen } from "@testing-library/react";
+import {
+  BracesIcon,
+  FileIcon,
+  FileTextIcon,
+  ImageIcon,
+  MusicIcon,
+  VideoIcon,
+} from "lucide-react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FileIconDisplay, getMimeTypeIcon } from "./file";
+
+afterEach(cleanup);
+
+const iconClass = (mimeType?: string) => {
+  const { container } = render(<FileIconDisplay mimeType={mimeType} />);
+  return (
+    container
+      .querySelector("[data-slot='file-icon'] svg")
+      ?.getAttribute("class") ?? ""
+  );
+};
+
+describe("FileIconDisplay", () => {
+  it("does not use a render-time component type as JSX", () => {
+    const source = readFileSync(
+      resolve("src/components/assistant-ui/file.tsx"),
+      "utf8",
+    );
+
+    expect(source).not.toMatch(
+      /const\s+\w+\s*=\s*(?:mimeType\s*\?\s*)?getMimeTypeIcon\(/,
+    );
+    expect(source).toMatch(/<ImageIcon\b/);
+  });
+
+  it.each([
+    ["image/png", "lucide-image"],
+    ["IMAGE/JPEG", "lucide-image"],
+    ["application/pdf", "lucide-file-text"],
+    ["application/json", "lucide-braces"],
+    ["text/plain", "lucide-file-text"],
+    ["audio/mpeg", "lucide-music"],
+    ["video/mp4", "lucide-video"],
+    ["application/octet-stream", "lucide-file"],
+    [undefined, "lucide-file"],
+  ] as const)("renders the %s icon", (mimeType, lucideClass) => {
+    expect(iconClass(mimeType)).toContain(lucideClass);
+  });
+
+  it("lets children replace the MIME icon", () => {
+    const { container } = render(
+      <FileIconDisplay mimeType="image/png">
+        <span data-testid="custom-icon">custom</span>
+      </FileIconDisplay>,
+    );
+
+    expect(screen.getByTestId("custom-icon")).toBeTruthy();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});
+
+describe("getMimeTypeIcon", () => {
+  it.each([
+    ["image/png", ImageIcon],
+    ["IMAGE/JPEG", ImageIcon],
+    ["application/pdf", FileTextIcon],
+    ["application/json", BracesIcon],
+    ["text/plain", FileTextIcon],
+    ["audio/mpeg", MusicIcon],
+    ["video/mp4", VideoIcon],
+    ["application/octet-stream", FileIcon],
+  ] as const)("maps %s", (mimeType, icon) => {
+    expect(getMimeTypeIcon(mimeType)).toBe(icon);
+  });
+});

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -116,21 +116,51 @@ type FileIconDisplayProps = React.ComponentProps<"span"> & {
   mimeType?: string;
 };
 
+function MimeTypeIcon({
+  mimeType,
+  className,
+}: {
+  mimeType?: string;
+  className?: string;
+}) {
+  if (!mimeType) {
+    return <FileIcon className={className} />;
+  }
+  const type = mimeType.toLowerCase();
+  if (type.startsWith("image/")) {
+    return <ImageIcon className={className} />;
+  }
+  if (type === "application/pdf") {
+    return <FileTextIcon className={className} />;
+  }
+  if (type === "application/json") {
+    return <BracesIcon className={className} />;
+  }
+  if (type.startsWith("text/")) {
+    return <FileTextIcon className={className} />;
+  }
+  if (type.startsWith("audio/")) {
+    return <MusicIcon className={className} />;
+  }
+  if (type.startsWith("video/")) {
+    return <VideoIcon className={className} />;
+  }
+  return <FileIcon className={className} />;
+}
+
 function FileIconDisplay({
   mimeType,
   className,
   children,
   ...props
 }: FileIconDisplayProps) {
-  const IconComponent = mimeType ? getMimeTypeIcon(mimeType) : FileIcon;
-
   return (
     <span
       data-slot="file-icon"
       className={cn("text-muted-foreground shrink-0", className)}
       {...props}
     >
-      {children ?? <IconComponent className="size-5" />}
+      {children ?? <MimeTypeIcon mimeType={mimeType} className="size-5" />}
     </span>
   );
 }

--- a/packages/ui/src/components/assistant-ui/reasoning.test.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.test.tsx
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ReasoningRoot } from "./reasoning";
+
+const stubs = vi.hoisted(() => ({
+  lockScroll: vi.fn(),
+}));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/react")>()),
+  useScrollLock: () => stubs.lockScroll,
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({
+    open,
+    onOpenChange,
+    children,
+    ...props
+  }: {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children?: ReactNode;
+  } & ComponentProps<"div">) => (
+    <div data-open={open ? "true" : "false"} {...props}>
+      {children}
+      <button
+        type="button"
+        data-testid="reasoning-toggle"
+        onClick={() => onOpenChange?.(!open)}
+      />
+    </div>
+  ),
+  CollapsibleTrigger: (props: ComponentProps<"button">) => (
+    <button type="button" {...props} />
+  ),
+  CollapsibleContent: (props: ComponentProps<"div">) => <div {...props} />,
+}));
+
+afterEach(() => {
+  cleanup();
+  stubs.lockScroll.mockReset();
+});
+
+const isOpen = () =>
+  document
+    .querySelector("[data-slot='reasoning-root']")
+    ?.getAttribute("data-open") === "true";
+
+describe("ReasoningRoot", () => {
+  it("does not read a ref while computing open state", () => {
+    const source = readFileSync(
+      resolve("src/components/assistant-ui/reasoning.tsx"),
+      "utf8",
+    );
+    const start = source.indexOf("function ReasoningRoot");
+    const end = source.indexOf("function ReasoningFade");
+    const body = source.slice(start, end);
+    const renderPhase = body.replace(
+      /useLayoutEffect\([\s\S]*?\n  \}, \[[^\]]*\]\);/,
+      "",
+    );
+
+    expect(renderPhase).not.toMatch(/\w+Ref\.current/);
+  });
+
+  it("stays collapsed when idle and defaultOpen is false", () => {
+    render(<ReasoningRoot>body</ReasoningRoot>);
+    expect(isOpen()).toBe(false);
+  });
+
+  it("opens when defaultOpen is true", () => {
+    render(<ReasoningRoot defaultOpen>body</ReasoningRoot>);
+    expect(isOpen()).toBe(true);
+  });
+
+  it("holds the panel open while streaming, then returns to defaultOpen", () => {
+    const { rerender } = render(<ReasoningRoot streaming>body</ReasoningRoot>);
+    expect(isOpen()).toBe(true);
+
+    rerender(<ReasoningRoot streaming={false}>body</ReasoningRoot>);
+    expect(isOpen()).toBe(false);
+  });
+
+  it("stays open across a streaming transition when defaultOpen is true", () => {
+    const { rerender } = render(
+      <ReasoningRoot defaultOpen streaming>
+        body
+      </ReasoningRoot>,
+    );
+    expect(isOpen()).toBe(true);
+
+    rerender(
+      <ReasoningRoot defaultOpen streaming={false}>
+        body
+      </ReasoningRoot>,
+    );
+    expect(isOpen()).toBe(true);
+  });
+
+  it("lets a controlled open value win over streaming", () => {
+    const { rerender } = render(
+      <ReasoningRoot open={false} streaming>
+        body
+      </ReasoningRoot>,
+    );
+    expect(isOpen()).toBe(false);
+
+    rerender(
+      <ReasoningRoot open streaming>
+        body
+      </ReasoningRoot>,
+    );
+    expect(isOpen()).toBe(true);
+  });
+
+  it("lets the first manual toggle take over from streaming", () => {
+    const { rerender } = render(<ReasoningRoot streaming>body</ReasoningRoot>);
+    expect(isOpen()).toBe(true);
+
+    fireEvent.click(
+      document.querySelector("[data-testid='reasoning-toggle']")!,
+    );
+    expect(isOpen()).toBe(false);
+
+    rerender(<ReasoningRoot streaming={false}>body</ReasoningRoot>);
+    expect(isOpen()).toBe(false);
+  });
+
+  it("locks scroll on a streaming transition only when the resting state is collapsed", () => {
+    const collapsed = render(<ReasoningRoot>body</ReasoningRoot>);
+    expect(stubs.lockScroll).not.toHaveBeenCalled();
+
+    collapsed.rerender(<ReasoningRoot streaming>body</ReasoningRoot>);
+    expect(stubs.lockScroll).toHaveBeenCalledTimes(1);
+
+    stubs.lockScroll.mockClear();
+    cleanup();
+
+    const opened = render(<ReasoningRoot defaultOpen>body</ReasoningRoot>);
+    opened.rerender(
+      <ReasoningRoot defaultOpen streaming>
+        body
+      </ReasoningRoot>,
+    );
+    expect(stubs.lockScroll).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -74,14 +74,14 @@ function ReasoningRoot({
   ...props
 }: ReasoningRootProps) {
   const collapsibleRef = useRef<HTMLDivElement>(null);
-  const initialOpenRef = useRef(defaultOpen);
+  const [initialOpen] = useState(defaultOpen);
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
 
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled
     ? controlledOpen
-    : (userOpen ?? (streaming || initialOpenRef.current));
+    : (userOpen ?? (streaming || initialOpen));
   const isPreview = streaming === true && isOpen;
 
   const prevStreamingRef = useRef(streaming);
@@ -90,10 +90,10 @@ function ReasoningRoot({
     prevStreamingRef.current = streaming;
     // A streaming transition only animates the panel when the resting state
     // is collapsed; with `defaultOpen` the disclosure stays open across it.
-    if (!isControlled && userOpen === null && !initialOpenRef.current) {
+    if (!isControlled && userOpen === null && !initialOpen) {
       lockScroll();
     }
-  }, [streaming, isControlled, userOpen, lockScroll]);
+  }, [streaming, isControlled, userOpen, initialOpen, lockScroll]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {


### PR DESCRIPTION
Registry-copied `FileIconDisplay` and `ReasoningRoot` fail `eslint-plugin-react-hooks` `static-components` and `refs` because they pick a component type during render and read a ref while computing open state.

`FileIconDisplay` now renders Lucide icons as static JSX. `ReasoningRoot` captures the initial `defaultOpen` in state instead of reading a ref during render. Streaming, controlled, and first-toggle behavior is unchanged.

Fixes #6362

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jOwaof8XpHa35tMM-VmhxdcAUfJPEL5posIRFwxY_Mw3GC0EuwipfLT1TwM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->