### PR TITLE
chore(scripts): share the workspace walkers and collapse the api-surface check path

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "api-surface": "pnpm api-surface:build && node scripts/generate-api-surface.mjs",
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*'",
     "api-surface:check": "node scripts/check-api-surface.mjs",
-    "api-surface:test": "node --test scripts/generate-api-surface.test.mjs",
+    "api-surface:test": "node --test scripts/generate-api-surface.test.mjs scripts/lib/workspace.test.mjs",
     "declarations:check": "node scripts/check-built-declarations.mjs",
     "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -31,4 +31,3 @@ run("node", [
   "--check",
   ...optionArgs("--filter", filters),
 ]);
-run("pnpm", ["--filter", "@assistant-ui/api-surface", "check"]);

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -31,3 +31,4 @@ run("node", [
   "--check",
   ...optionArgs("--filter", filters),
 ]);
+run("pnpm", ["--filter", "@assistant-ui/api-surface", "check"]);

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -4,7 +4,6 @@ import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
-  readFileSync,
   readdirSync,
   realpathSync,
   rmSync,
@@ -12,17 +11,14 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { optionArgs, optionValues } from "./lib/script-options.mjs";
+import { optionValues } from "./lib/script-options.mjs";
+import {
+  collectPackages,
+  collectTurboFilteredPackageNames,
+  posixPath,
+} from "./lib/workspace.mjs";
 
 const TSC_ERROR = /^(.+)\(\d+,\d+\): error TS\d+:/;
-
-function readJson(file) {
-  return JSON.parse(readFileSync(file, "utf8"));
-}
-
-function posixPath(file) {
-  return file.replaceAll("\\", "/");
-}
 
 function spawnTsc(repoRoot, args) {
   const local = path.join(repoRoot, "node_modules", ".bin", "tsc");
@@ -188,50 +184,6 @@ export function declarationGateResult({
   return "pass";
 }
 
-function collectPackages(repoRoot, filteredPackageNames) {
-  const packagesRoot = path.join(repoRoot, "packages");
-  return readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
-    .filter(existsSync)
-    .map((packageJsonPath) => ({
-      packageDir: path.dirname(packageJsonPath),
-      pkg: readJson(packageJsonPath),
-    }))
-    .filter(({ pkg }) => !pkg.private)
-    .filter(
-      ({ pkg }) => !filteredPackageNames || filteredPackageNames.has(pkg.name),
-    )
-    .sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
-}
-
-function collectTurboFilteredPackageNames(repoRoot, filters) {
-  if (filters.length === 0) return null;
-  const result = spawnSync(
-    "pnpm",
-    [
-      "exec",
-      "turbo",
-      "ls",
-      ...optionArgs("--filter", filters),
-      "--output=json",
-    ],
-    { cwd: repoRoot, encoding: "utf8" },
-  );
-  if (result.status !== 0) {
-    throw new Error(
-      `Failed to list filtered packages:\n${result.stdout}${result.stderr}`,
-    );
-  }
-
-  const jsonStart = result.stdout.indexOf("{");
-  if (jsonStart === -1) {
-    throw new Error(`Turbo did not return JSON output:\n${result.stdout}`);
-  }
-  const output = JSON.parse(result.stdout.slice(jsonStart));
-  return new Set(output.packages.items.map((item) => item.name));
-}
-
 function checkPackage(repoRoot, packageDir, pkg) {
   let probe;
   try {
@@ -299,8 +251,15 @@ function main() {
   const filteredPackageNames = collectTurboFilteredPackageNames(
     repoRoot,
     filters,
+    {
+      failureMessage: "Failed to list filtered packages",
+      getPackageName: (item) => item.name,
+      skipWithoutFilters: true,
+    },
   );
-  const packages = collectPackages(repoRoot, filteredPackageNames);
+  const packages = collectPackages(repoRoot, filteredPackageNames, (a, b) =>
+    a.localeCompare(b),
+  );
   if (packages.length === 0) {
     console.log("No public packages matched the filter.");
     return;

--- a/scripts/check-built-declarations.mjs
+++ b/scripts/check-built-declarations.mjs
@@ -253,7 +253,6 @@ function main() {
     filters,
     {
       failureMessage: "Failed to list filtered packages",
-      getPackageName: (item) => item.name,
       skipWithoutFilters: true,
     },
   );

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -13,7 +13,12 @@ import { createRequire } from "node:module";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { optionArgs, optionValues } from "./lib/script-options.mjs";
+import { optionValues } from "./lib/script-options.mjs";
+import {
+  collectPackages,
+  collectTurboFilteredPackageNames,
+  posixPath,
+} from "./lib/workspace.mjs";
 
 const repoRoot = process.cwd();
 const packagesRoot = path.join(repoRoot, "packages");
@@ -28,20 +33,12 @@ const requireFromBuildUtils = createRequire(
 const { build } = await import(requireFromBuildUtils.resolve("tsdown"));
 const ts = requireFromBuildUtils("typescript");
 
-function readJson(file) {
-  return JSON.parse(readFileSync(file, "utf8"));
-}
-
 function packageFileName(packageName) {
   return `${packageName.replace(/^@/, "").replaceAll("/", "__")}.ts`;
 }
 
 function packageEntryName(packageName) {
   return packageFileName(packageName).replace(/\.ts$/, "");
-}
-
-function posixPath(file) {
-  return file.replaceAll("\\", "/");
 }
 
 function relativeImport(fromDir, toFile) {
@@ -113,62 +110,6 @@ function declarationFilesForTarget(packageDir, typePath) {
     );
   }
   return files;
-}
-
-function collectPackages(filteredPackageNames) {
-  return readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
-    .filter((packageJsonPath) => existsSync(packageJsonPath))
-    .map((packageJsonPath) => {
-      const pkg = readJson(packageJsonPath);
-      return {
-        packageDir: path.dirname(packageJsonPath),
-        pkg,
-      };
-    })
-    .filter(({ pkg }) => !pkg.private)
-    .filter(
-      ({ pkg }) => !filteredPackageNames || filteredPackageNames.has(pkg.name),
-    )
-    .sort((a, b) => compareStrings(a.pkg.name, b.pkg.name));
-}
-
-function collectTurboFilteredPackageNames(filters) {
-  const result = spawnSync(
-    "pnpm",
-    [
-      "exec",
-      "turbo",
-      "ls",
-      ...optionArgs("--filter", filters),
-      "--output=json",
-    ],
-    {
-      cwd: repoRoot,
-      encoding: "utf8",
-    },
-  );
-  if (result.status !== 0) {
-    throw new Error(
-      `Failed to list packages for API surface filter:\n${result.stdout}${result.stderr}`,
-    );
-  }
-
-  const jsonStart = result.stdout.indexOf("{");
-  if (jsonStart === -1) {
-    throw new Error(`Turbo did not return JSON output:\n${result.stdout}`);
-  }
-
-  const output = JSON.parse(result.stdout.slice(jsonStart));
-  return new Set(
-    output.packages.items.map((item) => {
-      if (typeof item.name !== "string") {
-        throw new Error("Turbo package list included an item without a name.");
-      }
-      return item.name;
-    }),
-  );
 }
 
 function collectDeclarationEntries(packageDir, pkg) {
@@ -934,9 +875,23 @@ export function selectStaleSurfaceFiles({
 }
 
 async function main() {
-  const allPackages = collectPackages(undefined);
+  const allPackages = collectPackages(repoRoot, undefined, compareStrings);
   const packages = turboFilters.length
-    ? collectPackages(collectTurboFilteredPackageNames(turboFilters))
+    ? collectPackages(
+        repoRoot,
+        collectTurboFilteredPackageNames(repoRoot, turboFilters, {
+          failureMessage: "Failed to list packages for API surface filter",
+          getPackageName(item) {
+            if (typeof item.name !== "string") {
+              throw new Error(
+                "Turbo package list included an item without a name.",
+              );
+            }
+            return item.name;
+          },
+        }),
+        compareStrings,
+      )
     : allPackages;
   const generatedFiles = new Set();
   const changedFiles = [];

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -881,14 +881,6 @@ async function main() {
         repoRoot,
         collectTurboFilteredPackageNames(repoRoot, turboFilters, {
           failureMessage: "Failed to list packages for API surface filter",
-          getPackageName(item) {
-            if (typeof item.name !== "string") {
-              throw new Error(
-                "Turbo package list included an item without a name.",
-              );
-            }
-            return item.name;
-          },
         }),
         compareStrings,
       )

--- a/scripts/lib/workspace.mjs
+++ b/scripts/lib/workspace.mjs
@@ -35,7 +35,7 @@ export function collectPackages(
 export function collectTurboFilteredPackageNames(
   repoRoot,
   filters,
-  { failureMessage, getPackageName, skipWithoutFilters = false },
+  { failureMessage, skipWithoutFilters = false },
 ) {
   if (skipWithoutFilters && filters.length === 0) return null;
 
@@ -60,5 +60,12 @@ export function collectTurboFilteredPackageNames(
   }
 
   const output = JSON.parse(result.stdout.slice(jsonStart));
-  return new Set(output.packages.items.map(getPackageName));
+  return new Set(
+    output.packages.items.map((item) => {
+      if (typeof item.name !== "string") {
+        throw new Error("Turbo package list included an item without a name.");
+      }
+      return item.name;
+    }),
+  );
 }

--- a/scripts/lib/workspace.mjs
+++ b/scripts/lib/workspace.mjs
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { optionArgs } from "./script-options.mjs";
+
+export function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+export function posixPath(file) {
+  return file.replaceAll("\\", "/");
+}
+
+export function collectPackages(
+  repoRoot,
+  filteredPackageNames,
+  comparePackageNames,
+) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  return readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesRoot, entry.name, "package.json"))
+    .filter(existsSync)
+    .map((packageJsonPath) => ({
+      packageDir: path.dirname(packageJsonPath),
+      pkg: readJson(packageJsonPath),
+    }))
+    .filter(({ pkg }) => !pkg.private)
+    .filter(
+      ({ pkg }) => !filteredPackageNames || filteredPackageNames.has(pkg.name),
+    )
+    .sort((a, b) => comparePackageNames(a.pkg.name, b.pkg.name));
+}
+
+export function collectTurboFilteredPackageNames(
+  repoRoot,
+  filters,
+  { failureMessage, getPackageName, skipWithoutFilters = false },
+) {
+  if (skipWithoutFilters && filters.length === 0) return null;
+
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "turbo",
+      "ls",
+      ...optionArgs("--filter", filters),
+      "--output=json",
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`${failureMessage}:\n${result.stdout}${result.stderr}`);
+  }
+
+  const jsonStart = result.stdout.indexOf("{");
+  if (jsonStart === -1) {
+    throw new Error(`Turbo did not return JSON output:\n${result.stdout}`);
+  }
+
+  const output = JSON.parse(result.stdout.slice(jsonStart));
+  return new Set(output.packages.items.map(getPackageName));
+}

--- a/scripts/lib/workspace.test.mjs
+++ b/scripts/lib/workspace.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { collectPackages, posixPath, readJson } from "./workspace.mjs";
+
+const makeRepo = (packages) => {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), "workspace-test-"));
+  for (const [dir, pkg] of Object.entries(packages)) {
+    const packageDir = path.join(repoRoot, "packages", dir);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(path.join(packageDir, "package.json"), JSON.stringify(pkg));
+  }
+  return repoRoot;
+};
+
+const byName = (a, b) => a.localeCompare(b);
+
+test("collectPackages skips private packages and sorts by comparator", () => {
+  const repoRoot = makeRepo({
+    zeta: { name: "zeta" },
+    alpha: { name: "alpha" },
+    hidden: { name: "hidden", private: true },
+  });
+  try {
+    const names = collectPackages(repoRoot, null, byName).map(
+      ({ pkg }) => pkg.name,
+    );
+    assert.deepEqual(names, ["alpha", "zeta"]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("collectPackages honors the filtered name set", () => {
+  const repoRoot = makeRepo({
+    alpha: { name: "alpha" },
+    beta: { name: "beta" },
+  });
+  try {
+    const names = collectPackages(repoRoot, new Set(["beta"]), byName).map(
+      ({ pkg }) => pkg.name,
+    );
+    assert.deepEqual(names, ["beta"]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("collectPackages ignores directories without a package.json", () => {
+  const repoRoot = makeRepo({ alpha: { name: "alpha" } });
+  mkdirSync(path.join(repoRoot, "packages", "empty"));
+  try {
+    const names = collectPackages(repoRoot, null, byName).map(
+      ({ pkg }) => pkg.name,
+    );
+    assert.deepEqual(names, ["alpha"]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("posixPath and readJson round-trip", () => {
+  assert.equal(posixPath("a\\b\\c.ts"), "a/b/c.ts");
+  const repoRoot = makeRepo({ alpha: { name: "alpha" } });
+  try {
+    assert.deepEqual(
+      readJson(path.join(repoRoot, "packages", "alpha", "package.json")),
+      { name: "alpha" },
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## summary

- generate-api-surface.mjs and check-built-declarations.mjs carried near-identical copies of the workspace walkers (package.json reading, POSIX paths, public-package discovery, turbo filter resolution); the shared ones now live in scripts/lib/workspace.mjs, and the genuinely divergent pieces stay local (the generator keeps export-condition target paths and recursive wildcard support, the declarations checker keeps flat paths and resolved-directory scans)
- check-api-surface.mjs is orchestration only (build + invoke the generator's --check), so the generator's --check is the single validation path
- repo-internal scripts, no changeset; CLI flags, output lines, and exit codes unchanged

## test plan

### already verified

- [x] over a fully built tree: node scripts/generate-api-surface.mjs --check (40 surface files, no drift), node scripts/check-built-declarations.mjs (green), node scripts/check-api-surface.mjs --skip-build (green), all rerun independently outside the sandbox
- [x] focused script tests 25/25

no reviewer steps beyond CI's own API Reference Drift and api-surface jobs exercising these paths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6VU506Ag-RyPR83nuJu9s-EaNJLp7Zxj1tc_trnY70Ykfk1jTGW8NVuAJPI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->