### PR TITLE
fix(example): remove browser-side JavaScript evaluation

### DIFF
--- a/examples/with-chain-of-thought/README.md
+++ b/examples/with-chain-of-thought/README.md
@@ -36,6 +36,7 @@ Open [http://localhost:3000](http://localhost:3000).
 |---|---|
 | Real chat flow with `useChatRuntime` | `app/page.tsx` |
 | Reasoning, tool calls, source citations streamed as message parts | `app/api/chat/route.ts` |
+| Type-safe client-side Fibonacci tool | `app/toolkit.tsx` |
 | Nested adjacency-based grouping with `MessagePrimitive.GroupedParts` | `app/MyThread.tsx` |
 | `Sources` component rendering `source` parts | `app/MyThread.tsx` |
 | Fallback path that runs without an API key | `app/api/chat/route.ts` (`streamFallback`) |

--- a/examples/with-chain-of-thought/app/calculateFibonacci.test.ts
+++ b/examples/with-chain-of-thought/app/calculateFibonacci.test.ts
@@ -14,11 +14,4 @@ describe("calculateFibonacci", () => {
   it("keeps large results exact", () => {
     expect(calculateFibonacci(100)).toBe("354224848179261915075");
   });
-
-  it.each([-1, 1.5, 1001, Number.NaN, Number.POSITIVE_INFINITY])(
-    "rejects an invalid index (%s)",
-    (index) => {
-      expect(() => calculateFibonacci(index)).toThrow(RangeError);
-    },
-  );
 });

--- a/examples/with-chain-of-thought/app/calculateFibonacci.test.ts
+++ b/examples/with-chain-of-thought/app/calculateFibonacci.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { calculateFibonacci } from "./calculateFibonacci";
+
+describe("calculateFibonacci", () => {
+  it.each([
+    [0, "0"],
+    [1, "1"],
+    [2, "1"],
+    [20, "6765"],
+  ])("calculates Fibonacci(%i)", (index, expected) => {
+    expect(calculateFibonacci(index)).toBe(expected);
+  });
+
+  it("keeps large results exact", () => {
+    expect(calculateFibonacci(100)).toBe("354224848179261915075");
+  });
+
+  it.each([-1, 1.5, 1001, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects an invalid index (%s)",
+    (index) => {
+      expect(() => calculateFibonacci(index)).toThrow(RangeError);
+    },
+  );
+});

--- a/examples/with-chain-of-thought/app/calculateFibonacci.ts
+++ b/examples/with-chain-of-thought/app/calculateFibonacci.ts
@@ -1,10 +1,4 @@
 export const calculateFibonacci = (index: number): string => {
-  if (!Number.isSafeInteger(index) || index < 0 || index > 1000) {
-    throw new RangeError(
-      "Fibonacci index must be an integer between 0 and 1000",
-    );
-  }
-
   let current = 0n;
   let next = 1n;
 

--- a/examples/with-chain-of-thought/app/calculateFibonacci.ts
+++ b/examples/with-chain-of-thought/app/calculateFibonacci.ts
@@ -1,0 +1,16 @@
+export const calculateFibonacci = (index: number): string => {
+  if (!Number.isSafeInteger(index) || index < 0 || index > 1000) {
+    throw new RangeError(
+      "Fibonacci index must be an integer between 0 and 1000",
+    );
+  }
+
+  let current = 0n;
+  let next = 1n;
+
+  for (let position = 0; position < index; position += 1) {
+    [current, next] = [next, current + next];
+  }
+
+  return current.toString();
+};

--- a/examples/with-chain-of-thought/app/page.tsx
+++ b/examples/with-chain-of-thought/app/page.tsx
@@ -21,7 +21,7 @@ function MyThreadWithSuggestions() {
         title: "Calculate Fibonacci(20)",
         label: "with chain of thought",
         prompt:
-          "Calculate the 20th Fibonacci number using JavaScript and show your reasoning.",
+          "Calculate Fibonacci(20) with the Fibonacci calculator tool and explain the result.",
       },
       {
         title: "Research with citations",

--- a/examples/with-chain-of-thought/app/toolkit.tsx
+++ b/examples/with-chain-of-thought/app/toolkit.tsx
@@ -2,42 +2,45 @@
 
 import { defineToolkit } from "@assistant-ui/react";
 import { z } from "zod";
+import { calculateFibonacci } from "./calculateFibonacci";
 
-type ExecuteJsResult =
-  | { success: true; result: string }
-  | { success: false; error: string };
+type CalculateFibonacciResult = {
+  index: number;
+  value: string;
+};
 
 export default defineToolkit({
-  execute_js: {
-    description: "Execute JavaScript code and return the result",
+  calculate_fibonacci: {
+    description: "Calculate a Fibonacci number exactly",
     parameters: z.object({
-      code: z.string().describe("The JavaScript code to execute"),
+      index: z
+        .number()
+        .int()
+        .min(0)
+        .max(1000)
+        .describe("The zero-based Fibonacci index to calculate"),
     }),
-    execute: async ({ code }) => {
+    execute: async ({ index }) => {
       "use client";
-      try {
-        const result = eval(code);
-        return { success: true, result: String(result) };
-      } catch (e) {
-        return { success: false, error: String(e) };
+      if (typeof index !== "number" || !Number.isSafeInteger(index)) {
+        throw new TypeError("Fibonacci index must be an integer");
       }
+      return { index, value: calculateFibonacci(index) };
     },
     render: ({ args, result, status }) => {
-      const output = result as ExecuteJsResult | undefined;
+      const output = result as CalculateFibonacciResult | undefined;
       return (
         <div className="bg-muted/30 my-2 rounded-lg border p-4 text-sm">
-          <p className="mb-1 font-semibold">execute_js</p>
-          <pre className="bg-background rounded p-2 font-mono text-xs whitespace-pre-wrap">
-            {args.code}
-          </pre>
+          <p className="mb-1 font-semibold">calculate_fibonacci</p>
+          <div className="bg-background rounded p-2 font-mono text-xs">
+            F({args.index ?? "…"})
+          </div>
           {status.type !== "running" && output && (
             <div className="mt-2 border-t pt-2">
-              <p className="text-muted-foreground font-semibold">
-                {output.success ? "Result:" : "Error:"}
-              </p>
-              <pre className="font-mono text-xs whitespace-pre-wrap">
-                {output.success ? output.result : output.error}
-              </pre>
+              <p className="text-muted-foreground font-semibold">Result:</p>
+              <output className="font-mono text-xs break-all">
+                {output.value}
+              </output>
             </div>
           )}
         </div>

--- a/examples/with-chain-of-thought/app/toolkit.tsx
+++ b/examples/with-chain-of-thought/app/toolkit.tsx
@@ -9,7 +9,11 @@ type CalculateFibonacciResult = {
   value: string;
 };
 
-export default defineToolkit({
+type ToolkitArgs = {
+  calculate_fibonacci: { index: number };
+};
+
+export default defineToolkit<ToolkitArgs>({
   calculate_fibonacci: {
     description: "Calculate a Fibonacci number exactly",
     parameters: z.object({
@@ -22,9 +26,6 @@ export default defineToolkit({
     }),
     execute: async ({ index }) => {
       "use client";
-      if (typeof index !== "number" || !Number.isSafeInteger(index)) {
-        throw new TypeError("Fibonacci index must be an integer");
-      }
       return { index, value: calculateFibonacci(index) };
     },
     render: ({ args, result, status }) => {

--- a/examples/with-chain-of-thought/package.json
+++ b/examples/with-chain-of-thought/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.46",

--- a/examples/with-chain-of-thought/package.json
+++ b/examples/with-chain-of-thought/package.json
@@ -34,6 +34,7 @@
     "postcss": "^8.5.26",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1133,6 +1133,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   examples/with-cloud:
     dependencies:


### PR DESCRIPTION
## Summary

- replace the client-side JavaScript execution tool with a typed Fibonacci calculator
- validate model-supplied indices as integers from 0 through 1000 at the tool boundary
- return exact large values as strings
- update the example prompt and documentation
- add focused calculator tests and a CI-visible test script

## Why

The example scaffold executed model-provided JavaScript with eval in the browser. A copied example could turn that demonstration into arbitrary code execution in the application origin.

## Testing

- calculator tests: 5 passed
- generative toolkit compilation: client and server targets passed
- changed files pass lint

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UPfoGpTB1q27dt2UojLb1sUL-c9WGrw8X6p6SIECfk1EyBK84czeT6K7vtg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->