### PR TITLE
docs(sources): add url sources example

### DIFF
--- a/apps/docs/components/pages/docs/samples/sources/url-sources.tsx
+++ b/apps/docs/components/pages/docs/samples/sources/url-sources.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { SourceMessagePartProps } from "@assistant-ui/react";
+import { Sources } from "@/components/assistant-ui/sources";
+import { SampleFrame } from "@/components/pages/docs/samples/sample-frame";
+
+export function SourcesUrlSample() {
+  const parts: SourceMessagePartProps[] = [
+    {
+      type: "source",
+      sourceType: "url",
+      id: "source-titled",
+      url: "https://react.dev/reference/react",
+      title: "React Reference",
+      status: { type: "complete" },
+    },
+    {
+      type: "source",
+      sourceType: "url",
+      id: "source-untitled",
+      url: "https://developer.mozilla.org/en-US/docs/Web",
+      status: { type: "complete" },
+    },
+  ];
+
+  return (
+    <SampleFrame className="flex h-auto flex-wrap items-center justify-center gap-2 p-6">
+      {parts.map((part) => (
+        <Sources key={part.id} {...part} />
+      ))}
+    </SampleFrame>
+  );
+}

--- a/apps/docs/content/docs/ui/sources.mdx
+++ b/apps/docs/content/docs/ui/sources.mdx
@@ -5,6 +5,7 @@ platforms: ["react"]
 ---
 
 import { SourcesSample } from "@/components/pages/docs/samples/sources";
+import { SourcesUrlSample } from "@/components/pages/docs/samples/sources/url-sources";
 
 <SourcesSample />
 
@@ -68,6 +69,14 @@ Use the `size` prop to change the size.
 <Source size="default" /> // Default
 <Source size="lg" />      // Large
 ```
+
+## Examples
+
+### URL Sources
+
+One source shows its supplied title. The other source uses its domain because its title is absent.
+
+<SourcesUrlSample />
 
 ## API Reference
 


### PR DESCRIPTION
The Sources page now has an `## Examples` section with a first live demo. The demo renders two complete URL source parts through `Sources`. One part supplies a title. The other part omits it, so the badge shows the domain instead.

The sample is a direct render without a Code tab, because a seeded-props snippet would repeat the Getting Started example. This PR is the base of a five-part stack that adds one Sources demo per PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.oxTogy14W5Q2B6t0CiiodbgjToT3rdm8M3NHpwgK_5jUsRgHDaHOESjicfo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


## Screenshots

### URL Sources example

![The URL Sources example section on the docs page](https://artifacts.duncan.land/sources-url-example.png)
