### PR TITLE
refactor(react-mcp,react-opencode): generate ids from the shared core generator

### DIFF
--- a/.changeset/shared-id-generators.md
+++ b/.changeset/shared-id-generators.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-opencode": patch
+"@assistant-ui/react-mcp": patch
+---
+
+refactor: generate ids from the shared core generator instead of per-call-site implementations

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -8,6 +8,7 @@ import {
 } from "@assistant-ui/store";
 import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import { ModelContext } from "@assistant-ui/core/store";
+import { createMcpId } from "../utils/createMcpId";
 import type { Tool } from "assistant-stream";
 import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
@@ -275,10 +276,7 @@ const useMcpManagerResource = (
       elicitation,
     }) => {
       const record: MCPCustomServerRecord = {
-        id:
-          typeof crypto !== "undefined" && "randomUUID" in crypto
-            ? crypto.randomUUID()
-            : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        id: createMcpId(),
         name,
         url,
         auth: auth as MCPAuthConfig,

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -24,6 +24,7 @@ import type {
   MCPServerState,
   MCPToolInfo,
 } from "../mcp-scope";
+import { createMcpId } from "../utils/createMcpId";
 
 export type McpServerResourceProps = {
   id: string;
@@ -305,10 +306,7 @@ const useMcpServerResource = (
             }
             const { message, requestedSchema } = request.params;
 
-            const id =
-              typeof crypto !== "undefined" && "randomUUID" in crypto
-                ? crypto.randomUUID()
-                : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            const id = createMcpId();
             const promise = new Promise<ElicitResult>((resolve) => {
               const onAbort = () => {
                 resolvePendingElicitation(id, { action: "cancel" });

--- a/packages/react-mcp/src/utils/createMcpId.test.ts
+++ b/packages/react-mcp/src/utils/createMcpId.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMcpId } from "./createMcpId";
+import { assertValidServerId } from "./serverId";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createMcpId", () => {
+  it("uses the platform UUID when one is available", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: () => "11111111-2222-3333-4444-555555555555",
+    });
+    expect(createMcpId()).toBe("11111111-2222-3333-4444-555555555555");
+  });
+
+  it("falls back to a prefixed generated id without randomUUID", () => {
+    vi.stubGlobal("crypto", {});
+    const first = createMcpId();
+    const second = createMcpId();
+    expect(first).toMatch(/^mcp-[0-9A-Za-z]+$/);
+    expect(second).not.toBe(first);
+    expect(() => assertValidServerId(first)).not.toThrow();
+  });
+});

--- a/packages/react-mcp/src/utils/createMcpId.ts
+++ b/packages/react-mcp/src/utils/createMcpId.ts
@@ -1,0 +1,10 @@
+import { generateId } from "@assistant-ui/core";
+
+/**
+ * Both forms are alphanumeric or hyphenated, so neither can contain the
+ * separators `assertValidServerId` reserves.
+ */
+export const createMcpId = (): string =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `mcp-${generateId()}`;

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -28,6 +28,7 @@ import {
   STREAM_RECONNECTED_EVENT_TYPE,
   type OpenCodeEventSource,
 } from "./OpenCodeEventSource";
+import { generateId } from "@assistant-ui/core";
 import {
   resolveFileMediaType,
   resolveImageMediaType,
@@ -43,9 +44,6 @@ type ChildControllerEntry = {
   controller: OpenCodeThreadController;
   unsubscribe: (() => void) | null;
 };
-
-const createLocalId = (prefix: string) =>
-  `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 
 const getTextContent = (parts: readonly ThreadUserMessagePart[]) =>
   serializeOpenCodeParts(parts).trim();
@@ -561,7 +559,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     ) as readonly ThreadUserMessagePart[];
 
     return {
-      clientId: createLocalId("local"),
+      clientId: generateId(),
       sessionId: this.sessionId,
       createdAt: Date.now(),
       parentId: message.parentId,


### PR DESCRIPTION
react-mcp repeated the same `crypto.randomUUID()`-or-hand-rolled-fallback ternary in two places (the custom-server record and the elicitation request id), and react-opencode carried its own `createLocalId` helper for a single ephemeral `clientId`. Core already ships `generateId`; three private copies of the same fallback logic is drift waiting to happen.

react-mcp keeps `crypto.randomUUID()` first, so a persisted `MCPCustomServerRecord` keeps the id format it has always had; only the no-randomUUID fallback changes, becoming a prefixed `generateId()`. One `createMcpId` helper now serves both sites. The ids are opaque: `assertValidServerId` only rejects empty ids, `"__"`, and `\x1f`, and nothing parses them. react-opencode's `clientId` keys an in-memory `pendingUserMessages` map and is never persisted or parsed, so it takes `generateId()` directly.

Two nearby generators are deliberately left alone: the OAuth state nonce in `createOAuthProvider` is a CSRF value whose fallback would lose entropy, and cloud-ai-sdk's `createSessionId` would need a new `@assistant-ui/core` dependency to reach `generateId`.

Note on the import: core's `generateId` carries an `@deprecated` JSDoc tag, but in this codebase that tag is used as an experimental-API marker, not a superseded-API marker; #6342 established the same convention of importing it from the public `@assistant-ui/core` entry, which this PR follows.

## Verification

- `pnpm -C packages/react-mcp test`: 132 tests pass (including a new `createMcpId` test covering both the UUID path and the fallback).
- `pnpm -C packages/react-opencode test`: 132 tests pass.
- 6 files, +47/−12, rebased onto current main (ff9ad444b).
- Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ntUpZqEzE-kH20OVNlzJHfd2fvs5f33MFKXXax02wXpirXe89GEYGipeyDw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->