### PR TITLE
fix(react-mcp): scope oauth callbacks to committed renders

### DIFF
--- a/.changeset/clean-rice-connect.md
+++ b/.changeset/clean-rice-connect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: keep OAuth lifecycle callbacks scoped to committed renders

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from "@testing-library/react";
+import {
+  createElement,
+  Suspense,
+  startTransition,
+  type PropsWithChildren,
+} from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -98,6 +104,57 @@ describe("useMcpOAuthCallback", () => {
       });
     },
   );
+
+  it("keeps callbacks scoped to committed renders", async () => {
+    let resolveAuth!: () => void;
+    mocks.completeAuth.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveAuth = resolve;
+      }),
+    );
+    const onCompleteA = vi.fn();
+    const onCompleteB = vi.fn();
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    let blocked = false;
+    const Blocker = () => {
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      return null;
+    };
+    const Wrapper = ({ children }: PropsWithChildren) =>
+      createElement(
+        Suspense,
+        { fallback: null },
+        children,
+        createElement(Blocker),
+      );
+
+    const { rerender } = renderHook(
+      ({ onComplete }) => useMcpOAuthCallback({ url: callbackUrl, onComplete }),
+      {
+        initialProps: { onComplete: onCompleteA },
+        wrapper: Wrapper,
+      },
+    );
+    await waitFor(() => expect(mocks.completeAuth).toHaveBeenCalledOnce());
+
+    act(() => {
+      blocked = true;
+      startTransition(() => rerender({ onComplete: onCompleteB }));
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+
+    await act(async () => {
+      resolveAuth();
+      await Promise.resolve();
+    });
+
+    expect(onCompleteB).not.toHaveBeenCalled();
+    expect(onCompleteA).toHaveBeenCalledWith("docs");
+  });
 });
 
 describe("createMcpOAuthCallbackError", () => {

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -1,4 +1,11 @@
-import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  type ReactNode,
+  useEffect,
+  useInsertionEffect,
+  useRef,
+  useState,
+} from "react";
 import { useAui } from "@assistant-ui/store";
 import { decodeServerIdFromState } from "../auth/createOAuthProvider";
 import { invokeMcpCallback } from "../utils/invokeMcpCallback";
@@ -44,7 +51,9 @@ export function useMcpOAuthCallback(
   // single-use OAuth code is double-redeemed and the second attempt 4xxs.
   const startedRef = useRef<string | null>(null);
   const optsRef = useRef(opts);
-  optsRef.current = opts;
+  useInsertionEffect(() => {
+    optsRef.current = opts;
+  });
 
   useEffect(() => {
     const url =


### PR DESCRIPTION
## Summary

- publish OAuth lifecycle callback options only after a React render commits
- prevent an interrupted prop update from replacing callbacks used by an in-flight OAuth completion
- add a concurrent-render regression test and patch changeset

## Why

`useMcpOAuthCallback()` updated its options ref during render. If one mounted hook instance started `completeAuth()`, then received new callback props in a concurrent render that suspended and never committed, the discarded render's callback remained published. When authentication completed, the hook invoked that uncommitted callback instead of the callback belonging to the UI that remained committed. Account or workspace transitions are one way an application can trigger this sequence.

The ref now publishes from `useInsertionEffect`, which keeps reads tied to the latest committed render while making the callbacks available before other commit-phase effects.

## Verification

- reproduced on `main`: the discarded render's callback ran once and the committed callback ran zero times
- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm lint`
- `pnpm turbo build --filter=@assistant-ui/react-mcp...`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.V3Y3Nd9X4SV9-A4oaqBBuLgPXQTCazuK-JJVrzj1iUdUMEuEYbOWfTQOTBs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->