### PR TITLE
refactor(core): share the file part source resolution branch

### DIFF
--- a/.changeset/file-part-source-resolution.md
+++ b/.changeset/file-part-source-resolution.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/eve": patch
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-langchain": patch
+---
+
+refactor: share the file part source resolution branch

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1968,6 +1968,15 @@ type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
 
 type FileMessagePartProps = MessagePartState & FileMessagePart;
 
+type FilePartSource = {
+  kind: "url";
+  url: string;
+} | {
+  kind: "data";
+  data: string;
+  mimeType: string;
+};
+
 type FrameMessage = {
   type: "model-context-request";
 } | {
@@ -6066,7 +6075,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AbortableThreadLoadPurpose, AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRepositorySession, MessageRepositorySessionOptions, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createAbortableThreadLoad, createCloudThreadListAdapterCreateFallback, createMessageRepositorySession, createThreadMappingId, createToolCallCancellationStub, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, scanPendingToolCalls, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AbortableThreadLoadPurpose, AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, FilePartSource, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRepositorySession, MessageRepositorySessionOptions, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createAbortableThreadLoad, createCloudThreadListAdapterCreateFallback, createMessageRepositorySession, createThreadMappingId, createToolCallCancellationStub, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, invokeUserCallback, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, notifyEventListeners, parseDataUrl, resolveFileMediaType, resolveFilePartSource, resolveImageMediaType, resolveToolApprovalResponse, scanPendingToolCalls, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {
@@ -6115,6 +6124,12 @@ declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptio
 declare function providerTool(_config: ProviderToolConfig): never;
 
 declare function resolveFileMediaType(data: string, mimeType?: string | undefined): string;
+
+declare const resolveFilePartSource: (part: {
+  data: string;
+  mimeType: string;
+  sourceType?: string | undefined;
+}) => FilePartSource;
 
 declare function resolveImageMediaType(image: string, contentType?: string | undefined): string;
 

--- a/packages/ai-sdk/src/converters/toCreateMessage.ts
+++ b/packages/ai-sdk/src/converters/toCreateMessage.ts
@@ -1,8 +1,7 @@
 import type { AppendMessage } from "@assistant-ui/core";
 import {
-  httpUrlPattern,
-  parseDataUrl,
   resolveFileMediaType,
+  resolveFilePartSource,
   resolveImageMediaType,
   toMediaWireUrl,
 } from "@assistant-ui/core/internal";
@@ -72,11 +71,13 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
         // envelope is rebuilt from the typed format rather than forwarded.
         const mediaType = `audio/${part.audio.format}`;
         const data = part.audio.data;
+        const source = resolveFilePartSource({ data, mimeType: mediaType });
         return {
           type: "file",
-          url: httpUrlPattern.test(data)
-            ? data
-            : `data:${mediaType};base64,${parseDataUrl(data)?.data ?? data}`,
+          url:
+            source.kind === "url"
+              ? source.url
+              : `data:${mediaType};base64,${source.data}`,
           mediaType,
           ...(part.filename && { filename: part.filename }),
         };

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -60,9 +60,11 @@ export { isJSONValue, isRecord } from "./utils/json/is-json";
 // outbound part conversion lives in one place.
 export {
   dataUrlMediaType,
+  type FilePartSource,
   httpUrlPattern,
   isParsableUrl,
   parseDataUrl,
+  resolveFilePartSource,
 } from "./utils/data-url";
 export { invokeUserCallback } from "./utils/invoke-user-callback";
 export { detectImageMediaType } from "./utils/image-media-type";

--- a/packages/core/src/utils/data-url.test.ts
+++ b/packages/core/src/utils/data-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { httpUrlPattern, parseDataUrl } from "./data-url";
+import {
+  httpUrlPattern,
+  parseDataUrl,
+  resolveFilePartSource,
+} from "./data-url";
 
 describe("parseDataUrl", () => {
   it("parses a base64 data URL", () => {
@@ -71,4 +75,51 @@ describe("httpUrlPattern", () => {
       expect(httpUrlPattern.test(value)).toBe(false);
     },
   );
+});
+
+describe("resolveFilePartSource", () => {
+  it("uses an explicit url source type for opaque values", () => {
+    expect(
+      resolveFilePartSource({
+        data: "provider-file-id",
+        mimeType: "application/pdf",
+        sourceType: "url",
+      }),
+    ).toEqual({ kind: "url", url: "provider-file-id" });
+  });
+
+  it("uses http URLs as url sources", () => {
+    expect(
+      resolveFilePartSource({
+        data: "https://example.com/file.pdf",
+        mimeType: "application/pdf",
+      }),
+    ).toEqual({ kind: "url", url: "https://example.com/file.pdf" });
+  });
+
+  it("decodes data URLs and uses their media type", () => {
+    expect(
+      resolveFilePartSource({
+        data: "data:image/png;base64,aGVsbG8=",
+        mimeType: "application/octet-stream",
+      }),
+    ).toEqual({
+      kind: "data",
+      data: "aGVsbG8=",
+      mimeType: "image/png",
+    });
+  });
+
+  it("passes through opaque data with its declared media type", () => {
+    expect(
+      resolveFilePartSource({
+        data: "provider-file-id",
+        mimeType: "application/pdf",
+      }),
+    ).toEqual({
+      kind: "data",
+      data: "provider-file-id",
+      mimeType: "application/pdf",
+    });
+  });
 });

--- a/packages/core/src/utils/data-url.ts
+++ b/packages/core/src/utils/data-url.ts
@@ -1,5 +1,9 @@
 export const httpUrlPattern = /^https?:\/\//i;
 
+export type FilePartSource =
+  | { kind: "url"; url: string }
+  | { kind: "data"; data: string; mimeType: string };
+
 export function parseDataUrl(
   value: string,
 ): { mimeType: string; data: string } | null {
@@ -7,6 +11,23 @@ export function parseDataUrl(
   if (!match) return null;
   return { mimeType: match[1]!.toLowerCase(), data: match[2]! };
 }
+
+export const resolveFilePartSource = (part: {
+  data: string;
+  mimeType: string;
+  sourceType?: string | undefined;
+}): FilePartSource => {
+  if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
+    return { kind: "url", url: part.data };
+  }
+
+  const parsed = parseDataUrl(part.data);
+  return {
+    kind: "data",
+    data: parsed?.data ?? part.data,
+    mimeType: parsed?.mimeType ?? part.mimeType,
+  };
+};
 
 /**
  * Whether a payload is something `new URL()` accepts. Adapters that place a

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -16,7 +16,10 @@ import {
   type ToolApprovalOption,
   type ToolCallMessagePart,
 } from "@assistant-ui/core";
-import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
+import {
+  httpUrlPattern,
+  resolveFilePartSource,
+} from "@assistant-ui/core/internal";
 import type {
   EveAuthorizationOutcome,
   EveAuthorizationPart,
@@ -526,11 +529,13 @@ export const getEveMessageContent = (
         // envelope is rebuilt from the typed format rather than forwarded.
         const mediaType = `audio/${part.audio.format}`;
         const data = part.audio.data;
+        const source = resolveFilePartSource({ data, mimeType: mediaType });
         return {
           type: "file" as const,
-          data: httpUrlPattern.test(data)
-            ? data
-            : `data:${mediaType};base64,${parseDataUrl(data)?.data ?? data}`,
+          data:
+            source.kind === "url"
+              ? source.url
+              : `data:${mediaType};base64,${source.data}`,
           mediaType,
         };
       }

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import type { MessageStatus, ThreadAssistantMessage } from "@assistant-ui/core";
-import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
+import {
+  parseDataUrl,
+  resolveFilePartSource,
+} from "@assistant-ui/core/internal";
 import type { A2AMessage, A2APart, A2ATaskState } from "./types";
 
 function isImageMediaType(mediaType?: string): boolean {
@@ -134,9 +137,14 @@ export function contentPartsToA2AParts(
         case "file": {
           if (typeof part.data !== "string" || !part.data) return null;
           const declaredMimeType = part.mimeType || fallbackMimeType;
-          if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
+          const source = resolveFilePartSource({
+            data: part.data,
+            mimeType: declaredMimeType ?? "application/octet-stream",
+            sourceType: part.sourceType,
+          });
+          if (source.kind === "url") {
             return {
-              url: part.data,
+              url: source.url,
               ...(declaredMimeType && { mediaType: declaredMimeType }),
               ...(part.filename && { filename: part.filename }),
             };
@@ -144,8 +152,8 @@ export function contentPartsToA2AParts(
           const parsed = parseDataUrl(part.data);
           if (parsed) {
             return {
-              raw: parsed.data,
-              mediaType: parsed.mimeType,
+              raw: source.data,
+              mediaType: source.mimeType,
               ...(part.filename && { filename: part.filename }),
             };
           }
@@ -157,7 +165,7 @@ export function contentPartsToA2AParts(
             };
           }
           return {
-            raw: part.data,
+            raw: source.data,
             ...(declaredMimeType && { mediaType: declaredMimeType }),
             ...(part.filename && { filename: part.filename }),
           };

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -10,8 +10,8 @@ import type {
 } from "@assistant-ui/core";
 import {
   getAutoStatus,
-  httpUrlPattern,
   parseDataUrl,
+  resolveFilePartSource,
 } from "@assistant-ui/core/internal";
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
@@ -236,17 +236,20 @@ function buildInputSource(
   declaredMimeType: string | undefined,
   sourceType?: string,
 ): InputContentSource {
-  if (sourceType === "url" || httpUrlPattern.test(value)) {
+  const source = resolveFilePartSource({
+    data: value,
+    mimeType: declaredMimeType ?? "application/octet-stream",
+    sourceType,
+  });
+  if (source.kind === "url") {
     return declaredMimeType !== undefined
-      ? { type: "url", value, mimeType: declaredMimeType }
-      : { type: "url", value };
+      ? { type: "url", value: source.url, mimeType: declaredMimeType }
+      : { type: "url", value: source.url };
   }
-  const parsed = parseDataUrl(value);
   return {
     type: "data",
-    value: parsed?.data ?? value,
-    mimeType:
-      parsed?.mimeType ?? declaredMimeType ?? "application/octet-stream",
+    value: source.data,
+    mimeType: source.mimeType,
   };
 }
 

--- a/packages/react-google-adk/src/convertToAdkMessages.ts
+++ b/packages/react-google-adk/src/convertToAdkMessages.ts
@@ -6,8 +6,8 @@ import {
 } from "@assistant-ui/core";
 import {
   createToolCallCancellationStub,
-  httpUrlPattern,
   parseDataUrl,
+  resolveFilePartSource,
   scanPendingToolCalls,
 } from "@assistant-ui/core/internal";
 import type { AdkMessage } from "./types";
@@ -25,11 +25,12 @@ export const getMessageContent = (msg: AppendMessage) => {
         return { type: "text" as const, text: part.text };
       case "image":
         return { type: "image_url" as const, url: part.image };
-      case "file":
-        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
+      case "file": {
+        const source = resolveFilePartSource(part);
+        if (source.kind === "url") {
           return {
             type: "file_url" as const,
-            url: part.data,
+            url: source.url,
             mimeType: part.mimeType,
           };
         }
@@ -38,9 +39,10 @@ export const getMessageContent = (msg: AppendMessage) => {
           mimeType: part.mimeType,
           // Lands in Gemini `inlineData.data`, which takes bare base64, so a
           // data URL envelope is stripped rather than forwarded.
-          data: parseDataUrl(part.data)?.data ?? part.data,
+          data: source.data,
           ...(part.filename != null && { filename: part.filename }),
         };
+      }
       case "audio": {
         const parsed = parseDataUrl(part.audio.data);
         return {

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -4,7 +4,10 @@ import type {
   ThreadAssistantMessage,
   ThreadUserMessage,
 } from "@assistant-ui/core";
-import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
+import {
+  parseDataUrl,
+  resolveFilePartSource,
+} from "@assistant-ui/core/internal";
 import type { StreamingTimingAccessors } from "@assistant-ui/core/react";
 
 /** Known content block types from @langchain/core messages. */
@@ -200,32 +203,32 @@ export const getMessageContent = (msg: AppendMessage) => {
             source_type: "id" as const,
           };
         }
-        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
+        const source = resolveFilePartSource(part);
+        if (source.kind === "url") {
           return {
             type: "file" as const,
-            url: part.data,
+            url: source.url,
             mime_type: part.mimeType,
             filename: metadata.filename,
             metadata,
             source_type: "url" as const,
           };
         }
-        const parsed = parseDataUrl(part.data);
         const audioMimeType = audioBlockMimeTypes.get(
-          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
+          source.mimeType.toLowerCase(),
         );
         if (audioMimeType) {
           return {
             type: "audio" as const,
-            data: parsed?.data ?? part.data,
+            data: source.data,
             mime_type: audioMimeType,
             source_type: "base64" as const,
           };
         }
         return {
           type: "file" as const,
-          data: parsed?.data ?? part.data,
-          mime_type: parsed?.mimeType ?? part.mimeType,
+          data: source.data,
+          mime_type: source.mimeType,
           filename: metadata.filename,
           metadata,
           source_type: "base64" as const,


### PR DESCRIPTION
## summary

six converters (ai-sdk, eve, a2a, ag-ui, google-adk, langchain's shared converter) carried the same ~6-line branch deciding whether an outgoing file part is url-shaped or data-shaped: `sourceType === "url" || httpUrlPattern.test(data)` picks the url form, otherwise `parseDataUrl` supplies decoded data with a parsed-mime-type-first fallback. this moves the decision into `resolveFilePartSource` next to `httpUrlPattern`/`parseDataUrl` in core's `data-url.ts` (internal export), returning a `{ kind: "url" } | { kind: "data" }` union.

each site keeps its provider-specific wire field names and surrounding branches (langchain's `source_type: "id"` handling and audio MIME map, adapters' declared-mime-type fallbacks); only the shared decision moved. sites that never consulted `sourceType` (ai-sdk, eve) simply do not pass it, preserving their original predicate.

## test plan

- all seven package suites green: core 1498 (includes 4 new `resolveFilePartSource` cases), ai-sdk 254, eve 148, react-a2a 267, react-ag-ui 471, react-google-adk 323, react-langchain 117
- `tsc --noEmit` error sets byte-identical to main in all seven packages
- no `httpUrlPattern.test(` remains in the six converter files (eve's two inbound uses are unrelated and untouched)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.td8rlqpc5vU1pxJcn5OUNgnYC6vDnA-JdMuBFw87alhuGmtkxEXcZOS8WeI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->