### PR TITLE
fix(mcp-docs-server): validate template catalog entries

### DIFF
--- a/.changeset/calm-catalog-contract.md
+++ b/.changeset/calm-catalog-contract.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix: validate template catalog entries before using them

--- a/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
@@ -134,6 +134,33 @@ describe("assistant-ui template MCP tools", () => {
     );
   });
 
+  it("uses the fallback catalog when a live template entry is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          ...LIVE_CATALOG,
+          templates: [
+            {
+              id: "broken",
+              templateId: "broken",
+              kind: "template",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await callTool(xuluxTemplatesListTool, {});
+    expect(result.catalogDegraded).toBe(true);
+    expect(result.catalogDegradedReason).toContain(
+      "Catalog response is malformed",
+    );
+    expect(result.templates.map((t: { id: string }) => t.id)).toContain(
+      "base-assistant-ui",
+    );
+  });
+
   it("returns details and fetches exampleConfig from the selected sandbox contract", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
       const href = String(url);

--- a/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
@@ -161,6 +161,19 @@ describe("assistant-ui template MCP tools", () => {
     );
   });
 
+  it("names the version when the live catalog is a newer revision", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ ...LIVE_CATALOG, version: 2 })),
+    );
+
+    const result = await callTool(xuluxTemplatesListTool, {});
+    expect(result.catalogDegraded).toBe(true);
+    expect(result.catalogDegradedReason).toContain(
+      "Unsupported catalog version: 2. Expected 1.",
+    );
+  });
+
   it("uses the fallback catalog when a live template URL is malformed", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts
@@ -161,6 +161,29 @@ describe("assistant-ui template MCP tools", () => {
     );
   });
 
+  it("uses the fallback catalog when a live template URL is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          ...LIVE_CATALOG,
+          templates: [
+            {
+              ...LIVE_CATALOG.templates[0],
+              sandboxBaseUrl: "not a URL",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await callTool(xuluxTemplatesListTool, {});
+    expect(result.catalogDegraded).toBe(true);
+    expect(result.catalogDegradedReason).toContain(
+      "Catalog response is malformed",
+    );
+  });
+
   it("returns details and fetches exampleConfig from the selected sandbox contract", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
       const href = String(url);

--- a/packages/mcp-docs-server/src/xulux/catalog-client.ts
+++ b/packages/mcp-docs-server/src/xulux/catalog-client.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { logger } from "../utils/logger.js";
 import { FALLBACK_CATALOG, FALLBACK_NOTE } from "./fallback-catalog.js";
-import type { XuluxCatalog, XuluxCatalogResult } from "./types.js";
+import {
+  XULUX_MCP_CATALOG_VERSION,
+  type XuluxCatalog,
+  type XuluxCatalogResult,
+} from "./types.js";
 
 export const DEFAULT_CATALOG_URL =
   "https://www.assistant-ui.com/api/xulux/mcp-catalog";
@@ -61,6 +65,14 @@ export function getCatalogUrl(): string {
 }
 
 function validateCatalog(data: unknown): XuluxCatalog {
+  // Checked ahead of the schema so a catalog rollout reports its version
+  // rather than reading as a malformed payload.
+  const version = (data as { version?: unknown } | null)?.version;
+  if (version !== undefined && version !== XULUX_MCP_CATALOG_VERSION) {
+    throw new Error(
+      `Unsupported catalog version: ${String(version)}. Expected ${XULUX_MCP_CATALOG_VERSION}.`,
+    );
+  }
   const result = catalogSchema.safeParse(data);
   if (!result.success) {
     const issue = result.error.issues[0];
@@ -69,7 +81,7 @@ function validateCatalog(data: unknown): XuluxCatalog {
       `Catalog response is malformed${path}: ${issue?.message ?? "invalid catalog"}.`,
     );
   }
-  return result.data as XuluxCatalog;
+  return result.data;
 }
 
 interface CacheEntry {

--- a/packages/mcp-docs-server/src/xulux/catalog-client.ts
+++ b/packages/mcp-docs-server/src/xulux/catalog-client.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { logger } from "../utils/logger.js";
 import { FALLBACK_CATALOG, FALLBACK_NOTE } from "./fallback-catalog.js";
 import type { XuluxCatalog, XuluxCatalogResult } from "./types.js";
@@ -7,38 +8,67 @@ export const DEFAULT_CATALOG_URL =
 
 const CATALOG_TTL_MS = 5 * 60 * 1000;
 
+const catalogVersionSchema = z.looseObject({
+  id: z.string(),
+  entryId: z.string(),
+  name: z.string(),
+  description: z.string(),
+  previewUrl: z.string(),
+  downloadUrl: z.string(),
+});
+
+const catalogTemplateSchema = z.looseObject({
+  id: z.string(),
+  templateId: z.string(),
+  versionId: z.string().nullable(),
+  kind: z.enum(["template", "example"]),
+  name: z.string(),
+  summary: z.string(),
+  assistantPlacement: z.string(),
+  features: z.array(z.string()),
+  customizable: z.array(z.string()),
+  versions: z.array(catalogVersionSchema),
+  previewUrl: z.string().optional(),
+  downloadUrl: z.string().optional(),
+  sandboxBaseUrl: z.string().optional(),
+  configRoots: z.record(z.string(), z.unknown()).optional(),
+  rules: z
+    .looseObject({
+      required: z.array(z.string()),
+      unsupported: z.array(z.string()).optional(),
+    })
+    .optional(),
+  tools: z
+    .looseObject({
+      builtIn: z.array(z.unknown()),
+      customToolSupported: z.boolean(),
+      renderers: z.array(z.unknown()),
+    })
+    .optional(),
+});
+
+const catalogSchema = z.looseObject({
+  version: z.literal(1),
+  generatedAt: z.string(),
+  docsOrigin: z.string(),
+  templates: z.array(catalogTemplateSchema),
+});
+
 export function getCatalogUrl(): string {
   const override = process.env.XULUX_CATALOG_URL?.trim();
   return override || DEFAULT_CATALOG_URL;
 }
 
 function validateCatalog(data: unknown): XuluxCatalog {
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
-    throw new Error("Catalog response is not a JSON object.");
-  }
-  const catalog = data as XuluxCatalog;
-  if (catalog.version !== 1) {
+  const result = catalogSchema.safeParse(data);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const path = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
     throw new Error(
-      `Unsupported catalog version: ${String(catalog.version)}. Expected 1.`,
+      `Catalog response is malformed${path}: ${issue?.message ?? "invalid catalog"}.`,
     );
   }
-  if (!Array.isArray(catalog.templates)) {
-    throw new Error("Catalog response has no templates array.");
-  }
-  for (const template of catalog.templates) {
-    if (
-      !template ||
-      typeof template !== "object" ||
-      typeof template.id !== "string" ||
-      typeof template.templateId !== "string" ||
-      (template.kind !== "template" && template.kind !== "example")
-    ) {
-      throw new Error(
-        "Catalog response contains a malformed template entry (missing id/templateId/kind).",
-      );
-    }
-  }
-  return catalog;
+  return result.data as XuluxCatalog;
 }
 
 interface CacheEntry {

--- a/packages/mcp-docs-server/src/xulux/catalog-client.ts
+++ b/packages/mcp-docs-server/src/xulux/catalog-client.ts
@@ -54,8 +54,10 @@ const catalogTemplateSchema = z.looseObject({
 
 const catalogSchema = z.looseObject({
   version: z.literal(1),
+  // Not read anywhere in the package; validated for shape only, so an unused
+  // field cannot veto the whole catalog.
   generatedAt: z.string(),
-  docsOrigin: catalogUrlSchema,
+  docsOrigin: z.string(),
   templates: z.array(catalogTemplateSchema),
 });
 

--- a/packages/mcp-docs-server/src/xulux/catalog-client.ts
+++ b/packages/mcp-docs-server/src/xulux/catalog-client.ts
@@ -7,14 +7,15 @@ export const DEFAULT_CATALOG_URL =
   "https://www.assistant-ui.com/api/xulux/mcp-catalog";
 
 const CATALOG_TTL_MS = 5 * 60 * 1000;
+const catalogUrlSchema = z.url();
 
 const catalogVersionSchema = z.looseObject({
   id: z.string(),
   entryId: z.string(),
   name: z.string(),
   description: z.string(),
-  previewUrl: z.string(),
-  downloadUrl: z.string(),
+  previewUrl: catalogUrlSchema,
+  downloadUrl: catalogUrlSchema,
 });
 
 const catalogTemplateSchema = z.looseObject({
@@ -28,9 +29,9 @@ const catalogTemplateSchema = z.looseObject({
   features: z.array(z.string()),
   customizable: z.array(z.string()),
   versions: z.array(catalogVersionSchema),
-  previewUrl: z.string().optional(),
-  downloadUrl: z.string().optional(),
-  sandboxBaseUrl: z.string().optional(),
+  previewUrl: catalogUrlSchema.optional(),
+  downloadUrl: catalogUrlSchema.optional(),
+  sandboxBaseUrl: catalogUrlSchema.optional(),
   configRoots: z.record(z.string(), z.unknown()).optional(),
   rules: z
     .looseObject({
@@ -50,7 +51,7 @@ const catalogTemplateSchema = z.looseObject({
 const catalogSchema = z.looseObject({
   version: z.literal(1),
   generatedAt: z.string(),
-  docsOrigin: z.string(),
+  docsOrigin: catalogUrlSchema,
   templates: z.array(catalogTemplateSchema),
 });
 

--- a/packages/mcp-docs-server/src/xulux/catalog-client.ts
+++ b/packages/mcp-docs-server/src/xulux/catalog-client.ts
@@ -53,7 +53,7 @@ const catalogTemplateSchema = z.looseObject({
 });
 
 const catalogSchema = z.looseObject({
-  version: z.literal(1),
+  version: z.literal(XULUX_MCP_CATALOG_VERSION),
   // Not read anywhere in the package; validated for shape only, so an unused
   // field cannot veto the whole catalog.
   generatedAt: z.string(),

--- a/packages/mcp-docs-server/src/xulux/types.ts
+++ b/packages/mcp-docs-server/src/xulux/types.ts
@@ -24,19 +24,23 @@ export interface XuluxCatalogTemplate {
   features: string[];
   customizable: string[];
   versions: XuluxCatalogVersion[];
-  previewUrl?: string;
-  downloadUrl?: string;
-  sandboxBaseUrl?: string;
-  configRoots?: Record<string, unknown>;
-  rules?: {
-    required: string[];
-    unsupported?: string[];
-  };
-  tools?: {
-    builtIn: unknown[];
-    customToolSupported: boolean;
-    renderers: unknown[];
-  };
+  previewUrl?: string | undefined;
+  downloadUrl?: string | undefined;
+  sandboxBaseUrl?: string | undefined;
+  configRoots?: Record<string, unknown> | undefined;
+  rules?:
+    | {
+        required: string[];
+        unsupported?: string[] | undefined;
+      }
+    | undefined;
+  tools?:
+    | {
+        builtIn: unknown[];
+        customToolSupported: boolean;
+        renderers: unknown[];
+      }
+    | undefined;
 }
 
 export interface XuluxCatalog {


### PR DESCRIPTION
## Summary

- validate the complete live Xulux catalog contract before caching or consuming it
- keep unknown fields for forward compatibility while checking every field used by the template tools
- fall back to the bundled catalog when a successful HTTP response contains malformed entries

## Why

The previous validator checked only a template's `id`, `templateId`, and `kind`. A successful response such as `{ version: 1, templates: [{ id, templateId, kind }] }` passed validation, then `listTemplates()` crashed when it called `template.versions.map(...)`.

Validating at the fetch boundary turns malformed 200 responses into the existing degraded-catalog path, so tools return usable fallback data and a clear reason instead of throwing a low-context runtime error.

## Testing

- `vitest run packages/mcp-docs-server/src/tools/tests/xulux-templates.test.ts` (8 tests)
- `aui-build` in `packages/mcp-docs-server`
- `oxlint` on the changed source and test files

Includes a patch changeset for `@assistant-ui/mcp-docs-server`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8kLqQF8nTn18vOHYfTlIeAsyo7iMPyv6Ylw4kYiZx310pXO2aSofb_NBb6Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->