### PR TITLE
fix(docs): map @assistant-ui/store/internal to its src entry

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -27,6 +27,7 @@
         "../../packages/react-generative-ui/src/*"
       ],
       "@assistant-ui/store/client": ["../../packages/store/src/client"],
+      "@assistant-ui/store/internal": ["../../packages/store/src/internal"],
       "@assistant-ui/*": ["../../packages/*/src"],
       "@assistant-ui/core/*": ["../../packages/core/src/*"],
       "@assistant-ui/react/*": ["../../packages/react/src/*"],


### PR DESCRIPTION
Local docs dev serves pages again. Before this change, every docs page returned a 500 in `next dev` with a module-not-found error for `@assistant-ui/store/internal`.

The docs app aliases `@assistant-ui/*` to `packages/*/src`. For this subpath, the wildcard resolves to `packages/store/internal/src`, a directory that does not exist. One explicit path entry, next to the existing `@assistant-ui/store/client` entry, points the subpath to `packages/store/src/internal`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2TAwf49oAExjWuRUI_pgF98Wz6IGp_PDFjYYosaAdYeYl1NXu7sKnc8yrF0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
