### PR TITLE
refactor(ui): render all three diff-viewer row variants through one cell helper

### DIFF
--- a/packages/ui/src/components/assistant-ui/diff-viewer.test.tsx
+++ b/packages/ui/src/components/assistant-ui/diff-viewer.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DiffViewer } from "./diff-viewer";
+
+/** An insertion offsets the old and new numbering of the later change. */
+const PATCH = `--- a/example.ts
++++ b/example.ts
+@@ -1,3 +1,4 @@
+ const a = 1;
++const inserted = 0;
+ const b = 2;
+-const c = 3;
++const c = 4;
+`;
+
+afterEach(cleanup);
+
+const cellsOf = (row: Element) =>
+  Array.from(row.children).map((cell) => ({
+    slot: cell.getAttribute("data-slot"),
+    text: cell.textContent,
+  }));
+
+describe("DiffViewer unified rows", () => {
+  it("names each cell and numbers a deletion from the old file", () => {
+    const { container } = render(<DiffViewer patch={PATCH} />);
+    const rows = container.querySelectorAll('[data-slot="diff-viewer-line"]');
+
+    expect(cellsOf(rows[3]!)).toEqual([
+      { slot: "diff-viewer-line-number", text: "3" },
+      { slot: "diff-viewer-indicator", text: "-" },
+      { slot: "diff-viewer-content", text: "const c = 3;" },
+    ]);
+    expect(cellsOf(rows[4]!)).toEqual([
+      { slot: "diff-viewer-line-number", text: "4" },
+      { slot: "diff-viewer-indicator", text: "+" },
+      { slot: "diff-viewer-content", text: "const c = 4;" },
+    ]);
+  });
+
+  it("drops the number cell when line numbers are hidden", () => {
+    const { container } = render(
+      <DiffViewer patch={PATCH} showLineNumbers={false} />,
+    );
+    const row = container.querySelector('[data-slot="diff-viewer-line"]')!;
+
+    expect(cellsOf(row).map((cell) => cell.slot)).toEqual([
+      "diff-viewer-indicator",
+      "diff-viewer-content",
+    ]);
+  });
+});
+
+describe("DiffViewer split rows", () => {
+  it("numbers each half from its own side and leaves the cells unnamed", () => {
+    const { container } = render(<DiffViewer patch={PATCH} viewMode="split" />);
+    const row = Array.from(
+      container.querySelectorAll('[data-slot="diff-viewer-split-line"]'),
+    ).find((candidate) =>
+      candidate
+        .querySelector('[data-slot="diff-viewer-split-left"]')
+        ?.textContent?.includes("const c = 3;"),
+    )!;
+    const left = row.querySelector('[data-slot="diff-viewer-split-left"]')!;
+    const right = row.querySelector('[data-slot="diff-viewer-split-right"]')!;
+
+    expect(cellsOf(left)).toEqual([
+      { slot: null, text: "3" },
+      { slot: null, text: "-" },
+      { slot: null, text: "const c = 3;" },
+    ]);
+    expect(cellsOf(right)).toEqual([
+      { slot: null, text: "4" },
+      { slot: null, text: "+" },
+      { slot: null, text: "const c = 4;" },
+    ]);
+  });
+
+  it("renders an absent half empty and a context half with a blank indicator", () => {
+    const { container } = render(
+      <DiffViewer
+        patch={`--- a/example.ts
++++ b/example.ts
+@@ -1,1 +1,2 @@
+ const a = 1;
++const b = 2;
+`}
+        viewMode="split"
+      />,
+    );
+    const rows = container.querySelectorAll(
+      '[data-slot="diff-viewer-split-line"]',
+    );
+
+    const context = rows[0]!.querySelector(
+      '[data-slot="diff-viewer-split-left"]',
+    )!;
+    expect(cellsOf(context).map((cell) => cell.text)).toEqual([
+      "1",
+      " ",
+      "const a = 1;",
+    ]);
+
+    const absent = rows[1]!.querySelector(
+      '[data-slot="diff-viewer-split-left"]',
+    )!;
+    expect(absent.getAttribute("data-type")).toBe("empty");
+    expect(cellsOf(absent).map((cell) => cell.text)).toEqual(["", "", ""]);
+  });
+});

--- a/packages/ui/src/components/assistant-ui/diff-viewer.tsx
+++ b/packages/ui/src/components/assistant-ui/diff-viewer.tsx
@@ -296,6 +296,57 @@ function DiffViewerHeader({
   );
 }
 
+/**
+ * The three cells every diff row is built from. Only the unified view names
+ * them; a split half is addressed through its own container slot instead.
+ */
+function diffRowCells({
+  type,
+  lineNumber,
+  indicator,
+  content,
+  showLineNumbers,
+  named,
+}: {
+  type: DiffLineType | "empty";
+  lineNumber: string | number | undefined;
+  indicator: string;
+  content: string;
+  showLineNumbers: boolean;
+  named?: boolean;
+}) {
+  return (
+    <>
+      {showLineNumbers && (
+        <span
+          data-slot={named ? "diff-viewer-line-number" : undefined}
+          className="text-muted-foreground w-12 shrink-0 px-2 text-end select-none"
+        >
+          {lineNumber}
+        </span>
+      )}
+      <span
+        data-slot={named ? "diff-viewer-indicator" : undefined}
+        className={cn(
+          "w-4 shrink-0 text-center select-none",
+          diffLineTextVariants({ type }),
+        )}
+      >
+        {indicator}
+      </span>
+      <span
+        data-slot={named ? "diff-viewer-content" : undefined}
+        className={cn(
+          "flex-1 break-all whitespace-pre-wrap",
+          diffLineTextVariants({ type }),
+        )}
+      >
+        {content}
+      </span>
+    </>
+  );
+}
+
 interface DiffViewerLineProps extends ComponentProps<"div"> {
   line: ParsedLine;
   showLineNumbers?: boolean;
@@ -316,36 +367,19 @@ function DiffViewerLine({
       className={cn(diffLineVariants({ type: line.type }), className)}
       {...props}
     >
-      {showLineNumbers && (
-        <span
-          data-slot="diff-viewer-line-number"
-          className="text-muted-foreground w-12 shrink-0 px-2 text-end select-none"
-        >
-          {line.type === "del"
+      {diffRowCells({
+        type: line.type,
+        lineNumber:
+          line.type === "del"
             ? line.oldLineNumber
             : line.type === "add"
               ? line.newLineNumber
-              : line.oldLineNumber}
-        </span>
-      )}
-      <span
-        data-slot="diff-viewer-indicator"
-        className={cn(
-          "w-4 shrink-0 text-center select-none",
-          diffLineTextVariants({ type: line.type }),
-        )}
-      >
-        {indicator}
-      </span>
-      <span
-        data-slot="diff-viewer-content"
-        className={cn(
-          "flex-1 break-all whitespace-pre-wrap",
-          diffLineTextVariants({ type: line.type }),
-        )}
-      >
-        {line.content}
-      </span>
+              : line.oldLineNumber,
+        indicator,
+        content: line.content,
+        showLineNumbers,
+        named: true,
+      })}
     </div>
   );
 }
@@ -377,27 +411,13 @@ function DiffViewerSplitLine({
           diffLineVariants({ type: left?.type ?? "empty" }),
         )}
       >
-        {showLineNumbers && (
-          <span className="text-muted-foreground w-12 shrink-0 px-2 text-end select-none">
-            {left?.oldLineNumber ?? ""}
-          </span>
-        )}
-        <span
-          className={cn(
-            "w-4 shrink-0 text-center select-none",
-            diffLineTextVariants({ type: left?.type ?? "empty" }),
-          )}
-        >
-          {left ? (left.type === "del" ? "-" : " ") : ""}
-        </span>
-        <span
-          className={cn(
-            "flex-1 break-all whitespace-pre-wrap",
-            diffLineTextVariants({ type: left?.type ?? "empty" }),
-          )}
-        >
-          {left?.content ?? ""}
-        </span>
+        {diffRowCells({
+          type: left?.type ?? "empty",
+          lineNumber: left?.oldLineNumber ?? "",
+          indicator: left ? (left.type === "del" ? "-" : " ") : "",
+          content: left?.content ?? "",
+          showLineNumbers,
+        })}
       </div>
       <div
         data-slot="diff-viewer-split-right"
@@ -407,27 +427,13 @@ function DiffViewerSplitLine({
           diffLineVariants({ type: right?.type ?? "empty" }),
         )}
       >
-        {showLineNumbers && (
-          <span className="text-muted-foreground w-12 shrink-0 px-2 text-end select-none">
-            {right?.newLineNumber ?? ""}
-          </span>
-        )}
-        <span
-          className={cn(
-            "w-4 shrink-0 text-center select-none",
-            diffLineTextVariants({ type: right?.type ?? "empty" }),
-          )}
-        >
-          {right ? (right.type === "add" ? "+" : " ") : ""}
-        </span>
-        <span
-          className={cn(
-            "flex-1 break-all whitespace-pre-wrap",
-            diffLineTextVariants({ type: right?.type ?? "empty" }),
-          )}
-        >
-          {right?.content ?? ""}
-        </span>
+        {diffRowCells({
+          type: right?.type ?? "empty",
+          lineNumber: right?.newLineNumber ?? "",
+          indicator: right ? (right.type === "add" ? "+" : " ") : "",
+          content: right?.content ?? "",
+          showLineNumbers,
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
The diff viewer renders the same line-number / indicator / content cell trio in three places: the unified line and each half of the split view. Any styling or markup fix to a row has to be repeated in all three copies.

This routes all three through one `diffRowCells` helper. It is a plain render function rather than a component, so a large diff gains no extra fibers per cell. Behavior is unchanged: the unified cells keep their `data-slot` names while the split halves stay unnamed, each split half keeps its fixed column (left reads `oldLineNumber`, right reads `newLineNumber`), and an absent half still renders `""` where a present context half renders `" "`. The PR also adds the component's first test file, pinning exactly those invariants so the shared helper cannot silently change either view. Part of the ongoing duplication-reduction series.

## Verification

- `pnpm -C packages/ui test`: 372 passed, 15 skipped
- Rebased onto current main (ff9ad444b) before filing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.idKg4IT66AKyYlHt_ln9G1dBNFYauimWe95BP6sVPUfF2sgkls8Jrzk8Z5k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->