### PR TITLE
refactor(react-markdown): single-source the code-fence contract on a subpath

### DIFF
--- a/.changeset/shared-code-fence-contract.md
+++ b/.changeset/shared-code-fence-contract.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+refactor: single-source the code-fence contract on a react-markdown subpath. the CodeHeader/SyntaxHighlighter prop types, the by-language override entry, and the language-class parser now live in @assistant-ui/react-markdown/code-fence; react-streamdown re-exports the types from there instead of keeping structurally compatible copies. @types/hast moves to dependencies in both packages so the published declarations reference hast by name instead of a broken store-relative path.

--- a/api-surface/assistant-ui__react-markdown.ts
+++ b/api-surface/assistant-ui__react-markdown.ts
@@ -188,10 +188,7 @@ type MarkdownTextPrimitiveProps = Omit<Options, "children" | "components"> & {
     SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
     CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
   }) | undefined;
-  componentsByLanguage?: Record<string, {
-    CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
-    SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
-  }> | undefined;
+  componentsByLanguage?: ComponentsByLanguage | undefined;
   smooth?: boolean | SmoothOptions | undefined;
   defer?: boolean | undefined;
   preprocess?: (text: string) => string;

--- a/api-surface/assistant-ui__react-markdown.ts
+++ b/api-surface/assistant-ui__react-markdown.ts
@@ -116,6 +116,11 @@ type Components = {
   CodeHeader?: ComponentType<Omit<CodeHeaderProps, "node">> | undefined;
 };
 
+type ComponentsByLanguage = Record<string, {
+  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
+  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
+}>;
+
 interface Data extends Data$1 {
 }
 
@@ -958,6 +963,10 @@ type WildcardPayload = {
   };
 }[Extract<keyof ClientEventMap, string>];
 
+declare namespace entry_code_fence_exports {
+  export { CodeComponent, CodeHeaderProps, ComponentsByLanguage, PreComponent, SyntaxHighlighterProps, parseLanguageClass };
+}
+
 declare function escapeCurrencyDollars(text: string): string;
 
 declare global {
@@ -985,10 +994,12 @@ declare const memoizeMarkdownComponents: (components?: Components) => {
 
 declare function normalizeMathDelimiters(text: string): string;
 
+declare const parseLanguageClass: (className: string | undefined) => string;
+
 declare function rewriteCustomMathTags(text: string): string;
 
 declare function rewriteLatexBracketDelimiters(text: string): string;
 
 declare const useIsMarkdownCodeBlock: () => boolean;
 
-export { entry_root_exports as entry_root };
+export { entry_code_fence_exports as entry_code_fence, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -107,6 +107,10 @@ type ClientScopes = {
   [K in ClientNames]: AssistantClientAccessor<K>;
 };
 
+type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {
+  node?: Element | undefined;
+}>;
+
 type CodeHeaderProps = {
   node?: Element | undefined;
   language: string | undefined;
@@ -247,6 +251,10 @@ interface Position {
   start: Point;
   end: Point;
 }
+
+type PreComponent = ComponentType<ComponentPropsWithoutRef<"pre"> & {
+  node?: Element | undefined;
+}>;
 
 type PreOverrideProps = ComponentPropsWithoutRef<"pre"> & {
   node?: Element | undefined;
@@ -1028,12 +1036,8 @@ type StreamdownTextPrimitiveProps = Omit<StreamdownProps$2, "BlockComponent" | "
 type SyntaxHighlighterProps = {
   node?: Element | undefined;
   components: {
-    Pre: ComponentType<ComponentPropsWithoutRef<"pre"> & {
-      node?: Element | undefined;
-    }>;
-    Code: ComponentType<ComponentPropsWithoutRef<"code"> & {
-      node?: Element | undefined;
-    }>;
+    Pre: PreComponent;
+    Code: CodeComponent;
   };
   language: string;
   code: string;

--- a/packages/react-markdown/package.json
+++ b/packages/react-markdown/package.json
@@ -22,6 +22,17 @@
     "./styles/dot.css": {
       "style": "./styles/dot.css",
       "default": "./styles/dot.css"
+    },
+    "./code-fence": {
+      "types": "./dist/code-fence.d.ts",
+      "default": "./dist/code-fence.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "code-fence": [
+        "./dist/code-fence.d.ts"
+      ]
     }
   },
   "main": "./dist/index.js",
@@ -41,6 +52,7 @@
   "dependencies": {
     "@radix-ui/react-primitive": "^2.1.10",
     "@radix-ui/react-use-callback-ref": "^1.1.4",
+    "@types/hast": "^3.0.5",
     "classnames": "^2.5.1",
     "react-markdown": "^10.1.0"
   },
@@ -57,7 +69,6 @@
   "devDependencies": {
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
-    "@types/hast": "^3.0.5",
     "@types/react": "^19.2.18",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/react-markdown/src/code-fence.test.ts
+++ b/packages/react-markdown/src/code-fence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseLanguageClass } from "./code-fence";
+
+describe("parseLanguageClass", () => {
+  it("extracts the language id from a language- class", () => {
+    expect(parseLanguageClass("language-tsx")).toBe("tsx");
+  });
+
+  it("keeps punctuation-bearing language ids intact", () => {
+    expect(parseLanguageClass("language-c++")).toBe("c++");
+    expect(parseLanguageClass("language-objective-c")).toBe("objective-c");
+  });
+
+  it("extracts the id when unrelated classes surround the token", () => {
+    expect(parseLanguageClass("hljs language-python line-numbers")).toBe(
+      "python",
+    );
+  });
+
+  it("stops the id at whitespace", () => {
+    expect(parseLanguageClass("language-ts extra")).toBe("ts");
+  });
+
+  it("returns an empty string for a missing or unrelated class", () => {
+    expect(parseLanguageClass(undefined)).toBe("");
+    expect(parseLanguageClass("")).toBe("");
+    expect(parseLanguageClass("hljs line-numbers")).toBe("");
+  });
+});

--- a/packages/react-markdown/src/code-fence.ts
+++ b/packages/react-markdown/src/code-fence.ts
@@ -1,0 +1,36 @@
+import type { Element } from "hast";
+import type { ComponentPropsWithoutRef, ComponentType } from "react";
+
+export type PreComponent = ComponentType<
+  ComponentPropsWithoutRef<"pre"> & { node?: Element | undefined }
+>;
+export type CodeComponent = ComponentType<
+  ComponentPropsWithoutRef<"code"> & { node?: Element | undefined }
+>;
+
+export type CodeHeaderProps = {
+  node?: Element | undefined;
+  language: string | undefined;
+  code: string;
+};
+
+export type SyntaxHighlighterProps = {
+  node?: Element | undefined;
+  components: {
+    Pre: PreComponent;
+    Code: CodeComponent;
+  };
+  language: string;
+  code: string;
+};
+
+export type ComponentsByLanguage = Record<
+  string,
+  {
+    CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
+    SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
+  }
+>;
+
+export const parseLanguageClass = (className: string | undefined): string =>
+  /language-([^\s]+)/.exec(className ?? "")?.[1] ?? "";

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -13,6 +13,7 @@ import type {
   SyntaxHighlighterProps,
 } from "./types";
 import { DefaultCodeBlock } from "./CodeBlock";
+import { parseLanguageClass } from "../code-fence";
 import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { withDefaultProps } from "./withDefaults";
 import { DefaultCodeBlockContent } from "./defaultComponents";
@@ -41,8 +42,7 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
     <Code {...getCodeProps(props)} />
   ));
 
-  const language =
-    /language-([^\s]+)/.exec(codeProps.className || "")?.[1] ?? "";
+  const language = parseLanguageClass(codeProps.className);
 
   // if the code content is not string (due to rehype plugins), return a default code block
   if (typeof children !== "string") {

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -13,7 +13,7 @@ import type {
   SyntaxHighlighterProps,
 } from "./types";
 import { DefaultCodeBlock } from "./CodeBlock";
-import { parseLanguageClass } from "../code-fence";
+import { type ComponentsByLanguage, parseLanguageClass } from "../code-fence";
 import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { withDefaultProps } from "./withDefaults";
 import { DefaultCodeBlockContent } from "./defaultComponents";
@@ -84,15 +84,7 @@ export type CodeOverrideProps = ComponentPropsWithoutRef<CodeComponent> & {
     CodeHeader: ComponentType<CodeHeaderProps>;
     SyntaxHighlighter: ComponentType<SyntaxHighlighterProps>;
   };
-  componentsByLanguage?:
-    | Record<
-        string,
-        {
-          CodeHeader?: ComponentType<CodeHeaderProps>;
-          SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps>;
-        }
-      >
-    | undefined;
+  componentsByLanguage?: ComponentsByLanguage | undefined;
 };
 
 const CodeOverrideImpl: FC<CodeOverrideProps> = ({
@@ -116,16 +108,11 @@ const CodeOverrideImpl: FC<CodeOverrideProps> = ({
 // Compared structurally: the prop's documented usage is an inline object
 // literal, so a fresh-but-equal identity per render must not re-render (and
 // re-tokenize) every code block during streaming.
-type LanguageComponentEntry = {
-  CodeHeader?: ComponentType<CodeHeaderProps>;
-  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps>;
-};
-
 // Entries may be undefined at runtime (conditional map building, plain JS
 // consumers), so the comparator accepts and distinguishes them.
 export const compareComponentsByLanguage = (
-  prev: Record<string, LanguageComponentEntry | undefined> | undefined,
-  next: Record<string, LanguageComponentEntry | undefined> | undefined,
+  prev: Record<string, ComponentsByLanguage[string] | undefined> | undefined,
+  next: Record<string, ComponentsByLanguage[string] | undefined> | undefined,
 ): boolean => {
   if (prev === next) return true;
   if (!prev || !next) return false;

--- a/packages/react-markdown/src/overrides/types.ts
+++ b/packages/react-markdown/src/overrides/types.ts
@@ -1,25 +1,6 @@
-import type { Element } from "hast";
-import type { ComponentPropsWithoutRef, ComponentType } from "react";
-
-export type PreComponent = ComponentType<
-  ComponentPropsWithoutRef<"pre"> & { node?: Element | undefined }
->;
-export type CodeComponent = ComponentType<
-  ComponentPropsWithoutRef<"code"> & { node?: Element | undefined }
->;
-
-export type CodeHeaderProps = {
-  node?: Element | undefined;
-  language: string | undefined;
-  code: string;
-};
-
-export type SyntaxHighlighterProps = {
-  node?: Element | undefined;
-  components: {
-    Pre: PreComponent;
-    Code: CodeComponent;
-  };
-  language: string;
-  code: string;
-};
+export type {
+  CodeComponent,
+  CodeHeaderProps,
+  PreComponent,
+  SyntaxHighlighterProps,
+} from "../code-fence";

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -22,6 +22,7 @@ import type {
   SyntaxHighlighterProps,
   CodeHeaderProps,
 } from "../overrides/types";
+import type { ComponentsByLanguage } from "../code-fence";
 import { PreOverride } from "../overrides/PreOverride";
 import {
   DefaultPre,
@@ -56,15 +57,7 @@ export type MarkdownTextPrimitiveProps = Omit<
    * Language-specific component overrides.
    * @example { mermaid: { SyntaxHighlighter: MermaidDiagram } }
    */
-  componentsByLanguage?:
-    | Record<
-        string,
-        {
-          CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
-          SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
-        }
-      >
-    | undefined;
+  componentsByLanguage?: ComponentsByLanguage | undefined;
   /**
    * Whether to enable smooth text streaming animation.
    * When enabled, text appears with a typing effect as it streams in.

--- a/packages/react-streamdown/package.json
+++ b/packages/react-streamdown/package.json
@@ -34,6 +34,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@assistant-ui/react-markdown": "^0.14.12",
+    "@types/hast": "^3.0.5",
     "rehype-harden": "^1.1.8",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
@@ -71,7 +73,6 @@
     "@assistant-ui/x-buildutils": "workspace:*",
     "@streamdown/code": "^1.1.1",
     "@testing-library/react": "^16.3.2",
-    "@types/hast": "^3.0.5",
     "@types/react": "^19.2.18",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -8,13 +8,12 @@ import {
   memo,
   type ReactNode,
 } from "react";
+import { parseLanguageClass } from "@assistant-ui/react-markdown/code-fence";
 import type {
   CodeHeaderProps,
   ComponentsByLanguage,
   SyntaxHighlighterProps,
 } from "../types";
-
-const LANGUAGE_REGEX = /language-([^\s]+)/;
 
 type CodeProps = ComponentPropsWithoutRef<"code"> & {
   node?: Element | undefined;
@@ -86,8 +85,7 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     }
 
     // Block code - extract language and code content
-    const match = className?.match(LANGUAGE_REGEX);
-    const language = match?.[1] ?? "";
+    const language = parseLanguageClass(className);
     const code = extractCode(children);
 
     // Get language-specific or fallback components

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -1,5 +1,9 @@
 import type { SmoothOptions } from "@assistant-ui/react";
-import type { Element } from "hast";
+import type {
+  CodeHeaderProps,
+  ComponentsByLanguage,
+  SyntaxHighlighterProps,
+} from "@assistant-ui/react-markdown/code-fence";
 import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from "react";
 import type { Options as RemarkRehypeOptions } from "remark-rehype";
 import type {
@@ -93,44 +97,7 @@ export type RemendConfig = {
   handlers?: RemendHandler[];
 };
 
-/**
- * Props for the SyntaxHighlighter component.
- * Compatible with @assistant-ui/react-markdown API.
- */
-export type SyntaxHighlighterProps = {
-  node?: Element | undefined;
-  components: {
-    Pre: ComponentType<
-      ComponentPropsWithoutRef<"pre"> & { node?: Element | undefined }
-    >;
-    Code: ComponentType<
-      ComponentPropsWithoutRef<"code"> & { node?: Element | undefined }
-    >;
-  };
-  language: string;
-  code: string;
-};
-
-/**
- * Props for the CodeHeader component.
- * Compatible with @assistant-ui/react-markdown API.
- */
-export type CodeHeaderProps = {
-  node?: Element | undefined;
-  language: string | undefined;
-  code: string;
-};
-
-/**
- * Language-specific component overrides.
- */
-export type ComponentsByLanguage = Record<
-  string,
-  {
-    CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
-    SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
-  }
->;
+export type { CodeHeaderProps, ComponentsByLanguage, SyntaxHighlighterProps };
 
 /**
  * Extended components prop that includes SyntaxHighlighter and CodeHeader.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4566,6 +4566,9 @@ importers:
       '@radix-ui/react-use-callback-ref':
         specifier: ^1.1.4
         version: 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -4579,9 +4582,6 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
-      '@types/hast':
-        specifier: ^3.0.5
-        version: 3.0.5
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -4809,6 +4809,9 @@ importers:
 
   packages/react-streamdown:
     dependencies:
+      '@assistant-ui/react-markdown':
+        specifier: ^0.14.12
+        version: link:../react-markdown
       '@streamdown/cjk':
         specifier: ^1.0.0
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(react@19.2.8)(supports-color@10.2.2)(unified@11.0.5)
@@ -4818,6 +4821,9 @@ importers:
       '@streamdown/mermaid':
         specifier: ^1.0.0
         version: 1.0.2(react@19.2.8)
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
       rehype-harden:
         specifier: ^1.1.8
         version: 1.1.8
@@ -4846,9 +4852,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@types/hast':
-        specifier: ^3.0.5
-        version: 3.0.5
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18


### PR DESCRIPTION
## summary

react-streamdown kept structurally compatible copies of react-markdown's code-fence contract, each annotated "Compatible with @assistant-ui/react-markdown API": the `CodeHeaderProps`/`SyntaxHighlighterProps` prop types (with inlined `Pre`/`Code` component shapes), the by-language override entry, and the `language-` class parser.

this single-sources the contract on a new public `@assistant-ui/react-markdown/code-fence` subpath (pure module, no `"use client"`, exports map + `typesVersions` mirroring the repo's subpath pattern): the four component/prop types, `ComponentsByLanguage`, and `parseLanguageClass`. react-markdown's `overrides/types.ts` becomes a re-export and `CodeOverride` uses the shared parser; react-streamdown gains a `@assistant-ui/react-markdown` dependency, re-exports the types (compatibility upgrades from structural convention to nominal identity), and drops its local regex.

deliberately not extracted: the `PreOverride` pair (same skeleton, genuinely divergent behavior: markdown's raw-html fallback path vs streamdown's `cloneElement` data-block marking) and the code-block assembly (markdown always renders through `DefaultCodeBlock`; streamdown conditionally assembles header + highlighter).

sharing the types across packages exposed a real published-declarations bug: both packages' d.ts referenced hast through a store-relative path (`./node_modules/.pnpm/@types_hast@3.0.5/...`) that does not exist in a consumer install, because `@types/hast` sat in devDependencies. it moves to dependencies in both packages, and the emitted declarations now reference `hast` by name.

## test plan

- react-markdown vitest: 50 passed; react-streamdown vitest: 142 passed; kit (packages/ui, a consumer of both): 374 passed
- `tsc --noEmit` error sets byte-identical to main in react-markdown, react-streamdown, and packages/ui (after building the worktree's dep closure)
- `dist/code-fence.d.ts` is self-contained: only `react` and bare `hast` imports

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.LH76J-EWuQRxxOeSewkloKlHaljGzs7bDO0z6CkYyAKSpUnuh9i4s1kU7Ao?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->