### PR TITLE
fix(eve): scope runtime state to committed agents

### DIFF
--- a/.changeset/scope-eve-refetch-agents.md
+++ b/.changeset/scope-eve-refetch-agents.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: keep thread refetches scoped to the committed Eve agent

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1821,10 +1821,37 @@ describe("useEveAgentRuntime thread refetch", () => {
   it("keeps refetches scoped to the committed agent", async () => {
     const resumeA = vi.fn().mockResolvedValue(undefined);
     const resumeB = vi.fn().mockResolvedValue(undefined);
-    const agentA = createAgent({ session, resume: resumeA });
-    const agentB = createAgent({ session, resume: resumeB });
-    let currentAgent = agentA;
-    mockUseEveAgent.mockImplementation(() => currentAgent as never);
+    const agentA = createAgent({
+      data: {
+        messages: [
+          {
+            id: "workspace-a",
+            role: "user",
+            parts: [{ type: "text", text: "workspace A" }],
+          },
+        ],
+      },
+      session,
+      resume: resumeA,
+    });
+    const agentB = createAgent({
+      data: {
+        messages: [
+          {
+            id: "workspace-b",
+            role: "user",
+            parts: [{ type: "text", text: "workspace B" }],
+          },
+        ],
+      },
+      session,
+      resume: resumeB,
+    });
+    mockUseEveAgent.mockImplementation((options) =>
+      (options as { workspace: string }).workspace === "A"
+        ? (agentA as never)
+        : (agentB as never),
+    );
 
     const pending = new Promise<never>(() => {});
     let blocked = false;
@@ -1839,14 +1866,17 @@ describe("useEveAgentRuntime thread refetch", () => {
       </Suspense>
     );
 
-    const { result, rerender } = renderHook(() => useEveAgentRuntime(), {
-      wrapper: Wrapper,
-    });
+    const { result, rerender } = renderHook(
+      ({ workspace }) => useEveAgentRuntime({ workspace } as never),
+      {
+        initialProps: { workspace: "A" },
+        wrapper: Wrapper,
+      },
+    );
 
-    currentAgent = agentB;
     act(() => {
       blocked = true;
-      startTransition(() => rerender());
+      startTransition(() => rerender({ workspace: "B" }));
     });
     expect(mockUseEveAgent.mock.results.at(-1)?.value).toBe(agentB);
 
@@ -1856,6 +1886,9 @@ describe("useEveAgentRuntime thread refetch", () => {
 
     expect(resumeB).not.toHaveBeenCalled();
     expect(resumeA).toHaveBeenCalledTimes(1);
+
+    await stageMessage(result.current, "draft from A");
+    expect(getText(result.current)).toEqual(["workspace A", "draft from A"]);
   });
 
   it("replays the session through eve resume when the thread is refetched", async () => {

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { startTransition, Suspense, type PropsWithChildren } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { mockUseEveAgent } = vi.hoisted(() => ({
@@ -1816,6 +1817,46 @@ describe("useEveAgentRuntime cancel binding", () => {
 
 describe("useEveAgentRuntime thread refetch", () => {
   const session = { sessionId: "s1" };
+
+  it("keeps refetches scoped to the committed agent", async () => {
+    const resumeA = vi.fn().mockResolvedValue(undefined);
+    const resumeB = vi.fn().mockResolvedValue(undefined);
+    const agentA = createAgent({ session, resume: resumeA });
+    const agentB = createAgent({ session, resume: resumeB });
+    let currentAgent = agentA;
+    mockUseEveAgent.mockImplementation(() => currentAgent as never);
+
+    const pending = new Promise<never>(() => {});
+    let blocked = false;
+    const Blocker = () => {
+      if (blocked) throw pending;
+      return null;
+    };
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <Suspense fallback={null}>
+        {children}
+        <Blocker />
+      </Suspense>
+    );
+
+    const { result, rerender } = renderHook(() => useEveAgentRuntime(), {
+      wrapper: Wrapper,
+    });
+
+    currentAgent = agentB;
+    act(() => {
+      blocked = true;
+      startTransition(() => rerender());
+    });
+    expect(mockUseEveAgent.mock.results.at(-1)?.value).toBe(agentB);
+
+    await act(async () => {
+      await result.current.threads.reloadMainThread();
+    });
+
+    expect(resumeB).not.toHaveBeenCalled();
+    expect(resumeA).toHaveBeenCalledTimes(1);
+  });
 
   it("replays the session through eve resume when the thread is refetched", async () => {
     const resume = vi.fn().mockResolvedValue(undefined);

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { startTransition, Suspense, type PropsWithChildren } from "react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import {
+  startTransition,
+  Suspense,
+  useLayoutEffect,
+  type PropsWithChildren,
+} from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { mockUseEveAgent } = vi.hoisted(() => ({
@@ -1818,7 +1823,7 @@ describe("useEveAgentRuntime cancel binding", () => {
 describe("useEveAgentRuntime thread refetch", () => {
   const session = { sessionId: "s1" };
 
-  it("keeps refetches scoped to the committed agent", async () => {
+  const mockWorkspaceAgents = () => {
     const resumeA = vi.fn().mockResolvedValue(undefined);
     const resumeB = vi.fn().mockResolvedValue(undefined);
     const agentA = createAgent({
@@ -1852,6 +1857,58 @@ describe("useEveAgentRuntime thread refetch", () => {
         ? (agentA as never)
         : (agentB as never),
     );
+    return { agentA, agentB, resumeA, resumeB };
+  };
+
+  it("publishes committed state before descendant layout effects", async () => {
+    const { resumeA, resumeB } = mockWorkspaceAgents();
+
+    let refetch: Promise<void> | undefined;
+    let currentRuntime: ReturnType<typeof useEveAgentRuntime> | undefined;
+    const RefetchOnLayout = ({
+      runtime,
+      enabled,
+    }: {
+      runtime: ReturnType<typeof useEveAgentRuntime>;
+      enabled: boolean;
+    }) => {
+      useLayoutEffect(() => {
+        if (!enabled) return;
+        runtime.thread.append({
+          role: "user",
+          content: [{ type: "text", text: "draft from B" }],
+          startRun: false,
+        });
+        refetch = runtime.threads.reloadMainThread();
+      }, [enabled, runtime]);
+      return null;
+    };
+    const Probe = ({
+      workspace,
+      refetchOnLayout,
+    }: {
+      workspace: string;
+      refetchOnLayout: boolean;
+    }) => {
+      const runtime = useEveAgentRuntime({ workspace } as never);
+      currentRuntime = runtime;
+      return <RefetchOnLayout runtime={runtime} enabled={refetchOnLayout} />;
+    };
+
+    const view = render(<Probe workspace="A" refetchOnLayout={false} />);
+    view.rerender(<Probe workspace="B" refetchOnLayout />);
+    await act(async () => {
+      await refetch;
+    });
+
+    expect(resumeA).not.toHaveBeenCalled();
+    expect(resumeB).toHaveBeenCalledTimes(1);
+    expect(getText(currentRuntime!)).toEqual(["workspace B", "draft from B"]);
+    view.unmount();
+  });
+
+  it("keeps refetches scoped to the committed agent", async () => {
+    const { agentA, agentB, resumeA, resumeB } = mockWorkspaceAgents();
 
     const pending = new Promise<never>(() => {});
     let blocked = false;
@@ -1879,6 +1936,17 @@ describe("useEveAgentRuntime thread refetch", () => {
       startTransition(() => rerender({ workspace: "B" }));
     });
     expect(mockUseEveAgent.mock.results.at(-1)?.value).toBe(agentB);
+
+    const resetNotification = vi.spyOn(
+      result.current.thread,
+      "unstable_notifySessionReset",
+    );
+    act(() => {
+      eveExtras.tryGet(result.current.thread.getState().extras)!.reset();
+    });
+    expect(resetNotification).toHaveBeenCalledTimes(1);
+    expect(agentA.reset).toHaveBeenCalledTimes(1);
+    expect(agentB.reset).not.toHaveBeenCalled();
 
     await act(async () => {
       await result.current.threads.reloadMainThread();

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1908,7 +1908,7 @@ describe("useEveAgentRuntime thread refetch", () => {
   });
 
   it("keeps refetches scoped to the committed agent", async () => {
-    const { agentA, agentB, resumeA, resumeB } = mockWorkspaceAgents();
+    const { agentB, resumeA, resumeB } = mockWorkspaceAgents();
 
     const pending = new Promise<never>(() => {});
     let blocked = false;
@@ -1936,17 +1936,6 @@ describe("useEveAgentRuntime thread refetch", () => {
       startTransition(() => rerender({ workspace: "B" }));
     });
     expect(mockUseEveAgent.mock.results.at(-1)?.value).toBe(agentB);
-
-    const resetNotification = vi.spyOn(
-      result.current.thread,
-      "unstable_notifySessionReset",
-    );
-    act(() => {
-      eveExtras.tryGet(result.current.thread.getState().extras)!.reset();
-    });
-    expect(resetNotification).toHaveBeenCalledTimes(1);
-    expect(agentA.reset).toHaveBeenCalledTimes(1);
-    expect(agentB.reset).not.toHaveBeenCalled();
 
     await act(async () => {
       await result.current.threads.reloadMainThread();

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -3,7 +3,7 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useState,
@@ -237,8 +237,8 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);
   const agentRef = useRef(agent);
-  // Async dispatches must only observe values from committed renders.
-  useLayoutEffect(() => {
+  // Runtime actions must observe the current commit before descendant effects.
+  useInsertionEffect(() => {
     messagesRef.current = messages;
     agentRef.current = agent;
   }, [agent, messages]);
@@ -489,7 +489,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       );
     },
   });
-  useLayoutEffect(() => {
+  useInsertionEffect(() => {
     runtimeRef.current = runtime;
   }, [runtime]);
 

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   fromThreadMessageLike,
   generateId,
@@ -229,11 +236,12 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
 
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);
-  messagesRef.current = messages;
   const agentRef = useRef(agent);
-  useEffect(() => {
+  // Async dispatches must only observe values from committed renders.
+  useLayoutEffect(() => {
+    messagesRef.current = messages;
     agentRef.current = agent;
-  }, [agent]);
+  }, [agent, messages]);
 
   // Upstream `EveAgentStore` `send` and `respond` reject while a turn is in
   // flight and only resolve once the turn's stream parks, so a pending chain
@@ -481,7 +489,9 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       );
     },
   });
-  runtimeRef.current = runtime;
+  useLayoutEffect(() => {
+    runtimeRef.current = runtime;
+  }, [runtime]);
 
   return runtime;
 };

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -237,7 +237,8 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);
   const agentRef = useRef(agent);
-  // Runtime actions must observe the current commit before descendant effects.
+  // Descendant layout effects can dispatch runtime actions synchronously, so
+  // committed state must publish before child-first layout effects run.
   useInsertionEffect(() => {
     messagesRef.current = messages;
     agentRef.current = agent;
@@ -489,6 +490,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       );
     },
   });
+  // Reset callbacks share the commit boundary used by agent and message refs.
   useInsertionEffect(() => {
     runtimeRef.current = runtime;
   }, [runtime]);

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -237,8 +237,8 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);
   const agentRef = useRef(agent);
-  // Descendant layout effects can dispatch runtime actions synchronously, so
-  // committed state must publish before child-first layout effects run.
+  // Descendant layout effects can dispatch against these refs synchronously;
+  // this matches useA2ARuntime's commit-scoped ref publication.
   useInsertionEffect(() => {
     messagesRef.current = messages;
     agentRef.current = agent;
@@ -490,10 +490,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       );
     },
   });
-  // Reset callbacks share the commit boundary used by agent and message refs.
-  useInsertionEffect(() => {
-    runtimeRef.current = runtime;
-  }, [runtime]);
+  runtimeRef.current = runtime;
 
   return runtime;
 };

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -231,7 +231,9 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
   const agentRef = useRef(agent);
-  agentRef.current = agent;
+  useEffect(() => {
+    agentRef.current = agent;
+  }, [agent]);
 
   // Upstream `EveAgentStore` `send` and `respond` reject while a turn is in
   // flight and only resolve once the turn's stream parks, so a pending chain


### PR DESCRIPTION
## Summary

- publish Eve agent and message refs only after their render commits
- make those committed values available before descendant layout effects run
- prevent interrupted account or workspace renders from redirecting refetches or leaking messages
- add focused concurrent-render regressions and a patch changeset

## Why

`useEveAgentRuntime()` published render-derived agent and message values into shared refs during render, while queued refetches and message staging read those refs later. React may abandon a render after those refs have already been mutated.

In a focused reproduction, workspace A remained committed while workspace B rendered and suspended. Before the fix:

- refetching A called B's `resume()` once and never called A's `resume()`
- staging a draft in A produced `["workspace B", "draft from A"]`

A second committed-render probe showed that publishing in `useLayoutEffect` was still too late for synchronous actions from descendant layout effects: B's staged draft was lost.

The refs now update in `useInsertionEffect`, matching the commit-scoped publication pattern in `useA2ARuntime`. Abandoned renders cannot publish these values, and descendant layout actions see the current agent/message snapshot. Deliberate imperative message-ref updates during staging and reload remain unchanged.

## Verification

- reproduced the misdirected refetch and cross-workspace message leak before the fix
- reproduced a lost draft when publication waited until the parent layout effect
- verified committed A receives the refetch while suspended B receives none
- verified a descendant layout action retains B's history and draft and refetches B
- `pnpm --filter @assistant-ui/eve test` (150 tests)
- `pnpm --filter @assistant-ui/eve build`
- `pnpm exec oxlint packages/eve/src/useEveAgentRuntime.ts packages/eve/src/useEveAgentRuntime.test.tsx`
- `pnpm exec oxfmt --check packages/eve/src/useEveAgentRuntime.ts packages/eve/src/useEveAgentRuntime.test.tsx .changeset/scope-eve-refetch-agents.md`