### PR TITLE
feat(registry): vue flavor machinery with staged thread sources

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -21,6 +21,7 @@
     "@assistant-ui/x-buildutils": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^26.2.0",
+    "@vue/compiler-sfc": "^3.5.41",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -104,7 +104,7 @@ test("vue flavor content validation rejects forbidden package subpaths", () => {
         createBuilt("thread", [
           [
             "components/assistant-ui/thread.vue",
-            '<script setup lang="ts">\nimport { jsx } from "react/jsx-runtime";\nimport "react-dom/client";\nimport "@assistant-ui/react/runtime";\n</script>',
+            '<script setup lang="ts">\nimport { jsx } from "react/jsx-runtime";\nimport "react-dom/client";\nimport "@assistant-ui/react/runtime";\nimport { CopyIcon } from "lucide-react";\nimport "@assistant-ui/react-ui/lib/utils";\n</script>',
           ],
         ]),
       ]),
@@ -126,6 +126,16 @@ test("vue flavor content validation rejects forbidden package subpaths", () => {
           '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "@assistant-ui/react/runtime"',
         ),
       );
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "lucide-react"',
+        ),
+      );
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "@assistant-ui/react-ui/lib/utils"',
+        ),
+      );
       return true;
     },
   );
@@ -138,7 +148,7 @@ test("vue flavor content validation scans script tags closed with whitespace", (
         createBuilt("thread", [
           [
             "components/assistant-ui/thread.vue",
-            '<script setup lang="ts">\nimport { createElement } from "react";\n</script >',
+            '<script setup lang="ts">\nimport { createElement } from "react";\n</script \t\nbar>',
           ],
         ]),
       ]),

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -63,7 +63,7 @@ const createBuilt = (
     new Map(files.map(([filePath, content]) => [filePath, content])),
 });
 
-test("vue registry build emits a self-contained thread", async () => {
+test("vue registry build emits a self-contained thread with its type-only dependency", async () => {
   const { registry, vueRegistry } = await import("../src/registry.ts");
   await buildRegistry(registry, vueRegistry);
 
@@ -77,26 +77,68 @@ test("vue registry build emits a self-contained thread", async () => {
     (file) => file.path === "components/assistant-ui/thread.vue",
   );
 
+  assert.ok(
+    threadFile,
+    "vue thread registry output includes components/assistant-ui/thread.vue",
+  );
   assert.deepEqual(
     vueIndex.items.map((item) => item.name),
     ["thread"],
   );
-  assert.deepEqual(thread.dependencies, ["@assistant-ui/vue", "@lucide/vue"]);
-  assert.equal(threadFile.target, "@/components/assistant-ui/thread.vue");
+  assert.deepEqual(thread.dependencies, [
+    "@assistant-ui/core",
+    "@assistant-ui/vue",
+    "@lucide/vue",
+  ]);
+  assert.equal("target" in threadFile, false);
   assert.match(
     threadFile.content,
     /import Message from "@\/components\/assistant-ui\/message\.vue"/,
   );
 });
 
-test("vue flavor content validation rejects react imports", () => {
+test("vue flavor content validation rejects forbidden package subpaths", () => {
   assert.throws(
     () =>
       validateVueFlavorContent([
         createBuilt("thread", [
           [
             "components/assistant-ui/thread.vue",
-            '<script setup lang="ts">\nimport { createElement } from "react";\n</script>',
+            '<script setup lang="ts">\nimport { jsx } from "react/jsx-runtime";\nimport "react-dom/client";\nimport "@assistant-ui/react/runtime";\n</script>',
+          ],
+        ]),
+      ]),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid vue flavor content:/);
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "react/jsx-runtime"',
+        ),
+      );
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "react-dom/client"',
+        ),
+      );
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "@assistant-ui/react/runtime"',
+        ),
+      );
+      return true;
+    },
+  );
+});
+
+test("vue flavor content validation scans script tags closed with whitespace", () => {
+  assert.throws(
+    () =>
+      validateVueFlavorContent([
+        createBuilt("thread", [
+          [
+            "components/assistant-ui/thread.vue",
+            '<script setup lang="ts">\nimport { createElement } from "react";\n</script >',
           ],
         ]),
       ]),
@@ -106,6 +148,30 @@ test("vue flavor content validation rejects react imports", () => {
       assert.ok(
         error.message.includes(
           '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "react"',
+        ),
+      );
+      return true;
+    },
+  );
+});
+
+test("vue flavor content validation rejects unsupported script languages", () => {
+  assert.throws(
+    () =>
+      validateVueFlavorContent([
+        createBuilt("thread", [
+          [
+            "components/assistant-ui/thread.vue",
+            '<script setup lang="tsx">\nconst thread = <div />;\n</script>',
+          ],
+        ]),
+      ]),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid vue flavor content:/);
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue has unsupported script lang "tsx"',
         ),
       );
       return true;

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import "tsx/esm";
 
 const {
   collectAttributeSelectorValues,
+  buildRegistry,
   createBaseRegistryItem,
   createRadixRegistryItem,
   expandBundledRegistryDependencies,
@@ -16,6 +18,7 @@ const {
   validateEmittedSpecifierHygiene,
   validateStyleScopedDependencies,
   validateUniversalItems,
+  validateVueFlavorContent,
   validateVariantExportParity,
   validateVariantSlotParity,
   validateVariantTreesDiffer,
@@ -58,6 +61,56 @@ const createBuilt = (
   sourceContentsByOutputPath:
     sourceContentsByOutputPath ??
     new Map(files.map(([filePath, content]) => [filePath, content])),
+});
+
+test("vue registry build emits a self-contained thread", async () => {
+  const { registry, vueRegistry } = await import("../src/registry.ts");
+  await buildRegistry(registry, vueRegistry);
+
+  const [registryContent, threadContent] = await Promise.all([
+    readFile("dist/vue/registry.json", "utf8"),
+    readFile("dist/vue/thread.json", "utf8"),
+  ]);
+  const vueIndex = JSON.parse(registryContent);
+  const thread = JSON.parse(threadContent);
+  const threadFile = thread.files.find(
+    (file) => file.path === "components/assistant-ui/thread.vue",
+  );
+
+  assert.deepEqual(
+    vueIndex.items.map((item) => item.name),
+    ["thread"],
+  );
+  assert.deepEqual(thread.dependencies, ["@assistant-ui/vue", "@lucide/vue"]);
+  assert.equal(threadFile.target, "@/components/assistant-ui/thread.vue");
+  assert.match(
+    threadFile.content,
+    /import Message from "@\/components\/assistant-ui\/message\.vue"/,
+  );
+});
+
+test("vue flavor content validation rejects react imports", () => {
+  assert.throws(
+    () =>
+      validateVueFlavorContent([
+        createBuilt("thread", [
+          [
+            "components/assistant-ui/thread.vue",
+            '<script setup lang="ts">\nimport { createElement } from "react";\n</script>',
+          ],
+        ]),
+      ]),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid vue flavor content:/);
+      assert.ok(
+        error.message.includes(
+          '- thread: vue tree file components/assistant-ui/thread.vue imports forbidden "react"',
+        ),
+      );
+      return true;
+    },
+  );
 });
 
 test("base registry item merges, rewrites, and deduplicates dependencies in order", () => {

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -97,34 +97,31 @@ test("vue registry build emits a self-contained thread with its type-only depend
   );
 });
 
-test("the production vue registry stays empty until the publish flip", async () => {
-  const { registry, vueRegistry } = await import("../src/registry.ts");
-  assert.deepEqual(vueRegistry, []);
-  await buildRegistry(registry, vueRegistry);
-  const vueIndex = JSON.parse(await readFile("dist/vue/registry.json", "utf8"));
-  assert.deepEqual(vueIndex.items, []);
-});
-
-test("staged vue kit sources compile as SFCs and pass the vue purity gate", async () => {
+test("emitted vue artifacts compile as SFCs and pass the vue purity gate", async () => {
   const { parse, compileScript } = await import("@vue/compiler-sfc");
-  const sources = await Promise.all(
-    ["thread.vue", "message.vue"].map(async (name) => [
-      `components/assistant-ui/${name}`,
-      await readFile(
-        `../../packages/ui/src/components/assistant-ui-vue/${name}`,
-        "utf8",
-      ),
-    ]),
-  );
+  const thread = JSON.parse(await readFile("dist/vue/thread.json", "utf8"));
+  const emitted = thread.files.map((file) => [file.path, file.content]);
+  assert.deepEqual(emitted.map(([outputPath]) => outputPath).sort(), [
+    "components/assistant-ui/message.vue",
+    "components/assistant-ui/thread.vue",
+  ]);
 
-  for (const [outputPath, content] of sources) {
+  for (const [outputPath, content] of emitted) {
     const { descriptor, errors } = parse(content, { filename: outputPath });
     assert.deepEqual(errors, []);
     const compiled = compileScript(descriptor, { id: outputPath });
     assert.ok(compiled.content.length > 0);
   }
 
-  validateVueFlavorContent([createBuilt("thread", sources)]);
+  validateVueFlavorContent([createBuilt("thread", emitted)]);
+});
+
+test("the production vue registry stays empty until the publish flip", async () => {
+  const { registry, vueRegistry } = await import("../src/registry.ts");
+  assert.deepEqual(vueRegistry, []);
+  await buildRegistry(registry, vueRegistry);
+  const vueIndex = JSON.parse(await readFile("dist/vue/registry.json", "utf8"));
+  assert.deepEqual(vueIndex.items, []);
 });
 
 test("vue flavor content validation rejects forbidden package subpaths", () => {

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -64,8 +64,8 @@ const createBuilt = (
 });
 
 test("vue registry build emits a self-contained thread with its type-only dependency", async () => {
-  const { registry, vueRegistry } = await import("../src/registry.ts");
-  await buildRegistry(registry, vueRegistry);
+  const { registry, stagedVueRegistry } = await import("../src/registry.ts");
+  await buildRegistry(registry, stagedVueRegistry);
 
   const [registryContent, threadContent] = await Promise.all([
     readFile("dist/vue/registry.json", "utf8"),
@@ -95,6 +95,36 @@ test("vue registry build emits a self-contained thread with its type-only depend
     threadFile.content,
     /import Message from "@\/components\/assistant-ui\/message\.vue"/,
   );
+});
+
+test("the production vue registry stays empty until the publish flip", async () => {
+  const { registry, vueRegistry } = await import("../src/registry.ts");
+  assert.deepEqual(vueRegistry, []);
+  await buildRegistry(registry, vueRegistry);
+  const vueIndex = JSON.parse(await readFile("dist/vue/registry.json", "utf8"));
+  assert.deepEqual(vueIndex.items, []);
+});
+
+test("staged vue kit sources compile as SFCs and pass the vue purity gate", async () => {
+  const { parse, compileScript } = await import("@vue/compiler-sfc");
+  const sources = await Promise.all(
+    ["thread.vue", "message.vue"].map(async (name) => [
+      `components/assistant-ui/${name}`,
+      await readFile(
+        `../../packages/ui/src/components/assistant-ui-vue/${name}`,
+        "utf8",
+      ),
+    ]),
+  );
+
+  for (const [outputPath, content] of sources) {
+    const { descriptor, errors } = parse(content, { filename: outputPath });
+    assert.deepEqual(errors, []);
+    const compiled = compileScript(descriptor, { id: outputPath });
+    assert.ok(compiled.content.length > 0);
+  }
+
+  validateVueFlavorContent([createBuilt("thread", sources)]);
 });
 
 test("vue flavor content validation rejects forbidden package subpaths", () => {

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -7,13 +7,15 @@ import {
   type CssDeclarationBlock,
   type CssMediaBlock,
 } from "@assistant-ui/ui/lib/generative-ui-vocabulary-css.ts";
-import { registry } from "../src/registry";
+import { registry, vueRegistry } from "../src/registry";
 import { registrySchema, type RegistryItem } from "../src/schema";
 
 const REGISTRY_PATH = path.join(process.cwd(), "dist");
 const BASE_REGISTRY_PATH = path.join(REGISTRY_PATH, "base");
+const VUE_REGISTRY_PATH = path.join(REGISTRY_PATH, "vue");
 const REGISTRY_INDEX_PATH = path.join(REGISTRY_PATH, "registry.json");
 const BASE_REGISTRY_INDEX_PATH = path.join(BASE_REGISTRY_PATH, "registry.json");
+const VUE_REGISTRY_INDEX_PATH = path.join(VUE_REGISTRY_PATH, "registry.json");
 const REGISTRY_ITEM_SCHEMA_URL =
   "https://ui.shadcn.com/schema/registry-item.json";
 const ASSISTANT_REGISTRY_DEPENDENCY_RE =
@@ -156,6 +158,32 @@ export function validateBaseTreeRadixImports(
   }
 
   throwIfFindings("Invalid base tree imports:", findings);
+}
+
+export function validateVueFlavorContent(vueBuilt: BuiltRegistryPayload[]) {
+  const findings = new Set<string>();
+
+  for (const { payload } of vueBuilt) {
+    for (const file of payload.files ?? []) {
+      for (const specifier of collectModuleSpecifiers(file)) {
+        if (
+          specifier === "react" ||
+          specifier === "react-dom" ||
+          specifier === "radix-ui" ||
+          specifier.startsWith("radix-ui/") ||
+          specifier.startsWith("@radix-ui/") ||
+          specifier.startsWith("@base-ui/") ||
+          specifier.startsWith("@assistant-ui/react")
+        ) {
+          findings.add(
+            `${payload.name}: vue tree file ${file.path} imports forbidden "${specifier}"`,
+          );
+        }
+      }
+    }
+  }
+
+  throwIfFindings("Invalid vue flavor content:", findings);
 }
 
 export function validateEmittedSpecifierHygiene(built: BuiltRegistryPayload[]) {
@@ -784,6 +812,7 @@ function isStringLiteralLike(
 }
 
 function getScriptKind(filePath: string) {
+  if (filePath.endsWith(".vue")) return ts.ScriptKind.TS;
   if (filePath.endsWith(".tsx")) return ts.ScriptKind.TSX;
   if (filePath.endsWith(".jsx")) return ts.ScriptKind.JSX;
   if (filePath.endsWith(".ts")) return ts.ScriptKind.TS;
@@ -791,48 +820,67 @@ function getScriptKind(filePath: string) {
   return ts.ScriptKind.Unknown;
 }
 
-function collectModuleSpecifiers(file: RegistryOutputFile) {
-  const sourceFile = ts.createSourceFile(
-    file.path,
-    file.content,
-    ts.ScriptTarget.Latest,
-    true,
-    getScriptKind(file.path),
-  );
+function getScriptContents(file: RegistryOutputFile) {
+  if (!file.path.endsWith(".vue")) return [file.content];
+
+  return [
+    ...file.content.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi),
+  ].map((match) => match[1] ?? "");
+}
+
+function collectModuleSpecifiers(
+  file: RegistryOutputFile,
+  includeTypeOnly = true,
+) {
   const specifiers = new Set<string>();
 
-  const visit = (node: ts.Node) => {
-    if (
-      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
-      node.moduleSpecifier &&
-      isStringLiteralLike(node.moduleSpecifier)
-    ) {
-      specifiers.add(node.moduleSpecifier.text);
-    }
+  for (const content of getScriptContents(file)) {
+    const sourceFile = ts.createSourceFile(
+      file.path,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      getScriptKind(file.path),
+    );
 
-    if (
-      ts.isCallExpression(node) &&
-      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-      node.arguments.length === 1
-    ) {
-      const importArgument = node.arguments[0];
-      if (importArgument && isStringLiteralLike(importArgument)) {
-        specifiers.add(importArgument.text);
+    const visit = (node: ts.Node) => {
+      if (
+        (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+        node.moduleSpecifier &&
+        isStringLiteralLike(node.moduleSpecifier) &&
+        (includeTypeOnly ||
+          (!node.isTypeOnly &&
+            (!ts.isImportDeclaration(node) || !node.importClause?.isTypeOnly)))
+      ) {
+        specifiers.add(node.moduleSpecifier.text);
       }
-    }
 
-    if (
-      ts.isImportTypeNode(node) &&
-      ts.isLiteralTypeNode(node.argument) &&
-      isStringLiteralLike(node.argument.literal)
-    ) {
-      specifiers.add(node.argument.literal.text);
-    }
+      if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments.length === 1
+      ) {
+        const importArgument = node.arguments[0];
+        if (importArgument && isStringLiteralLike(importArgument)) {
+          specifiers.add(importArgument.text);
+        }
+      }
 
-    ts.forEachChild(node, visit);
-  };
+      if (
+        includeTypeOnly &&
+        ts.isImportTypeNode(node) &&
+        ts.isLiteralTypeNode(node.argument) &&
+        isStringLiteralLike(node.argument.literal)
+      ) {
+        specifiers.add(node.argument.literal.text);
+      }
 
-  visit(sourceFile);
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+  }
+
   return specifiers;
 }
 
@@ -886,8 +934,13 @@ const EXPLICIT_EXTENSIONS = new Set([
   ".otf",
   ".md",
   ".mdx",
+  ".vue",
   ".txt",
 ]);
+
+function getInstallPath(file: RegistryOutputFile) {
+  return (file.target ?? file.path).replace(/^@\//, "");
+}
 
 /**
  * The install paths a relative specifier may resolve to once the item is
@@ -966,9 +1019,7 @@ function collectInstallContext(
 
   seen.add(item.name);
 
-  const files = new Set(
-    item.files?.map((file) => file.target ?? file.path) ?? [],
-  );
+  const files = new Set(item.files?.map(getInstallPath) ?? []);
   const packages = new Set([
     ...(item.dependencies ?? []),
     ...(item.devDependencies ?? []),
@@ -1019,7 +1070,7 @@ export function validateRegistryInstallMetadata(
     const installContext = collectInstallContext(item, itemByName);
 
     for (const file of item.files ?? []) {
-      for (const specifier of collectModuleSpecifiers(file)) {
+      for (const specifier of collectModuleSpecifiers(file, false)) {
         const localCandidates = getLocalComponentCandidates(specifier);
 
         if (localCandidates) {
@@ -1037,7 +1088,7 @@ export function validateRegistryInstallMetadata(
         }
 
         if (specifier.startsWith(".")) {
-          const installedPath = file.target ?? file.path;
+          const installedPath = getInstallPath(file);
           const candidates = getRelativeImportCandidates(
             specifier,
             installedPath,
@@ -1129,8 +1180,12 @@ export function validateUniversalItems(
   throwIfFindings("Invalid universal registry items:", findings);
 }
 
-async function buildRegistry(registry: RegistryItem[]) {
+export async function buildRegistry(
+  registry: RegistryItem[],
+  vueRegistry: RegistryItem[],
+) {
   validateRegistrySchema(registry);
+  validateRegistrySchema(vueRegistry);
 
   const universalNames = new Set(
     registry
@@ -1162,6 +1217,7 @@ async function buildRegistry(registry: RegistryItem[]) {
   const baseBuilt = baseRegistry.map((item) =>
     createRegistryPayload(item, false),
   );
+  const vueBuilt = vueRegistry.map((item) => createRegistryPayload(item));
   validateBaseVariantContent(radixBuilt, baseBuilt);
   validateBaseTreeRadixImports(baseBuilt);
   validateEmittedSpecifierHygiene([...radixBuilt, ...baseBuilt]);
@@ -1170,14 +1226,18 @@ async function buildRegistry(registry: RegistryItem[]) {
   validateVariantSlotParity(radixBuilt, baseBuilt);
   validateVariantExportParity(radixBuilt, baseBuilt);
   validateStyleScopedDependencies(radixBuilt, baseBuilt);
+  validateVueFlavorContent(vueBuilt);
 
   const payloads = radixBuilt.map((built) => built.payload);
   const basePayloads = baseBuilt.map((built) => built.payload);
+  const vuePayloads = vueBuilt.map((built) => built.payload);
   validateRegistryInstallMetadata(payloads);
   validateRegistryInstallMetadata(basePayloads);
+  validateRegistryInstallMetadata(vuePayloads);
 
   await fs.mkdir(REGISTRY_PATH, { recursive: true });
   await fs.mkdir(BASE_REGISTRY_PATH, { recursive: true });
+  await fs.mkdir(VUE_REGISTRY_PATH, { recursive: true });
 
   for (const payload of payloads) {
     const p = path.join(REGISTRY_PATH, `${payload.name}.json`);
@@ -1188,6 +1248,13 @@ async function buildRegistry(registry: RegistryItem[]) {
 
   for (const payload of basePayloads) {
     const p = path.join(BASE_REGISTRY_PATH, `${payload.name}.json`);
+    await fs.mkdir(path.dirname(p), { recursive: true });
+
+    await fs.writeFile(p, JSON.stringify(payload, null, 2), "utf8");
+  }
+
+  for (const payload of vuePayloads) {
+    const p = path.join(VUE_REGISTRY_PATH, `${payload.name}.json`);
     await fs.mkdir(path.dirname(p), { recursive: true });
 
     await fs.writeFile(p, JSON.stringify(payload, null, 2), "utf8");
@@ -1211,6 +1278,12 @@ async function buildRegistry(registry: RegistryItem[]) {
     JSON.stringify({ ...registryIndex, items: baseRegistry }, null, 2),
     "utf8",
   );
+
+  await fs.writeFile(
+    VUE_REGISTRY_INDEX_PATH,
+    JSON.stringify({ ...registryIndex, items: vueRegistry }, null, 2),
+    "utf8",
+  );
 }
 
 const entrypoint = process.argv[1];
@@ -1218,5 +1291,5 @@ if (
   entrypoint &&
   import.meta.url === pathToFileURL(path.resolve(entrypoint)).href
 ) {
-  await buildRegistry(registry);
+  await buildRegistry(registry, vueRegistry);
 }

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -163,16 +163,20 @@ export function validateBaseTreeRadixImports(
 const VUE_FORBIDDEN_PACKAGES = [
   "react",
   "react-dom",
+  "lucide-react",
   "radix-ui",
   "@radix-ui",
   "@base-ui",
   "@assistant-ui/react",
 ];
+const VUE_FORBIDDEN_PREFIXES = ["@assistant-ui/react-"];
 
 function isVueForbiddenPackage(specifier: string) {
-  return VUE_FORBIDDEN_PACKAGES.some(
-    (packageName) =>
-      specifier === packageName || specifier.startsWith(`${packageName}/`),
+  return (
+    VUE_FORBIDDEN_PACKAGES.some(
+      (packageName) =>
+        specifier === packageName || specifier.startsWith(`${packageName}/`),
+    ) || VUE_FORBIDDEN_PREFIXES.some((prefix) => specifier.startsWith(prefix))
   );
 }
 
@@ -851,7 +855,7 @@ function getScriptContents(file: RegistryOutputFile) {
   if (!file.path.endsWith(".vue")) return [{ content: file.content }];
 
   return [
-    ...file.content.matchAll(/<script(\s[^>]*)?>([\s\S]*?)<\/script\s*>/gi),
+    ...file.content.matchAll(/<script(\s[^>]*)?>([\s\S]*?)<\/script\b[^>]*>/gi),
   ].map((match) => ({
     content: match[2] ?? "",
     lang: getVueScriptLanguage(match[1] ?? ""),

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -160,21 +160,41 @@ export function validateBaseTreeRadixImports(
   throwIfFindings("Invalid base tree imports:", findings);
 }
 
+const VUE_FORBIDDEN_PACKAGES = [
+  "react",
+  "react-dom",
+  "radix-ui",
+  "@radix-ui",
+  "@base-ui",
+  "@assistant-ui/react",
+];
+
+function isVueForbiddenPackage(specifier: string) {
+  return VUE_FORBIDDEN_PACKAGES.some(
+    (packageName) =>
+      specifier === packageName || specifier.startsWith(`${packageName}/`),
+  );
+}
+
 export function validateVueFlavorContent(vueBuilt: BuiltRegistryPayload[]) {
   const findings = new Set<string>();
 
   for (const { payload } of vueBuilt) {
     for (const file of payload.files ?? []) {
-      for (const specifier of collectModuleSpecifiers(file)) {
+      for (const script of getScriptContents(file)) {
         if (
-          specifier === "react" ||
-          specifier === "react-dom" ||
-          specifier === "radix-ui" ||
-          specifier.startsWith("radix-ui/") ||
-          specifier.startsWith("@radix-ui/") ||
-          specifier.startsWith("@base-ui/") ||
-          specifier.startsWith("@assistant-ui/react")
+          script.lang !== undefined &&
+          script.lang !== "ts" &&
+          script.lang !== "js"
         ) {
+          findings.add(
+            `${payload.name}: vue tree file ${file.path} has unsupported script lang "${script.lang}"`,
+          );
+        }
+      }
+
+      for (const specifier of collectModuleSpecifiers(file)) {
+        if (isVueForbiddenPackage(specifier)) {
           findings.add(
             `${payload.name}: vue tree file ${file.path} imports forbidden "${specifier}"`,
           );
@@ -820,21 +840,28 @@ function getScriptKind(filePath: string) {
   return ts.ScriptKind.Unknown;
 }
 
-function getScriptContents(file: RegistryOutputFile) {
-  if (!file.path.endsWith(".vue")) return [file.content];
-
-  return [
-    ...file.content.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi),
-  ].map((match) => match[1] ?? "");
+function getVueScriptLanguage(attributes: string) {
+  const match = attributes.match(
+    /(?:^|\s)lang\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i,
+  );
+  return match?.[1] ?? match?.[2] ?? match?.[3];
 }
 
-function collectModuleSpecifiers(
-  file: RegistryOutputFile,
-  includeTypeOnly = true,
-) {
+function getScriptContents(file: RegistryOutputFile) {
+  if (!file.path.endsWith(".vue")) return [{ content: file.content }];
+
+  return [
+    ...file.content.matchAll(/<script(\s[^>]*)?>([\s\S]*?)<\/script\s*>/gi),
+  ].map((match) => ({
+    content: match[2] ?? "",
+    lang: getVueScriptLanguage(match[1] ?? ""),
+  }));
+}
+
+function collectModuleSpecifiers(file: RegistryOutputFile) {
   const specifiers = new Set<string>();
 
-  for (const content of getScriptContents(file)) {
+  for (const { content } of getScriptContents(file)) {
     const sourceFile = ts.createSourceFile(
       file.path,
       content,
@@ -847,10 +874,7 @@ function collectModuleSpecifiers(
       if (
         (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
         node.moduleSpecifier &&
-        isStringLiteralLike(node.moduleSpecifier) &&
-        (includeTypeOnly ||
-          (!node.isTypeOnly &&
-            (!ts.isImportDeclaration(node) || !node.importClause?.isTypeOnly)))
+        isStringLiteralLike(node.moduleSpecifier)
       ) {
         specifiers.add(node.moduleSpecifier.text);
       }
@@ -867,7 +891,6 @@ function collectModuleSpecifiers(
       }
 
       if (
-        includeTypeOnly &&
         ts.isImportTypeNode(node) &&
         ts.isLiteralTypeNode(node.argument) &&
         isStringLiteralLike(node.argument.literal)
@@ -937,10 +960,6 @@ const EXPLICIT_EXTENSIONS = new Set([
   ".vue",
   ".txt",
 ]);
-
-function getInstallPath(file: RegistryOutputFile) {
-  return (file.target ?? file.path).replace(/^@\//, "");
-}
 
 /**
  * The install paths a relative specifier may resolve to once the item is
@@ -1019,7 +1038,9 @@ function collectInstallContext(
 
   seen.add(item.name);
 
-  const files = new Set(item.files?.map(getInstallPath) ?? []);
+  const files = new Set(
+    item.files?.map((file) => file.target ?? file.path) ?? [],
+  );
   const packages = new Set([
     ...(item.dependencies ?? []),
     ...(item.devDependencies ?? []),
@@ -1070,7 +1091,7 @@ export function validateRegistryInstallMetadata(
     const installContext = collectInstallContext(item, itemByName);
 
     for (const file of item.files ?? []) {
-      for (const specifier of collectModuleSpecifiers(file, false)) {
+      for (const specifier of collectModuleSpecifiers(file)) {
         const localCandidates = getLocalComponentCandidates(specifier);
 
         if (localCandidates) {
@@ -1088,7 +1109,7 @@ export function validateRegistryInstallMetadata(
         }
 
         if (specifier.startsWith(".")) {
-          const installedPath = getInstallPath(file);
+          const installedPath = file.target ?? file.path;
           const candidates = getRelativeImportCandidates(
             specifier,
             installedPath,

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1766,16 +1766,14 @@ export const vueRegistry: RegistryItem[] = [
         path: "components/assistant-ui/thread.vue",
         sourcePath:
           "../../packages/ui/src/components/assistant-ui-vue/thread.vue",
-        target: "@/components/assistant-ui/thread.vue",
       },
       {
         type: "registry:component",
         path: "components/assistant-ui/message.vue",
         sourcePath:
           "../../packages/ui/src/components/assistant-ui-vue/message.vue",
-        target: "@/components/assistant-ui/message.vue",
       },
     ],
-    dependencies: ["@assistant-ui/vue", "@lucide/vue"],
+    dependencies: ["@assistant-ui/core", "@assistant-ui/vue", "@lucide/vue"],
   },
 ];

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1752,3 +1752,30 @@ export const registry: RegistryItem[] = [
     ],
   },
 ];
+
+export const vueRegistry: RegistryItem[] = [
+  {
+    name: "thread",
+    type: "registry:component",
+    title: "Thread",
+    description:
+      "Chat container with message list, composer, auto scroll, and accessibility built in.",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/thread.vue",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui-vue/thread.vue",
+        target: "@/components/assistant-ui/thread.vue",
+      },
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/message.vue",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui-vue/message.vue",
+        target: "@/components/assistant-ui/message.vue",
+      },
+    ],
+    dependencies: ["@assistant-ui/vue", "@lucide/vue"],
+  },
+];

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1753,7 +1753,14 @@ export const registry: RegistryItem[] = [
   },
 ];
 
-export const vueRegistry: RegistryItem[] = [
+export const vueRegistry: RegistryItem[] = [];
+
+/**
+ * Vue items staged for the `@assistant-ui/vue` publish flip. The build
+ * machinery and tests exercise them, but they stay out of the emitted
+ * registry until the package they install is public.
+ */
+export const stagedVueRegistry: RegistryItem[] = [
   {
     name: "thread",
     type: "registry:component",

--- a/packages/ui/src/components/assistant-ui-vue/message.vue
+++ b/packages/ui/src/components/assistant-ui-vue/message.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import {
+  ActionBarPrimitiveCopy,
+  ActionBarPrimitiveEdit,
+  ActionBarPrimitiveReload,
+  AuiIf,
+  BranchPickerPrimitiveCount,
+  BranchPickerPrimitiveNext,
+  BranchPickerPrimitiveNumber,
+  BranchPickerPrimitivePrevious,
+  ComposerPrimitiveCancel,
+  ComposerPrimitiveInput,
+  ComposerPrimitiveSend,
+  MessagePrimitiveParts,
+  useAuiState,
+} from "@assistant-ui/vue";
+import type {} from "@assistant-ui/core/store";
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  PencilIcon,
+  RefreshCwIcon,
+} from "@lucide/vue";
+
+const role = useAuiState((s) => s.message.role);
+const pulsing = useAuiState(
+  (s) => s.message.content.length === 0 && s.thread.isRunning,
+);
+const editing = useAuiState((s) => s.composer.isEditing);
+const copied = useAuiState((s) => s.message.isCopied);
+const error = useAuiState((s) => {
+  const message = s.message;
+  if (
+    message.role !== "assistant" ||
+    message.status.type !== "incomplete" ||
+    message.status.reason !== "error"
+  ) {
+    return null;
+  }
+  const value = message.status.error;
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "message" in value) {
+    return String(value.message);
+  }
+  return "An error occurred.";
+});
+</script>
+
+<template>
+  <li
+    :data-role="role"
+    class="group flex flex-col gap-1"
+    :class="role === 'user' ? 'items-end' : 'items-start'"
+  >
+    <div
+      v-if="editing"
+      class="border-border/60 flex w-full max-w-[80%] flex-col gap-2 rounded-xl border p-2"
+    >
+      <ComposerPrimitiveInput
+        class="w-full resize-none bg-transparent px-1 py-0.5 outline-none"
+        rows="2"
+      />
+      <div class="flex justify-end gap-2 text-sm">
+        <ComposerPrimitiveCancel
+          class="text-muted-foreground rounded-lg px-2 py-1"
+        >
+          Discard
+        </ComposerPrimitiveCancel>
+        <ComposerPrimitiveSend
+          class="bg-primary text-primary-foreground rounded-lg px-2 py-1 disabled:opacity-50"
+        >
+          Save
+        </ComposerPrimitiveSend>
+      </div>
+    </div>
+    <div
+      v-else
+      class="px-2 wrap-break-word"
+      :class="
+        role === 'user'
+          ? 'bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2'
+          : 'text-foreground leading-relaxed'
+      "
+    >
+      <MessagePrimitiveParts />
+      <span v-if="pulsing" class="animate-pulse">…</span>
+      <span v-if="error" class="text-destructive text-sm">{{ error }}</span>
+    </div>
+    <div
+      class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+    >
+      <ActionBarPrimitiveEdit
+        v-if="role === 'user'"
+        class="hover:text-foreground rounded p-1"
+        aria-label="Edit"
+      >
+        <PencilIcon class="size-3.5" />
+      </ActionBarPrimitiveEdit>
+      <ActionBarPrimitiveCopy
+        class="hover:text-foreground rounded p-1"
+        aria-label="Copy"
+      >
+        <CheckIcon v-if="copied" class="size-3.5" />
+        <CopyIcon v-else class="size-3.5" />
+      </ActionBarPrimitiveCopy>
+      <ActionBarPrimitiveReload
+        v-if="role === 'assistant'"
+        class="hover:text-foreground rounded p-1"
+        aria-label="Regenerate"
+      >
+        <RefreshCwIcon class="size-3.5" />
+      </ActionBarPrimitiveReload>
+      <AuiIf :condition="(s) => s.message.branchCount > 1">
+        <span class="flex items-center gap-0.5 text-xs">
+          <BranchPickerPrimitivePrevious
+            class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+            aria-label="Previous branch"
+          >
+            <ChevronLeftIcon class="size-3.5" />
+          </BranchPickerPrimitivePrevious>
+          <BranchPickerPrimitiveNumber /> / <BranchPickerPrimitiveCount />
+          <BranchPickerPrimitiveNext
+            class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+            aria-label="Next branch"
+          >
+            <ChevronRightIcon class="size-3.5" />
+          </BranchPickerPrimitiveNext>
+        </span>
+      </AuiIf>
+    </div>
+  </li>
+</template>

--- a/packages/ui/src/components/assistant-ui-vue/thread.vue
+++ b/packages/ui/src/components/assistant-ui-vue/thread.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import {
+  AuiIf,
+  ComposerPrimitiveCancel,
+  ComposerPrimitiveInput,
+  ComposerPrimitiveSend,
+  SuggestionPrimitiveDescription,
+  SuggestionPrimitiveTitle,
+  SuggestionPrimitiveTrigger,
+  ThreadPrimitiveMessages,
+  ThreadPrimitiveScrollToBottom,
+  ThreadPrimitiveSuggestions,
+  ThreadPrimitiveViewport,
+} from "@assistant-ui/vue";
+import type {} from "@assistant-ui/core/store";
+import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
+import Message from "@/components/assistant-ui/message.vue";
+</script>
+
+<template>
+  <div class="bg-background flex h-full">
+    <div class="flex min-w-0 flex-1 flex-col">
+      <ThreadPrimitiveViewport
+        class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+      >
+        <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+          <AuiIf :condition="(s) => s.thread.messages.length === 0">
+            <div
+              class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
+            >
+              <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+              <div
+                class="flex flex-wrap items-center justify-center gap-2 px-4"
+              >
+                <ThreadPrimitiveSuggestions>
+                  <SuggestionPrimitiveTrigger
+                    send
+                    class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+                  >
+                    <span class="font-medium"
+                      ><SuggestionPrimitiveTitle
+                    /></span>
+                    <span class="text-muted-foreground text-xs">
+                      <SuggestionPrimitiveDescription />
+                    </span>
+                  </SuggestionPrimitiveTrigger>
+                </ThreadPrimitiveSuggestions>
+              </div>
+            </div>
+          </AuiIf>
+          <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
+            <ThreadPrimitiveMessages>
+              <Message />
+            </ThreadPrimitiveMessages>
+          </ol>
+          <ThreadPrimitiveScrollToBottom
+            class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
+            aria-label="Scroll to bottom"
+          >
+            <ArrowDownIcon class="size-4" />
+          </ThreadPrimitiveScrollToBottom>
+        </div>
+      </ThreadPrimitiveViewport>
+      <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+        <div
+          class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+        >
+          <ComposerPrimitiveInput
+            class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+            placeholder="Send a message..."
+            rows="1"
+          />
+          <div class="flex items-center justify-end">
+            <AuiIf :condition="(s) => !s.thread.isRunning">
+              <ComposerPrimitiveSend
+                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+                aria-label="Send"
+              >
+                <ArrowUpIcon class="size-4.5" />
+              </ComposerPrimitiveSend>
+            </AuiIf>
+            <AuiIf :condition="(s) => s.thread.isRunning">
+              <ComposerPrimitiveCancel
+                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+                aria-label="Stop"
+              >
+                <SquareIcon class="size-3.5 fill-current" />
+              </ComposerPrimitiveCancel>
+            </AuiIf>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@vue/compiler-sfc':
+        specifier: ^3.5.41
+        version: 3.5.41
       ai:
         specifier: ^7.0.77
         version: 7.0.77(zod@4.4.3)


### PR DESCRIPTION
## summary

- the registry build can now emit a third flavor tree at `dist/vue/` with its own `registry.json`, following the existing `dist/base/` pattern; radix and base outputs are untouched
- the first vue item (`thread`, serving `thread.vue` + `message.vue` with dependencies `@assistant-ui/core`, `@assistant-ui/vue`, `@lucide/vue`) is **staged, not served**: `vueRegistry` is empty until the `@assistant-ui/vue` publish flip, so the deployed registry never publishes an install recipe for a private package; the flip PR moves the item from `stagedVueRegistry` into `vueRegistry`
- kit sources live at `packages/ui/src/components/assistant-ui-vue/`, adapted from the with-nuxt canonical-styled components (single-sourcing them and deleting the example copies is #6474)
- vue flavor purity is validated at build time (no `react`, `react-dom`, `lucide-react`, `radix-ui`, `@radix-ui/*`, `@base-ui/*`, `@assistant-ui/react`, or `@assistant-ui/react-*` imports, subpaths included), script blocks must be ts/js, and the SFC end-tag scan tolerates whitespace and stray attributes (CodeQL js/bad-tag-filter clean)

## test plan

### already verified

- [x] `pnpm -C apps/registry test` -> 50/50 green (staged-item emission with alias rewrite and type-only dependency closure, empty production index, SFC parse + compileScript smoke over both kit sources, purity rejections incl. `react/jsx-runtime`, `lucide-react`, `@assistant-ui/react-ui/lib/utils`, whitespace/attribute end tags, unsupported script langs)
- [x] `pnpm -C apps/registry build` -> `dist/vue/registry.json` emits `items: []` in production shape
- [x] baseline purity: built main's registry and `diff -rq` the two dist trees; radix and base are byte-identical

### reviewer should verify

- [ ] `pnpm -C apps/registry build` and confirm `dist/vue/registry.json` lists no items

## notes

- follow-up #6474 single-sources the vue kit (packages/ui vue devDependencies, with-nuxt aliasing the kit, delete the example copies)
- CLI and docs wiring for the vue flavor is follow-up work; this PR only builds the machinery
- no changeset: only private surfaces (`@assistant-ui/ui`, apps/registry) are touched