### PR TITLE
fix(react): apply mcp app host options after commit

### DIFF
--- a/.changeset/mcp-app-host-options-after-commit.md
+++ b/.changeset/mcp-app-host-options-after-commit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep committed MCP App host options active during interrupted renders

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
@@ -113,11 +113,11 @@ describe("McpAppsRemoteHost concurrent rendering", () => {
       <Probe url="/workspace-b/mcp" authorization="Bearer workspace-b" />,
     );
 
-    expect(fetch).toHaveBeenNthCalledWith(1, "/workspace-a/mcp", {
+    expect(fetch).toHaveBeenNthCalledWith(1, "/workspace-b/mcp", {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: "Bearer workspace-a",
+        authorization: "Bearer workspace-b",
       },
       body: JSON.stringify({
         method: "tools/call",

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
@@ -75,5 +75,70 @@ describe("McpAppsRemoteHost concurrent rendering", () => {
         params: { name: "search" },
       }),
     });
+
+    view.unmount();
+  });
+
+  it("keeps the URL and authorization from one committed options snapshot", async () => {
+    const fetch = vi.fn(async () => Response.json({ content: [] }));
+    let currentHost: McpAppsHost | undefined;
+
+    const Probe = ({
+      url,
+      authorization,
+    }: {
+      url: string;
+      authorization: string;
+    }) => {
+      const host = useResource(
+        McpAppsRemoteHost({
+          url,
+          fetch,
+          headers: { authorization },
+        }),
+      );
+      useLayoutEffect(() => {
+        currentHost = host;
+        void host.callTool({ name: "layout-request" });
+      }, [host]);
+      return null;
+    };
+
+    const view = render(
+      <Probe url="/workspace-a/mcp" authorization="Bearer workspace-a" />,
+    );
+    fetch.mockClear();
+
+    view.rerender(
+      <Probe url="/workspace-b/mcp" authorization="Bearer workspace-b" />,
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(1, "/workspace-a/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer workspace-a",
+      },
+      body: JSON.stringify({
+        method: "tools/call",
+        params: { name: "layout-request" },
+      }),
+    });
+
+    await currentHost?.callTool({ name: "committed-request" });
+
+    expect(fetch).toHaveBeenNthCalledWith(2, "/workspace-b/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer workspace-b",
+      },
+      body: JSON.stringify({
+        method: "tools/call",
+        params: { name: "committed-request" },
+      }),
+    });
+
+    view.unmount();
   });
 });

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { act, render } from "@testing-library/react";
+import { useResource } from "@assistant-ui/tap";
+import {
+  startTransition,
+  Suspense,
+  useLayoutEffect,
+  type ReactNode,
+} from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { McpAppsHost } from "./types";
+import { McpAppsRemoteHost } from "./McpAppsRemoteHost";
+
+describe("McpAppsRemoteHost concurrent rendering", () => {
+  it("keeps committed authorization options during an interrupted render", async () => {
+    const pending = new Promise<never>(() => {});
+    const fetch = vi.fn(async () => Response.json({ content: [] }));
+    let committedHost: McpAppsHost | undefined;
+
+    const Probe = ({
+      authorization,
+      suspend,
+      children,
+    }: {
+      authorization: string;
+      suspend: boolean;
+      children: ReactNode;
+    }) => {
+      const host = useResource(
+        McpAppsRemoteHost({
+          url: "/api/mcp-apps",
+          fetch,
+          headers: { authorization },
+        }),
+      );
+      useLayoutEffect(() => {
+        committedHost = host;
+      }, [host]);
+      if (suspend) throw pending;
+      return children;
+    };
+
+    const view = render(
+      <Suspense fallback={null}>
+        <Probe authorization="Bearer workspace-a" suspend={false}>
+          workspace-a
+        </Probe>
+      </Suspense>,
+    );
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(
+          <Suspense fallback={null}>
+            <Probe authorization="Bearer workspace-b" suspend>
+              workspace-b
+            </Probe>
+          </Suspense>,
+        );
+      });
+    });
+
+    expect(view.container.textContent).toBe("workspace-a");
+    await committedHost?.callTool({ name: "search" });
+
+    expect(fetch).toHaveBeenCalledWith("/api/mcp-apps", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer workspace-a",
+      },
+      body: JSON.stringify({
+        method: "tools/call",
+        params: { name: "search" },
+      }),
+    });
+  });
+});

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.concurrent.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, render } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { useResource } from "@assistant-ui/tap";
 import {
   startTransition,
@@ -140,5 +140,76 @@ describe("McpAppsRemoteHost concurrent rendering", () => {
     });
 
     view.unmount();
+  });
+
+  it("refreshes pending options when a URL switch render retries", async () => {
+    let authorization = "Bearer workspace-b-old";
+    let resumed = false;
+    let resume: (() => void) | undefined;
+    const pending = new Promise<void>((resolve) => {
+      resume = () => {
+        resumed = true;
+        resolve();
+      };
+    });
+    const fetch = vi.fn(async () => Response.json({ content: [] }));
+
+    const Probe = ({ url }: { url: string }) => {
+      const host = useResource(
+        McpAppsRemoteHost({
+          url,
+          fetch,
+          headers: {
+            authorization:
+              url === "/workspace-a/mcp" ? "Bearer workspace-a" : authorization,
+          },
+        }),
+      );
+      useLayoutEffect(() => {
+        void host.callTool({ name: "layout-request" });
+      }, [host]);
+      if (url === "/workspace-b/mcp" && !resumed) throw pending;
+      return <span>{url}</span>;
+    };
+
+    const view = render(
+      <Suspense fallback={null}>
+        <Probe url="/workspace-a/mcp" />
+      </Suspense>,
+    );
+    try {
+      fetch.mockClear();
+
+      act(() => {
+        startTransition(() => {
+          view.rerender(
+            <Suspense fallback={null}>
+              <Probe url="/workspace-b/mcp" />
+            </Suspense>,
+          );
+        });
+      });
+      expect(view.container.textContent).toBe("/workspace-a/mcp");
+
+      authorization = "Bearer workspace-b-new";
+      await act(async () => resume?.());
+      await waitFor(() =>
+        expect(view.container.textContent).toBe("/workspace-b/mcp"),
+      );
+
+      expect(fetch).toHaveBeenCalledWith("/workspace-b/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer workspace-b-new",
+        },
+        body: JSON.stringify({
+          method: "tools/call",
+          params: { name: "layout-request" },
+        }),
+      });
+    } finally {
+      view.unmount();
+    }
   });
 });

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -118,14 +118,7 @@ const useMcpAppsRemoteHost = (
   const url = options.url;
 
   return useMemo((): McpAppsHost => {
-    const getCurrentOptions = (): McpAppsRemoteHostOptions => {
-      const current = optionsRef.current;
-      return {
-        url,
-        ...(current.fetch !== undefined ? { fetch: current.fetch } : {}),
-        ...(current.headers !== undefined ? { headers: current.headers } : {}),
-      };
-    };
+    const getCurrentOptions = () => optionsRef.current;
     return {
       loadResource: async (params) => {
         const options = getCurrentOptions();
@@ -141,6 +134,7 @@ const useMcpAppsRemoteHost = (
       listResources: (params) =>
         postToHost(getCurrentOptions(), "resources/list", params),
     };
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- URL changes replace the host identity so renderer resources reload
   }, [url]);
 };
 

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { resource } from "@assistant-ui/tap";
 import type {
   McpAppResource,
@@ -111,7 +111,9 @@ const useMcpAppsRemoteHost = (
   options: McpAppsRemoteHostOptions,
 ): McpAppsHost => {
   const optionsRef = useRef(options);
-  optionsRef.current = options;
+  useEffect(() => {
+    optionsRef.current = options;
+  });
 
   const url = options.url;
 

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -145,6 +145,8 @@ const useMcpAppsRemoteHost = (
     // oxlint-disable-next-line react/exhaustive-deps -- URL changes replace the host identity; pending and same-URL options are refreshed outside the memo
   }, [url]);
 
+  // A URL mismatch identifies an unpublished WIP host. React flushes its Tap
+  // commit before that host can be reused as the matching live host.
   if (optionsRef.current.url !== url) {
     hostState.updatePendingOptions(options);
   }

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -118,7 +118,9 @@ const useMcpAppsRemoteHost = (
   const url = options.url;
 
   return useMemo((): McpAppsHost => {
-    const getCurrentOptions = () => optionsRef.current;
+    const initialOptions = options;
+    const getCurrentOptions = () =>
+      optionsRef.current.url === url ? optionsRef.current : initialOptions;
     return {
       loadResource: async (params) => {
         const options = getCurrentOptions();
@@ -134,7 +136,7 @@ const useMcpAppsRemoteHost = (
       listResources: (params) =>
         postToHost(getCurrentOptions(), "resources/list", params),
     };
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- URL changes replace the host identity so renderer resources reload
+    // oxlint-disable-next-line react/exhaustive-deps -- URL changes replace the host identity; same-URL options flow through optionsRef after commit
   }, [url]);
 };
 

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -145,8 +145,12 @@ const useMcpAppsRemoteHost = (
     // oxlint-disable-next-line react/exhaustive-deps -- URL changes replace the host identity; pending and same-URL options are refreshed outside the memo
   }, [url]);
 
-  // A URL mismatch identifies an unpublished WIP host. React flushes its Tap
-  // commit before that host can be reused as the matching live host.
+  // The pending snapshot is read only while the committed ref still lags this
+  // host's URL, and every write to it carries that same render's options, so
+  // no render can pair one URL with another's credentials. A committed host can
+  // be written here (a child layout effect re-rendering synchronously runs
+  // before passive effects publish the ref), which stays coherent for the same
+  // reason.
   if (optionsRef.current.url !== url) {
     hostState.updatePendingOptions(options);
   }

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.ts
@@ -117,11 +117,11 @@ const useMcpAppsRemoteHost = (
 
   const url = options.url;
 
-  return useMemo((): McpAppsHost => {
-    const initialOptions = options;
+  const hostState = useMemo(() => {
+    let pendingOptions = options;
     const getCurrentOptions = () =>
-      optionsRef.current.url === url ? optionsRef.current : initialOptions;
-    return {
+      optionsRef.current.url === url ? optionsRef.current : pendingOptions;
+    const host: McpAppsHost = {
       loadResource: async (params) => {
         const options = getCurrentOptions();
         return parseMcpAppResource(
@@ -136,8 +136,20 @@ const useMcpAppsRemoteHost = (
       listResources: (params) =>
         postToHost(getCurrentOptions(), "resources/list", params),
     };
-    // oxlint-disable-next-line react/exhaustive-deps -- URL changes replace the host identity; same-URL options flow through optionsRef after commit
+    return {
+      host,
+      updatePendingOptions: (next: McpAppsRemoteHostOptions) => {
+        pendingOptions = next;
+      },
+    };
+    // oxlint-disable-next-line react/exhaustive-deps -- URL changes replace the host identity; pending and same-URL options are refreshed outside the memo
   }, [url]);
+
+  if (optionsRef.current.url !== url) {
+    hostState.updatePendingOptions(options);
+  }
+
+  return hostState.host;
 };
 
 export const McpAppsRemoteHost = resource(useMcpAppsRemoteHost);


### PR DESCRIPTION
## Summary

- publish MCP App host options only after the Tap resource commits
- pair newly keyed hosts with WIP-local pending options before commit
- refresh pending options when a suspended URL-switch render retries with newer values
- keep same-URL fetch and header changes flowing through the committed options ref
- preserve URL-keyed host identity so renderer resources still reload when the endpoint changes

## Why

A render-phase ref write could leak credentials from an abandoned render into the still-committed host. Deferring the ref update fixes that, but a host newly keyed for URL B must not serve URL A while it waits for the Tap commit effect. It also must not retain credentials from an abandoned URL-B attempt when React retries that same URL with newer credentials.

Each URL-keyed WIP host owns an unpublished pending snapshot. While its URL differs from the committed ref, retries refresh only that WIP-local snapshot. Once Tap commits the matching URL, requests use the live committed ref. Abandoned renders can therefore affect neither the committed host nor later retries, while URL and credentials remain coherent from the first post-switch request.

For same-URL option changes, requests intentionally switch to the new fetch and headers when the Tap commit publishes them. A child effect earlier in that same React commit can still observe the previous coherent snapshot; this is the safety tradeoff that prevents an abandoned render from exposing uncommitted credentials.

## Test plan

- focused MCP host suites: 2 files, 9 tests pass
- suspended-retry regression fails with the old credentials when the pending refresh is removed, then passes with this fix
- Vitest type checking reports no errors
- Oxlint passes on the changed files
- Oxfmt passes on the changed files