### PR TITLE
refactor(assistant-stream): share one SSE encoder and decoder across the transport pipelines

### DIFF
--- a/.changeset/sse-shared-pipeline.md
+++ b/.changeset/sse-shared-pipeline.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: build the assistant-transport and UI-message-stream SSE pipelines on one shared encoder and decoder

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -234,13 +234,13 @@ type AssistantTransformerStartCallback = (controller: AssistantStreamController)
 
 type AssistantTransformerTransformCallback<I> = (chunk: I, controller: AssistantStreamController) => void | PromiseLike<void>;
 
-declare class AssistantTransportDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
+declare class AssistantTransportDecoder extends SSEMessageDecoder<AssistantStreamChunk> {
   constructor(options?: {
     strict?: boolean | undefined;
   });
 }
 
-declare class AssistantTransportEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
+declare class AssistantTransportEncoder extends SSEEncoder<AssistantStreamChunk> implements AssistantStreamEncoder {
   headers: Headers;
   constructor();
 }
@@ -24278,6 +24278,14 @@ interface ResumableStreamStore {
 
 type RetryStrategy = ((times: number) => number | void | null) | null | undefined;
 
+declare class SSEEncoder<T> extends PipeableTransformStream<T, Uint8Array<ArrayBuffer>> {
+  static readonly headers: Headers;
+  headers: Headers;
+  constructor(options?: {
+    doneSentinel?: string | undefined;
+  });
+}
+
 type SSEEvent = {
   event?: string;
   data: string;
@@ -24293,6 +24301,17 @@ declare class SSEEventDecoder {
   push(text: string): SSEEvent[];
   flush(): SSEEvent | null;
 }
+
+declare class SSEMessageDecoder<T> extends PipeableTransformStream<Uint8Array<ArrayBuffer>, T> {
+  constructor(options: SSEMessageDecoderOptions<T>);
+}
+
+type SSEMessageDecoderOptions<T> = {
+  strict?: boolean | undefined;
+  doneSentinel?: string | undefined;
+  onMessage: (data: string, controller: TransformStreamDefaultController<T>) => void;
+  onDone?: ((controller: TransformStreamDefaultController<T>) => void) | undefined;
+};
 
 declare class ScanStream extends Readable {
   #private;

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -1,10 +1,6 @@
 import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
-import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import {
-  SSEEventDecoderStream,
-  type PipelineSSEEvent,
-} from "../../utils/stream/SSEEventDecoderStream";
+import { SSEEncoder, SSEMessageDecoder } from "../../utils/stream/SSE";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
 type ChunkFields = Record<string, unknown>;
@@ -71,35 +67,22 @@ const parseChunk = (data: string): AssistantStreamChunk | string => {
   return value as AssistantStreamChunk;
 };
 
+const DONE_SENTINEL = "[DONE]";
+
 /**
  * AssistantTransportEncoder encodes AssistantStreamChunks into SSE format
  * and emits [DONE] when the stream completes.
  */
 export class AssistantTransportEncoder
-  extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>>
+  extends SSEEncoder<AssistantStreamChunk>
   implements AssistantStreamEncoder
 {
-  headers = new Headers({
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
+  // Shadows SSEEncoder's shared static Headers so a caller mutating these does
+  // not reach every other SSE encoder.
+  override headers = new Headers(SSEEncoder.headers);
 
   constructor() {
-    super((readable) => {
-      return readable
-        .pipeThrough(
-          new TransformStream<AssistantStreamChunk, string>({
-            transform(chunk, controller) {
-              controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
-            },
-            flush(controller) {
-              controller.enqueue("data: [DONE]\n\n");
-            },
-          }),
-        )
-        .pipeThrough(new TextEncoderStream());
-    });
+    super({ doneSentinel: DONE_SENTINEL });
   }
 }
 
@@ -107,67 +90,26 @@ export class AssistantTransportEncoder
  * AssistantTransportDecoder decodes SSE format into AssistantStreamChunks.
  * It stops decoding when it encounters [DONE].
  */
-export class AssistantTransportDecoder extends PipeableTransformStream<
-  Uint8Array<ArrayBuffer>,
-  AssistantStreamChunk
-> {
+export class AssistantTransportDecoder extends SSEMessageDecoder<AssistantStreamChunk> {
   constructor(options: { strict?: boolean | undefined } = {}) {
     const strict = options.strict ?? true;
-    super((readable) => {
-      let receivedDone = false;
-      const warnedReasons = new Set<string>();
-
-      return readable
-        .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new SSEEventDecoderStream())
-        .pipeThrough(
-          new TransformStream<PipelineSSEEvent, AssistantStreamChunk>({
-            transform(event, controller) {
-              switch (event.event) {
-                case "message":
-                  if (event.data === "[DONE]") {
-                    // Mark that we received [DONE]
-                    receivedDone = true;
-                    // Stop processing when we encounter [DONE]
-                    controller.terminate();
-                  } else {
-                    const chunk = parseChunk(event.data);
-                    if (typeof chunk === "string") {
-                      if (!warnedReasons.has(chunk)) {
-                        warnedReasons.add(chunk);
-                        console.warn(
-                          `Dropped invalid assistant-transport chunk (${chunk}): ${event.data.slice(0, 200)}`,
-                        );
-                      }
-                    } else {
-                      controller.enqueue(chunk);
-                    }
-                  }
-                  break;
-                default:
-                  if (strict)
-                    throw new Error(`Unknown SSE event type: ${event.event}`);
-                  if (!warnedReasons.has(`event:${event.event}`)) {
-                    warnedReasons.add(`event:${event.event}`);
-                    console.error(
-                      `Ignored unknown SSE event type: ${event.event}`,
-                    );
-                  }
-              }
-            },
-            flush() {
-              if (!receivedDone) {
-                if (strict)
-                  throw new Error(
-                    "Stream ended abruptly without receiving [DONE] marker",
-                  );
-                console.warn(
-                  "Stream ended abruptly without receiving [DONE] marker",
-                );
-              }
-            },
-          }),
-        );
+    const warnedReasons = new Set<string>();
+    super({
+      strict,
+      doneSentinel: DONE_SENTINEL,
+      onMessage(data, controller) {
+        const chunk = parseChunk(data);
+        if (typeof chunk === "string") {
+          if (!warnedReasons.has(chunk)) {
+            warnedReasons.add(chunk);
+            console.warn(
+              `Dropped invalid assistant-transport chunk (${chunk}): ${data.slice(0, 200)}`,
+            );
+          }
+          return;
+        }
+        controller.enqueue(chunk);
+      },
     });
   }
 }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -2,10 +2,7 @@ import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { AssistantTransformStream } from "../../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import {
-  SSEEventDecoderStream,
-  type PipelineSSEEvent,
-} from "../../utils/stream/SSEEventDecoderStream";
+import { SSEMessageDecoder } from "../../utils/stream/SSE";
 import type {
   UIMessageStreamChunk,
   UIMessageStreamDataChunk,
@@ -41,7 +38,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
       const toolCallPartRegistry = createToolCallPartRegistry();
       let activeToolCallId: string | undefined;
       let currentMessageId: string | undefined;
-      let receivedDone = false;
       type PendingTool = {
         toolCallId: string;
         toolName: string;
@@ -258,27 +254,19 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
       });
 
       return readable
-        .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
-          new TransformStream<PipelineSSEEvent, UIMessageStreamChunk>({
-            transform(event, controller) {
-              if (event.event !== "message") {
-                throw new Error(`Unknown SSE event type: ${event.event}`);
+          new SSEMessageDecoder<UIMessageStreamChunk>({
+            strict: true,
+            doneSentinel: "[DONE]",
+            onDone(controller) {
+              for (const tool of pendingTools.values()) {
+                emitPendingTool(controller, tool);
               }
-
-              if (event.data === "[DONE]") {
-                for (const tool of pendingTools.values()) {
-                  emitPendingTool(controller, tool);
-                }
-                receivedDone = true;
-                controller.terminate();
-                return;
-              }
-
+            },
+            onMessage(data, controller) {
               let chunk;
               try {
-                chunk = sjson.parse(event.data);
+                chunk = sjson.parse(data);
               } catch {
                 chunk = undefined;
               }
@@ -289,7 +277,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 typeof chunk.type !== "string"
               ) {
                 console.warn(
-                  `Dropped invalid UIMessageStream chunk: ${event.data.slice(0, 200)}`,
+                  `Dropped invalid UIMessageStream chunk: ${data.slice(0, 200)}`,
                 );
                 return;
               }
@@ -435,13 +423,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               }
 
               controller.enqueue(chunk);
-            },
-            flush() {
-              if (!receivedDone) {
-                throw new Error(
-                  "Stream ended abruptly without receiving [DONE] marker",
-                );
-              }
             },
           }),
         )

--- a/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SSEDecoder, SSEEncoder } from "./SSE";
+import { SSEDecoder, SSEEncoder, SSEMessageDecoder } from "./SSE";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -118,5 +118,101 @@ describe("SSEDecoder", () => {
       "Ignored unknown SSE event type: custom",
     );
     error.mockRestore();
+  });
+});
+
+describe("SSEEncoder doneSentinel", () => {
+  const encodeAll = async <T>(values: T[], encoder: SSEEncoder<T>) => {
+    const source = new ReadableStream<T>({
+      start(controller) {
+        for (const v of values) controller.enqueue(v);
+        controller.close();
+      },
+    });
+    const bytes = await collectChunks(source.pipeThrough(encoder));
+    return new TextDecoder().decode(
+      new Uint8Array(bytes.flatMap((b) => [...b])),
+    );
+  };
+
+  it("writes the sentinel verbatim after the last chunk", async () => {
+    const text = await encodeAll(
+      [{ ok: 1 }],
+      new SSEEncoder<{ ok: number }>({ doneSentinel: "[DONE]" }),
+    );
+    expect(text).toBe('data: {"ok":1}\n\ndata: [DONE]\n\n');
+  });
+
+  it("writes the sentinel on an empty stream", async () => {
+    const text = await encodeAll(
+      [],
+      new SSEEncoder<{ ok: number }>({ doneSentinel: "[DONE]" }),
+    );
+    expect(text).toBe("data: [DONE]\n\n");
+  });
+
+  it("writes no trailer without a sentinel", async () => {
+    const text = await encodeAll([{ ok: 1 }], new SSEEncoder<{ ok: number }>());
+    expect(text).toBe('data: {"ok":1}\n\n');
+  });
+});
+
+describe("SSEMessageDecoder sentinel", () => {
+  const passthrough = (
+    data: string,
+    controller: TransformStreamDefaultController<string>,
+  ) => controller.enqueue(data);
+
+  it("terminates on the sentinel", async () => {
+    const chunks = await collectChunks(
+      createSSEStream(["a", "[DONE]"]).pipeThrough(
+        new SSEMessageDecoder<string>({
+          doneSentinel: "[DONE]",
+          onMessage: passthrough,
+        }),
+      ),
+    );
+    expect(chunks).toEqual(["a"]);
+  });
+
+  it("runs onDone before terminating, so flushed chunks land in the output", async () => {
+    const chunks = await collectChunks(
+      createSSEStream(["a", "[DONE]", "b"]).pipeThrough(
+        new SSEMessageDecoder<string>({
+          doneSentinel: "[DONE]",
+          onMessage: passthrough,
+          onDone(controller) {
+            controller.enqueue("pending-1");
+            controller.enqueue("pending-2");
+          },
+        }),
+      ),
+    );
+    expect(chunks).toEqual(["a", "pending-1", "pending-2"]);
+  });
+
+  it("does not run onDone when the stream ends without the sentinel", async () => {
+    const onDone = vi.fn();
+    await expect(
+      collectChunks(
+        createSSEStream(["a"]).pipeThrough(
+          new SSEMessageDecoder<string>({
+            doneSentinel: "[DONE]",
+            onMessage: passthrough,
+            onDone,
+          }),
+        ),
+      ),
+    ).rejects.toThrow("Stream ended abruptly without receiving [DONE] marker");
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("treats the sentinel as data when no sentinel is configured", async () => {
+    const chunks = await collectChunks(
+      createSSEStream(["a", "[DONE]"]).pipeThrough(
+        new SSEMessageDecoder<string>({ onMessage: passthrough }),
+      ),
+    );
+    expect(chunks).toEqual(["a", "[DONE]"]);
   });
 });

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -17,13 +17,22 @@ export class SSEEncoder<T> extends PipeableTransformStream<
 
   headers = SSEEncoder.headers;
 
-  constructor() {
+  /**
+   * `doneSentinel` is written verbatim after the last chunk, so a protocol that
+   * terminates on a marker emits it without passing it through JSON.
+   */
+  constructor(options: { doneSentinel?: string | undefined } = {}) {
+    const { doneSentinel } = options;
     super((readable) =>
       readable
         .pipeThrough(
           new TransformStream<T, string>({
             transform(chunk, controller) {
               controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
+            },
+            flush(controller) {
+              if (doneSentinel === undefined) return;
+              controller.enqueue(`data: ${doneSentinel}\n\n`);
             },
           }),
         )
@@ -32,34 +41,52 @@ export class SSEEncoder<T> extends PipeableTransformStream<
   }
 }
 
-export class SSEDecoder<T> extends PipeableTransformStream<
+export type SSEMessageDecoderOptions<T> = {
+  strict?: boolean | undefined;
+  doneSentinel?: string | undefined;
+  onMessage: (
+    data: string,
+    controller: TransformStreamDefaultController<T>,
+  ) => void;
+  onDone?:
+    | ((controller: TransformStreamDefaultController<T>) => void)
+    | undefined;
+};
+
+/**
+ * The SSE half of a decode pipeline: byte decoding, event framing, unknown-event
+ * policy and the terminating sentinel. What a `message` payload means is the
+ * protocol's business and stays with the caller in `onMessage`; `onDone` runs
+ * before the sentinel terminates the stream, so a protocol can flush buffered
+ * state into the output first.
+ */
+export class SSEMessageDecoder<T> extends PipeableTransformStream<
   Uint8Array<ArrayBuffer>,
   T
 > {
-  constructor(options: { strict?: boolean | undefined } = {}) {
-    const strict = options.strict ?? true;
-    const ignoredEvents = new Set<string>();
-    super((readable) =>
-      readable
+  constructor(options: SSEMessageDecoderOptions<T>) {
+    const { strict = true, doneSentinel, onMessage, onDone } = options;
+    super((readable) => {
+      const ignoredEvents = new Set<string>();
+
+      return readable
         .pipeThrough(new TextDecoderStream())
         .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
           new TransformStream<PipelineSSEEvent, T>({
             transform(event, controller) {
               switch (event.event) {
-                case "message": {
-                  let value;
-                  try {
-                    value = sjson.parse(event.data);
-                  } catch {
-                    console.warn(
-                      `Dropped invalid SSE message: ${event.data.slice(0, 200)}`,
-                    );
+                case "message":
+                  if (
+                    doneSentinel !== undefined &&
+                    event.data === doneSentinel
+                  ) {
+                    onDone?.(controller);
+                    controller.terminate();
                     break;
                   }
-                  controller.enqueue(value);
+                  onMessage(event.data, controller);
                   break;
-                }
                 default:
                   if (strict)
                     throw new Error(`Unknown SSE event type: ${event.event}`);
@@ -71,8 +98,32 @@ export class SSEDecoder<T> extends PipeableTransformStream<
                   }
               }
             },
+            flush() {
+              if (doneSentinel === undefined) return;
+              const message = `Stream ended abruptly without receiving ${doneSentinel} marker`;
+              if (strict) throw new Error(message);
+              console.warn(message);
+            },
           }),
-        ),
-    );
+        );
+    });
+  }
+}
+
+export class SSEDecoder<T> extends SSEMessageDecoder<T> {
+  constructor(options: { strict?: boolean | undefined } = {}) {
+    super({
+      strict: options.strict ?? true,
+      onMessage(data, controller) {
+        let value;
+        try {
+          value = sjson.parse(data);
+        } catch {
+          console.warn(`Dropped invalid SSE message: ${data.slice(0, 200)}`);
+          return;
+        }
+        controller.enqueue(value);
+      },
+    });
   }
 }


### PR DESCRIPTION
`assistant-transport` and `ui-message-stream` each rebuild the SSE plumbing that `SSE.ts` already owns: the same `data: ${JSON.stringify(chunk)}` frame on the way out, and the same `TextDecoderStream` → `SSEEventDecoderStream` → per-event switch on the way in, down to identical unknown-event and missing-`[DONE]` error text. Gorp already builds on `SSE.ts`; the other two pipelines carry ~100 lines of divergence-prone copies.

This PR moves both onto the shared classes. `SSEEncoder` gains an optional `doneSentinel`, written verbatim on flush so `[DONE]` never passes through JSON. On the decode side, a new `SSEMessageDecoder` owns the SSE half — byte decoding, event framing, the strict-versus-lenient unknown-event policy, and the terminating sentinel — and hands each message payload to the protocol's own `onMessage`. An optional `onDone` hook runs before the sentinel terminates the stream, which is how `ui-message-stream` keeps flushing its pending tool calls on `[DONE]` exactly as before (#6155). What a payload means stays with each protocol: assistant-transport keeps `parseChunk` and its warn-once-per-reason drops, ui-message-stream keeps its shape validation and field normalizations, and `SSEDecoder` becomes the plain-JSON specialization of the same base. Part of a series replacing duplicated plumbing with the shared primitives.

No wire change: every frame and error message is byte-identical, and the cross-language interop suite passes untouched.

## Verification

- `pnpm --filter assistant-stream test` — 490 passed, 20 skipped in both test configs, rebased onto current main and re-verified today
- `AssistantTransport.interop.test.ts` and its Python encoder fixture pass unmodified, as do the four decoder suites
- `api-surface` regenerated: the new `SSEEncoder` option and `SSEMessageDecoder` types, plus the two transport classes re-declared on the shared bases

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RcSfvHcxuA66PTB06p8D1O0bjQu7cedzyG4yRD8DsdvMtZeOUU8co7YkEM8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->