### PR TITLE
fix(react): apply live completion fetchers after commit

### DIFF
--- a/.changeset/steady-live-completions.md
+++ b/.changeset/steady-live-completions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep live completion fetchers scoped to committed renders

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
-import { act, renderHook } from "@testing-library/react";
+import { startTransition, Suspense } from "react";
+import { act, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Unstable_TriggerItem } from "@assistant-ui/core";
 import { unstable_useLiveCompletionAdapter } from "./useLiveCompletionAdapter";
@@ -228,6 +229,64 @@ describe("unstable_useLiveCompletionAdapter", () => {
     });
     expect(second).not.toHaveBeenCalled();
     expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
+  });
+
+  it("keeps pending queries scoped to the committed fetcher", async () => {
+    const fetcherA = vi.fn(async () => [item("workspace-a")]);
+    const fetcherB = vi.fn(async () => [item("workspace-b")]);
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    let adapter!: ReturnType<
+      typeof unstable_useLiveCompletionAdapter
+    >["adapter"];
+    const Harness = ({
+      fetcher,
+      cacheKey,
+      blocked,
+    }: {
+      fetcher: typeof fetcherA;
+      cacheKey: string;
+      blocked: boolean;
+    }) => {
+      const result = unstable_useLiveCompletionAdapter({
+        fetcher,
+        cacheKey,
+        debounceMs: 50,
+      });
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      adapter = result.adapter;
+      return null;
+    };
+    const view = (
+      fetcher: typeof fetcherA,
+      cacheKey: string,
+      blocked: boolean,
+    ) => (
+      <Suspense fallback={null}>
+        <Harness fetcher={fetcher} cacheKey={cacheKey} blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view(fetcherA, "workspace-a", false));
+
+    await act(async () => {
+      adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      startTransition(() =>
+        rendered.rerender(view(fetcherB, "workspace-b", true)),
+      );
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(fetcherA).toHaveBeenCalledOnce();
+    expect(fetcherB).not.toHaveBeenCalled();
   });
 
   it("drops a pending result when only the cache key changes", async () => {

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -74,7 +74,10 @@ export function unstable_useLiveCompletionAdapter(
   const [isLoading, setIsLoading] = useState(false);
 
   const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
+  // The debounce timer must only observe fetchers from committed renders.
+  useLayoutEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tokenRef = useRef(0);


### PR DESCRIPTION
## Summary

- publish replacement live-completion fetchers only after React commits them
- keep debounced pending queries scoped to the visible data source
- add a regression test for an interrupted workspace render

## Why

The live-completion hook previously mutated `fetcherRef` during render. A workspace or account render that suspended and never committed could still replace the fetcher used by a query scheduled under the currently visible workspace. That query could then run with the uncommitted workspace's data source.

The fetcher ref is now updated in a layout effect, preserving dynamic fetchers without exposing interrupted render state.

## Testing

- `vitest run src/unstable/useLiveCompletionAdapter.test.tsx`
- `aui-build`
- focused oxfmt and oxlint checks

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IK8pJe_Fcba93Wp341fIqOn10jcsmAgI4Pw7_vkdHSQacSL6QDXWP6uTtB4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->