### PR TITLE
feat(vue): attachment primitives

### DIFF
--- a/packages/vue/src/__tests__/primitives-attachment.test.ts
+++ b/packages/vue/src/__tests__/primitives-attachment.test.ts
@@ -38,7 +38,9 @@ type DemoMessage = {
   attachments?: ThreadMessageLike["attachments"];
 };
 
-const createTestAttachmentAdapter = (): AttachmentAdapter & {
+const createTestAttachmentAdapter = (
+  accept = "*",
+): AttachmentAdapter & {
   added: File[];
   removed: string[];
 } => {
@@ -46,7 +48,7 @@ const createTestAttachmentAdapter = (): AttachmentAdapter & {
   const removed: string[] = [];
   let nextId = 0;
   return {
-    accept: "*",
+    accept,
     added,
     removed,
     async add({ file }): Promise<PendingAttachment> {
@@ -75,9 +77,10 @@ const createTestAttachmentAdapter = (): AttachmentAdapter & {
 
 const createTestRuntime = ({
   withAttachments = true,
-}: { withAttachments?: boolean } = {}) => {
+  accept = "*",
+}: { withAttachments?: boolean; accept?: string } = {}) => {
   let messages: DemoMessage[] = [];
-  const attachmentAdapter = createTestAttachmentAdapter();
+  const attachmentAdapter = createTestAttachmentAdapter(accept);
   const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
     messages,
     isRunning: false,
@@ -217,6 +220,31 @@ describe("composer attachment primitives", () => {
 
     unmount();
   });
+
+  it("applies a non-wildcard adapter accept to the file picker", async () => {
+    const { runtime } = createTestRuntime({ accept: "image/*" });
+    const view = defineComponent({
+      setup: () => () =>
+        h(
+          ComposerPrimitiveAddAttachment,
+          { class: "add" },
+          {
+            default: () => "+",
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, view);
+    await nextTick();
+
+    (el.querySelector("button.add") as HTMLButtonElement).click();
+    const input = document.body.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input.accept).toBe("image/*");
+    input.remove();
+
+    unmount();
+  });
 });
 
 const dragEvent = (type: string, files: File[] = [], kinds = ["Files"]) => {
@@ -260,6 +288,55 @@ describe("ComposerPrimitiveAttachmentDropzone", () => {
       flushTapSync(() => {});
       expect(client().composer.getState().attachments).toHaveLength(1);
     });
+
+    unmount();
+  });
+
+  it("keeps data-dragging across descendant transitions and restores it on dragover", async () => {
+    const { runtime } = createTestRuntime();
+    const inner = defineComponent({
+      setup: () => () => h("span", { class: "inner" }, "target"),
+    });
+    const view = defineComponent({
+      setup: () => () =>
+        h(
+          ComposerPrimitiveAttachmentDropzone,
+          { class: "dz" },
+          {
+            default: () => h(inner),
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, view);
+    await nextTick();
+    const dz = el.querySelector(".dz") as HTMLElement;
+    const child = el.querySelector(".inner") as HTMLElement;
+
+    dz.dispatchEvent(dragEvent("dragenter"));
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBe("true");
+
+    const leaveToChild = dragEvent("dragleave");
+    Object.defineProperty(leaveToChild, "relatedTarget", {
+      value: child,
+      configurable: true,
+    });
+    dz.dispatchEvent(leaveToChild);
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBe("true");
+
+    const leaveOutside = dragEvent("dragleave");
+    Object.defineProperty(leaveOutside, "relatedTarget", {
+      value: document.body,
+      configurable: true,
+    });
+    dz.dispatchEvent(leaveOutside);
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBeUndefined();
+
+    dz.dispatchEvent(dragEvent("dragover"));
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBe("true");
 
     unmount();
   });

--- a/packages/vue/src/__tests__/primitives-attachment.test.ts
+++ b/packages/vue/src/__tests__/primitives-attachment.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type {
+  AttachmentAdapter,
+  ExternalStoreAdapter,
+  PendingAttachment,
+  ThreadMessageLike,
+} from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import {
+  AttachmentPrimitiveName,
+  AttachmentPrimitiveRemove,
+  AttachmentPrimitiveThumb,
+} from "../primitives/attachment";
+import {
+  ComposerPrimitiveAddAttachment,
+  ComposerPrimitiveAttachmentDropzone,
+  ComposerPrimitiveAttachments,
+} from "../primitives/composerAttachments";
+import { MessagePrimitiveAttachments } from "../primitives/messageAttachments";
+
+type DemoMessage = {
+  role: "user" | "assistant";
+  content: ThreadMessageLike["content"];
+  attachments?: ThreadMessageLike["attachments"];
+};
+
+const createTestAttachmentAdapter = (): AttachmentAdapter & {
+  added: File[];
+  removed: string[];
+} => {
+  const added: File[] = [];
+  const removed: string[] = [];
+  let nextId = 0;
+  return {
+    accept: "*",
+    added,
+    removed,
+    async add({ file }): Promise<PendingAttachment> {
+      added.push(file);
+      return {
+        id: `att-${nextId++}`,
+        type: "file",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      };
+    },
+    async send(attachment) {
+      return {
+        ...attachment,
+        status: { type: "complete" },
+        content: [],
+      };
+    },
+    async remove(attachment) {
+      removed.push(attachment.id);
+    },
+  };
+};
+
+const createTestRuntime = ({
+  withAttachments = true,
+}: { withAttachments?: boolean } = {}) => {
+  let messages: DemoMessage[] = [];
+  const attachmentAdapter = createTestAttachmentAdapter();
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    isRunning: false,
+    convertMessage: (message) => ({
+      role: message.role,
+      content: message.content,
+      attachments: message.attachments,
+    }),
+    onNew: async () => {},
+    ...(withAttachments && { adapters: { attachments: attachmentAdapter } }),
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const append = (message: DemoMessage) => {
+    messages = [...messages, message];
+    core.setAdapter(makeAdapter());
+  };
+  return { runtime, append, attachmentAdapter };
+};
+
+const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+  let client: any;
+  const CaptureClient = defineComponent({
+    setup() {
+      client = useAui();
+      return () => null;
+    },
+  });
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => [h(CaptureClient), h(view)] },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, client: () => client, unmount: () => app.unmount() };
+};
+
+const makeFile = (name: string, type = "text/plain") =>
+  new File(["data"], name, { type });
+
+const ComposerAttachmentsView = defineComponent({
+  setup: () => () =>
+    h("div", null, [
+      h(ComposerPrimitiveAttachments, null, {
+        default: () =>
+          h("span", { class: "att" }, [
+            h(AttachmentPrimitiveName),
+            h(AttachmentPrimitiveThumb, { class: "thumb" }),
+            h(
+              AttachmentPrimitiveRemove,
+              { class: "remove" },
+              {
+                default: () => "x",
+              },
+            ),
+          ]),
+      }),
+    ]),
+});
+
+describe("composer attachment primitives", () => {
+  it("iterates composer attachments with name and thumb labels", async () => {
+    const { runtime } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, ComposerAttachmentsView);
+
+    await client().composer.addAttachment(makeFile("report.pdf"));
+    await client().composer.addAttachment(makeFile("noext", "text/plain"));
+    flushTapSync(() => {});
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("span.att")).toHaveLength(2);
+    });
+    const thumbs = [...el.querySelectorAll(".thumb")].map((n) => n.textContent);
+    expect(el.textContent).toContain("report.pdf");
+    expect(thumbs[0]).toBe(".pdf");
+    expect(thumbs[1]).toBe("file");
+
+    unmount();
+  });
+
+  it("removes an attachment through the remove button", async () => {
+    const { runtime, attachmentAdapter } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, ComposerAttachmentsView);
+
+    await client().composer.addAttachment(makeFile("a.txt"));
+    flushTapSync(() => {});
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("button.remove")).not.toBeNull();
+    });
+
+    (el.querySelector("button.remove") as HTMLButtonElement).click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("span.att")).toHaveLength(0);
+    });
+    expect(attachmentAdapter.removed).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("opens a file picker with the composer's accept filter and cleans it up", async () => {
+    const { runtime } = createTestRuntime();
+    const view = defineComponent({
+      setup: () => () =>
+        h(
+          ComposerPrimitiveAddAttachment,
+          { class: "add" },
+          {
+            default: () => "+",
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, view);
+    await nextTick();
+
+    const button = el.querySelector("button.add") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    button.click();
+
+    const input = document.body.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.multiple).toBe(true);
+    expect(input.accept).toBe("");
+
+    input.dispatchEvent(new Event("change"));
+    expect(document.body.querySelector('input[type="file"]')).toBeNull();
+
+    unmount();
+  });
+});
+
+const dragEvent = (type: string, files: File[] = [], kinds = ["Files"]) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    value: { types: kinds, files, dropEffect: "" },
+    configurable: true,
+  });
+  return event as DragEvent;
+};
+
+describe("ComposerPrimitiveAttachmentDropzone", () => {
+  const DropzoneView = defineComponent({
+    setup: () => () =>
+      h(
+        ComposerPrimitiveAttachmentDropzone,
+        { class: "dz" },
+        {
+          default: () => "drop here",
+        },
+      ),
+  });
+
+  it("flags data-dragging on file drag and adds dropped files", async () => {
+    const { runtime, attachmentAdapter } = createTestRuntime();
+    const { el, client, unmount } = mountChat(runtime, DropzoneView);
+    await nextTick();
+    const dz = el.querySelector(".dz") as HTMLElement;
+
+    dz.dispatchEvent(dragEvent("dragenter"));
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBe("true");
+
+    dz.dispatchEvent(dragEvent("drop", [makeFile("dropped.txt")]));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(attachmentAdapter.added).toHaveLength(1);
+    });
+    expect(dz.dataset["dragging"]).toBeUndefined();
+    await vi.waitFor(() => {
+      flushTapSync(() => {});
+      expect(client().composer.getState().attachments).toHaveLength(1);
+    });
+
+    unmount();
+  });
+
+  it("ignores non-file drags and rejects drops without attachment support", async () => {
+    const { runtime, attachmentAdapter } = createTestRuntime({
+      withAttachments: false,
+    });
+    const { el, unmount } = mountChat(runtime, DropzoneView);
+    await nextTick();
+    const dz = el.querySelector(".dz") as HTMLElement;
+
+    dz.dispatchEvent(dragEvent("dragenter", [], ["text/plain"]));
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBeUndefined();
+
+    const enter = dragEvent("dragenter");
+    dz.dispatchEvent(enter);
+    await nextTick();
+    expect(dz.dataset["dragging"]).toBeUndefined();
+    expect((enter as any).dataTransfer.dropEffect).toBe("none");
+
+    dz.dispatchEvent(dragEvent("drop", [makeFile("a.txt")]));
+    await nextTick();
+    expect(attachmentAdapter.added).toHaveLength(0);
+
+    unmount();
+  });
+});
+
+describe("MessagePrimitiveAttachments", () => {
+  it("iterates the current message's attachments", async () => {
+    const { runtime, append } = createTestRuntime();
+    const view = defineComponent({
+      setup: () => () =>
+        h("li", null, [
+          h(ThreadPrimitiveMessages, null, {
+            default: () =>
+              h(MessagePrimitiveAttachments, null, {
+                default: () =>
+                  h("span", { class: "matt" }, [h(AttachmentPrimitiveName)]),
+              }),
+          }),
+        ]),
+    });
+    const { el, unmount } = mountChat(runtime, view);
+
+    flushTapSync(() =>
+      append({
+        role: "user",
+        content: [{ type: "text", text: "see attached" }],
+        attachments: [
+          {
+            id: "att-a",
+            type: "file",
+            name: "notes.md",
+            contentType: "text/markdown",
+            status: { type: "complete" },
+            content: [],
+          },
+        ],
+      }),
+    );
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.matt")).not.toBeNull();
+    });
+    expect(el.textContent).toContain("notes.md");
+
+    unmount();
+  });
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -41,6 +41,19 @@ export {
   ThreadListItemPrimitiveTrigger,
   ThreadListItemPrimitiveTitle,
 } from "./primitives/threadList";
+export { AttachmentByIndexProvider } from "./primitives/AttachmentByIndexProvider";
+export {
+  AttachmentPrimitiveRoot,
+  AttachmentPrimitiveName,
+  AttachmentPrimitiveThumb,
+  AttachmentPrimitiveRemove,
+} from "./primitives/attachment";
+export {
+  ComposerPrimitiveAttachments,
+  ComposerPrimitiveAddAttachment,
+  ComposerPrimitiveAttachmentDropzone,
+} from "./primitives/composerAttachments";
+export { MessagePrimitiveAttachments } from "./primitives/messageAttachments";
 
 export {
   AuiConfig,

--- a/packages/vue/src/primitives/AttachmentByIndexProvider.ts
+++ b/packages/vue/src/primitives/AttachmentByIndexProvider.ts
@@ -1,0 +1,80 @@
+import {
+  computed,
+  defineComponent,
+  h,
+  onScopeDispose,
+  type PropType,
+  type SlotsType,
+} from "vue";
+import { AuiConfig, Derived } from "@assistant-ui/store/client";
+import type { AssistantClient } from "@assistant-ui/store/client";
+import type { AttachmentMethods } from "@assistant-ui/core/store";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { createLastValidCache, createStaleReporter } from "./lastValidCache";
+
+const attachmentSourceOf = (
+  aui: AssistantClient,
+  source: "composer" | "message",
+) => (source === "composer" ? aui.composer : aui.message);
+
+const attachmentCountOf = (
+  aui: AssistantClient,
+  source: "composer" | "message",
+) => attachmentSourceOf(aui, source).getState().attachments?.length ?? 0;
+
+/**
+ * Scopes the subtree to the attachment at `index` of `source` (the composer's
+ * pending attachments or the current message's attachments): descendants read
+ * the attachment through `s.attachment`.
+ */
+export const AttachmentByIndexProvider = defineComponent({
+  name: "AttachmentByIndexProvider",
+  props: {
+    source: {
+      type: String as PropType<"composer" | "message">,
+      required: true,
+    },
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const aui = useAui();
+    let disposed = false;
+    onScopeDispose(() => {
+      disposed = true;
+    });
+    const config = computed(() => {
+      const source = props.source;
+      const index = props.index;
+      const cache = createLastValidCache<AttachmentMethods>(
+        createStaleReporter({
+          name: "AttachmentByIndexProvider",
+          index,
+          isCurrent: () =>
+            !disposed && index === props.index && source === props.source,
+          isValid: () => index < attachmentCountOf(aui, source),
+        }),
+      );
+      return AuiConfig({
+        attachment: Derived({
+          source,
+          query: { type: "index", index },
+          get: (aui) =>
+            cache.resolve(index < attachmentCountOf(aui, source), () =>
+              attachmentSourceOf(aui, source).attachment({ index }),
+            ),
+        }),
+      });
+    });
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});

--- a/packages/vue/src/primitives/attachment.ts
+++ b/packages/vue/src/primitives/attachment.ts
@@ -19,15 +19,13 @@ export const AttachmentPrimitiveRoot = defineComponent({
   },
 });
 
-/** Renders the current attachment's file name. */
+/** Renders the current attachment's file name as raw text. */
 export const AttachmentPrimitiveName = defineComponent({
   name: "AttachmentPrimitiveName",
-  inheritAttrs: false,
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
-  setup(_, { attrs, slots }) {
+  setup(_, { slots }) {
     const name = useAuiState((s) => s.attachment.name);
-    return () =>
-      h("span", mergeProps(attrs, {}), slots.default?.() ?? name.value);
+    return () => slots.default?.() ?? name.value;
   },
 });
 

--- a/packages/vue/src/primitives/attachment.ts
+++ b/packages/vue/src/primitives/attachment.ts
@@ -1,0 +1,78 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+/** A wrapper element scoped to the current attachment. */
+export const AttachmentPrimitiveRoot = defineComponent({
+  name: "AttachmentPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    return () => h("div", mergeProps(attrs, {}), slots.default?.());
+  },
+});
+
+/** Renders the current attachment's file name. */
+export const AttachmentPrimitiveName = defineComponent({
+  name: "AttachmentPrimitiveName",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const name = useAuiState((s) => s.attachment.name);
+    return () =>
+      h("span", mergeProps(attrs, {}), slots.default?.() ?? name.value);
+  },
+});
+
+/**
+ * Renders a short label for the current attachment: the file extension when
+ * the name has one, otherwise the attachment type.
+ */
+export const AttachmentPrimitiveThumb = defineComponent({
+  name: "AttachmentPrimitiveThumb",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const label = useAuiState((s) => {
+      const name = s.attachment.name;
+      const dot = name.lastIndexOf(".");
+      if (dot > 0 && dot < name.length - 1) {
+        return `.${name.slice(dot + 1)}`;
+      }
+      return s.attachment.type;
+    });
+    return () =>
+      h("div", mergeProps(attrs, {}), slots.default?.() ?? label.value);
+  },
+});
+
+/** A button that removes the current attachment. */
+export const AttachmentPrimitiveRemove = defineComponent({
+  name: "AttachmentPrimitiveRemove",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+      void aui.attachment.remove();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/composerAttachments.ts
+++ b/packages/vue/src/primitives/composerAttachments.ts
@@ -129,10 +129,14 @@ export const ComposerPrimitiveAttachmentDropzone = defineComponent({
       event.preventDefault();
       if (!aui.thread.getState().capabilities.attachments) {
         event.dataTransfer!.dropEffect = "none";
+        return;
       }
+      if (!isDragging.value) isDragging.value = true;
     };
     const onDragleaveCapture = (event: DragEvent) => {
       if (props.disabled || !isFileDrag(event)) return;
+      const related = event.relatedTarget as Node | null;
+      if (related && (event.currentTarget as Node).contains(related)) return;
       isDragging.value = false;
     };
     const onDropCapture = (event: DragEvent) => {

--- a/packages/vue/src/primitives/composerAttachments.ts
+++ b/packages/vue/src/primitives/composerAttachments.ts
@@ -1,0 +1,164 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  ref,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { AttachmentByIndexProvider } from "./AttachmentByIndexProvider";
+
+/**
+ * Renders the composer's pending attachments in order, each scoped through
+ * {@link AttachmentByIndexProvider}; the `default` slot renders each
+ * attachment.
+ */
+export const ComposerPrimitiveAttachments = defineComponent({
+  name: "ComposerPrimitiveAttachments",
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { slots }) {
+    const count = useAuiState((s) => s.composer.attachments.length);
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          AttachmentByIndexProvider,
+          { source: "composer", index, key: index },
+          { default: () => slots.default?.() },
+        ),
+      );
+  },
+});
+
+/**
+ * A button that opens a file picker and adds the selected files to the
+ * composer. Disabled while the composer is not editable. The picker's accept
+ * filter follows the composer's `attachmentAccept`.
+ */
+export const ComposerPrimitiveAddAttachment = defineComponent({
+  name: "ComposerPrimitiveAddAttachment",
+  inheritAttrs: false,
+  props: {
+    multiple: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(props, { attrs, slots }) {
+    const aui = useAui();
+    const disabled = useAuiState((s) => !s.composer.isEditing);
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+
+      const input = document.createElement("input");
+      input.type = "file";
+      input.multiple = props.multiple;
+      input.hidden = true;
+
+      const attachmentAccept = aui.composer.getState().attachmentAccept;
+      if (attachmentAccept !== "*") {
+        input.accept = attachmentAccept;
+      }
+
+      document.body.appendChild(input);
+
+      input.onchange = (e) => {
+        const fileList = (e.target as HTMLInputElement).files;
+        if (fileList) {
+          for (const file of Array.from(fileList)) {
+            aui.composer.addAttachment(file).catch(() => {});
+          }
+        }
+        input.remove();
+      };
+      input.oncancel = () => input.remove();
+
+      input.click();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+/**
+ * A drop target that adds dropped files to the composer. `data-dragging` is
+ * present while a file drag hovers the element. File drags are claimed via
+ * `preventDefault` even when the runtime does not support attachments, since
+ * an unprevented file drop navigates the tab to the file.
+ */
+export const ComposerPrimitiveAttachmentDropzone = defineComponent({
+  name: "ComposerPrimitiveAttachmentDropzone",
+  inheritAttrs: false,
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(props, { attrs, slots }) {
+    const aui = useAui();
+    const isDragging = ref(false);
+
+    const isFileDrag = (event: DragEvent) =>
+      event.dataTransfer?.types.includes("Files") === true;
+
+    const onDragenterCapture = (event: DragEvent) => {
+      if (props.disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      if (!aui.thread.getState().capabilities.attachments) {
+        event.dataTransfer!.dropEffect = "none";
+        return;
+      }
+      isDragging.value = true;
+    };
+    const onDragoverCapture = (event: DragEvent) => {
+      if (props.disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      if (!aui.thread.getState().capabilities.attachments) {
+        event.dataTransfer!.dropEffect = "none";
+      }
+    };
+    const onDragleaveCapture = (event: DragEvent) => {
+      if (props.disabled || !isFileDrag(event)) return;
+      isDragging.value = false;
+    };
+    const onDropCapture = (event: DragEvent) => {
+      if (props.disabled) return;
+      isDragging.value = false;
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (!aui.thread.getState().capabilities.attachments || files.length === 0)
+        return;
+      for (const file of files) {
+        aui.composer.addAttachment(file).catch(() => {});
+      }
+    };
+
+    return () =>
+      h(
+        "div",
+        mergeProps(attrs, {
+          ...(isDragging.value && { "data-dragging": "true" }),
+          onDragenterCapture,
+          onDragoverCapture,
+          onDragleaveCapture,
+          onDropCapture,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/messageAttachments.ts
+++ b/packages/vue/src/primitives/messageAttachments.ts
@@ -11,7 +11,9 @@ export const MessagePrimitiveAttachments = defineComponent({
   name: "MessagePrimitiveAttachments",
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(_, { slots }) {
-    const count = useAuiState((s) => s.message.attachments?.length ?? 0);
+    const count = useAuiState((s) =>
+      s.message.role === "user" ? (s.message.attachments?.length ?? 0) : 0,
+    );
     return () =>
       Array.from({ length: count.value }, (_, index) =>
         h(

--- a/packages/vue/src/primitives/messageAttachments.ts
+++ b/packages/vue/src/primitives/messageAttachments.ts
@@ -1,0 +1,24 @@
+import { defineComponent, h, type SlotsType } from "vue";
+import { useAuiState } from "../useAuiState";
+import { AttachmentByIndexProvider } from "./AttachmentByIndexProvider";
+
+/**
+ * Renders the current message's attachments in order, each scoped through
+ * {@link AttachmentByIndexProvider}; the `default` slot renders each
+ * attachment.
+ */
+export const MessagePrimitiveAttachments = defineComponent({
+  name: "MessagePrimitiveAttachments",
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { slots }) {
+    const count = useAuiState((s) => s.message.attachments?.length ?? 0);
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          AttachmentByIndexProvider,
+          { source: "message", index, key: index },
+          { default: () => slots.default?.() },
+        ),
+      );
+  },
+});


### PR DESCRIPTION
## summary

- adds the attachment family to the vue face: `AttachmentPrimitive{Root,Name,Thumb,Remove}`, `ComposerPrimitive{Attachments,AddAttachment,AttachmentDropzone}`, `MessagePrimitiveAttachments`, and an `AttachmentByIndexProvider` scoping `s.attachment` from either the composer's pending attachments or the current message's attachments (same Derived + lastValidCache pattern as the part/message providers)
- behavior mirrors react point for point: the add button opens a file picker filtered by the composer's `attachmentAccept` and is disabled while the composer is not editable; the dropzone uses capture-phase handlers, sets `data-dragging`, rejects drops when `capabilities.attachments` is off, and still claims file drags via `preventDefault` so an unhandled drop cannot navigate the tab
- new files declare their slots as `() => VNodeChild[]` instead of the package's older `() => unknown`, which is what keeps them out of the pre-existing TS2769 class

## test plan

### already verified

- [x] `pnpm exec turbo run test --filter=@assistant-ui/vue` -> 76/76 green (6 new tests: iteration with name/thumb labels, remove routed to the adapter, file picker creation and cleanup, drop adds files, non-file drags and unsupported runtimes rejected, message attachment iteration)
- [x] `tsc --noEmit` error count identical to main (20, all pre-existing)
- [x] oxlint and oxfmt clean on the new files

### reviewer should verify

- [ ] run the vue suite; the dropzone tests stub `dataTransfer` since jsdom has no DataTransfer constructor

## notes

- example wiring (attachment UI in with-nuxt) follows separately once an attachment adapter story for the AI SDK example is picked
- no changeset: `@assistant-ui/vue` is private

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.PFFUJDG1UBKGz2IDo2m7236mEOv_XoYcQ9l4rtcKRdGaTKo-PoZPpeVoxiw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->