### PR TITLE
refactor(x-generative-compiler): share the generative source predicate across bundler integrations

### DIFF
--- a/.changeset/solid-seahorses-dream.md
+++ b/.changeset/solid-seahorses-dream.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/x-generative-compiler": patch
+"@assistant-ui/vite": patch
+"@assistant-ui/metro": patch
+---
+
+refactor: share the generative source predicate across bundler integrations

--- a/api-surface/assistant-ui__x-generative-compiler.ts
+++ b/api-surface/assistant-ui__x-generative-compiler.ts
@@ -24,9 +24,11 @@ type ToolType = "backend" | "frontend" | "human" | "provider";
 declare function compileGenerative(code: string, options: CompileOptions): CompileResult;
 
 declare namespace entry_root_exports {
-  export { CompileOptions, CompileResult, DIRECTIVE, GenerativeCompileError, Target, ToolType, compileGenerative, isGenerativeModule };
+  export { CompileOptions, CompileResult, DIRECTIVE, GenerativeCompileError, Target, ToolType, compileGenerative, isGenerativeModule, isGenerativeSource };
 }
 
 declare function isGenerativeModule(code: string): boolean;
+
+declare const isGenerativeSource: (filename: string, source: string) => boolean;
 
 export { entry_root_exports as entry_root };

--- a/packages/metro/src/transformer.ts
+++ b/packages/metro/src/transformer.ts
@@ -3,14 +3,11 @@ import { statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   compileGenerative,
-  isGenerativeModule,
+  isGenerativeSource,
 } from "@assistant-ui/x-generative-compiler";
 import { BACKENDLESS_ENV, UPSTREAM_TRANSFORMER_ENV } from "./index";
 
 const require = createRequire(import.meta.url);
-
-/** Source modules a `"use generative"` directive can appear in. */
-const SOURCE_RE = /\.[cm]?[jt]sx?$/;
 
 /** Minimal shape of a Metro babel transformer. */
 type BabelTransformer = {
@@ -72,7 +69,7 @@ export function transform(
   const upstream = upstreamTransformer();
   const { filename, src, options } = props;
 
-  if (SOURCE_RE.test(filename) && isGenerativeModule(src)) {
+  if (isGenerativeSource(filename, src)) {
     const target = isServerEnvironment(
       options?.customTransformOptions?.environment,
     )

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,11 +1,8 @@
 import type { Plugin, TransformResult } from "vite";
 import {
   compileGenerative,
-  isGenerativeModule,
+  isGenerativeSource,
 } from "@assistant-ui/x-generative-compiler";
-
-/** Source modules a `"use generative"` directive can appear in. */
-const SOURCE_RE = /\.[cm]?[jt]sx?($|\?)/;
 
 export interface AuiOptions {
   /**
@@ -22,8 +19,7 @@ function generativePlugin(pluginOptions: AuiOptions): Plugin {
     name: "assistant-ui:use-generative",
     enforce: "pre",
     transform(code, id, options) {
-      if (!SOURCE_RE.test(id)) return;
-      if (!isGenerativeModule(code)) return;
+      if (!isGenerativeSource(id.split("?")[0]!, code)) return;
 
       // Vite 6+ exposes the environment; `consumer` is the stable client/server
       // axis. Fall back to the legacy `options.ssr` boolean for older Vite.

--- a/packages/x-generative-compiler/src/compile.test.ts
+++ b/packages/x-generative-compiler/src/compile.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   compileGenerative,
   isGenerativeModule,
+  isGenerativeSource,
   GenerativeCompileError,
 } from "./compile";
 
@@ -1883,6 +1884,22 @@ export default defineToolkit({
         `"use generative" /* first line\nsecond line */ + suffix;\nexport default {};`,
       ),
     ).toBe(false);
+  });
+
+  it("detects generative source files", () => {
+    const source = `"use generative";\nexport default {};`;
+
+    for (const filename of [
+      "toolkit.ts",
+      "toolkit.tsx",
+      "toolkit.mts",
+      "toolkit.cjsx",
+    ]) {
+      expect(isGenerativeSource(filename, source)).toBe(true);
+    }
+
+    expect(isGenerativeSource("toolkit.css", source)).toBe(false);
+    expect(isGenerativeSource("toolkit.ts", "export default {};")).toBe(false);
   });
 });
 

--- a/packages/x-generative-compiler/src/compile.ts
+++ b/packages/x-generative-compiler/src/compile.ts
@@ -142,6 +142,9 @@ export function isGenerativeModule(code: string): boolean {
   return hasDirectiveTerminator(code, directiveEnd + 1);
 }
 
+export const isGenerativeSource = (filename: string, source: string): boolean =>
+  /\.[cm]?[jt]sx?$/.test(filename) && isGenerativeModule(source);
+
 function hasDirectiveTerminator(code: string, start: number): boolean {
   let i = start;
   let sawLineTerminator = false;

--- a/packages/x-generative-compiler/src/index.ts
+++ b/packages/x-generative-compiler/src/index.ts
@@ -1,6 +1,7 @@
 export {
   compileGenerative,
   isGenerativeModule,
+  isGenerativeSource,
   GenerativeCompileError,
   type ToolType,
   type CompileOptions,


### PR DESCRIPTION
## summary

the vite plugin and the metro transformer each kept a local `SOURCE_RE` plus the same `extension test && isGenerativeModule(code)` gate. this moves the pair into `@assistant-ui/x-generative-compiler` as one exported predicate, `isGenerativeSource(filename, source)`, and both integrations consume it.

the vite side strips the module query before the extension test instead of carrying a `($|\?)` alternative in the regex. for supported ids this is equivalent; it also stops the old unanchored pattern from accidentally matching an extension inside the query tail (for example `foo.css?lang.ts`), which was never an intended source shape.

## test plan

- x-generative-compiler vitest: 96 passed, including new predicate cases (extension matrix, non-source filename, missing directive)
- tsc --noEmit clean in x-generative-compiler, vite, and metro

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YWnr026mmXv6oVDRTP97mKMWIGzOEtA_7Icg-txkBWrSAGBd0T_eFKnYYiM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->