### PR TITLE
fix(core): clear the thread list loading state after a superseded load

### DIFF
--- a/.changeset/quiet-thread-list-loads.md
+++ b/.changeset/quiet-thread-list-loads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: clear stale remote thread list loading states after reloads

--- a/.changeset/quiet-thread-list-loads.md
+++ b/.changeset/quiet-thread-list-loads.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: clear stale remote thread list loading states after reloads
+fix: clear the thread list loading state when a reload or adapter change supersedes the request

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -427,6 +427,63 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("clears loading when a reload supersedes a hung list", async () => {
+    const adapter = makeAdapter({
+      list: vi
+        .fn()
+        .mockImplementationOnce(() => new Promise<never>(() => {}))
+        .mockResolvedValueOnce({
+          threads: [
+            { status: "regular" as const, remoteId: "fresh", title: "Fresh" },
+          ],
+        }),
+    });
+    const { handle } = mountList(adapter);
+    const threads = handle.getClient().threads;
+
+    void threads.getLoadThreadsPromise();
+    await threads.reload();
+
+    await vi.waitFor(() => {
+      const state = handle.getClient().threads.getState();
+      expect(state.threadIds).toEqual(["fresh"]);
+      expect(state.isLoading).toBe(false);
+    });
+    handle.destroy();
+  });
+
+  it("clears loadingMore when a reload supersedes a hung loadMore", async () => {
+    const adapter = makeAdapter({
+      list: vi
+        .fn()
+        .mockResolvedValueOnce({
+          threads: [
+            { status: "regular" as const, remoteId: "t1", title: "One" },
+          ],
+          nextCursor: "c1",
+        })
+        .mockImplementationOnce(() => new Promise<never>(() => {}))
+        .mockResolvedValueOnce({
+          threads: [
+            { status: "regular" as const, remoteId: "fresh", title: "Fresh" },
+          ],
+        }),
+    });
+    const { handle } = mountList(adapter);
+    const threads = handle.getClient().threads;
+
+    await threads.getLoadThreadsPromise();
+    void threads.loadMore();
+    await threads.reload();
+
+    await vi.waitFor(() => {
+      const state = handle.getClient().threads.getState();
+      expect(state.threadIds).toEqual(["fresh"]);
+      expect(state.isLoadingMore).toBe(false);
+    });
+    handle.destroy();
+  });
+
   it("opens a controlled threadId without echoing it back", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -390,7 +390,10 @@ const useRemoteThreadList = (
     session.loadPromise = store
       .optimisticUpdate({
         execute: () => adapter.list(),
-        loading: (state) => ({ ...state, isLoading: true }),
+        loading: (state) => {
+          if (generation !== session.loadGeneration) return state;
+          return { ...state, isLoading: true };
+        },
         then: (state, page) => {
           if (generation !== session.loadGeneration) return state;
           session.adapterAtLoad = adapter;
@@ -486,7 +489,10 @@ const useRemoteThreadList = (
     const task = store
       .optimisticUpdate({
         execute: () => currentAdapter.list({ after: cursor }),
-        loading: (state) => ({ ...state, isLoadingMore: true }),
+        loading: (state) => {
+          if (generation !== session.loadGeneration) return state;
+          return { ...state, isLoadingMore: true };
+        },
         then: (state, page) => {
           if (generation !== session.loadGeneration) return state;
           const appended = classifyThreads(page.threads, {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -126,6 +126,7 @@ export class RemoteThreadListThreadListRuntimeCore
         .optimisticUpdate({
           execute: () => this._options.adapter.list(),
           loading: (state) => {
+            if (generation !== this._loadGeneration) return state;
             return {
               ...state,
               isLoading: true,
@@ -206,7 +207,10 @@ export class RemoteThreadListThreadListRuntimeCore
     const dedup = this._state
       .optimisticUpdate({
         execute: () => adapter.list({ after: cursor }),
-        loading: (state) => ({ ...state, isLoadingMore: true }),
+        loading: (state) =>
+          generation === this._loadGeneration
+            ? { ...state, isLoadingMore: true }
+            : state,
         then: (state, l) => {
           if (generation !== this._loadGeneration) return state;
           if (adapter !== this._options.adapter) return state;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -207,10 +207,10 @@ export class RemoteThreadListThreadListRuntimeCore
     const dedup = this._state
       .optimisticUpdate({
         execute: () => adapter.list({ after: cursor }),
-        loading: (state) =>
-          generation === this._loadGeneration
-            ? { ...state, isLoadingMore: true }
-            : state,
+        loading: (state) => {
+          if (generation !== this._loadGeneration) return state;
+          return { ...state, isLoadingMore: true };
+        },
         then: (state, l) => {
           if (generation !== this._loadGeneration) return state;
           if (adapter !== this._options.adapter) return state;

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
@@ -195,6 +195,30 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     expect(core.hasMore).toBe(false);
   });
 
+  it("clears loadingMore when the superseded request never settles", async () => {
+    const listFn = vi
+      .fn<ListFn>()
+      .mockResolvedValueOnce({
+        threads: [{ status: "regular", remoteId: "a", externalId: "a" }],
+        nextCursor: "c1",
+      })
+      .mockReturnValueOnce(new Promise<never>(() => {}))
+      .mockResolvedValueOnce({
+        threads: [
+          { status: "regular", remoteId: "fresh", externalId: "fresh" },
+        ],
+      });
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    await core.getLoadThreadsPromise();
+    void core.loadMore();
+    await core.reload();
+
+    expect(core.threadIds).toEqual(["fresh"]);
+    expect(core.isLoadingMore).toBe(false);
+  });
+
   it("releases the dedup handle after a rejection so retries can proceed", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const listFn = vi

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
@@ -119,6 +119,34 @@ describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
     expect(core.isLoading).toBe(false);
   });
 
+  it("clears loading once the fresh list arrives, before the superseded request settles", async () => {
+    const first = deferred<RemoteThreadListResponse>();
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({
+        threads: [
+          {
+            status: "regular",
+            remoteId: "fresh",
+            externalId: "fresh",
+            title: "Fresh",
+          },
+        ],
+      });
+    const core = createCore(makeAdapter({ list: listFn }));
+
+    void core.getLoadThreadsPromise();
+    await core.reload();
+
+    expect(core.threadIds).toEqual(["fresh"]);
+    expect(core.isLoading).toBe(false);
+
+    first.resolve({ threads: [] });
+    await Promise.resolve();
+    expect(core.isLoading).toBe(false);
+  });
+
   it("recovers after a failed initial load", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const listFn = vi

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts
@@ -95,6 +95,30 @@ describe("RemoteThreadListThreadListRuntimeCore.reload", () => {
     expect(core.threadIds).not.toContain("stale");
   });
 
+  it("clears loading when the superseded request never settles", async () => {
+    const listFn = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockReturnValueOnce(new Promise<never>(() => {}))
+      .mockResolvedValueOnce({
+        threads: [
+          {
+            status: "regular",
+            remoteId: "fresh",
+            externalId: "fresh",
+            title: "Fresh",
+          },
+        ],
+      });
+    const adapter = makeAdapter({ list: listFn });
+    const core = createCore(adapter);
+
+    void core.getLoadThreadsPromise();
+    await core.reload();
+
+    expect(core.threadIds).toEqual(["fresh"]);
+    expect(core.isLoading).toBe(false);
+  });
+
   it("recovers after a failed initial load", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const listFn = vi

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -51,6 +51,27 @@ describe("RemoteThreadList adapter changes", () => {
     expect(adapterB.rename).not.toHaveBeenCalled();
   });
 
+  it("clears loading when the replaced adapter's list never settles", async () => {
+    const adapterA = makeAdapter({
+      list: vi.fn(() => new Promise<never>(() => {})),
+    });
+    const adapterB = makeAdapter({
+      list: vi.fn(async () => ({ threads: [thread("thread-b")] })),
+    });
+    const core = createCore(adapterA);
+
+    void core.getLoadThreadsPromise();
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.threadIds).toEqual(["thread-b"]);
+    expect(core.isLoading).toBe(false);
+  });
+
   it("does not resume an old adapter mutation through the new adapter", async () => {
     const adapterA = makeAdapter({
       list: async () => ({ threads: [thread("thread-a")] }),


### PR DESCRIPTION
## Problem

after `reload()` or a thread-list adapter swap, the remote thread list can keep reporting `isLoading` (or `isLoadingMore`) even though the fresh list has already arrived and rendered. the spinner stays up, and because `loadMore()` bails on `initialState.isLoading` (`RemoteThreadListThreadListRuntimeCore.tsx:200`), pagination goes quiet with no error.

it does not take a hung request. any superseded `list()` that settles later than its replacement holds the flag for that whole window, which is why this mostly looks like a spinner that lingers and then fixes itself. a request that never settles makes it permanent.

## Root cause

`OptimisticState._updateState()` (`optimistic-state.ts:62`) recomputes the visible state by replaying the `loading` callback of every transform still in `_pendingTransforms`, and a transform only leaves that list when its own task settles (`:148`). `reload()` and the adapter swap advance `_loadGeneration`, and `then` and `catch` both already discard results from an older generation, but nothing stopped the older transform's `loading` callback from re-asserting the flag on every recompute.

## Change

every loading callback now returns the state untouched once its generation is stale, matching the guard `then` and `catch` already use in the same methods. checking the generation alone is sufficient for the adapter swap too, since `__internal_setOptions` advances `_loadGeneration` (`:304`) before calling `_state.update`, so the recompute that follows already sees the new generation. no optimistic thread mutation is reset, which is why this is a guard rather than an `OptimisticState.reset()`.

the tap client (`packages/core/src/react/client/RemoteThreadList.ts:393` and `:489`) carries the same two callbacks over the same `OptimisticState` and needs the same guard. its `reload()` only clears pending transforms on the adapter-changed path, which goes through `store.reset`; the ordinary reload path takes `store.update` and leaves them in place, so the flag sticks there exactly as it does in the legacy core.

## Verification

`pnpm -C packages/core exec vitest run src/react/client/RemoteThreadList.test.ts src/tests/RemoteThreadListThreadListRuntimeCore-reload.test.ts src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts src/tests/remote-thread-list-adapter-switch.test.ts`, 76 passed. reverting either changed source file to its pre-fix state fails exactly its own new tests with `expected true to be false`, so each one pins the guard rather than passing either way.

legacy core, four cases: a hung initial load superseded by `reload()`, a hung `loadMore()` superseded by `reload()`, an initial load that settles late rather than hanging, and a hung initial load superseded by an adapter swap. tap client, two cases: a hung initial load and a hung `loadMore()`, both superseded by `reload()`.

also `pnpm -C packages/core build` and `pnpm lint`, both clean.

## Public surface

none. no exports change, and the guard is internal to the runtime core. changeset: patch for `@assistant-ui/core`.
