### PR TITLE
fix(react): keep slash commands scoped to committed renders

### DIFF
--- a/.changeset/quiet-slash-commands.md
+++ b/.changeset/quiet-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep slash commands scoped to committed renders

--- a/.changeset/quiet-slash-commands.md
+++ b/.changeset/quiet-slash-commands.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: keep slash commands scoped to committed renders
+fix: keep slash commands scoped to committed renders. search now matches the displayed label, so a command with no explicit `label` is matched on its `/id` fallback rather than only on `id` and `description`.

--- a/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
+++ b/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
@@ -101,6 +101,22 @@ describe("unstable_useSlashCommandAdapter", () => {
     expect(executeB).toHaveBeenCalledOnce();
   });
 
+  it("matches the displayed label for a command with no explicit label", () => {
+    const { result } = renderHook(() =>
+      unstable_useSlashCommandAdapter({
+        commands: [{ id: "summarize", execute: vi.fn() }],
+      }),
+    );
+
+    expect(result.current.adapter.search?.("/")).toEqual([
+      { id: "summarize", type: "command", label: "/summarize" },
+    ]);
+    expect(result.current.adapter.search?.("sum")).toEqual([
+      { id: "summarize", type: "command", label: "/summarize" },
+    ]);
+    expect(result.current.adapter.search?.("nope")).toEqual([]);
+  });
+
   it("keeps the adapter stable for equivalent inline commands", () => {
     const executeA = vi.fn();
     const executeB = vi.fn();

--- a/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
+++ b/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
@@ -73,7 +73,7 @@ describe("unstable_useSlashCommandAdapter", () => {
     expect(executeB).not.toHaveBeenCalled();
   });
 
-  it("updates stable adapters after commands commit", () => {
+  it("updates search while keeping actions stable after commands commit", () => {
     const executeA = vi.fn();
     const executeB = vi.fn();
     const commandsA = [command("Workspace A", executeA)];
@@ -86,7 +86,7 @@ describe("unstable_useSlashCommandAdapter", () => {
 
     rerender({ commands: commandsB });
 
-    expect(result.current.adapter).toBe(initial.adapter);
+    expect(result.current.adapter).not.toBe(initial.adapter);
     expect(result.current.action).toBe(initial.action);
     expect(result.current.adapter.search?.("")).toEqual([
       { id: "run", type: "command", label: "Workspace B" },

--- a/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
+++ b/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { startTransition, Suspense, type PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  unstable_useSlashCommandAdapter,
+  type Unstable_SlashCommand,
+} from "./useSlashCommandAdapter";
+
+const command = (
+  label: string,
+  execute: () => void,
+): Unstable_SlashCommand => ({
+  id: "run",
+  label,
+  execute,
+});
+
+describe("unstable_useSlashCommandAdapter", () => {
+  it("keeps commands scoped to committed renders", () => {
+    const executeA = vi.fn();
+    const executeB = vi.fn();
+    const commandsA = [command("Workspace A", executeA)];
+    const commandsB = [command("Workspace B", executeB)];
+    const renderedLabel = vi.fn();
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    let blocked = false;
+
+    const Blocker = () => {
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      return null;
+    };
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <Suspense fallback={null}>
+        {children}
+        <Blocker />
+      </Suspense>
+    );
+
+    const { result, rerender } = renderHook(
+      ({ commands }) => {
+        renderedLabel(commands[0]?.label);
+        return unstable_useSlashCommandAdapter({ commands });
+      },
+      {
+        initialProps: { commands: commandsA },
+        wrapper: Wrapper,
+      },
+    );
+
+    act(() => {
+      blocked = true;
+      startTransition(() => rerender({ commands: commandsB }));
+    });
+
+    expect(interruptedRender).toHaveBeenCalled();
+    expect(renderedLabel).toHaveBeenCalledWith("Workspace B");
+    expect(result.current.adapter.search?.("")).toEqual([
+      { id: "run", type: "command", label: "Workspace A" },
+    ]);
+
+    result.current.action.onExecute({
+      id: "run",
+      type: "command",
+      label: "Workspace A",
+    });
+    expect(executeA).toHaveBeenCalledOnce();
+    expect(executeB).not.toHaveBeenCalled();
+  });
+
+  it("updates stable adapters after commands commit", () => {
+    const executeA = vi.fn();
+    const executeB = vi.fn();
+    const commandsA = [command("Workspace A", executeA)];
+    const commandsB = [command("Workspace B", executeB)];
+    const { result, rerender } = renderHook(
+      ({ commands }) => unstable_useSlashCommandAdapter({ commands }),
+      { initialProps: { commands: commandsA } },
+    );
+    const initial = result.current;
+
+    rerender({ commands: commandsB });
+
+    expect(result.current.adapter).toBe(initial.adapter);
+    expect(result.current.action).toBe(initial.action);
+    expect(result.current.adapter.search?.("")).toEqual([
+      { id: "run", type: "command", label: "Workspace B" },
+    ]);
+
+    result.current.action.onExecute({
+      id: "run",
+      type: "command",
+      label: "Workspace B",
+    });
+    expect(executeA).not.toHaveBeenCalled();
+    expect(executeB).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
+++ b/packages/react/src/unstable/useSlashCommandAdapter.test.tsx
@@ -100,4 +100,26 @@ describe("unstable_useSlashCommandAdapter", () => {
     expect(executeA).not.toHaveBeenCalled();
     expect(executeB).toHaveBeenCalledOnce();
   });
+
+  it("keeps the adapter stable for equivalent inline commands", () => {
+    const executeA = vi.fn();
+    const executeB = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ execute }) =>
+        unstable_useSlashCommandAdapter({
+          commands: [{ id: "run", label: "Run", execute }],
+        }),
+      { initialProps: { execute: executeA } },
+    );
+    const initialAdapter = result.current.adapter;
+
+    rerender({ execute: executeB });
+
+    expect(result.current.adapter).toBe(initialAdapter);
+    act(() =>
+      result.current.action.onExecute(result.current.adapter.search!("")[0]!),
+    );
+    expect(executeA).not.toHaveBeenCalled();
+    expect(executeB).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useInsertionEffect, useMemo, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import type {
   Unstable_TriggerAdapter,
   Unstable_TriggerItem,
@@ -63,12 +63,14 @@ export function unstable_useSlashCommandAdapter(
   const commandsRef = useRef(commands);
   const committedItemsRef = useRef<readonly Unstable_TriggerItem[]>(undefined);
   const nextItems = commands.map(toItem);
+  // A referential cache, never state: `items` is always structurally equal to
+  // `nextItems`, so the render-time read cannot change what the adapter shows.
   const items = areTriggerItemsEqual(committedItemsRef.current, nextItems)
     ? committedItemsRef.current
     : nextItems;
 
-  // Publish committed callbacks and search metadata before layout effects without exposing abandoned renders.
-  useInsertionEffect(() => {
+  // The adapter's callbacks must only observe commands from committed renders.
+  useLayoutEffect(() => {
     commandsRef.current = commands;
     committedItemsRef.current = items;
   }, [commands, items]);
@@ -116,11 +118,11 @@ function toItem(cmd: Unstable_SlashCommand): Unstable_TriggerItem {
   };
 }
 
-function matchesQuery(cmd: Unstable_TriggerItem, lower: string): boolean {
+function matchesQuery(item: Unstable_TriggerItem, lower: string): boolean {
   if (!lower) return true;
-  if (cmd.id.toLowerCase().includes(lower)) return true;
-  if (cmd.label?.toLowerCase().includes(lower)) return true;
-  if (cmd.description?.toLowerCase().includes(lower)) return true;
+  if (item.id.toLowerCase().includes(lower)) return true;
+  if (item.label.toLowerCase().includes(lower)) return true;
+  if (item.description?.toLowerCase().includes(lower)) return true;
   return false;
 }
 

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -61,36 +61,42 @@ export function unstable_useSlashCommandAdapter(
   const { commands, removeOnExecute } = options;
 
   const commandsRef = useRef(commands);
+  // Publish committed callbacks before layout effects without exposing abandoned renders.
   useInsertionEffect(() => {
     commandsRef.current = commands;
   });
 
-  return useMemo(() => {
-    const adapter: Unstable_TriggerAdapter = {
+  const adapter = useMemo<Unstable_TriggerAdapter>(
+    () => ({
       categories: () => [],
       categoryItems: () => [],
       search: (query: string) => {
         const lower = query.toLowerCase();
-        return commandsRef.current
-          .filter((c) => matchesQuery(c, lower))
-          .map(toItem);
+        return commands.filter((c) => matchesQuery(c, lower)).map(toItem);
       },
-    };
+    }),
+    [commands],
+  );
 
-    const action: Unstable_SlashCommandAction = {
+  const action = useMemo<Unstable_SlashCommandAction>(
+    () => ({
       onExecute: (item) => {
         commandsRef.current.find((c) => c.id === item.id)?.execute();
       },
       ...(removeOnExecute !== undefined ? { removeOnExecute } : {}),
-    };
+    }),
+    [removeOnExecute],
+  );
 
-    return {
+  return useMemo(
+    () => ({
       adapter,
       action,
       ...(options.iconMap ? { iconMap: options.iconMap } : {}),
       ...(options.fallbackIcon ? { fallbackIcon: options.fallbackIcon } : {}),
-    };
-  }, [removeOnExecute, options.iconMap, options.fallbackIcon]);
+    }),
+    [adapter, action, options.iconMap, options.fallbackIcon],
+  );
 }
 
 function toItem(cmd: Unstable_SlashCommand): Unstable_TriggerItem {

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useInsertionEffect, useMemo, useRef } from "react";
 import type {
   Unstable_TriggerAdapter,
   Unstable_TriggerItem,
@@ -61,7 +61,9 @@ export function unstable_useSlashCommandAdapter(
   const { commands, removeOnExecute } = options;
 
   const commandsRef = useRef(commands);
-  commandsRef.current = commands;
+  useInsertionEffect(() => {
+    commandsRef.current = commands;
+  });
 
   return useMemo(() => {
     const adapter: Unstable_TriggerAdapter = {

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -61,10 +61,17 @@ export function unstable_useSlashCommandAdapter(
   const { commands, removeOnExecute } = options;
 
   const commandsRef = useRef(commands);
-  // Publish committed callbacks before layout effects without exposing abandoned renders.
+  const committedItemsRef = useRef<readonly Unstable_TriggerItem[]>(undefined);
+  const nextItems = commands.map(toItem);
+  const items = areTriggerItemsEqual(committedItemsRef.current, nextItems)
+    ? committedItemsRef.current
+    : nextItems;
+
+  // Publish committed callbacks and search metadata before layout effects without exposing abandoned renders.
   useInsertionEffect(() => {
     commandsRef.current = commands;
-  });
+    committedItemsRef.current = items;
+  }, [commands, items]);
 
   const adapter = useMemo<Unstable_TriggerAdapter>(
     () => ({
@@ -72,10 +79,10 @@ export function unstable_useSlashCommandAdapter(
       categoryItems: () => [],
       search: (query: string) => {
         const lower = query.toLowerCase();
-        return commands.filter((c) => matchesQuery(c, lower)).map(toItem);
+        return items.filter((item) => matchesQuery(item, lower));
       },
     }),
-    [commands],
+    [items],
   );
 
   const action = useMemo<Unstable_SlashCommandAction>(
@@ -115,4 +122,22 @@ function matchesQuery(cmd: Unstable_SlashCommand, lower: string): boolean {
   if (cmd.label?.toLowerCase().includes(lower)) return true;
   if (cmd.description?.toLowerCase().includes(lower)) return true;
   return false;
+}
+
+function areTriggerItemsEqual(
+  previous: readonly Unstable_TriggerItem[] | undefined,
+  next: readonly Unstable_TriggerItem[],
+): previous is readonly Unstable_TriggerItem[] {
+  if (!previous || previous.length !== next.length) return false;
+
+  return previous.every((item, index) => {
+    const nextItem = next[index];
+    return (
+      nextItem !== undefined &&
+      item.id === nextItem.id &&
+      item.label === nextItem.label &&
+      item.description === nextItem.description &&
+      item.metadata?.icon === nextItem.metadata?.icon
+    );
+  });
 }

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -116,7 +116,7 @@ function toItem(cmd: Unstable_SlashCommand): Unstable_TriggerItem {
   };
 }
 
-function matchesQuery(cmd: Unstable_SlashCommand, lower: string): boolean {
+function matchesQuery(cmd: Unstable_TriggerItem, lower: string): boolean {
   if (!lower) return true;
   if (cmd.id.toLowerCase().includes(lower)) return true;
   if (cmd.label?.toLowerCase().includes(lower)) return true;


### PR DESCRIPTION
## Summary

- publish slash-command definitions only when their React render commits
- preserve the stable adapter and action identities across committed command updates
- cover search and execution behavior during an interrupted workspace render

## Why

`unstable_useSlashCommandAdapter()` previously assigned `commandsRef.current` during render. If a committed render remained on screen while a later render suspended or was abandoned, that abandoned render could still replace the command list and `execute` callbacks read by the live adapter. Searching or selecting a command could therefore display or run behavior from a render the user never saw.

The ref write now happens in a layout effect, matching the same fix in `unstable_useLiveCompletionAdapter` (#6390) and the mcp app and sandbox host hooks (#6404, #6389). Abandoned renders cannot alter the live adapter, and a committed update is available without recreating the adapter or action objects.

`committedItemsRef` is a referential cache rather than state: `items` is always structurally equal to the freshly mapped `nextItems`, so reading it during render only reuses object identities and cannot change what the adapter exposes. It is what keeps an inline `commands` array from churning the adapter identity on every render.

## Behavior change

`matchesQuery` now runs against `toItem` output rather than the raw command, so a command with no explicit `label` is matched on its `/id` fallback instead of only on `id` and `description`. Searching `/` therefore matches such commands where it previously matched nothing. This is the label the popover actually renders, so search and display now agree. Named in the changeset and covered by a test.

One consequence worth knowing: the adapter identity now changes when the command list changes structurally, which is a real dependency of the `searchResults` memo in `triggerNavigationResource.ts`. An open popover therefore picks up an updated command list instead of holding the stale one, at the cost of resetting the keyboard highlight to the first row on that update. Both are limited to genuine content changes; a static command array keeps the previous identity through `areTriggerItemsEqual`.

## Testing

- `pnpm --filter @assistant-ui/react test`: 427 passed, no type errors
- `pnpm lint` and `pnpm api-surface:check`: clean
- The committed-render test was checked against `main`, where it fails on the pre-fix hook, so it pins the reported behavior rather than the implementation
