### PR TITLE
fix(core): default assistant frames to same-origin

### DIFF
--- a/.changeset/friendly-frames-rest.md
+++ b/.changeset/friendly-frames-rest.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: default assistant frame messaging to the current origin

--- a/apps/docs/content/docs/(reference)/api-reference/transport/frame.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/transport/frame.mdx
@@ -51,7 +51,7 @@ function MyComponent() {
 
   useAssistantFrameHost({
     iframeRef,
-    targetOrigin: "https://trusted-domain.com", // optional
+    targetOrigin: "https://trusted-domain.com",
   });
 
   return <iframe ref={iframeRef} src="..." />;

--- a/apps/docs/content/docs/copilots/assistant-frame.mdx
+++ b/apps/docs/content/docs/copilots/assistant-frame.mdx
@@ -29,7 +29,10 @@ import { z } from "zod";
 const registry = new ModelContextRegistry();
 
 // Expose the registry to the parent window
-AssistantFrameProvider.addModelContextProvider(registry);
+AssistantFrameProvider.addModelContextProvider(
+  registry,
+  "https://parent-app.com",
+);
 
 // Add tools that will be available to the parent assistant
 registry.addTool({
@@ -70,7 +73,7 @@ function ParentComponent() {
   // Connect to the iframe's model context
   useAssistantFrameHost({
     iframeRef,
-    targetOrigin: "https://trusted-iframe-domain.com", // optional for increased security
+    targetOrigin: "https://trusted-iframe-domain.com",
   });
 
   return (
@@ -160,9 +163,15 @@ analyticsRegistry.addTool({
 
 // Register both providers
 const unsubscribe1 =
-  AssistantFrameProvider.addModelContextProvider(catalogRegistry);
+  AssistantFrameProvider.addModelContextProvider(
+    catalogRegistry,
+    "https://parent-app.com",
+  );
 const unsubscribe2 =
-  AssistantFrameProvider.addModelContextProvider(analyticsRegistry);
+  AssistantFrameProvider.addModelContextProvider(
+    analyticsRegistry,
+    "https://parent-app.com",
+  );
 
 // Later, unsubscribe if needed
 unsubscribe1();
@@ -173,7 +182,7 @@ unsubscribe2();
 
 #### Origin Validation
 
-Both the provider and host can specify allowed origins for security:
+Both the provider and host validate message origins. They default to the current page's origin, so cross-origin frames must specify the exact trusted origin on both sides:
 
 ```tsx
 // In iframe - only accept messages from specific parent
@@ -222,11 +231,11 @@ Registers a model context provider to share with parent windows.
 ```tsx
 const unsubscribe = AssistantFrameProvider.addModelContextProvider(
   registry,
-  "https://parent-domain.com", // Optional origin restriction
+  "https://parent-domain.com",
 );
 ```
 
-All providers in a frame share one origin policy. Registering an explicit origin tightens an existing wildcard policy, while registering two different explicit origins throws an error. Unsubscribing drops that registration's requirement. When no explicit origin remains, the policy returns to `*`.
+When `targetOrigin` is omitted, the provider only communicates with `window.location.origin`. All providers in a frame share one origin policy. Registering an explicit origin tightens an existing wildcard policy, while registering two different explicit origins throws an error. Unsubscribing drops that registration's requirement. The wildcard value `*` is available as an explicit opt-in, but it should not be used for contexts that expose tools or sensitive instructions.
 
 ##### `dispose()`
 
@@ -245,7 +254,7 @@ Class that connects to an iframe's model context providers.
 ```tsx
 const host = new AssistantFrameHost(
   iframeWindow,
-  targetOrigin? // Optional origin restriction
+  targetOrigin?, // Defaults to window.location.origin
 );
 ```
 
@@ -285,7 +294,7 @@ React hook that manages the lifecycle of an AssistantFrameHost.
 ```tsx
 useAssistantFrameHost({
   iframeRef: RefObject<HTMLIFrameElement>,
-  targetOrigin?: string,
+  targetOrigin?: string, // Defaults to window.location.origin
 });
 ```
 

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -8,7 +8,9 @@ const executionContext = {
   human: async () => undefined,
 };
 
-const createHost = () => {
+const DEFAULT_ORIGIN = "https://host.example";
+
+const createHost = (targetOrigin?: string) => {
   let handleMessage: ((event: MessageEvent) => void) | undefined;
   const addEventListener = vi.fn(
     (_type: string, listener: EventListenerOrEventListenerObject) => {
@@ -16,15 +18,23 @@ const createHost = () => {
     },
   );
   const removeEventListener = vi.fn();
-  vi.stubGlobal("window", { addEventListener, removeEventListener });
+  vi.stubGlobal("window", {
+    addEventListener,
+    removeEventListener,
+    location: { origin: DEFAULT_ORIGIN },
+  });
 
   const postMessage = vi.fn();
   const iframeWindow = { postMessage } as unknown as Window;
-  const host = new AssistantFrameHost(iframeWindow);
+  const host = new AssistantFrameHost(iframeWindow, targetOrigin);
 
-  const dispatchMessage = (message: FrameMessage) =>
+  const dispatchMessage = (
+    message: FrameMessage,
+    origin = targetOrigin ?? DEFAULT_ORIGIN,
+  ) =>
     handleMessage?.({
       source: iframeWindow,
+      origin,
       data: {
         channel: FRAME_MESSAGE_CHANNEL,
         message,
@@ -67,6 +77,45 @@ afterEach(() => {
 });
 
 describe("AssistantFrameHost", () => {
+  it("defaults to the current origin", () => {
+    const { host, postMessage } = createHost();
+
+    expect(postMessage).toHaveBeenCalledWith(expect.anything(), DEFAULT_ORIGIN);
+
+    host.dispose();
+  });
+
+  it("ignores context updates from another origin", () => {
+    const { dispatchMessage, host } = createHost();
+
+    dispatchMessage(
+      {
+        type: "model-context-update",
+        context: { system: "untrusted instructions" },
+      },
+      "https://untrusted.example",
+    );
+
+    expect(host.getModelContext().system).toBeUndefined();
+    host.dispose();
+  });
+
+  it("allows an explicit wildcard origin", () => {
+    const { dispatchMessage, host, postMessage } = createHost("*");
+
+    dispatchMessage(
+      {
+        type: "model-context-update",
+        context: { system: "cross-origin instructions" },
+      },
+      "https://iframe.example",
+    );
+
+    expect(postMessage).toHaveBeenCalledWith(expect.anything(), "*");
+    expect(host.getModelContext().system).toBe("cross-origin instructions");
+    host.dispose();
+  });
+
   it("resolves tool calls from frame results", async () => {
     const { dispatchMessage, execute, getToolCallId, host } = createHost();
     const result = Promise.resolve(
@@ -134,7 +183,7 @@ describe("AssistantFrameHost", () => {
         channel: FRAME_MESSAGE_CHANNEL,
         message: { type: "tool-cancel", id: toolCallId },
       },
-      "*",
+      DEFAULT_ORIGIN,
     );
     expect(vi.getTimerCount()).toBe(0);
   });
@@ -166,7 +215,7 @@ describe("AssistantFrameHost", () => {
         channel: FRAME_MESSAGE_CHANNEL,
         message: { type: "tool-cancel", id: toolCallId },
       },
-      "*",
+      DEFAULT_ORIGIN,
     );
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();
@@ -188,7 +237,7 @@ describe("AssistantFrameHost", () => {
         channel: FRAME_MESSAGE_CHANNEL,
         message: { type: "tool-cancel", id: toolCallId },
       },
-      "*",
+      DEFAULT_ORIGIN,
     );
     expect(vi.getTimerCount()).toBe(0);
     host.dispose();

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -10,6 +10,8 @@ import {
   type SerializedTool,
 } from "./types";
 
+const getDefaultTargetOrigin = () => window.location.origin;
+
 /**
  * Deserializes tools from JSON Schema format back to Tool objects
  */
@@ -63,7 +65,10 @@ export class AssistantFrameHost implements ModelContextProvider {
   private _targetOrigin: string;
   private _disposed = false;
 
-  constructor(iframeWindow: Window, targetOrigin: string = "*") {
+  constructor(
+    iframeWindow: Window,
+    targetOrigin: string = getDefaultTargetOrigin(),
+  ) {
     this._iframeWindow = iframeWindow;
     this._targetOrigin = targetOrigin;
 

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -99,6 +99,26 @@ describe("AssistantFrameProvider", () => {
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
   });
 
+  it("defaults to the current origin", async () => {
+    const execute = vi.fn(async () => "result");
+    AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute } },
+      }),
+    });
+
+    expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      window.location.origin,
+    );
+
+    dispatchToolCall("https://untrusted.example");
+    expect(execute).not.toHaveBeenCalled();
+
+    dispatchToolCall(window.location.origin);
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+  });
+
   it("reports a failure even when the thrown error has an empty message", async () => {
     const execute = vi.fn(async () => {
       throw new Error();
@@ -111,7 +131,7 @@ describe("AssistantFrameProvider", () => {
       }),
     });
 
-    dispatchToolCall("https://parent.example");
+    dispatchToolCall(window.location.origin);
 
     await vi.waitFor(() => {
       const frame = (
@@ -145,10 +165,10 @@ describe("AssistantFrameProvider", () => {
       }),
     });
 
-    dispatchToolCall("*");
+    dispatchToolCall(window.location.origin);
     await vi.waitFor(() => expect(toolSignal).toBeDefined());
 
-    dispatchToolCancel("*");
+    dispatchToolCancel(window.location.origin);
 
     expect(toolSignal?.aborted).toBe(true);
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -181,11 +201,11 @@ describe("AssistantFrameProvider", () => {
       getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
     });
 
-    dispatchToolCall("*", parentWindow, "tool-a");
-    dispatchToolCall("*", parentWindow, "tool-b");
+    dispatchToolCall(window.location.origin, parentWindow, "tool-a");
+    dispatchToolCall(window.location.origin, parentWindow, "tool-b");
     await vi.waitFor(() => expect(signals.size).toBe(2));
 
-    dispatchToolCancel("*", parentWindow, "tool-a");
+    dispatchToolCancel(window.location.origin, parentWindow, "tool-a");
 
     expect(signals.get("tool-a")?.aborted).toBe(true);
     expect(signals.get("tool-b")?.aborted).toBe(false);
@@ -209,9 +229,9 @@ describe("AssistantFrameProvider", () => {
       getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
     });
 
-    dispatchToolCall("*", parentWindow, "duplicate");
+    dispatchToolCall(window.location.origin, parentWindow, "duplicate");
     await vi.waitFor(() => expect(signals).toHaveLength(1));
-    dispatchToolCall("*", parentWindow, "duplicate");
+    dispatchToolCall(window.location.origin, parentWindow, "duplicate");
     await vi.waitFor(() => expect(signals).toHaveLength(2));
 
     expect(signals[0]?.aborted).toBe(true);
@@ -236,7 +256,7 @@ describe("AssistantFrameProvider", () => {
       getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
     });
 
-    dispatchToolCall("*");
+    dispatchToolCall(window.location.origin);
     await vi.waitFor(() => expect(toolSignal).toBeDefined());
 
     AssistantFrameProvider.dispose();
@@ -251,7 +271,7 @@ describe("AssistantFrameProvider", () => {
           error: "AssistantFrameProvider has been disposed",
         },
       },
-      { targetOrigin: "*" },
+      { targetOrigin: window.location.origin },
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
     const toolResults = vi
@@ -418,7 +438,7 @@ describe("AssistantFrameProvider", () => {
           },
         },
       },
-      "*",
+      window.location.origin,
     );
   });
 
@@ -516,7 +536,7 @@ describe("AssistantFrameProvider", () => {
     expect(window.addEventListener).toHaveBeenCalledTimes(2);
   });
 
-  it("resets the origin policy after every provider unsubscribes", () => {
+  it("returns to the same-origin policy after every provider unsubscribes", () => {
     const unsubscribe = AssistantFrameProvider.addModelContextProvider(
       { getModelContext: () => ({}) },
       "https://first.example",
@@ -526,7 +546,7 @@ describe("AssistantFrameProvider", () => {
 
     expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
       expect.anything(),
-      "*",
+      window.location.origin,
     );
 
     expect(() =>
@@ -564,7 +584,7 @@ describe("AssistantFrameProvider", () => {
 
     expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
       expect.anything(),
-      "*",
+      window.location.origin,
     );
   });
 
@@ -579,6 +599,37 @@ describe("AssistantFrameProvider", () => {
     );
 
     unsubscribeStrict();
+
+    expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "*",
+    );
+  });
+
+  it("returns to the same-origin policy after a wildcard provider unsubscribes", () => {
+    const unsubscribe = AssistantFrameProvider.addModelContextProvider(
+      { getModelContext: () => ({}) },
+      "*",
+    );
+
+    unsubscribe();
+
+    expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      window.location.origin,
+    );
+  });
+
+  it("allows opting back into a wildcard policy after every provider unsubscribes", () => {
+    const unsubscribe = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({}),
+    });
+    unsubscribe();
+
+    AssistantFrameProvider.addModelContextProvider(
+      { getModelContext: () => ({}) },
+      "*",
+    );
 
     expect(parentWindow.postMessage).toHaveBeenLastCalledWith(
       expect.anything(),

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -29,6 +29,8 @@ const serializeModelContext = (
   }),
 });
 
+const getDefaultTargetOrigin = () => window.location.origin;
+
 export class AssistantFrameProvider {
   private static _instance: AssistantFrameProvider | null = null;
 
@@ -40,8 +42,9 @@ export class AssistantFrameProvider {
   >();
   private _targetOrigin: string;
   private _strictRegistrations = 0;
+  private _wildcardRegistrations = 0;
 
-  private constructor(targetOrigin: string = "*") {
+  private constructor(targetOrigin: string = getDefaultTargetOrigin()) {
     this._targetOrigin = targetOrigin;
     this.handleMessage = this.handleMessage.bind(this);
     window.addEventListener("message", this.handleMessage);
@@ -60,8 +63,17 @@ export class AssistantFrameProvider {
     return AssistantFrameProvider._instance;
   }
 
-  private reconcileTargetOrigin(targetOrigin: string = "*") {
-    if (targetOrigin === "*" || targetOrigin === this._targetOrigin) return;
+  private reconcileTargetOrigin(
+    targetOrigin: string = getDefaultTargetOrigin(),
+  ) {
+    if (targetOrigin === this._targetOrigin) return;
+
+    if (this._providers.size === 0) {
+      this._targetOrigin = targetOrigin;
+      return;
+    }
+
+    if (targetOrigin === "*") return;
 
     if (this._targetOrigin === "*") {
       this._targetOrigin = targetOrigin;
@@ -192,9 +204,20 @@ export class AssistantFrameProvider {
     this._providers.delete(id);
     const unsubscribe = this._providerUnsubscribes.get(id);
     this._providerUnsubscribes.delete(id);
-    if (origin !== "*") {
+    if (origin === "*") {
+      this._wildcardRegistrations -= 1;
+      if (
+        this._wildcardRegistrations === 0 &&
+        this._strictRegistrations === 0
+      ) {
+        this._targetOrigin = getDefaultTargetOrigin();
+      }
+    } else {
       this._strictRegistrations -= 1;
-      if (this._strictRegistrations === 0) this._targetOrigin = "*";
+      if (this._strictRegistrations === 0) {
+        this._targetOrigin =
+          this._wildcardRegistrations > 0 ? "*" : getDefaultTargetOrigin();
+      }
     }
     return unsubscribe;
   }
@@ -203,11 +226,15 @@ export class AssistantFrameProvider {
     provider: ModelContextProvider,
     targetOrigin?: string,
   ): Unsubscribe {
-    const origin = targetOrigin ?? "*";
+    const origin = targetOrigin ?? getDefaultTargetOrigin();
     const instance = AssistantFrameProvider.getInstance(origin);
     const id = Symbol();
     instance._providers.set(id, provider);
-    if (origin !== "*") instance._strictRegistrations += 1;
+    if (origin === "*") {
+      instance._wildcardRegistrations += 1;
+    } else {
+      instance._strictRegistrations += 1;
+    }
 
     try {
       const unsubscribe = provider.subscribe?.(() =>

--- a/packages/react/src/model-context/frame/AssistantFrame.test.ts
+++ b/packages/react/src/model-context/frame/AssistantFrame.test.ts
@@ -27,7 +27,7 @@ describe("AssistantFrame Integration", () => {
             parentHandler({
               data,
               source: iframeWindow,
-              origin: "*",
+              origin: window.location.origin,
             } as MessageEvent);
           });
         }
@@ -44,7 +44,7 @@ describe("AssistantFrame Integration", () => {
             iframeHandler({
               data,
               source: parentWindow, // parent window is the source for subscription
-              origin: "*",
+              origin: window.location.origin,
             } as MessageEvent);
           });
         }
@@ -104,7 +104,7 @@ describe("AssistantFrame Integration", () => {
             type: "model-context-request",
           }),
         }),
-        "*",
+        window.location.origin,
       );
     });
 

--- a/packages/react/src/model-context/frame/SPEC_AssistantFrame.md
+++ b/packages/react/src/model-context/frame/SPEC_AssistantFrame.md
@@ -88,7 +88,7 @@ All messages are wrapped with a channel identifier to avoid conflicts with other
 
 #### Security Considerations
 
-1. **Origin Validation**: Both sides can specify `targetOrigin` to restrict message sources; providers share a fail-closed origin policy
+1. **Origin Validation**: Both sides default to the current page's origin and can specify an exact `targetOrigin` for cross-origin frames; providers share a fail-closed origin policy
 2. **Window Reference**: Host (parent) only accepts messages from the specific iframe window it's connected to
 3. **Message Channel**: Using a unique channel identifier prevents cross-talk with other postMessage users
 

--- a/packages/react/src/model-context/frame/useAssistantFrameHost.ts
+++ b/packages/react/src/model-context/frame/useAssistantFrameHost.ts
@@ -20,7 +20,7 @@ type UseAssistantFrameHostOptions = {
  *
  *   useAssistantFrameHost({
  *     iframeRef,
- *     targetOrigin: "https://trusted-domain.com", // optional
+ *     targetOrigin: "https://trusted-domain.com",
  *   });
  *
  *   return <iframe ref={iframeRef} src="..." />;
@@ -29,7 +29,7 @@ type UseAssistantFrameHostOptions = {
  */
 export const useAssistantFrameHost = ({
   iframeRef,
-  targetOrigin = "*",
+  targetOrigin,
   register,
 }: UseAssistantFrameHostOptions): void => {
   useEffect(() => {


### PR DESCRIPTION
## Summary

- default AssistantFrame host and provider messaging to the current page origin
- keep exact cross-origin targets and explicit wildcard opt-in available
- preserve the origin policy across failed, duplicate, and removed provider registrations
- update the frame documentation and add a patch changeset

## Why

Omitting `targetOrigin` previously selected `*`. A frame that exposed tools or instructions could therefore accept messages from an unintended origin unless both sides were configured perfectly.

## Testing

- core frame tests: 36 passed
- React frame integration tests: 8 passed with no type errors

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rC-Ap_yBNUVYayKA5HVohLQm98AUicTRK_IcqabqBiTbFHJD1JALhZ0FBpU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->