### PR TITLE
refactor(assistant-stream): share the sse, stream factory, and drop scaffolding

### DIFF
--- a/.changeset/stream-plumbing-scaffolding.md
+++ b/.changeset/stream-plumbing-scaffolding.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: share the sse pipeline, stream factory, and closed-stream drop scaffolding.

--- a/packages/assistant-stream/src/core/gorp/createGorpStream.ts
+++ b/packages/assistant-stream/src/core/gorp/createGorpStream.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyJSONValue } from "../../utils";
+import { createControllerStreamPair } from "../utils/stream/createControllerStream";
 import { withPromiseOrValue } from "../utils/withPromiseOrValue";
 import { GorpStreamAccumulator } from "./GorpStreamAccumulator";
 import type { GorpStreamOperation, GorpStreamChunk } from "./types";
@@ -54,20 +55,6 @@ class GorpStreamControllerImpl implements GorpStreamController {
   }
 }
 
-const getStreamControllerPair = (defaultValue: ReadonlyJSONValue) => {
-  let controller!: GorpStreamControllerImpl;
-  const stream = new ReadableStream<GorpStreamChunk>({
-    start(c) {
-      controller = new GorpStreamControllerImpl(c, defaultValue);
-    },
-    cancel(reason: unknown) {
-      controller.__internalCancel(reason);
-    },
-  });
-
-  return [stream, controller] as const;
-};
-
 type CreateGorpStreamOptions = {
   execute: (controller: GorpStreamController) => void | PromiseLike<void>;
   defaultValue?: ReadonlyJSONValue;
@@ -77,7 +64,14 @@ export const createGorpStream = ({
   execute,
   defaultValue = {},
 }: CreateGorpStreamOptions) => {
-  const [stream, controller] = getStreamControllerPair(defaultValue);
+  const [stream, controller] = createControllerStreamPair<
+    GorpStreamChunk,
+    GorpStreamControllerImpl
+  >(
+    (streamController) =>
+      new GorpStreamControllerImpl(streamController, defaultValue),
+    (streamController, reason) => streamController.__internalCancel(reason),
+  );
 
   withPromiseOrValue(
     () => execute(controller),

--- a/packages/assistant-stream/src/core/modules/text.ts
+++ b/packages/assistant-stream/src/core/modules/text.ts
@@ -1,6 +1,10 @@
 import type { AssistantStream } from "../AssistantStream";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import { closeIfOpen, enqueueIfOpen } from "../utils/stream/controller-guards";
+import {
+  createControllerStream,
+  createControllerStreamPair,
+} from "../utils/stream/createControllerStream";
 import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 
 export type TextStreamController = {
@@ -36,14 +40,12 @@ class TextStreamControllerImpl implements TextStreamController {
       this._controller.enqueue(chunk);
       return this;
     }
-    try {
-      this._controller.enqueue(chunk);
-    } catch (error) {
+    enqueueIfOpen(this._controller, chunk, (error) => {
       if (!this._warnedDropped) {
         this._warnedDropped = true;
         console.error(`Dropped text delta for closed stream: ${String(error)}`);
       }
-    }
+    });
     return this;
   }
 
@@ -62,28 +64,14 @@ export const createTextStream = (
   readable: UnderlyingReadable<TextStreamController>,
   options: TextStreamOptions = {},
 ): AssistantStream => {
-  return new ReadableStream({
-    start(c) {
-      return readable.start?.(new TextStreamControllerImpl(c, options));
-    },
-    pull(c) {
-      return readable.pull?.(new TextStreamControllerImpl(c, options));
-    },
-    cancel(c) {
-      return readable.cancel?.(c);
-    },
-  });
+  return createControllerStream(
+    readable,
+    (controller) => new TextStreamControllerImpl(controller, options),
+  );
 };
 
 export const createTextStreamController = (options: TextStreamOptions = {}) => {
-  let controller!: TextStreamController;
-  const stream = createTextStream(
-    {
-      start(c) {
-        controller = c;
-      },
-    },
-    options,
+  return createControllerStreamPair<AssistantStreamChunk, TextStreamController>(
+    (controller) => new TextStreamControllerImpl(controller, options),
   );
-  return [stream, controller] as const;
 };

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -5,6 +5,10 @@ import type { ReadonlyJSONValue } from "../../utils/json/json-value";
 import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 import { createTextStream, type TextStreamController } from "./text";
 import { closeIfOpen, enqueueIfOpen } from "../utils/stream/controller-guards";
+import {
+  createControllerStream,
+  createControllerStreamPair,
+} from "../utils/stream/createControllerStream";
 
 export type ToolCallStreamController = {
   argsText: TextStreamController;
@@ -116,25 +120,15 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
 export const createToolCallStream = (
   readable: UnderlyingReadable<ToolCallStreamController>,
 ): AssistantStream => {
-  return new ReadableStream({
-    start(c) {
-      return readable.start?.(new ToolCallStreamControllerImpl(c));
-    },
-    pull(c) {
-      return readable.pull?.(new ToolCallStreamControllerImpl(c));
-    },
-    cancel(c) {
-      return readable.cancel?.(c);
-    },
-  });
+  return createControllerStream(
+    readable,
+    (controller) => new ToolCallStreamControllerImpl(controller),
+  );
 };
 
 export const createToolCallStreamController = () => {
-  let controller!: ToolCallStreamController;
-  const stream = createToolCallStream({
-    start(c) {
-      controller = c;
-    },
-  });
-  return [stream, controller] as const;
+  return createControllerStreamPair<
+    AssistantStreamChunk,
+    ToolCallStreamController
+  >((controller) => new ToolCallStreamControllerImpl(controller));
 };

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -1,10 +1,10 @@
 import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import { SSEEncoder } from "../../utils/stream/SSE";
 import {
   createSSEJsonDecoder,
   createSSEJsonEncoder,
+  SSE_HEADERS,
 } from "../../utils/stream/SSEJson";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
@@ -80,14 +80,10 @@ export class AssistantTransportEncoder
   extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>>
   implements AssistantStreamEncoder
 {
-  headers = new Headers(SSEEncoder.headers);
+  headers = new Headers(SSE_HEADERS);
 
   constructor() {
-    super((readable) =>
-      readable.pipeThrough(
-        createSSEJsonEncoder<AssistantStreamChunk>("[DONE]"),
-      ),
-    );
+    super(createSSEJsonEncoder<AssistantStreamChunk>("[DONE]"));
   }
 }
 
@@ -101,46 +97,47 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
 > {
   constructor(options: { strict?: boolean | undefined } = {}) {
     const strict = options.strict ?? true;
-    super((readable) => {
-      const warnedReasons = new Set<string>();
-
-      return readable.pipeThrough(
-        createSSEJsonDecoder<AssistantStreamChunk>({
-          strict,
-          parse(data, controller) {
-            const chunk = parseChunk(data);
-            if (typeof chunk === "string") {
-              if (!warnedReasons.has(chunk)) {
-                warnedReasons.add(chunk);
-                console.warn(
-                  `Dropped invalid assistant-transport chunk (${chunk}): ${data.slice(0, 200)}`,
-                );
-              }
-            } else {
-              controller.enqueue(chunk);
-            }
-          },
-          done: {
-            marker: "[DONE]",
-            onMissing() {
-              if (strict) {
-                throw new Error(
-                  "Stream ended abruptly without receiving [DONE] marker",
-                );
-              }
+    const warnedReasons = new Set<string>();
+    super(
+      createSSEJsonDecoder<AssistantStreamChunk>({
+        parse(data, controller) {
+          const chunk = parseChunk(data);
+          if (typeof chunk === "string") {
+            if (!warnedReasons.has(chunk)) {
+              warnedReasons.add(chunk);
               console.warn(
+                `Dropped invalid assistant-transport chunk (${chunk}): ${data.slice(0, 200)}`,
+              );
+            }
+          } else {
+            controller.enqueue(chunk);
+          }
+        },
+        done: {
+          marker: "[DONE]",
+          onMissing() {
+            if (strict) {
+              throw new Error(
                 "Stream ended abruptly without receiving [DONE] marker",
               );
-            },
-          },
-          onUnknownEvent(event) {
-            if (!warnedReasons.has(`event:${event}`)) {
-              warnedReasons.add(`event:${event}`);
-              console.error(`Ignored unknown SSE event type: ${event}`);
             }
+            console.warn(
+              "Stream ended abruptly without receiving [DONE] marker",
+            );
           },
-        }),
-      );
-    });
+        },
+        ...(strict
+          ? { strict: true }
+          : {
+              strict: false,
+              onUnknownEvent(event) {
+                if (!warnedReasons.has(`event:${event}`)) {
+                  warnedReasons.add(`event:${event}`);
+                  console.error(`Ignored unknown SSE event type: ${event}`);
+                }
+              },
+            }),
+      }),
+    );
   }
 }

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -1,10 +1,11 @@
 import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
+import { SSEEncoder } from "../../utils/stream/SSE";
 import {
-  SSEEventDecoderStream,
-  type PipelineSSEEvent,
-} from "../../utils/stream/SSEEventDecoderStream";
+  createSSEJsonDecoder,
+  createSSEJsonEncoder,
+} from "../../utils/stream/SSEJson";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
 type ChunkFields = Record<string, unknown>;
@@ -79,27 +80,14 @@ export class AssistantTransportEncoder
   extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>>
   implements AssistantStreamEncoder
 {
-  headers = new Headers({
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
+  headers = new Headers(SSEEncoder.headers);
 
   constructor() {
-    super((readable) => {
-      return readable
-        .pipeThrough(
-          new TransformStream<AssistantStreamChunk, string>({
-            transform(chunk, controller) {
-              controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
-            },
-            flush(controller) {
-              controller.enqueue("data: [DONE]\n\n");
-            },
-          }),
-        )
-        .pipeThrough(new TextEncoderStream());
-    });
+    super((readable) =>
+      readable.pipeThrough(
+        createSSEJsonEncoder<AssistantStreamChunk>("[DONE]"),
+      ),
+    );
   }
 }
 
@@ -114,60 +102,45 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
   constructor(options: { strict?: boolean | undefined } = {}) {
     const strict = options.strict ?? true;
     super((readable) => {
-      let receivedDone = false;
       const warnedReasons = new Set<string>();
 
-      return readable
-        .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new SSEEventDecoderStream())
-        .pipeThrough(
-          new TransformStream<PipelineSSEEvent, AssistantStreamChunk>({
-            transform(event, controller) {
-              switch (event.event) {
-                case "message":
-                  if (event.data === "[DONE]") {
-                    // Mark that we received [DONE]
-                    receivedDone = true;
-                    // Stop processing when we encounter [DONE]
-                    controller.terminate();
-                  } else {
-                    const chunk = parseChunk(event.data);
-                    if (typeof chunk === "string") {
-                      if (!warnedReasons.has(chunk)) {
-                        warnedReasons.add(chunk);
-                        console.warn(
-                          `Dropped invalid assistant-transport chunk (${chunk}): ${event.data.slice(0, 200)}`,
-                        );
-                      }
-                    } else {
-                      controller.enqueue(chunk);
-                    }
-                  }
-                  break;
-                default:
-                  if (strict)
-                    throw new Error(`Unknown SSE event type: ${event.event}`);
-                  if (!warnedReasons.has(`event:${event.event}`)) {
-                    warnedReasons.add(`event:${event.event}`);
-                    console.error(
-                      `Ignored unknown SSE event type: ${event.event}`,
-                    );
-                  }
-              }
-            },
-            flush() {
-              if (!receivedDone) {
-                if (strict)
-                  throw new Error(
-                    "Stream ended abruptly without receiving [DONE] marker",
-                  );
+      return readable.pipeThrough(
+        createSSEJsonDecoder<AssistantStreamChunk>({
+          strict,
+          parse(data, controller) {
+            const chunk = parseChunk(data);
+            if (typeof chunk === "string") {
+              if (!warnedReasons.has(chunk)) {
+                warnedReasons.add(chunk);
                 console.warn(
+                  `Dropped invalid assistant-transport chunk (${chunk}): ${data.slice(0, 200)}`,
+                );
+              }
+            } else {
+              controller.enqueue(chunk);
+            }
+          },
+          done: {
+            marker: "[DONE]",
+            onMissing() {
+              if (strict) {
+                throw new Error(
                   "Stream ended abruptly without receiving [DONE] marker",
                 );
               }
+              console.warn(
+                "Stream ended abruptly without receiving [DONE] marker",
+              );
             },
-          }),
-        );
+          },
+          onUnknownEvent(event) {
+            if (!warnedReasons.has(`event:${event}`)) {
+              warnedReasons.add(`event:${event}`);
+              console.error(`Ignored unknown SSE event type: ${event}`);
+            }
+          },
+        }),
+      );
     });
   }
 }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -2,10 +2,7 @@ import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { AssistantTransformStream } from "../../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import {
-  SSEEventDecoderStream,
-  type PipelineSSEEvent,
-} from "../../utils/stream/SSEEventDecoderStream";
+import { createSSEJsonDecoder } from "../../utils/stream/SSEJson";
 import type {
   UIMessageStreamChunk,
   UIMessageStreamDataChunk,
@@ -41,7 +38,6 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
       const toolCallPartRegistry = createToolCallPartRegistry();
       let activeToolCallId: string | undefined;
       let currentMessageId: string | undefined;
-      let receivedDone = false;
       type PendingTool = {
         toolCallId: string;
         toolName: string;
@@ -258,27 +254,13 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
       });
 
       return readable
-        .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
-          new TransformStream<PipelineSSEEvent, UIMessageStreamChunk>({
-            transform(event, controller) {
-              if (event.event !== "message") {
-                throw new Error(`Unknown SSE event type: ${event.event}`);
-              }
-
-              if (event.data === "[DONE]") {
-                for (const tool of pendingTools.values()) {
-                  emitPendingTool(controller, tool);
-                }
-                receivedDone = true;
-                controller.terminate();
-                return;
-              }
-
+          createSSEJsonDecoder<UIMessageStreamChunk>({
+            strict: true,
+            parse(data, controller) {
               let chunk;
               try {
-                chunk = sjson.parse(event.data);
+                chunk = sjson.parse(data);
               } catch {
                 chunk = undefined;
               }
@@ -289,7 +271,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 typeof chunk.type !== "string"
               ) {
                 console.warn(
-                  `Dropped invalid UIMessageStream chunk: ${event.data.slice(0, 200)}`,
+                  `Dropped invalid UIMessageStream chunk: ${data.slice(0, 200)}`,
                 );
                 return;
               }
@@ -436,12 +418,18 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
               controller.enqueue(chunk);
             },
-            flush() {
-              if (!receivedDone) {
+            done: {
+              marker: "[DONE]",
+              onDone(controller) {
+                for (const tool of pendingTools.values()) {
+                  emitPendingTool(controller, tool);
+                }
+              },
+              onMissing() {
                 throw new Error(
                   "Stream ended abruptly without receiving [DONE] marker",
                 );
-              }
+              },
             },
           }),
         )

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -253,187 +253,175 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
         },
       });
 
-      return readable
-        .pipeThrough(
-          createSSEJsonDecoder<UIMessageStreamChunk>({
-            strict: true,
-            parse(data, controller) {
-              let chunk;
-              try {
-                chunk = sjson.parse(data);
-              } catch {
-                chunk = undefined;
-              }
-              if (
-                typeof chunk !== "object" ||
-                chunk === null ||
-                Array.isArray(chunk) ||
-                typeof chunk.type !== "string"
-              ) {
-                console.warn(
-                  `Dropped invalid UIMessageStream chunk: ${data.slice(0, 200)}`,
-                );
-                return;
-              }
-              if (
-                chunk.type === "text-delta" &&
-                chunk.textDelta === undefined
-              ) {
-                const { delta, ...rest } = chunk;
-                controller.enqueue({ ...rest, textDelta: delta ?? "" });
-                return;
-              }
-              if (chunk.type === "start") {
-                controller.enqueue({
-                  ...chunk,
-                  messageId: chunk.messageId ?? generateId(),
-                });
-                return;
-              }
-              if (chunk.type === "source-url") {
-                controller.enqueue({
-                  type: "source",
-                  source: {
-                    sourceType: "url",
-                    id: chunk.sourceId,
-                    url: chunk.url,
-                    ...(chunk.title && { title: chunk.title }),
-                  },
-                });
-                return;
-              }
-              if (chunk.type === "source" && chunk.source == null) return;
-              if (chunk.type === "file" && chunk.file == null) {
-                if (chunk.url === undefined) return;
-                controller.enqueue({
-                  type: "file",
-                  file: { mimeType: chunk.mediaType, data: chunk.url },
-                });
-                return;
-              }
-              if (chunk.type === "finish-step") {
-                controller.enqueue({
-                  ...chunk,
-                  finishReason: chunk.finishReason ?? "unknown",
-                  usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
-                  isContinued: chunk.isContinued ?? false,
-                });
-                return;
-              }
-              if (chunk.type === "finish") {
-                controller.enqueue({
-                  ...chunk,
-                  finishReason: chunk.finishReason ?? "unknown",
-                  usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
-                });
-                return;
-              }
-              if (chunk.type === "tool-input-start") {
-                if (typeof chunk.toolCallId !== "string") return;
-                if (pendingTools.has(chunk.toolCallId)) return;
-                pendingTools.set(chunk.toolCallId, {
-                  toolCallId: chunk.toolCallId,
-                  toolName:
-                    typeof chunk.toolName === "string" ? chunk.toolName : "",
-                  deltas: [],
-                  emitted: false,
-                  resultEmitted: false,
-                });
-                return;
-              }
-              if (chunk.type === "tool-input-delta") {
-                if (typeof chunk.toolCallId !== "string") return;
-                if (typeof chunk.inputTextDelta !== "string") return;
-                const tool = pendingTools.get(chunk.toolCallId);
-                if (!tool || tool.emitted) return;
-                tool.deltas.push(chunk.inputTextDelta);
-                return;
-              }
-              if (
-                chunk.type === "tool-input-available" ||
-                chunk.type === "tool-input-error"
-              ) {
-                if (typeof chunk.toolCallId !== "string") return;
-                let tool = pendingTools.get(chunk.toolCallId);
-                if (!tool) {
-                  tool = {
-                    toolCallId: chunk.toolCallId,
-                    toolName:
-                      typeof chunk.toolName === "string" ? chunk.toolName : "",
-                    deltas: [],
-                    emitted: false,
-                    resultEmitted: false,
-                  };
-                  pendingTools.set(chunk.toolCallId, tool);
-                }
-                if (tool.emitted) return;
-                if (chunk.input !== undefined) {
-                  tool.deltas = [
-                    typeof chunk.input === "string"
-                      ? chunk.input
-                      : JSON.stringify(chunk.input),
-                  ];
-                }
-                if (chunk.type === "tool-input-error") {
-                  tool.pendingResult = {
+      return createSSEJsonDecoder<UIMessageStreamChunk>({
+        strict: true,
+        parse(data, controller) {
+          let chunk;
+          try {
+            chunk = sjson.parse(data);
+          } catch {
+            chunk = undefined;
+          }
+          if (
+            typeof chunk !== "object" ||
+            chunk === null ||
+            Array.isArray(chunk) ||
+            typeof chunk.type !== "string"
+          ) {
+            console.warn(
+              `Dropped invalid UIMessageStream chunk: ${data.slice(0, 200)}`,
+            );
+            return;
+          }
+          if (chunk.type === "text-delta" && chunk.textDelta === undefined) {
+            const { delta, ...rest } = chunk;
+            controller.enqueue({ ...rest, textDelta: delta ?? "" });
+            return;
+          }
+          if (chunk.type === "start") {
+            controller.enqueue({
+              ...chunk,
+              messageId: chunk.messageId ?? generateId(),
+            });
+            return;
+          }
+          if (chunk.type === "source-url") {
+            controller.enqueue({
+              type: "source",
+              source: {
+                sourceType: "url",
+                id: chunk.sourceId,
+                url: chunk.url,
+                ...(chunk.title && { title: chunk.title }),
+              },
+            });
+            return;
+          }
+          if (chunk.type === "source" && chunk.source == null) return;
+          if (chunk.type === "file" && chunk.file == null) {
+            if (chunk.url === undefined) return;
+            controller.enqueue({
+              type: "file",
+              file: { mimeType: chunk.mediaType, data: chunk.url },
+            });
+            return;
+          }
+          if (chunk.type === "finish-step") {
+            controller.enqueue({
+              ...chunk,
+              finishReason: chunk.finishReason ?? "unknown",
+              usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+              isContinued: chunk.isContinued ?? false,
+            });
+            return;
+          }
+          if (chunk.type === "finish") {
+            controller.enqueue({
+              ...chunk,
+              finishReason: chunk.finishReason ?? "unknown",
+              usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+            });
+            return;
+          }
+          if (chunk.type === "tool-input-start") {
+            if (typeof chunk.toolCallId !== "string") return;
+            if (pendingTools.has(chunk.toolCallId)) return;
+            pendingTools.set(chunk.toolCallId, {
+              toolCallId: chunk.toolCallId,
+              toolName:
+                typeof chunk.toolName === "string" ? chunk.toolName : "",
+              deltas: [],
+              emitted: false,
+              resultEmitted: false,
+            });
+            return;
+          }
+          if (chunk.type === "tool-input-delta") {
+            if (typeof chunk.toolCallId !== "string") return;
+            if (typeof chunk.inputTextDelta !== "string") return;
+            const tool = pendingTools.get(chunk.toolCallId);
+            if (!tool || tool.emitted) return;
+            tool.deltas.push(chunk.inputTextDelta);
+            return;
+          }
+          if (
+            chunk.type === "tool-input-available" ||
+            chunk.type === "tool-input-error"
+          ) {
+            if (typeof chunk.toolCallId !== "string") return;
+            let tool = pendingTools.get(chunk.toolCallId);
+            if (!tool) {
+              tool = {
+                toolCallId: chunk.toolCallId,
+                toolName:
+                  typeof chunk.toolName === "string" ? chunk.toolName : "",
+                deltas: [],
+                emitted: false,
+                resultEmitted: false,
+              };
+              pendingTools.set(chunk.toolCallId, tool);
+            }
+            if (tool.emitted) return;
+            if (chunk.input !== undefined) {
+              tool.deltas = [
+                typeof chunk.input === "string"
+                  ? chunk.input
+                  : JSON.stringify(chunk.input),
+              ];
+            }
+            if (chunk.type === "tool-input-error") {
+              tool.pendingResult = {
+                result:
+                  typeof chunk.errorText === "string" ? chunk.errorText : "",
+                isError: true,
+              };
+            }
+            emitPendingTool(controller, tool);
+            return;
+          }
+          if (
+            chunk.type === "tool-output-available" ||
+            chunk.type === "tool-output-error"
+          ) {
+            if (typeof chunk.toolCallId !== "string") return;
+            if (chunk.type === "tool-output-available" && chunk.preliminary) {
+              return;
+            }
+            const tool = pendingTools.get(chunk.toolCallId);
+            if (!tool || tool.resultEmitted) return;
+            tool.pendingResult =
+              chunk.type === "tool-output-error"
+                ? {
                     result:
                       typeof chunk.errorText === "string"
                         ? chunk.errorText
                         : "",
                     isError: true,
+                  }
+                : {
+                    result: chunk.output as ReadonlyJSONValue,
+                    isError: false,
                   };
-                }
-                emitPendingTool(controller, tool);
-                return;
-              }
-              if (
-                chunk.type === "tool-output-available" ||
-                chunk.type === "tool-output-error"
-              ) {
-                if (typeof chunk.toolCallId !== "string") return;
-                if (
-                  chunk.type === "tool-output-available" &&
-                  chunk.preliminary
-                ) {
-                  return;
-                }
-                const tool = pendingTools.get(chunk.toolCallId);
-                if (!tool || tool.resultEmitted) return;
-                tool.pendingResult =
-                  chunk.type === "tool-output-error"
-                    ? {
-                        result:
-                          typeof chunk.errorText === "string"
-                            ? chunk.errorText
-                            : "",
-                        isError: true,
-                      }
-                    : {
-                        result: chunk.output as ReadonlyJSONValue,
-                        isError: false,
-                      };
-                if (tool.emitted) emitPendingTool(controller, tool);
-                return;
-              }
+            if (tool.emitted) emitPendingTool(controller, tool);
+            return;
+          }
 
-              controller.enqueue(chunk);
-            },
-            done: {
-              marker: "[DONE]",
-              onDone(controller) {
-                for (const tool of pendingTools.values()) {
-                  emitPendingTool(controller, tool);
-                }
-              },
-              onMissing() {
-                throw new Error(
-                  "Stream ended abruptly without receiving [DONE] marker",
-                );
-              },
-            },
-          }),
-        )
-        .pipeThrough(transform);
+          controller.enqueue(chunk);
+        },
+        done: {
+          marker: "[DONE]",
+          onDone(controller) {
+            for (const tool of pendingTools.values()) {
+              emitPendingTool(controller, tool);
+            }
+          },
+          onMissing() {
+            throw new Error(
+              "Stream ended abruptly without receiving [DONE] marker",
+            );
+          },
+        },
+      })(readable).pipeThrough(transform);
     });
   }
 }

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -1,21 +1,21 @@
 import sjson from "secure-json-parse";
 import { PipeableTransformStream } from "./PipeableTransformStream";
-import { createSSEJsonDecoder, createSSEJsonEncoder } from "./SSEJson";
+import {
+  createSSEJsonDecoder,
+  createSSEJsonEncoder,
+  SSE_HEADERS,
+} from "./SSEJson";
 
 export class SSEEncoder<T> extends PipeableTransformStream<
   T,
   Uint8Array<ArrayBuffer>
 > {
-  static readonly headers = new Headers({
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
+  static readonly headers = new Headers(SSE_HEADERS);
 
   headers = SSEEncoder.headers;
 
   constructor() {
-    super((readable) => readable.pipeThrough(createSSEJsonEncoder<T>()));
+    super(createSSEJsonEncoder<T>());
   }
 }
 
@@ -26,30 +26,30 @@ export class SSEDecoder<T> extends PipeableTransformStream<
   constructor(options: { strict?: boolean | undefined } = {}) {
     const strict = options.strict ?? true;
     const ignoredEvents = new Set<string>();
-    super((readable) =>
-      readable.pipeThrough(
-        createSSEJsonDecoder<T>({
-          strict,
-          parse(data, controller) {
-            let value;
-            try {
-              value = sjson.parse(data);
-            } catch {
-              console.warn(
-                `Dropped invalid SSE message: ${data.slice(0, 200)}`,
-              );
-              return;
-            }
-            controller.enqueue(value);
-          },
-          onUnknownEvent(event) {
-            if (!ignoredEvents.has(event)) {
-              ignoredEvents.add(event);
-              console.error(`Ignored unknown SSE event type: ${event}`);
-            }
-          },
-        }),
-      ),
+    super(
+      createSSEJsonDecoder<T>({
+        parse(data, controller) {
+          let value;
+          try {
+            value = sjson.parse(data);
+          } catch {
+            console.warn(`Dropped invalid SSE message: ${data.slice(0, 200)}`);
+            return;
+          }
+          controller.enqueue(value);
+        },
+        ...(strict
+          ? { strict: true }
+          : {
+              strict: false,
+              onUnknownEvent(event) {
+                if (!ignoredEvents.has(event)) {
+                  ignoredEvents.add(event);
+                  console.error(`Ignored unknown SSE event type: ${event}`);
+                }
+              },
+            }),
+      }),
     );
   }
 }

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -1,9 +1,6 @@
 import sjson from "secure-json-parse";
 import { PipeableTransformStream } from "./PipeableTransformStream";
-import {
-  SSEEventDecoderStream,
-  type PipelineSSEEvent,
-} from "./SSEEventDecoderStream";
+import { createSSEJsonDecoder, createSSEJsonEncoder } from "./SSEJson";
 
 export class SSEEncoder<T> extends PipeableTransformStream<
   T,
@@ -18,17 +15,7 @@ export class SSEEncoder<T> extends PipeableTransformStream<
   headers = SSEEncoder.headers;
 
   constructor() {
-    super((readable) =>
-      readable
-        .pipeThrough(
-          new TransformStream<T, string>({
-            transform(chunk, controller) {
-              controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
-            },
-          }),
-        )
-        .pipeThrough(new TextEncoderStream()),
-    );
+    super((readable) => readable.pipeThrough(createSSEJsonEncoder<T>()));
   }
 }
 
@@ -40,39 +27,29 @@ export class SSEDecoder<T> extends PipeableTransformStream<
     const strict = options.strict ?? true;
     const ignoredEvents = new Set<string>();
     super((readable) =>
-      readable
-        .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new SSEEventDecoderStream())
-        .pipeThrough(
-          new TransformStream<PipelineSSEEvent, T>({
-            transform(event, controller) {
-              switch (event.event) {
-                case "message": {
-                  let value;
-                  try {
-                    value = sjson.parse(event.data);
-                  } catch {
-                    console.warn(
-                      `Dropped invalid SSE message: ${event.data.slice(0, 200)}`,
-                    );
-                    break;
-                  }
-                  controller.enqueue(value);
-                  break;
-                }
-                default:
-                  if (strict)
-                    throw new Error(`Unknown SSE event type: ${event.event}`);
-                  if (!ignoredEvents.has(event.event)) {
-                    ignoredEvents.add(event.event);
-                    console.error(
-                      `Ignored unknown SSE event type: ${event.event}`,
-                    );
-                  }
-              }
-            },
-          }),
-        ),
+      readable.pipeThrough(
+        createSSEJsonDecoder<T>({
+          strict,
+          parse(data, controller) {
+            let value;
+            try {
+              value = sjson.parse(data);
+            } catch {
+              console.warn(
+                `Dropped invalid SSE message: ${data.slice(0, 200)}`,
+              );
+              return;
+            }
+            controller.enqueue(value);
+          },
+          onUnknownEvent(event) {
+            if (!ignoredEvents.has(event)) {
+              ignoredEvents.add(event);
+              console.error(`Ignored unknown SSE event type: ${event}`);
+            }
+          },
+        }),
+      ),
     );
   }
 }

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
@@ -115,6 +115,7 @@ describe("createSSEJsonDecoder", () => {
     const chunks = await collectChunks(
       createSSEJsonDecoder({
         parse: jsonParse,
+        strict: false,
         onUnknownEvent,
       })(fromSSEText('event: custom\ndata: {"a":1}\n\ndata: {"b":2}\n\n')),
     );

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
@@ -77,6 +77,28 @@ describe("createSSEJsonDecoder", () => {
     expect(chunks).toEqual([{ a: 1 }]);
   });
 
+  it("invokes the done callback when the marker arrives", async () => {
+    const onDone = vi.fn();
+    await collectChunks(
+      createSSEJsonDecoder({
+        parse: jsonParse,
+        done: { marker: "[DONE]", onDone },
+      })(fromSSEText('data: {"a":1}\n\ndata: [DONE]\n\n')),
+    );
+    expect(onDone).toHaveBeenCalledOnce();
+  });
+
+  it("invokes the missing callback when the stream ends without the marker", async () => {
+    const onMissing = vi.fn();
+    await collectChunks(
+      createSSEJsonDecoder({
+        parse: jsonParse,
+        done: { marker: "[DONE]", onMissing },
+      })(fromSSEText('data: {"a":1}\n\n')),
+    );
+    expect(onMissing).toHaveBeenCalledOnce();
+  });
+
   it("throws on unknown event names in strict mode", async () => {
     await expect(
       collectChunks(

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSSEJsonDecoder, createSSEJsonEncoder } from "./SSEJson";
+
+async function collectChunks<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const chunks: T[] = [];
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return chunks;
+}
+
+function fromValues<T>(values: T[]): ReadableStream<T> {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const value of values) controller.enqueue(value);
+      controller.close();
+    },
+  });
+}
+
+function fromSSEText(text: string): ReadableStream<Uint8Array<ArrayBuffer>> {
+  return fromValues([new TextEncoder().encode(text)]) as ReadableStream<
+    Uint8Array<ArrayBuffer>
+  >;
+}
+
+const jsonParse = (
+  data: string,
+  controller: TransformStreamDefaultController<unknown>,
+) => {
+  controller.enqueue(JSON.parse(data));
+};
+
+describe("createSSEJsonEncoder", () => {
+  it("frames each chunk as an sse data line", async () => {
+    const encoded = await collectChunks(
+      createSSEJsonEncoder()(fromValues([{ a: 1 }, { b: 2 }])),
+    );
+    const text = new TextDecoder().decode(
+      encoded.reduce(
+        (acc, part) => new Uint8Array([...acc, ...part]),
+        new Uint8Array(),
+      ),
+    );
+    expect(text).toBe('data: {"a":1}\n\ndata: {"b":2}\n\n');
+  });
+
+  it("appends the done marker on flush when configured", async () => {
+    const encoded = await collectChunks(
+      createSSEJsonEncoder("[DONE]")(fromValues([{ a: 1 }])),
+    );
+    const text = new TextDecoder().decode(
+      encoded.reduce(
+        (acc, part) => new Uint8Array([...acc, ...part]),
+        new Uint8Array(),
+      ),
+    );
+    expect(text).toBe('data: {"a":1}\n\ndata: [DONE]\n\n');
+  });
+});
+
+describe("createSSEJsonDecoder", () => {
+  it("parses message events and terminates on the done marker", async () => {
+    const chunks = await collectChunks(
+      createSSEJsonDecoder({
+        parse: jsonParse,
+        done: { marker: "[DONE]" },
+      })(fromSSEText('data: {"a":1}\n\ndata: [DONE]\n\ndata: {"b":2}\n\n')),
+    );
+    expect(chunks).toEqual([{ a: 1 }]);
+  });
+
+  it("throws on unknown event names in strict mode", async () => {
+    await expect(
+      collectChunks(
+        createSSEJsonDecoder({
+          parse: jsonParse,
+          strict: true,
+        })(fromSSEText('event: custom\ndata: {"a":1}\n\n')),
+      ),
+    ).rejects.toThrow("Unknown SSE event type: custom");
+  });
+
+  it("reports unknown event names through the lenient callback", async () => {
+    const onUnknownEvent = vi.fn();
+    const chunks = await collectChunks(
+      createSSEJsonDecoder({
+        parse: jsonParse,
+        onUnknownEvent,
+      })(fromSSEText('event: custom\ndata: {"a":1}\n\ndata: {"b":2}\n\n')),
+    );
+    expect(chunks).toEqual([{ b: 2 }]);
+    expect(onUnknownEvent).toHaveBeenCalledExactlyOnceWith("custom");
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
@@ -22,9 +22,9 @@ type SSEJsonDecoderOptions<T> = {
   ) => void;
   done?: SSEJsonDoneOptions<T>;
 } & (
-  | { strict: true }
+  | { strict?: true }
   | {
-      strict?: false;
+      strict: false;
       onUnknownEvent?: (event: string) => void;
     }
 );
@@ -59,7 +59,7 @@ export const createSSEJsonDecoder =
         new TransformStream<PipelineSSEEvent, T>({
           transform(event, controller) {
             if (event.event !== "message") {
-              if (options.strict) {
+              if (options.strict !== false) {
                 throw new Error(`Unknown SSE event type: ${event.event}`);
               }
               options.onUnknownEvent?.(event.event);

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
@@ -1,8 +1,13 @@
-import { PipeableTransformStream } from "./PipeableTransformStream";
 import {
   SSEEventDecoderStream,
   type PipelineSSEEvent,
 } from "./SSEEventDecoderStream";
+
+export const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+};
 
 type SSEJsonDoneOptions<T> = {
   marker: string;
@@ -16,12 +21,17 @@ type SSEJsonDecoderOptions<T> = {
     controller: TransformStreamDefaultController<T>,
   ) => void;
   done?: SSEJsonDoneOptions<T>;
-  strict?: boolean | undefined;
-  onUnknownEvent?: (event: string) => void;
-};
+} & (
+  | { strict: true }
+  | {
+      strict?: false;
+      onUnknownEvent?: (event: string) => void;
+    }
+);
 
-export const createSSEJsonEncoder = <T>(doneMarker?: string) =>
-  new PipeableTransformStream<T, Uint8Array<ArrayBuffer>>((readable) =>
+export const createSSEJsonEncoder =
+  <T>(doneMarker?: string) =>
+  (readable: ReadableStream<T>) =>
     readable
       .pipeThrough(
         new TransformStream<T, string>({
@@ -35,47 +45,44 @@ export const createSSEJsonEncoder = <T>(doneMarker?: string) =>
           },
         }),
       )
-      .pipeThrough(new TextEncoderStream()),
-  );
+      .pipeThrough(new TextEncoderStream());
 
-export const createSSEJsonDecoder = <T>({
-  parse,
-  done,
-  strict = true,
-  onUnknownEvent,
-}: SSEJsonDecoderOptions<T>) => {
-  let receivedDone = false;
+export const createSSEJsonDecoder =
+  <T>(options: SSEJsonDecoderOptions<T>) =>
+  (readable: ReadableStream<Uint8Array<ArrayBuffer>>) => {
+    let receivedDone = false;
 
-  return new PipeableTransformStream<Uint8Array<ArrayBuffer>, T>((readable) =>
-    readable
+    return readable
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(new SSEEventDecoderStream())
       .pipeThrough(
         new TransformStream<PipelineSSEEvent, T>({
           transform(event, controller) {
             if (event.event !== "message") {
-              if (strict) {
+              if (options.strict) {
                 throw new Error(`Unknown SSE event type: ${event.event}`);
               }
-              onUnknownEvent?.(event.event);
+              options.onUnknownEvent?.(event.event);
               return;
             }
 
-            if (done !== undefined && event.data === done.marker) {
-              done.onDone?.(controller);
+            if (
+              options.done !== undefined &&
+              event.data === options.done.marker
+            ) {
+              options.done.onDone?.(controller);
               receivedDone = true;
               controller.terminate();
               return;
             }
 
-            parse(event.data, controller);
+            options.parse(event.data, controller);
           },
           flush() {
-            if (done !== undefined && !receivedDone) {
-              done.onMissing?.();
+            if (options.done !== undefined && !receivedDone) {
+              options.done.onMissing?.();
             }
           },
         }),
-      ),
-  );
-};
+      );
+  };

--- a/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEJson.ts
@@ -1,0 +1,81 @@
+import { PipeableTransformStream } from "./PipeableTransformStream";
+import {
+  SSEEventDecoderStream,
+  type PipelineSSEEvent,
+} from "./SSEEventDecoderStream";
+
+type SSEJsonDoneOptions<T> = {
+  marker: string;
+  onDone?: (controller: TransformStreamDefaultController<T>) => void;
+  onMissing?: () => void;
+};
+
+type SSEJsonDecoderOptions<T> = {
+  parse: (
+    data: string,
+    controller: TransformStreamDefaultController<T>,
+  ) => void;
+  done?: SSEJsonDoneOptions<T>;
+  strict?: boolean | undefined;
+  onUnknownEvent?: (event: string) => void;
+};
+
+export const createSSEJsonEncoder = <T>(doneMarker?: string) =>
+  new PipeableTransformStream<T, Uint8Array<ArrayBuffer>>((readable) =>
+    readable
+      .pipeThrough(
+        new TransformStream<T, string>({
+          transform(chunk, controller) {
+            controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`);
+          },
+          flush(controller) {
+            if (doneMarker !== undefined) {
+              controller.enqueue(`data: ${doneMarker}\n\n`);
+            }
+          },
+        }),
+      )
+      .pipeThrough(new TextEncoderStream()),
+  );
+
+export const createSSEJsonDecoder = <T>({
+  parse,
+  done,
+  strict = true,
+  onUnknownEvent,
+}: SSEJsonDecoderOptions<T>) => {
+  let receivedDone = false;
+
+  return new PipeableTransformStream<Uint8Array<ArrayBuffer>, T>((readable) =>
+    readable
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new SSEEventDecoderStream())
+      .pipeThrough(
+        new TransformStream<PipelineSSEEvent, T>({
+          transform(event, controller) {
+            if (event.event !== "message") {
+              if (strict) {
+                throw new Error(`Unknown SSE event type: ${event.event}`);
+              }
+              onUnknownEvent?.(event.event);
+              return;
+            }
+
+            if (done !== undefined && event.data === done.marker) {
+              done.onDone?.(controller);
+              receivedDone = true;
+              controller.terminate();
+              return;
+            }
+
+            parse(event.data, controller);
+          },
+          flush() {
+            if (done !== undefined && !receivedDone) {
+              done.onMissing?.();
+            }
+          },
+        }),
+      ),
+  );
+};

--- a/packages/assistant-stream/src/core/utils/stream/controller-guards.ts
+++ b/packages/assistant-stream/src/core/utils/stream/controller-guards.ts
@@ -2,16 +2,19 @@ import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 
 // A controller throws TypeError once its stream is closed or cancelled; that
 // is the only portable signal a producer gets that the consumer went away.
-const isClosedControllerError = (error: unknown) => error instanceof TypeError;
+const isClosedControllerError = (error: unknown): error is TypeError =>
+  error instanceof TypeError;
 
 export const enqueueIfOpen = (
   controller: { enqueue(chunk: AssistantStreamChunk): void },
   chunk: AssistantStreamChunk,
+  onDrop?: (error: TypeError) => void,
 ) => {
   try {
     controller.enqueue(chunk);
   } catch (error) {
     if (!isClosedControllerError(error)) throw error;
+    onDrop?.(error);
   }
 };
 

--- a/packages/assistant-stream/src/core/utils/stream/createControllerStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/createControllerStream.ts
@@ -1,0 +1,44 @@
+import type { UnderlyingReadable } from "./UnderlyingReadable";
+
+export const createControllerStream = <TChunk, TController>(
+  readable: UnderlyingReadable<TController>,
+  makeController: (
+    controller: ReadableStreamDefaultController<TChunk>,
+  ) => TController,
+) =>
+  new ReadableStream<TChunk>({
+    start(controller) {
+      return readable.start?.(makeController(controller));
+    },
+    pull(controller) {
+      return readable.pull?.(makeController(controller));
+    },
+    cancel(reason) {
+      return readable.cancel?.(reason);
+    },
+  });
+
+export const createControllerStreamPair = <TChunk, TController>(
+  makeController: (
+    controller: ReadableStreamDefaultController<TChunk>,
+  ) => TController,
+  onCancel?: (
+    controller: TController,
+    reason: unknown,
+  ) => void | PromiseLike<void>,
+) => {
+  let controller!: TController;
+  const stream = createControllerStream<TChunk, TController>(
+    {
+      start(value) {
+        controller = value;
+      },
+      cancel(reason) {
+        return onCancel?.(controller, reason);
+      },
+    },
+    makeController,
+  );
+
+  return [stream, controller] as const;
+};


### PR DESCRIPTION
## summary

- three SSE json pipelines (SSE.ts, the assistant-transport serializer, the ui-message-stream serializer) each hand-rolled `data: ${JSON.stringify(chunk)}` encoding and the TextDecoderStream → SSEEventDecoderStream → parse/[DONE] decode chain; they now share createSSEJsonEncoder(doneMarker?) and createSSEJsonDecoder({ parse, done, strict, onUnknownEvent }), with byte-identical framing and per-site policies kept (assistant-transport keeps its fresh copy of SSEEncoder.headers)
- the ReadableStream start/pull/cancel wrapping repeated by createTextStream, createToolCallStream, and gorp's controller pair collapses into createControllerStream / createControllerStreamPair
- enqueueIfOpen gains an optional onDrop, and text.ts's append routes through it, preserving the exact warn-once text; the #6316 close-after-cancel guard tests pass untouched
- no public exports, no wire changes, and the ui-message-stream tool-call dispatch regions are untouched (the two-generation decoder split is tracked separately)

## test plan

### already verified

- [x] full assistant-stream vitest: 36 files, 483 tests green with zero test edits (rerun independently); build green

### reviewer should verify

- [ ] the assistant-transport SSE response still ends with the data: [DONE] frame and unknown event names still follow each decoder's existing policy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.va2zq4hacL5eiUkrRhrYZ3SrUNNoz5MK8C5lRY08MACuLsxTrRfrgUQikak?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->