### PR TITLE
fix(react-a2a): apply managed headers after commit

### DIFF
--- a/.changeset/gentle-a2a-headers.md
+++ b/.changeset/gentle-a2a-headers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: keep managed A2A headers scoped to committed renders

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -224,6 +224,7 @@ describe("useA2ARuntime", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const interruptedRender = vi.fn();
+    const renderedToken = vi.fn();
     const pending = new Promise<never>(() => {});
     let blocked = false;
     const Blocker = ({ blocked }: { blocked: boolean }) => {
@@ -241,11 +242,13 @@ describe("useA2ARuntime", () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ token }) =>
-        useA2ARuntime({
+      ({ token }) => {
+        renderedToken(token);
+        return useA2ARuntime({
           baseUrl: "https://agent.test",
           headers: { Authorization: `Bearer ${token}` },
-        }),
+        });
+      },
       {
         initialProps: { token: "workspace-a" },
         wrapper: Wrapper,
@@ -260,6 +263,7 @@ describe("useA2ARuntime", () => {
       });
     });
     expect(interruptedRender).toHaveBeenCalled();
+    expect(renderedToken).toHaveBeenCalledWith("workspace-b");
 
     act(() => {
       result.current.thread.append({

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { startTransition, Suspense, type PropsWithChildren } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { A2AClient } from "./A2AClient";
 import type { A2AStreamEvent } from "./types";
@@ -56,6 +57,32 @@ const createMockClient = (waitForAbort = false) => {
     },
   };
 };
+
+const createFetchMock = () =>
+  vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url.endsWith("/.well-known/agent-card.json")) {
+      return new Response(
+        JSON.stringify({ capabilities: { streaming: true } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    return new Response(
+      'data: {"message":{"message_id":"response","role":"ROLE_AGENT","parts":[{"text":"Done"}]}}\n\n',
+      {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      },
+    );
+  });
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -160,32 +187,7 @@ describe("useA2ARuntime", () => {
   });
 
   it("uses current headers without recreating the managed client", async () => {
-    const fetchMock = vi.fn(
-      async (input: string | URL | Request, _init?: RequestInit) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : input.url;
-        if (url.endsWith("/.well-known/agent-card.json")) {
-          return new Response(
-            JSON.stringify({ capabilities: { streaming: true } }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            },
-          );
-        }
-        return new Response(
-          'data: {"message":{"message_id":"response","role":"ROLE_AGENT","parts":[{"text":"Done"}]}}\n\n',
-          {
-            status: 200,
-            headers: { "Content-Type": "text/event-stream" },
-          },
-        );
-      },
-    );
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     const { result, rerender } = renderHook(
@@ -214,6 +216,61 @@ describe("useA2ARuntime", () => {
     const streamRequest = fetchMock.mock.calls[1]!;
     expect(streamRequest[1]?.headers).toMatchObject({
       Authorization: "Bearer second",
+    });
+  });
+
+  it("keeps managed headers scoped to committed renders", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    let blocked = false;
+    const Blocker = ({ blocked }: { blocked: boolean }) => {
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      return null;
+    };
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <Suspense fallback={null}>
+        {children}
+        <Blocker blocked={blocked} />
+      </Suspense>
+    );
+
+    const { result, rerender } = renderHook(
+      ({ token }) =>
+        useA2ARuntime({
+          baseUrl: "https://agent.test",
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      {
+        initialProps: { token: "workspace-a" },
+        wrapper: Wrapper,
+      },
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    act(() => {
+      blocked = true;
+      startTransition(() => {
+        rerender({ token: "workspace-b" });
+      });
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1]![1]?.headers).toMatchObject({
+      Authorization: "Bearer workspace-a",
     });
   });
 });

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   useExternalStoreRuntime,
   useExternalStoreSharedOptions,
@@ -42,9 +49,9 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   const threadListAdapter = options.adapters?.threadList;
 
   const headersRef = useRef(options.headers);
-  useEffect(() => {
+  useInsertionEffect(() => {
     headersRef.current = options.headers;
-  }, [options.headers]);
+  });
   const resolveHeaders = useCallback(() => {
     const headers = headersRef.current;
     return typeof headers === "function" ? headers() : (headers ?? {});

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -42,7 +42,9 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   const threadListAdapter = options.adapters?.threadList;
 
   const headersRef = useRef(options.headers);
-  headersRef.current = options.headers;
+  useEffect(() => {
+    headersRef.current = options.headers;
+  }, [options.headers]);
   const resolveHeaders = useCallback(() => {
     const headers = headersRef.current;
     return typeof headers === "function" ? headers() : (headers ?? {});


### PR DESCRIPTION
## Summary

- publish managed A2A header updates only after their React render commits
- keep the managed client and its header resolver stable across committed header changes
- cover an interrupted workspace render with a focused concurrency regression

## Why

`useA2ARuntime()` previously assigned `headersRef.current` during render. If workspace A remained committed while a workspace B render suspended or was abandoned, B could still overwrite the shared resolver state. A later request from A would then carry B's authentication or tenant headers.

Updating the ref in an effect ties the resolver to the latest committed render. Normal committed header changes still flow through the existing client without recreating it.

## Testing

- `pnpm --filter @assistant-ui/react-a2a test` (267 tests)
- `pnpm exec oxlint packages/react-a2a/src/useA2ARuntime.ts packages/react-a2a/src/useA2ARuntime.test.tsx`
- `pnpm --filter @assistant-ui/react-a2a build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9CtrFnziW9MHCQRWSznS8cFEWvM8ED7A_HaCuEUVfN5lX9KOM236-zl83q4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->