### PR TITLE
fix(with-react-hook-form): declare the deps shadcn's form component installs

### DIFF
--- a/examples/with-react-hook-form/package.json
+++ b/examples/with-react-hook-form/package.json
@@ -15,6 +15,7 @@
     "@assistant-ui/react-hook-form": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",
     "@assistant-ui/ui": "workspace:*",
+    "@hookform/resolvers": "^5.9.1",
     "ai": "^7.0.77",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -23,7 +24,8 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-hook-form": "^7.86.0",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@assistant-ui/next": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2841,6 +2841,9 @@ importers:
       '@assistant-ui/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hookform/resolvers':
+        specifier: ^5.9.1
+        version: 5.9.1(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.86.0(react@19.2.8))(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3)
       ai:
         specifier: ^7.0.77
         version: 7.0.77(zod@4.4.3)
@@ -2868,6 +2871,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@assistant-ui/next':
         specifier: workspace:*


### PR DESCRIPTION
closes #6462

## summary

- `npx assistant-ui@latest create <dir> --example with-react-hook-form --use-npm` exited 1 with `Project created with missing components`, leaving `components/ui/form.tsx` and `components/assistant-ui/thread.tsx` unwritten. it now exits 0 with every component in place.
- the cause is two npm resolution passes, not a peer range that is too strict. `create` runs `npm install` for the example's declared dependencies, which pins zod 4 through `@assistant-ui/react-hook-form`'s hard `zod@^4.4.3`. it then runs `shadcn add form ...`, which runs a second `npm install` adding `@hookform/resolvers` as a new root dependency. npm re-walks the peer graph and treats `@typeschema/zod@0.14.0`'s `peerOptional zod@^3.23.8` as fatal against the zod 4 already installed.
- resolved in one pass the same graph is fine, because an unsatisfiable optional peer is what optional means. so the example declares `@hookform/resolvers` and `zod` up front and the second pass becomes a no-op.
- the reviewable change is three lines in `examples/with-react-hook-form/package.json`; `pnpm-lock.yaml` is the generated companion (6 added lines, no version churn elsewhere).

the example already declared `react-hook-form@^7.86.0` because the shadcn `form` component needs it. that registry item declares three dependencies (`react-hook-form`, `@hookform/resolvers`, `zod`); this completes the set rather than introducing a new pattern. `apps/docs` is the in-repo precedent, carrying `@hookform/resolvers@^5.9.1` for the same reason (`content/examples/form-demo.mdx` renders the form component). both versions are copied from existing declarations rather than invented: `zod@^4.4.3` is the repo-wide range.

neither package is imported by the example, and neither is imported by our own `packages/ui/src/components/ui/radix/form.tsx`, which pulls only `react-hook-form`, `radix-ui`, and local utils. they are declared because shadcn's registry item installs them into the scaffolded project regardless, and the whole defect is that the install happened in the second pass instead of the first.

`with-react-hook-form` is the only example that can hit this. `form` is the only shadcn registry item declaring `@hookform/resolvers`, and `grep -rln "components/ui/form" examples templates` matches only this example's `app/page.tsx` and `components/SignupForm.tsx`. fourteen other examples also receive zod 4 transitively without declaring it, but none of them install resolvers, so none of them reach the conflicting walk.

## test plan

### already verified

- [x] the reported command, both sides, through the real CLI against a local source root (`create gold-app --example with-react-hook-form --use-npm --no-skills --debug-source-root <tree>`): on `main` `CREATE EXIT=1` with `shadcn exited with code 1` and no `components/ui/form.tsx`; on this branch `CREATE EXIT=0` with `form.tsx` and `assistant-ui/thread.tsx` both written.
- [x] the resolution mechanism in isolation: `npm install -- radix-ui react-resizable-panels@^4 zustand @hookform/resolvers zod tw-shimmer remark-gfm` into a tree holding zod 4 fails `ERESOLVE / Conflicting peer dependency: zod@3.25.76`; with both declared up front, the base install and that same command both exit 0.
- [x] `pnpm --filter with-react-hook-form... build` -> next build green, 4 routes.
- [x] `pnpm exec tsc --noEmit` in the example -> clean.
- [x] `pnpm --filter assistant-ui exec vitest run` -> 26 files, 296 tests passed.
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` on the example -> clean.

### reviewer should verify

- [ ] on npm 11, `npx assistant-ui@latest create <dir> --example with-react-hook-form --use-npm` against a release carrying this change exits 0 and writes `components/ui/form.tsx`.

## notes

- no changeset: `examples/with-react-hook-form` is `private: true`, and no published package changes. the fix reaches users when the next release tag is cut, since `create` fetches the example from the repo at the resolved release ref.
- #6464 proposes passing `--legacy-peer-deps` on the npx launcher instead. that mechanism does work (verified: `npx --legacy-peer-deps` exports `npm_config_legacy_peer_deps=true`, and the failing install then succeeds), but it disables npm's peer resolution for every npm scaffold to work around one example, and it is a loud failure of exactly this kind that surfaced this bug.
- the two-pass resolution in `create` stays structurally fragile: any future registry item whose dependencies collide with the first pass fails the same way. worth a separate decision about whether `create` should retry once with `--legacy-peer-deps` after a failure, which keeps the peer check on by default.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ctyZuBU7I3_a8eAlHmYQnLvTapbedfVpZCNfvq1cl3osuov8g9rJjGSY0EA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->