### PR TITLE
fix(core): publish transport callbacks before layout effects

### DIFF
--- a/.changeset/steady-callback-publication.md
+++ b/.changeset/steady-callback-publication.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: publish assistant transport callbacks before descendant layout effects

--- a/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
@@ -4,7 +4,6 @@ import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { createElement, StrictMode, useLayoutEffect, useRef } from "react";
 import { useCommandQueue } from "./commandQueue";
-import { useLatestRef } from "./useLatestRef";
 import { useRunManager } from "./runManager";
 import type { AssistantTransportCommand } from "./types";
 
@@ -86,36 +85,50 @@ const useTransportSchedulingHarness = (
 };
 
 describe("assistant transport scheduling contracts", () => {
-  it("publishes current callbacks before descendant layout effects", () => {
-    const callbackA = vi.fn();
-    const callbackB = vi.fn();
-    const seen: unknown[] = [];
+  it("uses current callbacks when scheduled by a descendant layout effect", async () => {
+    const onRunA = vi.fn(async () => {});
+    const onRunB = vi.fn(async () => {});
+    const queueMicrotaskSpy = vi
+      .spyOn(globalThis, "queueMicrotask")
+      .mockImplementation((callback) => callback());
 
-    const Reader = ({
-      read,
-      callbackRef,
+    const Scheduler = ({
+      schedule,
+      enabled,
     }: {
-      read: boolean;
-      callbackRef: { current: unknown };
+      schedule: () => void;
+      enabled: boolean;
     }) => {
       useLayoutEffect(() => {
-        if (read) seen.push(callbackRef.current);
-      }, [read, callbackRef]);
+        if (enabled) schedule();
+      }, [enabled, schedule]);
       return null;
     };
-    const Probe = ({ read, callback }: { read: boolean; callback: unknown }) =>
-      createElement(Reader, {
-        read,
-        callbackRef: useLatestRef(callback),
+    const Probe = ({
+      enabled,
+      onRun,
+    }: {
+      enabled: boolean;
+      onRun: (signal: AbortSignal) => Promise<void>;
+    }) => {
+      const runManager = useRunManager({ onRun });
+      return createElement(Scheduler, {
+        enabled,
+        schedule: runManager.schedule,
       });
+    };
 
-    const view = render(
-      createElement(Probe, { read: false, callback: callbackA }),
-    );
-    view.rerender(createElement(Probe, { read: true, callback: callbackB }));
+    try {
+      const view = render(
+        createElement(Probe, { enabled: false, onRun: onRunA }),
+      );
+      view.rerender(createElement(Probe, { enabled: true, onRun: onRunB }));
 
-    expect(seen).toHaveLength(1);
-    expect(seen[0]).toBe(callbackB);
+      await waitFor(() => expect(onRunB).toHaveBeenCalledTimes(1));
+      expect(onRunA).not.toHaveBeenCalled();
+    } finally {
+      queueMicrotaskSpy.mockRestore();
+    }
   });
 
   it("runs in single-flight mode and schedules exactly one follow-up run", async () => {

--- a/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { createElement, StrictMode, useRef } from "react";
+import { createElement, StrictMode, useLayoutEffect, useRef } from "react";
 import { useCommandQueue } from "./commandQueue";
+import { useLatestRef } from "./useLatestRef";
 import { useRunManager } from "./runManager";
 import type { AssistantTransportCommand } from "./types";
 
@@ -85,6 +86,38 @@ const useTransportSchedulingHarness = (
 };
 
 describe("assistant transport scheduling contracts", () => {
+  it("publishes current callbacks before descendant layout effects", () => {
+    const callbackA = vi.fn();
+    const callbackB = vi.fn();
+    const seen: unknown[] = [];
+
+    const Reader = ({
+      read,
+      callbackRef,
+    }: {
+      read: boolean;
+      callbackRef: { current: unknown };
+    }) => {
+      useLayoutEffect(() => {
+        if (read) seen.push(callbackRef.current);
+      }, [read, callbackRef]);
+      return null;
+    };
+    const Probe = ({ read, callback }: { read: boolean; callback: unknown }) =>
+      createElement(Reader, {
+        read,
+        callbackRef: useLatestRef(callback),
+      });
+
+    const view = render(
+      createElement(Probe, { read: false, callback: callbackA }),
+    );
+    view.rerender(createElement(Probe, { read: true, callback: callbackB }));
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(callbackB);
+  });
+
   it("runs in single-flight mode and schedules exactly one follow-up run", async () => {
     const gate = createDeferred();
     const { result } = renderHook(() =>

--- a/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
@@ -85,9 +85,11 @@ const useTransportSchedulingHarness = (
 };
 
 describe("assistant transport scheduling contracts", () => {
-  it("uses current callbacks when scheduled by a descendant layout effect", async () => {
+  it("uses current callbacks when scheduled by a descendant layout effect", () => {
     const onRunA = vi.fn(async () => {});
     const onRunB = vi.fn(async () => {});
+    // act flushes passive effects before real microtasks, so preserve the
+    // browser's microtask-before-passive-effect ordering at the layout boundary.
     const queueMicrotaskSpy = vi
       .spyOn(globalThis, "queueMicrotask")
       .mockImplementation((callback) => callback());
@@ -124,7 +126,7 @@ describe("assistant transport scheduling contracts", () => {
       );
       view.rerender(createElement(Probe, { enabled: true, onRun: onRunB }));
 
-      await waitFor(() => expect(onRunB).toHaveBeenCalledTimes(1));
+      expect(onRunB).toHaveBeenCalledTimes(1);
       expect(onRunA).not.toHaveBeenCalled();
     } finally {
       queueMicrotaskSpy.mockRestore();

--- a/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/transport-scheduling.test.ts
@@ -85,7 +85,7 @@ const useTransportSchedulingHarness = (
 };
 
 describe("assistant transport scheduling contracts", () => {
-  it("uses current callbacks when scheduled by a descendant layout effect", () => {
+  it("uses current callbacks when scheduled by a descendant layout effect", async () => {
     const onRunA = vi.fn(async () => {});
     const onRunB = vi.fn(async () => {});
     // act flushes passive effects before real microtasks, so preserve the
@@ -125,6 +125,7 @@ describe("assistant transport scheduling contracts", () => {
         createElement(Probe, { enabled: false, onRun: onRunA }),
       );
       view.rerender(createElement(Probe, { enabled: true, onRun: onRunB }));
+      await act(async () => {});
 
       expect(onRunB).toHaveBeenCalledTimes(1);
       expect(onRunA).not.toHaveBeenCalled();

--- a/packages/core/src/react/runtimes/assistant-transport/useLatestRef.ts
+++ b/packages/core/src/react/runtimes/assistant-transport/useLatestRef.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useInsertionEffect, useRef } from "react";
 
 export function useLatestRef<T>(value: T) {
   const ref = useRef(value);
-  useEffect(() => {
+  useInsertionEffect(() => {
     ref.current = value;
   }, [value]);
   return ref as { current: T };


### PR DESCRIPTION
Closes #6421

## Summary

- publish assistant-transport callback refs during the insertion phase
- prevent descendant layout effects from observing callbacks from the previous render
- add a focused timing regression and a patch changeset

## Why

`useLatestRef()` updated its ref from a passive effect. After React committed a render with callback B, a descendant layout effect could schedule transport work before that passive effect ran and still invoke callback A. The assistant-transport run manager uses this helper for `onRun`, `onFinish`, `onCancel`, and `onError`, so the stale callback could belong to a previous configuration or scope.

Publishing the ref from `useInsertionEffect` closes that same-commit window without mutating shared state during render.

## Verification

- reproduced on current main: after rerendering from callback A to callback B, a descendant layout effect observed callback A
- `pnpm --filter @assistant-ui/core test`
- `pnpm lint`
- `pnpm turbo build --filter=@assistant-ui/core...`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uLKNxFS01t6HALXxl122VB0SC7PPDtH1JS3kxIN7TtGCZI0jMMT1RllZXgU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->