### PR TITLE
feat(vue): markdown rendering for the styled surface

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -91,6 +91,7 @@ test("vue registry build emits a self-contained thread with its type-only depend
     "@lucide/vue",
     "markdown-it",
   ]);
+  assert.deepEqual(thread.devDependencies, ["@types/markdown-it"]);
   assert.equal("target" in threadFile, false);
   assert.match(
     threadFile.content,

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -89,6 +89,7 @@ test("vue registry build emits a self-contained thread with its type-only depend
     "@assistant-ui/core",
     "@assistant-ui/vue",
     "@lucide/vue",
+    "markdown-it",
   ]);
   assert.equal("target" in threadFile, false);
   assert.match(
@@ -102,6 +103,7 @@ test("emitted vue artifacts compile as SFCs and pass the vue purity gate", async
   const thread = JSON.parse(await readFile("dist/vue/thread.json", "utf8"));
   const emitted = thread.files.map((file) => [file.path, file.content]);
   assert.deepEqual(emitted.map(([outputPath]) => outputPath).sort(), [
+    "components/assistant-ui/markdown-text.vue",
     "components/assistant-ui/message.vue",
     "components/assistant-ui/thread.vue",
   ]);

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -41,6 +41,7 @@ const PROJECT_PACKAGE_IMPORTS = new Set([
   "next-themes",
   "react",
   "react-dom",
+  "vue",
 ]);
 
 type RegistryFile = NonNullable<RegistryItem["files"]>[number];

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1793,5 +1793,6 @@ export const stagedVueRegistry: RegistryItem[] = [
       "@lucide/vue",
       "markdown-it",
     ],
+    devDependencies: ["@types/markdown-it"],
   },
 ];

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1780,7 +1780,18 @@ export const stagedVueRegistry: RegistryItem[] = [
         sourcePath:
           "../../packages/ui/src/components/assistant-ui-vue/message.vue",
       },
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/markdown-text.vue",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui-vue/markdown-text.vue",
+      },
     ],
-    dependencies: ["@assistant-ui/core", "@assistant-ui/vue", "@lucide/vue"],
+    dependencies: [
+      "@assistant-ui/core",
+      "@assistant-ui/vue",
+      "@lucide/vue",
+      "markdown-it",
+    ],
   },
 ];

--- a/examples/with-nuxt/README.md
+++ b/examples/with-nuxt/README.md
@@ -8,7 +8,7 @@ assistant-ui in a Nuxt 4 app: `@assistant-ui/vue` primitives on the client, stre
 - `server/api/chat.post.ts` runs `streamText` over `convertToModelMessages` and returns the AI SDK UI message stream, exactly like the Next.js templates; the default `AssistantChatTransport` posts the `UIMessage` array to `/api/chat`.
 - `app/components/Assistant.client.vue` mounts the provider client-only. `AuiProvider` creates its client in component setup, and Vue SSR never disposes effect scopes, so rendering it on the server would leak one runtime per request.
 - React is a small runtime dependency of the AI SDK integration: `@assistant-ui/tap` installs its hook dispatcher while the chat resource renders, so `useChat`'s React hook calls route to tap and React never renders anything.
-- Messages render as plain text. `@assistant-ui/vue` has no markdown renderer yet.
+- Assistant text renders as markdown through `app/components/MarkdownText.vue` (markdown-it behind the `#text` slot of `MessagePrimitiveParts`); user messages stay plain text.
 
 ## Run
 

--- a/examples/with-nuxt/app/components/MarkdownText.vue
+++ b/examples/with-nuxt/app/components/MarkdownText.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import MarkdownIt from "markdown-it";
+import { useAuiState } from "@assistant-ui/vue";
+
+const md = new MarkdownIt({ linkify: true });
+
+const text = useAuiState((s) => (s.part.type === "text" ? s.part.text : ""));
+const html = computed(() => md.render(text.value));
+</script>
+
+<template>
+  <div class="aui-md" v-html="html" />
+</template>
+
+<style scoped>
+.aui-md :deep(p) {
+  margin: 0.5rem 0;
+}
+.aui-md :deep(p:first-child) {
+  margin-top: 0;
+}
+.aui-md :deep(p:last-child) {
+  margin-bottom: 0;
+}
+.aui-md :deep(h1),
+.aui-md :deep(h2),
+.aui-md :deep(h3) {
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+.aui-md :deep(h1) {
+  font-size: 1.25rem;
+}
+.aui-md :deep(h2) {
+  font-size: 1.125rem;
+}
+.aui-md :deep(ul),
+.aui-md :deep(ol) {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+.aui-md :deep(ul) {
+  list-style: disc;
+}
+.aui-md :deep(ol) {
+  list-style: decimal;
+}
+.aui-md :deep(li) {
+  margin: 0.125rem 0;
+}
+.aui-md :deep(code) {
+  background: var(--color-muted);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875em;
+}
+.aui-md :deep(pre) {
+  background: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+}
+.aui-md :deep(pre code) {
+  background: transparent;
+  padding: 0;
+}
+.aui-md :deep(a) {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.aui-md :deep(blockquote) {
+  border-left: 2px solid var(--color-border);
+  padding-left: 0.75rem;
+  color: var(--color-muted-foreground);
+  margin: 0.5rem 0;
+}
+</style>

--- a/examples/with-nuxt/app/components/MarkdownText.vue
+++ b/examples/with-nuxt/app/components/MarkdownText.vue
@@ -1,9 +1,12 @@
+<script lang="ts">
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+</script>
+
 <script setup lang="ts">
 import { computed } from "vue";
-import MarkdownIt from "markdown-it";
 import { useAuiState } from "@assistant-ui/vue";
-
-const md = new MarkdownIt({ linkify: true });
 
 const text = useAuiState((s) => (s.part.type === "text" ? s.part.text : ""));
 const html = computed(() => md.render(text.value));

--- a/examples/with-nuxt/app/components/Message.vue
+++ b/examples/with-nuxt/app/components/Message.vue
@@ -84,7 +84,11 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <MessagePrimitiveParts />
+      <MessagePrimitiveParts>
+        <template #text>
+          <MarkdownText />
+        </template>
+      </MessagePrimitiveParts>
       <span v-if="pulsing" class="animate-pulse">…</span>
       <span v-if="error" class="text-destructive text-sm">{{ error }}</span>
     </div>

--- a/examples/with-nuxt/app/components/Message.vue
+++ b/examples/with-nuxt/app/components/Message.vue
@@ -84,11 +84,12 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <MessagePrimitiveParts>
+      <MessagePrimitiveParts v-if="role === 'assistant'">
         <template #text>
           <MarkdownText />
         </template>
       </MessagePrimitiveParts>
+      <MessagePrimitiveParts v-else />
       <span v-if="pulsing" class="animate-pulse">…</span>
       <span v-if="error" class="text-destructive text-sm">{{ error }}</span>
     </div>

--- a/examples/with-nuxt/package.json
+++ b/examples/with-nuxt/package.json
@@ -18,12 +18,14 @@
     "@assistant-ui/vue": "workspace:*",
     "@lucide/vue": "^1.33.0",
     "ai": "^7.0.77",
+    "markdown-it": "^14.1.0",
     "nuxt": "^4.5.2",
     "react": "^19.2.8",
     "vue": "^3.5.41"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
+    "@types/markdown-it": "^14.1.2",
     "@types/react": "^19.2.18",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2"

--- a/packages/ui/src/components/assistant-ui-vue/markdown-text.vue
+++ b/packages/ui/src/components/assistant-ui-vue/markdown-text.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import MarkdownIt from "markdown-it";
+import { useAuiState } from "@assistant-ui/vue";
+
+const md = new MarkdownIt({ linkify: true });
+
+const text = useAuiState((s) => (s.part.type === "text" ? s.part.text : ""));
+const html = computed(() => md.render(text.value));
+</script>
+
+<template>
+  <div class="aui-md" v-html="html" />
+</template>
+
+<style scoped>
+.aui-md :deep(p) {
+  margin: 0.5rem 0;
+}
+.aui-md :deep(p:first-child) {
+  margin-top: 0;
+}
+.aui-md :deep(p:last-child) {
+  margin-bottom: 0;
+}
+.aui-md :deep(h1),
+.aui-md :deep(h2),
+.aui-md :deep(h3) {
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+.aui-md :deep(h1) {
+  font-size: 1.25rem;
+}
+.aui-md :deep(h2) {
+  font-size: 1.125rem;
+}
+.aui-md :deep(ul),
+.aui-md :deep(ol) {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+.aui-md :deep(ul) {
+  list-style: disc;
+}
+.aui-md :deep(ol) {
+  list-style: decimal;
+}
+.aui-md :deep(li) {
+  margin: 0.125rem 0;
+}
+.aui-md :deep(code) {
+  background: var(--color-muted);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875em;
+}
+.aui-md :deep(pre) {
+  background: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+}
+.aui-md :deep(pre code) {
+  background: transparent;
+  padding: 0;
+}
+.aui-md :deep(a) {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.aui-md :deep(blockquote) {
+  border-left: 2px solid var(--color-border);
+  padding-left: 0.75rem;
+  color: var(--color-muted-foreground);
+  margin: 0.5rem 0;
+}
+</style>

--- a/packages/ui/src/components/assistant-ui-vue/markdown-text.vue
+++ b/packages/ui/src/components/assistant-ui-vue/markdown-text.vue
@@ -1,9 +1,12 @@
+<script lang="ts">
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt({ html: false, linkify: true, breaks: true });
+</script>
+
 <script setup lang="ts">
 import { computed } from "vue";
-import MarkdownIt from "markdown-it";
 import { useAuiState } from "@assistant-ui/vue";
-
-const md = new MarkdownIt({ linkify: true });
 
 const text = useAuiState((s) => (s.part.type === "text" ? s.part.text : ""));
 const html = computed(() => md.render(text.value));

--- a/packages/ui/src/components/assistant-ui-vue/message.vue
+++ b/packages/ui/src/components/assistant-ui-vue/message.vue
@@ -23,6 +23,7 @@ import {
   PencilIcon,
   RefreshCwIcon,
 } from "@lucide/vue";
+import MarkdownText from "@/components/assistant-ui/markdown-text.vue";
 
 const role = useAuiState((s) => s.message.role);
 const pulsing = useAuiState(
@@ -84,7 +85,11 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <MessagePrimitiveParts />
+      <MessagePrimitiveParts>
+        <template #text>
+          <MarkdownText />
+        </template>
+      </MessagePrimitiveParts>
       <span v-if="pulsing" class="animate-pulse">…</span>
       <span v-if="error" class="text-destructive text-sm">{{ error }}</span>
     </div>

--- a/packages/ui/src/components/assistant-ui-vue/message.vue
+++ b/packages/ui/src/components/assistant-ui-vue/message.vue
@@ -85,11 +85,12 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <MessagePrimitiveParts>
+      <MessagePrimitiveParts v-if="role === 'assistant'">
         <template #text>
           <MarkdownText />
         </template>
       </MessagePrimitiveParts>
+      <MessagePrimitiveParts v-else />
       <span v-if="pulsing" class="animate-pulse">…</span>
       <span v-if="error" class="text-destructive text-sm">{{ error }}</span>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2576,6 +2576,9 @@ importers:
       ai:
         specifier: ^7.0.77
         version: 7.0.77(zod@4.4.3)
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.3.0
       nuxt:
         specifier: ^4.5.2
         version: 4.5.2(@azure/identity@4.13.2(supports-color@10.2.2))(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@types/node@26.2.0)(@upstash/redis@1.38.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4(mysql2@3.20.0(@types/node@26.2.0))(sqlite3@5.1.7(supports-color@10.2.2)))(encoding@0.1.13)(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(mysql2@3.20.0(@types/node@26.2.0))(oxlint@1.79.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.5))(rollup@4.62.5)(sqlite3@5.1.7(supports-color@10.2.2))(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(yaml@2.9.0)
@@ -2589,6 +2592,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.2.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -11432,8 +11438,17 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.2.0':
+    resolution: {integrity: sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
@@ -15773,6 +15788,9 @@ packages:
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -15957,6 +15975,10 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -16064,6 +16086,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -17621,6 +17646,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -19224,6 +19253,9 @@ packages:
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -27334,9 +27366,18 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.2.0':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/mdx@2.0.14': {}
 
@@ -31850,6 +31891,10 @@ snapshots:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
@@ -32075,6 +32120,15 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
@@ -32294,6 +32348,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.1.0: {}
 
   media-typer@0.3.0: {}
 
@@ -34633,6 +34689,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   qs@6.15.3:
@@ -36687,6 +36745,8 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   ua-parser-js@1.0.41: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 


### PR DESCRIPTION
## summary

- adds `MarkdownText.vue` (markdown-it with raw HTML disabled, linkify on, styles bound to the theme variables) and wires it through `MessagePrimitiveParts`' `#text` slot in with-nuxt's `Message.vue` and the staged vue kit copy
- the staged registry thread item gains the `markdown-text.vue` file and a `markdown-it` dependency; `vue` joins `PROJECT_PACKAGE_IMPORTS` in the registry validator (framework imports assumed present in the target project, same treatment as `react`)
- closes the plain-text gap from #6470 where assistant responses showed literal `**`

## test plan

### already verified

- [x] `pnpm -C apps/registry test` -> 50/50 green (emitted-artifact compile smoke now covers markdown-text.vue; staged item dependency and file-list assertions updated)
- [x] `pnpm -C apps/registry build` -> production `dist/vue/registry.json` still emits `items: []`
- [x] browser end to end on with-nuxt against a streaming mock: `**bold**`, `` `code` ``, `*italic*`, and list items render as strong/code/em/li elements (verified via the accessibility tree), zero console errors

### reviewer should verify

- [ ] `pnpm -C examples/with-nuxt dev`, send a prompt, confirm markdown renders in the reply

## notes

- markdown-it over a streamdown port for now: the full re-render per token is fine at example scale; streaming-aware preprocess parity with the react renderers (#5160 doctrine) is future work on this surface
- no changeset: only private surfaces (with-nuxt, `@assistant-ui/ui`, apps/registry) are touched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

