### PR TITLE
refactor: share the pending tool-call scan, abortable load, and create fallback

### DIFF
--- a/.changeset/shared-runtime-helpers.md
+++ b/.changeset/shared-runtime-helpers.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+refactor: share the pending tool-call scan, abortable thread load, and cloud create fallback via core.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -24,6 +24,15 @@ interface ScopeRegistry {
     unstable_interactables: Unstable_InteractablesClientSchema;
 }
 
+type AbortableThreadLoadOptions = {
+  purpose?: AbortableThreadLoadPurpose;
+  load: (signal: AbortSignal) => Promise<void>;
+  onSettled: () => void;
+  onInitialError: (error: unknown) => void;
+};
+
+type AbortableThreadLoadPurpose = "initial" | "reload";
+
 type AddMessageCommand = {
   readonly type: "add-message";
   readonly message: UserMessage | AssistantMessage;
@@ -3279,6 +3288,12 @@ type PendingAttachmentStatus = {
   message?: string;
 };
 
+type PendingToolCallMessage<TToolCall> = {
+  toolCalls: readonly TToolCall[];
+} | {
+  toolCallId: string;
+} | undefined;
+
 type PropFieldStatus = "complete" | "streaming";
 
 type ProviderOptions = Record<string, Record<string, unknown>>;
@@ -4415,6 +4430,10 @@ type ThreadData$1 = {
   externalId: string | undefined;
 };
 
+type ThreadData$2 = {
+  externalId: string | undefined;
+};
+
 type ThreadEvents = {
   "thread.runStart": {
     threadId: string;
@@ -4448,6 +4467,11 @@ declare const ThreadListClient: Resource<ClientOutput<"threads">, [
     __internal_assistantRuntime: AssistantRuntime;
   }
 ]>;
+
+type ThreadListItem = {
+  source: unknown;
+  initialize: () => Promise<ThreadData$2>;
+};
 
 declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
   index: number;
@@ -5867,10 +5891,17 @@ declare const consumeSuggestionResult: (result: ReturnType<SuggestionAdapter["ge
 
 declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
 
+declare const createAbortableThreadLoad: () => {
+  abort(purpose?: AbortableThreadLoadPurpose): void;
+  run(_param14: AbortableThreadLoadOptions): Promise<void>;
+};
+
+declare const createCloudThreadListAdapterCreateFallback: (create: (() => Promise<ThreadData$2>) | undefined, threadListItem: ThreadListItem) => (() => Promise<ThreadData$2>);
+
 declare const createLocalStorageAdapter: (options: LocalStorageAdapterOptions) => RemoteThreadListAdapter;
 
 declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
-  useThreadMessages: (_param14: {
+  useThreadMessages: (_param15: {
     messages: T[];
     isRunning: boolean;
     joinStrategy?: JoinStrategy | undefined;
@@ -5897,6 +5928,17 @@ declare const createSuggestionAdapter: (options: CreateSuggestionAdapterOptions)
 
 declare function createThreadMappingId(id: string): THREAD_MAPPING_ID;
 
+declare const createToolCallCancellationStub: (toolCall: {
+  readonly id: string;
+  readonly name: string;
+}) => {
+  type: "tool";
+  name: string;
+  tool_call_id: string;
+  content: string;
+  status: "error";
+};
+
 declare function createVoiceSession(options: {
   abortSignal?: AbortSignal;
 }, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
@@ -5910,8 +5952,8 @@ declare const defaultComponents: {
   Image: () => null;
   File: () => null;
   Unstable_Audio: () => null;
-  ToolGroup: (_param15: PropsWithChildren) => ReactNode;
-  ReasoningGroup: (_param16: PropsWithChildren) => ReactNode;
+  ToolGroup: (_param16: PropsWithChildren) => ReactNode;
+  ReasoningGroup: (_param17: PropsWithChildren) => ReactNode;
 };
 
 declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
@@ -5997,7 +6039,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createThreadMappingId, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AbortableThreadLoadPurpose, AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createAbortableThreadLoad, createCloudThreadListAdapterCreateFallback, createThreadMappingId, createToolCallCancellationStub, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, scanPendingToolCalls, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {
@@ -6055,6 +6097,8 @@ declare const resolveToolApprovalResponse: (approval: {
 }, response: ToolApprovalResponse) => RespondToToolApprovalOptions;
 
 declare const runtimeAdapterTransformScopes: (scopes: ScopesConfig, parent: AssistantClient) => void;
+
+declare const scanPendingToolCalls: <TMessage, TToolCall>(messages: readonly TMessage[], getMessage: (message: TMessage) => PendingToolCallMessage<TToolCall>, getToolCallId: (toolCall: TToolCall) => string) => TToolCall[];
 
 declare const shouldContinue: (result: ThreadAssistantMessage, humanToolNames: string[] | undefined) => boolean;
 
@@ -6159,7 +6203,7 @@ declare const unstable_useThreadMessageIds: () => readonly string[];
 
 declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "archived" | "deleted" | "regular") => RemoteThreadState;
 
-declare const useActionBarCopy: (_param17?: UseActionBarCopyOptions) => {
+declare const useActionBarCopy: (_param18?: UseActionBarCopyOptions) => {
   copy: () => void;
   disabled: boolean;
   isCopied: boolean;
@@ -6231,7 +6275,7 @@ declare const useBranchPickerPrevious: () => {
 
 declare const useCloudThreadListAdapter: (adapter: CloudThreadListAdapterOptions) => RemoteThreadListAdapter;
 
-declare function useCloudThreadListRuntime(_param18: CloudThreadListAdapter): AssistantRuntime;
+declare function useCloudThreadListRuntime(_param19: CloudThreadListAdapter): AssistantRuntime;
 
 declare const useComposerAddAttachment: () => {
   addAttachment: (file: File | CreateAttachment) => Promise<void>;
@@ -6268,7 +6312,7 @@ declare namespace useExternalMessageConverter {
   type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
-declare const useExternalMessageConverter: <T extends WeakKey>(_param19: {
+declare const useExternalMessageConverter: <T extends WeakKey>(_param20: {
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;
@@ -6293,7 +6337,7 @@ declare const useInteractableState: <TState>(id: string, fallback: TState) => [
   }
 ];
 
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param20?: LocalRuntimeOptions) => AssistantRuntime;
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param21?: LocalRuntimeOptions) => AssistantRuntime;
 
 declare const useMessageBranching: () => {
   branchNumber: number;
@@ -6315,7 +6359,7 @@ declare const useRuntimeAdapters: () => RuntimeAdapters | null;
 
 declare const useStreamingTiming: <TMessage>(messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options?: StreamingTimingOptions) => Record<string, MessageTiming>;
 
-declare const useSuggestionTrigger: (_param21: UseSuggestionTriggerOptions) => {
+declare const useSuggestionTrigger: (_param22: UseSuggestionTriggerOptions) => {
   trigger: () => void;
   disabled: boolean;
 };

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -71,6 +71,15 @@ export {
   resolveImageMediaType,
   toMediaWireUrl,
 } from "./utils/wire-media";
+export {
+  createToolCallCancellationStub,
+  scanPendingToolCalls,
+} from "./runtime/utils/pending-tool-calls";
+export {
+  createAbortableThreadLoad,
+  type AbortableThreadLoadPurpose,
+} from "./runtime/utils/abortable-thread-load";
+export { createCloudThreadListAdapterCreateFallback } from "./react/runtimes/cloud/createCloudThreadListAdapterCreateFallback";
 
 export * from "./runtime/internal";
 export * from "./runtimes/internal";

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapterCreateFallback.test.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapterCreateFallback.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCloudThreadListAdapterCreateFallback } from "./createCloudThreadListAdapterCreateFallback";
+
+describe("createCloudThreadListAdapterCreateFallback", () => {
+  it("prefers the custom create function", async () => {
+    const create = vi.fn().mockResolvedValue({ externalId: "custom" });
+    const initialize = vi.fn().mockResolvedValue({ externalId: "nested" });
+    const fallback = createCloudThreadListAdapterCreateFallback(create, {
+      source: {},
+      initialize,
+    });
+
+    await expect(fallback()).resolves.toEqual({ externalId: "custom" });
+    expect(initialize).not.toHaveBeenCalled();
+  });
+
+  it("initializes a sourced thread list item", async () => {
+    const result = { externalId: "nested" };
+    const fallback = createCloudThreadListAdapterCreateFallback(undefined, {
+      source: {},
+      initialize: vi.fn().mockResolvedValue(result),
+    });
+
+    await expect(fallback()).resolves.toBe(result);
+  });
+
+  it("falls back to an undefined external ID", async () => {
+    const initialize = vi.fn();
+    const fallback = createCloudThreadListAdapterCreateFallback(undefined, {
+      source: null,
+      initialize,
+    });
+
+    await expect(fallback()).resolves.toEqual({ externalId: undefined });
+    expect(initialize).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapterCreateFallback.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapterCreateFallback.ts
@@ -1,0 +1,18 @@
+type ThreadData = {
+  externalId: string | undefined;
+};
+
+type ThreadListItem = {
+  source: unknown;
+  initialize: () => Promise<ThreadData>;
+};
+
+export const createCloudThreadListAdapterCreateFallback = (
+  create: (() => Promise<ThreadData>) | undefined,
+  threadListItem: ThreadListItem,
+): (() => Promise<ThreadData>) =>
+  async function createThread() {
+    if (create) return create();
+    if (threadListItem.source) return threadListItem.initialize();
+    return { externalId: undefined };
+  };

--- a/packages/core/src/runtime/utils/abortable-thread-load.test.ts
+++ b/packages/core/src/runtime/utils/abortable-thread-load.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAbortableThreadLoad } from "./abortable-thread-load";
+
+const callbacks = () => ({
+  onSettled: vi.fn(),
+  onInitialError: vi.fn(),
+});
+
+describe("createAbortableThreadLoad", () => {
+  it("defers a reload to an in-flight initial load", async () => {
+    let resolveInitial!: () => void;
+    const initialLoad = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveInitial = resolve;
+        }),
+    );
+    const reloadLoad = vi.fn(() => Promise.resolve());
+    const controller = createAbortableThreadLoad();
+
+    const initial = controller.run({
+      purpose: "initial",
+      load: initialLoad,
+      ...callbacks(),
+    });
+    const reload = controller.run({
+      purpose: "reload",
+      load: reloadLoad,
+      ...callbacks(),
+    });
+
+    expect(reloadLoad).not.toHaveBeenCalled();
+    resolveInitial();
+    await Promise.all([initial, reload]);
+  });
+
+  it("aborts a superseded load and swallows its failure", async () => {
+    let rejectFirst!: (error: Error) => void;
+    let firstSignal!: AbortSignal;
+    const controller = createAbortableThreadLoad();
+    const first = controller.run({
+      purpose: "reload",
+      load: (signal) => {
+        firstSignal = signal;
+        return new Promise<void>((_, reject) => {
+          rejectFirst = reject;
+        });
+      },
+      ...callbacks(),
+    });
+
+    const second = controller.run({
+      purpose: "initial",
+      load: () => Promise.resolve(),
+      ...callbacks(),
+    });
+    rejectFirst(new Error("aborted"));
+
+    expect(firstSignal.aborted).toBe(true);
+    await expect(first).resolves.toBeUndefined();
+    await second;
+  });
+
+  it("swallows initial failures and surfaces reload failures", async () => {
+    const controller = createAbortableThreadLoad();
+    const initialCallbacks = callbacks();
+    const initialError = new Error("initial");
+
+    await expect(
+      controller.run({
+        purpose: "initial",
+        load: () => Promise.reject(initialError),
+        ...initialCallbacks,
+      }),
+    ).resolves.toBeUndefined();
+    expect(initialCallbacks.onInitialError).toHaveBeenCalledWith(initialError);
+
+    const reloadError = new Error("reload");
+    await expect(
+      controller.run({
+        purpose: "reload",
+        load: () => Promise.reject(reloadError),
+        ...callbacks(),
+      }),
+    ).rejects.toBe(reloadError);
+  });
+});

--- a/packages/core/src/runtime/utils/abortable-thread-load.ts
+++ b/packages/core/src/runtime/utils/abortable-thread-load.ts
@@ -1,0 +1,53 @@
+export type AbortableThreadLoadPurpose = "initial" | "reload";
+
+type AbortableThreadLoadOptions = {
+  purpose?: AbortableThreadLoadPurpose;
+  load: (signal: AbortSignal) => Promise<void>;
+  onSettled: () => void;
+  onInitialError: (error: unknown) => void;
+};
+
+export const createAbortableThreadLoad = () => {
+  let current: {
+    controller: AbortController;
+    purpose: AbortableThreadLoadPurpose;
+    promise?: Promise<void>;
+  } | null = null;
+
+  return {
+    abort(purpose?: AbortableThreadLoadPurpose) {
+      if (purpose !== undefined && current?.purpose !== purpose) return;
+      current?.controller.abort();
+    },
+    run({
+      purpose = "initial",
+      load,
+      onSettled,
+      onInitialError,
+    }: AbortableThreadLoadOptions): Promise<void> {
+      if (purpose === "reload" && current?.purpose === "initial") {
+        return current.promise ?? Promise.resolve();
+      }
+
+      current?.controller.abort();
+      const controller = new AbortController();
+      const record: NonNullable<typeof current> = { controller, purpose };
+      current = record;
+
+      const task = load(controller.signal)
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          throw error;
+        })
+        .finally(() => {
+          if (current?.controller === controller) current = null;
+          if (controller.signal.aborted) return;
+          onSettled();
+        });
+      record.promise = task;
+
+      if (purpose === "reload") return task;
+      return task.catch(onInitialError);
+    },
+  };
+};

--- a/packages/core/src/runtime/utils/pending-tool-calls.test.ts
+++ b/packages/core/src/runtime/utils/pending-tool-calls.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  createToolCallCancellationStub,
+  scanPendingToolCalls,
+} from "./pending-tool-calls";
+
+type Message =
+  | { type: "assistant"; toolCalls: { id: string; name: string }[] }
+  | { type: "tool"; toolCallId: string };
+
+const getPendingToolCalls = (messages: readonly Message[]) =>
+  scanPendingToolCalls(
+    messages,
+    (message) =>
+      message.type === "assistant"
+        ? { toolCalls: message.toolCalls }
+        : { toolCallId: message.toolCallId },
+    (toolCall) => toolCall.id,
+  );
+
+describe("scanPendingToolCalls", () => {
+  it("returns tool calls without matching results in history order", () => {
+    expect(
+      getPendingToolCalls([
+        {
+          type: "assistant",
+          toolCalls: [
+            { id: "call-1", name: "first" },
+            { id: "call-2", name: "second" },
+          ],
+        },
+        { type: "tool", toolCallId: "call-1" },
+        {
+          type: "assistant",
+          toolCalls: [{ id: "call-3", name: "third" }],
+        },
+      ]),
+    ).toEqual([
+      { id: "call-2", name: "second" },
+      { id: "call-3", name: "third" },
+    ]);
+  });
+});
+
+describe("createToolCallCancellationStub", () => {
+  it("creates an error tool result with the cancellation payload", () => {
+    expect(
+      createToolCallCancellationStub({ id: "call-1", name: "lookup" }),
+    ).toEqual({
+      type: "tool",
+      name: "lookup",
+      tool_call_id: "call-1",
+      content: JSON.stringify({ cancelled: true }),
+      status: "error",
+    });
+  });
+});

--- a/packages/core/src/runtime/utils/pending-tool-calls.ts
+++ b/packages/core/src/runtime/utils/pending-tool-calls.ts
@@ -1,0 +1,35 @@
+type PendingToolCallMessage<TToolCall> =
+  | { toolCalls: readonly TToolCall[] }
+  | { toolCallId: string }
+  | undefined;
+
+export const scanPendingToolCalls = <TMessage, TToolCall>(
+  messages: readonly TMessage[],
+  getMessage: (message: TMessage) => PendingToolCallMessage<TToolCall>,
+  getToolCallId: (toolCall: TToolCall) => string,
+): TToolCall[] => {
+  const pending = new Map<string, TToolCall>();
+  for (const message of messages) {
+    const value = getMessage(message);
+    if (!value) continue;
+    if ("toolCalls" in value) {
+      for (const toolCall of value.toolCalls) {
+        pending.set(getToolCallId(toolCall), toolCall);
+      }
+    } else {
+      pending.delete(value.toolCallId);
+    }
+  }
+  return [...pending.values()];
+};
+
+export const createToolCallCancellationStub = (toolCall: {
+  readonly id: string;
+  readonly name: string;
+}) => ({
+  type: "tool" as const,
+  name: toolCall.name,
+  tool_call_id: toolCall.id,
+  content: JSON.stringify({ cancelled: true }),
+  status: "error" as const,
+});

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -13,7 +13,14 @@ import {
   type ToolExecutionStatus,
   generateId,
 } from "@assistant-ui/core";
-import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
+import {
+  createAbortableThreadLoad,
+  createCloudThreadListAdapterCreateFallback,
+  createToolCallCancellationStub,
+  httpUrlPattern,
+  parseDataUrl,
+  scanPendingToolCalls,
+} from "@assistant-ui/core/internal";
 import {
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
@@ -104,18 +111,19 @@ export const getMessageContent = (msg: AppendMessage) => {
 
 /** @internal — exported for unit tests. */
 export const getPendingToolCalls = (messages: AdkMessage[]) => {
-  const pending = new Map<string, { id: string; name: string }>();
-  for (const msg of messages) {
-    if (msg.type === "ai" && msg.tool_calls) {
-      for (const tc of msg.tool_calls) {
-        pending.set(tc.id, tc);
+  return scanPendingToolCalls(
+    messages,
+    (message) => {
+      if (message.type === "ai") {
+        return { toolCalls: message.tool_calls ?? [] };
       }
-    }
-    if (msg.type === "tool") {
-      pending.delete(msg.tool_call_id);
-    }
-  }
-  return [...pending.values()];
+      if (message.type === "tool") {
+        return { toolCallId: message.tool_call_id };
+      }
+      return undefined;
+    },
+    (toolCall) => toolCall.id,
+  );
 };
 
 /**
@@ -138,11 +146,7 @@ export const getPendingCancellations = (
       (t) =>
         ({
           id: generateId(),
-          type: "tool",
-          name: t.name,
-          tool_call_id: t.id,
-          content: JSON.stringify({ cancelled: true }),
-          status: "error",
+          ...createToolCallCancellationStub(t),
         }) satisfies AdkMessage & { type: "tool" },
     );
 };
@@ -256,11 +260,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
 
   const loadRef = useRef(load);
   loadRef.current = load;
-  const loadControllerRef = useRef<{
-    controller: AbortController;
-    purpose: "initial" | "reload";
-    promise?: Promise<void> | undefined;
-  } | null>(null);
+  const loadController = useMemo(createAbortableThreadLoad, []);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
   const [isLoadingThread, setIsLoadingThread] = useState(
@@ -372,26 +372,17 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
 
       // The initial load is already fetching what a refetch would ask for, and
       // taking it over strands the thread's history if the refetch then fails.
-      if (
-        purpose === "reload" &&
-        loadControllerRef.current?.purpose === "initial"
-      )
-        return loadControllerRef.current.promise ?? Promise.resolve();
-
-      loadControllerRef.current?.controller.abort();
-      const controller = new AbortController();
-      const record: NonNullable<typeof loadControllerRef.current> = {
-        controller,
+      // Aborting a load the runtime no longer needs is not a failure.
+      // A refetch reports the failure to whoever awaited it; the initial load
+      // has no caller to tell.
+      return loadController.run({
         purpose,
-      };
-      loadControllerRef.current = record;
+        load: async (signal) => {
+          const messagesAtLoadStart = messagesRef.current;
+          if (purpose === "initial") setIsLoadingThread(true);
 
-      const messagesAtLoadStart = messagesRef.current;
-      if (purpose === "initial") setIsLoadingThread(true);
-
-      const task = loadFn(externalId, { signal: controller.signal })
-        .then((snapshot) => {
-          if (controller.signal.aborted) return;
+          const snapshot = await loadFn(externalId, { signal });
+          if (signal.aborted) return;
           // A snapshot the session assembled before a run cannot speak for what
           // that run has since produced, and an ADK id cannot correlate a
           // message sent optimistically with the one the session stored for it,
@@ -405,29 +396,16 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
           )
             return;
           applySnapshot(snapshot);
-        })
-        .catch((error: unknown) => {
-          // Aborting a load the runtime no longer needs is not a failure.
-          if (controller.signal.aborted) return;
-          throw error;
-        })
-        .finally(() => {
-          if (loadControllerRef.current?.controller === controller) {
-            loadControllerRef.current = null;
-          }
-          if (controller.signal.aborted) return;
+        },
+        onSettled: () => {
           setIsLoadingThread(false);
-        });
-      record.promise = task;
-
-      // A refetch reports the failure to whoever awaited it; the initial load
-      // has no caller to tell.
-      if (purpose === "reload") return task;
-      return task.catch((e: unknown) => {
-        console.warn("Failed to load ADK session:", e);
+        },
+        onInitialError: (error) => {
+          console.warn("Failed to load ADK session:", error);
+        },
       });
     },
-    [threadListItem, applySnapshot],
+    [threadListItem, loadController, applySnapshot],
   );
 
   useEffect(() => {
@@ -435,10 +413,10 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     return () => {
       // Whatever is current, not this effect's own controller: a refetch swaps
       // the ref, and one in flight at unmount must be aborted too.
-      loadControllerRef.current?.controller.abort();
+      loadController.abort();
       setIsLoadingThread(false);
     };
-  }, [runLoad]);
+  }, [loadController, runLoad]);
 
   const runtime = useExternalStoreRuntime({
     ...pickExternalStoreSharedOptions(options),
@@ -605,11 +583,10 @@ export const useAdkRuntime = ({
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
-    create: async () => {
-      if (create) return create();
-      if (aui.threadListItem.source) return aui.threadListItem.initialize();
-      return { externalId: undefined };
-    },
+    create: createCloudThreadListAdapterCreateFallback(
+      create,
+      aui.threadListItem,
+    ),
     delete: deleteFn,
   });
 

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -10,6 +10,11 @@ import {
 } from "@assistant-ui/core";
 import type { ThreadMessage } from "@assistant-ui/core";
 import {
+  createCloudThreadListAdapterCreateFallback,
+  createToolCallCancellationStub,
+  scanPendingToolCalls,
+} from "@assistant-ui/core/internal";
+import {
   useCloudThreadListAdapter,
   useExternalStoreRuntime,
   useExternalMessageConverter,
@@ -73,18 +78,19 @@ export const groupUIMessagesByParent = (
 
 const getPendingToolCalls = (
   messages: readonly LangChainBaseMessage[],
-): LangChainToolCall[] => {
-  const pending = new Map<string, LangChainToolCall>();
-  for (const m of messages) {
-    const type = getMessageType(m);
-    if (type === "ai") {
-      for (const tc of m.tool_calls ?? []) pending.set(tc.id, tc);
-    } else if (type === "tool" && m.tool_call_id) {
-      pending.delete(m.tool_call_id);
-    }
-  }
-  return [...pending.values()];
-};
+): LangChainToolCall[] =>
+  scanPendingToolCalls(
+    messages,
+    (message) => {
+      const type = getMessageType(message);
+      if (type === "ai") return { toolCalls: message.tool_calls ?? [] };
+      if (type === "tool" && message.tool_call_id) {
+        return { toolCallId: message.tool_call_id };
+      }
+      return undefined;
+    },
+    (toolCall) => toolCall.id,
+  );
 
 const toStagedHumanMessage = (
   msg: AppendMessage,
@@ -430,13 +436,7 @@ const useStreamThreadRuntime = (
         autoCancelPendingToolCalls !== false
           ? getPendingToolCalls(
               streamRef.current.messages as readonly LangChainBaseMessage[],
-            ).map((t) => ({
-              type: "tool" as const,
-              name: t.name,
-              tool_call_id: t.id,
-              content: JSON.stringify({ cancelled: true }),
-              status: "error" as const,
-            }))
+            ).map(createToolCallCancellationStub)
           : [];
       // A null threadId is not a no-op for the SDK: it rebinds the controller
       // away from its self-created thread and forces a fresh one, so the
@@ -637,9 +637,13 @@ export const useStreamRuntime = (rawOptions: UseStreamRuntimeOptions) => {
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
+  const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
-    create,
+    create: createCloudThreadListAdapterCreateFallback(
+      create,
+      aui.threadListItem,
+    ),
     delete: deleteFn,
   });
   const adapter = unstable_threadListAdapter ?? cloudAdapter;

--- a/packages/react-langgraph/src/messageHelpers.ts
+++ b/packages/react-langgraph/src/messageHelpers.ts
@@ -2,6 +2,7 @@ import {
   getExternalStoreMessages,
   type ThreadMessage,
 } from "@assistant-ui/core";
+import { scanPendingToolCalls } from "@assistant-ui/core/internal";
 import type { LangChainMessage, LangChainToolCall, UIMessage } from "./types";
 
 export type PendingToolCallGroup = {
@@ -24,23 +25,28 @@ export const getPendingToolCallGroups = (
     message: Extract<LangChainMessage, { type: "ai" }>,
   ) => string | undefined = pendingToolCallGroupKey,
 ): PendingToolCallGroup[] => {
-  const pendingToolCalls = new Map<
-    string,
-    { toolCall: LangChainToolCall; groupKey: string }
-  >();
-  for (const message of messages) {
-    if (message.type === "ai") {
-      const groupKey =
-        resolveGroupKey(message) ?? pendingToolCallGroupKey(message);
-      if (!groupKey) continue;
-      for (const toolCall of message.tool_calls ?? []) {
-        pendingToolCalls.set(toolCall.id, { toolCall, groupKey });
+  const pendingToolCalls = scanPendingToolCalls(
+    messages,
+    (message) => {
+      if (message.type === "ai") {
+        const groupKey =
+          resolveGroupKey(message) ?? pendingToolCallGroupKey(message);
+        return {
+          toolCalls: groupKey
+            ? (message.tool_calls ?? []).map((toolCall) => ({
+                toolCall,
+                groupKey,
+              }))
+            : [],
+        };
       }
-    }
-    if (message.type === "tool") {
-      pendingToolCalls.delete(message.tool_call_id);
-    }
-  }
+      if (message.type === "tool") {
+        return { toolCallId: message.tool_call_id };
+      }
+      return undefined;
+    },
+    ({ toolCall }) => toolCall.id,
+  );
 
   const groups = new Map<string, LangChainToolCall[]>();
   for (const { toolCall, groupKey } of pendingToolCalls.values()) {

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -22,6 +22,11 @@ import {
 import type { ToolExecutionStatus } from "@assistant-ui/core";
 import type { QueueItemState } from "@assistant-ui/core/store";
 import {
+  createAbortableThreadLoad,
+  createCloudThreadListAdapterCreateFallback,
+  createToolCallCancellationStub,
+} from "@assistant-ui/core/internal";
+import {
   type DataMessagePartComponent,
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
@@ -338,11 +343,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const queueRef = useRef<MessageQueueController | null>(null);
   // The purpose rides along because only a refetch may be superseded by a
   // send: aborting an initial load would strand its history and loading flag.
-  const loadControllerRef = useRef<{
-    controller: AbortController;
-    purpose: "initial" | "reload";
-    promise?: Promise<void>;
-  } | null>(null);
+  const loadController = useMemo(createAbortableThreadLoad, []);
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
@@ -427,9 +428,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     config: LangGraphSendMessageConfig,
   ) => {
     // Only a refetch: its landing snapshot would erase the message just sent.
-    if (loadControllerRef.current?.purpose === "reload") {
-      loadControllerRef.current.controller.abort();
-    }
+    loadController.abort("reload");
     seedMessageOwnership(langGraphMessagesRef.current);
     const state = pendingStateRef.current;
     pendingStateRef.current = undefined;
@@ -479,13 +478,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       autoCancelPendingToolCalls !== false
         ? getPendingToolCalls(messages).map(
             (t) =>
-              ({
-                type: "tool",
-                name: t.name,
-                tool_call_id: t.id,
-                content: JSON.stringify({ cancelled: true }),
-                status: "error",
-              }) satisfies LangChainMessage & { type: "tool" },
+              createToolCallCancellationStub(t) satisfies LangChainMessage & {
+                type: "tool";
+              },
           )
         : [];
 
@@ -611,44 +606,36 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
 
       // The initial load is already fetching what a refetch would ask for,
       // and taking it over strands its history if the refetch then fails.
-      if (
-        purpose === "reload" &&
-        loadControllerRef.current?.purpose === "initial"
-      )
-        // Settle with the load deferred to, so awaiting a refetch still means
-        // the thread is fresh.
-        return loadControllerRef.current.promise ?? Promise.resolve();
-
-      loadControllerRef.current?.controller.abort();
-      const controller = new AbortController();
-      const record: NonNullable<typeof loadControllerRef.current> = {
-        controller,
+      // Settle with the load deferred to, so awaiting a refetch still means
+      // the thread is fresh.
+      // The load rejects so a refetch deferring to it learns of the failure;
+      // only the initial load's caller swallows it.
+      return loadController.run({
         purpose,
-      };
-      loadControllerRef.current = record;
+        load: async (signal) => {
+          const messagesAtLoadStart = langGraphMessagesRef.current;
+          const uiMessagesAtLoadStart = uiMessagesRef.current;
+          const interruptAtLoadStart = interruptRef.current;
 
-      const messagesAtLoadStart = langGraphMessagesRef.current;
-      const uiMessagesAtLoadStart = uiMessagesRef.current;
-      const interruptAtLoadStart = interruptRef.current;
-
-      if (purpose === "initial") {
-        toolResultBufferRef.current.clear();
-        pendingStateRef.current = undefined;
-        effectiveStateRef.current = undefined;
-        runConfigByMessageIdRef.current.clear();
-        runConfigByToolCallIdRef.current.clear();
-        runIdByMessageIdRef.current.clear();
-        runIdByToolCallIdRef.current.clear();
-        interruptRunConfigRef.current = undefined;
-        setOptimisticState(undefined);
-        setValues(undefined);
-        setIsLoadingThread(true);
-      }
-      // A refetch touches nothing else: the load boundary already decides
-      // what a run started since keeps, so it needs no reset and no cancel.
-      const task = load(externalId, { signal: controller.signal })
-        .then(({ messages, interrupts, uiMessages }) => {
-          if (controller.signal.aborted) return;
+          if (purpose === "initial") {
+            toolResultBufferRef.current.clear();
+            pendingStateRef.current = undefined;
+            effectiveStateRef.current = undefined;
+            runConfigByMessageIdRef.current.clear();
+            runConfigByToolCallIdRef.current.clear();
+            runIdByMessageIdRef.current.clear();
+            runIdByToolCallIdRef.current.clear();
+            interruptRunConfigRef.current = undefined;
+            setOptimisticState(undefined);
+            setValues(undefined);
+            setIsLoadingThread(true);
+          }
+          // A refetch touches nothing else: the load boundary already decides
+          // what a run started since keeps, so it needs no reset and no cancel.
+          const { messages, interrupts, uiMessages } = await load(externalId, {
+            signal,
+          });
+          if (signal.aborted) return;
           // Only an initial load is the whole thread; a refetch can race
           // output the server has not stored yet.
           const opts = { snapshotIsComplete: purpose === "initial" };
@@ -656,28 +643,18 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
           seedMessageOwnership(messages);
           reconcileUIMessages(uiMessages ?? [], uiMessagesAtLoadStart, opts);
           reconcileInterrupt(interrupts?.[0], interruptAtLoadStart);
-        })
-        .catch((error) => {
-          if (controller.signal.aborted) return;
-          throw error;
-        })
-        .finally(() => {
-          if (loadControllerRef.current?.controller === controller) {
-            loadControllerRef.current = null;
-          }
-          if (controller.signal.aborted) return;
+        },
+        onSettled: () => {
           setIsLoadingThread(false);
-        });
-      // `task` rejects so a refetch deferring to it learns of the failure;
-      // only the initial load's caller swallows it.
-      record.promise = task;
-      if (purpose === "reload") return task;
-      return task.catch((error) => {
-        console.warn("useLangGraphRuntime: load handler rejected", error);
+        },
+        onInitialError: (error) => {
+          console.warn("useLangGraphRuntime: load handler rejected", error);
+        },
       });
     },
     [
       threadListItem,
+      loadController,
       setValues,
       reconcileMessages,
       seedMessageOwnership,
@@ -691,10 +668,10 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     return () => {
       // Whatever is current, not this effect's own controller: a refetch swaps
       // the ref, and one in flight at unmount must be aborted too.
-      loadControllerRef.current?.controller.abort();
+      loadController.abort();
       setIsLoadingThread(false);
     };
-  }, [runLoad]);
+  }, [loadController, runLoad]);
 
   useEffect(() => cancelActiveRun, [cancelActiveRun]);
 
@@ -902,17 +879,10 @@ export const useLangGraphRuntime = ({
   const aui = useAui();
   const cloudAdapter = useCloudThreadListAdapter({
     cloud,
-    create: async () => {
-      if (create) {
-        return create();
-      }
-
-      if (aui.threadListItem.source) {
-        return aui.threadListItem.initialize();
-      }
-
-      return { externalId: undefined };
-    },
+    create: createCloudThreadListAdapterCreateFallback(
+      create,
+      aui.threadListItem,
+    ),
     delete: deleteFn,
   });
 


### PR DESCRIPTION
## summary

- three helpers the langchain, langgraph, and google-adk runtimes each hand-rolled now live once in core internals: scanPendingToolCalls plus createToolCallCancellationStub (assistant tool_calls into a map, tool results delete by id, and the shared { cancelled: true } tool-message payload), createAbortableThreadLoad (reload defers to an in-flight initial load, aborts the previous controller, swallows initial failure, surfaces reload failure), and createCloudThreadListAdapterCreateFallback (custom create ?? initialize when sourced ?? { externalId: undefined })
- adapter-local semantics stay put: langgraph's group-key tracking and reload cancellation on send, adk's long-running HITL filtering and generated cancellation ids, each package's warning text and cloud adapter precedence
- exposure is internal-only (@assistant-ui/core/internal and the react cloud runtime folder); no public surface changes; each helper has a colocated test

## test plan

### already verified

- [x] full suites rerun independently: core 1487, react-langchain 117, react-langgraph 293, react-google-adk 323, all green
- [x] adapter tests unchanged; behavior byte-identical per extraction

### reviewer should verify

- [ ] cancelling a run mid tool-call in any of the three runtimes still sends the {"cancelled":true} tool result for exactly the pending calls

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tshHW3LtNrE2I5dqopW2wl_cHnTF4K03RQB14mncV48NZHzBujYKanLOGPw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->