### PR TITLE
refactor(core): share the message repository session layer between a2a and ag-ui

### DIFF
--- a/.changeset/message-repository-session.md
+++ b/.changeset/message-repository-session.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+---
+
+refactor: share the message repository session layer between a2a and ag-ui

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2916,6 +2916,12 @@ declare class MessageRepository {
   import(_param9: ExportedMessageRepository): void;
 }
 
+type MessageRepositorySession = ReturnType<typeof createMessageRepositorySession>;
+
+type MessageRepositorySessionOptions = {
+  decorateExport?: (exported: ExportedMessageRepository, repository: MessageRepository) => ExportedMessageRepository;
+};
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -5916,6 +5922,27 @@ declare const createMessageConverter: <T extends object>(callback: useExternalMe
 
 declare const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController;
 
+declare const createMessageRepositorySession: (options?: MessageRepositorySessionOptions) => {
+  getMessages: () => readonly ThreadMessage[];
+  readonly headId: string | null;
+  export: () => ExportedMessageRepository;
+  tryGetMessage: (messageId: string) => {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  } | undefined;
+  tryGetMessages: (messageId: string) => readonly ThreadMessage[] | undefined;
+  hasMessage: (messageId: string) => boolean;
+  addOrUpdateMessage: (parentId: string | null, message: ThreadMessage) => void;
+  deleteMessage: (messageId: string, replacementId?: string | null) => void;
+  tryDeleteMessage: (messageId: string) => boolean;
+  switchToBranch: (messageId: string) => void;
+  resetHead: (messageId: string | null) => void;
+  clear: () => void;
+  updateMessage: (messageId: string, updater: (message: ThreadMessage) => ThreadMessage) => boolean;
+  applyExternalMessageRepository: (loaded: ExportedMessageRepository) => void;
+};
+
 declare function createRequestHeaders(headersValue: Record<string, string> | Headers | (() => Promise<Record<string, string> | Headers>)): Promise<Headers>;
 
 declare const createRuntimeExtras: <T extends object>(runtimeName: string) => RuntimeExtras<T>;
@@ -6039,7 +6066,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AbortableThreadLoadPurpose, AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createAbortableThreadLoad, createCloudThreadListAdapterCreateFallback, createThreadMappingId, createToolCallCancellationStub, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, scanPendingToolCalls, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AbortableThreadLoadPurpose, AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRepositorySession, MessageRepositorySessionOptions, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createAbortableThreadLoad, createCloudThreadListAdapterCreateFallback, createMessageRepositorySession, createThreadMappingId, createToolCallCancellationStub, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, scanPendingToolCalls, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {

--- a/packages/core/src/runtime/internal.ts
+++ b/packages/core/src/runtime/internal.ts
@@ -56,3 +56,8 @@ export {
   MessageRepository,
 } from "./utils/message-repository";
 export type { ExportedMessageRepositoryItem } from "./utils/message-repository";
+export { createMessageRepositorySession } from "./utils/message-repository-session";
+export type {
+  MessageRepositorySession,
+  MessageRepositorySessionOptions,
+} from "./utils/message-repository-session";

--- a/packages/core/src/runtime/utils/message-repository-session.test.ts
+++ b/packages/core/src/runtime/utils/message-repository-session.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadUserMessage } from "../../types/message";
+import { createMessageRepositorySession } from "./message-repository-session";
+
+const message = (id: string, text = id): ThreadUserMessage => ({
+  id,
+  role: "user",
+  createdAt: new Date(0),
+  content: [{ type: "text", text }],
+  attachments: [],
+  metadata: { custom: {} },
+});
+
+const withRootAndChild = () => {
+  const session = createMessageRepositorySession();
+  session.addOrUpdateMessage(null, message("root"));
+  session.addOrUpdateMessage("root", message("child"));
+  return session;
+};
+
+describe("createMessageRepositorySession", () => {
+  it("memoizes exports and invalidates them after every mutator", () => {
+    const cases = [
+      () => {
+        const session = createMessageRepositorySession();
+        return {
+          session,
+          mutate: () => session.addOrUpdateMessage(null, message("root")),
+        };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        session.addOrUpdateMessage("root", message("child"));
+        return { session, mutate: () => session.deleteMessage("child") };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        session.addOrUpdateMessage("root", message("child"));
+        return {
+          session,
+          mutate: () => expect(session.tryDeleteMessage("child")).toBe(true),
+        };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        session.addOrUpdateMessage("root", message("first"));
+        session.addOrUpdateMessage("root", message("second"));
+        return { session, mutate: () => session.switchToBranch("first") };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        session.addOrUpdateMessage("root", message("child"));
+        return { session, mutate: () => session.resetHead("root") };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        return { session, mutate: () => session.clear() };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("root"));
+        return {
+          session,
+          mutate: () =>
+            expect(
+              session.updateMessage("root", (current) => ({
+                ...current,
+                content: [{ type: "text", text: "updated" }],
+              })),
+            ).toBe(true),
+        };
+      },
+      () => {
+        const session = createMessageRepositorySession();
+        session.addOrUpdateMessage(null, message("previous"));
+        return {
+          session,
+          mutate: () =>
+            session.applyExternalMessageRepository({
+              headId: "root",
+              messages: [{ parentId: null, message: message("root") }],
+            }),
+        };
+      },
+    ];
+
+    for (const createCase of cases) {
+      const { session, mutate } = createCase();
+      const exported = session.export();
+      expect(session.export()).toBe(exported);
+
+      mutate();
+
+      expect(session.export()).not.toBe(exported);
+    }
+  });
+
+  it("decorates and memoizes exports", () => {
+    let decorations = 0;
+    const session = createMessageRepositorySession({
+      decorateExport: (exported) => {
+        decorations++;
+        return { ...exported, headId: "decorated" };
+      },
+    });
+    session.addOrUpdateMessage(null, message("root"));
+
+    const exported = session.export();
+
+    expect(exported.headId).toBe("decorated");
+    expect(session.export()).toBe(exported);
+    expect(decorations).toBe(1);
+
+    session.addOrUpdateMessage("root", message("child"));
+
+    expect(session.export()).not.toBe(exported);
+    expect(decorations).toBe(2);
+  });
+
+  it("preserves the export cache when an update returns the current message", () => {
+    const session = withRootAndChild();
+    const exported = session.export();
+
+    expect(session.updateMessage("child", (current) => current)).toBe(false);
+    expect(session.export()).toBe(exported);
+  });
+
+  it("imports out-of-order parent-child pairs topologically", () => {
+    const session = createMessageRepositorySession();
+
+    session.applyExternalMessageRepository({
+      headId: "child",
+      messages: [
+        { parentId: "root", message: message("child") },
+        { parentId: null, message: message("root") },
+      ],
+    });
+
+    expect(session.getMessages().map((item) => item.id)).toEqual([
+      "root",
+      "child",
+    ]);
+  });
+
+  it("uses the degenerate linear path for duplicate message ids", () => {
+    const session = createMessageRepositorySession();
+
+    session.applyExternalMessageRepository({
+      headId: "root",
+      messages: [
+        { parentId: null, message: message("root", "first") },
+        { parentId: "root", message: message("child") },
+        { parentId: "child", message: message("root", "replacement") },
+      ],
+    });
+
+    expect(session.tryGetMessage("root")?.message.content).toEqual([
+      { type: "text", text: "replacement" },
+    ]);
+  });
+
+  it("uses the degenerate linear path when the head is missing", () => {
+    const session = createMessageRepositorySession();
+
+    session.applyExternalMessageRepository({
+      headId: "missing",
+      messages: [
+        { parentId: null, message: message("root") },
+        { parentId: null, message: message("child") },
+      ],
+    });
+
+    expect(session.tryGetMessage("child")?.parentId).toBe("root");
+  });
+
+  it("preserves an already-imported message parent in the degenerate path", () => {
+    const session = createMessageRepositorySession();
+
+    session.applyExternalMessageRepository({
+      messages: [
+        { parentId: null, message: message("root") },
+        { parentId: "root", message: message("branch", "first") },
+        { parentId: "branch", message: message("child") },
+        { parentId: "child", message: message("branch", "replacement") },
+      ],
+    });
+
+    expect(session.tryGetMessage("branch")?.parentId).toBe("root");
+  });
+});

--- a/packages/core/src/runtime/utils/message-repository-session.ts
+++ b/packages/core/src/runtime/utils/message-repository-session.ts
@@ -1,0 +1,176 @@
+import type { ThreadMessage } from "../../types/message";
+import {
+  MessageRepository,
+  type ExportedMessageRepository,
+} from "./message-repository";
+
+export type MessageRepositorySessionOptions = {
+  decorateExport?: (
+    exported: ExportedMessageRepository,
+    repository: MessageRepository,
+  ) => ExportedMessageRepository;
+};
+
+export const createMessageRepositorySession = (
+  options: MessageRepositorySessionOptions = {},
+) => {
+  const repository = new MessageRepository();
+  let exportedRepository: ExportedMessageRepository | undefined;
+
+  const getMessages = (): readonly ThreadMessage[] => {
+    return repository.getMessages();
+  };
+
+  const tryGetMessage = (messageId: string) => {
+    try {
+      return repository.getMessage(messageId);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const tryGetMessages = (
+    messageId: string,
+  ): readonly ThreadMessage[] | undefined => {
+    try {
+      return repository.getMessages(messageId);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const hasMessage = (messageId: string): boolean => {
+    return tryGetMessage(messageId) !== undefined;
+  };
+
+  const addOrUpdateMessage = (
+    parentId: string | null,
+    message: ThreadMessage,
+  ): void => {
+    repository.addOrUpdateMessage(parentId, message);
+    exportedRepository = undefined;
+  };
+
+  const deleteMessage = (
+    messageId: string,
+    replacementId?: string | null,
+  ): void => {
+    repository.deleteMessage(messageId, replacementId);
+    exportedRepository = undefined;
+  };
+
+  const tryDeleteMessage = (messageId: string): boolean => {
+    if (!hasMessage(messageId)) return false;
+    deleteMessage(messageId);
+    return true;
+  };
+
+  const switchToBranch = (messageId: string): void => {
+    repository.switchToBranch(messageId);
+    exportedRepository = undefined;
+  };
+
+  const resetHead = (messageId: string | null): void => {
+    repository.resetHead(messageId);
+    exportedRepository = undefined;
+  };
+
+  const clear = (): void => {
+    repository.clear();
+    exportedRepository = undefined;
+  };
+
+  const updateMessage = (
+    messageId: string,
+    updater: (message: ThreadMessage) => ThreadMessage,
+  ): boolean => {
+    const item = tryGetMessage(messageId);
+    if (!item) return false;
+    const message = updater(item.message);
+    if (message === item.message) return false;
+    addOrUpdateMessage(item.parentId, message);
+    return true;
+  };
+
+  const applyExternalMessageRepository = (
+    loaded: ExportedMessageRepository,
+  ): void => {
+    const headId = loaded.headId ?? loaded.messages.at(-1)?.message.id ?? null;
+    const ids = new Set<string>();
+    let degenerate = false;
+    for (const { message } of loaded.messages) {
+      if (ids.has(message.id)) {
+        degenerate = true;
+        break;
+      }
+      ids.add(message.id);
+    }
+    if (headId !== null && !ids.has(headId)) degenerate = true;
+
+    if (!degenerate) {
+      clear();
+      let pending = [...loaded.messages];
+      const importedIds = new Set<string>();
+
+      while (pending.length > 0) {
+        const unresolved: typeof pending = [];
+        let progressed = false;
+        for (const item of pending) {
+          if (item.parentId !== null && !importedIds.has(item.parentId)) {
+            unresolved.push(item);
+            continue;
+          }
+          addOrUpdateMessage(item.parentId, item.message);
+          importedIds.add(item.message.id);
+          progressed = true;
+        }
+        if (!progressed) {
+          degenerate = true;
+          break;
+        }
+        pending = unresolved;
+      }
+    }
+
+    if (degenerate) {
+      clear();
+      let previousId: string | null = null;
+      for (const { message } of loaded.messages) {
+        const existing = tryGetMessage(message.id);
+        addOrUpdateMessage(existing ? existing.parentId : previousId, message);
+        previousId = message.id;
+      }
+      resetHead(previousId);
+    } else {
+      resetHead(headId);
+    }
+  };
+
+  return {
+    getMessages,
+    get headId() {
+      return repository.headId;
+    },
+    export: (): ExportedMessageRepository => {
+      exportedRepository ??= options.decorateExport
+        ? options.decorateExport(repository.export(), repository)
+        : repository.export();
+      return exportedRepository;
+    },
+    tryGetMessage,
+    tryGetMessages,
+    hasMessage,
+    addOrUpdateMessage,
+    deleteMessage,
+    tryDeleteMessage,
+    switchToBranch,
+    resetHead,
+    clear,
+    updateMessage,
+    applyExternalMessageRepository,
+  };
+};
+
+export type MessageRepositorySession = ReturnType<
+  typeof createMessageRepositorySession
+>;

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -11,8 +11,8 @@ import type {
   ThreadMessage,
 } from "@assistant-ui/core";
 import {
+  createMessageRepositorySession,
   invokeUserCallback,
-  MessageRepository,
 } from "@assistant-ui/core/internal";
 import type { A2AClient } from "./A2AClient";
 import type {
@@ -77,8 +77,7 @@ export class A2AThreadRuntimeCore {
   private readonly notifyUpdate: () => void;
 
   private runtime: AssistantRuntime | undefined;
-  private readonly repository = new MessageRepository();
-  private exportedRepository: ExportedMessageRepository | undefined;
+  private readonly session = createMessageRepositorySession();
   private isRunningFlag = false;
   private abortController: AbortController | null = null;
   private pendingError: Error | null = null;
@@ -132,7 +131,7 @@ export class A2AThreadRuntimeCore {
       !this._loadPromise &&
       !previousHistory &&
       options.history &&
-      this.repository.getMessages().length === 0
+      this.session.getMessages().length === 0
     ) {
       void this.__internal_load();
     }
@@ -172,69 +171,11 @@ export class A2AThreadRuntimeCore {
   }
 
   getMessages(): readonly ThreadMessage[] {
-    return this.repository.getMessages();
+    return this.session.getMessages();
   }
 
   getMessageRepository(): ExportedMessageRepository {
-    this.exportedRepository ??= this.repository.export();
-    return this.exportedRepository;
-  }
-
-  private tryGetMessage(messageId: string) {
-    try {
-      return this.repository.getMessage(messageId);
-    } catch {
-      return undefined;
-    }
-  }
-
-  private tryGetMessages(
-    messageId: string,
-  ): readonly ThreadMessage[] | undefined {
-    try {
-      return this.repository.getMessages(messageId);
-    } catch {
-      return undefined;
-    }
-  }
-
-  private hasMessage(messageId: string): boolean {
-    return this.tryGetMessage(messageId) !== undefined;
-  }
-
-  private addOrUpdateMessage(
-    parentId: string | null,
-    message: ThreadMessage,
-  ): void {
-    this.repository.addOrUpdateMessage(parentId, message);
-    this.exportedRepository = undefined;
-  }
-
-  private switchToBranch(messageId: string): void {
-    this.repository.switchToBranch(messageId);
-    this.exportedRepository = undefined;
-  }
-
-  private resetRepositoryHead(messageId: string | null): void {
-    this.repository.resetHead(messageId);
-    this.exportedRepository = undefined;
-  }
-
-  private clearRepository(): void {
-    this.repository.clear();
-    this.exportedRepository = undefined;
-  }
-
-  private updateMessage(
-    messageId: string,
-    updater: (message: ThreadMessage) => ThreadMessage,
-  ): boolean {
-    const item = this.tryGetMessage(messageId);
-    if (!item) return false;
-    const message = updater(item.message);
-    if (message === item.message) return false;
-    this.addOrUpdateMessage(item.parentId, message);
-    return true;
+    return this.session.export();
   }
 
   getTask(): A2ATask | undefined {
@@ -277,7 +218,8 @@ export class A2AThreadRuntimeCore {
     this._loadPromise = Promise.all([historyPromise, this._agentCardPromise])
       .then(([repo]) => {
         if (repo) {
-          this.applyExternalMessageRepository(repo);
+          this.session.applyExternalMessageRepository(repo);
+          this.finalizeExternalApply();
         }
       })
       .catch((error) => {
@@ -307,11 +249,11 @@ export class A2AThreadRuntimeCore {
     const parentId =
       message.parentId === null
         ? null
-        : message.parentId && this.hasMessage(message.parentId)
+        : message.parentId && this.session.hasMessage(message.parentId)
           ? message.parentId
-          : this.repository.headId;
-    this.addOrUpdateMessage(parentId, threadMessage);
-    this.switchToBranch(threadMessage.id);
+          : this.session.headId;
+    this.session.addOrUpdateMessage(parentId, threadMessage);
+    this.session.switchToBranch(threadMessage.id);
     this.notifyUpdate();
     this.recordHistoryEntry(parentId, threadMessage);
 
@@ -330,7 +272,7 @@ export class A2AThreadRuntimeCore {
     const messages =
       parentId === null
         ? []
-        : (this.tryGetMessages(parentId) ?? this.getMessages());
+        : (this.session.tryGetMessages(parentId) ?? this.getMessages());
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i]!.role === "user") {
         await this.startRun(messages[i]!);
@@ -364,7 +306,7 @@ export class A2AThreadRuntimeCore {
     for (const message of messages) {
       if (seen.has(message.id)) continue;
       seen.add(message.id);
-      this.addOrUpdateMessage(parentId, message);
+      this.session.addOrUpdateMessage(parentId, message);
       parentId = message.id;
       lastId = message.id;
     }
@@ -385,7 +327,7 @@ export class A2AThreadRuntimeCore {
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
     if (messages.length === 0) {
-      this.clearRepository();
+      this.session.clear();
     } else {
       let expectedParentId: string | null = null;
       let lastAppliedId: string | null = null;
@@ -395,81 +337,22 @@ export class A2AThreadRuntimeCore {
       for (const message of messages) {
         if (seen.has(message.id)) continue;
         seen.add(message.id);
-        const existing = this.tryGetMessage(message.id);
+        const existing = this.session.tryGetMessage(message.id);
         if (existing && existing.parentId !== expectedParentId) {
           hardReplace = true;
           break;
         }
-        this.addOrUpdateMessage(expectedParentId, message);
+        this.session.addOrUpdateMessage(expectedParentId, message);
         expectedParentId = message.id;
         lastAppliedId = message.id;
       }
 
       if (hardReplace) {
-        this.clearRepository();
+        this.session.clear();
         lastAppliedId = this.appendLinearChain(messages);
       }
 
-      this.resetRepositoryHead(lastAppliedId);
-    }
-
-    this.finalizeExternalApply();
-  }
-
-  private applyExternalMessageRepository(
-    loaded: ExportedMessageRepository,
-  ): void {
-    const headId = loaded.headId ?? loaded.messages.at(-1)?.message.id ?? null;
-    const ids = new Set<string>();
-    let degenerate = false;
-    for (const { message } of loaded.messages) {
-      if (ids.has(message.id)) {
-        degenerate = true;
-        break;
-      }
-      ids.add(message.id);
-    }
-    if (headId !== null && !ids.has(headId)) degenerate = true;
-
-    if (!degenerate) {
-      this.clearRepository();
-      let pending = [...loaded.messages];
-      const importedIds = new Set<string>();
-
-      while (pending.length > 0) {
-        const unresolved: typeof pending = [];
-        let progressed = false;
-        for (const item of pending) {
-          if (item.parentId !== null && !importedIds.has(item.parentId)) {
-            unresolved.push(item);
-            continue;
-          }
-          this.addOrUpdateMessage(item.parentId, item.message);
-          importedIds.add(item.message.id);
-          progressed = true;
-        }
-        if (!progressed) {
-          degenerate = true;
-          break;
-        }
-        pending = unresolved;
-      }
-    }
-
-    if (degenerate) {
-      this.clearRepository();
-      let previousId: string | null = null;
-      for (const { message } of loaded.messages) {
-        const existing = this.tryGetMessage(message.id);
-        this.addOrUpdateMessage(
-          existing ? existing.parentId : previousId,
-          message,
-        );
-        previousId = message.id;
-      }
-      this.resetRepositoryHead(previousId);
-    } else {
-      this.resetRepositoryHead(headId);
+      this.session.resetHead(lastAppliedId);
     }
 
     this.finalizeExternalApply();
@@ -807,8 +690,8 @@ export class A2AThreadRuntimeCore {
         custom: {},
       },
     };
-    this.addOrUpdateMessage(parentId, assistant);
-    this.switchToBranch(id);
+    this.session.addOrUpdateMessage(parentId, assistant);
+    this.session.switchToBranch(id);
     this.notifyUpdate();
     return id;
   }
@@ -817,14 +700,14 @@ export class A2AThreadRuntimeCore {
     messageId: string,
     content: ThreadAssistantMessage["content"],
   ) {
-    this.updateMessage(messageId, (message) => {
+    this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       return { ...message, content };
     });
   }
 
   private updateAssistantStatus(messageId: string, status: MessageStatus) {
-    const touched = this.updateMessage(messageId, (message) => {
+    const touched = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       return { ...message, status };
     });
@@ -837,7 +720,7 @@ export class A2AThreadRuntimeCore {
   }
 
   private getAssistantStatus(messageId: string): MessageStatus | undefined {
-    const msg = this.tryGetMessage(messageId)?.message;
+    const msg = this.session.tryGetMessage(messageId)?.message;
     if (msg?.role !== "assistant") return undefined;
     return msg.status;
   }
@@ -873,7 +756,7 @@ export class A2AThreadRuntimeCore {
     if (!this.history) return;
     const parentId = this.assistantHistoryParents.get(messageId);
     if (parentId === undefined) return;
-    const message = this.tryGetMessage(messageId)?.message;
+    const message = this.session.tryGetMessage(messageId)?.message;
     if (!message || message.role !== "assistant") return;
     if (
       message.status?.type !== "complete" &&

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -21,8 +21,8 @@ import type {
   ToolCallMessagePart,
 } from "@assistant-ui/core";
 import {
+  createMessageRepositorySession,
   invokeUserCallback,
-  MessageRepository,
 } from "@assistant-ui/core/internal";
 import type {
   AbstractAgent,
@@ -142,8 +142,22 @@ export class AgUiThreadRuntimeCore {
   private readonly reportedErrors = new WeakSet<object>();
 
   private runtime: AssistantRuntime | undefined;
-  private readonly repository = new MessageRepository();
-  private exportedRepository: ExportedMessageRepository | undefined;
+  private readonly session = createMessageRepositorySession({
+    decorateExport: (exported, repository) => {
+      let parentId: string | null = null;
+      for (const message of repository.getMessages()) {
+        if (message.metadata.isOptimistic) {
+          exported.messages.push({ parentId, message });
+        }
+        parentId = message.id;
+      }
+
+      return {
+        ...exported,
+        headId: repository.headId,
+      };
+    },
+  });
   private isRunningFlag = false;
   private abortController: AbortController | null = null;
   // The agent that started the active run. updateOptions can swap this.agent
@@ -192,7 +206,7 @@ export class AgUiThreadRuntimeCore {
       !this._loadPromise &&
       !previousHistory &&
       options.history &&
-      this.repository.getMessages().length === 0
+      this.session.getMessages().length === 0
     ) {
       void this.__internal_load();
     }
@@ -210,97 +224,11 @@ export class AgUiThreadRuntimeCore {
   }
 
   getMessages(): readonly ThreadMessage[] {
-    return this.repository.getMessages();
+    return this.session.getMessages();
   }
 
   getMessageRepository(): ExportedMessageRepository {
-    if (this.exportedRepository) return this.exportedRepository;
-
-    const exportedRepository = this.repository.export();
-    let parentId: string | null = null;
-    for (const message of this.repository.getMessages()) {
-      if (message.metadata.isOptimistic) {
-        exportedRepository.messages.push({ parentId, message });
-      }
-      parentId = message.id;
-    }
-
-    this.exportedRepository = {
-      ...exportedRepository,
-      headId: this.repository.headId,
-    };
-    return this.exportedRepository;
-  }
-
-  private tryGetMessage(messageId: string) {
-    try {
-      return this.repository.getMessage(messageId);
-    } catch {
-      return undefined;
-    }
-  }
-
-  private tryGetMessages(
-    messageId: string,
-  ): readonly ThreadMessage[] | undefined {
-    try {
-      return this.repository.getMessages(messageId);
-    } catch {
-      return undefined;
-    }
-  }
-
-  private hasMessage(messageId: string): boolean {
-    return this.tryGetMessage(messageId) !== undefined;
-  }
-
-  private addOrUpdateMessage(
-    parentId: string | null,
-    message: ThreadMessage,
-  ): void {
-    this.repository.addOrUpdateMessage(parentId, message);
-    this.exportedRepository = undefined;
-  }
-
-  private deleteMessage(
-    messageId: string,
-    replacementId?: string | null,
-  ): void {
-    this.repository.deleteMessage(messageId, replacementId);
-    this.exportedRepository = undefined;
-  }
-
-  private tryDeleteMessage(messageId: string): boolean {
-    if (!this.hasMessage(messageId)) return false;
-    this.deleteMessage(messageId);
-    return true;
-  }
-
-  private switchToBranch(messageId: string): void {
-    this.repository.switchToBranch(messageId);
-    this.exportedRepository = undefined;
-  }
-
-  private resetRepositoryHead(messageId: string | null): void {
-    this.repository.resetHead(messageId);
-    this.exportedRepository = undefined;
-  }
-
-  private clearRepository(): void {
-    this.repository.clear();
-    this.exportedRepository = undefined;
-  }
-
-  private updateMessage(
-    messageId: string,
-    updater: (message: ThreadMessage) => ThreadMessage,
-  ): boolean {
-    const item = this.tryGetMessage(messageId);
-    if (!item) return false;
-    const message = updater(item.message);
-    if (message === item.message) return false;
-    this.addOrUpdateMessage(item.parentId, message);
-    return true;
+    return this.session.export();
   }
 
   getState(): ReadonlyJSONValue | undefined {
@@ -328,14 +256,21 @@ export class AgUiThreadRuntimeCore {
       .then(async (repo) => {
         if (!repo) return;
 
-        this.applyExternalMessageRepository(repo);
+        this.session.applyExternalMessageRepository(repo);
+        this.assistantHistoryParents.clear();
+        this.snapshotHistoryIds.clear();
+        this.persistedHistoryIds.clear();
+        for (const { message } of repo.messages) {
+          this.persistedHistoryIds.add(message.id);
+        }
+        this.notifyUpdate();
 
         if (repo.state !== undefined) {
           this.loadExternalState(repo.state);
         }
 
         if (repo.unstable_resume) {
-          const parentId = repo.headId ?? this.repository.headId;
+          const parentId = repo.headId ?? this.session.headId;
           const resumeStream = this.history?.resume?.bind(this.history);
           await this.startRun(
             parentId,
@@ -382,17 +317,17 @@ export class AgUiThreadRuntimeCore {
   }
 
   private appendEntry(message: AppendMessage): string {
-    if (message.sourceId) this.tryDeleteMessage(message.sourceId);
+    if (message.sourceId) this.session.tryDeleteMessage(message.sourceId);
 
     const threadMessage = this.toThreadMessage(message);
     const parentId =
       message.parentId === null
         ? null
-        : message.parentId && this.hasMessage(message.parentId)
+        : message.parentId && this.session.hasMessage(message.parentId)
           ? message.parentId
-          : this.repository.headId;
-    this.addOrUpdateMessage(parentId, threadMessage);
-    this.switchToBranch(threadMessage.id);
+          : this.session.headId;
+    this.session.addOrUpdateMessage(parentId, threadMessage);
+    this.session.switchToBranch(threadMessage.id);
     this.notifyUpdate();
     this.recordHistoryEntry(parentId, threadMessage);
     return threadMessage.id;
@@ -617,9 +552,8 @@ export class AgUiThreadRuntimeCore {
 
     // Bound against the message the gates landed on, so this check claims a
     // batch only where the projection did.
-    const gatedMessage = this.tryGetMessage(pending.messageId)?.message as
-      | ThreadAssistantMessage
-      | undefined;
+    const gatedMessage = this.session.tryGetMessage(pending.messageId)
+      ?.message as ThreadAssistantMessage | undefined;
     const gated = projectAgUiToolApprovals(
       pending.interrupts,
       new Set(
@@ -645,13 +579,16 @@ export class AgUiThreadRuntimeCore {
       pending.interrupts,
     );
 
-    const recorded = this.updateMessage(pending.messageId, (message) => {
-      if (message.role !== "assistant") return message;
-      const assistant = message as ThreadAssistantMessage;
-      const content = withToolApprovalDecision(assistant.content, options);
-      if (content === assistant.content) return assistant;
-      return { ...assistant, content };
-    });
+    const recorded = this.session.updateMessage(
+      pending.messageId,
+      (message) => {
+        if (message.role !== "assistant") return message;
+        const assistant = message as ThreadAssistantMessage;
+        const content = withToolApprovalDecision(assistant.content, options);
+        if (content === assistant.content) return assistant;
+        return { ...assistant, content };
+      },
+    );
     if (!recorded) {
       throw new Error(
         `[agui] respondToToolApproval: approval "${options.approvalId}" is already decided`,
@@ -659,7 +596,7 @@ export class AgUiThreadRuntimeCore {
     }
     this.notifyUpdate();
 
-    const assistant = this.tryGetMessage(pending.messageId)?.message as
+    const assistant = this.session.tryGetMessage(pending.messageId)?.message as
       | ThreadAssistantMessage
       | undefined;
     if (!assistant) return;
@@ -774,7 +711,7 @@ export class AgUiThreadRuntimeCore {
     if (typeof message === "string") {
       return {
         createdAt: new Date(),
-        parentId: this.repository.headId,
+        parentId: this.session.headId,
         sourceId: null,
         runConfig: {},
         role: "user",
@@ -785,7 +722,7 @@ export class AgUiThreadRuntimeCore {
     }
     return {
       createdAt: message.createdAt ?? new Date(),
-      parentId: message.parentId ?? this.repository.headId,
+      parentId: message.parentId ?? this.session.headId,
       sourceId: message.sourceId ?? null,
       role: message.role ?? "user",
       content: message.content,
@@ -800,7 +737,7 @@ export class AgUiThreadRuntimeCore {
     messageId: string,
     resume: readonly AgUiResumeEntry[],
   ): void {
-    const touched = this.updateMessage(messageId, (message) => {
+    const touched = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       if (
@@ -850,7 +787,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private cancelUnresolvedToolCalls(messageId: string): void {
-    const updated = this.updateMessage(messageId, (message) => {
+    const updated = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       const content = assistant.content.map((part) => {
@@ -867,7 +804,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   addToolResult(options: AddToolResultOptions): void {
-    const updated = this.updateMessage(options.messageId, (message) => {
+    const updated = this.session.updateMessage(options.messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
@@ -894,7 +831,7 @@ export class AgUiThreadRuntimeCore {
   sendA2uiAction(action: Record<string, unknown>): void {
     this.assertNoPendingInterrupts();
     this.maybeAutoCancelPendingToolCalls();
-    const parentId = this.repository.headId;
+    const parentId = this.session.headId;
     if (parentId === null) {
       this.logger.debug(
         "[agui] sendA2uiAction: no messages to resume, dropping action",
@@ -932,7 +869,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private maybeCompleteAfterToolResults(messageId: string): boolean {
-    const message = this.tryGetMessage(messageId)?.message;
+    const message = this.session.tryGetMessage(messageId)?.message;
     if (!message || message.role !== "assistant") return false;
     const assistant = message as ThreadAssistantMessage;
     if (
@@ -946,7 +883,7 @@ export class AgUiThreadRuntimeCore {
     );
     if (!allResolved) return false;
 
-    const updated = this.updateMessage(messageId, (current) =>
+    const updated = this.session.updateMessage(messageId, (current) =>
       current.role === "assistant"
         ? {
             ...(current as ThreadAssistantMessage),
@@ -976,7 +913,7 @@ export class AgUiThreadRuntimeCore {
     this.assistantHistoryParents.clear();
 
     if (messages.length === 0) {
-      this.clearRepository();
+      this.session.clear();
     } else {
       let expectedParentId: string | null = null;
       let lastAppliedId: string | null = null;
@@ -986,101 +923,36 @@ export class AgUiThreadRuntimeCore {
       for (const message of messages) {
         if (seen.has(message.id)) continue;
         seen.add(message.id);
-        const existing = this.tryGetMessage(message.id);
+        const existing = this.session.tryGetMessage(message.id);
         if (existing && existing.parentId !== expectedParentId) {
           hardReplace = true;
           break;
         }
-        this.addOrUpdateMessage(expectedParentId, message);
+        this.session.addOrUpdateMessage(expectedParentId, message);
         expectedParentId = message.id;
         lastAppliedId = message.id;
       }
 
       if (hardReplace) {
-        this.clearRepository();
+        this.session.clear();
         expectedParentId = null;
         lastAppliedId = null;
         seen.clear();
         for (const message of messages) {
           if (seen.has(message.id)) continue;
           seen.add(message.id);
-          this.addOrUpdateMessage(expectedParentId, message);
+          this.session.addOrUpdateMessage(expectedParentId, message);
           expectedParentId = message.id;
           lastAppliedId = message.id;
         }
       }
 
-      this.resetRepositoryHead(lastAppliedId);
+      this.session.resetHead(lastAppliedId);
     }
 
     this.snapshotHistoryIds.clear();
     for (const { message } of this.getMessageRepository().messages) {
       this.snapshotHistoryIds.add(message.id);
-    }
-    this.notifyUpdate();
-  }
-
-  private applyExternalMessageRepository(
-    loaded: ExportedMessageRepository,
-  ): void {
-    const headId = loaded.headId ?? loaded.messages.at(-1)?.message.id ?? null;
-    const ids = new Set<string>();
-    let degenerate = false;
-    for (const { message } of loaded.messages) {
-      if (ids.has(message.id)) {
-        degenerate = true;
-        break;
-      }
-      ids.add(message.id);
-    }
-    if (headId !== null && !ids.has(headId)) degenerate = true;
-
-    if (!degenerate) {
-      this.clearRepository();
-      let pending = [...loaded.messages];
-      const importedIds = new Set<string>();
-
-      while (pending.length > 0) {
-        const unresolved: typeof pending = [];
-        let progressed = false;
-        for (const item of pending) {
-          if (item.parentId !== null && !importedIds.has(item.parentId)) {
-            unresolved.push(item);
-            continue;
-          }
-          this.addOrUpdateMessage(item.parentId, item.message);
-          importedIds.add(item.message.id);
-          progressed = true;
-        }
-        if (!progressed) {
-          degenerate = true;
-          break;
-        }
-        pending = unresolved;
-      }
-    }
-
-    if (degenerate) {
-      this.clearRepository();
-      let previousId: string | null = null;
-      for (const { message } of loaded.messages) {
-        const existing = this.tryGetMessage(message.id);
-        this.addOrUpdateMessage(
-          existing ? existing.parentId : previousId,
-          message,
-        );
-        previousId = message.id;
-      }
-      this.resetRepositoryHead(previousId);
-    } else {
-      this.resetRepositoryHead(headId);
-    }
-
-    this.assistantHistoryParents.clear();
-    this.snapshotHistoryIds.clear();
-    this.persistedHistoryIds.clear();
-    for (const { message } of loaded.messages) {
-      this.persistedHistoryIds.add(message.id);
     }
     this.notifyUpdate();
   }
@@ -1113,22 +985,23 @@ export class AgUiThreadRuntimeCore {
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
-    const parent = parentId === null ? undefined : this.tryGetMessage(parentId);
+    const parent =
+      parentId === null ? undefined : this.session.tryGetMessage(parentId);
     const shouldEagerlyInsertAssistant =
       parentId !== null &&
       parent !== undefined &&
-      parentId !== this.repository.headId;
+      parentId !== this.session.headId;
     const historicalMessages = [
       ...(shouldEagerlyInsertAssistant
-        ? (this.tryGetMessages(parentId) ?? this.repository.getMessages())
-        : this.repository.getMessages()),
+        ? (this.session.tryGetMessages(parentId) ?? this.session.getMessages())
+        : this.session.getMessages()),
     ];
     const runStartMessageIds = new Set(
       this.getMessageRepository().messages.map(({ message }) => message.id),
     );
 
     this.pendingError = null;
-    const assistantParentId = parent ? parentId : this.repository.headId;
+    const assistantParentId = parent ? parentId : this.session.headId;
     let assistantMessageId: string | undefined;
     // A snapshot the preserve gate declines still evicts the in-flight
     // assistant; recreating under the cached id on the next content-bearing
@@ -1140,11 +1013,12 @@ export class AgUiThreadRuntimeCore {
     let assistantCollided = false;
     const ensureAssistant = (allowRecreate = false): string => {
       const cached = assistantMessageId;
-      if (cached !== undefined && this.tryGetMessage(cached)) return cached;
+      if (cached !== undefined && this.session.tryGetMessage(cached))
+        return cached;
       if (cached !== undefined && (assistantCollided || !allowRecreate)) {
         return cached;
       }
-      const repositoryHeadId = this.repository.headId;
+      const repositoryHeadId = this.session.headId;
       const shouldUseSelectedParent =
         cached === undefined ||
         (shouldEagerlyInsertAssistant &&
@@ -1155,7 +1029,7 @@ export class AgUiThreadRuntimeCore {
       const parentId =
         shouldUseSelectedParent &&
         assistantParentId &&
-        this.hasMessage(assistantParentId)
+        this.session.hasMessage(assistantParentId)
           ? assistantParentId
           : repositoryHeadId;
       const created = this.insertAssistantPlaceholder(parentId, cached);
@@ -1187,7 +1061,7 @@ export class AgUiThreadRuntimeCore {
         applyUpdate({ status: { type: "complete", reason: "unknown" } });
         const previousId = assistantMessageId;
         assistantMessageId = undefined;
-        if (this.tryGetMessage(previousId)) {
+        if (this.session.tryGetMessage(previousId)) {
           const created = this.insertAssistantPlaceholder(previousId);
           assistantMessageId = created;
           this.markPendingAssistantHistory(created, previousId);
@@ -1203,11 +1077,12 @@ export class AgUiThreadRuntimeCore {
       const adoptsVisibleCollision =
         !reassigned &&
         !runStartMessageIds.has(serverId) &&
-        this.repository.headId === serverId;
+        this.session.headId === serverId;
       if (reassigned || adoptsVisibleCollision) {
         assistantMessageId = serverId;
         if (adoptsVisibleCollision) {
-          const parentId = this.tryGetMessage(serverId)?.parentId ?? null;
+          const parentId =
+            this.session.tryGetMessage(serverId)?.parentId ?? null;
           this.markPendingAssistantHistory(serverId, parentId);
         }
       } else {
@@ -1335,7 +1210,7 @@ export class AgUiThreadRuntimeCore {
           return;
         }
         this.maybeAutoCancelPendingToolCalls();
-        const parentId = this.repository.headId;
+        const parentId = this.session.headId;
         if (parentId !== null) {
           this.startResumeRun(parentId);
         } else {
@@ -1377,7 +1252,7 @@ export class AgUiThreadRuntimeCore {
       unstable_threadId: ctx.threadId,
       unstable_parentId: ctx.parentId,
       unstable_getMessage: () => {
-        const message = this.tryGetMessage(currentId())?.message;
+        const message = this.session.tryGetMessage(currentId())?.message;
         if (!message) {
           throw new Error(
             "[agui] resume stream requested the assistant message before it existed",
@@ -1404,7 +1279,7 @@ export class AgUiThreadRuntimeCore {
     }
 
     if (ctx.abortSignal.aborted) return;
-    const current = this.tryGetMessage(currentId())?.message;
+    const current = this.session.tryGetMessage(currentId())?.message;
     if (!current || current.status?.type === "running") {
       ctx.applyUpdate({ status: { type: "complete", reason: "unknown" } });
     }
@@ -1418,7 +1293,7 @@ export class AgUiThreadRuntimeCore {
   ) {
     const threadId = this.agent.threadId || "main";
     const messages = toAgUiMessages(
-      historyMessages ?? this.repository.getMessages(),
+      historyMessages ?? this.session.getMessages(),
     );
     const context = this.runtime?.thread.getModelContext();
     const input = {
@@ -1497,34 +1372,34 @@ export class AgUiThreadRuntimeCore {
         custom: {},
       },
     };
-    this.addOrUpdateMessage(parentId ?? this.repository.headId, assistant);
-    this.switchToBranch(id);
+    this.session.addOrUpdateMessage(parentId ?? this.session.headId, assistant);
+    this.session.switchToBranch(id);
     this.notifyUpdate();
     return id;
   }
 
   private reassignAssistantId(oldId: string, newId: string): boolean {
     if (oldId === newId) return true;
-    const oldItem = this.tryGetMessage(oldId);
+    const oldItem = this.session.tryGetMessage(oldId);
     if (!oldItem) return false;
 
-    const collidesWithExisting = this.hasMessage(newId);
+    const collidesWithExisting = this.session.hasMessage(newId);
 
     if (collidesWithExisting) {
       this.logger.debug?.(
         "[agui] reassignAssistantId: server id already present in messages or repository, dropping placeholder",
         { oldId, newId },
       );
-      this.deleteMessage(oldId, oldItem.parentId ?? null);
+      this.session.deleteMessage(oldId, oldItem.parentId ?? null);
     } else {
       const { isOptimistic: _, ...metadata } = oldItem.message.metadata;
-      this.addOrUpdateMessage(oldItem.parentId, {
+      this.session.addOrUpdateMessage(oldItem.parentId, {
         ...oldItem.message,
         id: newId,
         metadata,
       } as ThreadMessage);
-      this.switchToBranch(newId);
-      this.tryDeleteMessage(oldId);
+      this.session.switchToBranch(newId);
+      this.session.tryDeleteMessage(oldId);
     }
 
     const pendingParent = this.assistantHistoryParents.get(oldId);
@@ -1574,7 +1449,7 @@ export class AgUiThreadRuntimeCore {
     update: ChatModelRunResult,
   ): string {
     let latestStatus: MessageStatus | undefined;
-    const touched = this.updateMessage(messageId, (message) => {
+    const touched = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       const metadata = update.metadata
@@ -1743,7 +1618,7 @@ export class AgUiThreadRuntimeCore {
     messageId: string,
     event: Extract<AgUiEvent, { type: "TOOL_CALL_RESULT" }>,
   ): void {
-    const updated = this.updateMessage(messageId, (message) => {
+    const updated = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       const mcpAppUri = readMcpAppResourceUri(event.mcpResult?._meta);
@@ -1830,7 +1705,7 @@ export class AgUiThreadRuntimeCore {
           ? serverHash
           : undefined;
     const result = event.content["result"];
-    const updated = this.updateMessage(messageId, (message) => {
+    const updated = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
@@ -1882,7 +1757,7 @@ export class AgUiThreadRuntimeCore {
   ) {
     try {
       const activeMessage = activeAssistantId
-        ? this.tryGetMessage(activeAssistantId)?.message
+        ? this.session.tryGetMessage(activeAssistantId)?.message
         : undefined;
       const activeAssistant =
         activeMessage?.role === "assistant" ? activeMessage : undefined;
@@ -1915,7 +1790,7 @@ export class AgUiThreadRuntimeCore {
       }
       this.applyExternalMessages(converted);
       if (activeAssistant !== undefined) {
-        const activeItem = this.tryGetMessage(activeAssistant.id);
+        const activeItem = this.session.tryGetMessage(activeAssistant.id);
         if (activeItem) {
           if (preservesActiveAssistant) {
             this.snapshotHistoryIds.delete(activeAssistant.id);
@@ -1967,7 +1842,7 @@ export class AgUiThreadRuntimeCore {
     if (!history) return;
     const parentId = this.assistantHistoryParents.get(messageId);
     if (parentId === undefined) return;
-    const message = this.tryGetMessage(messageId)?.message;
+    const message = this.session.tryGetMessage(messageId)?.message;
     if (!message || message.role !== "assistant") return;
     if (!this.isPersistableStatus(message.status)) return;
     const wasPersisted = this.persistedHistoryIds.has(messageId);


### PR DESCRIPTION
## summary

the a2a and ag-ui thread cores each carried an identical private session layer around `MessageRepository`: a memoized `exportedRepository` invalidated by every mutation, the `tryGetMessage`/`tryGetMessages`/`hasMessage`/`addOrUpdateMessage`/`switchToBranch`/`resetHead`/`clear`/`updateMessage` wrappers, and a byte-identical `applyExternalMessageRepository` (topological multi-pass import with duplicate-id and missing-head degenerate detection, plus the degenerate linear fallback that preserves an existing message's parent).

this moves the whole layer into `createMessageRepositorySession()` in core (`runtime/utils/message-repository-session.ts`, exported via `@assistant-ui/core/internal` next to `MessageRepository`). ag-ui's export decoration (re-appending optimistic messages and pinning `headId`) rides in as a `decorateExport` option, and its `deleteMessage`/`tryDeleteMessage` pair joins the session. the per-adapter tails after an external import stay in the cores: a2a keeps `finalizeExternalApply()`, ag-ui keeps its history-set bookkeeping and `notifyUpdate()`.

net −237 lines across the two cores; a colocated contract test pins the session's memoization, decoration, identity short-circuit, and both import paths.

## test plan

- core vitest: 1494 passed (includes the 7 new session contract tests)
- react-a2a vitest: 267 passed; react-ag-ui vitest: 471 passed
- `tsc --noEmit` clean in react-a2a and react-ag-ui; core's error set is byte-identical to main (2 pre-existing test-harness errors)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pCr_K0RaNas90oXXSezkOhx40l0WSalS2yO345iVzauXme8GbM91aeoteng?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->