### PR TITLE
fix(react): keep mcp app server routing commit-safe

### DIFF
--- a/.changeset/calm-mcp-app-routing.md
+++ b/.changeset/calm-mcp-app-routing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep MCP App server routing scoped to committed renders

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -61,14 +61,22 @@ const createPart = (serverId?: string): ToolCallMessagePartProps => ({
   respondToApproval: vi.fn(),
 });
 
+const createPartWithoutApp = (): ToolCallMessagePartProps => {
+  const part = createPart();
+  delete part.mcp;
+  return part;
+};
+
 function Harness({
   host,
   serverId,
   handlers,
+  part,
 }: {
   host: McpAppsHost;
   serverId?: string;
   handlers?: McpAppRendererOptions["handlers"];
+  part?: ToolCallMessagePartProps;
 }) {
   const renderer = useResource(
     McpAppRenderer({
@@ -77,7 +85,7 @@ function Harness({
     }),
   );
   const Renderer = renderer.render;
-  return <Renderer {...createPart(serverId)} />;
+  return <Renderer {...(part ?? createPart(serverId))} />;
 }
 
 const MemoizedPart = memo(function MemoizedPart({
@@ -171,23 +179,38 @@ describe("McpAppRenderer", () => {
       }
       return null;
     };
-    const view = (serverId: string, blocked: boolean) => (
+    const view = (part: ToolCallMessagePartProps, blocked: boolean) => (
       <Suspense fallback={null}>
-        <Harness host={host} serverId={serverId} />
+        <Harness host={host} part={part} />
         <Blocker blocked={blocked} />
       </Suspense>
     );
-    const rendered = render(view("server-a", false));
+    const rendered = render(view(createPart("server-a"), false));
     await waitFor(() => expect(framePropsMock).toHaveBeenCalled());
     const handlers = framePropsMock.mock.lastCall?.[0]
       .handlers as McpAppBridgeHandlers;
 
     act(() => {
-      startTransition(() => rendered.rerender(view("server-b", true)));
+      startTransition(() =>
+        rendered.rerender(view(createPart("server-b"), true)),
+      );
     });
     expect(interruptedRender).toHaveBeenCalled();
     await handlers.callTool?.({ name: "search" });
 
+    expect(host.callTool).toHaveBeenCalledWith({
+      name: "search",
+      serverId: "server-a",
+    });
+
+    framePropsMock.mockClear();
+    vi.mocked(host.callTool).mockClear();
+    rendered.rerender(view(createPartWithoutApp(), false));
+    await waitFor(() => expect(framePropsMock).toHaveBeenCalled());
+    expect(framePropsMock.mock.lastCall?.[0].app.serverId).toBe("server-a");
+    const fallbackHandlers = framePropsMock.mock.lastCall?.[0]
+      .handlers as McpAppBridgeHandlers;
+    await fallbackHandlers.callTool?.({ name: "search" });
     expect(host.callTool).toHaveBeenCalledWith({
       name: "search",
       serverId: "server-a",

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, waitFor } from "@testing-library/react";
 import { resource, useResource, withKey } from "@assistant-ui/tap";
-import { memo } from "react";
+import { act, memo, startTransition, Suspense } from "react";
 import type {
   ToolCallMessagePartComponent,
   ToolCallMessagePartProps,
@@ -148,6 +148,49 @@ describe("McpAppRenderer", () => {
     expect(loadResource).toHaveBeenLastCalledWith({
       uri: "ui://example/search",
       serverId: "server-b",
+    });
+  });
+
+  it("keeps bridge server ids scoped to committed renders", async () => {
+    const host: McpAppsHost = {
+      loadResource: vi.fn(async ({ uri }) => ({
+        uri,
+        mimeType: "text/html;profile=mcp-app" as const,
+        html: "",
+      })),
+      callTool: vi.fn(),
+      readResource: vi.fn(),
+      listResources: vi.fn(),
+    };
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    const Blocker = ({ blocked }: { blocked: boolean }) => {
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      return null;
+    };
+    const view = (serverId: string, blocked: boolean) => (
+      <Suspense fallback={null}>
+        <Harness host={host} serverId={serverId} />
+        <Blocker blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view("server-a", false));
+    await waitFor(() => expect(framePropsMock).toHaveBeenCalled());
+    const handlers = framePropsMock.mock.lastCall?.[0]
+      .handlers as McpAppBridgeHandlers;
+
+    act(() => {
+      startTransition(() => rendered.rerender(view("server-b", true)));
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+    await handlers.callTool?.({ name: "search" });
+
+    expect(host.callTool).toHaveBeenCalledWith({
+      name: "search",
+      serverId: "server-a",
     });
   });
 

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -2,6 +2,7 @@
 
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -114,13 +115,9 @@ function InlineRenderer({
   const aui = useAui();
   const app = getMcpAppFromToolPart(part);
   const cachedAppRef = useRef<McpAppMetadata | undefined>(undefined);
-  if (
-    app != null &&
-    (cachedAppRef.current?.resourceUri !== app.resourceUri ||
-      cachedAppRef.current?.serverId !== app.serverId)
-  ) {
-    cachedAppRef.current = app;
-  }
+  useLayoutEffect(() => {
+    if (app != null) cachedAppRef.current = app;
+  }, [app]);
   const appForRender = app ?? cachedAppRef.current;
 
   const [loadedResource, setLoadedResource] = useState<LoadedResourceState>();

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -128,8 +128,6 @@ function InlineRenderer({
   const host = useHostStore((state) => state.host);
   const resourceUri = appForRender?.resourceUri;
   const serverId = appForRender?.serverId;
-  const serverIdRef = useRef<string | undefined>(undefined);
-  serverIdRef.current = serverId;
   const callerHandlers = opts.handlers;
   useEffect(() => {
     if (resourceUri == null) return;
@@ -187,24 +185,24 @@ function InlineRenderer({
       callTool: (params) =>
         useHostStore.getState().host.callTool({
           ...params,
-          ...(serverIdRef.current ? { serverId: serverIdRef.current } : {}),
+          ...(serverId ? { serverId } : {}),
         }),
       readResource: (params) =>
         useHostStore.getState().host.readResource({
           ...params,
-          ...(serverIdRef.current ? { serverId: serverIdRef.current } : {}),
+          ...(serverId ? { serverId } : {}),
         }),
       listResources: (params) => {
-        if (!serverIdRef.current) {
+        if (!serverId) {
           return useHostStore.getState().host.listResources(params);
         }
         return useHostStore.getState().host.listResources({
           ...(isRecord(params) ? params : {}),
-          serverId: serverIdRef.current,
+          serverId,
         });
       },
     }),
-    [aui, callerHandlers, useHostStore],
+    [aui, callerHandlers, serverId, useHostStore],
   );
 
   const loadedResourceForApp =


### PR DESCRIPTION
## Summary

- capture MCP App server IDs in each render’s bridge handler closure
- prevent abandoned renders from changing routing for committed widgets
- add an interrupted-render regression covering tool-call routing

## Why

`InlineRenderer` assigned `serverIdRef.current` during render and stable bridge handlers read that shared ref later. A render for workspace/server B that suspended and never committed could therefore change the server ID used by the still-committed workspace/server A widget. Tool calls and resource requests from A could be routed through B.

Closing over the render’s `serverId` makes the handler object part of React’s render snapshot. If React abandons that render, the committed bridge keeps the previous handler and server ID.

## Test plan

- `vitest run src/mcp-apps/McpAppRenderer.test.tsx` (9 tests)
- focused oxlint on the changed TypeScript files
- `git diff --check`

## Changeset

- `@assistant-ui/react`: patch

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.aFX6s5_nEEz1qamCqLfTx0teXx_I6By_iJ54MeCoivhUmHveI6X2nmSc9BY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->