### PR TITLE
fix(react): apply sandbox bridge options after commit

### DIFF
--- a/.changeset/calm-sandbox-bridges.md
+++ b/.changeset/calm-sandbox-bridges.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep sandbox bridge options scoped to committed renders

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { act, startTransition, Suspense } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  SandboxBridge,
+  SandboxHostProps,
+} from "../sandbox-host/SandboxHost";
+import type { CreateMcpAppBridgeOptions, McpAppBridge } from "./bridge";
+import { MCP_APP_MIME_TYPE } from "./types";
+
+const { sandboxHostMock, createMcpAppBridgeMock } = vi.hoisted(() => ({
+  sandboxHostMock: vi.fn(),
+  createMcpAppBridgeMock: vi.fn(),
+}));
+
+vi.mock("../sandbox-host/SandboxHost", () => ({
+  SandboxHost: sandboxHostMock,
+}));
+
+vi.mock("./bridge", async (importOriginal) => ({
+  ...(await importOriginal()),
+  createMcpAppBridge: createMcpAppBridgeMock,
+}));
+
+import { McpAppFrame } from "./app-frame";
+
+describe("McpAppFrame", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps bridge options scoped to committed renders", async () => {
+    let committedCreateBridge: SandboxHostProps["createBridge"] | null = null;
+    sandboxHostMock.mockImplementation((props: SandboxHostProps) => {
+      committedCreateBridge ??= props.createBridge;
+      return null;
+    });
+    const bridge: McpAppBridge = {
+      onMessage: vi.fn(),
+      dispose: vi.fn(),
+      notifyToolInput: vi.fn(),
+      notifyToolResult: vi.fn(),
+      notifyHostContextChanged: vi.fn(),
+    };
+    createMcpAppBridgeMock.mockReturnValue(bridge);
+    const callToolA = vi.fn();
+    const callToolB = vi.fn();
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    const Block = () => {
+      interruptedRender();
+      throw pending;
+    };
+    const view = (
+      workspace: string,
+      callTool: typeof callToolA,
+      blocked: boolean,
+    ) => (
+      <Suspense fallback={null}>
+        <McpAppFrame
+          app={{ resourceUri: "ui://example/widget" }}
+          resource={{
+            uri: "ui://example/widget",
+            mimeType: MCP_APP_MIME_TYPE,
+            html: "",
+          }}
+          handlers={{ callTool }}
+          hostContext={{ workspace }}
+        />
+        {blocked ? <Block /> : null}
+      </Suspense>
+    );
+    const rendered = render(view("workspace-a", callToolA, false));
+
+    act(() => {
+      startTransition(() =>
+        rendered.rerender(view("workspace-b", callToolB, true)),
+      );
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+    expect(committedCreateBridge).not.toBeNull();
+
+    const sandboxBridge: SandboxBridge = committedCreateBridge!(
+      {
+        iframe: document.createElement("iframe"),
+        origin: "https://widget.example",
+        sendMessage: vi.fn(),
+      },
+      { setHeight: vi.fn() },
+    );
+    const options = createMcpAppBridgeMock.mock
+      .calls[0]![0] as CreateMcpAppBridgeOptions;
+    expect(options.hostContext).toEqual({ workspace: "workspace-a" });
+    await options.handlers?.callTool?.({ name: "search" });
+    expect(callToolA).toHaveBeenCalledOnce();
+    expect(callToolB).not.toHaveBeenCalled();
+
+    sandboxBridge.dispose();
+  });
+});

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { type MutableRefObject, useEffect, useRef } from "react";
+import {
+  type MutableRefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import { type McpAppBridge, createMcpAppBridge } from "./bridge";
 import {
   SandboxHost,
@@ -121,14 +126,22 @@ export function McpAppFrame({
     undefined,
   );
 
-  const liveRef = useRef<LiveSnapshot>(null!);
-  liveRef.current = {
+  const liveRef = useRef<LiveSnapshot>({
     handlers,
     hostInfo,
     hostContext,
     input,
     output,
-  };
+  });
+  useLayoutEffect(() => {
+    liveRef.current = {
+      handlers,
+      hostInfo,
+      hostContext,
+      input,
+      output,
+    };
+  }, [handlers, hostInfo, hostContext, input, output]);
 
   const createBridge = (
     frame: SandboxHostFrame,

--- a/packages/react/src/sandbox-host/SandboxHost.test.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act } from "react";
+import { act, startTransition, Suspense } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -317,5 +317,49 @@ describe("SandboxHost", () => {
       root.unmount();
     });
     expect(rendered.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps bridge options scoped to committed renders", async () => {
+    let resolveRender!: (frame: ReturnType<typeof fakeRendered>) => void;
+    renderHtmlMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRender = resolve;
+      }),
+    );
+    const rendered = fakeRendered();
+    const bridge = { onMessage: vi.fn(), dispose: vi.fn() };
+    const createBridgeA = vi.fn(() => bridge);
+    const createBridgeB = vi.fn(() => bridge);
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    const Block = () => {
+      interruptedRender();
+      throw pending;
+    };
+    const view = (createBridge: typeof createBridgeA, blocked: boolean) => (
+      <Suspense fallback={null}>
+        <SandboxHost
+          content={{ html: "" }}
+          contentKey="k"
+          createBridge={createBridge}
+        />
+        {blocked ? <Block /> : null}
+      </Suspense>
+    );
+
+    await act(async () => {
+      root.render(view(createBridgeA, false));
+    });
+    act(() => {
+      startTransition(() => root.render(view(createBridgeB, true)));
+    });
+    await vi.waitFor(() => expect(interruptedRender).toHaveBeenCalled());
+    await act(async () => {
+      resolveRender(rendered);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(createBridgeA).toHaveBeenCalledTimes(1);
+    expect(createBridgeB).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/sandbox-host/SandboxHost.tsx
+++ b/packages/react/src/sandbox-host/SandboxHost.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type CSSProperties, useEffect, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   type RenderedFrame,
   SafeContentFrame,
@@ -81,8 +87,15 @@ export function SandboxHost({
     undefined,
   );
 
-  const liveRef = useRef<LiveSnapshot>(null!);
-  liveRef.current = { content, sandbox, createBridge, onError };
+  const liveRef = useRef<LiveSnapshot>({
+    content,
+    sandbox,
+    createBridge,
+    onError,
+  });
+  useLayoutEffect(() => {
+    liveRef.current = { content, sandbox, createBridge, onError };
+  }, [content, sandbox, createBridge, onError]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary

- publish SandboxHost bridge options only after React commits them
- apply the same committed snapshot rule to MCP App handlers and host context
- add regressions for interrupted host and MCP App renders

## Why

SandboxHost and McpAppFrame previously updated live option refs during render. A workspace render that suspended and never committed could still replace `createBridge`, MCP handlers, host context, sandbox options, or error handlers used by the currently committed frame. When that frame finished loading, it could be wired to credentials or callbacks from the uncommitted workspace.

The snapshots are now published in layout effects. This keeps asynchronous frame setup and lazy bridge handlers on the committed configuration while still updating before passive frame work runs.

## Testing

- `vitest run src/sandbox-host/SandboxHost.test.tsx src/mcp-apps/app-frame.test.tsx`
- `aui-build`
- focused oxfmt and oxlint checks