### PR TITLE
fix(react-mcp): serialize OAuth state persistence

### DIFF
--- a/.changeset/serialize-react-mcp-oauth-state.md
+++ b/.changeset/serialize-react-mcp-oauth-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: serialize OAuth state persistence so concurrent updates are not lost

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -1,5 +1,5 @@
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { MCPStorage } from "../resources/storage/types";
 import type { MCPPersistedAuthState } from "./types";
 import { createOAuthProvider } from "./createOAuthProvider";
@@ -83,4 +83,86 @@ describe("createOAuthProvider discovery state", () => {
       );
     },
   );
+});
+
+describe("createOAuthProvider persistence", () => {
+  it("loads persisted auth state once for concurrent reads", async () => {
+    let resolveLoad!: (value: MCPPersistedAuthState | null) => void;
+    const loadAuthState = vi.fn(
+      () =>
+        new Promise<MCPPersistedAuthState | null>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const { storage } = createStorage();
+    storage.loadAuthState = loadAuthState;
+    const provider = createProvider(storage);
+
+    const tokens = provider.tokens();
+    const clientInformation = provider.clientInformation();
+
+    expect(loadAuthState).toHaveBeenCalledTimes(1);
+    resolveLoad(null);
+    await Promise.all([tokens, clientInformation]);
+  });
+
+  it("serializes writes so newer auth state is not overwritten", async () => {
+    const { storage } = createStorage();
+    const pendingWrites: Array<() => void> = [];
+    let persisted: MCPPersistedAuthState | null = null;
+    storage.saveAuthState = async (_serverId, next) => {
+      await new Promise<void>((resolve) => pendingWrites.push(resolve));
+      persisted = next;
+    };
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+
+    const verifierSave = provider.saveCodeVerifier("pkce-verifier");
+    await Promise.resolve();
+    expect(pendingWrites).toHaveLength(1);
+
+    pendingWrites.shift()!();
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+    pendingWrites.shift()!();
+    await Promise.all([tokenSave, verifierSave]);
+
+    expect(persisted).toEqual({
+      tokens: { access_token: "access-token", token_type: "bearer" },
+      codeVerifier: "pkce-verifier",
+    });
+  });
+
+  it("continues persisting after a failed auth state write", async () => {
+    const { storage } = createStorage();
+    const failure = new Error("storage unavailable");
+    let saveCount = 0;
+    let persisted: MCPPersistedAuthState | null = null;
+    storage.saveAuthState = async (_serverId, next) => {
+      saveCount += 1;
+      if (saveCount === 1) throw failure;
+      persisted = next;
+    };
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    const verifierSave = provider.saveCodeVerifier("pkce-verifier");
+
+    await expect(tokenSave).rejects.toBe(failure);
+    await expect(verifierSave).resolves.toBeUndefined();
+    expect(saveCount).toBe(2);
+    expect(persisted).toEqual({
+      tokens: { access_token: "access-token", token_type: "bearer" },
+      codeVerifier: "pkce-verifier",
+    });
+  });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -106,6 +106,27 @@ describe("createOAuthProvider persistence", () => {
     await Promise.all([tokens, clientInformation]);
   });
 
+  it("retries loading persisted auth state after a failure", async () => {
+    const failure = new Error("storage unavailable");
+    const loadAuthState = vi
+      .fn<() => Promise<MCPPersistedAuthState | null>>()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ codeVerifier: "pkce-verifier" });
+    const { storage } = createStorage();
+    storage.loadAuthState = loadAuthState;
+    const provider = createProvider(storage);
+
+    const tokens = provider.tokens();
+    const clientInformation = provider.clientInformation();
+
+    await expect(tokens).rejects.toBe(failure);
+    await expect(clientInformation).rejects.toBe(failure);
+    expect(loadAuthState).toHaveBeenCalledTimes(1);
+
+    await expect(provider.codeVerifier()).resolves.toBe("pkce-verifier");
+    expect(loadAuthState).toHaveBeenCalledTimes(2);
+  });
+
   it("serializes writes so newer auth state is not overwritten", async () => {
     const { storage } = createStorage();
     const pendingWrites: Array<() => void> = [];

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -124,7 +124,7 @@ describe("createOAuthProvider persistence", () => {
     await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
 
     const verifierSave = provider.saveCodeVerifier("pkce-verifier");
-    await Promise.resolve();
+    for (let i = 0; i < 10; i++) await Promise.resolve();
     expect(pendingWrites).toHaveLength(1);
 
     pendingWrites.shift()!();

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -143,9 +143,14 @@ describe("createOAuthProvider persistence", () => {
     const failure = new Error("storage unavailable");
     let saveCount = 0;
     let persisted: MCPPersistedAuthState | null = null;
+    let rejectFirstSave!: (reason: unknown) => void;
     storage.saveAuthState = async (_serverId, next) => {
       saveCount += 1;
-      if (saveCount === 1) throw failure;
+      if (saveCount === 1) {
+        await new Promise<void>((_resolve, reject) => {
+          rejectFirstSave = reject;
+        });
+      }
       persisted = next;
     };
     const provider = createProvider(storage);
@@ -157,7 +162,13 @@ describe("createOAuthProvider persistence", () => {
     });
     const verifierSave = provider.saveCodeVerifier("pkce-verifier");
 
-    await expect(tokenSave).rejects.toBe(failure);
+    await vi.waitFor(() => expect(saveCount).toBe(1));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(saveCount).toBe(1);
+
+    const tokenSaveResult = expect(tokenSave).rejects.toBe(failure);
+    rejectFirstSave(failure);
+    await tokenSaveResult;
     await expect(verifierSave).resolves.toBeUndefined();
     expect(saveCount).toBe(2);
     expect(persisted).toEqual({

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -74,38 +74,55 @@ export function createOAuthProvider(
     discoveryState?: OAuthDiscoveryState | undefined;
   };
   let cached: Cache | null = null;
+  let cachePromise: Promise<Cache> | null = null;
+  let persistenceQueue = Promise.resolve();
 
-  const loadCache = async (): Promise<Cache> => {
-    if (cached) return cached;
-    const persisted = await storage.loadAuthState(serverId);
-    const initial: Cache = {};
-    if (persisted?.tokens) initial.tokens = persisted.tokens;
-    if (config.clientId) {
-      const ci: OAuthClientInformationFull = {
-        client_id: config.clientId,
-        redirect_uris: [redirectUri],
-      };
-      if (config.clientSecret) ci.client_secret = config.clientSecret;
-      initial.clientInformation = ci;
-    } else if (persisted?.clientInformation) {
-      initial.clientInformation = persisted.clientInformation;
-    }
-    if (persisted?.codeVerifier) initial.codeVerifier = persisted.codeVerifier;
-    if (persisted?.discoveryState)
-      initial.discoveryState = persisted.discoveryState;
-    cached = initial;
-    return cached;
+  const loadCache = (): Promise<Cache> => {
+    if (cached) return Promise.resolve(cached);
+    if (cachePromise) return cachePromise;
+
+    cachePromise = storage.loadAuthState(serverId).then(
+      (persisted) => {
+        const initial: Cache = {};
+        if (persisted?.tokens) initial.tokens = persisted.tokens;
+        if (config.clientId) {
+          const ci: OAuthClientInformationFull = {
+            client_id: config.clientId,
+            redirect_uris: [redirectUri],
+          };
+          if (config.clientSecret) ci.client_secret = config.clientSecret;
+          initial.clientInformation = ci;
+        } else if (persisted?.clientInformation) {
+          initial.clientInformation = persisted.clientInformation;
+        }
+        if (persisted?.codeVerifier)
+          initial.codeVerifier = persisted.codeVerifier;
+        if (persisted?.discoveryState)
+          initial.discoveryState = persisted.discoveryState;
+        cached = initial;
+        return initial;
+      },
+      (error) => {
+        cachePromise = null;
+        throw error;
+      },
+    );
+    return cachePromise;
   };
 
-  const persist = async () => {
-    const c = cached;
-    if (!c) return;
-    const next: Parameters<typeof storage.saveAuthState>[1] = {};
-    if (c.tokens) next.tokens = c.tokens;
-    if (c.clientInformation) next.clientInformation = c.clientInformation;
-    if (c.codeVerifier) next.codeVerifier = c.codeVerifier;
-    if (c.discoveryState) next.discoveryState = c.discoveryState;
-    await storage.saveAuthState(serverId, next);
+  const persist = () => {
+    const task = persistenceQueue.then(async () => {
+      const c = cached;
+      if (!c) return;
+      const next: Parameters<typeof storage.saveAuthState>[1] = {};
+      if (c.tokens) next.tokens = c.tokens;
+      if (c.clientInformation) next.clientInformation = c.clientInformation;
+      if (c.codeVerifier) next.codeVerifier = c.codeVerifier;
+      if (c.discoveryState) next.discoveryState = c.discoveryState;
+      await storage.saveAuthState(serverId, next);
+    });
+    persistenceQueue = task.catch(() => {});
+    return task;
   };
 
   const clientMetadata: OAuthClientMetadata = {


### PR DESCRIPTION
## Summary

- share one in-flight OAuth state load within a provider
- serialize persisted OAuth state writes so newer fields cannot be overwritten by an older save
- keep the write queue usable after an individual storage failure

## Why

The MCP SDK can request or update OAuth fields concurrently. Previously, concurrent first reads loaded storage independently, and saves ran without ordering. If a token save completed after a newer PKCE verifier save, the older snapshot could overwrite storage and remove the verifier, breaking the OAuth callback after redirect.

A focused reproduction against current main observed two concurrent loads and, when writes completed out of order, final persisted state with the verifier missing. The provider now single-flights initialization and executes saves in call order while preserving each caller's rejection.

## Test plan

- `pnpm exec oxlint packages/react-mcp/src/auth/createOAuthProvider.ts packages/react-mcp/src/auth/createOAuthProvider.test.ts`
- `pnpm --filter @assistant-ui/react-mcp test` (11 files, 138 tests)
- `pnpm --filter @assistant-ui/react-mcp build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EqNwr1Jz_C_UcWyM5NPF5SEN9Rx1eQSoOZdZhuJVPRTNCKdHc4gZCf_U0pc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->