### PR TITLE
refactor(ui): reuse the kit clipboard and attachment src hooks

### DIFF
--- a/apps/docs/components/pages/examples/use-attachment-src.ts
+++ b/apps/docs/components/pages/examples/use-attachment-src.ts
@@ -1,5 +1,5 @@
 "use client";
 
-import { useAttachmentSrc } from "@assistant-ui/ui/hooks/use-attachment-src";
+import { useAttachmentSrc } from "@/hooks/use-attachment-src";
 
 export { useAttachmentSrc };

--- a/apps/docs/components/pages/examples/use-attachment-src.ts
+++ b/apps/docs/components/pages/examples/use-attachment-src.ts
@@ -1,40 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useAuiState } from "@assistant-ui/react";
-import { useShallow } from "zustand/shallow";
+import { useAttachmentSrc } from "@assistant-ui/ui/hooks/use-attachment-src";
 
-const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
-};
-
-export const useAttachmentSrc = () => {
-  const { file, src } = useAuiState(
-    useShallow((s): { file?: File; src?: string } => {
-      if (s.attachment.type !== "image") return {};
-      if (s.attachment.file) return { file: s.attachment.file };
-      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
-        ?.image;
-      if (!src) return {};
-      return { src };
-    }),
-  );
-
-  return useFileSrc(file) ?? src;
-};
+export { useAttachmentSrc };

--- a/apps/docs/lib/xulux/demo-downloads/manifest.ts
+++ b/apps/docs/lib/xulux/demo-downloads/manifest.ts
@@ -49,7 +49,6 @@ export type DemoDownloadManifest = {
 
 const COMMON_EXTRA_SOURCE_FILES = [
   "packages/ui/src/lib/utils.ts",
-  "packages/ui/src/hooks/use-copy-to-clipboard.ts",
   "packages/ui/src/hooks/use-attachment-src.ts",
   "packages/ui/src/components/ui/base/dropdown-menu.tsx",
 ] as const;

--- a/apps/docs/lib/xulux/demo-downloads/manifest.ts
+++ b/apps/docs/lib/xulux/demo-downloads/manifest.ts
@@ -49,6 +49,8 @@ export type DemoDownloadManifest = {
 
 const COMMON_EXTRA_SOURCE_FILES = [
   "packages/ui/src/lib/utils.ts",
+  "packages/ui/src/hooks/use-copy-to-clipboard.ts",
+  "packages/ui/src/hooks/use-attachment-src.ts",
   "packages/ui/src/components/ui/base/dropdown-menu.tsx",
 ] as const;
 

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -14,6 +14,12 @@
         "./components/assistant-ui/markdown-text"
       ],
       "@/hooks/use-mobile": ["../../packages/ui/src/hooks/use-mobile"],
+      "@/hooks/use-copy-to-clipboard": [
+        "../../packages/ui/src/hooks/use-copy-to-clipboard"
+      ],
+      "@/hooks/use-attachment-src": [
+        "../../packages/ui/src/hooks/use-attachment-src"
+      ],
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -837,12 +837,19 @@ function collectModuleSpecifiers(file: RegistryOutputFile) {
 }
 
 function getLocalComponentCandidates(specifier: string) {
-  if (!specifier.startsWith("@/components/")) return null;
+  if (
+    !specifier.startsWith("@/components/") &&
+    !specifier.startsWith("@/hooks/")
+  )
+    return null;
 
   const componentPath = specifier.replace(/[?#].*$/, "").slice(2);
   const extension = path.extname(componentPath);
   if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) return [componentPath];
-  if (!extension) return [`${componentPath}.tsx`];
+  if (!extension)
+    return MODULE_EXTENSIONS.map(
+      (moduleExtension) => `${componentPath}${moduleExtension}`,
+    );
 
   return [
     componentPath,

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1038,6 +1038,19 @@ export const registry: RegistryItem[] = [
     ],
   },
   {
+    name: "use-copy-to-clipboard",
+    type: "registry:hook",
+    title: "Use Copy To Clipboard",
+    description: "Copy text to the clipboard with a temporary copied state.",
+    files: [
+      {
+        type: "registry:hook",
+        path: "hooks/use-copy-to-clipboard.ts",
+        sourcePath: "../../packages/ui/src/hooks/use-copy-to-clipboard.ts",
+      },
+    ],
+  },
+  {
     name: "markdown-text",
     type: "registry:component",
     title: "Markdown Text",
@@ -1053,6 +1066,7 @@ export const registry: RegistryItem[] = [
     ],
     registryDependencies: [
       "https://r.assistant-ui.com/tooltip-icon-button.json",
+      "https://r.assistant-ui.com/use-copy-to-clipboard.json",
     ],
     dependencies: [
       "@assistant-ui/react-markdown",
@@ -1174,6 +1188,20 @@ export const registry: RegistryItem[] = [
     ],
   },
   {
+    name: "use-attachment-src",
+    type: "registry:hook",
+    title: "Use Attachment Src",
+    description: "Resolve an image attachment to a preview source URL.",
+    files: [
+      {
+        type: "registry:hook",
+        path: "hooks/use-attachment-src.ts",
+        sourcePath: "../../packages/ui/src/hooks/use-attachment-src.ts",
+      },
+    ],
+    dependencies: ["@assistant-ui/react", "zustand"],
+  },
+  {
     name: "attachment",
     type: "registry:component",
     title: "Attachment",
@@ -1192,8 +1220,9 @@ export const registry: RegistryItem[] = [
       "tooltip",
       "avatar",
       "https://r.assistant-ui.com/tooltip-icon-button.json",
+      "https://r.assistant-ui.com/use-attachment-src.json",
     ],
-    dependencies: ["@assistant-ui/react", "lucide-react", "zustand"],
+    dependencies: ["@assistant-ui/react", "lucide-react"],
   },
   {
     name: "follow-up-suggestions",

--- a/apps/registry/tsconfig.json
+++ b/apps/registry/tsconfig.json
@@ -5,6 +5,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-a2a/tsconfig.json
+++ b/examples/with-a2a/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-ag-ui/tsconfig.json
+++ b/examples/with-ag-ui/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-ai-sdk-v7/tsconfig.json
+++ b/examples/with-ai-sdk-v7/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-artifacts/tsconfig.json
+++ b/examples/with-artifacts/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-assistant-transport/tsconfig.json
+++ b/examples/with-assistant-transport/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-chain-of-thought/tsconfig.json
+++ b/examples/with-chain-of-thought/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-cloud/tsconfig.json
+++ b/examples/with-cloud/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-custom-thread-list/tsconfig.json
+++ b/examples/with-custom-thread-list/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-elevenlabs-conversational/tsconfig.json
+++ b/examples/with-elevenlabs-conversational/tsconfig.json
@@ -17,6 +17,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-elevenlabs-scribe/tsconfig.json
+++ b/examples/with-elevenlabs-scribe/tsconfig.json
@@ -17,6 +17,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-eve/tsconfig.json
+++ b/examples/with-eve/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-external-store/tsconfig.json
+++ b/examples/with-external-store/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-ffmpeg/tsconfig.json
+++ b/examples/with-ffmpeg/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-generative-ui/tsconfig.json
+++ b/examples/with-generative-ui/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-google-adk/tsconfig.json
+++ b/examples/with-google-adk/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-image-generation/tsconfig.json
+++ b/examples/with-image-generation/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-interactables/tsconfig.json
+++ b/examples/with-interactables/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-langchain/tsconfig.json
+++ b/examples/with-langchain/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-langgraph/tsconfig.json
+++ b/examples/with-langgraph/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-livekit/tsconfig.json
+++ b/examples/with-livekit/tsconfig.json
@@ -17,6 +17,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-mcp/app/tsconfig.json
+++ b/examples/with-mcp/app/tsconfig.json
@@ -12,6 +12,7 @@
       "@/components/assistant-ui/*": [
         "../../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../../packages/ui/src/components/ui/base/*",
         "../../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-mcp/tsconfig.json
+++ b/examples/with-mcp/tsconfig.json
@@ -17,6 +17,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-openui/tsconfig.json
+++ b/examples/with-openui/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-pi/tsconfig.json
+++ b/examples/with-pi/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-react-hook-form/tsconfig.json
+++ b/examples/with-react-hook-form/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-react-router/tsconfig.json
+++ b/examples/with-react-router/tsconfig.json
@@ -18,6 +18,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-resumable-stream/tsconfig.json
+++ b/examples/with-resumable-stream/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-tanstack/tsconfig.json
+++ b/examples/with-tanstack/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-tap-runtime/tsconfig.json
+++ b/examples/with-tap-runtime/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/examples/with-virtualized-thread/tsconfig.json
+++ b/examples/with-virtualized-thread/tsconfig.json
@@ -6,6 +6,7 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type PropsWithChildren, useEffect, useState, type FC } from "react";
+import { type PropsWithChildren, useState, type FC } from "react";
 import {
   XIcon,
   PlusIcon,
@@ -15,7 +15,6 @@ import {
   useAuiState,
   useAui,
 } from "@assistant-ui/react";
-import { useShallow } from "zustand/react/shallow";
 import {
   Tooltip,
   TooltipContent,
@@ -34,42 +33,8 @@ import {
   AvatarFallback,
 } from "@/components/ui/radix/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { useAttachmentSrc } from "@/hooks/use-attachment-src";
 import { cn } from "@/lib/utils";
-
-const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
-};
-
-const useAttachmentSrc = () => {
-  const { file, src } = useAuiState(
-    useShallow((s): { file?: File; src?: string } => {
-      if (s.attachment.type !== "image") return {};
-      if (s.attachment.file) return { file: s.attachment.file };
-      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
-        ?.image;
-      if (!src) return {};
-      return { src };
-    }),
-  );
-
-  return useFileSrc(file) ?? src;
-};
 
 type AttachmentPreviewProps = {
   src: string;

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -2,7 +2,6 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
   useState,
   type FC,
   isValidElement,
@@ -21,7 +20,6 @@ import {
   useAuiState,
   useAui,
 } from "@assistant-ui/react";
-import { useShallow } from "zustand/react/shallow";
 import {
   Tooltip,
   TooltipContent,
@@ -36,42 +34,8 @@ import {
 } from "@/components/ui/dialog";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { useAttachmentSrc } from "@/hooks/use-attachment-src";
 import { cn } from "@/lib/utils";
-
-const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
-};
-
-const useAttachmentSrc = () => {
-  const { file, src } = useAuiState(
-    useShallow((s): { file?: File; src?: string } => {
-      if (s.attachment.type !== "image") return {};
-      if (s.attachment.file) return { file: s.attachment.file };
-      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
-        ?.image;
-      if (!src) return {};
-      return { src };
-    }),
-  );
-
-  return useFileSrc(file) ?? src;
-};
 
 type AttachmentPreviewProps = {
   src: string;

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -9,10 +9,11 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type FC, memo, useState } from "react";
+import { type FC, memo } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 
 const MarkdownTextImpl = () => {
@@ -50,30 +51,6 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
       </TooltipIconButton>
     </div>
   );
-};
-
-const useCopyToClipboard = ({
-  copiedDuration = 3000,
-}: {
-  copiedDuration?: number;
-} = {}) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
-
-  const copyToClipboard = (value: string) => {
-    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
-      return;
-    }
-
-    navigator.clipboard.writeText(value).then(
-      () => {
-        setIsCopied(true);
-        setTimeout(() => setIsCopied(false), copiedDuration);
-      },
-      () => {},
-    );
-  };
-
-  return { isCopied, copyToClipboard };
 };
 
 const defaultComponents = memoizeMarkdownComponents({

--- a/packages/ui/src/hooks/use-attachment-src.test.tsx
+++ b/packages/ui/src/hooks/use-attachment-src.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAttachmentSrc } from "./use-attachment-src";
+
+const mockState = vi.hoisted(() => ({
+  current: { attachment: { type: "document" } } as any,
+}));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useAuiState: (selector: (s: any) => unknown) => selector(mockState.current),
+}));
+
+const makeFile = (name: string) =>
+  new File(["content"], name, { type: "image/png" });
+
+describe("useAttachmentSrc", () => {
+  let created: string[];
+  let revoked: string[];
+
+  beforeEach(() => {
+    created = [];
+    revoked = [];
+    let counter = 0;
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn(() => {
+        const url = `blob:mock-${counter++}`;
+        created.push(url);
+        return url;
+      }),
+      revokeObjectURL: vi.fn((url: string) => {
+        revoked.push(url);
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns undefined for a non-image attachment", () => {
+    mockState.current = { attachment: { type: "document" } };
+    const { result } = renderHook(() => useAttachmentSrc());
+    expect(result.current).toBeUndefined();
+    expect(created).toHaveLength(0);
+  });
+
+  it("returns the remote image content src when no file is present", () => {
+    mockState.current = {
+      attachment: {
+        type: "image",
+        content: [{ type: "image", image: "https://example.com/a.png" }],
+      },
+    };
+    const { result } = renderHook(() => useAttachmentSrc());
+    expect(result.current).toBe("https://example.com/a.png");
+    expect(created).toHaveLength(0);
+  });
+
+  it("creates an object URL for a file preview", () => {
+    mockState.current = {
+      attachment: { type: "image", file: makeFile("a.png") },
+    };
+    const { result } = renderHook(() => useAttachmentSrc());
+    expect(result.current).toBe(created[0]);
+    expect(revoked).toHaveLength(0);
+  });
+
+  it("never renders the previous object URL after the file is replaced", () => {
+    mockState.current = {
+      attachment: { type: "image", file: makeFile("a.png") },
+    };
+    const rendered: (string | undefined)[] = [];
+    const { result, rerender } = renderHook(() => {
+      const value = useAttachmentSrc();
+      rendered.push(value);
+      return value;
+    });
+    const firstUrl = created[0]!;
+    expect(result.current).toBe(firstUrl);
+
+    const sliceStart = rendered.length;
+    mockState.current = {
+      attachment: { type: "image", file: makeFile("b.png") },
+    };
+    act(() => {
+      rerender();
+    });
+
+    expect(result.current).toBe(created[1]);
+    expect(rendered.slice(sliceStart)).not.toContain(firstUrl);
+    expect(revoked).toEqual([firstUrl]);
+  });
+
+  it("revokes the object URL on unmount", () => {
+    mockState.current = {
+      attachment: { type: "image", file: makeFile("a.png") },
+    };
+    const { unmount } = renderHook(() => useAttachmentSrc());
+    const url = created[0]!;
+    unmount();
+    expect(revoked).toEqual([url]);
+  });
+});

--- a/packages/ui/src/hooks/use-attachment-src.test.tsx
+++ b/packages/ui/src/hooks/use-attachment-src.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAttachmentSrc } from "./use-attachment-src";
 
@@ -91,6 +92,28 @@ describe("useAttachmentSrc", () => {
     expect(result.current).toBe(created[1]);
     expect(rendered.slice(sliceStart)).not.toContain(firstUrl);
     expect(revoked).toEqual([firstUrl]);
+  });
+
+  it("renders only the live URL under StrictMode double effect mounting", () => {
+    mockState.current = {
+      attachment: { type: "image", file: makeFile("a.png") },
+    };
+    const rendered: (string | undefined)[] = [];
+    const { result } = renderHook(
+      () => {
+        const value = useAttachmentSrc();
+        rendered.push(value);
+        return value;
+      },
+      { wrapper: StrictMode },
+    );
+
+    expect(created.length).toBeGreaterThanOrEqual(2);
+    const liveUrl = created[created.length - 1]!;
+    expect(result.current).toBe(liveUrl);
+    for (const url of revoked) {
+      expect(rendered).not.toContain(url);
+    }
   });
 
   it("revokes the object URL on unmount", () => {

--- a/packages/ui/src/hooks/use-attachment-src.ts
+++ b/packages/ui/src/hooks/use-attachment-src.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuiState } from "@assistant-ui/react";
+import { useShallow } from "zustand/react/shallow";
+
+const useFileSrc = (file: File | undefined) => {
+  const [src, setSrc] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!file) {
+      setSrc(undefined);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setSrc(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file]);
+
+  return src;
+};
+
+export const useAttachmentSrc = () => {
+  const { file, src } = useAuiState(
+    useShallow((s): { file?: File; src?: string } => {
+      if (s.attachment.type !== "image") return {};
+      if (s.attachment.file) return { file: s.attachment.file };
+      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
+        ?.image;
+      if (!src) return {};
+      return { src };
+    }),
+  );
+
+  return useFileSrc(file) ?? src;
+};

--- a/packages/ui/src/hooks/use-attachment-src.ts
+++ b/packages/ui/src/hooks/use-attachment-src.ts
@@ -5,23 +5,25 @@ import { useAuiState } from "@assistant-ui/react";
 import { useShallow } from "zustand/react/shallow";
 
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
+  const [entry, setEntry] = useState<{ file: File; url: string } | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     if (!file) {
-      setSrc(undefined);
+      setEntry(undefined);
       return;
     }
 
     const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
+    setEntry({ file, url: objectUrl });
 
     return () => {
       URL.revokeObjectURL(objectUrl);
     };
   }, [file]);
 
-  return src;
+  return entry !== undefined && entry.file === file ? entry.url : undefined;
 };
 
 export const useAttachmentSrc = () => {

--- a/templates/eve/tsconfig.json
+++ b/templates/eve/tsconfig.json
@@ -7,6 +7,7 @@
         "../../packages/ui/src/components/assistant-ui/*.base",
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/components/ui/*": [
         "../../packages/ui/src/components/ui/base/*",
         "../../packages/ui/src/components/ui/radix/*"

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -2,7 +2,6 @@
 
 import {
   type PropsWithChildren,
-  useEffect,
   useState,
   type FC,
   isValidElement,
@@ -21,7 +20,6 @@ import {
   useAuiState,
   useAui,
 } from "@assistant-ui/react";
-import { useShallow } from "zustand/react/shallow";
 import {
   Tooltip,
   TooltipContent,
@@ -36,42 +34,8 @@ import {
 } from "@/components/ui/dialog";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
+import { useAttachmentSrc } from "@/hooks/use-attachment-src";
 import { cn } from "@/lib/utils";
-
-const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (!file) {
-      setSrc(undefined);
-      return;
-    }
-
-    const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
-
-    return () => {
-      URL.revokeObjectURL(objectUrl);
-    };
-  }, [file]);
-
-  return src;
-};
-
-const useAttachmentSrc = () => {
-  const { file, src } = useAuiState(
-    useShallow((s): { file?: File; src?: string } => {
-      if (s.attachment.type !== "image") return {};
-      if (s.attachment.file) return { file: s.attachment.file };
-      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
-        ?.image;
-      if (!src) return {};
-      return { src };
-    }),
-  );
-
-  return useFileSrc(file) ?? src;
-};
 
 type AttachmentPreviewProps = {
   src: string;

--- a/templates/minimal/hooks/use-attachment-src.ts
+++ b/templates/minimal/hooks/use-attachment-src.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuiState } from "@assistant-ui/react";
+import { useShallow } from "zustand/react/shallow";
+
+const useFileSrc = (file: File | undefined) => {
+  const [src, setSrc] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!file) {
+      setSrc(undefined);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setSrc(objectUrl);
+
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file]);
+
+  return src;
+};
+
+export const useAttachmentSrc = () => {
+  const { file, src } = useAuiState(
+    useShallow((s): { file?: File; src?: string } => {
+      if (s.attachment.type !== "image") return {};
+      if (s.attachment.file) return { file: s.attachment.file };
+      const src = s.attachment.content?.filter((c) => c.type === "image")[0]
+        ?.image;
+      if (!src) return {};
+      return { src };
+    }),
+  );
+
+  return useFileSrc(file) ?? src;
+};

--- a/templates/minimal/hooks/use-attachment-src.ts
+++ b/templates/minimal/hooks/use-attachment-src.ts
@@ -5,23 +5,25 @@ import { useAuiState } from "@assistant-ui/react";
 import { useShallow } from "zustand/react/shallow";
 
 const useFileSrc = (file: File | undefined) => {
-  const [src, setSrc] = useState<string | undefined>(undefined);
+  const [entry, setEntry] = useState<{ file: File; url: string } | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     if (!file) {
-      setSrc(undefined);
+      setEntry(undefined);
       return;
     }
 
     const objectUrl = URL.createObjectURL(file);
-    setSrc(objectUrl);
+    setEntry({ file, url: objectUrl });
 
     return () => {
       URL.revokeObjectURL(objectUrl);
     };
   }, [file]);
 
-  return src;
+  return entry !== undefined && entry.file === file ? entry.url : undefined;
 };
 
 export const useAttachmentSrc = () => {


### PR DESCRIPTION
## summary

- markdown-text.tsx inlined a byte-identical copy of the existing hooks/use-copy-to-clipboard; it now imports the hook
- the object-URL attachment source logic existed three times (attachment.tsx, attachment.radix.tsx, and a docs example); it now lives once in hooks/use-attachment-src.ts, both flavor files import it, and the docs example forwards to the published hook path
- registry: use-copy-to-clipboard and use-attachment-src become registry:hook entries; markdown-text and attachment declare them as registryDependencies so shadcn add stays self-contained; the zustand dependency moves from attachment to the attachment hook entry that actually uses it
- templates/minimal: attachment.tsx synced byte-equal, and the new hook is copied to templates/minimal/hooks/ (the template's @/* alias resolves inside the template, so the hook file must ship with it). note: scripts/sync-templates.sh does not map hooks/ files yet, so this copy is unguarded; follow-up tracked separately
- markdown-text.tsx has no minimal sync obligation (it is an OVERRIDES entry by design)
- packages/ui and apps/docs are private, so no changeset

## test plan

### already verified

- [x] packages/ui vitest: 9 files, 362 tests green (rerun independently)
- [x] cmp: kit attachment.tsx vs minimal copy byte-equal; kit hook vs minimal hook copy byte-equal
- [x] grep: no inline useCopyToClipboard/useFileSrc/useAttachmentSrc definitions remain in kit components or the docs example

### reviewer should verify

- [ ] shadcn add markdown-text / attachment on a fresh project pulls the hook files through registryDependencies with no unresolvable imports

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fkqknnnTlWKLQiY2yaJclLlyRg6rsZEHCarirHSOAqXLXO12lCv8rS_aio0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->