### PR TITLE
refactor(py-stream): share the tool-call args settlement reducer

### DIFF
--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -44,7 +44,11 @@ class _Canonicalizer:
         self._part_counter = 0
         self._append_part: tuple[str, list[int], str | None] | None = None
         self._tool_paths: dict[str, list[int]] = {}
-        self._tool_args = ToolCallArgsSettler(self._finish_tool_call_args, self._warn)
+        self._tool_args = ToolCallArgsSettler(
+            self._finish_tool_call_args,
+            self._warn,
+            emit_empty_args_text=False,
+        )
         self._warned_reasons: set[str] = set()
 
     def _warn(self, reason: str, detail: str) -> None:
@@ -162,9 +166,11 @@ class _Canonicalizer:
         return [result, *self._tool_args.finish(chunk.tool_call_id)]
 
     def _finish_tool_call_args(
-        self, tool_call_id: str, args_text_delta: str
+        self, tool_call_id: str, args_text_delta: str, has_args_text: bool
     ) -> list[dict[str, Any]]:
-        path = self._tool_paths[tool_call_id]
+        path = self._tool_paths.get(tool_call_id)
+        if path is None:
+            return []
         frames: list[dict[str, Any]] = []
         if args_text_delta:
             frames.append(
@@ -174,14 +180,22 @@ class _Canonicalizer:
                     "path": path,
                 }
             )
-        frames.extend(self._close_tool_part(path))
+        frames.extend(
+            self._close_tool_part(path, has_args_text or bool(args_text_delta))
+        )
         return frames
 
-    def _close_tool_part(self, path: list[int]) -> list[dict[str, Any]]:
-        return [
+    def _close_tool_part(
+        self, path: list[int], has_args_text: bool
+    ) -> list[dict[str, Any]]:
+        frames: list[dict[str, Any]] = []
+        if not has_args_text:
+            frames.append({"type": "text-delta", "textDelta": "{}", "path": path})
+        frames.extend([
             {"type": "tool-call-args-text-finish", "path": path},
             {"type": "part-finish", "path": path},
-        ]
+        ])
+        return frames
 
     def _source(self, chunk: SourceChunk) -> list[dict[str, Any]]:
         frames = self._close_append_part()

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -9,7 +9,6 @@ from assistant_stream.assistant_stream_chunk import (
     StepStartChunk,
     TextDeltaChunk,
     ToolCallBeginChunk,
-    ToolCallArgsTextFinishChunk,
     ToolCallDeltaChunk,
     ToolResultChunk,
 )
@@ -21,6 +20,7 @@ from assistant_stream.serialization.heartbeat import (
     HeartbeatOption,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
+from assistant_stream.serialization.tool_args_settle import ToolCallArgsSettler
 from assistant_stream.state_proxy import StateProxyJSONEncoder
 from typing import AsyncGenerator, Any
 import json
@@ -44,15 +44,17 @@ class _Canonicalizer:
         self._part_counter = 0
         self._append_part: tuple[str, list[int], str | None] | None = None
         self._tool_paths: dict[str, list[int]] = {}
-        self._tool_has_args: set[str] = set()
-        self._settled_tools: set[str] = set()
+        self._tool_args = ToolCallArgsSettler(self._finish_tool_call_args, self._warn)
         self._warned_reasons: set[str] = set()
+
+    def _warn(self, reason: str, detail: str) -> None:
+        logger.warning("Dropped assistant-transport chunk (%s): %s", reason, detail)
 
     def _warn_once(self, reason: str, detail: str) -> None:
         if reason in self._warned_reasons:
             return
         self._warned_reasons.add(reason)
-        logger.warning("Dropped assistant-transport chunk (%s): %s", reason, detail)
+        self._warn(reason, detail)
 
     def _next_path(self) -> list[int]:
         path = [self._part_counter]
@@ -117,6 +119,7 @@ class _Canonicalizer:
         frames = self._close_append_part()
         path = self._next_path()
         self._tool_paths[chunk.tool_call_id] = path
+        self._tool_args.begin(chunk.tool_call_id)
         part: dict[str, Any] = {
             "type": "tool-call",
             "toolCallId": chunk.tool_call_id,
@@ -135,15 +138,8 @@ class _Canonicalizer:
                 f"tool-call-delta for {chunk.tool_call_id}",
             )
             return []
-        if chunk.tool_call_id in self._settled_tools:
-            # The path outlives settlement so a deferred result can address the
-            # part; arguments cannot still be appended to it.
-            self._warn_once(
-                "settled-tool-call-id",
-                f"tool-call-delta for {chunk.tool_call_id}",
-            )
+        if not self._tool_args.append(chunk.tool_call_id):
             return []
-        self._tool_has_args.add(chunk.tool_call_id)
         return [
             {"type": "text-delta", "textDelta": chunk.args_text_delta, "path": path}
         ]
@@ -163,45 +159,29 @@ class _Canonicalizer:
             result["path"] = []
             return [result]
         result["path"] = path
-        if chunk.tool_call_id in self._settled_tools:
-            return [result]
-        self._settled_tools.add(chunk.tool_call_id)
-        return [result, *self._close_tool_part(chunk.tool_call_id, path)]
+        return [result, *self._tool_args.finish(chunk.tool_call_id)]
 
     def _finish_tool_call_args(
-        self, chunk: ToolCallArgsTextFinishChunk
+        self, tool_call_id: str, args_text_delta: str
     ) -> list[dict[str, Any]]:
-        # The path stays registered after the args settle: a two-phase
-        # human-in-the-loop call closes its arguments first and delivers the
-        # result later, and a result that cannot resolve a path is emitted at
-        # the message root, where the accumulator drops it.
-        path = self._tool_paths.get(chunk.tool_call_id)
-        if path is None or chunk.tool_call_id in self._settled_tools:
-            return []
-        self._settled_tools.add(chunk.tool_call_id)
+        path = self._tool_paths[tool_call_id]
         frames: list[dict[str, Any]] = []
-        if chunk.args_text_delta:
-            self._tool_has_args.add(chunk.tool_call_id)
+        if args_text_delta:
             frames.append(
                 {
                     "type": "text-delta",
-                    "textDelta": chunk.args_text_delta,
+                    "textDelta": args_text_delta,
                     "path": path,
                 }
             )
-        frames.extend(self._close_tool_part(chunk.tool_call_id, path))
+        frames.extend(self._close_tool_part(path))
         return frames
 
-    def _close_tool_part(
-        self, tool_call_id: str, path: list[int]
-    ) -> list[dict[str, Any]]:
-        frames: list[dict[str, Any]] = []
-        if tool_call_id not in self._tool_has_args:
-            frames.append({"type": "text-delta", "textDelta": "{}", "path": path})
-        self._tool_has_args.discard(tool_call_id)
-        frames.append({"type": "tool-call-args-text-finish", "path": path})
-        frames.append({"type": "part-finish", "path": path})
-        return frames
+    def _close_tool_part(self, path: list[int]) -> list[dict[str, Any]]:
+        return [
+            {"type": "tool-call-args-text-finish", "path": path},
+            {"type": "part-finish", "path": path},
+        ]
 
     def _source(self, chunk: SourceChunk) -> list[dict[str, Any]]:
         frames = self._close_append_part()
@@ -247,7 +227,7 @@ class _Canonicalizer:
             case "tool-call-delta":
                 return self._tool_call_delta(chunk)
             case "tool-call-args-text-finish":
-                return self._finish_tool_call_args(chunk)
+                return self._tool_args.finish(chunk.tool_call_id, chunk.args_text_delta)
             case "tool-result":
                 return self._tool_result(chunk)
             case "source":
@@ -284,12 +264,9 @@ class _Canonicalizer:
 
     def close(self) -> list[dict[str, Any]]:
         frames = self._close_append_part()
-        for tool_call_id, path in self._tool_paths.items():
-            if tool_call_id in self._settled_tools:
-                continue
-            frames.extend(self._close_tool_part(tool_call_id, path))
+        frames.extend(self._tool_args.finish_open())
         self._tool_paths.clear()
-        self._settled_tools.clear()
+        self._tool_args.clear()
         return frames
 
 

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -14,6 +14,7 @@ from assistant_stream.serialization.heartbeat import (
     HeartbeatOption,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
+from assistant_stream.serialization.tool_args_settle import ToolCallArgsSettler
 from assistant_stream.state_proxy import StateProxyJSONEncoder
 
 logger = logging.getLogger(__name__)
@@ -102,31 +103,10 @@ class DataStreamEncoder(StreamEncoder):
     async def encode_stream(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]
     ) -> AsyncGenerator[str, None]:
-        open_tool_call_args: dict[str, bool] = {}
-        settled_tool_call_args: set[str] = set()
-        warned_reasons: set[str] = set()
-
-        def warn_once(reason: str, detail: str) -> None:
-            if reason in warned_reasons:
-                return
-            warned_reasons.add(reason)
+        def warn(reason: str, detail: str) -> None:
             logger.warning("Dropped data-stream chunk (%s): %s", reason, detail)
 
-        def finish_tool_call_args(
-            tool_call_id: str, args_text_delta: str = ""
-        ) -> list[str]:
-            has_args_text = open_tool_call_args.pop(tool_call_id, None)
-            if has_args_text is None:
-                return []
-            settled_tool_call_args.add(tool_call_id)
-            if not args_text_delta and not has_args_text:
-                args_text_delta = "{}"
-
-            frames: list[str] = []
-            # A decoder that predates `isFinal` appends this delta and settles
-            # on what it has, and it skips its own empty-object default once
-            # any delta has arrived. The frame therefore has to carry the
-            # default itself rather than leave it to the decoder.
+        def finish_tool_call_args(tool_call_id: str, args_text_delta: str) -> list[str]:
             finish = self.encode_chunk(
                 ToolCallArgsTextFinishChunk(
                     tool_call_id=tool_call_id,
@@ -134,37 +114,24 @@ class DataStreamEncoder(StreamEncoder):
                 )
             )
             if finish is not None:
-                frames.append(finish)
-            return frames
+                return [finish]
+            return []
 
-        def finish_open_tool_call_args() -> list[str]:
-            frames: list[str] = []
-            for tool_call_id in tuple(open_tool_call_args):
-                frames.extend(finish_tool_call_args(tool_call_id))
-            return frames
+        tool_call_args = ToolCallArgsSettler(finish_tool_call_args, warn)
 
         async for chunk in stream:
             if chunk.type in ("step-finish", "error"):
-                for finish in finish_open_tool_call_args():
+                for finish in tool_call_args.finish_open():
                     yield finish
             if chunk.type == "tool-call-begin":
-                settled_tool_call_args.discard(chunk.tool_call_id)
-                open_tool_call_args[chunk.tool_call_id] = False
+                tool_call_args.begin(chunk.tool_call_id)
             elif chunk.type == "tool-result":
-                settled_tool_call_args.add(chunk.tool_call_id)
-                open_tool_call_args.pop(chunk.tool_call_id, None)
+                tool_call_args.settle_without_emitting(chunk.tool_call_id)
             elif chunk.type == "tool-call-delta":
-                if chunk.tool_call_id not in open_tool_call_args:
-                    warn_once(
-                        "settled-tool-call-id"
-                        if chunk.tool_call_id in settled_tool_call_args
-                        else "unknown-tool-call-id",
-                        f"tool-call-delta for {chunk.tool_call_id}",
-                    )
+                if not tool_call_args.append(chunk.tool_call_id):
                     continue
-                open_tool_call_args[chunk.tool_call_id] = True
             elif chunk.type == "tool-call-args-text-finish":
-                frames = finish_tool_call_args(
+                frames = tool_call_args.finish(
                     chunk.tool_call_id, chunk.args_text_delta
                 )
                 if not frames:
@@ -176,7 +143,7 @@ class DataStreamEncoder(StreamEncoder):
             if encoded is None:
                 continue
             yield encoded
-        for finish in finish_open_tool_call_args():
+        for finish in tool_call_args.finish_open():
             yield finish
 
 

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -106,7 +106,9 @@ class DataStreamEncoder(StreamEncoder):
         def warn(reason: str, detail: str) -> None:
             logger.warning("Dropped data-stream chunk (%s): %s", reason, detail)
 
-        def finish_tool_call_args(tool_call_id: str, args_text_delta: str) -> list[str]:
+        def finish_tool_call_args(
+            tool_call_id: str, args_text_delta: str, _: bool
+        ) -> list[str]:
             finish = self.encode_chunk(
                 ToolCallArgsTextFinishChunk(
                     tool_call_id=tool_call_id,
@@ -117,7 +119,11 @@ class DataStreamEncoder(StreamEncoder):
                 return [finish]
             return []
 
-        tool_call_args = ToolCallArgsSettler(finish_tool_call_args, warn)
+        tool_call_args = ToolCallArgsSettler(
+            finish_tool_call_args,
+            warn,
+            emit_empty_args_text=True,
+        )
 
         async for chunk in stream:
             if chunk.type in ("step-finish", "error"):

--- a/python/assistant-stream/src/assistant_stream/serialization/tool_args_settle.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/tool_args_settle.py
@@ -8,11 +8,14 @@ Frame = TypeVar("Frame")
 class ToolCallArgsSettler(Generic[Frame]):
     def __init__(
         self,
-        finish_frames: Callable[[str, str], list[Frame]],
+        finish_frames: Callable[[str, str, bool], list[Frame]],
         warn: Callable[[str, str], None],
+        *,
+        emit_empty_args_text: bool,
     ) -> None:
         self._finish_frames = finish_frames
         self._warn = warn
+        self._emit_empty_args_text = emit_empty_args_text
         self._open: dict[str, bool] = {}
         self._settled: set[str] = set()
         self._warned_reasons: set[str] = set()
@@ -43,9 +46,16 @@ class ToolCallArgsSettler(Generic[Frame]):
         if has_args_text is None:
             return []
         self._settled.add(tool_call_id)
-        if not args_text_delta and not has_args_text:
+        if (
+            self._emit_empty_args_text
+            and not args_text_delta
+            and not has_args_text
+        ):
+            # A decoder that predates `isFinal` appends this delta and settles
+            # on what it has, skipping its own empty-object default once any
+            # delta has arrived. The frame must therefore carry the default.
             args_text_delta = "{}"
-        return self._finish_frames(tool_call_id, args_text_delta)
+        return self._finish_frames(tool_call_id, args_text_delta, has_args_text)
 
     def finish_open(self) -> list[Frame]:
         frames: list[Frame] = []

--- a/python/assistant-stream/src/assistant_stream/serialization/tool_args_settle.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/tool_args_settle.py
@@ -1,0 +1,64 @@
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+
+Frame = TypeVar("Frame")
+
+
+class ToolCallArgsSettler(Generic[Frame]):
+    def __init__(
+        self,
+        finish_frames: Callable[[str, str], list[Frame]],
+        warn: Callable[[str, str], None],
+    ) -> None:
+        self._finish_frames = finish_frames
+        self._warn = warn
+        self._open: dict[str, bool] = {}
+        self._settled: set[str] = set()
+        self._warned_reasons: set[str] = set()
+
+    def begin(self, tool_call_id: str) -> None:
+        self._settled.discard(tool_call_id)
+        self._open[tool_call_id] = False
+
+    def append(self, tool_call_id: str) -> bool:
+        if tool_call_id not in self._open:
+            if tool_call_id in self._settled:
+                reason = "settled-tool-call-id"
+            else:
+                reason = "unknown-tool-call-id"
+            self._warn_once(reason, f"tool-call-delta for {tool_call_id}")
+            return False
+        self._open[tool_call_id] = True
+        return True
+
+    def settle_without_emitting(self, tool_call_id: str) -> None:
+        self._open.pop(tool_call_id, None)
+        self._settled.add(tool_call_id)
+
+    def finish(
+        self, tool_call_id: str, args_text_delta: str = ""
+    ) -> list[Frame]:
+        has_args_text = self._open.pop(tool_call_id, None)
+        if has_args_text is None:
+            return []
+        self._settled.add(tool_call_id)
+        if not args_text_delta and not has_args_text:
+            args_text_delta = "{}"
+        return self._finish_frames(tool_call_id, args_text_delta)
+
+    def finish_open(self) -> list[Frame]:
+        frames: list[Frame] = []
+        for tool_call_id in tuple(self._open):
+            frames.extend(self.finish(tool_call_id))
+        return frames
+
+    def clear(self) -> None:
+        self._open.clear()
+        self._settled.clear()
+
+    def _warn_once(self, reason: str, detail: str) -> None:
+        if reason in self._warned_reasons:
+            return
+        self._warned_reasons.add(reason)
+        self._warn(reason, detail)

--- a/python/assistant-stream/tests/test_tool_args_settle.py
+++ b/python/assistant-stream/tests/test_tool_args_settle.py
@@ -1,0 +1,74 @@
+from assistant_stream.serialization.tool_args_settle import ToolCallArgsSettler
+
+
+def create_settler(
+    *, emit_empty_args_text: bool
+) -> tuple[ToolCallArgsSettler[str], list[tuple[str, str, bool]], list[tuple[str, str]]]:
+    finished: list[tuple[str, str, bool]] = []
+    warnings: list[tuple[str, str]] = []
+
+    def finish_frames(
+        tool_call_id: str, args_text_delta: str, has_args_text: bool
+    ) -> list[str]:
+        finished.append((tool_call_id, args_text_delta, has_args_text))
+        return [f"{tool_call_id}:{args_text_delta}"]
+
+    def warn(reason: str, detail: str) -> None:
+        warnings.append((reason, detail))
+
+    return (
+        ToolCallArgsSettler(
+            finish_frames,
+            warn,
+            emit_empty_args_text=emit_empty_args_text,
+        ),
+        finished,
+        warnings,
+    )
+
+
+def test_tool_call_args_settler_tracks_begin_append_and_finish() -> None:
+    settler, finished, _ = create_settler(emit_empty_args_text=True)
+
+    settler.begin("t1")
+
+    assert settler.append("t1") is True
+    assert settler.finish("t1", "}") == ["t1:}"]
+    assert finished == [("t1", "}", True)]
+
+
+def test_tool_call_args_settler_configures_empty_args_completion() -> None:
+    emitting, emitting_finished, _ = create_settler(emit_empty_args_text=True)
+    non_emitting, non_emitting_finished, _ = create_settler(
+        emit_empty_args_text=False
+    )
+
+    emitting.begin("emitting")
+    non_emitting.begin("non-emitting")
+
+    assert emitting.finish("emitting") == ["emitting:{}"]
+    assert non_emitting.finish("non-emitting") == ["non-emitting:"]
+    assert emitting_finished == [("emitting", "{}", False)]
+    assert non_emitting_finished == [("non-emitting", "", False)]
+
+
+def test_tool_call_args_settler_drops_settled_ids_and_warns_once() -> None:
+    settler, _, warnings = create_settler(emit_empty_args_text=True)
+
+    settler.begin("t1")
+    settler.finish("t1")
+
+    assert settler.append("t1") is False
+    assert settler.append("t1") is False
+    assert warnings == [("settled-tool-call-id", "tool-call-delta for t1")]
+
+
+def test_tool_call_args_settler_flushes_open_calls() -> None:
+    settler, finished, _ = create_settler(emit_empty_args_text=True)
+
+    settler.begin("first")
+    settler.begin("second")
+    assert settler.append("second") is True
+
+    assert settler.finish_open() == ["first:{}", "second:"]
+    assert finished == [("first", "{}", False), ("second", "", True)]

--- a/python/assistant-stream/tests/test_tool_args_settle.py
+++ b/python/assistant-stream/tests/test_tool_args_settle.py
@@ -32,8 +32,11 @@ def test_tool_call_args_settler_tracks_begin_append_and_finish() -> None:
 
     settler.begin("t1")
 
-    assert settler.append("t1") is True
-    assert settler.finish("t1", "}") == ["t1:}"]
+    appended = settler.append("t1")
+    frames = settler.finish("t1", "}")
+
+    assert appended is True
+    assert frames == ["t1:}"]
     assert finished == [("t1", "}", True)]
 
 
@@ -58,8 +61,11 @@ def test_tool_call_args_settler_drops_settled_ids_and_warns_once() -> None:
     settler.begin("t1")
     settler.finish("t1")
 
-    assert settler.append("t1") is False
-    assert settler.append("t1") is False
+    first_append = settler.append("t1")
+    second_append = settler.append("t1")
+
+    assert first_append is False
+    assert second_append is False
     assert warnings == [("settled-tool-call-id", "tool-call-delta for t1")]
 
 
@@ -68,7 +74,8 @@ def test_tool_call_args_settler_flushes_open_calls() -> None:
 
     settler.begin("first")
     settler.begin("second")
-    assert settler.append("second") is True
+    appended = settler.append("second")
 
+    assert appended is True
     assert settler.finish_open() == ["first:{}", "second:"]
     assert finished == [("first", "{}", False), ("second", "", True)]


### PR DESCRIPTION
## summary

- the data-stream and assistant-transport serializers each hand-rolled the same tool-call args settlement machine: an open-args map, settled-id drops, the empty {} completion for argsless finishes, once-only dropped-delta warnings, and end-of-stream flushing of still-open args
- one shared reducer (serialization/tool_args_settle.py: begin, append, settle_without_emitting, finish, finish_open, clear) now owns the bookkeeping; each format supplies its frame constructors (the c: isFinal frame vs the path-addressed finish pair), so emitted frames, orderings, and the id-routed result-first canon are byte-identical
- format-specific semantics stay local: data-stream's boundary flush and implicit result closure, transport's path allocation, duplicate-begin rejection, and deferred-result path retention

## test plan

### already verified

- [x] full pytest suite: 167 passed, 7 skipped (rerun independently); interop fixtures untouched

no changeset; python packages release outside changesets.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.747Qpr8qlowRJjbhJpdKs2nXI0gZDKiHqVHIV4wl0nza9mayfWU_u9CovUk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->