### PR TITLE
refactor(core): share the indexed-items iterator across list primitives

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: share the indexed-items iterator across the list primitives

--- a/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
+++ b/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
@@ -5,9 +5,10 @@ import {
   type ReactNode,
   useMemo,
 } from "react";
-import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useAuiState } from "@assistant-ui/store";
 import type { PartState } from "../../../store/scopes/part";
 import { ChainOfThoughtPartByIndexProvider } from "../../providers/ChainOfThoughtPartByIndexProvider";
+import { createIndexedItems } from "../utils/createIndexedItems";
 import { MessagePartComponent } from "../message/MessageParts";
 import type {
   ReasoningMessagePartComponent,
@@ -41,31 +42,16 @@ export namespace ChainOfThoughtPrimitiveParts {
       };
 }
 
-const ChainOfThoughtPrimitivePartsInner: FC<{
-  children: (value: { part: PartState }) => ReactNode;
-}> = ({ children }) => {
-  const partsLength = useAuiState((s) => s.chainOfThought.parts.length);
-
-  return useMemo(
-    () =>
-      Array.from({ length: partsLength }, (_, index) => (
-        <ChainOfThoughtPartByIndexProvider key={index} index={index}>
-          <RenderChildrenWithAccessor
-            getItemState={(aui) => aui.part.getState()}
-          >
-            {(getItem) =>
-              children({
-                get part() {
-                  return getItem();
-                },
-              })
-            }
-          </RenderChildrenWithAccessor>
-        </ChainOfThoughtPartByIndexProvider>
-      )),
-    [partsLength, children],
-  );
-};
+const ChainOfThoughtPrimitivePartsInner = createIndexedItems({
+  useLength: () => useAuiState((s) => s.chainOfThought.parts.length),
+  Provider: ChainOfThoughtPartByIndexProvider,
+  getItemState: (aui) => aui.part.getState(),
+  getValue: (getItem) => ({
+    get part(): PartState {
+      return getItem();
+    },
+  }),
+});
 
 /**
  * Renders the parts within a chain of thought, with support for collapsed/expanded states.

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -1,13 +1,8 @@
 import type { Attachment } from "../../../types/attachment";
-import {
-  type ComponentType,
-  type FC,
-  type ReactNode,
-  memo,
-  useMemo,
-} from "react";
-import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { type ComponentType, type FC, type ReactNode, memo } from "react";
+import { useAuiState } from "@assistant-ui/store";
 import { ComposerAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
+import { createIndexedItems } from "../utils/createIndexedItems";
 
 type ComposerAttachmentsComponentConfig = {
   Image?: ComponentType | undefined;
@@ -88,33 +83,16 @@ export const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentB
 ComposerPrimitiveAttachmentByIndex.displayName =
   "ComposerPrimitive.AttachmentByIndex";
 
-const ComposerPrimitiveAttachmentsInner: FC<{
-  children: (value: { attachment: Attachment }) => ReactNode;
-}> = ({ children }) => {
-  const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
-
-  return useMemo(
-    () =>
-      Array.from({ length: attachmentsCount }, (_, index) => (
-        <ComposerAttachmentByIndexProvider key={index} index={index}>
-          <RenderChildrenWithAccessor
-            getItemState={(aui) =>
-              aui.composer.attachment({ index }).getState()
-            }
-          >
-            {(getItem) =>
-              children({
-                get attachment() {
-                  return getItem();
-                },
-              })
-            }
-          </RenderChildrenWithAccessor>
-        </ComposerAttachmentByIndexProvider>
-      )),
-    [attachmentsCount, children],
-  );
-};
+const ComposerPrimitiveAttachmentsInner = createIndexedItems({
+  useLength: () => useAuiState((s) => s.composer.attachments.length),
+  Provider: ComposerAttachmentByIndexProvider,
+  getItemState: (aui, index) => aui.composer.attachment({ index }).getState(),
+  getValue: (getItem) => ({
+    get attachment(): Attachment {
+      return getItem();
+    },
+  }),
+});
 
 export const ComposerPrimitiveAttachments: FC<
   ComposerPrimitiveAttachments.Props

--- a/packages/core/src/react/primitives/composer/ComposerQueue.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerQueue.tsx
@@ -1,7 +1,8 @@
-import { type FC, type ReactNode, memo, useMemo } from "react";
-import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { type ReactNode, memo } from "react";
+import { useAuiState } from "@assistant-ui/store";
 import type { QueueItemState } from "../../../store/scopes/queue-item";
 import { QueueItemByIndexProvider } from "../../providers/QueueItemByIndexProvider";
+import { createIndexedItems } from "../utils/createIndexedItems";
 
 export namespace ComposerPrimitiveQueue {
   export type Props = {
@@ -10,31 +11,16 @@ export namespace ComposerPrimitiveQueue {
   };
 }
 
-const ComposerPrimitiveQueueInner: FC<{
-  children: (value: { queueItem: QueueItemState }) => ReactNode;
-}> = ({ children }) => {
-  const queue = useAuiState((s) => s.composer.queue.length);
-
-  return useMemo(
-    () =>
-      Array.from({ length: queue }, (_, index) => (
-        <QueueItemByIndexProvider key={index} index={index}>
-          <RenderChildrenWithAccessor
-            getItemState={(aui) => aui.composer.queueItem({ index }).getState()}
-          >
-            {(getItem) =>
-              children({
-                get queueItem() {
-                  return getItem();
-                },
-              })
-            }
-          </RenderChildrenWithAccessor>
-        </QueueItemByIndexProvider>
-      )),
-    [queue, children],
-  );
-};
+const ComposerPrimitiveQueueInner = createIndexedItems({
+  useLength: () => useAuiState((s) => s.composer.queue.length),
+  Provider: QueueItemByIndexProvider,
+  getItemState: (aui, index) => aui.composer.queueItem({ index }).getState(),
+  getValue: (getItem): { queueItem: QueueItemState } => ({
+    get queueItem() {
+      return getItem();
+    },
+  }),
+});
 
 /**
  * Renders all queue items in the composer.

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -1,13 +1,8 @@
 import type { CompleteAttachment } from "../../../types/attachment";
-import {
-  type ComponentType,
-  type FC,
-  type ReactNode,
-  memo,
-  useMemo,
-} from "react";
-import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { type ComponentType, type FC, type ReactNode, memo } from "react";
+import { useAuiState } from "@assistant-ui/store";
 import { MessageAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
+import { createIndexedItems } from "../utils/createIndexedItems";
 
 type MessageAttachmentsComponentConfig = {
   Image?: ComponentType | undefined;
@@ -88,34 +83,20 @@ export const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByI
 MessagePrimitiveAttachmentByIndex.displayName =
   "MessagePrimitive.AttachmentByIndex";
 
-const MessagePrimitiveAttachmentsInner: FC<{
-  children: (value: { attachment: CompleteAttachment }) => ReactNode;
-}> = ({ children }) => {
-  const attachmentsCount = useAuiState((s) => {
-    if (s.message.role !== "user") return 0;
-    return (s.message.attachments ?? []).length;
-  });
-
-  return useMemo(
-    () =>
-      Array.from({ length: attachmentsCount }, (_, index) => (
-        <MessageAttachmentByIndexProvider key={index} index={index}>
-          <RenderChildrenWithAccessor
-            getItemState={(aui) => aui.message.attachment({ index }).getState()}
-          >
-            {(getItem) =>
-              children({
-                get attachment() {
-                  return getItem() as CompleteAttachment;
-                },
-              })
-            }
-          </RenderChildrenWithAccessor>
-        </MessageAttachmentByIndexProvider>
-      )),
-    [attachmentsCount, children],
-  );
-};
+const MessagePrimitiveAttachmentsInner = createIndexedItems({
+  useLength: () =>
+    useAuiState((s) => {
+      if (s.message.role !== "user") return 0;
+      return (s.message.attachments ?? []).length;
+    }),
+  Provider: MessageAttachmentByIndexProvider,
+  getItemState: (aui, index) => aui.message.attachment({ index }).getState(),
+  getValue: (getItem) => ({
+    get attachment(): CompleteAttachment {
+      return getItem() as CompleteAttachment;
+    },
+  }),
+});
 
 export const MessagePrimitiveAttachments: FC<
   MessagePrimitiveAttachments.Props

--- a/packages/core/src/react/primitives/utils/createIndexedItems.test.tsx
+++ b/packages/core/src/react/primitives/utils/createIndexedItems.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { FC, ReactNode } from "react";
+import { createIndexedItems } from "./createIndexedItems";
+
+const mockLength = vi.fn<() => number>();
+const getItemStateCalls: number[] = [];
+const providerIndices: number[] = [];
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    RenderChildrenWithAccessor: ({
+      getItemState,
+      children,
+    }: {
+      getItemState: (aui: unknown) => unknown;
+      children: (getItem: () => unknown) => ReactNode;
+    }) => children(() => getItemState({ aui: true })),
+  };
+});
+
+const Provider: FC<{ index: number; children: ReactNode }> = ({
+  index,
+  children,
+}) => {
+  providerIndices.push(index);
+  return <div data-index={index}>{children}</div>;
+};
+
+const Items = createIndexedItems({
+  useLength: () => mockLength(),
+  Provider,
+  getItemState: (_aui, index) => {
+    getItemStateCalls.push(index);
+    return `item-${index}`;
+  },
+  getValue: (getItem) => ({
+    get item() {
+      return getItem();
+    },
+  }),
+});
+
+afterEach(() => {
+  cleanup();
+  getItemStateCalls.length = 0;
+  providerIndices.length = 0;
+});
+
+describe("createIndexedItems", () => {
+  it("renders one provider per index, in order", () => {
+    mockLength.mockReturnValue(3);
+
+    const { container } = render(<Items>{({ item }) => <p>{item}</p>}</Items>);
+
+    expect(providerIndices).toEqual([0, 1, 2]);
+    expect(
+      [...container.querySelectorAll("p")].map((p) => p.textContent),
+    ).toEqual(["item-0", "item-1", "item-2"]);
+  });
+
+  it("resolves each item from its own index", () => {
+    mockLength.mockReturnValue(2);
+
+    render(<Items>{({ item }) => <p>{item}</p>}</Items>);
+
+    expect(getItemStateCalls).toEqual([0, 1]);
+  });
+
+  it("does not invoke the item accessor when children ignores the value", () => {
+    mockLength.mockReturnValue(2);
+
+    render(<Items>{() => <p>static</p>}</Items>);
+
+    expect(providerIndices).toEqual([0, 1]);
+    expect(getItemStateCalls).toEqual([]);
+  });
+
+  it("renders nothing when there are no items", () => {
+    mockLength.mockReturnValue(0);
+
+    const { container } = render(<Items>{({ item }) => <p>{item}</p>}</Items>);
+
+    expect(providerIndices).toEqual([]);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/core/src/react/primitives/utils/createIndexedItems.tsx
+++ b/packages/core/src/react/primitives/utils/createIndexedItems.tsx
@@ -1,0 +1,44 @@
+import { type ComponentType, type FC, type ReactNode, useMemo } from "react";
+import {
+  type AssistantClient,
+  RenderChildrenWithAccessor,
+} from "@assistant-ui/store";
+
+/**
+ * `getValue` receives the accessor rather than the item so a call site can hand
+ * `children` a getter. Touching that getter is what marks the item as accessed,
+ * which is how `useGetItemAccessor` decides to subscribe to its updates.
+ */
+export const createIndexedItems = <TItem, TValue>({
+  useLength,
+  Provider,
+  getItemState,
+  getValue,
+}: {
+  useLength: () => number;
+  Provider: ComponentType<{ index: number; children: ReactNode }>;
+  getItemState: (aui: AssistantClient, index: number) => TItem;
+  getValue: (getItem: () => TItem) => TValue;
+}): FC<{ children: (value: TValue) => ReactNode }> => {
+  const IndexedItems: FC<{ children: (value: TValue) => ReactNode }> = ({
+    children,
+  }) => {
+    const length = useLength();
+
+    return useMemo(
+      () =>
+        Array.from({ length }, (_, index) => (
+          <Provider key={index} index={index}>
+            <RenderChildrenWithAccessor
+              getItemState={(aui) => getItemState(aui, index)}
+            >
+              {(getItem) => children(getValue(getItem))}
+            </RenderChildrenWithAccessor>
+          </Provider>
+        )),
+      [length, children],
+    );
+  };
+
+  return IndexedItems;
+};


### PR DESCRIPTION
Four list primitives (ChainOfThoughtParts, ComposerAttachments, ComposerQueue, MessageAttachments) each spelled out the same inner iterator by hand: read a length off the store, `Array.from` over it building an index-keyed provider, a `RenderChildrenWithAccessor`, and a lazy getter handed to the render function. Only the length selector, the provider component, the accessor path, and the getter's property name differed between them.

They now build that inner component through a shared `createIndexedItems` factory, which owns the memoized iteration and the accessor wiring while each call site keeps its own selector, provider, accessor path, and value shape. The published render-prop signatures are unchanged and the generated API surface does not move. `ThreadMessages` and `ThreadSuggestions` are deliberately left out: both return `null` rather than an empty array at length zero, an observable difference (MessageAttachments' own test pins the empty-array behavior), and encoding it as a factory flag would cost more than it saves.

Part of a series of small deduplication refactors.

## Verification

- `pnpm -C packages/core test`: 1483 tests pass, including a new `createIndexedItems.test.tsx` covering the factory directly.
- 7 files, +195/−124, rebased onto current main (ff9ad444b).
- Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Pp9UTUpVIKx8GWdt6SFhru5mjMQ4N6foQAUDp7yps79TOJ0K1sMGTwX229c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->