### PR TITLE
refactor(core): extend BaseSubscribable in the thread runtime cores

### DIFF
--- a/.changeset/base-subscribable-inheritance.md
+++ b/.changeset/base-subscribable-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: notify every thread runtime subscriber before rethrowing a subscriber error.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -872,7 +872,7 @@ type BaseThreadMessage = {
   readonly attachments?: ThreadUserMessage["attachments"];
 };
 
-declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
+declare abstract class BaseThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
   #private;
   protected readonly repository: MessageRepository;
   abstract get adapters(): BaseThreadAdapters | undefined;
@@ -912,9 +912,7 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   } | undefined;
   getBranches(messageId: string): string[];
   switchToBranch(branchId: string): void;
-  protected _notifySubscribers(): void;
   _notifyEventSubscribers<E extends ThreadRuntimeEventType>(event: E, payload: ThreadRuntimeEventPayload[E]): void;
-  subscribe(callback: () => void): Unsubscribe$1;
   submitFeedback(_param1: SubmitFeedbackOptions): void;
   speech: SpeechState | undefined;
   speak(messageId: string): void;
@@ -1788,7 +1786,7 @@ type ExternalStoreThreadListAdapter = {
   onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
 };
 
-declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
+declare class ExternalStoreThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
   #private;
   get isLoading(): boolean;
   get newThreadId(): undefined;
@@ -1818,7 +1816,6 @@ declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCor
     externalId: string | undefined;
   }>;
   generateTitle(): never;
-  subscribe(callback: () => void): Unsubscribe$1;
 }
 
 declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -112,6 +112,22 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("BaseThreadRuntimeCore subscriptions", () => {
+  it("notifies later subscribers when an earlier subscriber throws", () => {
+    const runtime = new TestRuntime(createVoiceAdapter());
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+
+    runtime.subscribe(() => {
+      throw error;
+    });
+    runtime.subscribe(laterSubscriber);
+
+    expect(() => runtime.reset()).toThrow(error);
+    expect(laterSubscriber).toHaveBeenCalledOnce();
+  });
+});
+
 describe("BaseThreadRuntimeCore voice volume subscriptions", () => {
   it("continues notifying subscribers when one throws", () => {
     const consoleError = vi

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -36,6 +36,7 @@ import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { ThreadMessageLike } from "../utils/thread-message-like";
 import { notifyEventListeners } from "../../utils/notify-event-listeners";
 import { gateInteractableComposerMetadata } from "../../model-context/interactable-composer-metadata";
+import { BaseSubscribable } from "../../subscribable/subscribable";
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
@@ -44,8 +45,10 @@ type BaseThreadAdapters = {
   voice?: RealtimeVoiceAdapter | undefined;
 };
 
-export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
-  private _subscriptions = new Set<() => void>();
+export abstract class BaseThreadRuntimeCore
+  extends BaseSubscribable
+  implements ThreadRuntimeCore
+{
   private _isInitialized = false;
 
   protected readonly repository = new MessageRepository();
@@ -118,6 +121,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   private readonly _contextProvider: ModelContextProvider;
 
   constructor(_contextProvider: ModelContextProvider) {
+    super();
     this._contextProvider = _contextProvider;
   }
 
@@ -213,10 +217,6 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     this._notifySubscribers();
   }
 
-  protected _notifySubscribers() {
-    for (const callback of this._subscriptions) callback();
-  }
-
   public _notifyEventSubscribers<E extends ThreadRuntimeEventType>(
     event: E,
     payload: ThreadRuntimeEventPayload[E],
@@ -225,11 +225,6 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     if (!subscribers) return;
 
     notifyEventListeners(subscribers, payload, `Thread runtime "${event}"`);
-  }
-
-  public subscribe(callback: () => void): Unsubscribe {
-    this._subscriptions.add(callback);
-    return () => this._subscriptions.delete(callback);
   }
 
   public submitFeedback({ messageId, type }: SubmitFeedbackOptions) {

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -1,4 +1,3 @@
-import type { Unsubscribe } from "../../types/unsubscribe";
 import type { ExternalStoreThreadRuntimeCore } from "./external-store-thread-runtime-core";
 import type {
   ThreadListItemCoreState,
@@ -6,7 +5,7 @@ import type {
 } from "../../runtime/interfaces/thread-list-runtime-core";
 import type { ExternalStoreThreadListAdapter } from "./external-store-adapter";
 import { invalidateThreadRuntime } from "../../runtime/utils/thread-runtime-lifecycle";
-import { notifySubscribers } from "../../subscribable/subscribable";
+import { BaseSubscribable } from "../../subscribable/subscribable";
 
 export type ExternalStoreThreadFactory = () => ExternalStoreThreadRuntimeCore;
 
@@ -24,7 +23,10 @@ const DEFAULT_THREAD_DATA = Object.freeze({
   [DEFAULT_THREAD_ID]: DEFAULT_THREAD,
 });
 
-export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
+export class ExternalStoreThreadListRuntimeCore
+  extends BaseSubscribable
+  implements ThreadListRuntimeCore
+{
   private _mainThreadId: string = DEFAULT_THREAD_ID;
   private _threads: readonly string[] = DEFAULT_THREADS;
   private _archivedThreads: readonly string[] = EMPTY_ARRAY;
@@ -68,6 +70,7 @@ export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore
     adapter: ExternalStoreThreadListAdapter = {},
     threadFactory: ExternalStoreThreadFactory,
   ) {
+    super();
     this.threadFactory = threadFactory;
     this.__internal_setAdapter(adapter, true);
   }
@@ -261,16 +264,5 @@ export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore
 
   public generateTitle(): never {
     throw new Error("Method not implemented.");
-  }
-
-  private _subscriptions = new Set<() => void>();
-
-  public subscribe(callback: () => void): Unsubscribe {
-    this._subscriptions.add(callback);
-    return () => this._subscriptions.delete(callback);
-  }
-
-  private _notifySubscribers() {
-    notifySubscribers(this._subscriptions);
   }
 }


### PR DESCRIPTION
## summary

- BaseThreadRuntimeCore and ExternalStoreThreadListRuntimeCore were the last two runtime cores hand-rolling a subscription Set while every sibling already extends BaseSubscribable; both now extend it and drop the manual members
- behavior fix riding along, pinned by a red-then-green contract test: BaseThreadRuntimeCore's hand-rolled notify loop stopped at the first throwing subscriber, starving later subscribers; BaseSubscribable notifies every subscriber before rethrowing the first error (the semantic every sibling core already had). the external-store list core already routed through the shared notify helper, so its contract test passed before and after
- no public export changes; the Unsubscribe type import stays because surviving signatures use it

## test plan

### already verified

- [x] contract test failed against the old hand-rolled loop (later subscriber received 0 calls) and passes after the switch
- [x] full core vitest: 138 files, 1476 tests green (rerun independently); core build 7/7

### reviewer should verify

- [ ] a subscriber that throws during a thread state update no longer prevents later subscribers from observing the update, and the error still surfaces

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4jGeAWzsUW076uJwS_JbEyLlnIYXVxsVrVtBmxosz4yU6_gnWv7_VspDLQQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->