### PR TITLE
refactor(react-langchain): share the langchain converter layer with react-langgraph

### DIFF
--- a/.changeset/langchain-converter-seam.md
+++ b/.changeset/langchain-converter-seam.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor: share the langchain converter layer with react-langgraph. @langchain/react becomes an optional peer of react-langchain.

--- a/.changeset/langchain-converter-seam.md
+++ b/.changeset/langchain-converter-seam.md
@@ -3,4 +3,4 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-refactor: share the langchain converter layer with react-langgraph. @langchain/react becomes an optional peer of react-langchain.
+refactor: share the langchain converter layer with react-langgraph via the new @assistant-ui/react-langchain/converter subpath. @langchain/react becomes an optional peer of react-langchain.

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -541,6 +541,8 @@ type ComposerRuntimePath = (ThreadRuntimePath & {
 
 type ComposerState = ThreadComposerState | EditComposerState;
 
+type ConvertedContentPart = ThreadUserMessage["content"][number] | ThreadAssistantMessage["content"][number];
+
 type CreateAppendMessage = string | {
   parentId?: string | null | undefined;
   sourceId?: string | null | undefined;
@@ -1587,6 +1589,12 @@ type StartRunConfig = {
   runConfig: RunConfig;
 };
 
+type StreamingTimingAccessors<TMessage> = {
+  readonly getAssistantMessageId: (messages: readonly TMessage[]) => string | undefined;
+  readonly getTextLength: (messages: readonly TMessage[], messageId: string) => number;
+  readonly getToolCallCount: (messages: readonly TMessage[], messageId: string) => number;
+};
+
 declare const TOOL_RESPONSE_SYMBOL: unique symbol;
 
 type TextMessagePart = {
@@ -2127,6 +2135,96 @@ type VoiceSessionState = {
 
 declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metadata?: LangChainMessageConverterMetadata) => useExternalMessageConverter.Message;
 
+declare const convertLangChainContentBlock: (part: LangChainContentBlock) => ConvertedContentPart | null | undefined;
+
+declare namespace entry_converter_exports {
+  export { convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, uiMessageToDataPart, withAudioTranscript };
+}
+
+declare const createLangChainStreamingTimingAccessors: <TMessage extends {
+  id?: string | undefined;
+  content?: unknown;
+  tool_calls?: readonly unknown[] | undefined;
+}>(getType: (message: TMessage) => string) => StreamingTimingAccessors<TMessage>;
+
+declare const getCustomMetadata: (additionalKwargs: Record<string, unknown> | undefined) => Record<string, unknown>;
+
+declare const getMessageContent: (msg: AppendMessage) => string | ({
+  type: "text";
+  text: string;
+  image_url?: never;
+  id?: never;
+  mime_type?: never;
+  filename?: never;
+  metadata?: never;
+  source_type?: never;
+  url?: never;
+  data?: never;
+} | {
+  type: "image_url";
+  image_url: {
+    url: string;
+  };
+  text?: never;
+  id?: never;
+  mime_type?: never;
+  filename?: never;
+  metadata?: never;
+  source_type?: never;
+  url?: never;
+  data?: never;
+} | {
+  type: "file";
+  id: string;
+  mime_type: string;
+  filename: string;
+  metadata: {
+    filename: string;
+  };
+  source_type: "id";
+  text?: never;
+  image_url?: never;
+  url?: never;
+  data?: never;
+} | {
+  type: "file";
+  url: string;
+  mime_type: string;
+  filename: string;
+  metadata: {
+    filename: string;
+  };
+  source_type: "url";
+  text?: never;
+  image_url?: never;
+  id?: never;
+  data?: never;
+} | {
+  type: "file";
+  data: string;
+  mime_type: string;
+  filename: string;
+  metadata: {
+    filename: string;
+  };
+  source_type: "base64";
+  text?: never;
+  image_url?: never;
+  id?: never;
+  url?: never;
+} | {
+  type: "audio";
+  data: string;
+  mime_type: string;
+  source_type: "base64";
+  text?: never;
+  image_url?: never;
+  id?: never;
+  filename?: never;
+  metadata?: never;
+  url?: never;
+})[];
+
 declare global {
   interface Window {
     SpeechRecognition?: SpeechRecognitionConstructor;
@@ -2137,6 +2235,11 @@ declare global {
 declare namespace entry_root_exports {
   export { LangChainBaseMessage, LangChainContentBlock, LangChainToolCall, RemoveUIMessage, SubagentDiscoverySnapshot$1 as SubagentDiscoverySnapshot, SubgraphDiscoverySnapshot$1 as SubgraphDiscoverySnapshot, UIMessage, UseStreamRuntimeOptions, convertLangChainBaseMessage, useLangChainError, useLangChainInterruptState, useLangChainInterrupts, useLangChainRespond, useLangChainRespondAll, useLangChainSend, useLangChainSendCommand, useLangChainState, useLangChainStream, useLangChainStreamingTiming, useLangChainSubagents, useLangChainSubgraphs, useLangChainSubmit, useLangChainToolCalls, useStreamRuntime };
 }
+
+declare const uiMessageToDataPart: <TUIMessage extends {
+  name: string;
+  props: Record<string, unknown>;
+}>(ui: TUIMessage) => DataMessagePart;
 
 declare namespace useExternalMessageConverter {
   type Message = ExternalMessageConverterMessage;
@@ -2189,4 +2292,12 @@ declare const useLangChainToolCalls: () => readonly AssembledToolCall<string, un
 
 declare const useStreamRuntime: (rawOptions: UseStreamRuntimeOptions) => AssistantRuntime;
 
-export { entry_root_exports as entry_root };
+declare const withAudioTranscript: <T extends {
+  type: string;
+  text?: unknown;
+}>(parts: readonly T[], additionalKwargs: Record<string, unknown> | undefined) => readonly (T | {
+  type: "text";
+  text: string;
+})[];
+
+export { entry_converter_exports as entry_converter, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -2138,7 +2138,7 @@ declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metad
 declare const convertLangChainContentBlock: (part: LangChainContentBlock) => ConvertedContentPart | null | undefined;
 
 declare namespace entry_converter_exports {
-  export { convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, uiMessageToDataPart, withAudioTranscript };
+  export { LangChainContentBlock, convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, uiMessageToDataPart, withAudioTranscript };
 }
 
 declare const createLangChainStreamingTimingAccessors: <TMessage extends {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1,5 +1,7 @@
 import { Client, StreamMode } from "@langchain/langgraph-sdk";
 
+import "@langchain/react";
+
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ComponentType } from "react";

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1,7 +1,5 @@
 import { Client, StreamMode } from "@langchain/langgraph-sdk";
 
-import "@langchain/react";
-
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ComponentType } from "react";

--- a/packages/react-langchain/package.json
+++ b/packages/react-langchain/package.json
@@ -18,6 +18,17 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./converter": {
+      "types": "./dist/converter.d.ts",
+      "default": "./dist/converter.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "converter": [
+        "./dist/converter.d.ts"
+      ]
     }
   },
   "main": "./dist/index.js",
@@ -45,6 +56,9 @@
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {
+    "@langchain/react": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     }

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -1,13 +1,14 @@
 "use client";
 
+import type { MessageTiming } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
-import type {
-  AppendMessage,
-  DataMessagePart,
-  MessageTiming,
-} from "@assistant-ui/core";
-import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
+import {
+  convertLangChainContentBlock,
+  getCustomMetadata,
+  uiMessageToDataPart,
+  withAudioTranscript,
+} from "./converter";
 import type {
   LangChainBaseMessage,
   LangChainContentBlock,
@@ -19,12 +20,6 @@ type LangChainMessageConverterMetadata =
     uiMessagesByParent?: Map<string, UIMessage[]>;
     messageTiming?: Record<string, MessageTiming>;
   };
-
-const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
-  type: "data",
-  name: ui.name,
-  data: ui.props,
-});
 
 export const getMessageType = (message: LangChainBaseMessage): string => {
   if (typeof message._getType === "function") return message._getType();
@@ -39,96 +34,9 @@ const contentToParts = (content: unknown) => {
 
   const parts = content as readonly LangChainContentBlock[];
   return parts
-    .map((part) => {
-      const type = part.type;
-      switch (type) {
-        case "text":
-        case "text_delta":
-          return { type: "text" as const, text: part.text };
-        case "image_url": {
-          const image =
-            typeof part.image_url === "string"
-              ? part.image_url
-              : part.image_url?.url;
-          if (!image) return null;
-          return { type: "image" as const, image };
-        }
-        case "file":
-          return {
-            type: "file" as const,
-            filename: part.metadata?.filename ?? "file",
-            data:
-              part.source_type === "url"
-                ? part.url
-                : part.source_type === "id"
-                  ? part.id
-                  : part.data,
-            mimeType: part.mime_type ?? "application/octet-stream",
-            ...((part.source_type === "url" || part.source_type === "id") && {
-              sourceType: part.source_type,
-            }),
-          };
-        case "audio": {
-          const mimeType = part.mime_type ?? "application/octet-stream";
-          const subtype = mimeType.startsWith("audio/")
-            ? mimeType.slice("audio/".length)
-            : undefined;
-          return {
-            type: "file" as const,
-            filename: subtype ? `audio.${subtype}` : "audio",
-            data: part.data,
-            mimeType,
-          };
-        }
-        case "thinking":
-          return { type: "reasoning" as const, text: part.thinking };
-        case "reasoning":
-          return {
-            type: "reasoning" as const,
-            text:
-              part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ??
-              part.reasoning ??
-              "",
-          };
-        case "tool_use":
-        case "input_json_delta":
-          return null;
-        default:
-          return null;
-      }
-    })
-    .filter((p) => p !== null);
+    .map(convertLangChainContentBlock)
+    .filter((part) => part !== null && part !== undefined);
 };
-
-const hasVisibleText = (text: unknown): boolean =>
-  typeof text === "string" && text.trim() !== "";
-
-/**
- * Audio output arrives outside the content array: providers leave `content`
- * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
- * audio bytes stay behind because no provider reports their media type, and a
- * streamed response carries raw PCM rather than a playable file.
- */
-const withAudioTranscript = (
-  parts: ReturnType<typeof contentToParts>,
-  additionalKwargs: Record<string, unknown> | undefined,
-): ReturnType<typeof contentToParts> => {
-  const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
-  const transcript = audio?.transcript;
-  if (typeof transcript !== "string" || !hasVisibleText(transcript))
-    return parts;
-  if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
-    return parts;
-  return [
-    ...parts.filter((part) => part.type !== "text"),
-    { type: "text" as const, text: transcript },
-  ];
-};
-
-const getCustomMetadata = (
-  additionalKwargs: Record<string, unknown> | undefined,
-): Record<string, unknown> =>
-  (additionalKwargs?.metadata as Record<string, unknown>) ?? {};
 
 const getStringContent = (content: unknown): string => {
   if (typeof content === "string") return content;
@@ -234,109 +142,4 @@ export const convertLangChainBaseMessage = (
   }
 };
 
-/**
- * Audio media types that reach a provider's audio input through the LangChain
- * `audio` block. langchain-core derives OpenAI's `input_audio.format` by
- * splitting `mime_type` on `/`, and that format is a wav-or-mp3 enum, so
- * `audio/mpeg` passes the converter and is rejected at the provider.
- */
-const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
-  ["audio/mp3", "audio/mp3"],
-  ["audio/mpeg", "audio/mp3"],
-  ["audio/wav", "audio/wav"],
-  ["audio/wave", "audio/wav"],
-  ["audio/x-wav", "audio/wav"],
-]);
-
-export const getMessageContent = (msg: AppendMessage) => {
-  const allContent = [
-    ...msg.content,
-    ...(msg.attachments?.flatMap((a) => a.content) ?? []),
-  ];
-
-  const hasNonText = allContent.some(
-    (part) =>
-      part.type === "file" || part.type === "image" || part.type === "audio",
-  );
-  const hasText = allContent.some((part) => part.type === "text");
-  if (hasNonText && !hasText) {
-    allContent.unshift({ type: "text", text: " " });
-  }
-
-  const content = allContent.flatMap((part) => {
-    const type = part.type;
-    switch (type) {
-      case "text":
-        return { type: "text" as const, text: part.text };
-      case "image":
-        return { type: "image_url" as const, image_url: { url: part.image } };
-      case "file": {
-        const metadata = { filename: part.filename ?? "file" };
-        if (part.sourceType === "id") {
-          return {
-            type: "file" as const,
-            id: part.data,
-            mime_type: part.mimeType,
-            filename: metadata.filename,
-            metadata,
-            source_type: "id" as const,
-          };
-        }
-        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
-          return {
-            type: "file" as const,
-            url: part.data,
-            mime_type: part.mimeType,
-            filename: metadata.filename,
-            metadata,
-            source_type: "url" as const,
-          };
-        }
-        const parsed = parseDataUrl(part.data);
-        const audioMimeType = audioBlockMimeTypes.get(
-          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
-        );
-        if (audioMimeType) {
-          return {
-            type: "audio" as const,
-            data: parsed?.data ?? part.data,
-            mime_type: audioMimeType,
-            source_type: "base64" as const,
-          };
-        }
-        return {
-          type: "file" as const,
-          data: parsed?.data ?? part.data,
-          mime_type: parsed?.mimeType ?? part.mimeType,
-          filename: metadata.filename,
-          metadata,
-          source_type: "base64" as const,
-        };
-      }
-      case "audio": {
-        const parsed = parseDataUrl(part.audio.data);
-        return {
-          type: "audio" as const,
-          data: parsed?.data ?? part.audio.data,
-          mime_type: `audio/${part.audio.format}`,
-          source_type: "base64" as const,
-        };
-      }
-      case "data":
-        return [];
-      case "tool-call":
-        throw new Error("Tool call appends are not supported.");
-      default: {
-        const _exhaustiveCheck: "reasoning" | "source" | "generative-ui" = type;
-        throw new Error(
-          `Unsupported append message part type: ${_exhaustiveCheck}`,
-        );
-      }
-    }
-  });
-
-  if (content.length === 1 && content[0]?.type === "text") {
-    return content[0].text ?? "";
-  }
-  return content;
-};
+export { getMessageContent } from "./converter";

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -6,7 +6,46 @@ import type {
 } from "@assistant-ui/core";
 import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
 import type { StreamingTimingAccessors } from "@assistant-ui/core/react";
-import type { LangChainContentBlock } from "./types";
+
+/** Known content block types from @langchain/core messages. */
+export type LangChainContentBlock =
+  | { type: "text"; text: string }
+  | { type: "text_delta"; text: string }
+  | { type: "image_url"; image_url: string | { url?: string } }
+  | { type: "thinking"; thinking: string }
+  | {
+      type: "reasoning";
+      summary?: Array<{ type: "summary_text"; text?: string }>;
+      reasoning?: string;
+    }
+  | {
+      type: "file";
+      data: string;
+      mime_type: string;
+      source_type?: "base64";
+      metadata?: { filename?: string };
+    }
+  | {
+      type: "file";
+      url: string;
+      mime_type?: string;
+      source_type: "url";
+      metadata?: { filename?: string };
+    }
+  | {
+      type: "file";
+      id: string;
+      mime_type?: string;
+      source_type: "id";
+      metadata?: { filename?: string };
+    }
+  | {
+      type: "audio";
+      data: string;
+      mime_type: string;
+      source_type: "base64";
+    }
+  | { type: "tool_use" | "input_json_delta" };
 
 type ConvertedContentPart =
   | ThreadUserMessage["content"][number]

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -1,0 +1,296 @@
+import type {
+  AppendMessage,
+  DataMessagePart,
+  ThreadAssistantMessage,
+  ThreadUserMessage,
+} from "@assistant-ui/core";
+import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
+import type { StreamingTimingAccessors } from "@assistant-ui/core/react";
+import type { LangChainContentBlock } from "./types";
+
+type ConvertedContentPart =
+  | ThreadUserMessage["content"][number]
+  | ThreadAssistantMessage["content"][number];
+
+export const convertLangChainContentBlock = (
+  part: LangChainContentBlock,
+): ConvertedContentPart | null | undefined => {
+  const type = part.type;
+  switch (type) {
+    case "text":
+    case "text_delta":
+      return { type: "text" as const, text: part.text };
+    case "image_url": {
+      const image =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : part.image_url?.url;
+      if (!image) return null;
+      return { type: "image" as const, image };
+    }
+    case "file":
+      return {
+        type: "file" as const,
+        filename: part.metadata?.filename ?? "file",
+        data:
+          part.source_type === "url"
+            ? part.url
+            : part.source_type === "id"
+              ? part.id
+              : part.data,
+        mimeType: part.mime_type ?? "application/octet-stream",
+        ...((part.source_type === "url" || part.source_type === "id") && {
+          sourceType: part.source_type,
+        }),
+      };
+    case "audio": {
+      const mimeType = part.mime_type ?? "application/octet-stream";
+      const subtype = mimeType.startsWith("audio/")
+        ? mimeType.slice("audio/".length)
+        : undefined;
+      return {
+        type: "file" as const,
+        filename: subtype ? `audio.${subtype}` : "audio",
+        data: part.data,
+        mimeType,
+      };
+    }
+    case "thinking":
+      return { type: "reasoning" as const, text: part.thinking };
+    case "reasoning":
+      return {
+        type: "reasoning" as const,
+        text:
+          part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ??
+          part.reasoning ??
+          "",
+      };
+    case "tool_use":
+    case "input_json_delta":
+      return null;
+    default:
+      return undefined;
+  }
+};
+
+const hasVisibleText = (text: unknown): boolean =>
+  typeof text === "string" && text.trim() !== "";
+
+/**
+ * Audio output arrives outside the content array: providers leave `content`
+ * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
+ * audio bytes stay behind because no provider reports their media type, and a
+ * streamed response carries raw PCM rather than a playable file.
+ */
+export const withAudioTranscript = <T extends { type: string; text?: unknown }>(
+  parts: readonly T[],
+  additionalKwargs: Record<string, unknown> | undefined,
+): readonly (T | { type: "text"; text: string })[] => {
+  const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
+  const transcript = audio?.transcript;
+  if (typeof transcript !== "string" || !hasVisibleText(transcript))
+    return parts;
+  if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
+    return parts;
+  return [
+    ...parts.filter((part) => part.type !== "text"),
+    { type: "text" as const, text: transcript },
+  ];
+};
+
+export const getCustomMetadata = (
+  additionalKwargs: Record<string, unknown> | undefined,
+): Record<string, unknown> =>
+  (additionalKwargs?.metadata as Record<string, unknown>) ?? {};
+
+export const uiMessageToDataPart = <
+  TUIMessage extends { name: string; props: Record<string, unknown> },
+>(
+  ui: TUIMessage,
+): DataMessagePart => ({
+  type: "data",
+  name: ui.name,
+  data: ui.props,
+});
+
+/**
+ * Audio media types that reach a provider's audio input through the LangChain
+ * `audio` block. langchain-core derives OpenAI's `input_audio.format` by
+ * splitting `mime_type` on `/`, and that format is a wav-or-mp3 enum, so
+ * `audio/mpeg` passes the converter and is rejected at the provider.
+ */
+const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
+  ["audio/mp3", "audio/mp3"],
+  ["audio/mpeg", "audio/mp3"],
+  ["audio/wav", "audio/wav"],
+  ["audio/wave", "audio/wav"],
+  ["audio/x-wav", "audio/wav"],
+]);
+
+export const getMessageContent = (msg: AppendMessage) => {
+  const allContent = [
+    ...msg.content,
+    ...(msg.attachments?.flatMap((a) => a.content) ?? []),
+  ];
+
+  const hasNonText = allContent.some(
+    (part) =>
+      part.type === "file" || part.type === "image" || part.type === "audio",
+  );
+  const hasText = allContent.some((part) => part.type === "text");
+  if (hasNonText && !hasText) {
+    allContent.unshift({ type: "text", text: " " });
+  }
+
+  const content = allContent.flatMap((part) => {
+    const type = part.type;
+    switch (type) {
+      case "text":
+        return { type: "text" as const, text: part.text };
+      case "image":
+        return { type: "image_url" as const, image_url: { url: part.image } };
+      case "file": {
+        const metadata = { filename: part.filename ?? "file" };
+        if (part.sourceType === "id") {
+          return {
+            type: "file" as const,
+            id: part.data,
+            mime_type: part.mimeType,
+            filename: metadata.filename,
+            metadata,
+            source_type: "id" as const,
+          };
+        }
+        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
+          return {
+            type: "file" as const,
+            url: part.data,
+            mime_type: part.mimeType,
+            filename: metadata.filename,
+            metadata,
+            source_type: "url" as const,
+          };
+        }
+        const parsed = parseDataUrl(part.data);
+        const audioMimeType = audioBlockMimeTypes.get(
+          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
+        );
+        if (audioMimeType) {
+          return {
+            type: "audio" as const,
+            data: parsed?.data ?? part.data,
+            mime_type: audioMimeType,
+            source_type: "base64" as const,
+          };
+        }
+        return {
+          type: "file" as const,
+          data: parsed?.data ?? part.data,
+          mime_type: parsed?.mimeType ?? part.mimeType,
+          filename: metadata.filename,
+          metadata,
+          source_type: "base64" as const,
+        };
+      }
+      case "audio": {
+        const parsed = parseDataUrl(part.audio.data);
+        return {
+          type: "audio" as const,
+          data: parsed?.data ?? part.audio.data,
+          mime_type: `audio/${part.audio.format}`,
+          source_type: "base64" as const,
+        };
+      }
+      case "data":
+        return [];
+      case "tool-call":
+        throw new Error("Tool call appends are not supported.");
+      default: {
+        const _exhaustiveCheck: "reasoning" | "source" | "generative-ui" = type;
+        throw new Error(
+          `Unsupported append message part type: ${_exhaustiveCheck}`,
+        );
+      }
+    }
+  });
+
+  if (content.length === 1 && content[0]?.type === "text") {
+    return content[0].text ?? "";
+  }
+  return content;
+};
+
+const reasoningTextLength = (part: {
+  readonly summary?: ReadonlyArray<{ readonly text?: string }>;
+  readonly reasoning?: string;
+}): number => {
+  if (part.summary && part.summary.length > 0)
+    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
+  return part.reasoning?.length ?? 0;
+};
+
+export const createLangChainStreamingTimingAccessors = <
+  TMessage extends {
+    id?: string | undefined;
+    content?: unknown;
+    tool_calls?: readonly unknown[] | undefined;
+  },
+>(
+  getType: (message: TMessage) => string,
+): StreamingTimingAccessors<TMessage> => {
+  const findAiMessage = (
+    messages: readonly TMessage[],
+    messageId: string,
+  ): TMessage | undefined =>
+    messages.find(
+      (message) => getType(message) === "ai" && message.id === messageId,
+    );
+
+  const getTextLength = (
+    messages: readonly TMessage[],
+    messageId: string,
+  ): number => {
+    const message = findAiMessage(messages, messageId);
+    if (!message) return 0;
+    const content = message.content;
+    if (typeof content === "string") return content.length;
+    if (!Array.isArray(content)) return 0;
+    let len = 0;
+    for (const part of content as readonly LangChainContentBlock[]) {
+      switch (part.type) {
+        case "text":
+        case "text_delta":
+          if (typeof part.text === "string") len += part.text.length;
+          break;
+        case "thinking":
+          if (typeof part.thinking === "string") len += part.thinking.length;
+          break;
+        case "reasoning":
+          len += reasoningTextLength(part);
+          break;
+      }
+    }
+    return len;
+  };
+
+  const getToolCallCount = (
+    messages: readonly TMessage[],
+    messageId: string,
+  ): number => findAiMessage(messages, messageId)?.tool_calls?.length ?? 0;
+
+  const getAssistantMessageId = (
+    messages: readonly TMessage[],
+  ): string | undefined => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (message && getType(message) === "ai" && message.id) return message.id;
+    }
+    return undefined;
+  };
+
+  return {
+    getAssistantMessageId,
+    getTextLength,
+    getToolCallCount,
+  };
+};

--- a/packages/react-langchain/src/streamingTiming.ts
+++ b/packages/react-langchain/src/streamingTiming.ts
@@ -1,76 +1,13 @@
 "use client";
 
 import type { MessageTiming } from "@assistant-ui/core";
-import {
-  useStreamingTiming,
-  type StreamingTimingAccessors,
-} from "@assistant-ui/core/react";
-import type { LangChainBaseMessage, LangChainContentBlock } from "./types";
+import { useStreamingTiming } from "@assistant-ui/core/react";
+import { createLangChainStreamingTimingAccessors } from "./converter";
 import { getMessageType } from "./convertMessages";
+import type { LangChainBaseMessage } from "./types";
 
-const findAiMessage = (
-  messages: readonly LangChainBaseMessage[],
-  messageId: string,
-): LangChainBaseMessage | undefined =>
-  messages.find((m) => getMessageType(m) === "ai" && m.id === messageId);
-
-const reasoningTextLength = (part: {
-  readonly summary?: ReadonlyArray<{ readonly text?: string }>;
-  readonly reasoning?: string;
-}): number => {
-  if (part.summary && part.summary.length > 0)
-    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
-  return part.reasoning?.length ?? 0;
-};
-
-const getTextLength = (
-  messages: readonly LangChainBaseMessage[],
-  messageId: string,
-): number => {
-  const m = findAiMessage(messages, messageId);
-  if (!m) return 0;
-  const content = m.content;
-  if (typeof content === "string") return content.length;
-  if (!Array.isArray(content)) return 0;
-  let len = 0;
-  for (const part of content as readonly LangChainContentBlock[]) {
-    switch (part.type) {
-      case "text":
-      case "text_delta":
-        if (typeof part.text === "string") len += part.text.length;
-        break;
-      case "thinking":
-        if (typeof part.thinking === "string") len += part.thinking.length;
-        break;
-      case "reasoning":
-        len += reasoningTextLength(part);
-        break;
-    }
-  }
-  return len;
-};
-
-const getToolCallCount = (
-  messages: readonly LangChainBaseMessage[],
-  messageId: string,
-): number => findAiMessage(messages, messageId)?.tool_calls?.length ?? 0;
-
-const getAssistantMessageId = (
-  messages: readonly LangChainBaseMessage[],
-): string | undefined => {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (m && getMessageType(m) === "ai" && m.id) return m.id;
-  }
-  return undefined;
-};
-
-export const langChainStreamingTimingAccessors: StreamingTimingAccessors<LangChainBaseMessage> =
-  {
-    getAssistantMessageId,
-    getTextLength,
-    getToolCallCount,
-  };
+export const langChainStreamingTimingAccessors =
+  createLangChainStreamingTimingAccessors<LangChainBaseMessage>(getMessageType);
 
 /**
  * Tracks per-message streaming timing for LangChain messages. Delegates to

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -17,45 +17,7 @@ import type {
   SubgraphDiscoverySnapshot,
 } from "@langchain/react";
 
-/** Known content block types from @langchain/core messages. */
-export type LangChainContentBlock =
-  | { type: "text"; text: string }
-  | { type: "text_delta"; text: string }
-  | { type: "image_url"; image_url: string | { url?: string } }
-  | { type: "thinking"; thinking: string }
-  | {
-      type: "reasoning";
-      summary?: Array<{ type: "summary_text"; text?: string }>;
-      reasoning?: string;
-    }
-  | {
-      type: "file";
-      data: string;
-      mime_type: string;
-      source_type?: "base64";
-      metadata?: { filename?: string };
-    }
-  | {
-      type: "file";
-      url: string;
-      mime_type?: string;
-      source_type: "url";
-      metadata?: { filename?: string };
-    }
-  | {
-      type: "file";
-      id: string;
-      mime_type?: string;
-      source_type: "id";
-      metadata?: { filename?: string };
-    }
-  | {
-      type: "audio";
-      data: string;
-      mime_type: string;
-      source_type: "base64";
-    }
-  | { type: "tool_use" | "input_json_delta" };
+export type { LangChainContentBlock } from "./converter";
 
 export type LangChainToolCall = {
   id: string;

--- a/packages/react-langgraph/package.json
+++ b/packages/react-langgraph/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@assistant-ui/core": "^0.3.15",
+    "@assistant-ui/react-langchain": "^0.0.27",
     "@assistant-ui/store": "^0.3.10",
     "assistant-cloud": "*",
     "assistant-stream": "^0.3.39"

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import type {
-  AppendMessage,
   CompleteAttachment,
   DataMessagePart,
   MessageTiming,
@@ -11,11 +10,16 @@ import type {
 } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
 import {
-  httpUrlPattern,
   parseDataUrl,
   stableStringifyToolArgs,
   trackToolArgsKeyOrder,
 } from "@assistant-ui/core/internal";
+import {
+  convertLangChainContentBlock,
+  getCustomMetadata,
+  uiMessageToDataPart,
+  withAudioTranscript,
+} from "@assistant-ui/react-langchain/converter";
 import type {
   LangChainMessage,
   LangChainToolCall,
@@ -34,12 +38,6 @@ type LangGraphMessageConverterMetadata =
     messageTiming?: Record<string, MessageTiming>;
     attachmentsByMessageId?: Map<string, readonly CompleteAttachment[]>;
   };
-
-const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
-  type: "data",
-  name: ui.name,
-  data: ui.props,
-});
 
 const getToolArgsCacheKey = (
   messageId: string | undefined,
@@ -92,11 +90,6 @@ const resolveToolCallArgs = ({
   return { args, argsText };
 };
 
-const getCustomMetadata = (
-  additionalKwargs: Record<string, unknown> | undefined,
-): Record<string, unknown> =>
-  (additionalKwargs?.metadata as Record<string, unknown>) ?? {};
-
 const warnedMessagePartTypes = new Set<string>();
 const warnForUnknownMessagePartType = (type: string) => {
   if (
@@ -136,90 +129,27 @@ const contentToParts = (
       ):
         | (ThreadUserMessage | ThreadAssistantMessage)["content"][number]
         | null => {
-        const type = part.type;
-        switch (type) {
-          case "text":
-            return { type: "text", text: part.text };
-          case "text_delta":
-            return { type: "text", text: part.text };
-          case "image_url": {
-            const image =
-              typeof part.image_url === "string"
-                ? part.image_url
-                : part.image_url?.url;
-            if (!image) return null;
-            return { type: "image", image };
-          }
-          case "file":
-            return {
-              type: "file",
-              filename: part.metadata?.filename ?? "file",
-              data:
-                part.source_type === "url"
-                  ? part.url
-                  : part.source_type === "id"
-                    ? part.id
-                    : part.data,
-              mimeType: part.mime_type ?? "application/octet-stream",
-              ...((part.source_type === "url" || part.source_type === "id") && {
-                sourceType: part.source_type,
-              }),
-            };
-
-          case "audio": {
-            const mimeType = part.mime_type ?? "application/octet-stream";
-            const subtype = mimeType.startsWith("audio/")
-              ? mimeType.slice("audio/".length)
-              : undefined;
-            return {
-              type: "file" as const,
-              filename: subtype ? `audio.${subtype}` : "audio",
-              data: part.data,
-              mimeType,
-            };
-          }
-
-          case "thinking":
-            return { type: "reasoning", text: part.thinking };
-
-          case "reasoning":
-            return {
-              type: "reasoning",
-              text:
-                part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ??
-                part.reasoning ??
-                "",
-            };
-
-          case "tool_use":
-            return null;
-          case "input_json_delta":
-            return null;
-
-          case "computer_call": {
-            const args = part.action as ReadonlyJSONObject;
-            return {
-              type: "tool-call",
-              toolCallId: part.call_id,
-              toolName: "computer_call",
+        if (part.type === "computer_call") {
+          const args = part.action as ReadonlyJSONObject;
+          return {
+            type: "tool-call",
+            toolCallId: part.call_id,
+            toolName: "computer_call",
+            args,
+            argsText: stableStringifyToolArgs(
+              metadata.toolArgsKeyOrderCache,
+              getToolArgsCacheKey(messageId, "computer", part.call_id),
               args,
-              argsText: stableStringifyToolArgs(
-                metadata.toolArgsKeyOrderCache,
-                getToolArgsCacheKey(messageId, "computer", part.call_id),
-                args,
-              ),
-            };
-          }
-
-          default: {
-            const _exhaustiveCheck: never = type;
-            warnForUnknownMessagePartType(_exhaustiveCheck);
-            return null;
-          }
-
-          // const _exhaustiveCheck: never = type;
-          // throw new Error(`Unknown message part type: ${_exhaustiveCheck}`);
+            ),
+          };
         }
+
+        const converted = convertLangChainContentBlock(part);
+        if (converted === undefined) {
+          warnForUnknownMessagePartType(part.type);
+          return null;
+        }
+        return converted;
       },
     )
     .filter((a) => a !== null);
@@ -272,33 +202,6 @@ const dropAttachmentDuplicates = (
   }
   if (dropped.size === 0) return parts;
   return parts.filter((_, i) => !dropped.has(i));
-};
-
-const hasVisibleText = (text: unknown): boolean =>
-  typeof text === "string" && text.trim() !== "";
-
-/**
- * Audio output arrives outside the content array: providers leave `content`
- * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
- * audio bytes stay behind because no provider reports their media type, and a
- * streamed response carries raw PCM rather than a playable file.
- */
-const withAudioTranscript = (
-  parts: ReturnType<typeof contentToParts>,
-  additionalKwargs: Extract<
-    LangChainMessage,
-    { type: "ai" }
-  >["additional_kwargs"],
-): ReturnType<typeof contentToParts> => {
-  const transcript: unknown = additionalKwargs?.audio?.transcript;
-  if (typeof transcript !== "string" || !hasVisibleText(transcript))
-    return parts;
-  if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
-    return parts;
-  return [
-    ...parts.filter((part) => part.type !== "text"),
-    { type: "text" as const, text: transcript },
-  ];
 };
 
 export const convertLangChainMessages: useExternalMessageConverter.Callback<
@@ -414,114 +317,4 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
   }
 };
 
-/**
- * Audio media types that reach a provider's audio input through the LangChain
- * `audio` block. langchain-core derives OpenAI's `input_audio.format` by
- * splitting `mime_type` on `/`, and that format is a wav-or-mp3 enum, so
- * `audio/mpeg` passes the converter and is rejected at the provider.
- */
-const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
-  ["audio/mp3", "audio/mp3"],
-  ["audio/mpeg", "audio/mp3"],
-  ["audio/wav", "audio/wav"],
-  ["audio/wave", "audio/wav"],
-  ["audio/x-wav", "audio/wav"],
-]);
-
-export const getMessageContent = (msg: AppendMessage) => {
-  const allContent = [
-    ...msg.content,
-    ...(msg.attachments?.flatMap((a) => a.content) ?? []),
-  ];
-
-  const hasNonText = allContent.some(
-    (part) =>
-      part.type === "file" || part.type === "image" || part.type === "audio",
-  );
-  const hasText = allContent.some((part) => part.type === "text");
-  if (hasNonText && !hasText) {
-    allContent.unshift({ type: "text", text: " " });
-  }
-
-  const content = allContent.flatMap((part) => {
-    const type = part.type;
-    switch (type) {
-      case "text":
-        return { type: "text" as const, text: part.text };
-      case "image":
-        return { type: "image_url" as const, image_url: { url: part.image } };
-      case "file": {
-        const metadata = { filename: part.filename ?? "file" };
-        if (part.sourceType === "id") {
-          return {
-            type: "file" as const,
-            id: part.data,
-            mime_type: part.mimeType,
-            filename: metadata.filename,
-            metadata,
-            source_type: "id" as const,
-          };
-        }
-        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
-          return {
-            type: "file" as const,
-            url: part.data,
-            mime_type: part.mimeType,
-            filename: metadata.filename,
-            metadata,
-            source_type: "url" as const,
-          };
-        }
-        const parsed = parseDataUrl(part.data);
-        const audioMimeType = audioBlockMimeTypes.get(
-          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
-        );
-        if (audioMimeType) {
-          return {
-            type: "audio" as const,
-            data: parsed?.data ?? part.data,
-            mime_type: audioMimeType,
-            source_type: "base64" as const,
-          };
-        }
-        return {
-          type: "file" as const,
-          data: parsed?.data ?? part.data,
-          mime_type: parsed?.mimeType ?? part.mimeType,
-          filename: metadata.filename,
-          metadata,
-          source_type: "base64" as const,
-        };
-      }
-
-      case "audio": {
-        const parsed = parseDataUrl(part.audio.data);
-        return {
-          type: "audio" as const,
-          data: parsed?.data ?? part.audio.data,
-          mime_type: `audio/${part.audio.format}`,
-          source_type: "base64" as const,
-        };
-      }
-
-      case "data":
-        return [];
-
-      case "tool-call":
-        throw new Error("Tool call appends are not supported.");
-
-      default: {
-        const _exhaustiveCheck: "reasoning" | "source" | "generative-ui" = type;
-        throw new Error(
-          `Unsupported append message part type: ${_exhaustiveCheck}`,
-        );
-      }
-    }
-  });
-
-  if (content.length === 1 && content[0]?.type === "text") {
-    return content[0].text ?? "";
-  }
-
-  return content;
-};
+export { getMessageContent } from "@assistant-ui/react-langchain/converter";

--- a/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
+++ b/packages/react-langgraph/src/useLangGraphStreamingTiming.ts
@@ -1,74 +1,14 @@
 "use client";
 
-import type { LangChainMessage } from "./types";
 import type { MessageTiming } from "@assistant-ui/core";
-import {
-  useStreamingTiming,
-  type StreamingTimingAccessors,
-} from "@assistant-ui/core/react";
+import { useStreamingTiming } from "@assistant-ui/core/react";
+import { createLangChainStreamingTimingAccessors } from "@assistant-ui/react-langchain/converter";
+import type { LangChainMessage } from "./types";
 
-const reasoningTextLength = (part: {
-  readonly summary?: ReadonlyArray<{ readonly text?: string }>;
-  readonly reasoning?: string;
-}): number => {
-  if (part.summary && part.summary.length > 0)
-    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
-  return part.reasoning?.length ?? 0;
-};
-
-const getMessageTextLength = (
-  messages: readonly LangChainMessage[],
-  messageId: string,
-): number => {
-  const m = messages.find((msg) => msg.type === "ai" && msg.id === messageId);
-  if (!m) return 0;
-  const content = m.content;
-  if (typeof content === "string") return content.length;
-  if (!Array.isArray(content)) return 0;
-  let len = 0;
-  for (const part of content) {
-    switch (part.type) {
-      case "text":
-      case "text_delta":
-        if (typeof part.text === "string") len += part.text.length;
-        break;
-      case "thinking":
-        if (typeof part.thinking === "string") len += part.thinking.length;
-        break;
-      case "reasoning":
-        len += reasoningTextLength(part);
-        break;
-    }
-  }
-  return len;
-};
-
-const getMessageToolCallCount = (
-  messages: readonly LangChainMessage[],
-  messageId: string,
-): number => {
-  const m = messages.find((msg) => msg.type === "ai" && msg.id === messageId);
-  if (!m || m.type !== "ai") return 0;
-  return m.tool_calls?.length ?? 0;
-};
-
-const getLastAssistantId = (
-  messages: readonly LangChainMessage[],
-): string | undefined => {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.type === "ai" && messages[i]?.id) {
-      return messages[i]!.id;
-    }
-  }
-  return undefined;
-};
-
-const langGraphStreamingTimingAccessors: StreamingTimingAccessors<LangChainMessage> =
-  {
-    getAssistantMessageId: getLastAssistantId,
-    getTextLength: getMessageTextLength,
-    getToolCallCount: getMessageToolCallCount,
-  };
+const langGraphStreamingTimingAccessors =
+  createLangChainStreamingTimingAccessors<LangChainMessage>(
+    (message) => message.type,
+  );
 
 /**
  * Tracks per-message streaming timing for LangGraph messages. Delegates to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4477,6 +4477,9 @@ importers:
       '@assistant-ui/core':
         specifier: ^0.3.15
         version: link:../core
+      '@assistant-ui/react-langchain':
+        specifier: ^0.0.27
+        version: link:../react-langchain
       '@assistant-ui/store':
         specifier: ^0.3.10
         version: link:../store


### PR DESCRIPTION
## summary

react-langgraph forked react-langchain's conversion layer wholesale: the content-block switch (text/text_delta/image_url/file/audio/thinking/reasoning), `withAudioTranscript`, `getCustomMetadata`, `uiMessageToDataPart`, the audio MIME map, the entire ~100-line `getMessageContent`, and the streaming-timing accessors (differing only in how an ai message is detected).

this adds a public `@assistant-ui/react-langchain/converter` subpath (pure functions, no react imports, exports map + `typesVersions` mirroring core's subpath pattern) and langgraph consumes only that subpath, so it never pulls the react hook graph. langgraph keeps its genuine divergences as a thin overlay: the `computer_call` case, the null-content guard, dev-only unknown-type warnings, `resolveToolCallArgs`, and `dropAttachmentDuplicates`. shared cases live in `convertLangChainContentBlock`, which returns `undefined` for unhandled types so langchain drops them silently (current behavior) while langgraph warns. the timing accessors become `createLangChainStreamingTimingAccessors(getType)`, parameterized by the one thing that differed.

`@langchain/react` becomes an optional peer of react-langchain: with langgraph consuming the converter subpath only, the package is now usable without it, and optionalizing loosens the install contract rather than narrowing it. react-langgraph gains a `@assistant-ui/react-langchain` dependency (`^0.0.27`), and every existing export of both packages keeps its name and module.

## test plan

- react-langchain vitest: 117 passed; react-langgraph vitest: 293 passed (both suites unmodified)
- `tsc --noEmit` error sets byte-identical to main in both packages (after rebuilding stale workspace dists on both sides)
- `aui-build` emits `dist/converter.js` + `dist/converter.d.ts`; no per-package build config added

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YijX3hI9rjRgW6jqJ_WFlsL72N1VbxXgDkBuYJ1SAfKxGvs5W1FM8Gz8ka4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->