### PR TITLE
refactor: move shared pure converters to the converter seam

### DIFF
--- a/.changeset/shared-pure-converter-seam.md
+++ b/.changeset/shared-pure-converter-seam.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-a2a": patch
+---
+
+refactor: move shared pure converters to the converter seam. langgraph ui messages carrying the js sdk metadata.id parent field now attach to their assistant message.

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -2138,7 +2138,7 @@ declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metad
 declare const convertLangChainContentBlock: (part: LangChainContentBlock) => ConvertedContentPart | null | undefined;
 
 declare namespace entry_converter_exports {
-  export { LangChainContentBlock, convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, uiMessageToDataPart, withAudioTranscript };
+  export { LangChainContentBlock, convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, groupUIMessagesByParent, uiMessageToDataPart, withAudioTranscript };
 }
 
 declare const createLangChainStreamingTimingAccessors: <TMessage extends {
@@ -2231,6 +2231,13 @@ declare global {
     webkitSpeechRecognition?: SpeechRecognitionConstructor;
   }
 }
+
+declare const groupUIMessagesByParent: <T extends {
+  metadata?: {
+    message_id?: string;
+    id?: string;
+  } | undefined;
+}>(value: unknown) => Map<string, T[]>;
 
 declare namespace entry_root_exports {
   export { LangChainBaseMessage, LangChainContentBlock, LangChainToolCall, RemoveUIMessage, SubagentDiscoverySnapshot$1 as SubagentDiscoverySnapshot, SubgraphDiscoverySnapshot$1 as SubgraphDiscoverySnapshot, UIMessage, UseStreamRuntimeOptions, convertLangChainBaseMessage, useLangChainError, useLangChainInterruptState, useLangChainInterrupts, useLangChainRespond, useLangChainRespondAll, useLangChainSend, useLangChainSendCommand, useLangChainState, useLangChainStream, useLangChainStreamingTiming, useLangChainSubagents, useLangChainSubgraphs, useLangChainSubmit, useLangChainToolCalls, useStreamRuntime };

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -2138,7 +2138,7 @@ declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metad
 declare const convertLangChainContentBlock: (part: LangChainContentBlock) => ConvertedContentPart | null | undefined;
 
 declare namespace entry_converter_exports {
-  export { LangChainContentBlock, convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, groupUIMessagesByParent, uiMessageToDataPart, withAudioTranscript };
+  export { LangChainContentBlock, convertLangChainContentBlock, createLangChainStreamingTimingAccessors, getCustomMetadata, getMessageContent, getUIMessageParentId, groupUIMessagesByParent, uiMessageToDataPart, withAudioTranscript };
 }
 
 declare const createLangChainStreamingTimingAccessors: <TMessage extends {
@@ -2224,6 +2224,13 @@ declare const getMessageContent: (msg: AppendMessage) => string | ({
   metadata?: never;
   url?: never;
 })[];
+
+declare const getUIMessageParentId: (ui: {
+  metadata?: {
+    message_id?: string;
+    id?: string;
+  } | undefined;
+}) => string | undefined;
 
 declare global {
   interface Window {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -19,7 +19,6 @@ import type {
   A2AArtifact,
   A2AAgentCard,
   A2AMessage,
-  A2APart,
   A2ASendMessageConfiguration,
   A2AStreamEvent,
   A2ATask,
@@ -28,8 +27,8 @@ import type {
 } from "./types";
 import {
   a2aMessageToContent,
-  contentPartsToA2AParts,
   isTerminalTaskState,
+  threadMessageToA2AMessage,
   taskStateToMessageStatus,
 } from "./conversions";
 
@@ -367,7 +366,14 @@ export class A2AThreadRuntimeCore {
       this.abortController = null;
     }
 
-    const a2aMessage = this.threadMessageToA2AMessage(userThreadMessage);
+    const a2aMessage = threadMessageToA2AMessage(userThreadMessage, {
+      contextId: this.contextId,
+      taskId:
+        this.currentTask?.id &&
+        !isTerminalTaskState(this.currentTask.status.state)
+          ? this.currentTask.id
+          : undefined,
+    });
 
     // Clear task if previous task reached terminal state
     if (
@@ -638,41 +644,6 @@ export class A2AThreadRuntimeCore {
   }
 
   // --- Message helpers ---
-
-  private threadMessageToA2AMessage(message: ThreadMessage): A2AMessage {
-    const parts: A2APart[] = [];
-
-    if (message.role === "user") {
-      parts.push(...contentPartsToA2AParts(message.content));
-      for (const attachment of message.attachments ?? []) {
-        parts.push(
-          ...contentPartsToA2AParts(
-            attachment.content ?? [],
-            attachment.contentType,
-          ),
-        );
-      }
-    }
-
-    const a2aMsg: A2AMessage = {
-      messageId: message.id,
-      role: "user",
-      parts,
-    };
-
-    if (this.contextId) {
-      a2aMsg.contextId = this.contextId;
-    }
-    // Only attach taskId if current task is NOT in terminal state
-    if (
-      this.currentTask?.id &&
-      !isTerminalTaskState(this.currentTask.status.state)
-    ) {
-      a2aMsg.taskId = this.currentTask.id;
-    }
-
-    return a2aMsg;
-  }
 
   private insertAssistantPlaceholder(parentId: string): string {
     const id = generateId();

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -7,6 +7,7 @@ import {
   contentPartsToA2AParts,
   isTerminalTaskState,
   isInterruptedTaskState,
+  threadMessageToA2AMessage,
 } from "./conversions";
 import type { A2APart, A2AMessage, A2ATaskState } from "./types";
 
@@ -626,5 +627,53 @@ describe("contentPartsToA2AParts", () => {
 
   it("handles empty input", () => {
     expect(contentPartsToA2AParts([])).toEqual([]);
+  });
+});
+
+describe("threadMessageToA2AMessage", () => {
+  const userMessage = {
+    id: "msg-1",
+    role: "user",
+    createdAt: new Date(),
+    content: [{ type: "text" as const, text: "hello" }],
+    attachments: [
+      {
+        id: "att-1",
+        type: "file" as const,
+        name: "notes.txt",
+        contentType: "text/plain",
+        status: { type: "complete" as const },
+        content: [{ type: "text" as const, text: "attached" }],
+      },
+    ],
+    metadata: { custom: {} },
+  } as any;
+
+  it("converts user content and appends attachment parts", () => {
+    const result = threadMessageToA2AMessage(userMessage);
+    expect(result.messageId).toBe("msg-1");
+    expect(result.role).toBe("user");
+    expect(result.parts).toEqual([{ text: "hello" }, { text: "attached" }]);
+    expect(result.contextId).toBeUndefined();
+    expect(result.taskId).toBeUndefined();
+  });
+
+  it("attaches contextId and taskId when provided", () => {
+    const result = threadMessageToA2AMessage(userMessage, {
+      contextId: "ctx-1",
+      taskId: "task-1",
+    });
+    expect(result.contextId).toBe("ctx-1");
+    expect(result.taskId).toBe("task-1");
+  });
+
+  it("skips undefined options and non-user content", () => {
+    const result = threadMessageToA2AMessage(
+      { ...userMessage, role: "assistant" },
+      { contextId: undefined, taskId: undefined },
+    );
+    expect(result.parts).toEqual([]);
+    expect(result.contextId).toBeUndefined();
+    expect(result.taskId).toBeUndefined();
   });
 });

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -1,6 +1,10 @@
 "use client";
 
-import type { MessageStatus, ThreadAssistantMessage } from "@assistant-ui/core";
+import type {
+  MessageStatus,
+  ThreadAssistantMessage,
+  ThreadMessage,
+} from "@assistant-ui/core";
 import {
   parseDataUrl,
   resolveFilePartSource,
@@ -192,4 +196,41 @@ export function a2aMessageToContent(
   message: A2AMessage,
 ): ThreadAssistantMessage["content"] {
   return a2aPartsToContent(message?.parts ?? []);
+}
+
+export function threadMessageToA2AMessage(
+  message: ThreadMessage,
+  options: {
+    contextId?: string | undefined;
+    taskId?: string | undefined;
+  } = {},
+): A2AMessage {
+  const parts: A2APart[] = [];
+
+  if (message.role === "user") {
+    parts.push(...contentPartsToA2AParts(message.content));
+    for (const attachment of message.attachments ?? []) {
+      parts.push(
+        ...contentPartsToA2AParts(
+          attachment.content ?? [],
+          attachment.contentType,
+        ),
+      );
+    }
+  }
+
+  const a2aMsg: A2AMessage = {
+    messageId: message.id,
+    role: "user",
+    parts,
+  };
+
+  if (options.contextId) {
+    a2aMsg.contextId = options.contextId;
+  }
+  if (options.taskId) {
+    a2aMsg.taskId = options.taskId;
+  }
+
+  return a2aMsg;
 }

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -336,3 +336,31 @@ export const createLangChainStreamingTimingAccessors = <
     getToolCallCount,
   };
 };
+
+/**
+ * Group the graph's accumulated `UIMessage`s by the assistant message they
+ * belong to. Non-array state and entries without a parent link are dropped.
+ * The parent id comes from `metadata.message_id` (Python SDK) or
+ * `metadata.id` (JS SDK).
+ */
+export const groupUIMessagesByParent = <
+  T extends {
+    metadata?: { message_id?: string; id?: string } | undefined;
+  },
+>(
+  value: unknown,
+): Map<string, T[]> => {
+  const map = new Map<string, T[]>();
+  if (!Array.isArray(value)) return map;
+  for (const ui of value as T[]) {
+    const parentId = ui.metadata?.message_id ?? ui.metadata?.id;
+    if (!parentId) continue;
+    const existing = map.get(parentId);
+    if (existing) {
+      existing.push(ui);
+    } else {
+      map.set(parentId, [ui]);
+    }
+  }
+  return map;
+};

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -338,15 +338,17 @@ export const createLangChainStreamingTimingAccessors = <
 };
 
 /**
- * Group the graph's accumulated `UIMessage`s by the assistant message they
- * belong to. Non-array state and entries without a parent link are dropped.
- * The parent id comes from `metadata.message_id` (Python SDK) or
- * `metadata.id` (JS SDK).
+ * Resolve the assistant message a `UIMessage` belongs to: the parent id comes
+ * from `metadata.message_id` (Python SDK) or `metadata.id` (JS SDK).
  */
 export const getUIMessageParentId = (ui: {
   metadata?: { message_id?: string; id?: string } | undefined;
 }): string | undefined => ui.metadata?.message_id ?? ui.metadata?.id;
 
+/**
+ * Group the graph's accumulated `UIMessage`s by the assistant message they
+ * belong to. Non-array state and entries without a parent link are dropped.
+ */
 export const groupUIMessagesByParent = <
   T extends {
     metadata?: { message_id?: string; id?: string } | undefined;

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -343,6 +343,10 @@ export const createLangChainStreamingTimingAccessors = <
  * The parent id comes from `metadata.message_id` (Python SDK) or
  * `metadata.id` (JS SDK).
  */
+export const getUIMessageParentId = (ui: {
+  metadata?: { message_id?: string; id?: string } | undefined;
+}): string | undefined => ui.metadata?.message_id ?? ui.metadata?.id;
+
 export const groupUIMessagesByParent = <
   T extends {
     metadata?: { message_id?: string; id?: string } | undefined;
@@ -353,7 +357,7 @@ export const groupUIMessagesByParent = <
   const map = new Map<string, T[]>();
   if (!Array.isArray(value)) return map;
   for (const ui of value as T[]) {
-    const parentId = ui.metadata?.message_id ?? ui.metadata?.id;
+    const parentId = getUIMessageParentId(ui);
     if (!parentId) continue;
     const existing = map.get(parentId);
     if (existing) {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -29,6 +29,8 @@ import type {
   UIMessage,
   UseStreamRuntimeOptions,
 } from "./types";
+import { groupUIMessagesByParent } from "./converter";
+export { groupUIMessagesByParent } from "./converter";
 import {
   convertLangChainBaseMessage,
   getMessageContent,
@@ -51,30 +53,6 @@ export const runConfigToSubmitOptions = (
 type NormalizedRunConfigOptions = NonNullable<
   ReturnType<typeof runConfigToSubmitOptions>
 >;
-
-/**
- * Group the graph's accumulated `UIMessage`s by the assistant message they
- * belong to. Non-array state and entries without a parent link are dropped.
- * The parent id comes from `metadata.message_id` (Python SDK) or
- * `metadata.id` (JS SDK).
- */
-export const groupUIMessagesByParent = (
-  value: unknown,
-): Map<string, UIMessage[]> => {
-  const map = new Map<string, UIMessage[]>();
-  if (!Array.isArray(value)) return map;
-  for (const ui of value as UIMessage[]) {
-    const parentId = ui.metadata?.message_id ?? ui.metadata?.id;
-    if (!parentId) continue;
-    const existing = map.get(parentId);
-    if (existing) {
-      existing.push(ui);
-    } else {
-      map.set(parentId, [ui]);
-    }
-  }
-  return map;
-};
 
 const getPendingToolCalls = (
   messages: readonly LangChainBaseMessage[],
@@ -197,7 +175,8 @@ const useStreamThreadRuntime = (
   const convertWithUI = useMemo<
     useExternalMessageConverter.Callback<LangChainBaseMessage>
   >(() => {
-    const uiMessagesByParent = groupUIMessagesByParent(mergedUiMessages);
+    const uiMessagesByParent =
+      groupUIMessagesByParent<UIMessage>(mergedUiMessages);
     return (message, metadata) =>
       convertLangChainBaseMessage(message, {
         ...metadata,

--- a/packages/react-langgraph/src/messageHelpers.test.ts
+++ b/packages/react-langgraph/src/messageHelpers.test.ts
@@ -3,6 +3,7 @@ import {
   getPendingToolCallGroups,
   getPendingToolCalls,
   pendingToolCallGroupKey,
+  filterUIMessagesBySurvivingIds,
 } from "./messageHelpers";
 import type { LangChainMessage } from "./types";
 
@@ -135,5 +136,63 @@ describe("getPendingToolCalls", () => {
       { id: "tc-1", name: "a", args: {} },
       { id: "tc-2", name: "b", args: {} },
     ]);
+  });
+});
+
+describe("filterUIMessagesBySurvivingIds", () => {
+  const survivors = [{ type: "ai" as const, id: "ai-1", content: "" }];
+
+  it("prunes ui messages whose python sdk parent no longer survives", () => {
+    const kept = filterUIMessagesBySurvivingIds(
+      [
+        {
+          type: "ui",
+          id: "u1",
+          name: "w",
+          props: {},
+          metadata: { message_id: "ai-1" },
+        },
+        {
+          type: "ui",
+          id: "u2",
+          name: "w",
+          props: {},
+          metadata: { message_id: "gone" },
+        },
+      ],
+      survivors,
+    );
+    expect(kept.map((ui) => ui.id)).toEqual(["u1"]);
+  });
+
+  it("prunes ui messages whose js sdk parent no longer survives", () => {
+    const kept = filterUIMessagesBySurvivingIds(
+      [
+        {
+          type: "ui",
+          id: "u1",
+          name: "w",
+          props: {},
+          metadata: { id: "ai-1" },
+        },
+        {
+          type: "ui",
+          id: "u2",
+          name: "w",
+          props: {},
+          metadata: { id: "gone" },
+        },
+      ],
+      survivors,
+    );
+    expect(kept.map((ui) => ui.id)).toEqual(["u1"]);
+  });
+
+  it("keeps orphan ui messages without a parent id", () => {
+    const kept = filterUIMessagesBySurvivingIds(
+      [{ type: "ui", id: "u1", name: "w", props: {}, metadata: {} }],
+      survivors,
+    );
+    expect(kept.map((ui) => ui.id)).toEqual(["u1"]);
   });
 });

--- a/packages/react-langgraph/src/messageHelpers.ts
+++ b/packages/react-langgraph/src/messageHelpers.ts
@@ -1,3 +1,4 @@
+import { getUIMessageParentId } from "@assistant-ui/react-langchain/converter";
 import {
   getExternalStoreMessages,
   type ThreadMessage,
@@ -91,8 +92,8 @@ export const filterUIMessagesBySurvivingIds = (
     if (m.id) survivingIds.add(m.id);
   }
   return uiMessages.filter((ui) => {
-    const parentId = ui.metadata?.message_id;
-    // orphans (no message_id) represent global UI, cleared only via delete_ui_message
+    const parentId = getUIMessageParentId(ui);
+    // orphans (no parent id) represent global UI, cleared only via delete_ui_message
     if (!parentId) return true;
     return survivingIds.has(parentId);
   });

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -268,6 +268,56 @@ describe("useLangGraphRuntime", () => {
     });
   });
 
+  it("attaches UI messages carrying JS SDK parent IDs", async () => {
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() =>
+        mockStreamCallbackFactory([
+          {
+            event: "custom",
+            data: {
+              type: "ui",
+              id: "ui-1",
+              name: "chart",
+              props: { series: [1, 2, 3] },
+              metadata: { id: "ai-1" },
+            },
+          },
+          {
+            event: "messages",
+            data: [
+              { type: "ai", id: "ai-1", content: "Here's your chart." },
+              {},
+            ],
+          },
+        ])(),
+      );
+
+    const { result: runtimeResult } = renderHook(() =>
+      useLangGraphRuntime({ stream: streamMock }),
+    );
+    const wrapper = wrapperFactory(runtimeResult.current);
+    const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+    await act(async () => {
+      auiResult.current.composer.setText("show a chart");
+      await auiResult.current.composer.send();
+    });
+
+    await waitFor(() => {
+      const assistantMessage = runtimeResult.current.thread
+        .getState()
+        .messages.find((message) => message.id === "ai-1");
+      expect(assistantMessage).toMatchObject({
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here's your chart." },
+          { type: "data", name: "chart", data: { series: [1, 2, 3] } },
+        ],
+      });
+    });
+  });
+
   it("should work without any provided callbacks", async () => {
     const streamMock = vi
       .fn()

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -269,29 +269,24 @@ describe("useLangGraphRuntime", () => {
   });
 
   it("attaches UI messages carrying JS SDK parent IDs", async () => {
-    const streamMock = vi
-      .fn()
-      .mockImplementation(() =>
-        mockStreamCallbackFactory([
-          {
-            event: "custom",
-            data: {
-              type: "ui",
-              id: "ui-1",
-              name: "chart",
-              props: { series: [1, 2, 3] },
-              metadata: { id: "ai-1" },
-            },
+    const streamMock = vi.fn().mockImplementation(() =>
+      mockStreamCallbackFactory([
+        {
+          event: "custom",
+          data: {
+            type: "ui",
+            id: "ui-1",
+            name: "chart",
+            props: { series: [1, 2, 3] },
+            metadata: { id: "ai-1" },
           },
-          {
-            event: "messages",
-            data: [
-              { type: "ai", id: "ai-1", content: "Here's your chart." },
-              {},
-            ],
-          },
-        ])(),
-      );
+        },
+        {
+          event: "messages",
+          data: [{ type: "ai", id: "ai-1", content: "Here's your chart." }, {}],
+        },
+      ])(),
+    );
 
     const { result: runtimeResult } = renderHook(() =>
       useLangGraphRuntime({ stream: streamMock }),

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -6,7 +6,11 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import type { LangChainMessage, UseLangGraphRuntimeOptions } from "./types";
+import type {
+  LangChainMessage,
+  UIMessage,
+  UseLangGraphRuntimeOptions,
+} from "./types";
 import { groupUIMessagesByParent } from "@assistant-ui/react-langchain/converter";
 import {
   pickExternalStoreSharedOptions,
@@ -352,7 +356,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   );
 
   const uiMessagesByParent = useMemo(
-    () => groupUIMessagesByParent(uiMessages),
+    () => groupUIMessagesByParent<UIMessage>(uiMessages),
     [uiMessages],
   );
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -6,10 +6,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import type {
-  LangChainMessage,
-  UseLangGraphRuntimeOptions,
-} from "./types";
+import type { LangChainMessage, UseLangGraphRuntimeOptions } from "./types";
 import { groupUIMessagesByParent } from "@assistant-ui/react-langchain/converter";
 import {
   pickExternalStoreSharedOptions,

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -8,9 +8,9 @@ import {
 } from "react";
 import type {
   LangChainMessage,
-  UIMessage,
   UseLangGraphRuntimeOptions,
 } from "./types";
+import { groupUIMessagesByParent } from "@assistant-ui/react-langchain/converter";
 import {
   pickExternalStoreSharedOptions,
   createMessageQueue,
@@ -354,20 +354,10 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     effectiveIsRunning,
   );
 
-  const uiMessagesByParent = useMemo(() => {
-    const map = new Map<string, UIMessage[]>();
-    for (const ui of uiMessages) {
-      const parentId = ui.metadata?.message_id;
-      if (!parentId) continue;
-      const existing = map.get(parentId);
-      if (existing) {
-        existing.push(ui);
-      } else {
-        map.set(parentId, [ui]);
-      }
-    }
-    return map;
-  }, [uiMessages]);
+  const uiMessagesByParent = useMemo(
+    () => groupUIMessagesByParent(uiMessages),
+    [uiMessages],
+  );
 
   // fresh metadata identity invalidates the converter cache; each UI event re-converts all messages
   const converterMetadata = useMemo(


### PR DESCRIPTION
## summary

finishes the converter-seam work #6432 started, in two moves:

- `groupUIMessagesByParent` moves from react-langchain's `useStreamRuntime.ts` into the `/converter` subpath, generic over the ui-message shape; the old module re-exports it. react-langgraph drops its inlined copy, which read only `metadata.message_id`: langgraph's own `UIMessage` type documents that the parent id arrives as `metadata.message_id` from the python sdk and `metadata.id` from the js sdk, so the subset was a bug. ui messages carrying the js sdk field now attach to their assistant message (regression test added; disclosed in the changeset).
- a2a's `threadMessageToA2AMessage` moves off the thread core class into `conversions.ts` as a pure function. the two pieces of session state it read (`contextId`, and the current task id when the task is not terminal) become an explicit options argument computed at the call site, so the terminal-state policy stays with the session and the converter stays pure.

## test plan

- react-langchain vitest: 117 passed; react-langgraph vitest: 294 passed (includes the new js-sdk parent-id attachment test); react-a2a vitest: 267 passed
- react-a2a `tsc --noEmit` clean; langchain/langgraph error sets unchanged from main (3 and 6 pre-existing test-file errors)
- `aui-build` still emits `dist/converter.*`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.U7gJEZYkXwUJSRECsU0mnOyC5nnyy5E1lW3wNwLD6w0X0OuGyMdlIPF_Hyc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->