### PR TITLE
refactor(assistant-stream): share the decoder tool-call controller registry

### DIFF
--- a/.changeset/tool-call-part-registry.md
+++ b/.changeset/tool-call-part-registry.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: share the decoder tool-call controller registry between data-stream and ui-message-stream.

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -1,5 +1,4 @@
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
-import type { ToolCallStreamController } from "../../modules/tool-call";
 import { AssistantTransformStream } from "../../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
 import { type DataStreamChunk, DataStreamStreamChunkType } from "./chunk-types";
@@ -13,6 +12,7 @@ import {
   AssistantMetaTransformStream,
 } from "../../utils/stream/AssistantMetaTransformStream";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
+import { createToolCallPartRegistry } from "../tool-call-part-registry";
 
 type DataStreamOptions = {
   strict?: boolean | undefined;
@@ -287,7 +287,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
   constructor(options: DataStreamOptions = {}) {
     const strict = options.strict ?? true;
     super((readable) => {
-      const toolCallControllers = new Map<string, ToolCallStreamController>();
+      const toolCallPartRegistry = createToolCallPartRegistry();
       const closedToolCallArgs = new Set<string>();
       const warnedDroppedArgs = new Set<string>();
       const loggedDrops = new Set<string>();
@@ -297,11 +297,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
         console.error(message);
       };
       const closeOpenToolCallArgs = () => {
-        for (const [toolCallId, toolCallController] of toolCallControllers) {
-          if (closedToolCallArgs.has(toolCallId)) continue;
-          toolCallController.argsText.close();
-          closedToolCallArgs.add(toolCallId);
-        }
+        toolCallPartRegistry.closeOpenArgsText(closedToolCallArgs);
       };
       const transform = new AssistantTransformStream<DataStreamChunk>({
         strict,
@@ -350,7 +346,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 ? controller.withParentId(parentId)
                 : controller;
 
-              if (toolCallControllers.has(toolCallId)) {
+              if (toolCallPartRegistry.has(toolCallId)) {
                 if (strict)
                   throw new Error(
                     `Encountered duplicate tool call id: ${toolCallId}`,
@@ -362,11 +358,12 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 break;
               }
 
-              const toolCallController = ctrl.addToolCallPart({
-                toolCallId,
-                toolName,
-              });
-              toolCallControllers.set(toolCallId, toolCallController);
+              toolCallPartRegistry.start(toolCallId, () =>
+                ctrl.addToolCallPart({
+                  toolCallId,
+                  toolName,
+                }),
+              );
               break;
             }
 
@@ -381,8 +378,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 }
                 break;
               }
-              const toolCallController = toolCallControllers.get(toolCallId);
-              if (!toolCallController) {
+              if (!toolCallPartRegistry.has(toolCallId)) {
                 if (strict)
                   throw new Error(
                     `Encountered tool call with unknown id: ${toolCallId}`,
@@ -394,10 +390,10 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 break;
               }
               if (argsTextDelta.length > 0) {
-                toolCallController.argsText.append(argsTextDelta);
+                toolCallPartRegistry.appendArgsText(toolCallId, argsTextDelta);
               }
               if (isFinal === true) {
-                toolCallController.argsText.close();
+                toolCallPartRegistry.closeArgsText(toolCallId);
                 closedToolCallArgs.add(toolCallId);
               }
               break;
@@ -405,8 +401,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
 
             case DataStreamStreamChunkType.ToolCallResult: {
               const { toolCallId, artifact, result, isError } = value;
-              const toolCallController = toolCallControllers.get(toolCallId);
-              if (!toolCallController) {
+              if (!toolCallPartRegistry.has(toolCallId)) {
                 if (strict)
                   throw new Error(
                     `Encountered tool call result with unknown id: ${toolCallId}`,
@@ -417,11 +412,18 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 );
                 break;
               }
-              toolCallController.setResponse({
-                artifact,
-                result,
-                isError,
-              });
+              toolCallPartRegistry.setResponse(
+                toolCallId,
+                {
+                  artifact,
+                  result,
+                  isError,
+                },
+                () =>
+                  new Error(
+                    `Encountered tool call result with unknown id: ${toolCallId}`,
+                  ),
+              );
               closedToolCallArgs.add(toolCallId);
               break;
             }
@@ -429,16 +431,16 @@ export class DataStreamDecoder extends PipeableTransformStream<
             case DataStreamStreamChunkType.ToolCall: {
               const { toolCallId, toolName, args } = value;
 
-              let toolCallController = toolCallControllers.get(toolCallId);
-              if (toolCallController) {
-                toolCallController.argsText.close();
+              if (toolCallPartRegistry.has(toolCallId)) {
+                toolCallPartRegistry.closeArgsText(toolCallId);
               } else {
-                toolCallController = controller.addToolCallPart({
-                  toolCallId,
-                  toolName,
-                  args,
-                });
-                toolCallControllers.set(toolCallId, toolCallController);
+                toolCallPartRegistry.start(toolCallId, () =>
+                  controller.addToolCallPart({
+                    toolCallId,
+                    toolName,
+                    args,
+                  }),
+                );
               }
               closedToolCallArgs.add(toolCallId);
               break;
@@ -551,8 +553,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
         },
         flush() {
           closeOpenToolCallArgs();
-          toolCallControllers.forEach((controller) => controller.close());
-          toolCallControllers.clear();
+          toolCallPartRegistry.closeAll();
         },
       });
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -288,7 +288,6 @@ export class DataStreamDecoder extends PipeableTransformStream<
     const strict = options.strict ?? true;
     super((readable) => {
       const toolCallPartRegistry = createToolCallPartRegistry();
-      const closedToolCallArgs = new Set<string>();
       const warnedDroppedArgs = new Set<string>();
       const loggedDrops = new Set<string>();
       const logDropped = (key: string, message: string) => {
@@ -297,7 +296,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
         console.error(message);
       };
       const closeOpenToolCallArgs = () => {
-        toolCallPartRegistry.closeOpenArgsText(closedToolCallArgs);
+        toolCallPartRegistry.closeOpenArgsText();
       };
       const transform = new AssistantTransformStream<DataStreamChunk>({
         strict,
@@ -346,7 +345,7 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 ? controller.withParentId(parentId)
                 : controller;
 
-              if (toolCallPartRegistry.has(toolCallId)) {
+              if (toolCallPartRegistry.tryGet(toolCallId)) {
                 if (strict)
                   throw new Error(
                     `Encountered duplicate tool call id: ${toolCallId}`,
@@ -369,16 +368,9 @@ export class DataStreamDecoder extends PipeableTransformStream<
 
             case DataStreamStreamChunkType.ToolCallArgsTextDelta: {
               const { toolCallId, argsTextDelta, isFinal } = value;
-              if (closedToolCallArgs.has(toolCallId)) {
-                if (!warnedDroppedArgs.has(toolCallId)) {
-                  warnedDroppedArgs.add(toolCallId);
-                  console.warn(
-                    `Dropped tool-call args delta for closed args stream: ${toolCallId}`,
-                  );
-                }
-                break;
-              }
-              if (!toolCallPartRegistry.has(toolCallId)) {
+              const toolCallController =
+                toolCallPartRegistry.tryGet(toolCallId);
+              if (!toolCallController) {
                 if (strict)
                   throw new Error(
                     `Encountered tool call with unknown id: ${toolCallId}`,
@@ -389,19 +381,32 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 );
                 break;
               }
+              if (toolCallPartRegistry.isArgsTextClosed(toolCallController)) {
+                if (!warnedDroppedArgs.has(toolCallId)) {
+                  warnedDroppedArgs.add(toolCallId);
+                  console.warn(
+                    `Dropped tool-call args delta for closed args stream: ${toolCallId}`,
+                  );
+                }
+                break;
+              }
               if (argsTextDelta.length > 0) {
-                toolCallPartRegistry.appendArgsText(toolCallId, argsTextDelta);
+                toolCallPartRegistry.appendArgsText(
+                  toolCallController,
+                  argsTextDelta,
+                );
               }
               if (isFinal === true) {
-                toolCallPartRegistry.closeArgsText(toolCallId);
-                closedToolCallArgs.add(toolCallId);
+                toolCallPartRegistry.closeArgsText(toolCallController);
               }
               break;
             }
 
             case DataStreamStreamChunkType.ToolCallResult: {
               const { toolCallId, artifact, result, isError } = value;
-              if (!toolCallPartRegistry.has(toolCallId)) {
+              const toolCallController =
+                toolCallPartRegistry.tryGet(toolCallId);
+              if (!toolCallController) {
                 if (strict)
                   throw new Error(
                     `Encountered tool call result with unknown id: ${toolCallId}`,
@@ -412,37 +417,36 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 );
                 break;
               }
-              toolCallPartRegistry.setResponse(
-                toolCallId,
-                {
-                  artifact,
-                  result,
-                  isError,
-                },
-                () =>
-                  new Error(
-                    `Encountered tool call result with unknown id: ${toolCallId}`,
-                  ),
-              );
-              closedToolCallArgs.add(toolCallId);
+              toolCallPartRegistry.setResponse(toolCallController, {
+                artifact,
+                result,
+                isError,
+              });
               break;
             }
 
             case DataStreamStreamChunkType.ToolCall: {
               const { toolCallId, toolName, args } = value;
+              const toolCallController =
+                toolCallPartRegistry.tryGet(toolCallId);
 
-              if (toolCallPartRegistry.has(toolCallId)) {
-                toolCallPartRegistry.closeArgsText(toolCallId);
+              if (toolCallController) {
+                toolCallPartRegistry.closeArgsText(toolCallController);
               } else {
-                toolCallPartRegistry.start(toolCallId, () =>
-                  controller.addToolCallPart({
-                    toolCallId,
-                    toolName,
-                    args,
-                  }),
+                const toolCallController = toolCallPartRegistry.start(
+                  toolCallId,
+                  () =>
+                    controller.addToolCallPart({
+                      toolCallId,
+                      toolName,
+                    }),
                 );
+                toolCallPartRegistry.appendArgsText(
+                  toolCallController,
+                  JSON.stringify(args),
+                );
+                toolCallPartRegistry.closeArgsText(toolCallController);
               }
-              closedToolCallArgs.add(toolCallId);
               break;
             }
 

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -441,10 +441,12 @@ export class DataStreamDecoder extends PipeableTransformStream<
                       toolName,
                     }),
                 );
-                toolCallPartRegistry.appendArgsText(
-                  toolCallController,
-                  JSON.stringify(args),
-                );
+                if (args !== undefined) {
+                  toolCallPartRegistry.appendArgsText(
+                    toolCallController,
+                    JSON.stringify(args),
+                  );
+                }
                 toolCallPartRegistry.closeArgsText(toolCallController);
               }
               break;

--- a/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
+++ b/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
@@ -76,6 +76,21 @@ describe("registry-backed decoders", () => {
     ).toBe("Encountered tool result with unknown id: missing");
   });
 
+  it("finishes args for an argsless complete tool call before its result", async () => {
+    const chunks = await decodeDataStream([
+      '9:{"toolCallId":"t1","toolName":"search"}',
+      'a:{"toolCallId":"t1","result":"done"}',
+    ]);
+
+    const argsFinishIdx = chunks.findIndex(
+      (chunk) => chunk.type === "tool-call-args-text-finish",
+    );
+    const resultIdx = chunks.findIndex((chunk) => chunk.type === "result");
+    expect(argsFinishIdx).toBeGreaterThanOrEqual(0);
+    expect(resultIdx).toBeGreaterThanOrEqual(0);
+    expect(argsFinishIdx).toBeLessThan(resultIdx);
+  });
+
   it("closes every open controller on flush", async () => {
     const chunks = await decodeDataStream([
       'b:{"toolCallId":"t1","toolName":"search"}',

--- a/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
+++ b/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantStreamChunk } from "../AssistantStreamChunk";
+import { DataStreamDecoder } from "./data-stream/DataStream";
+import { UIMessageStreamDecoder } from "./ui-message-stream/UIMessageStream";
+
+async function collectChunks<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const chunks: T[] = [];
+  await stream.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    }),
+  );
+  return chunks;
+}
+
+function decodeDataStream(lines: string[]) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+      controller.close();
+    },
+  });
+  return collectChunks(stream.pipeThrough(new DataStreamDecoder()));
+}
+
+function decodeUIMessageStream(events: string[]) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(events.map((event) => `data: ${event}\n\n`).join("")),
+      );
+      controller.close();
+    },
+  });
+  return collectChunks(stream.pipeThrough(new UIMessageStreamDecoder()));
+}
+
+async function getErrorMessage(promise: Promise<unknown>) {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) return error.message;
+    throw error;
+  }
+  throw new Error("Expected decoder to throw");
+}
+
+describe("registry-backed decoders", () => {
+  it("preserves the strict duplicate-start error", async () => {
+    expect(
+      await getErrorMessage(
+        decodeDataStream([
+          'b:{"toolCallId":"t1","toolName":"search"}',
+          'b:{"toolCallId":"t1","toolName":"search"}',
+        ]),
+      ),
+    ).toBe("Encountered duplicate tool call id: t1");
+  });
+
+  it("preserves the UI Message Stream unknown tool-result error", async () => {
+    expect(
+      await getErrorMessage(
+        decodeUIMessageStream([
+          JSON.stringify({
+            type: "tool-result",
+            toolCallId: "missing",
+            result: "done",
+          }),
+          "[DONE]",
+        ]),
+      ),
+    ).toBe("Encountered tool result with unknown id: missing");
+  });
+
+  it("closes every open controller on flush", async () => {
+    const chunks = await decodeDataStream([
+      'b:{"toolCallId":"t1","toolName":"search"}',
+      'b:{"toolCallId":"t2","toolName":"lookup"}',
+    ]);
+
+    expect(
+      chunks.filter(
+        (chunk): chunk is AssistantStreamChunk & { type: "part-finish" } =>
+          chunk.type === "part-finish",
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
+++ b/packages/assistant-stream/src/core/serialization/tool-call-part-registry.test.ts
@@ -76,6 +76,26 @@ describe("registry-backed decoders", () => {
     ).toBe("Encountered tool result with unknown id: missing");
   });
 
+  it("preserves the UI Message Stream duplicate tool-call error", async () => {
+    expect(
+      await getErrorMessage(
+        decodeUIMessageStream([
+          JSON.stringify({
+            type: "tool-call-start",
+            toolCallId: "dup",
+            toolName: "search",
+          }),
+          JSON.stringify({
+            type: "tool-call-start",
+            toolCallId: "dup",
+            toolName: "search",
+          }),
+          "[DONE]",
+        ]),
+      ),
+    ).toBe("Encountered duplicate tool call id: dup");
+  });
+
   it("finishes args for an argsless complete tool call before its result", async () => {
     const chunks = await decodeDataStream([
       '9:{"toolCallId":"t1","toolName":"search"}',

--- a/packages/assistant-stream/src/core/serialization/tool-call-part-registry.ts
+++ b/packages/assistant-stream/src/core/serialization/tool-call-part-registry.ts
@@ -1,0 +1,65 @@
+import type { ToolCallStreamController } from "../modules/tool-call";
+
+type UnknownToolCallError = (toolCallId: string) => Error;
+
+const defaultUnknownToolCallError: UnknownToolCallError = (toolCallId) =>
+  new Error(`Encountered tool call with unknown id: ${toolCallId}`);
+
+export const createToolCallPartRegistry = () => {
+  const toolCallControllers = new Map<string, ToolCallStreamController>();
+
+  const get = (
+    toolCallId: string,
+    unknownError: UnknownToolCallError = defaultUnknownToolCallError,
+  ) => {
+    const toolCallController = toolCallControllers.get(toolCallId);
+    if (!toolCallController) throw unknownError(toolCallId);
+    return toolCallController;
+  };
+
+  return {
+    has: (toolCallId: string) => toolCallControllers.has(toolCallId),
+    start: (toolCallId: string, create: () => ToolCallStreamController) => {
+      if (toolCallControllers.has(toolCallId)) {
+        throw new Error(`Encountered duplicate tool call id: ${toolCallId}`);
+      }
+      const toolCallController = create();
+      toolCallControllers.set(toolCallId, toolCallController);
+      return toolCallController;
+    },
+    get,
+    appendArgsText: (
+      toolCallId: string,
+      argsTextDelta: string,
+      unknownError?: UnknownToolCallError,
+    ) => {
+      get(toolCallId, unknownError).argsText.append(argsTextDelta);
+    },
+    closeArgsText: (
+      toolCallId: string,
+      unknownError?: UnknownToolCallError,
+    ) => {
+      get(toolCallId, unknownError).argsText.close();
+    },
+    setResponse: (
+      toolCallId: string,
+      response: Parameters<ToolCallStreamController["setResponse"]>[0],
+      unknownError?: UnknownToolCallError,
+    ) => {
+      get(toolCallId, unknownError).setResponse(response);
+    },
+    closeOpenArgsText: (closedToolCallArgs: Set<string>) => {
+      for (const [toolCallId, toolCallController] of toolCallControllers) {
+        if (closedToolCallArgs.has(toolCallId)) continue;
+        toolCallController.argsText.close();
+        closedToolCallArgs.add(toolCallId);
+      }
+    },
+    closeAll: () => {
+      toolCallControllers.forEach((toolCallController) => {
+        toolCallController.close();
+      });
+      toolCallControllers.clear();
+    },
+  };
+};

--- a/packages/assistant-stream/src/core/serialization/tool-call-part-registry.ts
+++ b/packages/assistant-stream/src/core/serialization/tool-call-part-registry.ts
@@ -1,24 +1,25 @@
 import type { ToolCallStreamController } from "../modules/tool-call";
 
-type UnknownToolCallError = (toolCallId: string) => Error;
-
-const defaultUnknownToolCallError: UnknownToolCallError = (toolCallId) =>
-  new Error(`Encountered tool call with unknown id: ${toolCallId}`);
-
 export const createToolCallPartRegistry = () => {
   const toolCallControllers = new Map<string, ToolCallStreamController>();
+  const closedToolCallArgs = new Set<ToolCallStreamController>();
 
-  const get = (
-    toolCallId: string,
-    unknownError: UnknownToolCallError = defaultUnknownToolCallError,
-  ) => {
-    const toolCallController = toolCallControllers.get(toolCallId);
-    if (!toolCallController) throw unknownError(toolCallId);
+  const tryGet = (toolCallId: string) => toolCallControllers.get(toolCallId);
+
+  const get = (toolCallId: string) => {
+    const toolCallController = tryGet(toolCallId);
+    if (!toolCallController) {
+      throw new Error(`Encountered tool call with unknown id: ${toolCallId}`);
+    }
     return toolCallController;
   };
 
+  const closeArgsText = (toolCallController: ToolCallStreamController) => {
+    toolCallController.argsText.close();
+    closedToolCallArgs.add(toolCallController);
+  };
+
   return {
-    has: (toolCallId: string) => toolCallControllers.has(toolCallId),
     start: (toolCallId: string, create: () => ToolCallStreamController) => {
       if (toolCallControllers.has(toolCallId)) {
         throw new Error(`Encountered duplicate tool call id: ${toolCallId}`);
@@ -28,38 +29,37 @@ export const createToolCallPartRegistry = () => {
       return toolCallController;
     },
     get,
+    tryGet,
     appendArgsText: (
-      toolCallId: string,
+      toolCallController: ToolCallStreamController,
       argsTextDelta: string,
-      unknownError?: UnknownToolCallError,
     ) => {
-      get(toolCallId, unknownError).argsText.append(argsTextDelta);
+      toolCallController.argsText.append(argsTextDelta);
     },
-    closeArgsText: (
-      toolCallId: string,
-      unknownError?: UnknownToolCallError,
-    ) => {
-      get(toolCallId, unknownError).argsText.close();
+    closeArgsText,
+    isArgsTextClosed: (toolCallController: ToolCallStreamController) => {
+      return closedToolCallArgs.has(toolCallController);
     },
     setResponse: (
-      toolCallId: string,
+      toolCallController: ToolCallStreamController,
       response: Parameters<ToolCallStreamController["setResponse"]>[0],
-      unknownError?: UnknownToolCallError,
     ) => {
-      get(toolCallId, unknownError).setResponse(response);
+      toolCallController.setResponse(response);
+      closedToolCallArgs.add(toolCallController);
     },
-    closeOpenArgsText: (closedToolCallArgs: Set<string>) => {
-      for (const [toolCallId, toolCallController] of toolCallControllers) {
-        if (closedToolCallArgs.has(toolCallId)) continue;
-        toolCallController.argsText.close();
-        closedToolCallArgs.add(toolCallId);
+    closeOpenArgsText: () => {
+      for (const toolCallController of toolCallControllers.values()) {
+        if (closedToolCallArgs.has(toolCallController)) continue;
+        closeArgsText(toolCallController);
       }
     },
     closeAll: () => {
       toolCallControllers.forEach((toolCallController) => {
+        closedToolCallArgs.add(toolCallController);
         toolCallController.close();
       });
       toolCallControllers.clear();
+      closedToolCallArgs.clear();
     },
   };
 };

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -189,16 +189,21 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               if (chunk.toolCallId === activeToolCallId) {
                 activeToolCallId = undefined;
               }
-              toolCallPartRegistry.setResponse(
-                toolCallPartRegistry.get(chunk.toolCallId),
-                {
-                  result: chunk.result,
-                  isError: chunk.isError ?? false,
-                  ...(chunk.messages !== undefined
-                    ? { messages: chunk.messages }
-                    : {}),
-                },
+              const toolCallController = toolCallPartRegistry.tryGet(
+                chunk.toolCallId,
               );
+              if (!toolCallController) {
+                throw new Error(
+                  `Encountered tool result with unknown id: ${chunk.toolCallId}`,
+                );
+              }
+              toolCallPartRegistry.setResponse(toolCallController, {
+                result: chunk.result,
+                isError: chunk.isError ?? false,
+                ...(chunk.messages !== undefined
+                  ? { messages: chunk.messages }
+                  : {}),
+              });
               break;
             }
 

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -1,7 +1,5 @@
 import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
-import type { ToolCallStreamController } from "../../modules/tool-call";
-import type { TextStreamController } from "../../modules/text";
 import { AssistantTransformStream } from "../../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
 import {
@@ -14,6 +12,7 @@ import type {
 } from "./chunk-types";
 import { generateId } from "../../utils/generateId";
 import type { ReadonlyJSONValue } from "../../../utils/json/json-value";
+import { createToolCallPartRegistry } from "../tool-call-part-registry";
 
 export type { UIMessageStreamChunk, UIMessageStreamDataChunk };
 
@@ -39,8 +38,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 > {
   constructor(options: UIMessageStreamDecoderOptions = {}) {
     super((readable) => {
-      const toolCallControllers = new Map<string, ToolCallStreamController>();
-      let activeToolCallArgsText: TextStreamController | undefined;
+      const toolCallPartRegistry = createToolCallPartRegistry();
+      let activeToolCallId: string | undefined;
       let currentMessageId: string | undefined;
       let receivedDone = false;
       type PendingTool = {
@@ -151,52 +150,55 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               break;
 
             case "tool-call-start": {
-              activeToolCallArgsText?.close();
-              activeToolCallArgsText = undefined;
-
-              if (toolCallControllers.has(chunk.toolCallId)) {
-                throw new Error(
-                  `Encountered duplicate tool call id: ${chunk.toolCallId}`,
-                );
+              if (activeToolCallId !== undefined) {
+                toolCallPartRegistry.closeArgsText(activeToolCallId);
+                activeToolCallId = undefined;
               }
 
-              const toolCallController = controller.addToolCallPart({
-                toolCallId: chunk.toolCallId,
-                toolName: chunk.toolName,
-              });
-              toolCallControllers.set(chunk.toolCallId, toolCallController);
-              activeToolCallArgsText = toolCallController.argsText;
+              toolCallPartRegistry.start(chunk.toolCallId, () =>
+                controller.addToolCallPart({
+                  toolCallId: chunk.toolCallId,
+                  toolName: chunk.toolName,
+                }),
+              );
+              activeToolCallId = chunk.toolCallId;
               break;
             }
 
             case "tool-call-delta":
-              activeToolCallArgsText?.append(chunk.argsText);
+              if (activeToolCallId !== undefined) {
+                toolCallPartRegistry.appendArgsText(
+                  activeToolCallId,
+                  chunk.argsText,
+                );
+              }
               break;
 
             case "tool-call-end":
-              activeToolCallArgsText?.close();
-              activeToolCallArgsText = undefined;
+              if (activeToolCallId !== undefined) {
+                toolCallPartRegistry.closeArgsText(activeToolCallId);
+                activeToolCallId = undefined;
+              }
               break;
 
             case "tool-result": {
-              const toolCallController = toolCallControllers.get(
+              if (chunk.toolCallId === activeToolCallId) {
+                activeToolCallId = undefined;
+              }
+              toolCallPartRegistry.setResponse(
                 chunk.toolCallId,
+                {
+                  result: chunk.result,
+                  isError: chunk.isError ?? false,
+                  ...(chunk.messages !== undefined
+                    ? { messages: chunk.messages }
+                    : {}),
+                },
+                () =>
+                  new Error(
+                    `Encountered tool result with unknown id: ${chunk.toolCallId}`,
+                  ),
               );
-              if (!toolCallController) {
-                throw new Error(
-                  `Encountered tool result with unknown id: ${chunk.toolCallId}`,
-                );
-              }
-              if (toolCallController.argsText === activeToolCallArgsText) {
-                activeToolCallArgsText = undefined;
-              }
-              toolCallController.setResponse({
-                result: chunk.result,
-                isError: chunk.isError ?? false,
-                ...(chunk.messages !== undefined
-                  ? { messages: chunk.messages }
-                  : {}),
-              });
               break;
             }
 
@@ -241,9 +243,10 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
           }
         },
         flush() {
-          activeToolCallArgsText?.close();
-          toolCallControllers.forEach((ctrl) => ctrl.close());
-          toolCallControllers.clear();
+          if (activeToolCallId !== undefined) {
+            toolCallPartRegistry.closeArgsText(activeToolCallId);
+          }
+          toolCallPartRegistry.closeAll();
         },
       });
 

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -151,7 +151,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
             case "tool-call-start": {
               if (activeToolCallId !== undefined) {
-                toolCallPartRegistry.closeArgsText(activeToolCallId);
+                toolCallPartRegistry.closeArgsText(
+                  toolCallPartRegistry.get(activeToolCallId),
+                );
                 activeToolCallId = undefined;
               }
 
@@ -168,7 +170,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
             case "tool-call-delta":
               if (activeToolCallId !== undefined) {
                 toolCallPartRegistry.appendArgsText(
-                  activeToolCallId,
+                  toolCallPartRegistry.get(activeToolCallId),
                   chunk.argsText,
                 );
               }
@@ -176,7 +178,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
             case "tool-call-end":
               if (activeToolCallId !== undefined) {
-                toolCallPartRegistry.closeArgsText(activeToolCallId);
+                toolCallPartRegistry.closeArgsText(
+                  toolCallPartRegistry.get(activeToolCallId),
+                );
                 activeToolCallId = undefined;
               }
               break;
@@ -186,7 +190,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 activeToolCallId = undefined;
               }
               toolCallPartRegistry.setResponse(
-                chunk.toolCallId,
+                toolCallPartRegistry.get(chunk.toolCallId),
                 {
                   result: chunk.result,
                   isError: chunk.isError ?? false,
@@ -194,10 +198,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                     ? { messages: chunk.messages }
                     : {}),
                 },
-                () =>
-                  new Error(
-                    `Encountered tool result with unknown id: ${chunk.toolCallId}`,
-                  ),
               );
               break;
             }
@@ -244,7 +244,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
         },
         flush() {
           if (activeToolCallId !== undefined) {
-            toolCallPartRegistry.closeArgsText(activeToolCallId);
+            toolCallPartRegistry.closeArgsText(
+              toolCallPartRegistry.get(activeToolCallId),
+            );
           }
           toolCallPartRegistry.closeAll();
         },


### PR DESCRIPTION
## summary

- the data-stream and ui-message-stream decoders each kept a Map<toolCallId, ToolCallStreamController> with the same lifecycle machinery: duplicate-id start throw, unknown-id lookup throw, argsText append/close, setResponse, close-open-args, and close-all on flush
- both now consume one internal createToolCallPartRegistry (65 lines, not exported from the package barrel) that owns the map and the validation; per-decoder policies stay local (data-stream's non-strict drop-and-log and closed-args handling, ui-message-stream's active-tool routing for id-less deltas), and the differing unknown-id error texts stay byte-identical via a per-site error factory
- no public exports and no wire-format changes; chunk type strings and orderings are untouched

## test plan

### already verified

- [x] full assistant-stream vitest: 35 files, 478 tests green (rerun independently); build green

### reviewer should verify

- [ ] decoding a stream with a duplicate tool-call id still throws the same error text per decoder, and flush still closes every open controller

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5Dr3CwaXKUyYWEggC030pitxUnuBM3CbyLlhjc6nbdr1hacHB-OyS0CxSmQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

behavior note: an off-spec complete tool-call line without an args field now emits its empty-args finish at the chunk itself instead of at flush, so a following result arrives after the args finish; pinned by a registry test.