### PR TITLE
feat(vue): render registered tool UIs in message parts

### DIFF
--- a/examples/with-nuxt/app/components/Assistant.client.vue
+++ b/examples/with-nuxt/app/components/Assistant.client.vue
@@ -27,7 +27,8 @@ const config = AuiConfig({
 
 <template>
   <AuiProvider :config="config">
-    <RegisterToolUIs />
-    <Thread />
+    <RegisterToolUIs>
+      <Thread />
+    </RegisterToolUIs>
   </AuiProvider>
 </template>

--- a/examples/with-nuxt/app/components/Assistant.client.vue
+++ b/examples/with-nuxt/app/components/Assistant.client.vue
@@ -7,9 +7,9 @@ const config = AuiConfig({
   threads: AISDKChat(),
   suggestions: Suggestions([
     {
-      title: "Plan a weekend trip",
-      label: "three stops, one day each",
-      prompt: "Plan a weekend trip with three stops, one day each.",
+      title: "Check the weather",
+      label: "tool UI demo",
+      prompt: "What is the weather in San Francisco right now?",
     },
     {
       title: "Explain streaming",
@@ -27,6 +27,7 @@ const config = AuiConfig({
 
 <template>
   <AuiProvider :config="config">
+    <RegisterToolUIs />
     <Thread />
   </AuiProvider>
 </template>

--- a/examples/with-nuxt/app/components/RegisterToolUIs.vue
+++ b/examples/with-nuxt/app/components/RegisterToolUIs.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
+import { useAui } from "@assistant-ui/vue";
+import type {} from "@assistant-ui/core/store";
+import type { ToolCallMessagePartComponent } from "@assistant-ui/core/react";
+import WeatherToolUI from "./WeatherToolUI.vue";
+
+const aui = useAui();
+let unregister: (() => void) | undefined;
+onMounted(() => {
+  unregister = aui.tools.setToolUI(
+    "weather",
+    WeatherToolUI as unknown as ToolCallMessagePartComponent,
+  );
+});
+onUnmounted(() => unregister?.());
+</script>
+
+<template><slot /></template>

--- a/examples/with-nuxt/app/components/WeatherToolUI.vue
+++ b/examples/with-nuxt/app/components/WeatherToolUI.vue
@@ -3,16 +3,15 @@ import { computed } from "vue";
 import type { ToolUIProps } from "@assistant-ui/vue";
 
 const props = defineProps({
-  part: { type: Object, required: true },
-  addResult: { type: Function, required: true },
-  resume: { type: Function, required: true },
-  respondToApproval: { type: Function, required: true },
-}) as unknown as ToolUIProps;
+  tool: { type: Object, required: true },
+}) as unknown as { tool: ToolUIProps };
 
-const city = computed(() => (props.part.args as { city?: string }).city);
+const city = computed(() => (props.tool.part.args as { city?: string }).city);
 const result = computed(
   () =>
-    props.part.result as { temperature: number; condition: string } | undefined,
+    props.tool.part.result as
+      | { temperature: number; condition: string }
+      | undefined,
 );
 </script>
 

--- a/examples/with-nuxt/app/components/WeatherToolUI.vue
+++ b/examples/with-nuxt/app/components/WeatherToolUI.vue
@@ -1,10 +1,19 @@
 <script setup lang="ts">
-defineOptions({ inheritAttrs: false });
+import { computed } from "vue";
+import type { ToolUIProps } from "@assistant-ui/vue";
 
-defineProps<{
-  args?: { city?: string };
-  result?: { city: string; temperature: number; condition: string };
-}>();
+const props = defineProps({
+  part: { type: Object, required: true },
+  addResult: { type: Function, required: true },
+  resume: { type: Function, required: true },
+  respondToApproval: { type: Function, required: true },
+}) as unknown as ToolUIProps;
+
+const city = computed(() => (props.part.args as { city?: string }).city);
+const result = computed(
+  () =>
+    props.part.result as { temperature: number; condition: string } | undefined,
+);
 </script>
 
 <template>
@@ -12,7 +21,7 @@ defineProps<{
     class="border-border/60 my-2 flex items-center gap-3 rounded-xl border px-4 py-3 text-sm"
   >
     <span class="text-muted-foreground">Weather</span>
-    <span class="font-medium">{{ args?.city ?? "…" }}</span>
+    <span class="font-medium">{{ city ?? "…" }}</span>
     <span v-if="result" class="ml-auto"
       >{{ result.temperature }}°C · {{ result.condition }}</span
     >

--- a/examples/with-nuxt/app/components/WeatherToolUI.vue
+++ b/examples/with-nuxt/app/components/WeatherToolUI.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, type PropType } from "vue";
 import type { ToolUIProps } from "@assistant-ui/vue";
 
 const props = defineProps({
-  tool: { type: Object, required: true },
-}) as unknown as { tool: ToolUIProps };
+  tool: { type: Object as PropType<ToolUIProps>, required: true },
+});
 
 const city = computed(() => (props.tool.part.args as { city?: string }).city);
 const result = computed(

--- a/examples/with-nuxt/app/components/WeatherToolUI.vue
+++ b/examples/with-nuxt/app/components/WeatherToolUI.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+
+defineProps<{
+  args?: { city?: string };
+  result?: { city: string; temperature: number; condition: string };
+}>();
+</script>
+
+<template>
+  <div
+    class="border-border/60 my-2 flex items-center gap-3 rounded-xl border px-4 py-3 text-sm"
+  >
+    <span class="text-muted-foreground">Weather</span>
+    <span class="font-medium">{{ args?.city ?? "…" }}</span>
+    <span v-if="result" class="ml-auto"
+      >{{ result.temperature }}°C · {{ result.condition }}</span
+    >
+    <span v-else class="text-muted-foreground ml-auto animate-pulse"
+      >running…</span
+    >
+  </div>
+</template>

--- a/examples/with-nuxt/server/api/chat.post.ts
+++ b/examples/with-nuxt/server/api/chat.post.ts
@@ -1,5 +1,12 @@
 import { openai } from "@ai-sdk/openai";
-import { convertToModelMessages, streamText, type UIMessage } from "ai";
+import {
+  convertToModelMessages,
+  jsonSchema,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+} from "ai";
 
 export default defineEventHandler(async (event) => {
   const { messages, system } = await readBody<{
@@ -11,6 +18,25 @@ export default defineEventHandler(async (event) => {
     model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
+    stopWhen: stepCountIs(3),
+    tools: {
+      weather: tool({
+        description: "Get the current weather for a city",
+        inputSchema: jsonSchema<{ city: string }>({
+          type: "object",
+          properties: {
+            city: { type: "string", description: "City name" },
+          },
+          required: ["city"],
+          additionalProperties: false,
+        }),
+        execute: async ({ city }) => ({
+          city,
+          temperature: Math.round(8 + Math.random() * 20),
+          condition: "sunny",
+        }),
+      }),
+    },
   });
 
   return result.toUIMessageStreamResponse({

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -115,17 +115,17 @@ describe("MessagePrimitiveParts tool UI registry", () => {
     const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
 
     const WeatherTool = defineComponent({
-      props: ["part", "addResult", "resume", "respondToApproval"],
-      setup: (props: ToolUIProps) => () =>
+      props: ["tool"],
+      setup: (props: { tool: ToolUIProps }) => () =>
         h(
           "span",
           { class: "ui" },
           [
-            props.part.toolName,
-            (props.part.args as { city?: string }).city,
-            typeof props.addResult,
-            typeof props.resume,
-            typeof props.respondToApproval,
+            props.tool.part.toolName,
+            (props.tool.part.args as { city?: string }).city,
+            typeof props.tool.addResult,
+            typeof props.tool.resume,
+            typeof props.tool.respondToApproval,
           ].join(","),
         ),
     });
@@ -156,23 +156,23 @@ describe("MessagePrimitiveParts tool UI registry", () => {
     const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
 
     const CallbackTool = defineComponent({
-      props: ["part", "addResult", "resume", "respondToApproval"],
-      setup: (props: ToolUIProps) => () => [
+      props: ["tool"],
+      setup: (props: { tool: ToolUIProps }) => () => [
         h(
           "button",
-          { class: "add-result", onClick: () => props.addResult("72F") },
+          { class: "add-result", onClick: () => props.tool.addResult("72F") },
           "add",
         ),
         h(
           "button",
-          { class: "resume", onClick: () => props.resume("continue") },
+          { class: "resume", onClick: () => props.tool.resume("continue") },
           "resume",
         ),
         h(
           "button",
           {
             class: "approve",
-            onClick: () => props.respondToApproval({ approved: true }),
+            onClick: () => props.tool.respondToApproval({ approved: true }),
           },
           "approve",
         ),

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -33,6 +33,8 @@ type DemoMessage = {
 const createTestRuntime = () => {
   let messages: DemoMessage[] = [];
   const onAddToolResult = vi.fn();
+  const onResumeToolCall = vi.fn();
+  const onRespondToToolApproval = vi.fn();
   const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
     messages,
     isRunning: false,
@@ -42,6 +44,8 @@ const createTestRuntime = () => {
     }),
     onNew: async () => {},
     onAddToolResult,
+    onResumeToolCall,
+    onRespondToToolApproval,
   });
   const core = new ExternalStoreRuntimeCore(makeAdapter());
   const runtime = new AssistantRuntimeImpl(core);
@@ -49,7 +53,13 @@ const createTestRuntime = () => {
     messages = [...messages, message];
     core.setAdapter(makeAdapter());
   };
-  return { runtime, append, onAddToolResult };
+  return {
+    runtime,
+    append,
+    onAddToolResult,
+    onResumeToolCall,
+    onRespondToToolApproval,
+  };
 };
 
 const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
@@ -135,22 +145,55 @@ describe("MessagePrimitiveParts tool UI registry", () => {
     unmount();
   });
 
-  it("routes addResult from the registered tool UI to the adapter's onAddToolResult", async () => {
-    const { runtime, append, onAddToolResult } = createTestRuntime();
+  it("routes addResult, resume, and respondToApproval from the registered tool UI to the adapter callbacks", async () => {
+    const {
+      runtime,
+      append,
+      onAddToolResult,
+      onResumeToolCall,
+      onRespondToToolApproval,
+    } = createTestRuntime();
     const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
 
-    const ResultTool = defineComponent({
+    const CallbackTool = defineComponent({
       props: ["part", "addResult", "resume", "respondToApproval"],
-      setup: (props: ToolUIProps) => () =>
+      setup: (props: ToolUIProps) => () => [
         h(
           "button",
           { class: "add-result", onClick: () => props.addResult("72F") },
           "add",
         ),
+        h(
+          "button",
+          { class: "resume", onClick: () => props.resume("continue") },
+          "resume",
+        ),
+        h(
+          "button",
+          {
+            class: "approve",
+            onClick: () => props.respondToApproval({ approved: true }),
+          },
+          "approve",
+        ),
+      ],
     });
 
-    flushTapSync(() => client().tools.setToolUI("weather", ResultTool));
-    flushTapSync(() => append(toolCallMessage("weather")));
+    flushTapSync(() => client().tools.setToolUI("weather", CallbackTool));
+    flushTapSync(() =>
+      append({
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "weather",
+            args: { city: "sf" },
+            approval: { id: "approval-1" },
+          },
+        ],
+      }),
+    );
 
     await vi.waitFor(async () => {
       await nextTick();
@@ -165,6 +208,24 @@ describe("MessagePrimitiveParts tool UI registry", () => {
       toolCallId: "call-1",
       toolName: "weather",
       result: "72F",
+    });
+
+    (el.querySelector("button.resume") as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(onResumeToolCall).toHaveBeenCalledTimes(1);
+    });
+    expect(onResumeToolCall.mock.calls[0]![0]).toMatchObject({
+      toolCallId: "call-1",
+      payload: "continue",
+    });
+
+    (el.querySelector("button.approve") as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(onRespondToToolApproval).toHaveBeenCalledTimes(1);
+    });
+    expect(onRespondToToolApproval.mock.calls[0]![0]).toMatchObject({
+      approvalId: "approval-1",
+      approved: true,
     });
 
     unmount();

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -22,6 +22,7 @@ import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import {
   MessagePrimitiveParts,
   clearPartWarningsForTesting,
+  type ToolUIProps,
 } from "../primitives/MessagePrimitiveParts";
 
 type DemoMessage = {
@@ -31,6 +32,7 @@ type DemoMessage = {
 
 const createTestRuntime = () => {
   let messages: DemoMessage[] = [];
+  const onAddToolResult = vi.fn();
   const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
     messages,
     isRunning: false,
@@ -39,6 +41,7 @@ const createTestRuntime = () => {
       content: message.content,
     }),
     onNew: async () => {},
+    onAddToolResult,
   });
   const core = new ExternalStoreRuntimeCore(makeAdapter());
   const runtime = new AssistantRuntimeImpl(core);
@@ -46,7 +49,7 @@ const createTestRuntime = () => {
     messages = [...messages, message];
     core.setAdapter(makeAdapter());
   };
-  return { runtime, append };
+  return { runtime, append, onAddToolResult };
 };
 
 const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
@@ -97,19 +100,19 @@ const PartsWithToolSlot = defineComponent({
 });
 
 describe("MessagePrimitiveParts tool UI registry", () => {
-  it("renders a registered tool UI over the tool-call slot and passes part props with callbacks", async () => {
+  it("renders a registered tool UI over the tool-call slot with the part prop and callbacks", async () => {
     const { runtime, append } = createTestRuntime();
     const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
 
     const WeatherTool = defineComponent({
-      props: ["toolName", "args", "addResult", "resume", "respondToApproval"],
-      setup: (props: any) => () =>
+      props: ["part", "addResult", "resume", "respondToApproval"],
+      setup: (props: ToolUIProps) => () =>
         h(
           "span",
           { class: "ui" },
           [
-            props.toolName,
-            props.args?.city,
+            props.part.toolName,
+            (props.part.args as { city?: string }).city,
             typeof props.addResult,
             typeof props.resume,
             typeof props.respondToApproval,
@@ -128,6 +131,41 @@ describe("MessagePrimitiveParts tool UI registry", () => {
       "weather,sf,function,function,function",
     );
     expect(el.querySelector("span.slot")).toBeNull();
+
+    unmount();
+  });
+
+  it("routes addResult from the registered tool UI to the adapter's onAddToolResult", async () => {
+    const { runtime, append, onAddToolResult } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
+
+    const ResultTool = defineComponent({
+      props: ["part", "addResult", "resume", "respondToApproval"],
+      setup: (props: ToolUIProps) => () =>
+        h(
+          "button",
+          { class: "add-result", onClick: () => props.addResult("72F") },
+          "add",
+        ),
+    });
+
+    flushTapSync(() => client().tools.setToolUI("weather", ResultTool));
+    flushTapSync(() => append(toolCallMessage("weather")));
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("button.add-result")).not.toBeNull();
+    });
+
+    (el.querySelector("button.add-result") as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(onAddToolResult).toHaveBeenCalledTimes(1);
+    });
+    expect(onAddToolResult.mock.calls[0]![0]).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "weather",
+      result: "72F",
+    });
 
     unmount();
   });

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearPartWarningsForTesting();
+});
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type {
+  ExternalStoreAdapter,
+  ThreadMessageLike,
+} from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import {
+  MessagePrimitiveParts,
+  clearPartWarningsForTesting,
+} from "../primitives/MessagePrimitiveParts";
+
+type DemoMessage = {
+  role: "user" | "assistant";
+  content: ThreadMessageLike["content"];
+};
+
+const createTestRuntime = () => {
+  let messages: DemoMessage[] = [];
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    isRunning: false,
+    convertMessage: (message) => ({
+      role: message.role,
+      content: message.content,
+    }),
+    onNew: async () => {},
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const append = (message: DemoMessage) => {
+    messages = [...messages, message];
+    core.setAdapter(makeAdapter());
+  };
+  return { runtime, append };
+};
+
+const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+  let client: any;
+  const CaptureClient = defineComponent({
+    setup() {
+      client = useAui();
+      return () => null;
+    },
+  });
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => [h(CaptureClient), h(view)] },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, client: () => client, unmount: () => app.unmount() };
+};
+
+const toolCallMessage = (toolName: string): DemoMessage => ({
+  role: "assistant",
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName,
+      args: { city: "sf" },
+    },
+  ],
+});
+
+const PartsWithToolSlot = defineComponent({
+  setup: () => () =>
+    h("li", null, [
+      h(ThreadPrimitiveMessages, null, {
+        default: () =>
+          h(MessagePrimitiveParts, null, {
+            "tool-call": () => h("span", { class: "slot" }, "[slot]"),
+          }),
+      }),
+    ]),
+});
+
+describe("MessagePrimitiveParts tool UI registry", () => {
+  it("renders a registered tool UI over the tool-call slot and passes part props with callbacks", async () => {
+    const { runtime, append } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
+
+    const WeatherTool = defineComponent({
+      props: ["toolName", "args", "addResult", "resume", "respondToApproval"],
+      setup: (props: any) => () =>
+        h(
+          "span",
+          { class: "ui" },
+          [
+            props.toolName,
+            props.args?.city,
+            typeof props.addResult,
+            typeof props.resume,
+            typeof props.respondToApproval,
+          ].join(","),
+        ),
+    });
+
+    flushTapSync(() => client().tools.setToolUI("weather", WeatherTool));
+    flushTapSync(() => append(toolCallMessage("weather")));
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.ui")).not.toBeNull();
+    });
+    expect(el.querySelector("span.ui")!.textContent).toBe(
+      "weather,sf,function,function,function",
+    );
+    expect(el.querySelector("span.slot")).toBeNull();
+
+    unmount();
+  });
+
+  it("falls back to the tool-call slot without a matching registration and swaps live on register/unregister", async () => {
+    const { runtime, append } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
+
+    flushTapSync(() => append(toolCallMessage("weather")));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.slot")).not.toBeNull();
+    });
+
+    const Ui = defineComponent({
+      setup: () => () => h("span", { class: "ui" }, "ui"),
+    });
+    let dispose: () => void;
+    flushTapSync(() => {
+      dispose = client().tools.setToolUI("weather", Ui);
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.ui")).not.toBeNull();
+      expect(el.querySelector("span.slot")).toBeNull();
+    });
+
+    flushTapSync(() => dispose());
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.slot")).not.toBeNull();
+      expect(el.querySelector("span.ui")).toBeNull();
+    });
+
+    unmount();
+  });
+
+  it("does not route registrations for other tool names", async () => {
+    const { runtime, append } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
+
+    const Ui = defineComponent({
+      setup: () => () => h("span", { class: "ui" }, "ui"),
+    });
+    flushTapSync(() => client().tools.setToolUI("search", Ui));
+    flushTapSync(() => append(toolCallMessage("weather")));
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.slot")).not.toBeNull();
+    });
+    expect(el.querySelector("span.ui")).toBeNull();
+
+    unmount();
+  });
+
+  it("uses the first registration when a tool name is registered twice", async () => {
+    const { runtime, append } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, PartsWithToolSlot);
+
+    const First = defineComponent({
+      setup: () => () => h("span", { class: "first" }, "first"),
+    });
+    const Second = defineComponent({
+      setup: () => () => h("span", { class: "second" }, "second"),
+    });
+    flushTapSync(() => client().tools.setToolUI("weather", First));
+    flushTapSync(() => client().tools.setToolUI("weather", Second));
+    flushTapSync(() => append(toolCallMessage("weather")));
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.first")).not.toBeNull();
+    });
+    expect(el.querySelector("span.second")).toBeNull();
+
+    unmount();
+  });
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -9,7 +9,10 @@ export { PartByIndexProvider } from "./primitives/PartByIndexProvider";
 export { ThreadPrimitiveMessages } from "./primitives/ThreadPrimitiveMessages";
 export { ThreadPrimitiveViewport } from "./primitives/ThreadPrimitiveViewport";
 export { ThreadPrimitiveScrollToBottom } from "./primitives/ThreadPrimitiveScrollToBottom";
-export { MessagePrimitiveParts } from "./primitives/MessagePrimitiveParts";
+export {
+  MessagePrimitiveParts,
+  type ToolUIProps,
+} from "./primitives/MessagePrimitiveParts";
 export { ComposerPrimitiveInput } from "./primitives/ComposerPrimitiveInput";
 export { ComposerPrimitiveSend } from "./primitives/ComposerPrimitiveSend";
 export { ComposerPrimitiveCancel } from "./primitives/ComposerPrimitiveCancel";

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -12,15 +12,16 @@ const warnedTypes = new Set<string>();
 export const clearPartWarningsForTesting = () => warnedTypes.clear();
 
 /**
- * Props passed to a tool UI registered in the `tools` scope. Vue passes the
- * part state as a single `part` prop where React spreads it; spreading in Vue
- * would leak undeclared props onto the component's root element through
- * `$attrs`. The tools scope declares renderers as React's
- * `ToolCallMessagePartComponent`, so the Vue face bridges the seam with casts
- * at registration and render; a genuine React renderer arriving through a
- * shared toolkit type-checks at `setToolUI` and then fails when invoked as a
- * Vue component. This type is the Vue-facing contract until the scope's
- * renderer type goes framework-generic.
+ * The value of the single `tool` prop passed to a tool UI registered in the
+ * `tools` scope. React spreads the part state as individual props; in Vue any
+ * prop the component does not declare falls through to `$attrs` and gets
+ * stringified onto its root element, so the Vue face passes one `tool` object
+ * instead, which a component always declares in full. The tools scope
+ * declares renderers as React's `ToolCallMessagePartComponent`, so the Vue
+ * face bridges the seam with casts at registration and render; a genuine
+ * React renderer arriving through a shared toolkit type-checks at `setToolUI`
+ * and then fails when invoked as a Vue component. This type is the Vue-facing
+ * contract until the scope's renderer type goes framework-generic.
  */
 export type ToolUIProps = {
   part: Extract<AssistantState["part"], { type: "tool-call" }>;
@@ -33,7 +34,8 @@ export type ToolUIProps = {
  * Renders the current message's content parts in order, each scoped through
  * {@link PartByIndexProvider}. A `tool-call` part first resolves a renderer
  * registered in the `tools` scope by tool name (`aui.tools.setToolUI`, or a
- * `Tools({ toolkit })` config entry) and renders it with {@link ToolUIProps}.
+ * `Tools({ toolkit })` config entry) and renders it with a single `tool` prop
+ * of type {@link ToolUIProps}.
  * Otherwise a slot named after the part type (`text`, `reasoning`,
  * `tool-call`, ...) renders that part; the `default` slot is the fallback for
  * types without a named slot, except text, which always renders its text
@@ -66,11 +68,13 @@ export const MessagePrimitiveParts = defineComponent({
             const part = toolPart.value;
             if (render && part) {
               return h(render as unknown as Component, {
-                part,
-                addResult: aui.part.addToolResult,
-                resume: aui.part.resumeToolCall,
-                respondToApproval: aui.part.respondToToolApproval,
-              } satisfies ToolUIProps);
+                tool: {
+                  part,
+                  addResult: aui.part.addToolResult,
+                  resume: aui.part.resumeToolCall,
+                  respondToApproval: aui.part.respondToToolApproval,
+                } satisfies ToolUIProps,
+              });
             }
           }
           if (type.value === "text") {

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -15,9 +15,12 @@ export const clearPartWarningsForTesting = () => warnedTypes.clear();
  * Props passed to a tool UI registered in the `tools` scope. Vue passes the
  * part state as a single `part` prop where React spreads it; spreading in Vue
  * would leak undeclared props onto the component's root element through
- * `$attrs`. The tools scope stores renderers untyped across frameworks today;
- * this type is the Vue-facing contract until the scope's renderer type goes
- * framework-generic.
+ * `$attrs`. The tools scope declares renderers as React's
+ * `ToolCallMessagePartComponent`, so the Vue face bridges the seam with casts
+ * at registration and render; a genuine React renderer arriving through a
+ * shared toolkit type-checks at `setToolUI` and then fails when invoked as a
+ * Vue component. This type is the Vue-facing contract until the scope's
+ * renderer type goes framework-generic.
  */
 export type ToolUIProps = {
   part: Extract<AssistantState["part"], { type: "tool-call" }>;

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,6 +1,8 @@
 import { defineComponent, h, type Component, type SlotsType } from "vue";
 import type {} from "@assistant-ui/core/store";
+import type { PartMethods } from "@assistant-ui/core/store";
 import { isDevelopment } from "@assistant-ui/core/store/internal";
+import type { AssistantState } from "@assistant-ui/store/client";
 import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
 import { PartByIndexProvider } from "./PartByIndexProvider";
@@ -10,14 +12,29 @@ const warnedTypes = new Set<string>();
 export const clearPartWarningsForTesting = () => warnedTypes.clear();
 
 /**
+ * Props passed to a tool UI registered in the `tools` scope. Vue passes the
+ * part state as a single `part` prop where React spreads it; spreading in Vue
+ * would leak undeclared props onto the component's root element through
+ * `$attrs`. The tools scope stores renderers untyped across frameworks today;
+ * this type is the Vue-facing contract until the scope's renderer type goes
+ * framework-generic.
+ */
+export type ToolUIProps = {
+  part: Extract<AssistantState["part"], { type: "tool-call" }>;
+  addResult: PartMethods["addToolResult"];
+  resume: PartMethods["resumeToolCall"];
+  respondToApproval: PartMethods["respondToToolApproval"];
+};
+
+/**
  * Renders the current message's content parts in order, each scoped through
  * {@link PartByIndexProvider}. A `tool-call` part first resolves a renderer
  * registered in the `tools` scope by tool name (`aui.tools.setToolUI`, or a
- * `Tools({ toolkit })` config entry) and renders it with the part state plus
- * `addResult`/`resume`/`respondToApproval` callbacks. Otherwise a slot named
- * after the part type (`text`, `reasoning`, `tool-call`, ...) renders that
- * part; the `default` slot is the fallback for types without a named slot,
- * except text, which always renders its text unless a `text` slot overrides it.
+ * `Tools({ toolkit })` config entry) and renders it with {@link ToolUIProps}.
+ * Otherwise a slot named after the part type (`text`, `reasoning`,
+ * `tool-call`, ...) renders that part; the `default` slot is the fallback for
+ * types without a named slot, except text, which always renders its text
+ * unless a `text` slot overrides it.
  */
 export const MessagePrimitiveParts = defineComponent({
   name: "MessagePrimitiveParts",
@@ -46,11 +63,11 @@ export const MessagePrimitiveParts = defineComponent({
             const part = toolPart.value;
             if (render && part) {
               return h(render as unknown as Component, {
-                ...part,
+                part,
                 addResult: aui.part.addToolResult,
                 resume: aui.part.resumeToolCall,
                 respondToApproval: aui.part.respondToToolApproval,
-              });
+              } satisfies ToolUIProps);
             }
           }
           if (type.value === "text") {

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,5 +1,4 @@
 import { defineComponent, h, type Component, type SlotsType } from "vue";
-import type {} from "@assistant-ui/core/store";
 import type { PartMethods } from "@assistant-ui/core/store";
 import { isDevelopment } from "@assistant-ui/core/store/internal";
 import type { AssistantState } from "@assistant-ui/store/client";

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,6 +1,7 @@
-import { defineComponent, h, type SlotsType } from "vue";
+import { defineComponent, h, type Component, type SlotsType } from "vue";
 import type {} from "@assistant-ui/core/store";
 import { isDevelopment } from "@assistant-ui/core/store/internal";
+import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
 import { PartByIndexProvider } from "./PartByIndexProvider";
 
@@ -10,10 +11,13 @@ export const clearPartWarningsForTesting = () => warnedTypes.clear();
 
 /**
  * Renders the current message's content parts in order, each scoped through
- * {@link PartByIndexProvider}. A slot named after the part type (`text`,
- * `reasoning`, `tool-call`, ...) renders that part; the `default` slot is the
- * fallback for types without a named slot, except text, which always renders
- * its text unless a `text` slot overrides it.
+ * {@link PartByIndexProvider}. A `tool-call` part first resolves a renderer
+ * registered in the `tools` scope by tool name (`aui.tools.setToolUI`, or a
+ * `Tools({ toolkit })` config entry) and renders it with the part state plus
+ * `addResult`/`resume`/`respondToApproval` callbacks. Otherwise a slot named
+ * after the part type (`text`, `reasoning`, `tool-call`, ...) renders that
+ * part; the `default` slot is the fallback for types without a named slot,
+ * except text, which always renders its text unless a `text` slot overrides it.
  */
 export const MessagePrimitiveParts = defineComponent({
   name: "MessagePrimitiveParts",
@@ -23,11 +27,32 @@ export const MessagePrimitiveParts = defineComponent({
     const PartView = defineComponent({
       name: "MessagePartView",
       setup() {
+        const aui = useAui();
         const type = useAuiState((s) => s.part.type);
         const text = useAuiState((s) =>
           s.part.type === "text" ? s.part.text : "",
         );
+        const toolUI = useAuiState((s) =>
+          s.part.type === "tool-call"
+            ? (s.optional.tools?.toolUIs[s.part.toolName]?.[0]?.render ?? null)
+            : null,
+        );
+        const toolPart = useAuiState((s) =>
+          s.part.type === "tool-call" ? s.part : null,
+        );
         return () => {
+          if (type.value === "tool-call") {
+            const render = toolUI.value;
+            const part = toolPart.value;
+            if (render && part) {
+              return h(render as unknown as Component, {
+                ...part,
+                addResult: aui.part.addToolResult,
+                resume: aui.part.resumeToolCall,
+                respondToApproval: aui.part.respondToToolApproval,
+              });
+            }
+          }
           if (type.value === "text") {
             const slot = slots.text;
             return slot


### PR DESCRIPTION
## summary

- `MessagePrimitiveParts` now resolves a renderer registered in the `tools` scope for `tool-call` parts before falling back to the named `tool-call` slot, matching the react resolution order (registry first, generic fallback second)
- the registered component receives a single `tool` prop typed by the exported `ToolUIProps` (the part state plus `addResult`, `resume`, and `respondToApproval` callbacks); react spreads the part state instead, but in Vue every undeclared prop falls through to `$attrs` and gets stringified onto the root element, so one object prop removes that hazard structurally
- zero new runtime API on the vue face: registration goes through the existing `Tools({ toolkit })` config entry or the `aui.tools.setToolUI` client action, and the read side uses `s.optional.tools` so clients without a tools scope keep the slot behavior
- with-nuxt gains a working demo: a server-side `weather` tool (`stopWhen: stepCountIs(3)` so the model answers from the result), a `WeatherToolUI.vue` renderer, and a registration component

## test plan

### already verified

- [x] `pnpm exec turbo run test --filter=@assistant-ui/vue` -> 70/70 green (5 new tests: registry wins over slot with the tool prop, all three callbacks routed to the adapter's `onAddToolResult`/`onResumeToolCall`/`onRespondToToolApproval`, live register/unregister swap, no cross-tool routing, first registration wins)
- [x] `tsc --noEmit` error count identical to main (20, all pre-existing)
- [x] browser end to end on with-nuxt: tool card renders from the registered component with args and result bound through the tool prop, follow-up text streams after the tool result, zero console errors; also exercised the error path (upstream provider error renders in the message bubble)

### reviewer should verify

- [ ] `pnpm -C examples/with-nuxt dev`, click the "Check the weather" suggestion, and confirm the weather card renders followed by a text answer

## notes

- `defineProps<ToolUIProps>()` with the imported type does not compile in the SFC pipeline (`@vue/compiler-sfc` cannot resolve imported types there), so the example declares a runtime prop and casts; same pattern as the test components
- with-nuxt renders assistant text as plain text (`**` shows literally); markdown rendering lands with the styled thread work, not here
- `respondToApproval` is wired through and unit-tested against a pending approval; a full approval flow in the demo depends on runtime-side approval support and is tracked separately
- no changeset: only private packages (`@assistant-ui/vue`, with-nuxt example) are touched