### PR TITLE
refactor(py-stream): share the encoder, queue loop, and id generator

### DIFF
--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -21,6 +21,7 @@ from assistant_stream.modules.tool_call import (
     ToolCallController,
     generate_openai_style_tool_call_id,
 )
+from assistant_stream.queue_stream import enqueue_threadsafe, queue_stream
 from assistant_stream.state_manager import StateManager
 
 logger = logging.getLogger(__name__)
@@ -183,7 +184,7 @@ class RunController:
 
         This is used as a callback for the StateManager.
         """
-        self._loop.call_soon_threadsafe(self._queue.put_nowait, chunk)
+        enqueue_threadsafe(self._loop, self._queue, chunk)
 
     def _flush_and_put_chunk(self, chunk):
         """Helper method to flush state operations and put a chunk in the queue.
@@ -193,7 +194,7 @@ class RunController:
         # Flush any pending state operations first
         self._state_manager.flush()
         # Add the chunk to the queue
-        self._loop.call_soon_threadsafe(self._queue.put_nowait, chunk)
+        enqueue_threadsafe(self._loop, self._queue, chunk)
 
     @property
     def state(self):
@@ -268,19 +269,15 @@ async def create_run(
                 for task in controller._stream_tasks:
                     await task
             finally:
-                asyncio.get_running_loop().call_soon_threadsafe(queue.put_nowait, None)
+                enqueue_threadsafe(asyncio.get_running_loop(), queue, None)
 
     task = asyncio.create_task(background_task())
     ended_normally = False
 
     try:
-        while True:
-            chunk = await controller._queue.get()
-            if chunk is None:
-                ended_normally = True
-                break
+        async for chunk in queue_stream(controller._queue):
             yield chunk
-            controller._queue.task_done()
+        ended_normally = True
     finally:
         if ended_normally:
             # The `None` sentinel is queued at the end of `background_task`, so

--- a/python/assistant-stream/src/assistant_stream/identifiers.py
+++ b/python/assistant-stream/src/assistant_stream/identifiers.py
@@ -1,0 +1,7 @@
+import random
+import string
+
+
+def generate_prefixed_id(prefix: str, length: int = 24) -> str:
+    characters = string.ascii_letters + string.digits
+    return prefix + "".join(random.choices(characters, k=length))

--- a/python/assistant-stream/src/assistant_stream/modules/tool_call.py
+++ b/python/assistant-stream/src/assistant_stream/modules/tool_call.py
@@ -1,5 +1,7 @@
 import asyncio
 from typing import Any, AsyncGenerator
+from assistant_stream.identifiers import generate_prefixed_id
+from assistant_stream.queue_stream import enqueue_threadsafe, queue_stream
 from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
     ToolCallBeginChunk,
@@ -7,15 +9,10 @@ from assistant_stream.assistant_stream_chunk import (
     ToolCallDeltaChunk,
     ToolResultChunk,
 )
-import string
-import random
 
 
 def generate_openai_style_tool_call_id():
-    prefix = "call_"
-    characters = string.ascii_letters + string.digits
-    random_id = "".join(random.choices(characters, k=24))
-    return prefix + random_id
+    return generate_prefixed_id("call_")
 
 
 class ToolCallController:
@@ -39,7 +36,7 @@ class ToolCallController:
             tool_call_id=self.tool_call_id,
             args_text_delta=args_text_delta,
         )
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, chunk)
+        enqueue_threadsafe(self.loop, self.queue, chunk)
 
     def set_result(self, result: Any) -> None:
         """
@@ -67,7 +64,7 @@ class ToolCallController:
             artifact=artifact,
             is_error=is_error,
         )
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, chunk)
+        enqueue_threadsafe(self.loop, self.queue, chunk)
         self.close()
 
     def close(self) -> None:
@@ -75,11 +72,12 @@ class ToolCallController:
         if self._closed:
             return
         self._closed = True
-        self.loop.call_soon_threadsafe(
-            self.queue.put_nowait,
+        enqueue_threadsafe(
+            self.loop,
+            self.queue,
             ToolCallArgsTextFinishChunk(tool_call_id=self.tool_call_id),
         )
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, None)
+        enqueue_threadsafe(self.loop, self.queue, None)
 
 
 async def create_tool_call(
@@ -91,11 +89,7 @@ async def create_tool_call(
     controller = ToolCallController(queue, tool_name, tool_call_id, parent_id)
 
     async def stream():
-        while True:
-            chunk = await controller.queue.get()
-            if chunk is None:
-                break
+        async for chunk in queue_stream(controller.queue):
             yield chunk
-            controller.queue.task_done()
 
     return stream(), controller

--- a/python/assistant-stream/src/assistant_stream/modules/tool_call.py
+++ b/python/assistant-stream/src/assistant_stream/modules/tool_call.py
@@ -88,8 +88,4 @@ async def create_tool_call(
     queue = asyncio.Queue()
     controller = ToolCallController(queue, tool_name, tool_call_id, parent_id)
 
-    async def stream():
-        async for chunk in queue_stream(controller.queue):
-            yield chunk
-
-    return stream(), controller
+    return queue_stream(controller.queue), controller

--- a/python/assistant-stream/src/assistant_stream/queue_stream.py
+++ b/python/assistant-stream/src/assistant_stream/queue_stream.py
@@ -1,0 +1,22 @@
+import asyncio
+from typing import AsyncGenerator, TypeVar
+
+
+T = TypeVar("T")
+
+
+def enqueue_threadsafe(
+    loop: asyncio.AbstractEventLoop,
+    queue: asyncio.Queue[T | None],
+    item: T | None,
+) -> None:
+    loop.call_soon_threadsafe(queue.put_nowait, item)
+
+
+async def queue_stream(queue: asyncio.Queue[T | None]) -> AsyncGenerator[T, None]:
+    while True:
+        item = await queue.get()
+        if item is None:
+            break
+        yield item
+        queue.task_done()

--- a/python/assistant-stream/src/assistant_stream/queue_stream.py
+++ b/python/assistant-stream/src/assistant_stream/queue_stream.py
@@ -17,6 +17,7 @@ async def queue_stream(queue: asyncio.Queue[T | None]) -> AsyncGenerator[T, None
     while True:
         item = await queue.get()
         if item is None:
+            queue.task_done()
             break
         yield item
         queue.task_done()

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -21,21 +21,12 @@ from assistant_stream.serialization.heartbeat import (
     HeartbeatOption,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
-from assistant_stream.state_proxy import StateProxy
+from assistant_stream.state_proxy import StateProxyJSONEncoder
 from typing import AsyncGenerator, Any
 import json
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-class StateProxyJSONEncoder(json.JSONEncoder):
-    """Custom JSON encoder that can handle StateProxy objects."""
-
-    def default(self, obj: Any) -> Any:
-        if isinstance(obj, StateProxy):
-            return obj._get_value()
-        return super().default(obj)
 
 
 class _Canonicalizer:

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -14,17 +14,9 @@ from assistant_stream.serialization.heartbeat import (
     HeartbeatOption,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
-from assistant_stream.state_proxy import StateProxy
+from assistant_stream.state_proxy import StateProxyJSONEncoder
 
 logger = logging.getLogger(__name__)
-
-
-class StateProxyJSONEncoder(json.JSONEncoder):
-    """Custom JSON encoder that can handle StateProxy objects."""
-    def default(self, obj: Any) -> Any:
-        if isinstance(obj, StateProxy):
-            return obj._get_value()
-        return super().default(obj)
 
 
 class DataStreamEncoder(StreamEncoder):

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -1,8 +1,7 @@
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
+from assistant_stream.identifiers import generate_prefixed_id
 import json
 import time
-import string
-import random
 from typing import AsyncGenerator
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
@@ -15,10 +14,7 @@ from assistant_stream.serialization.stream_encoder import StreamEncoder
 
 
 def generate_openai_style_id():
-    prefix = "chatcmpl-"
-    characters = string.ascii_letters + string.digits
-    random_id = "".join(random.choices(characters, k=24))
-    return prefix + random_id
+    return generate_prefixed_id("chatcmpl-")
 
 
 class OpenAIStreamEncoder(StreamEncoder):

--- a/python/assistant-stream/src/assistant_stream/state_proxy.py
+++ b/python/assistant-stream/src/assistant_stream/state_proxy.py
@@ -1,3 +1,6 @@
+import json
+from typing import Any
+
 from assistant_stream.state import StateProxy as BaseStateProxy
 
 
@@ -10,3 +13,12 @@ class StateProxy(BaseStateProxy):
         state_proxy["messages"] += "Hello"
         state_proxy["items"].append("item")
     """
+
+
+class StateProxyJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder that can handle StateProxy objects."""
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, StateProxy):
+            return obj._get_value()
+        return super().default(obj)


### PR DESCRIPTION
## summary

- the python assistant-stream package carried three internal copies: an identical StateProxyJSONEncoder in both serializers, the asyncio.Queue plus None-sentinel stream loop (with call_soon_threadsafe dispatch) in both create_run and the tool-call module, and an OpenAI-style random id generator differing only in prefix
- one home each: the encoder next to the state proxy, a queue_stream utility, and generate_prefixed_id; call sites keep their own semantics (ended_normally tracking, task result propagation, cancellation handling, and the synchronous initial tool-call begin enqueue stay where they were)
- wire frames, orderings, and format strings are untouched; this is packaging only

## test plan

### already verified

- [x] full pytest suite: 167 passed, 7 skipped (rerun independently), including the interop fixtures untouched

no changeset; python packages release outside changesets.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dHH0Vhtj5KcYEvyGNGJ8MDwFL7PWGXKbhHbZXLxuqsf5FFXbe8QXay5lG7A?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->