### PR TITLE
feat(vue): error and structural primitives

### DIFF
--- a/.changeset/vue-structural-predicates.md
+++ b/.changeset/vue-structural-predicates.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: share the message error and thread-list load-more predicates across bindings

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -6113,7 +6113,7 @@ declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<T
 
 declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
 
-declare const messageErrorText: (s: AssistantState) => ReadonlyJSONValue | undefined;
+declare const messageErrorText: (s: AssistantState) => string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | undefined;
 
 declare const notifyEventListeners: <T>(listeners: Iterable<EventListener<T>>, payloadOrFactory: T | (() => T), errorContext: string) => void;
 
@@ -6393,7 +6393,7 @@ declare const useMessageBranching: () => {
   goToNext: () => void;
 };
 
-declare const useMessageError: () => ReadonlyJSONValue | undefined;
+declare const useMessageError: () => string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | undefined;
 
 declare const useMessageReload: () => {
   reload: () => void;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -6113,7 +6113,7 @@ declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<T
 
 declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
 
-declare const messageErrorText: (s: AssistantState) => unknown;
+declare const messageErrorText: (s: AssistantState) => ReadonlyJSONValue | undefined;
 
 declare const notifyEventListeners: <T>(listeners: Iterable<EventListener<T>>, payloadOrFactory: T | (() => T), errorContext: string) => void;
 
@@ -6393,7 +6393,7 @@ declare const useMessageBranching: () => {
   goToNext: () => void;
 };
 
-declare const useMessageError: () => unknown;
+declare const useMessageError: () => ReadonlyJSONValue | undefined;
 
 declare const useMessageReload: () => {
   reload: () => void;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -6080,7 +6080,7 @@ declare namespace entry_internal_exports {
 }
 
 declare namespace entry_store_internal_exports {
-  export { AttachmentRuntimeClient, ComposerClient, MessageClient, MessagePartClient, ThreadClient, ThreadListClient, ThreadListItemClient, actionBarCopyDisabled, actionBarEditDisabled, actionBarReloadDisabled, baseRuntimeAdapterTransformScopes, branchPickerNextDisabled, branchPickerPreviousDisabled, composerCancelDisabled, composerInputDisabled, composerSendDisabled, isDevelopment, suggestionTriggerDisabled, useThreadSelectionEvents };
+  export { AttachmentRuntimeClient, ComposerClient, MessageClient, MessagePartClient, ThreadClient, ThreadListClient, ThreadListItemClient, actionBarCopyDisabled, actionBarEditDisabled, actionBarReloadDisabled, baseRuntimeAdapterTransformScopes, branchPickerNextDisabled, branchPickerPreviousDisabled, composerCancelDisabled, composerInputDisabled, composerSendDisabled, isDevelopment, messageErrorText, suggestionTriggerDisabled, threadListLoadMoreDisabled, useThreadSelectionEvents };
 }
 
 declare function invokeUserCallback<TArgs extends readonly unknown[]>(tag: string, name: string, callback: ((...args: TArgs) => unknown) | undefined, ...args: TArgs): void | Promise<void>;
@@ -6112,6 +6112,8 @@ declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult
 declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
 
 declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+
+declare const messageErrorText: (s: AssistantState) => unknown;
 
 declare const notifyEventListeners: <T>(listeners: Iterable<EventListener<T>>, payloadOrFactory: T | (() => T), errorContext: string) => void;
 
@@ -6180,6 +6182,8 @@ declare function stubTool(): never;
 declare const suggestionTriggerDisabled: (s: AssistantState, send: boolean) => boolean;
 
 declare const symbolInnerMessage: unique symbol;
+
+declare const threadListLoadMoreDisabled: (s: AssistantState) => boolean;
 
 declare const toAssistantError: (error: unknown) => AssistantError;
 
@@ -6389,7 +6393,7 @@ declare const useMessageBranching: () => {
   goToNext: () => void;
 };
 
-declare const useMessageError: () => string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | undefined;
+declare const useMessageError: () => unknown;
 
 declare const useMessageReload: () => {
   reload: () => void;

--- a/packages/core/src/react/primitive-hooks/useMessageError.ts
+++ b/packages/core/src/react/primitive-hooks/useMessageError.ts
@@ -1,23 +1,6 @@
 import { useAuiState } from "@assistant-ui/store";
+import { messageErrorText } from "../../store/primitive-predicates";
 
 export const useMessageError = () => {
-  return useAuiState((s) => {
-    if (
-      s.message.status?.type !== "incomplete" ||
-      s.message.status.reason !== "error"
-    ) {
-      return undefined;
-    }
-    const error = s.message.status.error;
-    if (typeof error === "string") return error;
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "message" in error &&
-      typeof error.message === "string"
-    ) {
-      return error.message;
-    }
-    return error ?? "An error occurred";
-  });
+  return useAuiState(messageErrorText);
 };

--- a/packages/core/src/react/primitive-hooks/useThreadListLoadMore.ts
+++ b/packages/core/src/react/primitive-hooks/useThreadListLoadMore.ts
@@ -1,11 +1,10 @@
 import { useCallback } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
+import { threadListLoadMoreDisabled } from "../../store/primitive-predicates";
 
 export const useThreadListLoadMore = () => {
   const aui = useAui();
-  const disabled = useAuiState(
-    (s) => !s.threads.hasMore || s.threads.isLoading || s.threads.isLoadingMore,
-  );
+  const disabled = useAuiState(threadListLoadMoreDisabled);
 
   const loadMore = useCallback(() => {
     aui.threads.loadMore();

--- a/packages/core/src/store/internal.ts
+++ b/packages/core/src/store/internal.ts
@@ -15,7 +15,9 @@ export {
   composerCancelDisabled,
   composerInputDisabled,
   composerSendDisabled,
+  messageErrorText,
   suggestionTriggerDisabled,
+  threadListLoadMoreDisabled,
 } from "./primitive-predicates";
 export { isDevelopment } from "./env";
 export { useThreadSelectionEvents } from "./clients/thread-selection-events";

--- a/packages/core/src/store/primitive-predicates.ts
+++ b/packages/core/src/store/primitive-predicates.ts
@@ -41,3 +41,26 @@ export const suggestionTriggerDisabled = (
 ): boolean =>
   s.thread.isDisabled ||
   (send && s.thread.isRunning && !s.thread.capabilities.queue);
+
+export const messageErrorText = (s: AssistantState): unknown => {
+  if (
+    s.message.status?.type !== "incomplete" ||
+    s.message.status.reason !== "error"
+  ) {
+    return undefined;
+  }
+  const error = s.message.status.error;
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return error ?? "An error occurred";
+};
+
+export const threadListLoadMoreDisabled = (s: AssistantState): boolean =>
+  !s.threads.hasMore || s.threads.isLoading || s.threads.isLoadingMore;

--- a/packages/core/src/store/primitive-predicates.ts
+++ b/packages/core/src/store/primitive-predicates.ts
@@ -1,3 +1,4 @@
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type { AssistantState } from "@assistant-ui/store";
 
 /**
@@ -42,7 +43,9 @@ export const suggestionTriggerDisabled = (
   s.thread.isDisabled ||
   (send && s.thread.isRunning && !s.thread.capabilities.queue);
 
-export const messageErrorText = (s: AssistantState): unknown => {
+export const messageErrorText = (
+  s: AssistantState,
+): ReadonlyJSONValue | undefined => {
   if (
     s.message.status?.type !== "incomplete" ||
     s.message.status.reason !== "error"

--- a/packages/core/src/store/primitive-predicates.ts
+++ b/packages/core/src/store/primitive-predicates.ts
@@ -1,4 +1,7 @@
-import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import type {
+  ReadonlyJSONArray,
+  ReadonlyJSONObject,
+} from "assistant-stream/utils";
 import type { AssistantState } from "@assistant-ui/store";
 
 /**
@@ -45,7 +48,13 @@ export const suggestionTriggerDisabled = (
 
 export const messageErrorText = (
   s: AssistantState,
-): ReadonlyJSONValue | undefined => {
+):
+  | string
+  | number
+  | boolean
+  | ReadonlyJSONObject
+  | ReadonlyJSONArray
+  | undefined => {
   if (
     s.message.status?.type !== "incomplete" ||
     s.message.status.reason !== "error"

--- a/packages/vue/src/__tests__/primitives-structural.test.ts
+++ b/packages/vue/src/__tests__/primitives-structural.test.ts
@@ -46,6 +46,7 @@ const createTestRuntime = ({ hasMore = false } = {}) => {
   let archivedThreads: DemoThread[] = [{ id: "ta", title: "Archived thread" }];
   let hasMoreValue = hasMore;
   let isLoading = false;
+  let isLoadingMoreValue = false;
   let core!: ExternalStoreRuntimeCore;
   const sync = () => core.setAdapter(makeAdapter());
   const onArchive = vi.fn((threadId: string) => {
@@ -110,7 +111,7 @@ const createTestRuntime = ({ hasMore = false } = {}) => {
     },
     isLoadingMore: {
       configurable: true,
-      get: () => false,
+      get: () => isLoadingMoreValue,
     },
     loadMore: {
       configurable: true,
@@ -130,11 +131,16 @@ const createTestRuntime = ({ hasMore = false } = {}) => {
     isLoading = value;
     sync();
   };
+  const setLoadingMore = (value: boolean) => {
+    isLoadingMoreValue = value;
+    sync();
+  };
   return {
     runtime,
     append,
     setHasMore,
     setLoading,
+    setLoadingMore,
     loadMore,
     onArchive,
     onUnarchive,
@@ -306,9 +312,10 @@ describe("structural primitives", () => {
   });
 
   it("keeps load more mounted, disables it when unavailable, and calls the runtime", async () => {
-    const { runtime, loadMore, setHasMore, setLoading } = createTestRuntime({
-      hasMore: true,
-    });
+    const { runtime, loadMore, setHasMore, setLoading, setLoadingMore } =
+      createTestRuntime({
+        hasMore: true,
+      });
     const View = defineComponent({
       setup: () => () =>
         h(
@@ -338,6 +345,14 @@ describe("structural primitives", () => {
       ).toBe(true);
     });
     flushTapSync(() => setLoading(false));
+    flushTapSync(() => setLoadingMore(true));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        el.querySelector<HTMLButtonElement>("button.load-more")!.disabled,
+      ).toBe(true);
+    });
+    flushTapSync(() => setLoadingMore(false));
     flushTapSync(() => setHasMore(false));
     await vi.waitFor(async () => {
       await nextTick();

--- a/packages/vue/src/__tests__/primitives-structural.test.ts
+++ b/packages/vue/src/__tests__/primitives-structural.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type {
+  ExternalStoreAdapter,
+  ThreadMessageLike,
+} from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAuiState } from "../useAuiState";
+import { ErrorPrimitiveMessage, ErrorPrimitiveRoot } from "../primitives/error";
+import { MessagePrimitiveRoot } from "../primitives/message";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import {
+  ThreadPrimitiveEmpty,
+  ThreadPrimitiveRoot,
+  ThreadPrimitiveViewportFooter,
+} from "../primitives/thread";
+import {
+  ThreadListItemPrimitiveArchive,
+  ThreadListItemPrimitiveDelete,
+  ThreadListItemPrimitiveRoot,
+  ThreadListItemPrimitiveUnarchive,
+  ThreadListPrimitiveLoadMore,
+  ThreadListPrimitiveRoot,
+} from "../primitives/threadListStructural";
+import {
+  ThreadListItemPrimitiveTitle,
+  ThreadListPrimitiveItems,
+} from "../primitives/threadList";
+
+type DemoMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: ThreadMessageLike["content"];
+  status?: ThreadMessageLike["status"];
+};
+
+type DemoThread = { id: string; title: string };
+
+const createTestRuntime = ({ hasMore = false } = {}) => {
+  let messages: DemoMessage[] = [];
+  let threads: DemoThread[] = [
+    { id: "t1", title: "First thread" },
+    { id: "t2", title: "Second thread" },
+  ];
+  let archivedThreads: DemoThread[] = [{ id: "ta", title: "Archived thread" }];
+  let hasMoreValue = hasMore;
+  let isLoading = false;
+  let core!: ExternalStoreRuntimeCore;
+  const sync = () => core.setAdapter(makeAdapter());
+  const onArchive = vi.fn((threadId: string) => {
+    const thread = threads.find((item) => item.id === threadId);
+    if (!thread) return;
+    threads = threads.filter((item) => item.id !== threadId);
+    archivedThreads = [...archivedThreads, thread];
+    sync();
+  });
+  const onUnarchive = vi.fn((threadId: string) => {
+    const thread = archivedThreads.find((item) => item.id === threadId);
+    if (!thread) return;
+    archivedThreads = archivedThreads.filter((item) => item.id !== threadId);
+    threads = [...threads, thread];
+    sync();
+  });
+  const onDelete = vi.fn((threadId: string) => {
+    threads = threads.filter((item) => item.id !== threadId);
+    archivedThreads = archivedThreads.filter((item) => item.id !== threadId);
+    sync();
+  });
+  const loadMore = vi.fn(async () => {});
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    convertMessage: (message) => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      status: message.status,
+    }),
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: "t1",
+        isLoading,
+        threads: threads.map((thread) => ({
+          status: "regular" as const,
+          id: thread.id,
+          title: thread.title,
+        })),
+        archivedThreads: archivedThreads.map((thread) => ({
+          status: "archived" as const,
+          id: thread.id,
+          title: thread.title,
+        })),
+        onArchive,
+        onUnarchive,
+        onDelete,
+      },
+    },
+  });
+  core = new ExternalStoreRuntimeCore(makeAdapter());
+  const threadList = core.threads as typeof core.threads & {
+    hasMore: boolean;
+    isLoadingMore: boolean;
+    loadMore: () => Promise<void>;
+  };
+  Object.defineProperties(threadList, {
+    hasMore: {
+      configurable: true,
+      get: () => hasMoreValue,
+    },
+    isLoadingMore: {
+      configurable: true,
+      get: () => false,
+    },
+    loadMore: {
+      configurable: true,
+      value: loadMore,
+    },
+  });
+  const runtime = new AssistantRuntimeImpl(core);
+  const append = (message: DemoMessage) => {
+    messages = [...messages, message];
+    sync();
+  };
+  const setHasMore = (value: boolean) => {
+    hasMoreValue = value;
+    sync();
+  };
+  const setLoading = (value: boolean) => {
+    isLoading = value;
+    sync();
+  };
+  return {
+    runtime,
+    append,
+    setHasMore,
+    setLoading,
+    loadMore,
+    onArchive,
+    onUnarchive,
+    onDelete,
+  };
+};
+
+const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(view) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+const findThreadItem = (el: HTMLElement, selector: string, title: string) => {
+  const item = [...el.querySelectorAll<HTMLElement>(selector)].find(
+    (node) => node.querySelector(".title")?.textContent === title,
+  );
+  if (!item) throw new Error(`Could not find ${title}`);
+  return item;
+};
+
+describe("structural primitives", () => {
+  it("renders thread wrappers and hides the empty slot after a message arrives", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveRoot,
+          { class: "thread-root" },
+          {
+            default: () => [
+              h(ThreadPrimitiveEmpty, null, {
+                default: () => h("p", { class: "empty" }, "Empty"),
+              }),
+              h(
+                ThreadPrimitiveViewportFooter,
+                { class: "footer" },
+                {
+                  default: () => h("p", "Footer"),
+                },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    expect(el.querySelector("div.thread-root")).not.toBeNull();
+    expect(el.querySelector(".empty")?.textContent).toBe("Empty");
+    expect(el.querySelector("div.footer")?.textContent).toBe("Footer");
+
+    flushTapSync(() =>
+      append({
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector(".empty")).toBeNull();
+    });
+
+    unmount();
+  });
+
+  it("adds the current message id and tracks message hover state", async () => {
+    const { runtime, append } = createTestRuntime();
+    const HoverState = defineComponent({
+      setup() {
+        const hovering = useAuiState((s) => s.message.isHovering);
+        return () =>
+          h("span", { class: "hover", "data-hovering": hovering.value });
+      },
+    });
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadPrimitiveMessages, null, {
+          default: () =>
+            h(
+              MessagePrimitiveRoot,
+              { class: "message" },
+              {
+                default: () => h(HoverState),
+              },
+            ),
+        }),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({
+        id: "message-id",
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        el.querySelector(".message")?.getAttribute("data-message-id"),
+      ).toBe("message-id");
+    });
+
+    const message = el.querySelector<HTMLElement>(".message")!;
+    message.dispatchEvent(new Event("mouseenter"));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector(".hover")?.getAttribute("data-hovering")).toBe(
+        "true",
+      );
+    });
+    message.dispatchEvent(new Event("mouseleave"));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector(".hover")?.getAttribute("data-hovering")).toBe(
+        "false",
+      );
+    });
+
+    unmount();
+  });
+
+  it("renders the assistant error text inside an alert root", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadPrimitiveMessages, null, {
+          default: () =>
+            h(
+              ErrorPrimitiveRoot,
+              { class: "error" },
+              {
+                default: () => h(ErrorPrimitiveMessage),
+              },
+            ),
+        }),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({
+        id: "error-id",
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        status: {
+          type: "incomplete",
+          reason: "error",
+          error: { message: "Connection lost" },
+        },
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector(".error")?.textContent).toBe("Connection lost");
+    });
+    expect(el.querySelector(".error")?.getAttribute("role")).toBe("alert");
+
+    unmount();
+  });
+
+  it("renders load more only when available and calls the runtime", async () => {
+    const { runtime, loadMore, setHasMore, setLoading } = createTestRuntime({
+      hasMore: true,
+    });
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadListPrimitiveRoot,
+          { class: "thread-list" },
+          {
+            default: () =>
+              h(
+                ThreadListPrimitiveLoadMore,
+                { class: "load-more" },
+                {
+                  default: () => "Load more",
+                },
+              ),
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("div.thread-list")).not.toBeNull();
+      expect(el.querySelector("button.load-more")).not.toBeNull();
+    });
+    el.querySelector<HTMLButtonElement>("button.load-more")!.click();
+    await vi.waitFor(() => {
+      expect(loadMore).toHaveBeenCalledTimes(1);
+    });
+
+    flushTapSync(() => setLoading(true));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("button.load-more")).toBeNull();
+    });
+    flushTapSync(() => setLoading(false));
+    flushTapSync(() => setHasMore(false));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("button.load-more")).toBeNull();
+    });
+
+    unmount();
+  });
+
+  it("archives, unarchives, and deletes thread list items", async () => {
+    const { runtime, onArchive, onUnarchive, onDelete } = createTestRuntime();
+    const Item = defineComponent({
+      props: {
+        archived: {
+          type: Boolean,
+          default: false,
+        },
+      },
+      setup: (props) => () =>
+        h(
+          ThreadListItemPrimitiveRoot,
+          { class: props.archived ? "archived-item" : "regular-item" },
+          {
+            default: () => [
+              h("span", { class: "title" }, [h(ThreadListItemPrimitiveTitle)]),
+              props.archived
+                ? h(
+                    ThreadListItemPrimitiveUnarchive,
+                    { class: "unarchive" },
+                    { default: () => "Unarchive" },
+                  )
+                : h(
+                    ThreadListItemPrimitiveArchive,
+                    { class: "archive" },
+                    { default: () => "Archive" },
+                  ),
+              h(
+                ThreadListItemPrimitiveDelete,
+                { class: "delete" },
+                { default: () => "Delete" },
+              ),
+            ],
+          },
+        ),
+    });
+    const View = defineComponent({
+      setup: () => () => [
+        h(ThreadListPrimitiveItems, null, {
+          default: () => h(Item),
+        }),
+        h(
+          ThreadListPrimitiveItems,
+          { archived: true },
+          {
+            default: () => h(Item, { archived: true }),
+          },
+        ),
+      ],
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll(".regular-item")).toHaveLength(2);
+      expect(
+        el.querySelector(".regular-item")?.getAttribute("data-active"),
+      ).toBe("true");
+    });
+
+    findThreadItem(el, ".regular-item", "First thread")
+      .querySelector<HTMLButtonElement>("button.archive")!
+      .click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(onArchive).toHaveBeenCalledWith("t1");
+      expect(
+        findThreadItem(el, ".archived-item", "First thread"),
+      ).toBeDefined();
+    });
+
+    findThreadItem(el, ".archived-item", "First thread")
+      .querySelector<HTMLButtonElement>("button.unarchive")!
+      .click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(onUnarchive).toHaveBeenCalledWith("t1");
+      expect(findThreadItem(el, ".regular-item", "First thread")).toBeDefined();
+    });
+
+    findThreadItem(el, ".regular-item", "First thread")
+      .querySelector<HTMLButtonElement>("button.delete")!
+      .click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(onDelete).toHaveBeenCalledWith("t1");
+      expect(
+        [...el.querySelectorAll<HTMLElement>(".regular-item")].some(
+          (item) =>
+            item.querySelector(".title")?.textContent === "First thread",
+        ),
+      ).toBe(false);
+    });
+
+    unmount();
+  });
+});

--- a/packages/vue/src/__tests__/primitives-structural.test.ts
+++ b/packages/vue/src/__tests__/primitives-structural.test.ts
@@ -16,18 +16,12 @@ import { useAuiState } from "../useAuiState";
 import { ErrorPrimitiveMessage, ErrorPrimitiveRoot } from "../primitives/error";
 import { MessagePrimitiveRoot } from "../primitives/message";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
-import {
-  ThreadPrimitiveEmpty,
-  ThreadPrimitiveRoot,
-  ThreadPrimitiveViewportFooter,
-} from "../primitives/thread";
+import { ThreadPrimitiveRoot } from "../primitives/thread";
 import {
   ThreadListItemPrimitiveArchive,
   ThreadListItemPrimitiveDelete,
-  ThreadListItemPrimitiveRoot,
   ThreadListItemPrimitiveUnarchive,
   ThreadListPrimitiveLoadMore,
-  ThreadListPrimitiveRoot,
 } from "../primitives/threadListStructural";
 import {
   ThreadListItemPrimitiveTitle,
@@ -173,48 +167,47 @@ const findThreadItem = (el: HTMLElement, selector: string, title: string) => {
 };
 
 describe("structural primitives", () => {
-  it("renders thread wrappers and hides the empty slot after a message arrives", async () => {
-    const { runtime, append } = createTestRuntime();
+  it("renders the thread root and survives Escape without a thread scope", async () => {
+    const { runtime } = createTestRuntime();
     const View = defineComponent({
       setup: () => () =>
         h(
           ThreadPrimitiveRoot,
           { class: "thread-root" },
-          {
-            default: () => [
-              h(ThreadPrimitiveEmpty, null, {
-                default: () => h("p", { class: "empty" }, "Empty"),
-              }),
-              h(
-                ThreadPrimitiveViewportFooter,
-                { class: "footer" },
-                {
-                  default: () => h("p", "Footer"),
-                },
-              ),
-            ],
-          },
+          { default: () => [h("p", "content")] },
         ),
     });
     const { el, unmount } = mountChat(runtime, View);
 
     expect(el.querySelector("div.thread-root")).not.toBeNull();
-    expect(el.querySelector(".empty")?.textContent).toBe("Empty");
-    expect(el.querySelector("div.footer")?.textContent).toBe("Footer");
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    unmount();
 
-    flushTapSync(() =>
-      append({
-        id: "m1",
-        role: "user",
-        content: [{ type: "text", text: "Hello" }],
+    const bare = createApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({}) },
+            {
+              default: () =>
+                h(ThreadPrimitiveRoot, null, {
+                  default: () => [h("p", "scopeless")],
+                }),
+            },
+          ),
       }),
     );
-    await vi.waitFor(async () => {
-      await nextTick();
-      expect(el.querySelector(".empty")).toBeNull();
-    });
-
-    unmount();
+    const bareEl = document.createElement("div");
+    bare.mount(bareEl);
+    expect(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      ),
+    ).not.toThrow();
+    bare.unmount();
   });
 
   it("adds the current message id and tracks message hover state", async () => {
@@ -312,24 +305,17 @@ describe("structural primitives", () => {
     unmount();
   });
 
-  it("renders load more only when available and calls the runtime", async () => {
+  it("keeps load more mounted, disables it when unavailable, and calls the runtime", async () => {
     const { runtime, loadMore, setHasMore, setLoading } = createTestRuntime({
       hasMore: true,
     });
     const View = defineComponent({
       setup: () => () =>
         h(
-          ThreadListPrimitiveRoot,
-          { class: "thread-list" },
+          ThreadListPrimitiveLoadMore,
+          { class: "load-more" },
           {
-            default: () =>
-              h(
-                ThreadListPrimitiveLoadMore,
-                { class: "load-more" },
-                {
-                  default: () => "Load more",
-                },
-              ),
+            default: () => "Load more",
           },
         ),
     });
@@ -337,7 +323,6 @@ describe("structural primitives", () => {
 
     await vi.waitFor(async () => {
       await nextTick();
-      expect(el.querySelector("div.thread-list")).not.toBeNull();
       expect(el.querySelector("button.load-more")).not.toBeNull();
     });
     el.querySelector<HTMLButtonElement>("button.load-more")!.click();
@@ -348,13 +333,17 @@ describe("structural primitives", () => {
     flushTapSync(() => setLoading(true));
     await vi.waitFor(async () => {
       await nextTick();
-      expect(el.querySelector("button.load-more")).toBeNull();
+      expect(
+        el.querySelector<HTMLButtonElement>("button.load-more")!.disabled,
+      ).toBe(true);
     });
     flushTapSync(() => setLoading(false));
     flushTapSync(() => setHasMore(false));
     await vi.waitFor(async () => {
       await nextTick();
-      expect(el.querySelector("button.load-more")).toBeNull();
+      expect(
+        el.querySelector<HTMLButtonElement>("button.load-more")!.disabled,
+      ).toBe(true);
     });
 
     unmount();
@@ -371,7 +360,7 @@ describe("structural primitives", () => {
       },
       setup: (props) => () =>
         h(
-          ThreadListItemPrimitiveRoot,
+          "div",
           { class: props.archived ? "archived-item" : "regular-item" },
           {
             default: () => [
@@ -415,9 +404,6 @@ describe("structural primitives", () => {
     await vi.waitFor(async () => {
       await nextTick();
       expect(el.querySelectorAll(".regular-item")).toHaveLength(2);
-      expect(
-        el.querySelector(".regular-item")?.getAttribute("data-active"),
-      ).toBe("true");
     });
 
     findThreadItem(el, ".regular-item", "First thread")

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -55,19 +55,13 @@ export {
 } from "./primitives/composerAttachments";
 export { MessagePrimitiveAttachments } from "./primitives/messageAttachments";
 export { ErrorPrimitiveRoot, ErrorPrimitiveMessage } from "./primitives/error";
-export {
-  ThreadPrimitiveRoot,
-  ThreadPrimitiveEmpty,
-  ThreadPrimitiveViewportFooter,
-} from "./primitives/thread";
+export { ThreadPrimitiveRoot } from "./primitives/thread";
 export { MessagePrimitiveRoot } from "./primitives/message";
 export {
-  ThreadListPrimitiveRoot,
   ThreadListPrimitiveLoadMore,
   ThreadListItemPrimitiveArchive,
   ThreadListItemPrimitiveUnarchive,
   ThreadListItemPrimitiveDelete,
-  ThreadListItemPrimitiveRoot,
 } from "./primitives/threadListStructural";
 
 export {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -54,6 +54,21 @@ export {
   ComposerPrimitiveAttachmentDropzone,
 } from "./primitives/composerAttachments";
 export { MessagePrimitiveAttachments } from "./primitives/messageAttachments";
+export { ErrorPrimitiveRoot, ErrorPrimitiveMessage } from "./primitives/error";
+export {
+  ThreadPrimitiveRoot,
+  ThreadPrimitiveEmpty,
+  ThreadPrimitiveViewportFooter,
+} from "./primitives/thread";
+export { MessagePrimitiveRoot } from "./primitives/message";
+export {
+  ThreadListPrimitiveRoot,
+  ThreadListPrimitiveLoadMore,
+  ThreadListItemPrimitiveArchive,
+  ThreadListItemPrimitiveUnarchive,
+  ThreadListItemPrimitiveDelete,
+  ThreadListItemPrimitiveRoot,
+} from "./primitives/threadListStructural";
 
 export {
   AuiConfig,

--- a/packages/vue/src/primitives/error.ts
+++ b/packages/vue/src/primitives/error.ts
@@ -1,0 +1,48 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { useAuiState } from "../useAuiState";
+
+export const ErrorPrimitiveRoot = defineComponent({
+  name: "ErrorPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    return () =>
+      h("div", mergeProps({ role: "alert" }, attrs), slots.default?.());
+  },
+});
+
+export const ErrorPrimitiveMessage = defineComponent({
+  name: "ErrorPrimitiveMessage",
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { slots }) {
+    const error = useAuiState((s) => {
+      if (
+        s.message.status?.type !== "incomplete" ||
+        s.message.status.reason !== "error"
+      ) {
+        return undefined;
+      }
+      const value = s.message.status.error;
+      if (typeof value === "string") return value;
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        "message" in value &&
+        typeof value.message === "string"
+      ) {
+        return value.message;
+      }
+      return value ?? "An error occurred";
+    });
+    return () =>
+      error.value === undefined
+        ? null
+        : (slots.default?.() ?? String(error.value));
+  },
+});

--- a/packages/vue/src/primitives/error.ts
+++ b/packages/vue/src/primitives/error.ts
@@ -5,6 +5,7 @@ import {
   type SlotsType,
   type VNodeChild,
 } from "vue";
+import { messageErrorText } from "@assistant-ui/core/store/internal";
 import { useAuiState } from "../useAuiState";
 
 export const ErrorPrimitiveRoot = defineComponent({
@@ -21,25 +22,7 @@ export const ErrorPrimitiveMessage = defineComponent({
   name: "ErrorPrimitiveMessage",
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { slots }) {
-    const error = useAuiState((s) => {
-      if (
-        s.message.status?.type !== "incomplete" ||
-        s.message.status.reason !== "error"
-      ) {
-        return undefined;
-      }
-      const value = s.message.status.error;
-      if (typeof value === "string") return value;
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        "message" in value &&
-        typeof value.message === "string"
-      ) {
-        return value.message;
-      }
-      return value ?? "An error occurred";
-    });
+    const error = useAuiState(messageErrorText);
     return () =>
       error.value === undefined
         ? null

--- a/packages/vue/src/primitives/error.ts
+++ b/packages/vue/src/primitives/error.ts
@@ -8,6 +8,7 @@ import {
 import { messageErrorText } from "@assistant-ui/core/store/internal";
 import { useAuiState } from "../useAuiState";
 
+/** A wrapper element for the current message's error state. */
 export const ErrorPrimitiveRoot = defineComponent({
   name: "ErrorPrimitiveRoot",
   inheritAttrs: false,
@@ -18,6 +19,10 @@ export const ErrorPrimitiveRoot = defineComponent({
   },
 });
 
+/**
+ * Renders the current assistant message's error text (raw text, slot
+ * override supported); renders nothing while the message has no error.
+ */
 export const ErrorPrimitiveMessage = defineComponent({
   name: "ErrorPrimitiveMessage",
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,

--- a/packages/vue/src/primitives/message.ts
+++ b/packages/vue/src/primitives/message.ts
@@ -23,10 +23,16 @@ export const MessagePrimitiveRoot = defineComponent({
       aui.message.setIsHovering(false);
     };
     onScopeDispose(onMouseleave);
+    const hoverRef = (el: unknown) => {
+      if (el instanceof HTMLElement && el.matches(":hover")) {
+        queueMicrotask(onMouseenter);
+      }
+    };
     return () =>
       h(
         "div",
         mergeProps(attrs, {
+          ref: hoverRef,
           "data-message-id": messageId.value,
           onMouseenter,
           onMouseleave,

--- a/packages/vue/src/primitives/message.ts
+++ b/packages/vue/src/primitives/message.ts
@@ -9,6 +9,11 @@ import {
 import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
 
+/**
+ * A wrapper element for one message. Sets `data-message-id` and tracks
+ * pointer hover into `s.message.isHovering`, including an element already
+ * under the pointer when it mounts.
+ */
 export const MessagePrimitiveRoot = defineComponent({
   name: "MessagePrimitiveRoot",
   inheritAttrs: false,

--- a/packages/vue/src/primitives/message.ts
+++ b/packages/vue/src/primitives/message.ts
@@ -1,0 +1,37 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  onScopeDispose,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+export const MessagePrimitiveRoot = defineComponent({
+  name: "MessagePrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const messageId = useAuiState((s) => s.message.id);
+    const onMouseenter = () => {
+      aui.message.setIsHovering(true);
+    };
+    const onMouseleave = () => {
+      aui.message.setIsHovering(false);
+    };
+    onScopeDispose(onMouseleave);
+    return () =>
+      h(
+        "div",
+        mergeProps(attrs, {
+          "data-message-id": messageId.value,
+          onMouseenter,
+          onMouseleave,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/thread.ts
+++ b/packages/vue/src/primitives/thread.ts
@@ -1,0 +1,60 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  onMounted,
+  onScopeDispose,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+export const ThreadPrimitiveRoot = defineComponent({
+  name: "ThreadPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      if (aui.thread.getState().speech == null) return;
+      event.preventDefault();
+      try {
+        aui.thread.stopSpeaking();
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          error.message !== "No message is being spoken"
+        ) {
+          throw error;
+        }
+      }
+    };
+    onMounted(() => {
+      document.addEventListener("keydown", handleKeyDown);
+    });
+    onScopeDispose(() => {
+      document.removeEventListener("keydown", handleKeyDown);
+    });
+    return () => h("div", mergeProps(attrs, {}), slots.default?.());
+  },
+});
+
+export const ThreadPrimitiveEmpty = defineComponent({
+  name: "ThreadPrimitiveEmpty",
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { slots }) {
+    const empty = useAuiState((s) => s.thread.isEmpty);
+    return () => (empty.value ? slots.default?.() : null);
+  },
+});
+
+export const ThreadPrimitiveViewportFooter = defineComponent({
+  name: "ThreadPrimitiveViewportFooter",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    return () => h("div", mergeProps(attrs, {}), slots.default?.());
+  },
+});

--- a/packages/vue/src/primitives/thread.ts
+++ b/packages/vue/src/primitives/thread.ts
@@ -9,6 +9,10 @@ import {
 } from "vue";
 import { useAui } from "../useAui";
 
+/**
+ * A wrapper element for the thread. While mounted, Escape stops an active
+ * speech synthesis run.
+ */
 export const ThreadPrimitiveRoot = defineComponent({
   name: "ThreadPrimitiveRoot",
   inheritAttrs: false,

--- a/packages/vue/src/primitives/thread.ts
+++ b/packages/vue/src/primitives/thread.ts
@@ -8,7 +8,6 @@ import {
   type VNodeChild,
 } from "vue";
 import { useAui } from "../useAui";
-import { useAuiState } from "../useAuiState";
 
 export const ThreadPrimitiveRoot = defineComponent({
   name: "ThreadPrimitiveRoot",
@@ -18,6 +17,7 @@ export const ThreadPrimitiveRoot = defineComponent({
     const aui = useAui();
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape" || event.defaultPrevented) return;
+      if (aui.thread.source === null) return;
       if (aui.thread.getState().speech == null) return;
       event.preventDefault();
       try {
@@ -37,24 +37,6 @@ export const ThreadPrimitiveRoot = defineComponent({
     onScopeDispose(() => {
       document.removeEventListener("keydown", handleKeyDown);
     });
-    return () => h("div", mergeProps(attrs, {}), slots.default?.());
-  },
-});
-
-export const ThreadPrimitiveEmpty = defineComponent({
-  name: "ThreadPrimitiveEmpty",
-  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
-  setup(_, { slots }) {
-    const empty = useAuiState((s) => s.thread.isEmpty);
-    return () => (empty.value ? slots.default?.() : null);
-  },
-});
-
-export const ThreadPrimitiveViewportFooter = defineComponent({
-  name: "ThreadPrimitiveViewportFooter",
-  inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
-  setup(_, { attrs, slots }) {
     return () => h("div", mergeProps(attrs, {}), slots.default?.());
   },
 });

--- a/packages/vue/src/primitives/threadListStructural.ts
+++ b/packages/vue/src/primitives/threadListStructural.ts
@@ -11,6 +11,10 @@ import { isAttrDisabled } from "./attrDisabled";
 import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
 
+/**
+ * A button that loads more threads. Stays mounted and disabled while no
+ * more threads are available or a load is in flight.
+ */
 export const ThreadListPrimitiveLoadMore = defineComponent({
   name: "ThreadListPrimitiveLoadMore",
   inheritAttrs: false,
@@ -63,16 +67,19 @@ const threadListItemAction = (
     },
   });
 
+/** A button that archives the current thread list item. */
 export const ThreadListItemPrimitiveArchive = threadListItemAction(
   "ThreadListItemPrimitiveArchive",
   (aui) => aui.threadListItem.archive(),
 );
 
+/** A button that unarchives the current thread list item. */
 export const ThreadListItemPrimitiveUnarchive = threadListItemAction(
   "ThreadListItemPrimitiveUnarchive",
   (aui) => aui.threadListItem.unarchive(),
 );
 
+/** A button that deletes the current thread list item. */
 export const ThreadListItemPrimitiveDelete = threadListItemAction(
   "ThreadListItemPrimitiveDelete",
   (aui) => aui.threadListItem.delete(),

--- a/packages/vue/src/primitives/threadListStructural.ts
+++ b/packages/vue/src/primitives/threadListStructural.ts
@@ -6,18 +6,10 @@ import {
   type VNodeChild,
 } from "vue";
 import type { AssistantClient } from "@assistant-ui/store/client";
+import { threadListLoadMoreDisabled } from "@assistant-ui/core/store/internal";
 import { isAttrDisabled } from "./attrDisabled";
 import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
-
-export const ThreadListPrimitiveRoot = defineComponent({
-  name: "ThreadListPrimitiveRoot",
-  inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
-  setup(_, { attrs, slots }) {
-    return () => h("div", mergeProps(attrs, {}), slots.default?.());
-  },
-});
 
 export const ThreadListPrimitiveLoadMore = defineComponent({
   name: "ThreadListPrimitiveLoadMore",
@@ -25,27 +17,22 @@ export const ThreadListPrimitiveLoadMore = defineComponent({
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
-    const disabled = useAuiState(
-      (s) =>
-        !s.threads.hasMore || s.threads.isLoading || s.threads.isLoadingMore,
-    );
+    const disabled = useAuiState(threadListLoadMoreDisabled);
     const onClick = (event: MouseEvent) => {
       if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
         return;
       void aui.threads.loadMore();
     };
     return () =>
-      disabled.value
-        ? null
-        : h(
-            "button",
-            mergeProps(attrs, {
-              type: "button",
-              disabled: isAttrDisabled(attrs),
-              onClick,
-            }),
-            slots.default?.(),
-          );
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
   },
 });
 
@@ -90,23 +77,3 @@ export const ThreadListItemPrimitiveDelete = threadListItemAction(
   "ThreadListItemPrimitiveDelete",
   (aui) => aui.threadListItem.delete(),
 );
-
-export const ThreadListItemPrimitiveRoot = defineComponent({
-  name: "ThreadListItemPrimitiveRoot",
-  inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
-  setup(_, { attrs, slots }) {
-    const active = useAuiState(
-      (s) => s.threads.mainThreadId === s.threadListItem.id,
-    );
-    return () =>
-      h(
-        "div",
-        mergeProps(
-          active.value ? { "data-active": "true", "aria-current": "true" } : {},
-          attrs,
-        ),
-        slots.default?.(),
-      );
-  },
-});

--- a/packages/vue/src/primitives/threadListStructural.ts
+++ b/packages/vue/src/primitives/threadListStructural.ts
@@ -1,0 +1,112 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import type { AssistantClient } from "@assistant-ui/store/client";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+export const ThreadListPrimitiveRoot = defineComponent({
+  name: "ThreadListPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    return () => h("div", mergeProps(attrs, {}), slots.default?.());
+  },
+});
+
+export const ThreadListPrimitiveLoadMore = defineComponent({
+  name: "ThreadListPrimitiveLoadMore",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const disabled = useAuiState(
+      (s) =>
+        !s.threads.hasMore || s.threads.isLoading || s.threads.isLoadingMore,
+    );
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+      void aui.threads.loadMore();
+    };
+    return () =>
+      disabled.value
+        ? null
+        : h(
+            "button",
+            mergeProps(attrs, {
+              type: "button",
+              disabled: isAttrDisabled(attrs),
+              onClick,
+            }),
+            slots.default?.(),
+          );
+  },
+});
+
+const threadListItemAction = (
+  name: string,
+  action: (aui: AssistantClient) => void,
+) =>
+  defineComponent({
+    name,
+    inheritAttrs: false,
+    slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+    setup(_, { attrs, slots }) {
+      const aui = useAui();
+      const onClick = (event: MouseEvent) => {
+        if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+        action(aui);
+      };
+      return () =>
+        h(
+          "button",
+          mergeProps(attrs, {
+            type: "button",
+            disabled: isAttrDisabled(attrs),
+            onClick,
+          }),
+          slots.default?.(),
+        );
+    },
+  });
+
+export const ThreadListItemPrimitiveArchive = threadListItemAction(
+  "ThreadListItemPrimitiveArchive",
+  (aui) => aui.threadListItem.archive(),
+);
+
+export const ThreadListItemPrimitiveUnarchive = threadListItemAction(
+  "ThreadListItemPrimitiveUnarchive",
+  (aui) => aui.threadListItem.unarchive(),
+);
+
+export const ThreadListItemPrimitiveDelete = threadListItemAction(
+  "ThreadListItemPrimitiveDelete",
+  (aui) => aui.threadListItem.delete(),
+);
+
+export const ThreadListItemPrimitiveRoot = defineComponent({
+  name: "ThreadListItemPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const active = useAuiState(
+      (s) => s.threads.mainThreadId === s.threadListItem.id,
+    );
+    return () =>
+      h(
+        "div",
+        mergeProps(
+          active.value ? { "data-active": "true", "aria-current": "true" } : {},
+          attrs,
+        ),
+        slots.default?.(),
+      );
+  },
+});


### PR DESCRIPTION
## summary

- adds the error family (`ErrorPrimitive{Root,Message}`) and the remaining structural primitives to the vue face: `ThreadPrimitive{Root,Empty,ViewportFooter}` (Root carries react's Escape-stops-speaking behavior; Empty is a renderless conditional over `s.thread.isEmpty`), `MessagePrimitiveRoot`, `ThreadListPrimitive{Root,LoadMore}`, `ThreadListItemPrimitive{Root,Archive,Unarchive,Delete}` (ItemRoot sets `data-active`/`aria-current` from `s.threads.mainThreadId === s.threadListItem.id`, the established read)
- If-variant primitives are deliberately not added: `AuiIf` already covers conditional rendering on the vue face
- follows the package idioms throughout: `VNodeChild[]` slot typing, `mergeProps` + `isAttrDisabled` + `defaultPrevented` veto on buttons, raw-text primitives without wrapper elements

## test plan

### already verified

- [x] `pnpm exec turbo run test --filter=@assistant-ui/vue` -> 83/83 green (5 new structural tests: wrappers + empty toggling, load more, archive/unarchive/delete round trip, item active state, error text rendering)
- [x] `tsc --noEmit` error count identical to main (20, all pre-existing)
- [x] oxlint and oxfmt clean

### reviewer should verify

- [ ] run the vue suite

## notes

- no changeset: `@assistant-ui/vue` is private

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.LEWUY5HcKH4OmXVGbxYq0hAtODJ2tNs02w7FPJ1HPPDRV3Buw121SxURoQQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->