### PR TITLE
fix(registry): reject stale install dependencies

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -4,8 +4,9 @@ import test from "node:test";
 import "tsx/esm";
 
 const {
-  collectAttributeSelectorValues,
   buildRegistry,
+  collectAttributeSelectorValues,
+  createRegistryDependencyUsageExemptions,
   createBaseRegistryItem,
   createRadixRegistryItem,
   expandBundledRegistryDependencies,
@@ -234,6 +235,10 @@ test("base registry item merges, rewrites, and deduplicates dependencies in orde
       "popover",
       "https://r.assistant-ui.com/message.json",
     ],
+    radixRegistryDependencies: ["input"],
+    registryDependencyUsageExemptions: {
+      "https://example.com/foreign.json": "Installs external theme metadata.",
+    },
   };
 
   assert.deepEqual(createBaseRegistryItem(item), {
@@ -264,7 +269,7 @@ test("base registry item rewriting is idempotent", () => {
   ]);
 });
 
-test("radix registry item removes base-only dependencies without rewriting", () => {
+test("radix registry item merges radix-only registry dependencies and removes base-only ones", () => {
   assert.deepEqual(
     createRadixRegistryItem({
       name: "example",
@@ -273,7 +278,11 @@ test("radix registry item removes base-only dependencies without rewriting", () 
         "https://r.assistant-ui.com/thread.json",
         "tooltip",
       ],
+      radixRegistryDependencies: ["tooltip", "input"],
       baseRegistryDependencies: ["https://r.assistant-ui.com/popover.json"],
+      registryDependencyUsageExemptions: {
+        tooltip: "Installs tooltip styles selected at runtime.",
+      },
     }),
     {
       name: "example",
@@ -281,6 +290,7 @@ test("radix registry item removes base-only dependencies without rewriting", () 
       registryDependencies: [
         "https://r.assistant-ui.com/thread.json",
         "tooltip",
+        "input",
       ],
     },
   );
@@ -708,6 +718,8 @@ const bundleFixtures = () => {
       "button",
       "https://r.assistant-ui.com/reasoning.json",
     ],
+    radixRegistryDependencies: ["input"],
+    baseRegistryDependencies: ["popover"],
   };
   const reasoning = {
     name: "reasoning",
@@ -773,6 +785,11 @@ test("bundling inlines the closure as targeted files and merges its dependencies
         "components/ui/collapsible.tsx",
         "../../packages/ui/src/components/react/ui/radix/collapsible.tsx",
       ],
+      [
+        "registry:file",
+        "components/ui/input.tsx",
+        "../../packages/ui/src/components/react/ui/radix/input.tsx",
+      ],
     ],
   );
   assert.deepEqual(expanded.dependencies, [
@@ -796,6 +813,7 @@ test("bundling sources ui primitives and their package from the requested flavor
     [
       "../../packages/ui/src/components/react/ui/base/button.tsx",
       "../../packages/ui/src/components/react/ui/base/collapsible.tsx",
+      "../../packages/ui/src/components/react/ui/base/popover.tsx",
     ],
   );
   assert.deepEqual(expanded.baseDependencies, ["@base-ui/react"]);
@@ -1522,9 +1540,9 @@ const componentItem = (files, extra = {}) => ({
   ...extra,
 });
 
-const findingsFrom = (payloads) => {
+const findingsFrom = (payloads, usageExemptions) => {
   try {
-    validateRegistryInstallMetadata(payloads);
+    validateRegistryInstallMetadata(payloads, usageExemptions);
   } catch (error) {
     return error.message;
   }
@@ -1614,7 +1632,7 @@ test("install validation resolves a dotted alias basename to its shipped source"
 
   assert.match(
     findingsFrom([componentItem([importer])]),
-    /provides components\/assistant-ui\/tool\.config or components\/assistant-ui\/tool\.config\.tsx/,
+    /provides components\/assistant-ui\/tool\.config\.tsx/,
   );
 });
 
@@ -1637,6 +1655,69 @@ test("install validation resolves an alias asset import behind a query suffix", 
   assert.match(
     findingsFrom([componentItem([importer])]),
     /provides components\/assistant-ui\/logo\.svg/,
+  );
+});
+
+test("install validation resolves direct dependencies through any local alias target", () => {
+  for (const [specifier, providedPath] of [
+    ["@/lib/feature", "lib/feature.ts"],
+    ["@/server/config.js", "server/config.ts"],
+    ["@/data/client", "data/client/index.ts"],
+    ["@/assets/logo.svg?url", "assets/logo.svg"],
+  ]) {
+    const dependency = "https://r.assistant-ui.com/provider.json";
+    const findings = findingsFrom([
+      componentItem(
+        [
+          {
+            path: "components/assistant-ui/demo.tsx",
+            content: `import value from "${specifier}";\n`,
+          },
+        ],
+        { registryDependencies: [dependency] },
+      ),
+      {
+        name: "provider",
+        type: "registry:lib",
+        files: [
+          {
+            path: `source/${providedPath}`,
+            target: providedPath,
+            content: "export default true;\n",
+          },
+        ],
+      },
+    ]);
+
+    assert.equal(findings, null, `${specifier} resolves to ${providedPath}`);
+  }
+});
+
+test("install validation rejects an unresolved non-ambient local alias", () => {
+  const findings = findingsFrom([
+    componentItem([
+      {
+        path: "components/assistant-ui/demo.tsx",
+        content: 'import value from "@/lib/feature";\n',
+      },
+    ]),
+  ]);
+
+  assert.match(findings, /imports "@\/lib\/feature"/);
+  assert.match(findings, /provides lib\/feature\.tsx or lib\/feature\.ts/);
+});
+
+test("install validation allows the ambient shadcn utils alias", () => {
+  assert.equal(
+    findingsFrom([
+      componentItem([
+        {
+          path: "components/assistant-ui/demo.tsx",
+          content: 'import { cn } from "@/lib/utils";\n',
+        },
+      ]),
+    ]),
+    null,
   );
 });
 
@@ -1696,6 +1777,425 @@ test("cli scanner element mapping names a real registry item for every element f
     assert.ok(
       itemNames.has(expected),
       `the scanner maps a shipped element file to "${expected}", which is not a registry item`,
+    );
+  }
+});
+
+test("install validation rejects a stale shadcn UI registry dependency", () => {
+  const findings = findingsFrom([
+    componentItem(
+      [
+        {
+          path: "components/assistant-ui/demo.tsx",
+          content: "export const Demo = () => null;\n",
+        },
+      ],
+      { registryDependencies: ["button"] },
+    ),
+  ]);
+
+  assert.match(
+    findings,
+    /demo: registry dependency "button" is not imported directly by this item/,
+  );
+});
+
+test("install validation recognizes a shadcn UI dependency used through an alias", () => {
+  const findings = findingsFrom([
+    componentItem(
+      [
+        {
+          path: "components/assistant-ui/demo.tsx",
+          content: 'import { Button } from "@/components/ui/button";\n',
+        },
+      ],
+      { registryDependencies: ["button"] },
+    ),
+  ]);
+
+  assert.equal(findings, null);
+});
+
+test("install validation recognizes a direct assistant URL used through an alias", () => {
+  const findings = findingsFrom([
+    componentItem(
+      [
+        {
+          path: "components/assistant-ui/demo.tsx",
+          content: 'import { Badge } from "@/components/assistant-ui/badge";\n',
+        },
+      ],
+      {
+        registryDependencies: ["https://r.assistant-ui.com/badge.json"],
+      },
+    ),
+    {
+      name: "badge",
+      type: "registry:component",
+      files: [
+        {
+          path: "components/assistant-ui/badge.tsx",
+          content: "export const Badge = () => null;\n",
+        },
+      ],
+    },
+  ]);
+
+  assert.equal(findings, null);
+});
+
+test("install validation recognizes a direct assistant dependency through relative imports and targets", () => {
+  const findings = findingsFrom([
+    componentItem(
+      [
+        {
+          path: "packages/ui/src/components/thread.tsx",
+          target: "components/assistant-ui/thread.tsx",
+          content: 'import { Badge } from "./badge";\n',
+        },
+      ],
+      {
+        registryDependencies: ["https://r.assistant-ui.com/badge.json"],
+      },
+    ),
+    {
+      name: "badge",
+      type: "registry:component",
+      files: [
+        {
+          path: "packages/ui/src/components/badge.tsx",
+          target: "components/assistant-ui/badge.tsx",
+          content: "export const Badge = () => null;\n",
+        },
+      ],
+    },
+  ]);
+
+  assert.equal(findings, null);
+});
+
+test("install validation does not count a transitive install as direct dependency usage", () => {
+  const findings = findingsFrom([
+    componentItem(
+      [
+        {
+          path: "components/assistant-ui/demo.tsx",
+          content: 'import { Badge } from "@/components/assistant-ui/badge";\n',
+        },
+      ],
+      {
+        registryDependencies: ["https://r.assistant-ui.com/thread.json"],
+      },
+    ),
+    {
+      name: "thread",
+      type: "registry:component",
+      files: [
+        {
+          path: "components/assistant-ui/thread.tsx",
+          content: 'import { Badge } from "@/components/assistant-ui/badge";\n',
+        },
+      ],
+      registryDependencies: ["https://r.assistant-ui.com/badge.json"],
+    },
+    {
+      name: "badge",
+      type: "registry:component",
+      files: [
+        {
+          path: "components/assistant-ui/badge.tsx",
+          content: "export const Badge = () => null;\n",
+        },
+      ],
+    },
+  ]);
+
+  assert.match(
+    findings,
+    /demo: registry dependency "https:\/\/r\.assistant-ui\.com\/thread\.json" is not imported directly by this item/,
+  );
+});
+
+test("install validation accepts an explicitly documented non-imported style dependency", () => {
+  const style = {
+    name: "generative-ui-style",
+    type: "registry:style",
+  };
+  const item = {
+    ...componentItem([], {
+      registryDependencies: [
+        "https://r.assistant-ui.com/generative-ui-style.json",
+      ],
+      registryDependencyUsageExemptions: {
+        "https://r.assistant-ui.com/generative-ui-style.json":
+          "Installs CSS variables and vocabulary rules consumed through class names.",
+      },
+    }),
+    name: "generative-ui",
+  };
+
+  assert.equal(
+    findingsFrom(
+      [item, style],
+      createRegistryDependencyUsageExemptions([item, style], "radix"),
+    ),
+    null,
+  );
+
+  assert.match(
+    findingsFrom([
+      componentItem([], {
+        registryDependencies: [
+          "https://r.assistant-ui.com/generative-ui-style.json",
+        ],
+      }),
+      style,
+    ]),
+    /demo: registry dependency "https:\/\/r\.assistant-ui\.com\/generative-ui-style\.json" is not imported directly by this item/,
+  );
+});
+
+test("install validation accepts an explicitly documented page sidecar", () => {
+  const backend = {
+    name: "backend",
+    type: "registry:page",
+    files: [
+      {
+        path: "app/api/chat/route.ts",
+        content: "export const POST = () => null;\n",
+      },
+    ],
+  };
+  const quickStart = {
+    name: "quick-start",
+    type: "registry:page",
+    registryDependencies: ["https://r.assistant-ui.com/backend.json"],
+    registryDependencyUsageExemptions: {
+      "https://r.assistant-ui.com/backend.json":
+        "Installs the API route used by the page without importing it into the client bundle.",
+    },
+  };
+
+  assert.equal(
+    findingsFrom(
+      [quickStart, backend],
+      createRegistryDependencyUsageExemptions([quickStart, backend], "radix"),
+    ),
+    null,
+  );
+
+  assert.match(
+    findingsFrom([
+      componentItem([], {
+        registryDependencies: ["https://r.assistant-ui.com/backend.json"],
+      }),
+      backend,
+    ]),
+    /demo: registry dependency "https:\/\/r\.assistant-ui\.com\/backend\.json" is not imported directly by this item/,
+  );
+
+  assert.match(
+    findingsFrom([
+      {
+        name: "quick-start",
+        type: "registry:page",
+        registryDependencies: ["https://r.assistant-ui.com/thread.json"],
+      },
+      {
+        name: "thread",
+        type: "registry:component",
+        files: [
+          {
+            path: "components/assistant-ui/thread.tsx",
+            content: "export const Thread = () => null;\n",
+          },
+        ],
+      },
+    ]),
+    /quick-start: registry dependency "https:\/\/r\.assistant-ui\.com\/thread\.json" is not imported directly by this item/,
+  );
+});
+
+test("install validation requires foreign registry URLs to be explicitly documented", () => {
+  const item = componentItem([], {
+    registryDependencies: ["https://example.com/foreign.json"],
+    registryDependencyUsageExemptions: {
+      "https://example.com/foreign.json":
+        "Installs metadata whose foreign payload is unavailable to this build.",
+    },
+  });
+
+  assert.equal(
+    findingsFrom(
+      [item],
+      createRegistryDependencyUsageExemptions([item], "radix"),
+    ),
+    null,
+  );
+
+  assert.match(
+    findingsFrom([
+      componentItem([], {
+        registryDependencies: ["https://example.com/foreign.json"],
+      }),
+    ]),
+    /foreign\.json" is not imported directly by this item/,
+  );
+});
+
+test("registry dependency usage exemptions reject misspelled dependencies", () => {
+  const item = componentItem([], {
+    registryDependencies: ["button"],
+    registryDependencyUsageExemptions: {
+      buton: "Installs a component used outside this item's module graph.",
+    },
+  });
+
+  assert.throws(
+    () => createRegistryDependencyUsageExemptions([item], "radix"),
+    /demo: registryDependencyUsageExemptions entry "buton" does not match a declared registry dependency/,
+  );
+});
+
+test("registry dependency usage exemptions reject stale entries", () => {
+  const item = componentItem([], {
+    registryDependencies: [],
+    registryDependencyUsageExemptions: {
+      button: "Installs a component used outside this item's module graph.",
+    },
+  });
+
+  assert.throws(
+    () => createRegistryDependencyUsageExemptions([item], "base"),
+    /demo: registryDependencyUsageExemptions entry "button" does not match a declared registry dependency/,
+  );
+});
+
+test("registry dependency usage exemptions require a reviewable reason", async () => {
+  const item = componentItem([], {
+    registryDependencies: ["button"],
+    registryDependencyUsageExemptions: { button: "   " },
+  });
+
+  await assert.rejects(
+    () => buildRegistry([item], []),
+    /Invalid registry metadata:[\s\S]*registryDependencyUsageExemptions\.button/,
+  );
+});
+
+test("registry dependency usage exemptions do not hide missing local items", () => {
+  const dependency = "https://r.assistant-ui.com/missing.json";
+  const item = componentItem([], {
+    registryDependencies: [dependency],
+    registryDependencyUsageExemptions: {
+      [dependency]: "Installs runtime-selected metadata.",
+    },
+  });
+
+  const findings = findingsFrom(
+    [item],
+    createRegistryDependencyUsageExemptions([item], "radix"),
+  );
+  assert.match(findings, /does not match a local registry item/);
+});
+
+test("registry dependency usage exemptions reject directly imported dependencies", () => {
+  const item = componentItem(
+    [
+      {
+        path: "components/assistant-ui/demo.tsx",
+        content: 'import { Button } from "@/components/ui/button";\n',
+      },
+    ],
+    {
+      registryDependencies: ["button"],
+      registryDependencyUsageExemptions: {
+        button: "Installs a component selected at runtime.",
+      },
+    },
+  );
+
+  const findings = findingsFrom(
+    [item],
+    createRegistryDependencyUsageExemptions([item], "radix"),
+  );
+  assert.match(
+    findings,
+    /registryDependencyUsageExemptions entry "button" is unnecessary because the dependency is imported directly/,
+  );
+});
+
+test("registry dependency usage exemptions include only the active flavor", () => {
+  const commonDependency = "https://r.assistant-ui.com/theme.json";
+  const item = componentItem([], {
+    registryDependencies: [commonDependency],
+    radixRegistryDependencies: ["input"],
+    baseRegistryDependencies: ["popover"],
+    registryDependencyUsageExemptions: {
+      [commonDependency]: "Installs shared theme metadata.",
+      input: "Installs the Radix input for runtime composition.",
+      popover: "Installs the Base popover for runtime composition.",
+    },
+  });
+
+  const radixExemptions = createRegistryDependencyUsageExemptions(
+    [item],
+    "radix",
+  ).get("demo");
+  const baseExemptions = createRegistryDependencyUsageExemptions(
+    [item],
+    "base",
+  ).get("demo");
+
+  assert.deepEqual([...radixExemptions], [commonDependency, "input"]);
+  assert.deepEqual(
+    [...baseExemptions],
+    ["https://r.assistant-ui.com/base/theme.json", "popover"],
+  );
+});
+
+test("internal usage exemptions do not leak into Vue payloads or indexes", async () => {
+  const dependency = "https://example.com/theme.json";
+  const vueItem = {
+    name: "vue-theme",
+    type: "registry:style",
+    registryDependencies: [dependency],
+    registryDependencyUsageExemptions: {
+      [dependency]: "Installs foreign theme metadata.",
+    },
+  };
+
+  await buildRegistry([], [vueItem]);
+
+  for (const outputPath of [
+    "dist/vue/registry.json",
+    "dist/vue/vue-theme.json",
+  ]) {
+    const output = await readFile(outputPath, "utf8");
+    assert.equal(
+      output.includes("registryDependencyUsageExemptions"),
+      false,
+      `${outputPath} excludes internal validation metadata`,
+    );
+  }
+});
+
+test("the real registry build satisfies the emitted install metadata contract", async () => {
+  const { registry, vueRegistry } = await import("../src/registry.ts");
+
+  await assert.doesNotReject(() => buildRegistry(registry, vueRegistry));
+
+  for (const outputPath of [
+    "dist/registry.json",
+    "dist/base/registry.json",
+    "dist/generative-ui.json",
+    "dist/base/generative-ui.json",
+  ]) {
+    const output = await readFile(outputPath, "utf8");
+    assert.equal(
+      output.includes("registryDependencyUsageExemptions"),
+      false,
+      `${outputPath} excludes internal validation metadata`,
     );
   }
 });

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -48,10 +48,14 @@ type RegistryFile = NonNullable<RegistryItem["files"]>[number];
 type RegistryBuildItem = Omit<
   RegistryItem,
   | "bundledRegistryDependencies"
+  | "registryDependencyUsageExemptions"
+  | "radixRegistryDependencies"
   | "baseRegistryDependencies"
   | "radixDependencies"
   | "baseDependencies"
 >;
+type RegistryPayloadInput = RegistryBuildItem &
+  Pick<RegistryItem, "registryDependencyUsageExemptions">;
 type UiFlavor = "radix" | "base";
 type RegistryOutputFile = Omit<RegistryFile, "sourcePath"> & {
   content: string;
@@ -60,6 +64,12 @@ type RegistryOutputItem = Omit<RegistryBuildItem, "files"> & {
   $schema: string;
   files?: RegistryOutputFile[];
 };
+
+function stripRegistryDependencyUsageExemptions(item: RegistryItem) {
+  const { registryDependencyUsageExemptions: _usageExemptions, ...publicItem } =
+    item;
+  return publicItem;
+}
 
 /**
  * Transform @assistant-ui/react-ui/* imports to @/* imports for standalone projects
@@ -235,7 +245,7 @@ export function validateEmittedSpecifierHygiene(built: BuiltRegistryPayload[]) {
 }
 
 function createRegistryPayload(
-  item: RegistryBuildItem,
+  item: RegistryPayloadInput,
   useRadixVariants = false,
 ): BuiltRegistryPayload {
   const readPaths: string[] = [];
@@ -273,7 +283,8 @@ function createRegistryPayload(
       content,
     };
   });
-  const { files: _, ...itemOutput } = item;
+  const { files: _, ...itemOutput } =
+    stripRegistryDependencyUsageExemptions(item);
 
   const payload = {
     $schema: REGISTRY_ITEM_SCHEMA_URL,
@@ -641,6 +652,62 @@ function getAssistantRegistryDependencyName(dependency: string) {
   return ASSISTANT_REGISTRY_DEPENDENCY_RE.exec(dependency)?.[1] ?? null;
 }
 
+function getFlavorRegistryDependency(
+  dependency: string,
+  flavor: UiFlavor | undefined,
+) {
+  const name = getAssistantRegistryDependencyName(dependency);
+  return flavor === "base" && name
+    ? `https://r.assistant-ui.com/base/${name}.json`
+    : dependency;
+}
+
+type RegistryDependencyUsageExemptions = Map<string, Set<string>>;
+
+export function createRegistryDependencyUsageExemptions(
+  items: RegistryItem[],
+  flavor?: UiFlavor,
+): RegistryDependencyUsageExemptions {
+  const exemptionsByItem = new Map<string, Set<string>>();
+  const findings = new Set<string>();
+
+  for (const item of items) {
+    const declaredDependencies = new Set([
+      ...(item.registryDependencies ?? []),
+      ...(item.radixRegistryDependencies ?? []),
+      ...(item.baseRegistryDependencies ?? []),
+    ]);
+    const activeDependencies = new Set([
+      ...(item.registryDependencies ?? []),
+      ...(flavor === "radix" ? (item.radixRegistryDependencies ?? []) : []),
+      ...(flavor === "base" ? (item.baseRegistryDependencies ?? []) : []),
+    ]);
+    const activeExemptions = new Set<string>();
+
+    for (const dependency of Object.keys(
+      item.registryDependencyUsageExemptions ?? {},
+    )) {
+      if (!declaredDependencies.has(dependency)) {
+        findings.add(
+          `${item.name}: registryDependencyUsageExemptions entry "${dependency}" does not match a declared registry dependency`,
+        );
+        continue;
+      }
+
+      if (activeDependencies.has(dependency)) {
+        activeExemptions.add(getFlavorRegistryDependency(dependency, flavor));
+      }
+    }
+
+    if (activeExemptions.size > 0) {
+      exemptionsByItem.set(item.name, activeExemptions);
+    }
+  }
+
+  throwIfFindings("Invalid registry dependency usage exemptions:", findings);
+  return exemptionsByItem;
+}
+
 /**
  * Inlines the files and dependencies of `bundledRegistryDependencies` into the item.
  *
@@ -690,9 +757,9 @@ export function expandBundledRegistryDependencies(
       bundled.push(dependencyItem);
       walk([
         ...(dependencyItem.registryDependencies ?? []),
-        ...(flavor === "base"
-          ? (dependencyItem.baseRegistryDependencies ?? [])
-          : []),
+        ...(flavor === "radix"
+          ? (dependencyItem.radixRegistryDependencies ?? [])
+          : (dependencyItem.baseRegistryDependencies ?? [])),
       ]);
     }
   };
@@ -766,21 +833,41 @@ export function expandBundledRegistryDependencies(
 export function createRadixRegistryItem(item: RegistryItem): RegistryBuildItem {
   const {
     baseRegistryDependencies: _,
+    registryDependencyUsageExemptions: _usageExemptions,
+    radixRegistryDependencies,
     radixDependencies,
     baseDependencies: __,
     ...radixItem
   } = item;
 
+  const hasRegistryDependencies =
+    radixItem.registryDependencies !== undefined ||
+    radixRegistryDependencies !== undefined;
+
   const hasDependencies =
     radixItem.dependencies !== undefined || radixDependencies !== undefined;
 
-  if (!hasDependencies) return radixItem;
+  let result = radixItem;
+
+  if (hasRegistryDependencies) {
+    result = {
+      ...result,
+      registryDependencies: [
+        ...new Set([
+          ...(radixItem.registryDependencies ?? []),
+          ...(radixRegistryDependencies ?? []),
+        ]),
+      ],
+    };
+  }
+
+  if (!hasDependencies) return result;
 
   return {
-    ...radixItem,
+    ...result,
     dependencies: [
       ...new Set([
-        ...(radixItem.dependencies ?? []),
+        ...(result.dependencies ?? []),
         ...(radixDependencies ?? []),
       ]),
     ],
@@ -790,7 +877,9 @@ export function createRadixRegistryItem(item: RegistryItem): RegistryBuildItem {
 export function createBaseRegistryItem(item: RegistryItem): RegistryBuildItem {
   const {
     baseRegistryDependencies,
-    radixDependencies: _,
+    registryDependencyUsageExemptions: _usageExemptions,
+    radixRegistryDependencies: _,
+    radixDependencies: __,
     baseDependencies,
     ...baseItem
   } = item;
@@ -808,10 +897,7 @@ export function createBaseRegistryItem(item: RegistryItem): RegistryBuildItem {
     const registryDependencies = [
       ...(baseItem.registryDependencies ?? []),
       ...(baseRegistryDependencies ?? []),
-    ].map((dependency) => {
-      const name = getAssistantRegistryDependencyName(dependency);
-      return name ? `https://r.assistant-ui.com/base/${name}.json` : dependency;
-    });
+    ].map((dependency) => getFlavorRegistryDependency(dependency, "base"));
 
     result = {
       ...result,
@@ -919,30 +1005,14 @@ function collectModuleSpecifiers(file: RegistryOutputFile) {
   return specifiers;
 }
 
-function getLocalComponentCandidates(specifier: string) {
-  if (
-    !specifier.startsWith("@/components/") &&
-    !specifier.startsWith("@/hooks/")
-  )
-    return null;
+function getAliasImportCandidates(specifier: string) {
+  if (!specifier.startsWith("@/")) return null;
 
-  const componentPath = specifier.replace(/[?#].*$/, "").slice(2);
-  const extension = path.extname(componentPath);
-  if (EXPLICIT_EXTENSIONS.has(extension.toLowerCase())) return [componentPath];
-  if (!extension)
-    return MODULE_EXTENSIONS.map(
-      (moduleExtension) => `${componentPath}${moduleExtension}`,
-    );
-
-  return [
-    componentPath,
-    ...MODULE_EXTENSIONS.map(
-      (moduleExtension) => `${componentPath}${moduleExtension}`,
-    ),
-    ...MODULE_EXTENSIONS.map(
-      (moduleExtension) => `${componentPath}/index${moduleExtension}`,
-    ),
-  ];
+  const installPath = path.posix.normalize(
+    specifier.replace(/[?#].*$/, "").slice(2),
+  );
+  if (installPath === ".." || installPath.startsWith("../")) return [];
+  return getInstallPathCandidates(installPath);
 }
 
 const MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js"];
@@ -973,6 +1043,40 @@ const EXPLICIT_EXTENSIONS = new Set([
   ".txt",
 ]);
 
+const AMBIENT_LOCAL_IMPORT_PATHS = new Set(
+  MODULE_EXTENSIONS.map((extension) => `lib/utils${extension}`),
+);
+
+function getInstallPathCandidates(installPath: string) {
+  const extension = path.posix.extname(installPath).toLowerCase();
+  const candidates = new Set<string>();
+
+  if (EXPLICIT_EXTENSIONS.has(extension)) {
+    candidates.add(installPath);
+    if (extension === ".js" || extension === ".jsx") {
+      const base = installPath.slice(0, -extension.length);
+      for (const moduleExtension of MODULE_EXTENSIONS) {
+        candidates.add(`${base}${moduleExtension}`);
+      }
+    }
+  } else {
+    for (const moduleExtension of MODULE_EXTENSIONS) {
+      candidates.add(`${installPath}${moduleExtension}`);
+    }
+    for (const moduleExtension of MODULE_EXTENSIONS) {
+      candidates.add(`${installPath}/index${moduleExtension}`);
+    }
+  }
+
+  return [...candidates];
+}
+
+function isAmbientLocalImport(candidates: string[]) {
+  return candidates.some((candidate) =>
+    AMBIENT_LOCAL_IMPORT_PATHS.has(candidate),
+  );
+}
+
 /**
  * The install paths a relative specifier may resolve to once the item is
  * installed. A specifier is satisfied when the install closure provides any one
@@ -995,27 +1099,7 @@ export function getRelativeImportCandidates(
   );
   if (resolved === ".." || resolved.startsWith("../")) return null;
 
-  const extension = path.posix.extname(resolved).toLowerCase();
-  const candidates = new Set<string>();
-
-  if (EXPLICIT_EXTENSIONS.has(extension)) {
-    candidates.add(resolved);
-    if (extension === ".js" || extension === ".jsx") {
-      const base = resolved.slice(0, -extension.length);
-      for (const moduleExtension of MODULE_EXTENSIONS) {
-        candidates.add(`${base}${moduleExtension}`);
-      }
-    }
-  } else {
-    for (const moduleExtension of MODULE_EXTENSIONS) {
-      candidates.add(`${resolved}${moduleExtension}`);
-    }
-    for (const moduleExtension of MODULE_EXTENSIONS) {
-      candidates.add(`${resolved}/index${moduleExtension}`);
-    }
-  }
-
-  return [...candidates];
+  return getInstallPathCandidates(resolved);
 }
 
 function collectCssPackageImports(value: unknown, imports = new Set<string>()) {
@@ -1081,20 +1165,86 @@ function collectInstallContext(
   return { files, packages };
 }
 
+function collectDirectImportedPaths(item: RegistryOutputItem) {
+  const paths = new Set<string>();
+
+  for (const file of item.files ?? []) {
+    for (const specifier of collectModuleSpecifiers(file)) {
+      const aliasCandidates = getAliasImportCandidates(specifier);
+      if (aliasCandidates) {
+        for (const candidate of aliasCandidates) paths.add(candidate);
+        continue;
+      }
+
+      if (specifier.startsWith(".")) {
+        const candidates = getRelativeImportCandidates(
+          specifier,
+          file.target ?? file.path,
+        );
+        for (const candidate of candidates ?? []) paths.add(candidate);
+      }
+    }
+  }
+
+  return paths;
+}
+
+function isDirectRegistryDependencyUsed(
+  dependency: string,
+  dependencyItem: RegistryOutputItem | undefined,
+  directImportedPaths: Set<string>,
+) {
+  const providedPaths = dependencyItem
+    ? (dependencyItem.files ?? []).map((file) => file.target ?? file.path)
+    : dependency.startsWith("http")
+      ? []
+      : [`components/ui/${dependency}.tsx`];
+
+  return providedPaths.some((providedPath) =>
+    directImportedPaths.has(providedPath),
+  );
+}
+
 export function validateRegistryInstallMetadata(
   payloads: RegistryOutputItem[],
+  usageExemptions: RegistryDependencyUsageExemptions = new Map(),
 ) {
   const itemByName = new Map(payloads.map((item) => [item.name, item]));
   const findings = new Set<string>();
 
   for (const item of payloads) {
+    const directImportedPaths = collectDirectImportedPaths(item);
+
     for (const dependency of item.registryDependencies ?? []) {
       const assistantDependencyName =
         getAssistantRegistryDependencyName(dependency);
 
-      if (assistantDependencyName && !itemByName.has(assistantDependencyName)) {
+      const dependencyItem = assistantDependencyName
+        ? itemByName.get(assistantDependencyName)
+        : undefined;
+
+      if (assistantDependencyName && !dependencyItem) {
         findings.add(
           `${item.name}: registry dependency "${dependency}" does not match a local registry item`,
+        );
+        continue;
+      }
+
+      const isDirectlyUsed = isDirectRegistryDependencyUsed(
+        dependency,
+        dependencyItem,
+        directImportedPaths,
+      );
+      const isUsageExempt =
+        usageExemptions.get(item.name)?.has(dependency) ?? false;
+
+      if (isDirectlyUsed && isUsageExempt) {
+        findings.add(
+          `${item.name}: registryDependencyUsageExemptions entry "${dependency}" is unnecessary because the dependency is imported directly`,
+        );
+      } else if (!isDirectlyUsed && !isUsageExempt) {
+        findings.add(
+          `${item.name}: registry dependency "${dependency}" is not imported directly by this item and has no registryDependencyUsageExemptions entry`,
         );
       }
     }
@@ -1103,16 +1253,18 @@ export function validateRegistryInstallMetadata(
 
     for (const file of item.files ?? []) {
       for (const specifier of collectModuleSpecifiers(file)) {
-        const localCandidates = getLocalComponentCandidates(specifier);
+        const aliasCandidates = getAliasImportCandidates(specifier);
 
-        if (localCandidates) {
+        if (aliasCandidates) {
+          if (isAmbientLocalImport(aliasCandidates)) continue;
+
           if (
-            !localCandidates.some((candidate) =>
+            !aliasCandidates.some((candidate) =>
               installContext.files.has(candidate),
             )
           ) {
             findings.add(
-              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${localCandidates.join(" or ")}`,
+              `${item.name}: ${file.path} imports "${specifier}", but no file or registryDependency provides ${aliasCandidates.join(" or ")}`,
             );
           }
 
@@ -1139,10 +1291,6 @@ export function validateRegistryInstallMetadata(
             );
           }
 
-          continue;
-        }
-
-        if (specifier.startsWith("@/")) {
           continue;
         }
 
@@ -1218,6 +1366,16 @@ export async function buildRegistry(
 ) {
   validateRegistrySchema(registry);
   validateRegistrySchema(vueRegistry);
+  const radixUsageExemptions = createRegistryDependencyUsageExemptions(
+    registry,
+    "radix",
+  );
+  const baseUsageExemptions = createRegistryDependencyUsageExemptions(
+    registry,
+    "base",
+  );
+  const vueUsageExemptions =
+    createRegistryDependencyUsageExemptions(vueRegistry);
 
   const universalNames = new Set(
     registry
@@ -1263,9 +1421,9 @@ export async function buildRegistry(
   const payloads = radixBuilt.map((built) => built.payload);
   const basePayloads = baseBuilt.map((built) => built.payload);
   const vuePayloads = vueBuilt.map((built) => built.payload);
-  validateRegistryInstallMetadata(payloads);
-  validateRegistryInstallMetadata(basePayloads);
-  validateRegistryInstallMetadata(vuePayloads);
+  validateRegistryInstallMetadata(payloads, radixUsageExemptions);
+  validateRegistryInstallMetadata(basePayloads, baseUsageExemptions);
+  validateRegistryInstallMetadata(vuePayloads, vueUsageExemptions);
 
   await fs.mkdir(REGISTRY_PATH, { recursive: true });
   await fs.mkdir(BASE_REGISTRY_PATH, { recursive: true });
@@ -1296,7 +1454,7 @@ export async function buildRegistry(
     $schema: "https://ui.shadcn.com/schema/registry.json",
     name: "assistant-ui",
     homepage: "https://assistant-ui.com",
-    items: radixRegistry,
+    items: radixRegistry.map(stripRegistryDependencyUsageExemptions),
   };
 
   await fs.writeFile(
@@ -1307,13 +1465,27 @@ export async function buildRegistry(
 
   await fs.writeFile(
     BASE_REGISTRY_INDEX_PATH,
-    JSON.stringify({ ...registryIndex, items: baseRegistry }, null, 2),
+    JSON.stringify(
+      {
+        ...registryIndex,
+        items: baseRegistry.map(stripRegistryDependencyUsageExemptions),
+      },
+      null,
+      2,
+    ),
     "utf8",
   );
 
   await fs.writeFile(
     VUE_REGISTRY_INDEX_PATH,
-    JSON.stringify({ ...registryIndex, items: vueRegistry }, null, 2),
+    JSON.stringify(
+      {
+        ...registryIndex,
+        items: vueRegistry.map(stripRegistryDependencyUsageExemptions),
+      },
+      null,
+      2,
+    ),
     "utf8",
   );
 }

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -50,6 +50,7 @@ type ElementRegistryEntry = {
   dependencies?: string[];
   usesCollapsible?: boolean;
   usesElements?: string[];
+  usesSurfaces?: boolean;
 };
 
 const createElementRegistryItem = (
@@ -67,7 +68,9 @@ const createElementRegistryItem = (
     },
   ],
   registryDependencies: [
-    "https://r.assistant-ui.com/elements-surfaces.json",
+    ...(entry.usesSurfaces === false
+      ? []
+      : ["https://r.assistant-ui.com/elements-surfaces.json"]),
     ...(entry.usesElements ?? []).map(
       (slug) => `https://r.assistant-ui.com/elements-${slug}.json`,
     ),
@@ -141,6 +144,7 @@ const elementsRegistryItems: RegistryItem[] = [
     description:
       "Tokens arrive softly: the newest words land in blue and settle into ink.",
     file: "streaming-text.tsx",
+    usesSurfaces: false,
     usesElements: ["range"],
   }),
   createElementRegistryItem({
@@ -911,6 +915,10 @@ export const registry: RegistryItem[] = [
       "https://r.assistant-ui.com/ai-sdk-backend.json",
       "https://r.assistant-ui.com/thread.json",
     ],
+    registryDependencyUsageExemptions: {
+      "https://r.assistant-ui.com/ai-sdk-backend.json":
+        "Installs the API route used by the page without importing it into the client bundle.",
+    },
     dependencies: ["@assistant-ui/ai-sdk"],
     meta: {
       importSpecifier: "Assistant",
@@ -1187,7 +1195,6 @@ export const registry: RegistryItem[] = [
     dependencies: ["@assistant-ui/react", "@assistant-ui/ai-sdk"],
     registryDependencies: [
       "https://r.assistant-ui.com/elements-context-display.json",
-      "tooltip",
     ],
   },
   {
@@ -1225,10 +1232,10 @@ export const registry: RegistryItem[] = [
       "https://r.assistant-ui.com/badge.json",
       "button",
       "dialog",
-      "input",
       "label",
       "separator",
     ],
+    radixRegistryDependencies: ["input"],
     dependencies: [
       "@assistant-ui/react-mcp",
       "@assistant-ui/store",
@@ -1874,6 +1881,10 @@ export const registry: RegistryItem[] = [
     registryDependencies: [
       "https://r.assistant-ui.com/generative-ui-style.json",
     ],
+    registryDependencyUsageExemptions: {
+      "https://r.assistant-ui.com/generative-ui-style.json":
+        "Installs CSS variables and vocabulary rules consumed through class names.",
+    },
   },
 ];
 

--- a/apps/registry/src/schema.ts
+++ b/apps/registry/src/schema.ts
@@ -46,7 +46,11 @@ export const registryItemSchema = z.object({
   dependencies: z.array(z.string()).optional(),
   devDependencies: z.array(z.string()).optional(),
   registryDependencies: z.array(z.string()).optional(),
+  registryDependencyUsageExemptions: z
+    .record(z.string(), z.string().trim().min(1))
+    .optional(),
   bundledRegistryDependencies: z.array(z.string()).optional(),
+  radixRegistryDependencies: z.array(z.string()).optional(),
   baseRegistryDependencies: z.array(z.string()).optional(),
   radixDependencies: z.array(z.string()).optional(),
   baseDependencies: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- reject direct registry dependencies that are neither used by emitted imports nor explicitly documented as metadata-only
- validate documented exemptions against exact declared dependencies and the active registry flavor
- resolve every local `@/` alias against the files that the install closure actually provides
- keep streaming-text and MCP registry metadata exact for each emitted flavor

## Why

The existing Code Quality workflow already builds and tests `@assistant-ui/shadcn-registry` for relevant pull requests, so no additional workflow is needed.

The remaining gap was reverse validation: a stale `registryDependency` could continue installing unused files because the validator only checked whether emitted imports were satisfied.

## Implementation

The reverse check compares imports from each item's emitted files with files provided by its direct dependencies. Transitive installs do not count as direct usage.

Alias and relative imports share the same install-path resolution rules, including extensions, directory indexes, JavaScript-to-TypeScript source mapping, asset query suffixes, and `file.target`. The build rejects unresolved local aliases while preserving the ambient shadcn `@/lib/utils` helper.

Intentional non-import relationships use the internal `registryDependencyUsageExemptions` map. Each entry names the exact dependency and includes a non-empty reason. The build rejects misspelled or stale entries, applies only exemptions active for the current Radix/Base flavor, and strips the field from all public item payloads and registry indexes.

An exemption is also rejected when its dependency is already imported directly, keeping the escape hatch limited to genuinely metadata-only relationships.

The current explicit cases are:

- the AI SDK quick-start page installing its backend route
- generative UI installing CSS variables and vocabulary rules

Foreign registry URLs also require an explicit exemption because their payload cannot be inspected locally.

## Verification

- `pnpm -C apps/registry test` — 69 tests passed
- `pnpm -C apps/registry build`
- `pnpm turbo build --filter=@assistant-ui/shadcn-registry`
- `pnpm turbo test --filter=@assistant-ui/shadcn-registry`
- `pnpm lint`
- focused `oxlint` and `oxfmt --check`
- `git diff --check`

Closes #6443

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.T64cqPwYBTwKh84VZK_KHhK--uug_n3iSJKflGrp3BWb6X_Y-lmFrd1pWxk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
