### PR TITLE
refactor(core): collapse the external message converter derivation chains

### DIFF
--- a/.changeset/external-message-converter-split.md
+++ b/.changeset/external-message-converter-split.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: collapse the external message converter's duplicate derivation chains into one pure module.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1697,6 +1697,28 @@ type ExportedMessageRepositoryItem = {
   runConfig?: RunConfig;
 };
 
+type ExternalMessageConverterCallback<T> = (message: T, metadata: ExternalMessageConverterMetadata) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+type ExternalMessageConverterMessage = (ThreadMessageLike & {
+  readonly convertConfig?: {
+    readonly joinStrategy?: JoinStrategy;
+  };
+}) | {
+  role: "tool";
+  toolCallId: string;
+  toolName?: string | undefined;
+  result: any;
+  artifact?: any;
+  isError?: boolean;
+  messages?: readonly ThreadMessage[];
+};
+
+type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
 type ExternalStoreAdapterBase<T> = {
@@ -5846,7 +5868,7 @@ declare const consumeSuggestionResult: (result: ReturnType<SuggestionAdapter["ge
   onUpdate: (suggestions: readonly ThreadSuggestion[]) => void;
 }) => Promise<void>;
 
-declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
+declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: ExternalMessageConverterCallback<T>, isRunning: boolean, metadata: ExternalMessageConverterMetadata) => ThreadMessage[];
 
 declare const createLocalStorageAdapter: (options: LocalStorageAdapterOptions) => RemoteThreadListAdapter;
 
@@ -6244,25 +6266,9 @@ declare const useEditComposerSend: () => {
 };
 
 declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  type Message = ExternalMessageConverterMessage;
+  type Metadata = ExternalMessageConverterMetadata;
+  type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
 declare const useExternalMessageConverter: <T extends WeakKey>(_param19: {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1040,6 +1040,28 @@ type ExportedMessageRepositoryItem = {
   runConfig?: RunConfig;
 };
 
+type ExternalMessageConverterCallback<T> = (message: T, metadata: ExternalMessageConverterMetadata) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+type ExternalMessageConverterMessage = (ThreadMessageLike & {
+  readonly convertConfig?: {
+    readonly joinStrategy?: JoinStrategy;
+  };
+}) | {
+  role: "tool";
+  toolCallId: string;
+  toolName?: string | undefined;
+  result: any;
+  artifact?: any;
+  isError?: boolean;
+  messages?: readonly ThreadMessage[];
+};
+
+type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
 type ExternalStoreAdapterBase<T> = {
@@ -2506,25 +2528,9 @@ declare const useAdkToolConfirmations: () => AdkToolConfirmation[];
 declare const useAdkUserState: () => Record<string, unknown>;
 
 declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  type Message = ExternalMessageConverterMessage;
+  type Metadata = ExternalMessageConverterMetadata;
+  type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
 declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -667,6 +667,28 @@ type ExportedMessageRepositoryItem = {
   runConfig?: RunConfig;
 };
 
+type ExternalMessageConverterCallback<T> = (message: T, metadata: ExternalMessageConverterMetadata) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+type ExternalMessageConverterMessage = (ThreadMessageLike & {
+  readonly convertConfig?: {
+    readonly joinStrategy?: JoinStrategy;
+  };
+}) | {
+  role: "tool";
+  toolCallId: string;
+  toolName?: string | undefined;
+  result: any;
+  artifact?: any;
+  isError?: boolean;
+  messages?: readonly ThreadMessage[];
+};
+
+type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
 type ExternalStoreAdapterBase<T> = {
@@ -2117,25 +2139,9 @@ declare namespace entry_root_exports {
 }
 
 declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  type Message = ExternalMessageConverterMessage;
+  type Metadata = ExternalMessageConverterMetadata;
+  type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
 declare const useExternalMessageConverter: <T extends WeakKey>(_param2: {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -688,6 +688,28 @@ type ExportedMessageRepositoryItem = {
   runConfig?: RunConfig;
 };
 
+type ExternalMessageConverterCallback<T> = (message: T, metadata: ExternalMessageConverterMetadata) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+type ExternalMessageConverterMessage = (ThreadMessageLike & {
+  readonly convertConfig?: {
+    readonly joinStrategy?: JoinStrategy;
+  };
+}) | {
+  role: "tool";
+  toolCallId: string;
+  toolName?: string | undefined;
+  result: any;
+  artifact?: any;
+  isError?: boolean;
+  messages?: readonly ThreadMessage[];
+};
+
+type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
 type ExternalStoreAdapterBase<T> = {
@@ -2335,25 +2357,9 @@ declare namespace entry_root_exports {
 declare const unstable_createLangGraphStream: (_param3: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
 
 declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  type Message = ExternalMessageConverterMessage;
+  type Metadata = ExternalMessageConverterMetadata;
+  type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
 declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1,4 +1,4 @@
-import { AssistantMessage, Event, FilePart, GlobalSession, Message as Message$1, Message as Message$2, Model, OpencodeClient, OpencodeClient as OpencodeClient$1, OpencodeClientConfig, Part, Part as Part$1, PermissionRequest, PermissionRequest as PermissionRequest$1, Provider, QuestionAnswer, QuestionAnswer as QuestionAnswer$1, QuestionRequest, QuestionRequest as QuestionRequest$1, ReasoningPart, Session, Session as Session$1, SessionStatus, SessionStatus as SessionStatus$1, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpencodeClient as createOpencodeClient$1 } from "@opencode-ai/sdk/v2/client";
+import { AssistantMessage, Event, FilePart, GlobalSession, Message, Message as Message$1, Model, OpencodeClient, OpencodeClient as OpencodeClient$1, OpencodeClientConfig, Part, Part as Part$1, PermissionRequest, PermissionRequest as PermissionRequest$1, Provider, QuestionAnswer, QuestionAnswer as QuestionAnswer$1, QuestionRequest, QuestionRequest as QuestionRequest$1, ReasoningPart, Session, Session as Session$1, SessionStatus, SessionStatus as SessionStatus$1, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpencodeClient as createOpencodeClient$1 } from "@opencode-ai/sdk/v2/client";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -844,7 +844,7 @@ type MessageTiming = {
 };
 
 type MessageWithParts = {
-  info: Message$1;
+  info: Message;
   parts: Part[];
 };
 
@@ -987,7 +987,7 @@ type OpenCodeServerEvent = {
 
 type OpenCodeServerMessage = {
   id: string;
-  info: Message$1 | undefined;
+  info: Message | undefined;
   parts: readonly Part[];
   shadowParts: readonly ThreadUserMessagePart[] | undefined;
 };
@@ -1024,7 +1024,7 @@ type OpenCodeStateEvent = {
   error: unknown;
 } | {
   type: "message.updated";
-  info: Message$1;
+  info: Message;
 } | {
   type: "message.removed";
   messageId: string;
@@ -1955,7 +1955,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeAttachmentAdapter, OpenCodeAttachmentAdapterOptions, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
+  export { AssistantMessage, Event, FilePart, GlobalSession, Message$1 as Message, MessageWithParts, Model, OpenCodeAttachmentAdapter, OpenCodeAttachmentAdapterOptions, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
 }
 
 declare function projectOpenCodeThreadMessages(state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>): OpenCodeProjectedThreadMessage[];

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2099,6 +2099,28 @@ type ExportedMessageRepositoryItem = {
   runConfig?: RunConfig;
 };
 
+type ExternalMessageConverterCallback<T> = (message: T, metadata: ExternalMessageConverterMetadata) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+type ExternalMessageConverterMessage = (ThreadMessageLike & {
+  readonly convertConfig?: {
+    readonly joinStrategy?: JoinStrategy;
+  };
+}) | {
+  role: "tool";
+  toolCallId: string;
+  toolName?: string | undefined;
+  result: any;
+  artifact?: any;
+  isError?: boolean;
+  messages?: readonly ThreadMessage[];
+};
+
+type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
 type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
 
 type ExternalStoreAdapterBase<T> = {
@@ -5922,7 +5944,7 @@ declare namespace composer_d_exports {
   export { ComposerPrimitiveAddAttachment as AddAttachment, ComposerPrimitiveAttachmentByIndex as AttachmentByIndex, ComposerPrimitiveAttachmentDropzone as AttachmentDropzone, ComposerPrimitiveAttachments as Attachments, ComposerPrimitiveCancel as Cancel, ComposerPrimitiveDictate as Dictate, ComposerPrimitiveDictationTranscript as DictationTranscript, ComposerPrimitiveIf as If, ComposerPrimitiveInput as Input, ComposerPrimitiveQueue as Queue, ComposerPrimitiveQuote as Quote, ComposerPrimitiveQuoteDismiss as QuoteDismiss, ComposerPrimitiveQuoteText as QuoteText, ComposerPrimitiveRoot as Root, ComposerPrimitiveSend as Send, ComposerPrimitiveStopDictation as StopDictation, RegisteredTrigger as Unstable_RegisteredTrigger, TriggerMatcher as Unstable_TriggerMatcher, ComposerPrimitiveTriggerPopover as Unstable_TriggerPopover, ComposerPrimitiveTriggerPopoverBack as Unstable_TriggerPopoverBack, ComposerPrimitiveTriggerPopoverCategories as Unstable_TriggerPopoverCategories, ComposerPrimitiveTriggerPopoverCategoryItem as Unstable_TriggerPopoverCategoryItem, ComposerPrimitiveTriggerPopoverItem as Unstable_TriggerPopoverItem, ComposerPrimitiveTriggerPopoverItems as Unstable_TriggerPopoverItems, ComposerPrimitiveTriggerPopoverRoot as Unstable_TriggerPopoverRoot, useTriggerPopoverRootContext as unstable_useTriggerPopoverRootContext, useTriggerPopoverRootContextOptional as unstable_useTriggerPopoverRootContextOptional, useTriggerPopoverScopeContext as unstable_useTriggerPopoverScopeContext, useTriggerPopoverScopeContextOptional as unstable_useTriggerPopoverScopeContextOptional, useTriggerPopoverTriggers as unstable_useTriggerPopoverTriggers, useTriggerPopoverTriggersOptional as unstable_useTriggerPopoverTriggersOptional };
 }
 
-declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
+declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: ExternalMessageConverterCallback<T>, isRunning: boolean, metadata: ExternalMessageConverterMetadata) => ThreadMessage[];
 
 declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
   useThreadMessages: (_param8: {
@@ -6253,25 +6275,9 @@ declare const useComposerSend: () => (() => void) | null;
 declare const useComposerStopDictation: () => (() => void) | null;
 
 declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  type Message = ExternalMessageConverterMessage;
+  type Metadata = ExternalMessageConverterMetadata;
+  type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
 declare const useExternalMessageConverter: <T extends WeakKey>(_param14: {

--- a/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/external-store/message-conversion.mdx
@@ -23,7 +23,7 @@ const getExternalStoreMessages: <T>(input: { messages: readonly ThreadMessage[];
 ### unstable_convertExternalMessages
 
 ```ts
-const unstable_convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
+const unstable_convertExternalMessages: <T extends WeakKey>(messages: T[], callback: ExternalMessageConverterCallback<T>, isRunning: boolean, metadata: ExternalMessageConverterMetadata) => ThreadMessage[];
 ```
 
 ### unstable_createMessageConverter

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -1,424 +1,39 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import {
+  chunkExternalMessages,
+  completeExternalMessageConversion,
+  convertExternalMessageCallback,
+  convertExternalMessageChunk,
+  convertExternalMessages,
+  shallowArrayEqual,
+  type ExternalMessageConverterCallback,
+  type ExternalMessageConverterCallbackResult,
+  type ExternalMessageConverterChunk,
+  type ExternalMessageConverterMessage,
+  type ExternalMessageConverterMetadata,
+  type JoinStrategy,
+} from "../../runtime/utils/external-message-conversion";
+import { bindExternalStoreMessage } from "../../runtime/utils/external-store-message";
 import { ThreadMessageConverter } from "../../runtimes/external-store/thread-message-converter";
-import {
-  getExternalStoreMessages,
-  symbolInnerMessage,
-  bindExternalStoreMessage,
-  FALLBACK_ID_PREFIX,
-} from "../../runtime/utils/external-store-message";
-import {
-  fromThreadMessageLike,
-  type ThreadMessageLike,
-} from "../../runtime/utils/thread-message-like";
-import {
-  getAutoStatus,
-  isAutoStatus,
-  isInterruptedToolCall,
-  isPendingToolCall,
-} from "../../runtime/utils/auto-status";
-import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
-import type { ReadonlyJSONValue } from "assistant-stream/utils";
-import { generateErrorMessageId } from "../../utils/id";
-import type {
-  ThreadAssistantMessage,
-  ThreadMessage,
-  ToolCallMessagePart,
-} from "../../types/message";
-import type { MessageTiming } from "../../types/message";
 
 // Generatedness is tracked by identity, not by id shape: a caller-supplied id
 // that happens to match the generated pattern must never be rewritten.
 const generatedFallbackMessages = new WeakSet<object>();
 
-export type JoinStrategy = "concat-content" | "none";
+export { convertExternalMessages };
+export type { JoinStrategy };
 
 export namespace useExternalMessageConverter {
-  export type Message =
-    | (ThreadMessageLike & {
-        readonly convertConfig?: {
-          readonly joinStrategy?: JoinStrategy;
-        };
-      })
-    | {
-        role: "tool";
-        toolCallId: string;
-        toolName?: string | undefined;
-        result: any;
-        artifact?: any;
-        isError?: boolean;
-        messages?: readonly ThreadMessage[];
-      };
-
-  export type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-
-  export type Callback<T> = (
-    message: T,
-    metadata: Metadata,
-  ) => Message | Message[];
+  export type Message = ExternalMessageConverterMessage;
+  export type Metadata = ExternalMessageConverterMetadata;
+  export type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
-type CallbackResult<T> = {
-  input: T;
-  outputs: useExternalMessageConverter.Message[];
-};
-
-const stringifyForError = (value: unknown) => {
-  let text;
-  try {
-    text = value instanceof Error ? String(value) : JSON.stringify(value);
-  } catch {
-    /* circular */
-  }
-  text ??= String(value);
-  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
-};
-
-const toCallbackOutputs = (
-  output:
-    | useExternalMessageConverter.Message
-    | useExternalMessageConverter.Message[],
-  input: unknown,
-): useExternalMessageConverter.Message[] => {
-  const outputs = Array.isArray(output) ? output : [output];
-  for (const o of outputs) {
-    const valid =
-      typeof o === "object" &&
-      o !== null &&
-      (o.role === "tool" ||
-        ((o.role === "assistant" || o.role === "user" || o.role === "system") &&
-          (typeof o.content === "string" || Array.isArray(o.content))));
-    if (!valid)
-      throw new Error(
-        `External message converter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
-      );
-  }
-  return outputs;
-};
-
-type CallbackCacheEntry<T> = CallbackResult<T> & {
+type CallbackCacheEntry<T> = ExternalMessageConverterCallbackResult<T> & {
   metadata: useExternalMessageConverter.Metadata;
   callback: useExternalMessageConverter.Callback<T>;
-};
-
-type ChunkResult<T> = {
-  inputs: T[];
-  outputs: useExternalMessageConverter.Message[];
-};
-
-type Mutable<T> = {
-  -readonly [P in keyof T]: T[P];
-};
-
-const mergeInnerMessages = (existing: object, incoming: object) => ({
-  [symbolInnerMessage]: [
-    ...((existing as any)[symbolInnerMessage] ?? []),
-    ...((incoming as any)[symbolInnerMessage] ?? []),
-  ],
-});
-
-const joinExternalMessages = (
-  messages: readonly useExternalMessageConverter.Message[],
-): ThreadMessageLike => {
-  const assistantMessage: Mutable<Omit<ThreadMessageLike, "metadata">> & {
-    content: Exclude<ThreadMessageLike["content"][0], string>[];
-    metadata?: Mutable<ThreadMessageLike["metadata"]>;
-  } = {
-    role: "assistant",
-    content: [],
-  };
-  for (const output of messages) {
-    if (output.role === "tool") {
-      const toolCallIdx = assistantMessage.content.findIndex(
-        (c) => c.type === "tool-call" && c.toolCallId === output.toolCallId,
-      );
-      // Ignore orphaned tool results so one bad tool message does not
-      // prevent rendering the rest of the conversation.
-      if (toolCallIdx !== -1) {
-        const toolCall = assistantMessage.content[
-          toolCallIdx
-        ]! as ToolCallMessagePart;
-        if (output.toolName != null) {
-          if (toolCall.toolName !== output.toolName)
-            throw new Error(
-              `Tool call name ${output.toolCallId} ${output.toolName} does not match existing tool call ${toolCall.toolName}`,
-            );
-        }
-        assistantMessage.content[toolCallIdx] = {
-          ...toolCall,
-          ...{
-            [symbolInnerMessage]: [
-              ...((toolCall as any)[symbolInnerMessage] ?? []),
-              output,
-            ],
-          },
-          result: output.result,
-          artifact: output.artifact,
-          isError: output.isError,
-          messages: output.messages,
-        };
-      }
-    } else {
-      const role = output.role;
-      const content = (
-        typeof output.content === "string"
-          ? [{ type: "text" as const, text: output.content }]
-          : output.content
-      ).map((c) => ({
-        ...c,
-        ...{ [symbolInnerMessage]: [output] },
-      }));
-      switch (role) {
-        case "system":
-        case "user":
-          return {
-            ...output,
-            content,
-          };
-        case "assistant":
-          if (assistantMessage.content.length === 0) {
-            assistantMessage.id = output.id;
-            assistantMessage.createdAt ??= output.createdAt;
-            assistantMessage.status ??= output.status;
-
-            if (output.attachments) {
-              assistantMessage.attachments = [
-                ...(assistantMessage.attachments ?? []),
-                ...output.attachments,
-              ];
-            }
-          }
-
-          if (output.metadata) {
-            assistantMessage.metadata ??= {};
-            if (output.metadata.unstable_state !== undefined) {
-              assistantMessage.metadata.unstable_state =
-                output.metadata.unstable_state;
-            }
-            if (output.metadata.unstable_annotations) {
-              assistantMessage.metadata.unstable_annotations = [
-                ...(assistantMessage.metadata.unstable_annotations ?? []),
-                ...output.metadata.unstable_annotations,
-              ];
-            }
-            if (output.metadata.unstable_data) {
-              assistantMessage.metadata.unstable_data = [
-                ...(assistantMessage.metadata.unstable_data ?? []),
-                ...output.metadata.unstable_data,
-              ];
-            }
-            if (output.metadata.steps) {
-              assistantMessage.metadata.steps = [
-                ...(assistantMessage.metadata.steps ?? []),
-                ...output.metadata.steps,
-              ];
-            }
-            if (output.metadata.custom) {
-              assistantMessage.metadata.custom = {
-                ...(assistantMessage.metadata.custom ?? {}),
-                ...output.metadata.custom,
-              };
-            }
-
-            if (output.metadata.timing) {
-              assistantMessage.metadata.timing = output.metadata.timing;
-            }
-
-            if (output.metadata.submittedFeedback) {
-              assistantMessage.metadata.submittedFeedback =
-                output.metadata.submittedFeedback;
-            }
-
-            if (output.metadata.isOptimistic) {
-              assistantMessage.metadata.isOptimistic = true;
-            }
-            // TODO keep this in sync with ThreadMessageLike["metadata"] / fromThreadMessageLike
-          }
-
-          // Add content parts, merging reasoning parts with same parentId
-          for (const part of content) {
-            if (part.type === "tool-call") {
-              const existingIdx = assistantMessage.content.findIndex(
-                (c) =>
-                  c.type === "tool-call" && c.toolCallId === part.toolCallId,
-              );
-              if (existingIdx !== -1) {
-                const existing = assistantMessage.content[
-                  existingIdx
-                ] as typeof part;
-                assistantMessage.content[existingIdx] = {
-                  ...existing,
-                  ...part,
-                  ...mergeInnerMessages(existing, part),
-                };
-                continue;
-              }
-            }
-
-            if (
-              part.type === "reasoning" &&
-              "parentId" in part &&
-              part.parentId
-            ) {
-              const existingIdx = assistantMessage.content.findIndex(
-                (c) =>
-                  c.type === "reasoning" &&
-                  "parentId" in c &&
-                  c.parentId === part.parentId,
-              );
-              if (existingIdx !== -1) {
-                const existing = assistantMessage.content[
-                  existingIdx
-                ] as typeof part;
-                assistantMessage.content[existingIdx] = {
-                  ...existing,
-                  text: `${existing.text}\n\n${part.text}`,
-                  ...mergeInnerMessages(existing, part),
-                };
-                continue;
-              }
-            }
-            assistantMessage.content.push(part);
-          }
-          break;
-        default: {
-          const unsupportedRole: never = role;
-          throw new Error(`Unknown message role: ${unsupportedRole}`);
-        }
-      }
-    }
-  }
-  return assistantMessage;
-};
-
-const chunkExternalMessages = <T>(
-  callbackResults: CallbackResult<T>[],
-  joinStrategy?: JoinStrategy,
-) => {
-  const results: ChunkResult<T>[] = [];
-  let isAssistant = false;
-  let pendingNone = false; // true if the previous assistant message had joinStrategy "none"
-  let inputs: T[] = [];
-  let outputs: useExternalMessageConverter.Message[] = [];
-
-  const flush = () => {
-    if (outputs.length) {
-      results.push({
-        inputs,
-        outputs,
-      });
-    }
-    inputs = [];
-    outputs = [];
-    isAssistant = false;
-    pendingNone = false;
-  };
-
-  for (const callbackResult of callbackResults) {
-    for (const output of callbackResult.outputs) {
-      if (
-        (pendingNone && output.role !== "tool") ||
-        !isAssistant ||
-        output.role === "user" ||
-        output.role === "system"
-      ) {
-        flush();
-      }
-      isAssistant = output.role === "assistant" || output.role === "tool";
-
-      if (inputs.at(-1) !== callbackResult.input) {
-        inputs.push(callbackResult.input);
-      }
-      outputs.push(output);
-
-      if (
-        output.role === "assistant" &&
-        (output.convertConfig?.joinStrategy === "none" ||
-          joinStrategy === "none")
-      ) {
-        pendingNone = true;
-      }
-    }
-  }
-  flush();
-  return results;
-};
-
-function createErrorAssistantMessage(
-  error: ReadonlyJSONValue,
-): ThreadAssistantMessage {
-  const msg: ThreadAssistantMessage = {
-    id: generateErrorMessageId(),
-    role: "assistant",
-    content: [],
-    status: { type: "incomplete", reason: "error", error },
-    createdAt: new Date(),
-    metadata: {
-      unstable_state: null,
-      unstable_annotations: [],
-      unstable_data: [],
-      custom: {},
-      steps: [],
-    },
-  };
-  bindExternalStoreMessage(msg, []);
-  return msg;
-}
-
-export const convertExternalMessages = <T extends WeakKey>(
-  messages: T[],
-  callback: useExternalMessageConverter.Callback<T>,
-  isRunning: boolean,
-  metadata: useExternalMessageConverter.Metadata,
-) => {
-  const callbackResults: CallbackResult<T>[] = [];
-  for (const message of messages) {
-    const output = callback(message, metadata);
-    const outputs = toCallbackOutputs(output, message);
-    const result = { input: message, outputs };
-    callbackResults.push(result);
-  }
-
-  const chunks = chunkExternalMessages(callbackResults);
-
-  const result = chunks.map((message, idx) => {
-    const isLast = idx === chunks.length - 1;
-    const joined = joinExternalMessages(message.outputs);
-    const hasInterruptedToolCalls =
-      typeof joined.content === "object" &&
-      joined.content.some(isInterruptedToolCall);
-    const hasPendingToolCalls =
-      typeof joined.content === "object" &&
-      joined.content.some(isPendingToolCall);
-    const autoStatus = getAutoStatus(
-      isLast,
-      isRunning,
-      hasInterruptedToolCalls,
-      hasPendingToolCalls,
-      isLast ? metadata.error : undefined,
-    );
-    const newMessage = fromThreadMessageLike(
-      joined,
-      `${FALLBACK_ID_PREFIX}${idx}`,
-      autoStatus,
-    );
-    bindExternalStoreMessage(newMessage, message.inputs);
-    return newMessage;
-  });
-
-  if (metadata.error) {
-    const lastMessage = result.at(-1);
-    if (!lastMessage || lastMessage.role !== "assistant") {
-      result.push(createErrorAssistantMessage(metadata.error));
-    }
-  }
-
-  return result;
 };
 
 export const useExternalMessageConverter = <T extends WeakKey>({
@@ -444,8 +59,8 @@ export const useExternalMessageConverter = <T extends WeakKey>({
   const [caches] = useState(() => ({
     callbackCache: new WeakMap<T, CallbackCacheEntry<T>>(),
     chunkCache: new WeakMap<
-      useExternalMessageConverter.Message,
-      ChunkResult<T>
+      ExternalMessageConverterMessage,
+      ExternalMessageConverterChunk<T>
     >(),
     converterCache: new ThreadMessageConverter(),
   }));
@@ -460,7 +75,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
   );
 
   return useMemo(() => {
-    const callbackResults: CallbackResult<T>[] = [];
+    const callbackResults: ExternalMessageConverterCallbackResult<T>[] = [];
     for (const message of messages) {
       let result = state.callbackCache.get(message);
       if (
@@ -468,11 +83,12 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         result.metadata !== state.metadata ||
         result.callback !== state.callback
       ) {
-        const output = state.callback(message, state.metadata);
-        const outputs = toCallbackOutputs(output, message);
         result = {
-          input: message,
-          outputs,
+          ...convertExternalMessageCallback(
+            message,
+            state.callback,
+            state.metadata,
+          ),
           metadata: state.metadata,
           callback: state.callback,
         };
@@ -482,92 +98,39 @@ export const useExternalMessageConverter = <T extends WeakKey>({
     }
 
     const chunks = chunkExternalMessages(callbackResults, joinStrategy).map(
-      (m) => {
-        const key = m.outputs[0];
-        if (!key) return m;
+      (message) => {
+        const key = message.outputs[0];
+        if (!key) return message;
 
         const cached = state.chunkCache.get(key);
-        if (cached && shallowArrayEqual(cached.outputs, m.outputs))
+        if (cached && shallowArrayEqual(cached.outputs, message.outputs)) {
           return cached;
-        state.chunkCache.set(key, m);
-        return m;
+        }
+        state.chunkCache.set(key, message);
+        return message;
       },
     );
 
     const threadMessages = state.converterCache.convertMessages(
       chunks,
-      (cache, message, idx) => {
-        const isLast = idx === chunks.length - 1;
-
-        const joined = joinExternalMessages(message.outputs);
-        const hasInterruptedToolCalls =
-          typeof joined.content === "object" &&
-          joined.content.some(isInterruptedToolCall);
-        const hasPendingToolCalls =
-          typeof joined.content === "object" &&
-          joined.content.some(isPendingToolCall);
-        const autoStatus = getAutoStatus(
-          isLast,
+      (cache, message, idx) =>
+        convertExternalMessageChunk(
+          message,
+          idx,
+          chunks.length,
           isRunning,
-          hasInterruptedToolCalls,
-          hasPendingToolCalls,
-          isLast ? state.metadata.error : undefined,
-        );
-
-        const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
-
-        if (
-          cache &&
-          (cache.role !== "assistant" ||
-            !isAutoStatus(cache.status) ||
-            cache.status === autoStatus)
-        ) {
-          const inputs = getExternalStoreMessages<T>(cache);
-          if (shallowArrayEqual(inputs, message.inputs)) {
-            // A positional fallback id goes stale when messages are prepended
-            // or reordered; serving it unchanged makes two messages collide on
-            // one id and the dedup downstream drops one of them.
-            if (
-              generatedFallbackMessages.has(cache) &&
-              cache.id !== fallbackId
-            ) {
-              const updated = { ...cache, id: fallbackId };
-              generatedFallbackMessages.add(updated);
-              bindExternalStoreMessage(updated, message.inputs);
-              return updated;
-            }
-            return cache;
-          }
-        }
-
-        const newMessage = fromThreadMessageLike(
-          joined,
-          fallbackId,
-          autoStatus,
-        );
-        if (joined.id == null) generatedFallbackMessages.add(newMessage);
-        bindExternalStoreMessage(newMessage, message.inputs);
-        return newMessage;
-      },
+          state.metadata.error,
+          {
+            message: cache,
+            generatedFallbackMessages,
+          },
+        ),
     );
 
     bindExternalStoreMessage(threadMessages, messages);
-
-    if (state.metadata.error) {
-      const lastMessage = threadMessages.at(-1);
-      if (!lastMessage || lastMessage.role !== "assistant") {
-        threadMessages.push(createErrorAssistantMessage(state.metadata.error));
-      }
-    }
-
-    return threadMessages;
+    return completeExternalMessageConversion(
+      threadMessages,
+      state.metadata.error,
+    );
   }, [state, messages, isRunning, joinStrategy]);
-};
-
-const shallowArrayEqual = (a: unknown[], b: unknown[]) => {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
 };

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  chunkExternalMessages,
+  type ExternalMessageConverterCallbackResult,
+} from "./external-message-conversion";
+
+describe("chunkExternalMessages", () => {
+  it("keeps a tool result with a non-joining assistant before starting the next chunk", () => {
+    const toolCall = {};
+    const toolResult = {};
+    const answer = {};
+    const callbackResults: ExternalMessageConverterCallbackResult<object>[] = [
+      {
+        input: toolCall,
+        outputs: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call-1",
+                toolName: "search",
+                args: {},
+              },
+            ],
+            convertConfig: { joinStrategy: "none" },
+          },
+        ],
+      },
+      {
+        input: toolResult,
+        outputs: [
+          {
+            role: "tool",
+            toolCallId: "call-1",
+            toolName: "search",
+            result: "result",
+          },
+        ],
+      },
+      {
+        input: answer,
+        outputs: [{ role: "assistant", content: "answer" }],
+      },
+    ];
+
+    const chunks = chunkExternalMessages(callbackResults);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.inputs).toEqual([toolCall, toolResult]);
+    expect(chunks[0]?.outputs).toEqual([
+      callbackResults[0]?.outputs[0],
+      callbackResults[1]?.outputs[0],
+    ]);
+    expect(chunks[1]?.inputs).toEqual([answer]);
+  });
+});

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -1,0 +1,469 @@
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import type { ToolExecutionStatus } from "../../runtimes/tool-invocations/ToolInvocationTracker";
+import type {
+  ThreadAssistantMessage,
+  ThreadMessage,
+  ToolCallMessagePart,
+} from "../../types/message";
+import type { MessageTiming } from "../../types/message";
+import { generateErrorMessageId } from "../../utils/id";
+import {
+  getAutoStatus,
+  isAutoStatus,
+  isInterruptedToolCall,
+  isPendingToolCall,
+} from "./auto-status";
+import {
+  bindExternalStoreMessage,
+  FALLBACK_ID_PREFIX,
+  getExternalStoreMessages,
+  symbolInnerMessage,
+} from "./external-store-message";
+import {
+  fromThreadMessageLike,
+  type ThreadMessageLike,
+} from "./thread-message-like";
+
+export type JoinStrategy = "concat-content" | "none";
+
+export type ExternalMessageConverterMessage =
+  | (ThreadMessageLike & {
+      readonly convertConfig?: {
+        readonly joinStrategy?: JoinStrategy;
+      };
+    })
+  | {
+      role: "tool";
+      toolCallId: string;
+      toolName?: string | undefined;
+      result: any;
+      artifact?: any;
+      isError?: boolean;
+      messages?: readonly ThreadMessage[];
+    };
+
+export type ExternalMessageConverterMetadata = {
+  readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+  readonly error?: ReadonlyJSONValue;
+  readonly messageTiming?: Record<string, MessageTiming>;
+};
+
+export type ExternalMessageConverterCallback<T> = (
+  message: T,
+  metadata: ExternalMessageConverterMetadata,
+) => ExternalMessageConverterMessage | ExternalMessageConverterMessage[];
+
+export type ExternalMessageConverterCallbackResult<T> = {
+  input: T;
+  outputs: ExternalMessageConverterMessage[];
+};
+
+export type ExternalMessageConverterChunk<T> = {
+  inputs: T[];
+  outputs: ExternalMessageConverterMessage[];
+};
+
+type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};
+
+const stringifyForError = (value: unknown) => {
+  let text;
+  try {
+    text = value instanceof Error ? String(value) : JSON.stringify(value);
+  } catch {
+    /* circular */
+  }
+  text ??= String(value);
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+};
+
+const toCallbackOutputs = (
+  output: ExternalMessageConverterMessage | ExternalMessageConverterMessage[],
+  input: unknown,
+): ExternalMessageConverterMessage[] => {
+  const outputs = Array.isArray(output) ? output : [output];
+  for (const o of outputs) {
+    const valid =
+      typeof o === "object" &&
+      o !== null &&
+      (o.role === "tool" ||
+        ((o.role === "assistant" || o.role === "user" || o.role === "system") &&
+          (typeof o.content === "string" || Array.isArray(o.content))));
+    if (!valid)
+      throw new Error(
+        `External message converter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
+      );
+  }
+  return outputs;
+};
+
+export const convertExternalMessageCallback = <T>(
+  input: T,
+  callback: ExternalMessageConverterCallback<T>,
+  metadata: ExternalMessageConverterMetadata,
+): ExternalMessageConverterCallbackResult<T> => ({
+  input,
+  outputs: toCallbackOutputs(callback(input, metadata), input),
+});
+
+const mergeInnerMessages = (existing: object, incoming: object) => ({
+  [symbolInnerMessage]: [
+    ...((existing as any)[symbolInnerMessage] ?? []),
+    ...((incoming as any)[symbolInnerMessage] ?? []),
+  ],
+});
+
+export const joinExternalMessages = (
+  messages: readonly ExternalMessageConverterMessage[],
+): ThreadMessageLike => {
+  const assistantMessage: Mutable<Omit<ThreadMessageLike, "metadata">> & {
+    content: Exclude<ThreadMessageLike["content"][0], string>[];
+    metadata?: Mutable<ThreadMessageLike["metadata"]>;
+  } = {
+    role: "assistant",
+    content: [],
+  };
+  for (const output of messages) {
+    if (output.role === "tool") {
+      const toolCallIdx = assistantMessage.content.findIndex(
+        (c) => c.type === "tool-call" && c.toolCallId === output.toolCallId,
+      );
+      // Ignore orphaned tool results so one bad tool message does not
+      // prevent rendering the rest of the conversation.
+      if (toolCallIdx !== -1) {
+        const toolCall = assistantMessage.content[
+          toolCallIdx
+        ]! as ToolCallMessagePart;
+        if (output.toolName != null) {
+          if (toolCall.toolName !== output.toolName)
+            throw new Error(
+              `Tool call name ${output.toolCallId} ${output.toolName} does not match existing tool call ${toolCall.toolName}`,
+            );
+        }
+        assistantMessage.content[toolCallIdx] = {
+          ...toolCall,
+          ...{
+            [symbolInnerMessage]: [
+              ...((toolCall as any)[symbolInnerMessage] ?? []),
+              output,
+            ],
+          },
+          result: output.result,
+          artifact: output.artifact,
+          isError: output.isError,
+          messages: output.messages,
+        };
+      }
+    } else {
+      const role = output.role;
+      const content = (
+        typeof output.content === "string"
+          ? [{ type: "text" as const, text: output.content }]
+          : output.content
+      ).map((c) => ({
+        ...c,
+        ...{ [symbolInnerMessage]: [output] },
+      }));
+      switch (role) {
+        case "system":
+        case "user":
+          return {
+            ...output,
+            content,
+          };
+        case "assistant":
+          if (assistantMessage.content.length === 0) {
+            assistantMessage.id = output.id;
+            assistantMessage.createdAt ??= output.createdAt;
+            assistantMessage.status ??= output.status;
+
+            if (output.attachments) {
+              assistantMessage.attachments = [
+                ...(assistantMessage.attachments ?? []),
+                ...output.attachments,
+              ];
+            }
+          }
+
+          if (output.metadata) {
+            assistantMessage.metadata ??= {};
+            if (output.metadata.unstable_state !== undefined) {
+              assistantMessage.metadata.unstable_state =
+                output.metadata.unstable_state;
+            }
+            if (output.metadata.unstable_annotations) {
+              assistantMessage.metadata.unstable_annotations = [
+                ...(assistantMessage.metadata.unstable_annotations ?? []),
+                ...output.metadata.unstable_annotations,
+              ];
+            }
+            if (output.metadata.unstable_data) {
+              assistantMessage.metadata.unstable_data = [
+                ...(assistantMessage.metadata.unstable_data ?? []),
+                ...output.metadata.unstable_data,
+              ];
+            }
+            if (output.metadata.steps) {
+              assistantMessage.metadata.steps = [
+                ...(assistantMessage.metadata.steps ?? []),
+                ...output.metadata.steps,
+              ];
+            }
+            if (output.metadata.custom) {
+              assistantMessage.metadata.custom = {
+                ...(assistantMessage.metadata.custom ?? {}),
+                ...output.metadata.custom,
+              };
+            }
+
+            if (output.metadata.timing) {
+              assistantMessage.metadata.timing = output.metadata.timing;
+            }
+
+            if (output.metadata.submittedFeedback) {
+              assistantMessage.metadata.submittedFeedback =
+                output.metadata.submittedFeedback;
+            }
+
+            if (output.metadata.isOptimistic) {
+              assistantMessage.metadata.isOptimistic = true;
+            }
+            // TODO keep this in sync with ThreadMessageLike["metadata"] / fromThreadMessageLike
+          }
+
+          // Add content parts, merging reasoning parts with same parentId
+          for (const part of content) {
+            if (part.type === "tool-call") {
+              const existingIdx = assistantMessage.content.findIndex(
+                (c) =>
+                  c.type === "tool-call" && c.toolCallId === part.toolCallId,
+              );
+              if (existingIdx !== -1) {
+                const existing = assistantMessage.content[
+                  existingIdx
+                ] as typeof part;
+                assistantMessage.content[existingIdx] = {
+                  ...existing,
+                  ...part,
+                  ...mergeInnerMessages(existing, part),
+                };
+                continue;
+              }
+            }
+
+            if (
+              part.type === "reasoning" &&
+              "parentId" in part &&
+              part.parentId
+            ) {
+              const existingIdx = assistantMessage.content.findIndex(
+                (c) =>
+                  c.type === "reasoning" &&
+                  "parentId" in c &&
+                  c.parentId === part.parentId,
+              );
+              if (existingIdx !== -1) {
+                const existing = assistantMessage.content[
+                  existingIdx
+                ] as typeof part;
+                assistantMessage.content[existingIdx] = {
+                  ...existing,
+                  text: `${existing.text}\n\n${part.text}`,
+                  ...mergeInnerMessages(existing, part),
+                };
+                continue;
+              }
+            }
+            assistantMessage.content.push(part);
+          }
+          break;
+        default: {
+          const unsupportedRole: never = role;
+          throw new Error(`Unknown message role: ${unsupportedRole}`);
+        }
+      }
+    }
+  }
+  return assistantMessage;
+};
+
+export const chunkExternalMessages = <T>(
+  callbackResults: ExternalMessageConverterCallbackResult<T>[],
+  joinStrategy?: JoinStrategy,
+) => {
+  const results: ExternalMessageConverterChunk<T>[] = [];
+  let isAssistant = false;
+  let pendingNone = false; // true if the previous assistant message had joinStrategy "none"
+  let inputs: T[] = [];
+  let outputs: ExternalMessageConverterMessage[] = [];
+
+  const flush = () => {
+    if (outputs.length) {
+      results.push({
+        inputs,
+        outputs,
+      });
+    }
+    inputs = [];
+    outputs = [];
+    isAssistant = false;
+    pendingNone = false;
+  };
+
+  for (const callbackResult of callbackResults) {
+    for (const output of callbackResult.outputs) {
+      if (
+        (pendingNone && output.role !== "tool") ||
+        !isAssistant ||
+        output.role === "user" ||
+        output.role === "system"
+      ) {
+        flush();
+      }
+      isAssistant = output.role === "assistant" || output.role === "tool";
+
+      if (inputs.at(-1) !== callbackResult.input) {
+        inputs.push(callbackResult.input);
+      }
+      outputs.push(output);
+
+      if (
+        output.role === "assistant" &&
+        (output.convertConfig?.joinStrategy === "none" ||
+          joinStrategy === "none")
+      ) {
+        pendingNone = true;
+      }
+    }
+  }
+  flush();
+  return results;
+};
+
+export const shallowArrayEqual = (a: unknown[], b: unknown[]) => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
+type ExternalMessageConversionCache = {
+  message: ThreadMessage | undefined;
+  generatedFallbackMessages: WeakSet<object>;
+};
+
+export const convertExternalMessageChunk = <T>(
+  message: ExternalMessageConverterChunk<T>,
+  idx: number,
+  chunkCount: number,
+  isRunning: boolean,
+  error: ReadonlyJSONValue | undefined,
+  cache?: ExternalMessageConversionCache,
+) => {
+  const isLast = idx === chunkCount - 1;
+  const joined = joinExternalMessages(message.outputs);
+  const hasInterruptedToolCalls =
+    typeof joined.content === "object" &&
+    joined.content.some(isInterruptedToolCall);
+  const hasPendingToolCalls =
+    typeof joined.content === "object" &&
+    joined.content.some(isPendingToolCall);
+  const autoStatus = getAutoStatus(
+    isLast,
+    isRunning,
+    hasInterruptedToolCalls,
+    hasPendingToolCalls,
+    isLast ? error : undefined,
+  );
+  const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
+
+  const cachedMessage = cache?.message;
+  if (
+    cachedMessage &&
+    (cachedMessage.role !== "assistant" ||
+      !isAutoStatus(cachedMessage.status) ||
+      cachedMessage.status === autoStatus)
+  ) {
+    const inputs = getExternalStoreMessages<T>(cachedMessage);
+    if (shallowArrayEqual(inputs, message.inputs)) {
+      // A positional fallback id goes stale when messages are prepended
+      // or reordered; serving it unchanged makes two messages collide on
+      // one id and the dedup downstream drops one of them.
+      if (
+        cache.generatedFallbackMessages.has(cachedMessage) &&
+        cachedMessage.id !== fallbackId
+      ) {
+        const updated = { ...cachedMessage, id: fallbackId };
+        cache.generatedFallbackMessages.add(updated);
+        bindExternalStoreMessage(updated, message.inputs);
+        return updated;
+      }
+      return cachedMessage;
+    }
+  }
+
+  const newMessage = fromThreadMessageLike(joined, fallbackId, autoStatus);
+  if (cache && joined.id == null) {
+    cache.generatedFallbackMessages.add(newMessage);
+  }
+  bindExternalStoreMessage(newMessage, message.inputs);
+  return newMessage;
+};
+
+function createErrorAssistantMessage(
+  error: ReadonlyJSONValue,
+): ThreadAssistantMessage {
+  const msg: ThreadAssistantMessage = {
+    id: generateErrorMessageId(),
+    role: "assistant",
+    content: [],
+    status: { type: "incomplete", reason: "error", error },
+    createdAt: new Date(),
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      custom: {},
+      steps: [],
+    },
+  };
+  bindExternalStoreMessage(msg, []);
+  return msg;
+}
+
+export const completeExternalMessageConversion = (
+  messages: ThreadMessage[],
+  error: ReadonlyJSONValue | undefined,
+) => {
+  if (error) {
+    const lastMessage = messages.at(-1);
+    if (!lastMessage || lastMessage.role !== "assistant") {
+      messages.push(createErrorAssistantMessage(error));
+    }
+  }
+  return messages;
+};
+
+export const convertExternalMessages = <T extends WeakKey>(
+  messages: T[],
+  callback: ExternalMessageConverterCallback<T>,
+  isRunning: boolean,
+  metadata: ExternalMessageConverterMetadata,
+) => {
+  const callbackResults = messages.map((message) =>
+    convertExternalMessageCallback(message, callback, metadata),
+  );
+  const chunks = chunkExternalMessages(callbackResults);
+  const result = chunks.map((message, idx) =>
+    convertExternalMessageChunk(
+      message,
+      idx,
+      chunks.length,
+      isRunning,
+      metadata.error,
+    ),
+  );
+  return completeExternalMessageConversion(result, metadata.error);
+};


### PR DESCRIPTION
## summary

- external-message-converter.ts carried two parallel derivation chains (the plain convertExternalMessages path and the cached hook path), each joining chunk outputs, deriving interrupted and pending tool state, calling getAutoStatus, running fromThreadMessageLike, binding original messages, and appending the same synthesized error message
- the pure pipeline (callback validation, chunking, joining, the per-chunk derivation as ONE shared function, error completion) now lives in runtime/utils/external-message-conversion.ts; the hook module keeps only React cache ownership and memoization
- the single remaining plain/cached delta is an optional cache context (prior converted message plus the fallback-id identity tracker) that the cached path supplies for referential reuse and positional fallback-id refresh; everything else is shared
- every public name (convertExternalMessages, useExternalMessageConverter, createMessageConverter, JoinStrategy, and the unstable react aliases) keeps resolving from its current path; new colocated test covers the extracted pure module

## test plan

### already verified

- [x] full core vitest: 139 files, 1476 tests green (rerun independently); build 7/7; existing converter assertions untouched
- [x] store barrel and react alias re-exports verified unchanged

### reviewer should verify

- [ ] streaming conversion still reuses referentially-equal message objects across renders (the cache context path), and the synthesized error message still appends on error chunks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.0SlFsHDll7C83KveYHh7SGF-8yyJGfY_aF6sjKaNsInKqUX74-dKPCsR2x0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->