### PR TITLE
fix(ui): route the image and mermaid zoom views through the kit Dialog

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1402,6 +1402,7 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "@assistant-ui/react-markdown",
     ],
+    registryDependencies: ["dialog"],
   },
   {
     name: "diff-viewer",
@@ -1497,7 +1498,7 @@ export const registry: RegistryItem[] = [
       "lucide-react",
       "class-variance-authority",
     ],
-    registryDependencies: [],
+    registryDependencies: ["dialog"],
   },
   {
     name: "file",

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -8,7 +8,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ImageMessagePart } from "@assistant-ui/react";
 
-import { ImageActions } from "./image";
+import { ImageActions, ImageZoom } from "./image";
 
 class FakeClipboardItem {
   constructor(public readonly items: Record<string, Blob>) {}
@@ -162,5 +162,62 @@ describe("ImageActions regeneration", () => {
     } finally {
       process.off("unhandledRejection", onUnhandledRejection);
     }
+  });
+});
+
+const renderZoom = () =>
+  render(
+    <ImageZoom src="https://example.com/cat.png" alt="A cat">
+      <img src="https://example.com/cat.png" alt="A cat" />
+    </ImageZoom>,
+  );
+
+const openZoom = () => {
+  fireEvent.click(screen.getByLabelText("Click to zoom image"));
+  return screen.findByRole("dialog");
+};
+
+const zoomedImage = (dialog: HTMLElement) =>
+  dialog.querySelector('[data-slot="image-zoom-content"]')!;
+
+const expectClosed = () =>
+  waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+describe("ImageZoom", () => {
+  it("opens a titled dialog holding the full-size image", async () => {
+    renderZoom();
+    const dialog = await openZoom();
+
+    expect(dialog.textContent).toContain("A cat");
+    expect(zoomedImage(dialog).getAttribute("src")).toBe(
+      "https://example.com/cat.png",
+    );
+  });
+
+  it("closes on Escape", async () => {
+    renderZoom();
+    await openZoom();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await expectClosed();
+  });
+
+  it("closes when the image itself is clicked", async () => {
+    renderZoom();
+    const dialog = await openZoom();
+
+    fireEvent.click(zoomedImage(dialog));
+
+    await expectClosed();
+  });
+
+  it("closes when the area around the image is clicked", async () => {
+    renderZoom();
+    const dialog = await openZoom();
+
+    fireEvent.click(dialog);
+
+    await expectClosed();
   });
 });

--- a/packages/ui/src/components/assistant-ui/image.test.tsx
+++ b/packages/ui/src/components/assistant-ui/image.test.tsx
@@ -212,6 +212,15 @@ describe("ImageZoom", () => {
     await expectClosed();
   });
 
+  it("offers a labelled close control that dismisses the dialog", async () => {
+    renderZoom();
+    await openZoom();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await expectClosed();
+  });
+
   it("closes when the area around the image is clicked", async () => {
     renderZoom();
     const dialog = await openZoom();

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -276,8 +276,7 @@ function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
         {children}
       </div>
       <DialogContent
-        showCloseButton={false}
-        className="aui-image-zoom-overlay fixed inset-0 start-0 top-0 z-50 flex max-w-none translate-x-0 translate-y-0 items-center justify-center rounded-none border-0 bg-black/80 p-0 shadow-none sm:max-w-none"
+        className="aui-image-zoom-overlay fixed inset-0 start-0 top-0 z-50 flex max-w-none translate-x-0 translate-y-0 items-center justify-center rounded-none border-0 bg-black/80 p-0 text-white shadow-none sm:max-w-none"
         onClick={() => setIsOpen(false)}
       >
         <DialogTitle className="aui-sr-only sr-only">{alt}</DialogTitle>

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   type PropsWithChildren,
 } from "react";
-import { createPortal } from "react-dom";
 import { cva, type VariantProps } from "class-variance-authority";
 import {
   CopyIcon,
@@ -22,6 +21,12 @@ import type {
   ImageMessagePart,
   ImageMessagePartComponent,
 } from "@assistant-ui/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 const extensionForMimeType = (mimeType?: string): string => {
@@ -254,36 +259,12 @@ type ImageZoomProps = PropsWithChildren<{
 }>;
 
 function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
-  const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
   const handleOpen = () => setIsOpen(true);
-  const handleClose = () => setIsOpen(false);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, [isOpen]);
 
   return (
-    <>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <div
         onClick={handleOpen}
         onKeyDown={(e) => e.key === "Enter" && handleOpen()}
@@ -294,32 +275,23 @@ function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
       >
         {children}
       </div>
-      {isMounted &&
-        isOpen &&
-        createPortal(
-          <div
-            data-slot="image-zoom-overlay"
-            role="button"
-            tabIndex={0}
-            className="aui-image-zoom-overlay fade-in animate-in fixed inset-0 z-50 flex items-center justify-center bg-black/80 duration-200"
-            onClick={handleClose}
-            onKeyDown={(e) => e.key === "Enter" && handleClose()}
-            aria-label="Close zoomed image"
-          >
-            <img
-              data-slot="image-zoom-content"
-              src={src}
-              alt={alt}
-              className="aui-image-zoom-content fade-in zoom-in-95 animate-in max-h-[90vh] max-w-[90vw] cursor-zoom-out object-contain duration-200"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleClose();
-              }}
-            />
-          </div>,
-          document.body,
-        )}
-    </>
+      <DialogContent
+        showCloseButton={false}
+        className="aui-image-zoom-overlay fixed inset-0 start-0 top-0 z-50 flex max-w-none translate-x-0 translate-y-0 items-center justify-center rounded-none border-0 bg-black/80 p-0 shadow-none sm:max-w-none"
+        onClick={() => setIsOpen(false)}
+      >
+        <DialogTitle className="aui-sr-only sr-only">{alt}</DialogTitle>
+        <DialogDescription className="aui-sr-only sr-only">
+          Zoomed image
+        </DialogDescription>
+        <img
+          data-slot="image-zoom-content"
+          src={src}
+          alt={alt}
+          className="aui-image-zoom-content max-h-[90vh] max-w-[90vw] cursor-zoom-out object-contain"
+        />
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/packages/ui/src/components/assistant-ui/mermaid-diagram.test.tsx
+++ b/packages/ui/src/components/assistant-ui/mermaid-diagram.test.tsx
@@ -1,0 +1,71 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MermaidZoom } from "./mermaid-diagram";
+
+afterEach(cleanup);
+
+const SVG = '<svg id="graph"><rect fill="url(#grad)" /></svg>';
+
+const renderZoom = () =>
+  render(
+    <MermaidZoom svg={SVG}>
+      <div data-testid="inline-diagram" />
+    </MermaidZoom>,
+  );
+
+const trigger = () => screen.getByLabelText("Expand diagram");
+
+const openZoom = () => {
+  fireEvent.click(trigger());
+  return screen.findByRole("dialog");
+};
+
+const zoomContent = (dialog: HTMLElement) =>
+  dialog.querySelector<HTMLElement>('[data-slot="mermaid-zoom-content"]')!;
+
+describe("MermaidZoom", () => {
+  it("opens a titled dialog rendering the id-rewritten copy of the diagram", async () => {
+    renderZoom();
+    const dialog = await openZoom();
+
+    expect(trigger().getAttribute("aria-haspopup")).toBe("dialog");
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+    expect(trigger().getAttribute("aria-controls")).toBe(dialog.id);
+    expect(dialog.textContent).toContain("Diagram");
+    expect(zoomContent(dialog).innerHTML).toContain('id="graph-zoom"');
+    expect(zoomContent(dialog).innerHTML).toContain("url(#grad-zoom)");
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    renderZoom();
+    await openZoom();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(trigger()));
+  });
+
+  it("resets the pan and zoom transform when reopened", async () => {
+    renderZoom();
+    const dialog = await openZoom();
+
+    fireEvent.click(screen.getByLabelText("Zoom in"));
+    expect(zoomContent(dialog).style.transform).not.toContain("scale(1)");
+
+    fireEvent.click(screen.getByLabelText("Close"));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+    const reopened = await openZoom();
+    expect(zoomContent(reopened).style.transform).toBe(
+      "translate(0px, 0px) scale(1)",
+    );
+  });
+});

--- a/packages/ui/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/packages/ui/src/components/assistant-ui/mermaid-diagram.tsx
@@ -9,12 +9,17 @@ import {
   type ReactNode,
   memo,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 export type MermaidDiagramProps = SyntaxHighlighterProps & {
@@ -30,12 +35,8 @@ type MermaidZoomProps = {
 };
 
 function MermaidZoom({ svg, children }: MermaidZoomProps) {
-  const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 });
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const closeRef = useRef<HTMLButtonElement>(null);
-  const overlayRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const drag = useRef<{
     startX: number;
@@ -55,54 +56,13 @@ function MermaidZoom({ svg, children }: MermaidZoomProps) {
     [svg],
   );
 
-  useEffect(() => {
-    setIsMounted(true);
+  const onOpenChange = useCallback((nextOpen: boolean) => {
+    setIsOpen(nextOpen);
+    if (!nextOpen) {
+      drag.current = null;
+      setTransform({ x: 0, y: 0, scale: 1 });
+    }
   }, []);
-
-  const handleClose = useCallback(() => {
-    setIsOpen(false);
-    setTransform({ x: 0, y: 0, scale: 1 });
-    triggerRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        handleClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const focusables = overlayRef.current?.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (!focusables?.length) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, handleClose]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (isOpen) closeRef.current?.focus();
-  }, [isOpen]);
 
   const zoomBy = useCallback((factor: number, cx?: number, cy?: number) => {
     setTransform((t) => {
@@ -161,93 +121,86 @@ function MermaidZoom({ svg, children }: MermaidZoomProps) {
   }, []);
 
   return (
-    <div
-      data-slot="mermaid-zoom-wrap"
-      className="aui-mermaid-zoom-wrap group/mermaid relative"
-    >
-      {children}
-      <button
-        ref={triggerRef}
-        type="button"
-        data-slot="mermaid-zoom-trigger"
-        aria-label="Expand diagram"
-        onClick={() => setIsOpen(true)}
-        className="aui-mermaid-zoom-trigger text-muted-foreground hover:text-foreground hover:border-muted-foreground/70 border-border bg-background absolute top-2 right-2 cursor-pointer rounded-md border p-1.5 opacity-0 transition group-hover/mermaid:opacity-100 focus-visible:opacity-100"
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <div
+        data-slot="mermaid-zoom-wrap"
+        className="aui-mermaid-zoom-wrap group/mermaid relative"
       >
-        <Maximize2 className="size-3.5" />
-      </button>
-      {isMounted &&
-        isOpen &&
-        createPortal(
+        {children}
+        <DialogTrigger
+          data-slot="mermaid-zoom-trigger"
+          aria-label="Expand diagram"
+          className="aui-mermaid-zoom-trigger text-muted-foreground hover:text-foreground hover:border-muted-foreground/70 border-border bg-background absolute top-2 right-2 cursor-pointer rounded-md border p-1.5 opacity-0 transition group-hover/mermaid:opacity-100 focus-visible:opacity-100"
+        >
+          <Maximize2 className="size-3.5" />
+        </DialogTrigger>
+        <DialogContent
+          showCloseButton={false}
+          className="aui-mermaid-zoom-overlay bg-background fixed inset-0 start-0 top-0 z-50 max-w-none translate-x-0 translate-y-0 rounded-none border-0 p-0 shadow-none sm:max-w-none"
+        >
+          <DialogTitle className="aui-sr-only sr-only">Diagram</DialogTitle>
+          <DialogDescription className="aui-sr-only sr-only">
+            Expanded diagram viewer
+          </DialogDescription>
           <div
-            ref={overlayRef}
-            data-slot="mermaid-zoom-overlay"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Diagram"
-            className="aui-mermaid-zoom-overlay fade-in animate-in bg-background fixed inset-0 z-50 duration-200"
+            ref={viewportRef}
+            className="aui-mermaid-zoom-viewport h-full w-full cursor-grab touch-none overflow-hidden active:cursor-grabbing"
+            onWheel={onWheel}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerUp}
           >
             <div
-              ref={viewportRef}
-              className="aui-mermaid-zoom-viewport h-full w-full cursor-grab touch-none overflow-hidden active:cursor-grabbing"
-              onWheel={onWheel}
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
-              onPointerCancel={onPointerUp}
+              data-slot="mermaid-zoom-content"
+              className="aui-mermaid-zoom-content flex h-full w-full items-center justify-center [&_svg]:max-h-[80vh] [&_svg]:max-w-[90vw]"
+              style={{
+                transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+                transformOrigin: "0 0",
+              }}
+              dangerouslySetInnerHTML={{ __html: zoomSvg }}
+            />
+          </div>
+          <div
+            data-slot="mermaid-zoom-toolbar"
+            className="aui-mermaid-zoom-toolbar border-border bg-background absolute top-4 right-4 flex items-center gap-1 rounded-lg border p-1"
+          >
+            <button
+              type="button"
+              aria-label="Zoom in"
+              onClick={() => zoomBy(1.25)}
+              className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
             >
-              <div
-                data-slot="mermaid-zoom-content"
-                className="aui-mermaid-zoom-content flex h-full w-full items-center justify-center [&_svg]:max-h-[80vh] [&_svg]:max-w-[90vw]"
-                style={{
-                  transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
-                  transformOrigin: "0 0",
-                }}
-                dangerouslySetInnerHTML={{ __html: zoomSvg }}
-              />
-            </div>
-            <div
-              data-slot="mermaid-zoom-toolbar"
-              className="aui-mermaid-zoom-toolbar border-border bg-background absolute top-4 right-4 flex items-center gap-1 rounded-lg border p-1"
+              <Plus className="size-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Zoom out"
+              onClick={() => zoomBy(0.8)}
+              className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
             >
-              <button
-                type="button"
-                aria-label="Zoom in"
-                onClick={() => zoomBy(1.25)}
-                className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
-              >
-                <Plus className="size-4" />
-              </button>
-              <button
-                type="button"
-                aria-label="Zoom out"
-                onClick={() => zoomBy(0.8)}
-                className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
-              >
-                <Minus className="size-4" />
-              </button>
-              <button
-                type="button"
-                aria-label="Reset zoom"
-                onClick={() => setTransform({ x: 0, y: 0, scale: 1 })}
-                className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
-              >
-                <RotateCcw className="size-4" />
-              </button>
-              <button
-                ref={closeRef}
-                type="button"
-                aria-label="Close"
-                onClick={handleClose}
-                className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
-              >
-                <X className="size-4" />
-              </button>
-            </div>
-          </div>,
-          document.body,
-        )}
-    </div>
+              <Minus className="size-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Reset zoom"
+              onClick={() => setTransform({ x: 0, y: 0, scale: 1 })}
+              className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
+            >
+              <RotateCcw className="size-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={() => onOpenChange(false)}
+              className="text-muted-foreground hover:text-foreground cursor-pointer rounded-sm p-1.5"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        </DialogContent>
+      </div>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
The image and mermaid zoom views each hand-roll their own modal: a portal, an Escape listener, a body scroll lock, and (for mermaid) a `querySelector`-based focus trap. The image view has no focus trap or focus restoration at all, so a keyboard user can tab behind the overlay. `flow-expand.tsx` already shows the alternative: the kit Dialog owns portalling, dismissal, focus trapping and restoration, and scroll locking, so each view keeps only its own pan/zoom math.

This PR routes both views through the kit Dialog. Behavior kept: full-screen styling, the transform reset on close, and click-anywhere-to-close on the zoomed image; the image dialog keeps an explicit close button (the kit's own, styled `text-white` so it stays visible on the dark overlay), while the mermaid view keeps its toolbar Close instead. The mermaid trigger becomes a kit `DialogTrigger`, which supplies the aria wiring and focus return on close, and both views gain a real accessible name via a screen-reader-only `DialogTitle`. Both registry items declare the new `dialog` dependency so `shadcn add` still lands a self-contained file. Part of a series replacing hand-rolled plumbing with the shared kit primitives.

This adds the first tests for either view: opening a titled dialog, Escape / image-click / surrounding-area dismissal and the labelled close control on the image side; the id-rewritten SVG copy, focus return to the trigger, and the transform reset on reopen on the mermaid side.

## Verification

- `pnpm --filter @assistant-ui/ui test` — 376 passed, 15 skipped, rebased onto current main and re-verified today
- Registry validator passes with the added `registryDependencies` (and fails without them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.T1-57WVkcz6uXhRFkWru4cQGmECL5l8tD8mvoycDaYuV4vPsD0UzGxGr0CA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->