### PR TITLE
refactor(react-generative-ui): fold four duplicate run-consuming loops into one takeRun helper

### DIFF
--- a/.changeset/olive-pugs-smile.md
+++ b/.changeset/olive-pugs-smile.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-generative-ui": patch
 ---
 
-refactor: share one contiguous-run helper between the Slack and Teams sequence converters
+refactor: share one contiguous-run helper and one element predicate across the converters

--- a/.changeset/olive-pugs-smile.md
+++ b/.changeset/olive-pugs-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+refactor: share one contiguous-run helper between the Slack and Teams sequence converters

--- a/packages/react-generative-ui/src/convert/isElement.ts
+++ b/packages/react-generative-ui/src/convert/isElement.ts
@@ -1,0 +1,6 @@
+import type { NormalizedUIElement, NormalizedUINode } from "../ir";
+
+export const isElement = (
+  node: NormalizedUINode,
+): node is NormalizedUIElement =>
+  typeof node === "object" && node !== null && !Array.isArray(node);

--- a/packages/react-generative-ui/src/convert/takeRun.test.ts
+++ b/packages/react-generative-ui/src/convert/takeRun.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { NormalizedUIElement, NormalizedUINode } from "../ir";
+import { takeRun } from "./takeRun";
+
+const element = (type: string): NormalizedUIElement => ({ type, props: {} });
+
+const isFact = (candidate: NormalizedUIElement) => candidate.type === "Fact";
+
+describe("takeRun", () => {
+  it("collects the contiguous matching run and reports the resume index", () => {
+    const fact = element("Fact");
+    const nodes = [fact, fact, element("Text"), fact];
+
+    expect(takeRun(nodes, 0, isFact)).toEqual({ run: [fact, fact], next: 2 });
+  });
+
+  it("starts at the given index rather than the head of the list", () => {
+    const fact = element("Fact");
+    const nodes = [element("Text"), fact, fact];
+
+    expect(takeRun(nodes, 1, isFact)).toEqual({ run: [fact, fact], next: 3 });
+  });
+
+  it("stops at the end of the list", () => {
+    const fact = element("Fact");
+
+    expect(takeRun([fact, fact], 0, isFact)).toEqual({
+      run: [fact, fact],
+      next: 2,
+    });
+  });
+
+  it("returns an empty run without advancing when the first node does not match", () => {
+    expect(takeRun([element("Text"), element("Fact")], 0, isFact)).toEqual({
+      run: [],
+      next: 0,
+    });
+  });
+
+  it("stops on every non-element node shape", () => {
+    const fact = element("Fact");
+    const nonElements: (NormalizedUINode | undefined)[] = [
+      undefined,
+      null,
+      "",
+      "text",
+      0,
+      1,
+      [],
+      [fact],
+    ];
+
+    for (const nonElement of nonElements) {
+      expect(takeRun([fact, nonElement, fact], 0, isFact)).toEqual({
+        run: [fact],
+        next: 1,
+      });
+    }
+  });
+
+  it("stops past the end of the list", () => {
+    expect(takeRun([element("Fact")], 1, isFact)).toEqual({ run: [], next: 1 });
+  });
+});

--- a/packages/react-generative-ui/src/convert/takeRun.ts
+++ b/packages/react-generative-ui/src/convert/takeRun.ts
@@ -1,0 +1,21 @@
+import type { NormalizedUIElement, NormalizedUINode } from "../ir";
+
+const isElement = (node: NormalizedUINode): node is NormalizedUIElement =>
+  typeof node === "object" && node !== null && !Array.isArray(node);
+
+export function takeRun(
+  nodes: readonly (NormalizedUINode | undefined)[],
+  index: number,
+  matches: (element: NormalizedUIElement) => boolean,
+): { run: NormalizedUIElement[]; next: number } {
+  const run: NormalizedUIElement[] = [];
+  let next = index;
+  while (next < nodes.length) {
+    const candidate = nodes[next];
+    if (candidate === undefined || !isElement(candidate) || !matches(candidate))
+      break;
+    run.push(candidate);
+    next += 1;
+  }
+  return { run, next };
+}

--- a/packages/react-generative-ui/src/convert/takeRun.ts
+++ b/packages/react-generative-ui/src/convert/takeRun.ts
@@ -1,7 +1,5 @@
 import type { NormalizedUIElement, NormalizedUINode } from "../ir";
-
-const isElement = (node: NormalizedUINode): node is NormalizedUIElement =>
-  typeof node === "object" && node !== null && !Array.isArray(node);
+import { isElement } from "./isElement";
 
 export function takeRun(
   nodes: readonly (NormalizedUINode | undefined)[],

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -1,3 +1,4 @@
+import { takeRun } from "../convert/takeRun";
 import {
   normalizeSpec,
   type NormalizedUIElement,
@@ -1265,32 +1266,20 @@ function convertSequence(
       continue;
     }
     if (isElement(current) && current.type === "Fact") {
-      const facts: NormalizedUIElement[] = [];
-      while (index < nodes.length) {
-        const candidate = nodes[index];
-        if (!candidate || !isElement(candidate) || candidate.type !== "Fact") {
-          break;
-        }
-        facts.push(candidate);
-        index += 1;
-      }
+      const { run: facts, next } = takeRun(
+        nodes,
+        index,
+        (candidate) => candidate.type === "Fact",
+      );
+      index = next;
       blocks.push(...convertFacts(facts, context));
       continue;
     }
     if (isElement(current) && INTERACTIVE_TYPES.has(current.type)) {
-      const controls: NormalizedUIElement[] = [];
-      while (index < nodes.length) {
-        const candidate = nodes[index];
-        if (
-          !candidate ||
-          !isElement(candidate) ||
-          !INTERACTIVE_TYPES.has(candidate.type)
-        ) {
-          break;
-        }
-        controls.push(candidate);
-        index += 1;
-      }
+      const { run: controls, next } = takeRun(nodes, index, (candidate) =>
+        INTERACTIVE_TYPES.has(candidate.type),
+      );
+      index = next;
       blocks.push(...convertActions(controls, context));
       continue;
     }

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -1,3 +1,4 @@
+import { isElement } from "../convert/isElement";
 import { takeRun } from "../convert/takeRun";
 import {
   normalizeSpec,
@@ -87,9 +88,6 @@ const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isElement = (node: NormalizedUINode): node is NormalizedUIElement =>
-  isRecord(node);
 
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -1,3 +1,4 @@
+import { isElement } from "../convert/isElement";
 import { takeRun } from "../convert/takeRun";
 import {
   normalizeSpec,
@@ -44,9 +45,6 @@ export interface ConversionContext {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isElement = (node: NormalizedUINode): node is NormalizedUIElement =>
-  isRecord(node);
 
 const asString = (value: unknown): string =>
   typeof value === "string" ? value : "";

--- a/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
+++ b/packages/react-generative-ui/src/teams/toAdaptiveCard.ts
@@ -1,3 +1,4 @@
+import { takeRun } from "../convert/takeRun";
 import {
   normalizeSpec,
   type NormalizedUIElement,
@@ -729,32 +730,22 @@ export function convertSequence(
       continue;
     }
     if (isElement(current) && current.type === "Fact") {
-      const facts: NormalizedUIElement[] = [];
-      while (index < nodes.length) {
-        const candidate = nodes[index];
-        if (!candidate || !isElement(candidate) || candidate.type !== "Fact") {
-          break;
-        }
-        facts.push(candidate);
-        index += 1;
-      }
+      const { run: facts, next } = takeRun(
+        nodes,
+        index,
+        (candidate) => candidate.type === "Fact",
+      );
+      index = next;
       emit([convertFacts(facts)]);
       continue;
     }
     if (isElement(current) && current.type === "Button") {
-      const buttons: NormalizedUIElement[] = [];
-      while (index < nodes.length) {
-        const candidate = nodes[index];
-        if (
-          !candidate ||
-          !isElement(candidate) ||
-          candidate.type !== "Button"
-        ) {
-          break;
-        }
-        buttons.push(candidate);
-        index += 1;
-      }
+      const { run: buttons, next } = takeRun(
+        nodes,
+        index,
+        (candidate) => candidate.type === "Button",
+      );
+      index = next;
       emit([convertButtons(buttons, context)]);
       continue;
     }

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
@@ -1,3 +1,4 @@
+import { isElement } from "../convert/isElement";
 import {
   normalizeSpec,
   type NormalizedUIElement,
@@ -22,12 +23,6 @@ import type {
   TeamsConversionWarning,
   ToAdaptiveCardOptions,
 } from "./types";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isElement = (node: NormalizedUINode): node is NormalizedUIElement =>
-  isRecord(node);
 
 const normalizedList = (
   node: NormalizedUINode | undefined,


### PR DESCRIPTION
`convertSequence` in the Slack and Teams converters contains the same inner while loop four times: gather the contiguous run of sibling elements (Facts and interactive controls in Slack, Facts and Buttons in Teams) so they can be emitted as one block. Each copy repeats the bounds check, the element guard, and the index bookkeeping, so a fix to the run-collection logic has to land in four places.

This extracts a single `takeRun(nodes, index, matches)` helper that returns the run and the index to resume from, and routes all four sites through it. Run order and stop conditions are unchanged, and the Teams converter keeps its `emit()` closure at the call site so pending separator and spacing state still applies to the first element of each emitted group.

The element predicate those four sites guard on was itself copied per module, so `takeRun` would have introduced a fifth. It now lives in `convert/isElement.ts`, and `toSlackBlocks`, `toAdaptiveCard`, and `toTeamsAttachments` import it instead of redefining it; the private `isRecord` in `toTeamsAttachments` existed only to back that wrapper and goes with it. `convert/` is internal, so no export is added to the published surface.

Part of the ongoing duplication-reduction series.

## Verification

- `pnpm -C packages/react-generative-ui test`: 591/591 passing (585 existing, plus 6 new `takeRun` cases covering the run, the resume index, and every non-element stop shape)
- `pnpm lint` and `tsc --noEmit`: no new diagnostics
- `pnpm api-surface:check`: clean, the published surface is unchanged
- Equivalence against the four original loops checked exhaustively over every node shape (`undefined`, `null`, `""`, strings, numbers, arrays, elements) at every start index: 334084 cases, zero divergence

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.oms33nk7fQT4sspMEuhXfQc8Reo21weQEa-2pI4sGH66841XY2hvDY82b1U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->