### PR TITLE
feat(examples): multi-thread chat in with-nuxt

### DIFF
--- a/examples/with-nuxt/README.md
+++ b/examples/with-nuxt/README.md
@@ -4,7 +4,7 @@ assistant-ui in a Nuxt 4 app: `@assistant-ui/vue` primitives on the client, stre
 
 ## How it works
 
-- `app/components/Assistant.client.vue` wires the thread with `AISDKChat()` from `@assistant-ui/ai-sdk`: the AI SDK chat runs as the `threads` scope of the assistant client, no React host required. Edit, reload, and branch switching come with it.
+- `app/components/Assistant.client.vue` wires the thread list with `AISDKThreads()` from `@assistant-ui/ai-sdk`: each thread keeps its own AI SDK chat, and `app/components/ThreadListSidebar.vue` renders the thread list (new chat, switching, active highlight) with the `@assistant-ui/vue` thread-list primitives. Edit, reload, and branch switching come with it.
 - `server/api/chat.post.ts` runs `streamText` over `convertToModelMessages` and returns the AI SDK UI message stream, exactly like the Next.js templates; the default `AssistantChatTransport` posts the `UIMessage` array to `/api/chat`.
 - `app/components/Assistant.client.vue` mounts the provider client-only. `AuiProvider` creates its client in component setup, and Vue SSR never disposes effect scopes, so rendering it on the server would leak one runtime per request.
 - React is a small runtime dependency of the AI SDK integration: `@assistant-ui/tap` installs its hook dispatcher while the chat resource renders, so `useChat`'s React hook calls route to tap and React never renders anything.

--- a/examples/with-nuxt/app/components/Assistant.client.vue
+++ b/examples/with-nuxt/app/components/Assistant.client.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
 import { Suggestions } from "@assistant-ui/core/store";
-import { AISDKChat } from "@assistant-ui/ai-sdk";
+import { AISDKThreads } from "@assistant-ui/ai-sdk";
 
 const config = AuiConfig({
-  threads: AISDKChat(),
+  threads: AISDKThreads(),
   suggestions: Suggestions([
     {
       title: "Check the weather",
@@ -28,7 +28,10 @@ const config = AuiConfig({
 <template>
   <AuiProvider :config="config">
     <RegisterToolUIs>
-      <Thread />
+      <div class="bg-background flex h-full">
+        <ThreadListSidebar />
+        <Thread />
+      </div>
     </RegisterToolUIs>
   </AuiProvider>
 </template>

--- a/examples/with-nuxt/app/components/Thread.vue
+++ b/examples/with-nuxt/app/components/Thread.vue
@@ -17,76 +17,74 @@ import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
 </script>
 
 <template>
-  <div class="bg-background flex h-full">
-    <div class="flex min-w-0 flex-1 flex-col">
-      <ThreadPrimitiveViewport
-        class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
-      >
-        <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
-          <AuiIf :condition="(s) => s.thread.messages.length === 0">
-            <div
-              class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
-            >
-              <h1 class="text-2xl font-semibold">How can I help you today?</h1>
-              <div
-                class="flex flex-wrap items-center justify-center gap-2 px-4"
-              >
-                <ThreadPrimitiveSuggestions>
-                  <SuggestionPrimitiveTrigger
-                    send
-                    class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
-                  >
-                    <span class="font-medium"
-                      ><SuggestionPrimitiveTitle
-                    /></span>
-                    <span class="text-muted-foreground text-xs">
-                      <SuggestionPrimitiveDescription />
-                    </span>
-                  </SuggestionPrimitiveTrigger>
-                </ThreadPrimitiveSuggestions>
-              </div>
-            </div>
-          </AuiIf>
-          <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-            <ThreadPrimitiveMessages>
-              <Message />
-            </ThreadPrimitiveMessages>
-          </ol>
-          <ThreadPrimitiveScrollToBottom
-            class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
-            aria-label="Scroll to bottom"
+  <div class="flex h-full min-w-0 flex-1 flex-col">
+    <ThreadPrimitiveViewport
+      class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+    >
+      <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+        <AuiIf :condition="(s) => s.thread.messages.length === 0">
+          <div
+            class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
           >
-            <ArrowDownIcon class="size-4" />
-          </ThreadPrimitiveScrollToBottom>
-        </div>
-      </ThreadPrimitiveViewport>
-      <div class="mx-auto w-full max-w-2xl px-4 pb-4">
-        <div
-          class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
-        >
-          <ComposerPrimitiveInput
-            class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
-            placeholder="Send a message..."
-            rows="1"
-          />
-          <div class="flex items-center justify-end">
-            <AuiIf :condition="(s) => !s.thread.isRunning">
-              <ComposerPrimitiveSend
-                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
-                aria-label="Send"
-              >
-                <ArrowUpIcon class="size-4.5" />
-              </ComposerPrimitiveSend>
-            </AuiIf>
-            <AuiIf :condition="(s) => s.thread.isRunning">
-              <ComposerPrimitiveCancel
-                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
-                aria-label="Stop"
-              >
-                <SquareIcon class="size-3.5 fill-current" />
-              </ComposerPrimitiveCancel>
-            </AuiIf>
+            <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+            <div
+              class="flex flex-wrap items-center justify-center gap-2 px-4"
+            >
+              <ThreadPrimitiveSuggestions>
+                <SuggestionPrimitiveTrigger
+                  send
+                  class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+                >
+                  <span class="font-medium"
+                    ><SuggestionPrimitiveTitle
+                  /></span>
+                  <span class="text-muted-foreground text-xs">
+                    <SuggestionPrimitiveDescription />
+                  </span>
+                </SuggestionPrimitiveTrigger>
+              </ThreadPrimitiveSuggestions>
+            </div>
           </div>
+        </AuiIf>
+        <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
+          <ThreadPrimitiveMessages>
+            <Message />
+          </ThreadPrimitiveMessages>
+        </ol>
+        <ThreadPrimitiveScrollToBottom
+          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
+          aria-label="Scroll to bottom"
+        >
+          <ArrowDownIcon class="size-4" />
+        </ThreadPrimitiveScrollToBottom>
+      </div>
+    </ThreadPrimitiveViewport>
+    <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+      <div
+        class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+      >
+        <ComposerPrimitiveInput
+          class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+          placeholder="Send a message..."
+          rows="1"
+        />
+        <div class="flex items-center justify-end">
+          <AuiIf :condition="(s) => !s.thread.isRunning">
+            <ComposerPrimitiveSend
+              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+              aria-label="Send"
+            >
+              <ArrowUpIcon class="size-4.5" />
+            </ComposerPrimitiveSend>
+          </AuiIf>
+          <AuiIf :condition="(s) => s.thread.isRunning">
+            <ComposerPrimitiveCancel
+              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+              aria-label="Stop"
+            >
+              <SquareIcon class="size-3.5 fill-current" />
+            </ComposerPrimitiveCancel>
+          </AuiIf>
         </div>
       </div>
     </div>

--- a/examples/with-nuxt/app/components/Thread.vue
+++ b/examples/with-nuxt/app/components/Thread.vue
@@ -27,17 +27,13 @@ import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
             class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
           >
             <h1 class="text-2xl font-semibold">How can I help you today?</h1>
-            <div
-              class="flex flex-wrap items-center justify-center gap-2 px-4"
-            >
+            <div class="flex flex-wrap items-center justify-center gap-2 px-4">
               <ThreadPrimitiveSuggestions>
                 <SuggestionPrimitiveTrigger
                   send
                   class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
                 >
-                  <span class="font-medium"
-                    ><SuggestionPrimitiveTitle
-                  /></span>
+                  <span class="font-medium"><SuggestionPrimitiveTitle /></span>
                   <span class="text-muted-foreground text-xs">
                     <SuggestionPrimitiveDescription />
                   </span>

--- a/examples/with-nuxt/app/components/ThreadListSidebar.vue
+++ b/examples/with-nuxt/app/components/ThreadListSidebar.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import {
+  ThreadListItemPrimitiveTitle,
+  ThreadListItemPrimitiveTrigger,
+  ThreadListPrimitiveItems,
+  ThreadListPrimitiveNew,
+} from "@assistant-ui/vue";
+import { PlusIcon } from "@lucide/vue";
+</script>
+
+<template>
+  <aside
+    class="border-border/60 flex h-full w-64 shrink-0 flex-col gap-3 border-r p-3"
+  >
+    <ThreadListPrimitiveNew
+      class="border-border/60 hover:bg-muted flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors"
+    >
+      <PlusIcon class="size-4" />
+      New chat
+    </ThreadListPrimitiveNew>
+    <div class="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+      <ThreadListPrimitiveItems>
+        <ThreadListItemPrimitiveTrigger
+          class="hover:bg-muted text-muted-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground w-full truncate rounded-xl px-3 py-2 text-left text-sm transition-colors"
+        >
+          <ThreadListItemPrimitiveTitle fallback="New chat" />
+        </ThreadListItemPrimitiveTrigger>
+      </ThreadListPrimitiveItems>
+    </div>
+  </aside>
+</template>


### PR DESCRIPTION
## summary

- upgrades with-nuxt from single-thread `AISDKChat()` to `AISDKThreads()` with a thread-list sidebar (`ThreadListSidebar.vue`: new-chat action, titles with a fallback, active-thread highlight via the trigger's `data-active`)
- `Thread.vue` only loses its outer wrapper so it can sit in the two-column flex; the chat itself is unchanged
- this is the vue face's first end-to-end multi-thread exercise; creating threads, switching, and per-thread content persistence all verified live

## test plan

### already verified

- [x] `pnpm exec turbo run build --filter='with-nuxt^...'` green; dev server boots and serves
- [x] browser end to end against a streaming mock: send in Main Thread, new chat, send there, switch back; each thread keeps its own conversation, active item highlights, titles render with the fallback

### reviewer should verify

- [ ] `pnpm -C examples/with-nuxt dev`, create a second thread and switch between them

## notes

- verification surfaced a substrate defect filed as #6477: with `AISDKThreads`, switching threads merges histories into sibling branches on the shared message repository (visible only through the branch picker; framework-independent, not introduced by this PR). this example doubles as the repro for that issue
- no changeset: with-nuxt is private

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MOfr5gskxcu0kI7fSMa31keHxJsMC6QqC5o3StxzRU4nPtJ-ttL7QKMVPi4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->