### PR TITLE
test(core): pin LazyMemoizeSubject reference stability while unconnected

### DIFF
--- a/packages/core/src/subscribable/subscribable.test.ts
+++ b/packages/core/src/subscribable/subscribable.test.ts
@@ -32,6 +32,30 @@ const createBinding = (initialState: TestState) => {
   };
 };
 
+// Mirrors runtime bindings such as `getThreadListState`, which assemble a new
+// object on every read while the underlying values keep their identity.
+const createRebuildingBinding = (initialState: TestState) => {
+  let state = initialState;
+  const subscribers = new Set<() => void>();
+
+  const binding: SubscribableWithState<TestState, null> = {
+    path: null,
+    getState: () => ({ ...state }),
+    subscribe: (callback) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+  };
+
+  return {
+    binding,
+    update(nextState: TestState) {
+      state = nextState;
+      for (const callback of subscribers) callback();
+    },
+  };
+};
+
 describe("ShallowMemoizeSubject", () => {
   it("notifies subscribers when a state key is removed", () => {
     const source = createBinding({
@@ -130,5 +154,31 @@ describe("LazyMemoizeSubject", () => {
 
     expect(subject.getState()).toEqual({ status: "ready" });
     reconnect();
+  });
+
+  it("keeps one reference while unconnected and the state is unchanged", () => {
+    // A consumer that reads without subscribing (React's useSyncExternalStore
+    // calls getSnapshot outside the subscription) must not see a new object on
+    // every call: React compares snapshots with Object.is, so a fresh reference
+    // reads as a change and re-renders forever.
+    const source = createRebuildingBinding({ status: "ready" });
+    const subject = new LazyMemoizeSubject(source.binding);
+
+    const first = subject.getState();
+
+    expect(subject.getState()).toBe(first);
+    expect(subject.getState()).toBe(first);
+  });
+
+  it("returns a new reference once the unchanged state actually changes", () => {
+    const source = createRebuildingBinding({ status: "ready" });
+    const subject = new LazyMemoizeSubject(source.binding);
+
+    const first = subject.getState();
+    source.update({ status: "done" });
+
+    const second = subject.getState();
+    expect(second).not.toBe(first);
+    expect(second).toEqual({ status: "done" });
   });
 });


### PR DESCRIPTION
## Summary

Adds a regression test pinning `LazyMemoizeSubject`'s reference stability while unconnected. **Test-only — no behaviour change.**

Found while investigating #6440. The behaviour itself was already fixed by #5897, which taught `LazyMemoizeSubject.getState` to keep its cached reference when the recomputed state is shallow-equal:

```ts
if (
  newState !== SKIP_UPDATE &&
  (this._previousState === undefined ||
    !shallowEqual(newState, this._previousState))
) {
  this._previousState = newState;
}
```

That check is what lets React's `useSyncExternalStore` compare snapshots with `Object.is` without re-rendering forever — but nothing pins it:

- every existing `LazyMemoizeSubject` test asserts with `toEqual`, so identity is never checked, and
- the shared `createBinding` helper returns the *same stored object* on each read, so a binding that rebuilds its state on every read is never exercised.

Between the two, the `shallowEqual` call could be dropped and the suite would stay green — while every `useSyncExternalStore` consumer downstream span forever.

## What the test does

Adds `createRebuildingBinding`, which returns a fresh object per read while its values keep their identity. That mirrors real runtime bindings such as `getThreadListState` in `ThreadListRuntimeImpl`, which assembles a new literal on each call from stable stored values.

Two cases:

- **unconnected reads return one reference** while the state is unchanged
- **a real state change still yields a new reference**, so the first test can't be satisfied by over-caching

## Verification

Reverting the #5897 equality check (restoring the unconditional `this._previousState = newState`) fails the new test with:

```
AssertionError: expected { status: 'ready' } to be { status: 'ready' } // Object.is equality
```

and passes with it. `pnpm vitest run src/subscribable/subscribable.test.ts` in `packages/core`: 9 passed.

## Notes

No changeset: this touches only a test file, so there is nothing to publish. Happy to add one if you'd prefer the PR carry it.

## Context

The practical impact is on the frozen `@assistant-ui/react` 0.14.x / `@assistant-ui/core` 0.2.x line, where `tap` floats on a caret: a fresh install pairs `tap` 0.9.14 (which has the #5897 loop guard) with `core` 0.2.23 (published 2026-07-28, before the #5897 fix), so the guard fires against an unfixed core. Details and a minimal reproduction are in #6440; that release skew also looks like the most likely explanation for #6133, where reinstalling `node_modules` broke a project whose `package.json` had not changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.vtrG9nnRQI3mssVRC8_kpgrGeVfGpAQmgKc3SmlCe5Uhsb0ABAA9pMgvhwI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->