### PR TITLE
fix(cloud): coordinate anonymous auth across clients

### DIFF
--- a/.changeset/coordinate-cloud-anonymous-auth.md
+++ b/.changeset/coordinate-cloud-anonymous-auth.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: coordinate anonymous authentication across Cloud client instances

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -247,22 +247,37 @@ const removeRefreshToken = (baseUrl: string): void => {
   } catch {}
 };
 
-const anonymousAuthTokenRequests = new Map<string, Promise<string | null>>();
+const anonymousAuthTokenRequests = new WeakMap<
+  Storage,
+  Map<string, Promise<string | null>>
+>();
 
 const getSharedAnonymousAuthToken = (
   baseUrl: string,
   requestToken: () => Promise<string | null>,
 ): Promise<string | null> => {
-  const activeRequest = anonymousAuthTokenRequests.get(baseUrl);
+  const storage = getLocalStorage();
+  if (!storage) return requestToken();
+
+  let storageRequests = anonymousAuthTokenRequests.get(storage);
+  if (!storageRequests) {
+    storageRequests = new Map();
+    anonymousAuthTokenRequests.set(storage, storageRequests);
+  }
+
+  const activeRequest = storageRequests.get(baseUrl);
   if (activeRequest) return activeRequest;
 
   const request = requestToken();
   const sharedRequest = request.finally(() => {
-    if (anonymousAuthTokenRequests.get(baseUrl) === sharedRequest) {
-      anonymousAuthTokenRequests.delete(baseUrl);
+    if (storageRequests.get(baseUrl) === sharedRequest) {
+      storageRequests.delete(baseUrl);
+      if (storageRequests.size === 0) {
+        anonymousAuthTokenRequests.delete(storage);
+      }
     }
   });
-  anonymousAuthTokenRequests.set(baseUrl, sharedRequest);
+  storageRequests.set(baseUrl, sharedRequest);
   return sharedRequest;
 };
 

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -247,6 +247,7 @@ const removeRefreshToken = (baseUrl: string): void => {
   } catch {}
 };
 
+// In-flight sharing follows refresh-token storage scope to isolate server requests.
 const anonymousAuthTokenRequests = new WeakMap<
   Storage,
   Map<string, Promise<string | null>>
@@ -272,9 +273,6 @@ const getSharedAnonymousAuthToken = (
   const sharedRequest = request.finally(() => {
     if (storageRequests.get(baseUrl) === sharedRequest) {
       storageRequests.delete(baseUrl);
-      if (storageRequests.size === 0) {
-        anonymousAuthTokenRequests.delete(storage);
-      }
     }
   });
   storageRequests.set(baseUrl, sharedRequest);

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -247,6 +247,25 @@ const removeRefreshToken = (baseUrl: string): void => {
   } catch {}
 };
 
+const anonymousAuthTokenRequests = new Map<string, Promise<string | null>>();
+
+const getSharedAnonymousAuthToken = (
+  baseUrl: string,
+  requestToken: () => Promise<string | null>,
+): Promise<string | null> => {
+  const activeRequest = anonymousAuthTokenRequests.get(baseUrl);
+  if (activeRequest) return activeRequest;
+
+  const request = requestToken();
+  const sharedRequest = request.finally(() => {
+    if (anonymousAuthTokenRequests.get(baseUrl) === sharedRequest) {
+      anonymousAuthTokenRequests.delete(baseUrl);
+    }
+  });
+  anonymousAuthTokenRequests.set(baseUrl, sharedRequest);
+  return sharedRequest;
+};
+
 export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthStrategy {
   public readonly strategy = "anon";
 
@@ -255,7 +274,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
-    this.jwtStrategy = new AssistantCloudJWTAuthStrategy(async () => {
+    const requestAuthToken = async (): Promise<string | null> => {
       const currentTime = Date.now();
       const storedRefreshToken = readRefreshToken(this.baseUrl);
 
@@ -318,7 +337,10 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
         ),
       );
       return accessToken;
-    });
+    };
+    this.jwtStrategy = new AssistantCloudJWTAuthStrategy(() =>
+      getSharedAnonymousAuthToken(this.baseUrl, requestAuthToken),
+    );
   }
 
   public async getAuthHeaders(): Promise<Record<string, string> | false> {

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -132,7 +132,16 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
   });
 
   it("retries shared anonymous token requests after a failure", async () => {
-    delete (globalThis as { localStorage?: Storage }).localStorage;
+    const values = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
     const failure = new Error("authentication unavailable");
     const fetchMock = vi
       .fn()
@@ -157,6 +166,21 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     await expect(
       new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
     ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps anonymous token requests independent without localStorage", async () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    const fetchMock = mockAnonymousTokenFetch();
+    const first = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+    const second = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(
+      Promise.all([first.getAuthHeaders(), second.getAuthHeaders()]),
+    ).resolves.toEqual([
+      { Authorization: `Bearer ${accessToken}` },
+      { Authorization: `Bearer ${accessToken}` },
+    ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -106,6 +106,60 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates anonymous token requests across strategy instances", async () => {
+    const values = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    const fetchMock = mockAnonymousTokenFetch();
+    const first = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+    const second = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(
+      Promise.all([first.getAuthHeaders(), second.getAuthHeaders()]),
+    ).resolves.toEqual([
+      { Authorization: `Bearer ${accessToken}` },
+      { Authorization: `Bearer ${accessToken}` },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(values.get(refreshTokenKey)).toBe(JSON.stringify(refreshToken));
+  });
+
+  it("retries shared anonymous token requests after a failure", async () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    const failure = new Error("authentication unavailable");
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const first = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+    const second = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await Promise.all([
+      expect(first.getAuthHeaders()).rejects.toBe(failure),
+      expect(second.getAuthHeaders()).rejects.toBe(failure),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
+    ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("scopes anonymous refresh tokens by backend", async () => {
     const secondBaseUrl = "https://other.example.com";
     const values = new Map<string, string>();
@@ -140,10 +194,10 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       });
     vi.stubGlobal("fetch", fetchMock);
 
-    await new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders();
-    await new AssistantCloudAnonymousAuthStrategy(
-      secondBaseUrl,
-    ).getAuthHeaders();
+    await Promise.all([
+      new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
+      new AssistantCloudAnonymousAuthStrategy(secondBaseUrl).getAuthHeaders(),
+    ]);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,


### PR DESCRIPTION
## Summary

- share in-flight anonymous Cloud token acquisition across browser client instances using the same storage and backend
- keep different backend URLs and storage contexts independent
- avoid sharing credentials across SSR or other environments without accessible browser storage
- clear failed shared requests so later authentication attempts can retry

## Why

Request deduplication currently lives inside each JWT auth strategy instance. When two Cloud clients in the same browser storage context make their first request concurrently, both can read an empty refresh-token store and create separate anonymous identities. The last refresh token written wins, so one client may use an access token for an identity that cannot be restored after reload, making that identity's threads appear lost.

A regression test against current main created two anonymous auth strategies sharing one storage object and backend, and observed two `/v1/auth/tokens/anonymous` requests. Shared requests are now keyed first by the browser `Storage` object and then by backend URL. Clients in that scope receive one token acquisition, while different backends, different storage contexts, and no-storage server environments authenticate independently.

## Test plan

- `pnpm exec oxlint packages/cloud/src/AssistantCloudAuthStrategy.ts packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts`
- `pnpm --filter assistant-cloud test` (14 files, 102 tests)
- `pnpm --filter assistant-cloud build`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lOIU1NeuTYrF5v94eyko0Fw4yy_h6_7qqsYQ97gYN3tq9uKia7Uv5jkYRU0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->