### PR TITLE
refactor(assistant-stream): split the ui message stream chunk normalizer out of the decoder

### DIFF
--- a/.changeset/split-ui-message-stream-chunk-normalizer.md
+++ b/.changeset/split-ui-message-stream-chunk-normalizer.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: split the ui message stream chunk normalizer out of the decoder

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -8,8 +8,8 @@ import type {
   UIMessageStreamDataChunk,
 } from "./chunk-types";
 import { generateId } from "../../utils/generateId";
-import type { ReadonlyJSONValue } from "../../../utils/json/json-value";
 import { createToolCallPartRegistry } from "../tool-call-part-registry";
+import { createChunkNormalizer } from "./chunk-normalizer";
 
 export type { UIMessageStreamChunk, UIMessageStreamDataChunk };
 
@@ -36,44 +36,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
   constructor(options: UIMessageStreamDecoderOptions = {}) {
     super((readable) => {
       const toolCallPartRegistry = createToolCallPartRegistry();
+      const normalizer = createChunkNormalizer();
       let activeToolCallId: string | undefined;
       let currentMessageId: string | undefined;
-      type PendingTool = {
-        toolCallId: string;
-        toolName: string;
-        deltas: string[];
-        emitted: boolean;
-        resultEmitted: boolean;
-        pendingResult?: { result: ReadonlyJSONValue; isError: boolean };
-      };
-      const pendingTools = new Map<string, PendingTool>();
-      const emitPendingTool = (
-        out: TransformStreamDefaultController<UIMessageStreamChunk>,
-        tool: PendingTool,
-      ) => {
-        if (!tool.emitted) {
-          tool.emitted = true;
-          out.enqueue({
-            type: "tool-call-start",
-            id: generateId(),
-            toolCallId: tool.toolCallId,
-            toolName: tool.toolName,
-          });
-          for (const argsText of tool.deltas) {
-            out.enqueue({ type: "tool-call-delta", argsText });
-          }
-          out.enqueue({ type: "tool-call-end" });
-        }
-        if (tool.pendingResult && !tool.resultEmitted) {
-          out.enqueue({
-            type: "tool-result",
-            toolCallId: tool.toolCallId,
-            result: tool.pendingResult.result,
-            ...(tool.pendingResult.isError ? { isError: true } : {}),
-          });
-          tool.resultEmitted = true;
-        }
-      };
 
       const transform = new AssistantTransformStream<UIMessageStreamChunk>({
         transform(chunk, controller) {
@@ -273,147 +238,12 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
             );
             return;
           }
-          if (chunk.type === "text-delta" && chunk.textDelta === undefined) {
-            const { delta, ...rest } = chunk;
-            controller.enqueue({ ...rest, textDelta: delta ?? "" });
-            return;
-          }
-          if (chunk.type === "start") {
-            controller.enqueue({
-              ...chunk,
-              messageId: chunk.messageId ?? generateId(),
-            });
-            return;
-          }
-          if (chunk.type === "source-url") {
-            controller.enqueue({
-              type: "source",
-              source: {
-                sourceType: "url",
-                id: chunk.sourceId,
-                url: chunk.url,
-                ...(chunk.title && { title: chunk.title }),
-              },
-            });
-            return;
-          }
-          if (chunk.type === "source" && chunk.source == null) return;
-          if (chunk.type === "file" && chunk.file == null) {
-            if (chunk.url === undefined) return;
-            controller.enqueue({
-              type: "file",
-              file: { mimeType: chunk.mediaType, data: chunk.url },
-            });
-            return;
-          }
-          if (chunk.type === "finish-step") {
-            controller.enqueue({
-              ...chunk,
-              finishReason: chunk.finishReason ?? "unknown",
-              usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
-              isContinued: chunk.isContinued ?? false,
-            });
-            return;
-          }
-          if (chunk.type === "finish") {
-            controller.enqueue({
-              ...chunk,
-              finishReason: chunk.finishReason ?? "unknown",
-              usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
-            });
-            return;
-          }
-          if (chunk.type === "tool-input-start") {
-            if (typeof chunk.toolCallId !== "string") return;
-            if (pendingTools.has(chunk.toolCallId)) return;
-            pendingTools.set(chunk.toolCallId, {
-              toolCallId: chunk.toolCallId,
-              toolName:
-                typeof chunk.toolName === "string" ? chunk.toolName : "",
-              deltas: [],
-              emitted: false,
-              resultEmitted: false,
-            });
-            return;
-          }
-          if (chunk.type === "tool-input-delta") {
-            if (typeof chunk.toolCallId !== "string") return;
-            if (typeof chunk.inputTextDelta !== "string") return;
-            const tool = pendingTools.get(chunk.toolCallId);
-            if (!tool || tool.emitted) return;
-            tool.deltas.push(chunk.inputTextDelta);
-            return;
-          }
-          if (
-            chunk.type === "tool-input-available" ||
-            chunk.type === "tool-input-error"
-          ) {
-            if (typeof chunk.toolCallId !== "string") return;
-            let tool = pendingTools.get(chunk.toolCallId);
-            if (!tool) {
-              tool = {
-                toolCallId: chunk.toolCallId,
-                toolName:
-                  typeof chunk.toolName === "string" ? chunk.toolName : "",
-                deltas: [],
-                emitted: false,
-                resultEmitted: false,
-              };
-              pendingTools.set(chunk.toolCallId, tool);
-            }
-            if (tool.emitted) return;
-            if (chunk.input !== undefined) {
-              tool.deltas = [
-                typeof chunk.input === "string"
-                  ? chunk.input
-                  : JSON.stringify(chunk.input),
-              ];
-            }
-            if (chunk.type === "tool-input-error") {
-              tool.pendingResult = {
-                result:
-                  typeof chunk.errorText === "string" ? chunk.errorText : "",
-                isError: true,
-              };
-            }
-            emitPendingTool(controller, tool);
-            return;
-          }
-          if (
-            chunk.type === "tool-output-available" ||
-            chunk.type === "tool-output-error"
-          ) {
-            if (typeof chunk.toolCallId !== "string") return;
-            if (chunk.type === "tool-output-available" && chunk.preliminary) {
-              return;
-            }
-            const tool = pendingTools.get(chunk.toolCallId);
-            if (!tool || tool.resultEmitted) return;
-            tool.pendingResult =
-              chunk.type === "tool-output-error"
-                ? {
-                    result:
-                      typeof chunk.errorText === "string"
-                        ? chunk.errorText
-                        : "",
-                    isError: true,
-                  }
-                : {
-                    result: chunk.output as ReadonlyJSONValue,
-                    isError: false,
-                  };
-            if (tool.emitted) emitPendingTool(controller, tool);
-            return;
-          }
-
-          controller.enqueue(chunk);
+          normalizer.normalize(chunk, controller);
         },
         done: {
           marker: "[DONE]",
           onDone(controller) {
-            for (const tool of pendingTools.values()) {
-              emitPendingTool(controller, tool);
-            }
+            normalizer.flush(controller);
           },
           onMissing() {
             throw new Error(

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
@@ -4,7 +4,7 @@ import type { UIMessageStreamChunk } from "./chunk-types";
 
 export const createChunkNormalizer = (): {
   normalize(
-    chunk: any,
+    chunk: { type: string } & Record<string, any>,
     controller: TransformStreamDefaultController<UIMessageStreamChunk>,
   ): void;
   flush(
@@ -52,12 +52,17 @@ export const createChunkNormalizer = (): {
     normalize(chunk, controller) {
       if (chunk.type === "text-delta" && chunk.textDelta === undefined) {
         const { delta, ...rest } = chunk;
-        controller.enqueue({ ...rest, textDelta: delta ?? "" });
+        controller.enqueue({
+          ...rest,
+          type: "text-delta",
+          textDelta: delta ?? "",
+        });
         return;
       }
       if (chunk.type === "start") {
         controller.enqueue({
           ...chunk,
+          type: "start",
           messageId: chunk.messageId ?? generateId(),
         });
         return;
@@ -86,6 +91,7 @@ export const createChunkNormalizer = (): {
       if (chunk.type === "finish-step") {
         controller.enqueue({
           ...chunk,
+          type: "finish-step",
           finishReason: chunk.finishReason ?? "unknown",
           usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
           isContinued: chunk.isContinued ?? false,
@@ -95,6 +101,7 @@ export const createChunkNormalizer = (): {
       if (chunk.type === "finish") {
         controller.enqueue({
           ...chunk,
+          type: "finish",
           finishReason: chunk.finishReason ?? "unknown",
           usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
         });
@@ -178,7 +185,7 @@ export const createChunkNormalizer = (): {
         return;
       }
 
-      controller.enqueue(chunk);
+      controller.enqueue(chunk as UIMessageStreamChunk);
     },
     flush(controller) {
       for (const tool of pendingTools.values()) {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
@@ -1,0 +1,189 @@
+import { generateId } from "../../utils/generateId";
+import type { ReadonlyJSONValue } from "../../../utils/json/json-value";
+import type { UIMessageStreamChunk } from "./chunk-types";
+
+export const createChunkNormalizer = (): {
+  normalize(
+    chunk: any,
+    controller: TransformStreamDefaultController<UIMessageStreamChunk>,
+  ): void;
+  flush(
+    controller: TransformStreamDefaultController<UIMessageStreamChunk>,
+  ): void;
+} => {
+  type PendingTool = {
+    toolCallId: string;
+    toolName: string;
+    deltas: string[];
+    emitted: boolean;
+    resultEmitted: boolean;
+    pendingResult?: { result: ReadonlyJSONValue; isError: boolean };
+  };
+  const pendingTools = new Map<string, PendingTool>();
+  const emitPendingTool = (
+    out: TransformStreamDefaultController<UIMessageStreamChunk>,
+    tool: PendingTool,
+  ) => {
+    if (!tool.emitted) {
+      tool.emitted = true;
+      out.enqueue({
+        type: "tool-call-start",
+        id: generateId(),
+        toolCallId: tool.toolCallId,
+        toolName: tool.toolName,
+      });
+      for (const argsText of tool.deltas) {
+        out.enqueue({ type: "tool-call-delta", argsText });
+      }
+      out.enqueue({ type: "tool-call-end" });
+    }
+    if (tool.pendingResult && !tool.resultEmitted) {
+      out.enqueue({
+        type: "tool-result",
+        toolCallId: tool.toolCallId,
+        result: tool.pendingResult.result,
+        ...(tool.pendingResult.isError ? { isError: true } : {}),
+      });
+      tool.resultEmitted = true;
+    }
+  };
+
+  return {
+    normalize(chunk, controller) {
+      if (chunk.type === "text-delta" && chunk.textDelta === undefined) {
+        const { delta, ...rest } = chunk;
+        controller.enqueue({ ...rest, textDelta: delta ?? "" });
+        return;
+      }
+      if (chunk.type === "start") {
+        controller.enqueue({
+          ...chunk,
+          messageId: chunk.messageId ?? generateId(),
+        });
+        return;
+      }
+      if (chunk.type === "source-url") {
+        controller.enqueue({
+          type: "source",
+          source: {
+            sourceType: "url",
+            id: chunk.sourceId,
+            url: chunk.url,
+            ...(chunk.title && { title: chunk.title }),
+          },
+        });
+        return;
+      }
+      if (chunk.type === "source" && chunk.source == null) return;
+      if (chunk.type === "file" && chunk.file == null) {
+        if (chunk.url === undefined) return;
+        controller.enqueue({
+          type: "file",
+          file: { mimeType: chunk.mediaType, data: chunk.url },
+        });
+        return;
+      }
+      if (chunk.type === "finish-step") {
+        controller.enqueue({
+          ...chunk,
+          finishReason: chunk.finishReason ?? "unknown",
+          usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+          isContinued: chunk.isContinued ?? false,
+        });
+        return;
+      }
+      if (chunk.type === "finish") {
+        controller.enqueue({
+          ...chunk,
+          finishReason: chunk.finishReason ?? "unknown",
+          usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+        });
+        return;
+      }
+      if (chunk.type === "tool-input-start") {
+        if (typeof chunk.toolCallId !== "string") return;
+        if (pendingTools.has(chunk.toolCallId)) return;
+        pendingTools.set(chunk.toolCallId, {
+          toolCallId: chunk.toolCallId,
+          toolName: typeof chunk.toolName === "string" ? chunk.toolName : "",
+          deltas: [],
+          emitted: false,
+          resultEmitted: false,
+        });
+        return;
+      }
+      if (chunk.type === "tool-input-delta") {
+        if (typeof chunk.toolCallId !== "string") return;
+        if (typeof chunk.inputTextDelta !== "string") return;
+        const tool = pendingTools.get(chunk.toolCallId);
+        if (!tool || tool.emitted) return;
+        tool.deltas.push(chunk.inputTextDelta);
+        return;
+      }
+      if (
+        chunk.type === "tool-input-available" ||
+        chunk.type === "tool-input-error"
+      ) {
+        if (typeof chunk.toolCallId !== "string") return;
+        let tool = pendingTools.get(chunk.toolCallId);
+        if (!tool) {
+          tool = {
+            toolCallId: chunk.toolCallId,
+            toolName: typeof chunk.toolName === "string" ? chunk.toolName : "",
+            deltas: [],
+            emitted: false,
+            resultEmitted: false,
+          };
+          pendingTools.set(chunk.toolCallId, tool);
+        }
+        if (tool.emitted) return;
+        if (chunk.input !== undefined) {
+          tool.deltas = [
+            typeof chunk.input === "string"
+              ? chunk.input
+              : JSON.stringify(chunk.input),
+          ];
+        }
+        if (chunk.type === "tool-input-error") {
+          tool.pendingResult = {
+            result: typeof chunk.errorText === "string" ? chunk.errorText : "",
+            isError: true,
+          };
+        }
+        emitPendingTool(controller, tool);
+        return;
+      }
+      if (
+        chunk.type === "tool-output-available" ||
+        chunk.type === "tool-output-error"
+      ) {
+        if (typeof chunk.toolCallId !== "string") return;
+        if (chunk.type === "tool-output-available" && chunk.preliminary) {
+          return;
+        }
+        const tool = pendingTools.get(chunk.toolCallId);
+        if (!tool || tool.resultEmitted) return;
+        tool.pendingResult =
+          chunk.type === "tool-output-error"
+            ? {
+                result:
+                  typeof chunk.errorText === "string" ? chunk.errorText : "",
+                isError: true,
+              }
+            : {
+                result: chunk.output as ReadonlyJSONValue,
+                isError: false,
+              };
+        if (tool.emitted) emitPendingTool(controller, tool);
+        return;
+      }
+
+      controller.enqueue(chunk);
+    },
+    flush(controller) {
+      for (const tool of pendingTools.values()) {
+        emitPendingTool(controller, tool);
+      }
+    },
+  };
+};


### PR DESCRIPTION
## summary

the ui message stream decoder's sse parse callback mixed two protocol generations inline: the canonical chunk union handled by the transform switch, and the ai sdk v6 aliases (`delta` vs `textDelta`, `source-url`, url-shaped `file`, bare `finish`/`finish-step` defaults, and the buffered `tool-input-*`/`tool-output-*` remap onto `tool-call-*` + `tool-result`). this moves the whole normalization layer into a sibling `chunk-normalizer.ts` factory that owns the pending-tool buffer and the done-marker flush, so `UIMessageStream.ts` keeps only transport hygiene (json parse + shape validation) and the canonical switch.

structure-only: no wire string, emit ordering, error text, or union change; the module is internal and nothing new is exported from the package barrel.

## test plan

- `vitest run` in packages/assistant-stream: 490 passed | 20 skipped, including the 38 decoder contract tests that pin both generations end to end
- `tsc --noEmit -p packages/assistant-stream` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VhIdMH33YiaCSqG6Sqoe82n9Jw49MqPDdd4vdjg2wrBBDiQrj1A4_R4VRlA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->