### PR TITLE
refactor(react-pi): replace the controller version-counter bridge with stable snapshots

### DIFF
--- a/.changeset/pi-stable-snapshots.md
+++ b/.changeset/pi-stable-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+refactor: subscribe the Pi runtime to stable controller snapshots instead of a version counter

--- a/.changeset/pi-stable-snapshots.md
+++ b/.changeset/pi-stable-snapshots.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-pi": patch
 ---
 
-refactor: subscribe the Pi runtime to stable controller snapshots instead of a version counter
+refactor: subscribe the Pi runtime to stable controller snapshots instead of a version counter. a `PiThreadControllerLike` implementation must now return reference-stable values from `getState` (or the new optional `getStateSnapshot`) and `getMessageRepository`, since the React bindings read them as `useSyncExternalStore` snapshots.

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1384,6 +1384,7 @@ declare class PiThreadController implements PiThreadControllerLike {
     scheduleNotify?: PiNotificationScheduler;
   });
   getState(): PiThreadState;
+  getStateSnapshot(): PiThreadState;
   getProjectedMessages(): readonly ThreadMessageLike[];
   getMessageRepository(): ExportedMessageRepository;
   getVersion(): number;
@@ -1412,6 +1413,7 @@ declare class PiThreadController implements PiThreadControllerLike {
 
 interface PiThreadControllerLike {
   getState(): PiThreadState;
+  getStateSnapshot?(): PiThreadState;
   getProjectedMessages(): readonly ThreadMessageLike[];
   getMessageRepository(): ExportedMessageRepository;
   getVersion(): number;

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -851,7 +851,8 @@ describe("PiThreadController state snapshot", () => {
     const controller = new PiThreadController(client, THREAD, {
       scheduleNotify: (flush) => scheduled.push(flush),
     });
-    controller.subscribe(() => {});
+    const notify = vi.fn();
+    controller.subscribe(notify);
     controller.connect();
 
     client.emit(
@@ -874,6 +875,7 @@ describe("PiThreadController state snapshot", () => {
     );
     scheduled.at(-1)!();
     const projection = controller.getMessageRepository();
+    notify.mockClear();
 
     client.emit(
       ev({ type: "message_end", message: assistantMessage("a", 1) }, 3),
@@ -881,6 +883,31 @@ describe("PiThreadController state snapshot", () => {
 
     expect(controller.getMessageRepository()).toBe(projection);
     expect(controller.getState().streamingMessageIndex).toBeUndefined();
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify when neither the projection nor state moved", () => {
+    const client = createFakeClient();
+    const scheduled: Array<() => void> = [];
+    const controller = new PiThreadController(client, THREAD, {
+      scheduleNotify: (flush) => scheduled.push(flush),
+    });
+    const notify = vi.fn();
+    controller.subscribe(notify);
+    controller.connect();
+
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("", 1) }, 1),
+    );
+    notify.mockClear();
+
+    // A stale-seq event the reducer drops entirely.
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("", 1) }, 0),
+    );
+
+    expect(notify).not.toHaveBeenCalled();
     expect(controller.getStateSnapshot()).toBe(controller.getState());
   });
 

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -845,6 +845,45 @@ describe("PiThreadController state snapshot", () => {
     expect(seen[1]).toBe(controller.getState());
   });
 
+  it("publishes state when a message event leaves the projection unchanged", () => {
+    const client = createFakeClient();
+    const scheduled: Array<() => void> = [];
+    const controller = new PiThreadController(client, THREAD, {
+      scheduleNotify: (flush) => scheduled.push(flush),
+    });
+    controller.subscribe(() => {});
+    controller.connect();
+
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("", 1) }, 1),
+    );
+    client.emit(
+      ev(
+        {
+          type: "message_update",
+          message: assistantMessage("a", 1),
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "a",
+            partial: assistantMessage("a", 1),
+          },
+        },
+        2,
+      ),
+    );
+    scheduled.at(-1)!();
+    const projection = controller.getMessageRepository();
+
+    client.emit(
+      ev({ type: "message_end", message: assistantMessage("a", 1) }, 3),
+    );
+
+    expect(controller.getMessageRepository()).toBe(projection);
+    expect(controller.getState().streamingMessageIndex).toBeUndefined();
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
+  });
+
   it("starts the snapshot at the initial state", () => {
     const controller = new PiThreadController(createFakeClient(), THREAD);
     expect(controller.getStateSnapshot()).toBe(controller.getState());

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -852,7 +852,9 @@ describe("PiThreadController state snapshot", () => {
       scheduleNotify: (flush) => scheduled.push(flush),
     });
     const notify = vi.fn();
+    const notifyMetadata = vi.fn();
     controller.subscribe(notify);
+    controller.subscribeMetadata(notifyMetadata);
     controller.connect();
 
     client.emit(
@@ -876,6 +878,7 @@ describe("PiThreadController state snapshot", () => {
     scheduled.at(-1)!();
     const projection = controller.getMessageRepository();
     notify.mockClear();
+    notifyMetadata.mockClear();
 
     client.emit(
       ev({ type: "message_end", message: assistantMessage("a", 1) }, 3),
@@ -885,6 +888,7 @@ describe("PiThreadController state snapshot", () => {
     expect(controller.getState().streamingMessageIndex).toBeUndefined();
     expect(controller.getStateSnapshot()).toBe(controller.getState());
     expect(notify).toHaveBeenCalledTimes(1);
+    expect(notifyMetadata).not.toHaveBeenCalled();
   });
 
   it("does not notify when neither the projection nor state moved", () => {

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import type { AppendMessage } from "@assistant-ui/react";
 import { PiThreadController } from "./ThreadController";
+import type { PiThreadState } from "./threadState";
 import type {
   PiClient,
   PiClientEvent,
@@ -772,5 +773,125 @@ describe("PiThreadController", () => {
     expect(after[0]).toBe(stableUser);
     expect(after[1]).not.toBe(before[1]);
     expect(after[1]!.content).toMatchObject([{ type: "text", text: "ab" }]);
+  });
+});
+
+describe("PiThreadController state snapshot", () => {
+  it("holds the snapshot steady while a coalesced message frame is pending", () => {
+    const client = createFakeClient();
+    const scheduled: Array<() => void> = [];
+    const controller = new PiThreadController(client, THREAD, {
+      scheduleNotify: (flush) => scheduled.push(flush),
+    });
+    const notify = vi.fn();
+    controller.subscribe(notify);
+    controller.connect();
+
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("", 1) }, 1),
+    );
+    const settled = controller.getStateSnapshot();
+    expect(settled).toBe(controller.getState());
+    notify.mockClear();
+
+    client.emit(
+      ev(
+        {
+          type: "message_update",
+          message: assistantMessage("a", 1),
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "a",
+            partial: assistantMessage("a", 1),
+          },
+        },
+        2,
+      ),
+    );
+
+    expect(controller.getState()).not.toBe(settled);
+    expect(controller.getStateSnapshot()).toBe(settled);
+    expect(notify).not.toHaveBeenCalled();
+
+    scheduled.at(-1)!();
+
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("advances the snapshot to live state on every notification", () => {
+    const client = createFakeClient();
+    const controller = new PiThreadController(client, THREAD);
+    const seen: PiThreadState[] = [];
+    controller.subscribe(() => seen.push(controller.getStateSnapshot()));
+    controller.connect();
+
+    client.emit(
+      ev({ type: "queue_update", steering: ["now"], followUp: [] }, 1),
+    );
+    client.emit(
+      ev(
+        {
+          type: "message_start",
+          message: { role: "user", content: "hi", timestamp: 1 },
+        },
+        2,
+      ),
+    );
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(seen[1]);
+    expect(seen[1]).toBe(controller.getState());
+  });
+
+  it("starts the snapshot at the initial state", () => {
+    const controller = new PiThreadController(createFakeClient(), THREAD);
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
+  });
+
+  // A metadata notification publishes whatever the reducer has already applied,
+  // including a message frame whose projection has not been flushed yet, so
+  // state leads the repository until the frame lands.
+  it("publishes live state on a metadata notification mid-frame", () => {
+    const client = createFakeClient();
+    const scheduled: Array<() => void> = [];
+    const controller = new PiThreadController(client, THREAD, {
+      scheduleNotify: (flush) => scheduled.push(flush),
+    });
+    controller.subscribe(() => {});
+    controller.connect();
+
+    client.emit(
+      ev({ type: "message_start", message: assistantMessage("", 1) }, 1),
+    );
+    const repositoryBeforeFrame = controller.getMessageRepository();
+
+    client.emit(
+      ev(
+        {
+          type: "message_update",
+          message: assistantMessage("a", 1),
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "a",
+            partial: assistantMessage("a", 1),
+          },
+        },
+        2,
+      ),
+    );
+    client.emit(
+      ev({ type: "queue_update", steering: ["now"], followUp: [] }, 3),
+    );
+
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
+    expect(controller.getMessageRepository()).toBe(repositoryBeforeFrame);
+
+    scheduled.at(-1)!();
+
+    expect(controller.getMessageRepository()).not.toBe(repositoryBeforeFrame);
+    expect(controller.getStateSnapshot()).toBe(controller.getState());
   });
 });

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -48,6 +48,10 @@ export type PiSendOptions = {
 
 export type PiNotificationScheduler = (flush: () => void) => void;
 
+/** `getStateSnapshot` (or `getState` where it is absent) and
+ * `getMessageRepository` are read as `useSyncExternalStore` snapshots, so an
+ * implementation must return a reference that changes only when a subscribed
+ * channel notifies; a freshly built value per call loops React. */
 export interface PiThreadControllerLike {
   getState(): PiThreadState;
   /** The state as of the last listener notification. `getState()` can run
@@ -664,6 +668,9 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private recomputeProjectedMessagesAndNotify() {
+    // `message_end` advances state without moving the projection, and the
+    // early return below skips the notification that would publish it.
+    this.stateSnapshot = this.state;
     const next = this.projectMessages();
     if (next === this.projectedMessages) return;
     this.projectedMessages = next;
@@ -695,7 +702,6 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private notifyMessageListeners() {
-    this.stateSnapshot = this.state;
     this.bumpVersion();
     notifyListeners(this.messageListeners);
     notifyListeners(this.allListeners);

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -670,9 +670,7 @@ export class PiThreadController implements PiThreadControllerLike {
   private recomputeProjectedMessagesAndNotify() {
     const next = this.projectMessages();
     if (next === this.projectedMessages) {
-      // `message_end` advances state without moving the projection, so publish
-      // it here rather than stranding the snapshot behind `getState()`.
-      if (this.state !== this.stateSnapshot) this.notifyMetadataListeners();
+      if (this.state !== this.stateSnapshot) this.publishState();
       return;
     }
     this.projectedMessages = next;
@@ -694,6 +692,16 @@ export class PiThreadController implements PiThreadControllerLike {
 
   private bumpVersion() {
     this.version += 1;
+  }
+
+  /** `message_end` advances state without moving the projection, so neither
+   * the metadata nor the message channel describes what changed. Publishing on
+   * `all` alone reaches every state subscriber without redefining what
+   * `subscribeMetadata` fires for. */
+  private publishState() {
+    this.stateSnapshot = this.state;
+    this.bumpVersion();
+    notifyListeners(this.allListeners);
   }
 
   private notifyMetadataListeners() {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -50,6 +50,11 @@ export type PiNotificationScheduler = (flush: () => void) => void;
 
 export interface PiThreadControllerLike {
   getState(): PiThreadState;
+  /** The state as of the last listener notification. `getState()` can run
+   * ahead of it while a coalesced message frame is pending, so only this is a
+   * valid `useSyncExternalStore` snapshot. Optional for backwards
+   * compatibility; callers fall back to `getState()`. */
+  getStateSnapshot?(): PiThreadState;
   getProjectedMessages(): readonly ThreadMessageLike[];
   getMessageRepository(): ExportedMessageRepository;
   getVersion(): number;
@@ -228,6 +233,7 @@ const markStateRunning = (state: PiThreadState): PiThreadState => {
 
 export class PiThreadController implements PiThreadControllerLike {
   private state: PiThreadState;
+  private stateSnapshot: PiThreadState;
   private projectedMessages: readonly ThreadMessageLike[] = [];
   private messageRepository = ExportedMessageRepository.fromArray([]);
   private version = 0;
@@ -261,10 +267,15 @@ export class PiThreadController implements PiThreadControllerLike {
     this.threadId = threadId;
     this.options = options;
     this.state = createPiThreadState(threadId);
+    this.stateSnapshot = this.state;
   }
 
   public getState() {
     return this.state;
+  }
+
+  public getStateSnapshot() {
+    return this.stateSnapshot;
   }
 
   public getProjectedMessages() {
@@ -677,12 +688,14 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private notifyMetadataListeners() {
+    this.stateSnapshot = this.state;
     this.bumpVersion();
     notifyListeners(this.metadataListeners);
     notifyListeners(this.allListeners);
   }
 
   private notifyMessageListeners() {
+    this.stateSnapshot = this.state;
     this.bumpVersion();
     notifyListeners(this.messageListeners);
     notifyListeners(this.allListeners);

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -668,11 +668,13 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private recomputeProjectedMessagesAndNotify() {
-    // `message_end` advances state without moving the projection, and the
-    // early return below skips the notification that would publish it.
-    this.stateSnapshot = this.state;
     const next = this.projectMessages();
-    if (next === this.projectedMessages) return;
+    if (next === this.projectedMessages) {
+      // `message_end` advances state without moving the projection, so publish
+      // it here rather than stranding the snapshot behind `getState()`.
+      if (this.state !== this.stateSnapshot) this.notifyMetadataListeners();
+      return;
+    }
     this.projectedMessages = next;
     // `fromArray` chains messages linearly and keeps their stable `pi-msg:N`
     // ids (its generated id is only a fallback for id-less messages).
@@ -702,6 +704,7 @@ export class PiThreadController implements PiThreadControllerLike {
   }
 
   private notifyMessageListeners() {
+    this.stateSnapshot = this.state;
     this.bumpVersion();
     notifyListeners(this.messageListeners);
     notifyListeners(this.allListeners);

--- a/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.newThread.test.tsx
@@ -18,9 +18,11 @@ vi.mock("./ThreadController", async (importOriginal) => {
   const original = await importOriginal<typeof import("./ThreadController")>();
 
   class PiThreadController {
-    getState = () => createPiThreadState("t-new");
+    state = createPiThreadState("t-new");
+    repository = ExportedMessageRepository.fromArray([]);
+    getState = () => this.state;
     getProjectedMessages = () => [];
-    getMessageRepository = () => ExportedMessageRepository.fromArray([]);
+    getMessageRepository = () => this.repository;
     getVersion = () => 0;
     subscribe = () => () => {};
     subscribeMetadata = () => () => {};

--- a/packages/react-pi/src/runtime/usePiRuntime.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
     status: "regular" as "new" | "regular" | "archived",
   },
   mainThreadId: "t1",
+  allListeners: new Set<() => void>(),
+  messageListeners: new Set<() => void>(),
   controller: {
     load: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
@@ -49,12 +51,19 @@ vi.mock("./ThreadController", async (importOriginal) => {
 
   class PiThreadController {
     getState = () => mocks.state;
+    getStateSnapshot = () => mocks.state;
     getProjectedMessages = () => [];
     getMessageRepository = () => mocks.repository;
     getVersion = () => 0;
-    subscribe = () => () => {};
+    subscribe = (listener: () => void) => {
+      mocks.allListeners.add(listener);
+      return () => mocks.allListeners.delete(listener);
+    };
     subscribeMetadata = () => () => {};
-    subscribeMessages = () => () => {};
+    subscribeMessages = (listener: () => void) => {
+      mocks.messageListeners.add(listener);
+      return () => mocks.messageListeners.delete(listener);
+    };
     connect = () => () => {};
     load = mocks.controller.load;
     refresh = vi.fn().mockResolvedValue(undefined);
@@ -93,6 +102,8 @@ afterEach(() => {
     status: "regular",
   };
   mocks.mainThreadId = "t1";
+  mocks.allListeners.clear();
+  mocks.messageListeners.clear();
   vi.clearAllMocks();
   vi.restoreAllMocks();
 });
@@ -170,5 +181,79 @@ describe("usePiRuntime new-thread store", () => {
     const adapter = mocks.adapters.at(-1)!;
     expect(adapter.isDisabled).toBe(false);
     expect(adapter.isLoading).toBe(false);
+  });
+});
+
+describe("usePiRuntime controller subscriptions", () => {
+  const renderRuntime = async () => {
+    let renders = 0;
+    const App = () => {
+      renders += 1;
+      usePiRuntime({ client: {} as PiClient, initialThreadId: "t1" });
+      return null;
+    };
+    root = createRoot(document.createElement("div"));
+    await act(async () => root!.render(createElement(App)));
+    return { renderCount: () => renders };
+  };
+
+  // A metadata-only change (queue_update, agent_start, …) notifies the
+  // metadata and all channels but never the message channel, so the store must
+  // read state from the all channel, which fires with every notification.
+  it("republishes state on a metadata-only notification", async () => {
+    const initialState = createPiThreadState("t1");
+    mocks.state = initialState;
+    mocks.repository = ExportedMessageRepository.fromArray([]);
+
+    const { renderCount } = await renderRuntime();
+    const rendersAfterMount = renderCount();
+
+    const before = mocks.adapters.at(-1)!;
+    expect(before.isRunning).toBe(false);
+    expect(before.extras).toMatchObject({ state: initialState });
+
+    const runningState = { ...initialState, runStatus: "running" as const };
+    await act(async () => {
+      mocks.state = runningState;
+      for (const listener of [...mocks.allListeners]) listener();
+    });
+
+    const after = mocks.adapters.at(-1)!;
+    expect(after.isRunning).toBe(true);
+    expect(after.extras).toMatchObject({ state: runningState });
+    expect(renderCount()).toBe(rendersAfterMount + 1);
+  });
+
+  it("republishes the repository on a message notification", async () => {
+    const initialRepository = ExportedMessageRepository.fromArray([]);
+    mocks.state = createPiThreadState("t1");
+    mocks.repository = initialRepository;
+
+    await renderRuntime();
+    expect(mocks.adapters.at(-1)!.messageRepository).toBe(initialRepository);
+
+    const nextRepository = ExportedMessageRepository.fromArray([]);
+    await act(async () => {
+      mocks.repository = nextRepository;
+      for (const listener of [...mocks.messageListeners, ...mocks.allListeners])
+        listener();
+    });
+
+    expect(mocks.adapters.at(-1)!.messageRepository).toBe(nextRepository);
+  });
+
+  it("leaves the store untouched when nothing on the controller changed", async () => {
+    mocks.state = createPiThreadState("t1");
+    mocks.repository = ExportedMessageRepository.fromArray([]);
+
+    await renderRuntime();
+    const before = mocks.adapters.at(-1)!;
+
+    await act(async () => {
+      for (const listener of [...mocks.messageListeners, ...mocks.allListeners])
+        listener();
+    });
+
+    expect(mocks.adapters.at(-1)!).toBe(before);
   });
 });

--- a/packages/react-pi/src/runtime/usePiRuntime.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   adapters: [] as ExternalStoreAdapter[],
   repository: undefined as unknown,
   state: undefined as unknown,
+  liveState: undefined as unknown,
   threadListItem: {
     id: "t1",
     remoteId: "t1" as string | undefined,
@@ -50,7 +51,7 @@ vi.mock("./ThreadController", async (importOriginal) => {
   const original = await importOriginal<typeof import("./ThreadController")>();
 
   class PiThreadController {
-    getState = () => mocks.state;
+    getState = () => mocks.liveState ?? mocks.state;
     getStateSnapshot = () => mocks.state;
     getProjectedMessages = () => [];
     getMessageRepository = () => mocks.repository;
@@ -102,6 +103,7 @@ afterEach(() => {
     status: "regular",
   };
   mocks.mainThreadId = "t1";
+  mocks.liveState = undefined;
   mocks.allListeners.clear();
   mocks.messageListeners.clear();
   vi.clearAllMocks();
@@ -222,6 +224,24 @@ describe("usePiRuntime controller subscriptions", () => {
     expect(after.isRunning).toBe(true);
     expect(after.extras).toMatchObject({ state: runningState });
     expect(renderCount()).toBe(rendersAfterMount + 1);
+  });
+
+  it("publishes the snapshot, not the state running ahead of it", async () => {
+    const settled = createPiThreadState("t1");
+    mocks.state = settled;
+    mocks.repository = ExportedMessageRepository.fromArray([]);
+
+    await renderRuntime();
+    expect(mocks.adapters.at(-1)!.extras).toMatchObject({ state: settled });
+
+    // a coalesced message frame has reduced but not yet notified
+    mocks.liveState = { ...settled, runStatus: "running" as const };
+    await act(async () => {
+      for (const listener of [...mocks.allListeners]) listener();
+    });
+
+    expect(mocks.adapters.at(-1)!.isRunning).toBe(false);
+    expect(mocks.adapters.at(-1)!.extras).toMatchObject({ state: settled });
   });
 
   it("republishes the repository on a message notification", async () => {

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -142,38 +142,41 @@ export const EMPTY_RUNTIME_EXTRAS = buildExtras(
 // Per-thread runtime.
 // ---------------------------------------------------------------------------
 
-const usePiControllerVersion = (
-  controller: PiThreadControllerLike,
-  kind: "all" | "metadata" | "messages",
-): number => {
-  const subscribe = useCallback(
-    (listener: () => void) => {
-      if (kind === "metadata") return controller.subscribeMetadata(listener);
-      if (kind === "messages") return controller.subscribeMessages(listener);
-      return controller.subscribe(listener);
-    },
-    [controller, kind],
-  );
-  return useSyncExternalStore(
-    subscribe,
-    () => controller.getVersion(),
-    () => 0,
-  );
-};
+const stateSnapshotOf = (controller: PiThreadControllerLike): PiThreadState =>
+  controller.getStateSnapshot?.() ?? controller.getState();
 
 const usePiControllerState = (
   controller: PiThreadControllerLike,
-  kind: "all" | "metadata",
 ): PiThreadState => {
-  usePiControllerVersion(controller, kind);
-  return controller.getState();
+  const getSnapshot = useCallback(
+    () => stateSnapshotOf(controller),
+    [controller],
+  );
+  return useSyncExternalStore(
+    useCallback(
+      (listener: () => void) => controller.subscribe(listener),
+      [controller],
+    ),
+    getSnapshot,
+    getSnapshot,
+  );
 };
 
 const usePiControllerMessageRepository = (
   controller: PiThreadControllerLike,
 ): ExportedMessageRepository => {
-  usePiControllerVersion(controller, "messages");
-  return controller.getMessageRepository();
+  const getSnapshot = useCallback(
+    () => controller.getMessageRepository(),
+    [controller],
+  );
+  return useSyncExternalStore(
+    useCallback(
+      (listener: () => void) => controller.subscribeMessages(listener),
+      [controller],
+    ),
+    getSnapshot,
+    getSnapshot,
+  );
 };
 
 export const usePiControllerStateSelector = <T>(
@@ -182,7 +185,7 @@ export const usePiControllerStateSelector = <T>(
 ): T =>
   useSyncExternalStore(
     useCallback((listener) => controller.subscribe(listener), [controller]),
-    () => selector(controller.getState()),
+    () => selector(stateSnapshotOf(controller)),
     () => selector(EMPTY_THREAD_STATE),
   );
 
@@ -195,7 +198,7 @@ const usePiThreadStore = (
   controller: PiThreadControllerLike,
   options: PiRuntimeOptions,
 ): ExternalStoreAdapter<ThreadMessage> => {
-  const state = usePiControllerState(controller, "metadata");
+  const state = usePiControllerState(controller);
   const messageRepository = usePiControllerMessageRepository(controller);
 
   const {


### PR DESCRIPTION
`usePiRuntime` bridges `PiThreadController` into React by subscribing to a channel and snapshotting a monotonic version counter, the `notifyUpdate` plus version-counter re-render hack AGENTS.md tells adapters not to introduce. `useSyncExternalStore` wants a snapshot reference that changes exactly when the subscribed channel notifies, and the controller almost has one already: `getMessageRepository()` is rebuilt only in `recomputeProjectedMessagesAndNotify`, immediately before message listeners fire.

State has no such reference. `dispatch()` advances `this.state` as soon as an event reduces, but a coalesced message frame (`message_update`, `tool_execution_update`) defers its notification to the next animation frame, so `getState()` runs ahead of every listener. This PR adds `getStateSnapshot()`, advanced wherever state is published, and reads state off the `all` channel, the only one notified on every state change. `usePiControllerStateSelector`, which backs the published `usePiThreadState` hook, moves to the same snapshot, and the message-repository hook subscribes to its reference directly. `getStateSnapshot` is optional on the exported `PiThreadControllerLike` with a `getState()` fallback, so external implementations of the interface keep type-checking; `getVersion()` stays and keeps counting since it is published surface.

`recomputeProjectedMessagesAndNotify` returns early when the projection comes back reference-identical, and `message_end` reaches that path: it only clears `streamingMessageIndex`, so the projection does not move. Left alone, that strands the snapshot one state behind with no notification to correct it, where the previous bindings read `getState()` live and recovered on the next render. The early return therefore publishes state through `publishState()`, which advances the snapshot and notifies `all`. It deliberately does not go through `notifyMetadataListeners`: `subscribeMetadata` is published surface that names a metadata change, and nothing about `message_end` is one. `all` is the channel every state change reaches, so it is the only one that should carry this.

The React bindings now feed `getState()` (through the fallback) and `getMessageRepository()` straight into `useSyncExternalStore`, which turns reference stability into a hard requirement on `PiThreadControllerLike`: an implementation that builds a fresh value per call loops React with "The result of getSnapshot should be cached to avoid an infinite loop". That is stated on the interface and in the changeset, and it is why the controller mock in `usePiRuntime.newThread.test.tsx` now holds its state and repository in fields.

Part of a series replacing hand-rolled runtime plumbing with the shared core primitives.

## Verification

- `pnpm --filter @assistant-ui/react-pi test`: 237/237 passing
- `pnpm lint` and `tsc --noEmit`: no new diagnostics (5 pre-existing test-file type errors match main)
- `pnpm api-surface:check`: clean, the two added `getStateSnapshot` lines are the whole surface delta
- Behavior checked against the previous bindings at the React level: a component reading `usePiThreadState(s => s.streamingMessageIndex)` through `message_start` → `message_update` → frame flush → `message_end` ends on the same value as before this change, and now reaches it on the `message_end` notification instead of the next unrelated render
- Render count over `message_start` plus five coalesced frames plus `message_end`, driving the real controller: 6 store renders before and after, since the adjacent message-repository subscription already rendered once per frame

New contract tests pin the snapshot semantics: `getState()` may run ahead while a coalesced frame is pending, `getStateSnapshot()` may not, both notify paths advance it, a message event that leaves the projection unchanged still publishes state on `all` without waking metadata subscribers, and an event that moves neither notifies nothing at all.
