### PR TITLE
refactor(cli): consolidate the package manager resolver and project file iteration

### DIFF
--- a/.changeset/cli-shared-utils.md
+++ b/.changeset/cli-shared-utils.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+refactor: consolidate the package manager resolver and project file iteration

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -5,13 +5,12 @@ import {
   getComponentsJsonStyle,
   resolveRegistryItemUrl,
 } from "../lib/utils/registry";
-import {
-  dlxCommand,
-  resolvePackageManager,
-  resolvePackageManagerForCwd,
-  type PackageManagerName,
-} from "../lib/create-project";
+import { dlxCommand, resolvePackageManager } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
+import {
+  type PackageManagerName,
+  resolvePackageManagerForCwd,
+} from "../lib/utils/package-manager";
 
 export interface AddComponentsPlan {
   command: string;

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -9,12 +9,12 @@ import {
   downloadProject,
   resolveLatestReleaseRef,
   resolvePackageManager,
-  resolvePackageManagerForCwd,
   scaffoldProject,
   transformProject,
   type TransformResult,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
+import { resolvePackageManagerForCwd } from "../lib/utils/package-manager";
 import {
   buildSkillsAddCommand,
   resolveSkillsInstall,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,13 +1,10 @@
 import { Command, Option } from "commander";
 import fs from "node:fs";
 import path from "node:path";
-import {
-  dlxCommand,
-  resolvePackageManager,
-  resolvePackageManagerForCwd,
-} from "../lib/create-project";
+import { dlxCommand, resolvePackageManager } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
 import { logger } from "../lib/utils/logger";
+import { resolvePackageManagerForCwd } from "../lib/utils/package-manager";
 import {
   getComponentsJsonStyle,
   resolveQuickStartRegistryUrl,

--- a/packages/cli/src/lib/agent-skill.ts
+++ b/packages/cli/src/lib/agent-skill.ts
@@ -1,4 +1,5 @@
-import { dlxCommand, type PackageManagerName } from "./create-project";
+import { dlxCommand } from "./create-project";
+import { type PackageManagerName } from "./utils/package-manager";
 
 export const SKILLS_PACKAGE = "assistant-ui/skills";
 

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -1,8 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { downloadTemplate } from "giget";
-import { sync as globSync } from "glob";
-import { detect } from "detect-package-manager";
 import {
   parse as parseJsonc,
   printParseErrorCode,
@@ -10,8 +8,8 @@ import {
 } from "jsonc-parser";
 import { logger } from "./utils/logger";
 import { runSpawn, SpawnExitError } from "./run-spawn";
-
-export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
+import { type PackageManagerName } from "./utils/package-manager";
+import { readProjectFiles } from "./utils/file-scanner";
 
 export function dlxCommand(pm: PackageManagerName): [string, string[]] {
   switch (pm) {
@@ -183,30 +181,6 @@ export async function scaffoldProject(
       );
     }
     throw error;
-  }
-}
-
-function detectFromUserAgent(): PackageManagerName | undefined {
-  const ua = process.env.npm_config_user_agent;
-  if (!ua) return undefined;
-  if (ua.startsWith("bun/")) return "bun";
-  if (ua.startsWith("pnpm/")) return "pnpm";
-  if (ua.startsWith("yarn/")) return "yarn";
-  if (ua.startsWith("npm/")) return "npm";
-  return undefined;
-}
-
-export async function resolvePackageManagerForCwd(
-  cwd: string,
-  packageManager?: PackageManagerName,
-): Promise<PackageManagerName> {
-  if (packageManager) return packageManager;
-  const fromAgent = detectFromUserAgent();
-  if (fromAgent) return fromAgent;
-  try {
-    return await detect({ cwd });
-  } catch {
-    return "npm";
   }
 }
 
@@ -383,16 +357,11 @@ function transformTsConfig(projectDir: string): void {
 }
 
 function transformCssFiles(projectDir: string): void {
-  const cssFiles = globSync("**/*.css", {
+  for (const { fullPath, content } of readProjectFiles("**/*.css", {
     cwd: projectDir,
     ignore: LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES,
-  });
-
-  for (const file of cssFiles) {
-    const fullPath = path.join(projectDir, file);
+  })) {
     try {
-      const content = fs.readFileSync(fullPath, "utf-8");
-
       const newContent = content.replace(
         /@source\s+["'][^"']*packages\/ui\/src[^"']*["'];\s*\n?/g,
         "",
@@ -402,7 +371,7 @@ function transformCssFiles(projectDir: string): void {
         fs.writeFileSync(fullPath, newContent);
       }
     } catch {
-      // Ignore files that cannot be read/written
+      continue;
     }
   }
 }
@@ -417,31 +386,22 @@ function stripImportExtension(component: string): string {
 }
 
 function scanRequiredComponents(projectDir: string): RequiredComponents {
-  const files = globSync("**/*.{ts,tsx}", {
-    cwd: projectDir,
-    ignore: LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES,
-  });
-
   const assistantUIComponents = new Set<string>();
   const shadcnUIComponents = new Set<string>();
 
-  for (const file of files) {
-    const fullPath = path.join(projectDir, file);
-    try {
-      const content = fs.readFileSync(fullPath, "utf-8");
+  for (const { content } of readProjectFiles("**/*.{ts,tsx}", {
+    cwd: projectDir,
+    ignore: LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES,
+  })) {
+    const assistantUIRegex =
+      /from\s+["']@\/components\/assistant-ui\/([^"']+)["']/g;
+    for (const match of content.matchAll(assistantUIRegex)) {
+      assistantUIComponents.add(stripImportExtension(match[1]!));
+    }
 
-      const assistantUIRegex =
-        /from\s+["']@\/components\/assistant-ui\/([^"']+)["']/g;
-      for (const match of content.matchAll(assistantUIRegex)) {
-        assistantUIComponents.add(stripImportExtension(match[1]!));
-      }
-
-      const uiRegex = /from\s+["']@\/components\/ui\/([^"']+)["']/g;
-      for (const match of content.matchAll(uiRegex)) {
-        shadcnUIComponents.add(stripImportExtension(match[1]!));
-      }
-    } catch {
-      // Ignore files that cannot be read
+    const uiRegex = /from\s+["']@\/components\/ui\/([^"']+)["']/g;
+    for (const match of content.matchAll(uiRegex)) {
+      shadcnUIComponents.add(stripImportExtension(match[1]!));
     }
   }
 

--- a/packages/cli/src/lib/utils/file-scanner.ts
+++ b/packages/cli/src/lib/utils/file-scanner.ts
@@ -8,6 +8,23 @@ export interface ScanOptions {
   ignore?: string[];
 }
 
+export function* readProjectFiles(
+  pattern: string,
+  options: { cwd: string; ignore?: string[] },
+): Generator<{ file: string; fullPath: string; content: string }> {
+  const files = globSync(pattern, options);
+
+  for (const file of files) {
+    const fullPath = path.join(options.cwd, file);
+    try {
+      const content = fs.readFileSync(fullPath, "utf8");
+      yield { file, fullPath, content };
+    } catch {
+      continue;
+    }
+  }
+}
+
 export function scanForImport(
   importPattern: string | string[],
   options: ScanOptions = {},
@@ -20,20 +37,13 @@ export function scanForImport(
     "**/build/**",
   ];
 
-  const files = globSync(pattern, { cwd, ignore });
   const patterns = Array.isArray(importPattern)
     ? importPattern
     : [importPattern];
 
-  for (const file of files) {
-    const fullPath = path.join(cwd, file);
-    try {
-      const content = fs.readFileSync(fullPath, "utf8");
-      if (patterns.some((p) => content.includes(p))) {
-        return true;
-      }
-    } catch {
-      // Ignore files that cannot be read
+  for (const { content } of readProjectFiles(pattern, { cwd, ignore })) {
+    if (patterns.some((p) => content.includes(p))) {
+      return true;
     }
   }
 
@@ -52,18 +62,14 @@ export function getFilesContaining(
     "**/build/**",
   ];
 
-  const files = globSync(pattern, { cwd, ignore });
   const result: string[] = [];
 
-  for (const file of files) {
-    const fullPath = path.join(cwd, file);
-    try {
-      const content = fs.readFileSync(fullPath, "utf8");
-      if (content.includes(searchString)) {
-        result.push(fullPath);
-      }
-    } catch {
-      // Ignore files that cannot be read
+  for (const { fullPath, content } of readProjectFiles(pattern, {
+    cwd,
+    ignore,
+  })) {
+    if (content.includes(searchString)) {
+      result.push(fullPath);
     }
   }
 

--- a/packages/cli/src/lib/utils/package-manager.ts
+++ b/packages/cli/src/lib/utils/package-manager.ts
@@ -5,6 +5,8 @@ import { detect } from "detect-package-manager";
 import * as readline from "node:readline";
 import { logger } from "./logger";
 
+export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
+
 export function askQuestion(query: string): Promise<string> {
   return new Promise((resolve) => {
     const rl = readline.createInterface({
@@ -59,6 +61,30 @@ export async function getInstallCommand(
       return { command: "bun", args: ["add", ...packages] };
     default:
       return { command: "npm", args: ["install", ...packages] };
+  }
+}
+
+function detectFromUserAgent(): PackageManagerName | undefined {
+  const ua = process.env.npm_config_user_agent;
+  if (!ua) return undefined;
+  if (ua.startsWith("bun/")) return "bun";
+  if (ua.startsWith("pnpm/")) return "pnpm";
+  if (ua.startsWith("yarn/")) return "yarn";
+  if (ua.startsWith("npm/")) return "npm";
+  return undefined;
+}
+
+export async function resolvePackageManagerForCwd(
+  cwd: string,
+  packageManager?: PackageManagerName,
+): Promise<PackageManagerName> {
+  if (packageManager) return packageManager;
+  const fromAgent = detectFromUserAgent();
+  if (fromAgent) return fromAgent;
+  try {
+    return await detect({ cwd });
+  } catch {
+    return "npm";
   }
 }
 

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -40,10 +40,8 @@ vi.mock("detect-package-manager", () => ({
 // Import the mocks after vi.mock so we can inspect calls
 import { spawn } from "cross-spawn";
 import { downloadTemplate } from "giget";
-import {
-  dlxCommand,
-  type PackageManagerName,
-} from "../../src/lib/create-project";
+import { dlxCommand } from "../../src/lib/create-project";
+import { type PackageManagerName } from "../../src/lib/utils/package-manager";
 
 const TEST_PM: PackageManagerName = "pnpm";
 const [TEST_DLX_CMD] = dlxCommand(TEST_PM);


### PR DESCRIPTION
## summary

two consolidations inside the cli package, both landing in `lib/utils`:

- `detectFromUserAgent` and `resolvePackageManagerForCwd` (plus the `PackageManagerName` type) move from `lib/create-project.ts` into `lib/utils/package-manager.ts`, next to the other package-manager helpers; init/create/add/agent-skill and the test re-point their imports. `getInstallCommand` and `commands/info.ts` deliberately stay on bare `detect({ cwd })`: lockfile-first is the correct priority when operating inside an existing project, unlike the create flow where the invoking user agent wins.
- a `readProjectFiles` generator in `lib/utils/file-scanner.ts` owns the glob + read + skip-unreadable iteration; `scanForImport`, `getFilesContaining`, `transformCssFiles`, and `scanRequiredComponents` now iterate through it. signatures, default globs, ignore lists, and the write-error swallow in `transformCssFiles` are unchanged.

## test plan

- cli vitest: 282 passed
- `tsc --noEmit` error set is byte-identical to main except one environment-only miss (unbuilt `@assistant-ui/agent-launcher` dist in the fresh worktree; `commands/agent.ts` is untouched)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dNiu81nqc7CPm5UDERlpRNnwhjHiY8XLGzvFHGayG4ZeOgu8uQ7oYjGkHDA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->