### PR TITLE
fix(registry): drop the unused tooltip-icon-button dependency from thread-list

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1151,12 +1151,7 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/thread-list.tsx",
       },
     ],
-    registryDependencies: [
-      "button",
-      "input",
-      "skeleton",
-      "https://r.assistant-ui.com/tooltip-icon-button.json",
-    ],
+    registryDependencies: ["button", "input", "skeleton"],
     dependencies: ["@assistant-ui/react", "lucide-react"],
   },
   {


### PR DESCRIPTION
`shadcn add thread-list` pulls `tooltip-icon-button` into the user's project even though `thread-list.tsx` never imports or renders it — the component only uses `button`, `input`, and `skeleton`. The stale registry entry costs every consumer an extra component file (plus its tooltip dependency chain) they never asked for.

This drops the `https://r.assistant-ui.com/tooltip-icon-button.json` entry from the thread-list registry item's `registryDependencies`. No other item reaches `tooltip-icon-button` through thread-list: `threadlist-sidebar`, its only dependent, does not use it either, and the items that do use it declare it themselves.

## Verification

- 44 registry tests pass, including the self-containment validation that checks every `@/components/*` import in an item's files resolves through its declared `registryDependencies`.
- Semantically cross-checked against #6366, which reworks the same registry area, to confirm no overlap.
- Rebased onto current main (ff9ad444b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5CqZj6HSeexQ7HEx2HKNx-FXYVKLlT3J7BesNX8On6puvMvJYp8nzX_Ao9o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->