### PR TITLE
feat(vue): attachment UI in with-nuxt and the staged kit

### DIFF
--- a/examples/with-nuxt/app/components/Message.vue
+++ b/examples/with-nuxt/app/components/Message.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   ActionBarPrimitiveCopy,
+  AttachmentPrimitiveName,
   ActionBarPrimitiveEdit,
   ActionBarPrimitiveReload,
   AuiIf,
@@ -11,6 +12,7 @@ import {
   ComposerPrimitiveCancel,
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
+  MessagePrimitiveAttachments,
   MessagePrimitiveParts,
   useAuiState,
 } from "@assistant-ui/vue";
@@ -84,6 +86,14 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
+      <div class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden">
+        <MessagePrimitiveAttachments>
+          <span
+            class="border-border/60 bg-background/60 rounded-md border px-1.5 py-0.5 text-xs"
+            ><AttachmentPrimitiveName
+          /></span>
+        </MessagePrimitiveAttachments>
+      </div>
       <MessagePrimitiveParts v-if="role === 'assistant'">
         <template #text>
           <MarkdownText />

--- a/examples/with-nuxt/app/components/Message.vue
+++ b/examples/with-nuxt/app/components/Message.vue
@@ -86,7 +86,10 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <div class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden">
+      <div
+        v-if="role === 'user'"
+        class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden"
+      >
         <MessagePrimitiveAttachments>
           <span
             class="border-border/60 bg-background/60 rounded-md border px-1.5 py-0.5 text-xs"

--- a/examples/with-nuxt/app/components/Thread.vue
+++ b/examples/with-nuxt/app/components/Thread.vue
@@ -95,12 +95,14 @@ import {
           rows="1"
         />
         <div class="flex items-center justify-between">
-          <ComposerPrimitiveAddAttachment
-            class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
-            aria-label="Add attachment"
-          >
-            <PaperclipIcon class="size-4" />
-          </ComposerPrimitiveAddAttachment>
+          <AuiIf :condition="(s) => s.thread.capabilities.attachments">
+            <ComposerPrimitiveAddAttachment
+              class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+              aria-label="Add attachment"
+            >
+              <PaperclipIcon class="size-4" />
+            </ComposerPrimitiveAddAttachment>
+          </AuiIf>
           <AuiIf :condition="(s) => !s.thread.isRunning">
             <ComposerPrimitiveSend
               class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"

--- a/examples/with-nuxt/app/components/Thread.vue
+++ b/examples/with-nuxt/app/components/Thread.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import {
+  AttachmentPrimitiveName,
+  AttachmentPrimitiveRemove,
+  AttachmentPrimitiveThumb,
   AuiIf,
+  ComposerPrimitiveAddAttachment,
+  ComposerPrimitiveAttachmentDropzone,
+  ComposerPrimitiveAttachments,
   ComposerPrimitiveCancel,
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
@@ -13,7 +19,13 @@ import {
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
-import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  PaperclipIcon,
+  SquareIcon,
+  XIcon,
+} from "@lucide/vue";
 </script>
 
 <template>
@@ -56,15 +68,39 @@ import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
       </div>
     </ThreadPrimitiveViewport>
     <div class="mx-auto w-full max-w-2xl px-4 pb-4">
-      <div
-        class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+      <ComposerPrimitiveAttachmentDropzone
+        class="border-border/60 focus-within:border-border data-[dragging=true]:border-primary data-[dragging=true]:bg-primary/5 flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
       >
+        <div class="flex flex-wrap gap-2 empty:hidden">
+          <ComposerPrimitiveAttachments>
+            <div
+              class="border-border/60 bg-muted/40 flex items-center gap-2 rounded-lg border px-2 py-1 text-xs"
+            >
+              <AttachmentPrimitiveThumb
+                class="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px] uppercase"
+              />
+              <span class="max-w-40 truncate"><AttachmentPrimitiveName /></span>
+              <AttachmentPrimitiveRemove
+                class="text-muted-foreground hover:text-foreground rounded p-0.5"
+                aria-label="Remove attachment"
+              >
+                <XIcon class="size-3" />
+              </AttachmentPrimitiveRemove>
+            </div>
+          </ComposerPrimitiveAttachments>
+        </div>
         <ComposerPrimitiveInput
           class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
           placeholder="Send a message..."
           rows="1"
         />
-        <div class="flex items-center justify-end">
+        <div class="flex items-center justify-between">
+          <ComposerPrimitiveAddAttachment
+            class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+            aria-label="Add attachment"
+          >
+            <PaperclipIcon class="size-4" />
+          </ComposerPrimitiveAddAttachment>
           <AuiIf :condition="(s) => !s.thread.isRunning">
             <ComposerPrimitiveSend
               class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
@@ -82,7 +118,7 @@ import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
             </ComposerPrimitiveCancel>
           </AuiIf>
         </div>
-      </div>
+      </ComposerPrimitiveAttachmentDropzone>
     </div>
   </div>
 </template>

--- a/examples/with-nuxt/app/components/Thread.vue
+++ b/examples/with-nuxt/app/components/Thread.vue
@@ -95,14 +95,16 @@ import {
           rows="1"
         />
         <div class="flex items-center justify-between">
-          <AuiIf :condition="(s) => s.thread.capabilities.attachments">
-            <ComposerPrimitiveAddAttachment
-              class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
-              aria-label="Add attachment"
-            >
-              <PaperclipIcon class="size-4" />
-            </ComposerPrimitiveAddAttachment>
-          </AuiIf>
+          <div class="flex items-center">
+            <AuiIf :condition="(s) => s.thread.capabilities.attachments">
+              <ComposerPrimitiveAddAttachment
+                class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                aria-label="Add attachment"
+              >
+                <PaperclipIcon class="size-4" />
+              </ComposerPrimitiveAddAttachment>
+            </AuiIf>
+          </div>
           <AuiIf :condition="(s) => !s.thread.isRunning">
             <ComposerPrimitiveSend
               class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"

--- a/packages/ui/src/components/assistant-ui-vue/message.vue
+++ b/packages/ui/src/components/assistant-ui-vue/message.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   ActionBarPrimitiveCopy,
+  AttachmentPrimitiveName,
   ActionBarPrimitiveEdit,
   ActionBarPrimitiveReload,
   AuiIf,
@@ -11,6 +12,7 @@ import {
   ComposerPrimitiveCancel,
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
+  MessagePrimitiveAttachments,
   MessagePrimitiveParts,
   useAuiState,
 } from "@assistant-ui/vue";
@@ -85,6 +87,14 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
+      <div class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden">
+        <MessagePrimitiveAttachments>
+          <span
+            class="border-border/60 bg-background/60 rounded-md border px-1.5 py-0.5 text-xs"
+            ><AttachmentPrimitiveName
+          /></span>
+        </MessagePrimitiveAttachments>
+      </div>
       <MessagePrimitiveParts v-if="role === 'assistant'">
         <template #text>
           <MarkdownText />

--- a/packages/ui/src/components/assistant-ui-vue/message.vue
+++ b/packages/ui/src/components/assistant-ui-vue/message.vue
@@ -87,7 +87,10 @@ const error = useAuiState((s) => {
           : 'text-foreground leading-relaxed'
       "
     >
-      <div class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden">
+      <div
+        v-if="role === 'user'"
+        class="mb-1 flex flex-wrap justify-end gap-1.5 empty:hidden"
+      >
         <MessagePrimitiveAttachments>
           <span
             class="border-border/60 bg-background/60 rounded-md border px-1.5 py-0.5 text-xs"

--- a/packages/ui/src/components/assistant-ui-vue/thread.vue
+++ b/packages/ui/src/components/assistant-ui-vue/thread.vue
@@ -103,12 +103,14 @@ import Message from "@/components/assistant-ui/message.vue";
             rows="1"
           />
           <div class="flex items-center justify-between">
-            <ComposerPrimitiveAddAttachment
-              class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
-              aria-label="Add attachment"
-            >
-              <PaperclipIcon class="size-4" />
-            </ComposerPrimitiveAddAttachment>
+            <AuiIf :condition="(s) => s.thread.capabilities.attachments">
+              <ComposerPrimitiveAddAttachment
+                class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                aria-label="Add attachment"
+              >
+                <PaperclipIcon class="size-4" />
+              </ComposerPrimitiveAddAttachment>
+            </AuiIf>
             <AuiIf :condition="(s) => !s.thread.isRunning">
               <ComposerPrimitiveSend
                 class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"

--- a/packages/ui/src/components/assistant-ui-vue/thread.vue
+++ b/packages/ui/src/components/assistant-ui-vue/thread.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import {
+  AttachmentPrimitiveName,
+  AttachmentPrimitiveRemove,
+  AttachmentPrimitiveThumb,
   AuiIf,
+  ComposerPrimitiveAddAttachment,
+  ComposerPrimitiveAttachmentDropzone,
+  ComposerPrimitiveAttachments,
   ComposerPrimitiveCancel,
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
@@ -13,7 +19,13 @@ import {
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
-import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  PaperclipIcon,
+  SquareIcon,
+  XIcon,
+} from "@lucide/vue";
 import Message from "@/components/assistant-ui/message.vue";
 </script>
 
@@ -62,15 +74,41 @@ import Message from "@/components/assistant-ui/message.vue";
         </div>
       </ThreadPrimitiveViewport>
       <div class="mx-auto w-full max-w-2xl px-4 pb-4">
-        <div
-          class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+        <ComposerPrimitiveAttachmentDropzone
+          class="border-border/60 focus-within:border-border data-[dragging=true]:border-primary data-[dragging=true]:bg-primary/5 flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
         >
+          <div class="flex flex-wrap gap-2 empty:hidden">
+            <ComposerPrimitiveAttachments>
+              <div
+                class="border-border/60 bg-muted/40 flex items-center gap-2 rounded-lg border px-2 py-1 text-xs"
+              >
+                <AttachmentPrimitiveThumb
+                  class="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[10px] uppercase"
+                />
+                <span class="max-w-40 truncate"
+                  ><AttachmentPrimitiveName
+                /></span>
+                <AttachmentPrimitiveRemove
+                  class="text-muted-foreground hover:text-foreground rounded p-0.5"
+                  aria-label="Remove attachment"
+                >
+                  <XIcon class="size-3" />
+                </AttachmentPrimitiveRemove>
+              </div>
+            </ComposerPrimitiveAttachments>
+          </div>
           <ComposerPrimitiveInput
             class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
             placeholder="Send a message..."
             rows="1"
           />
-          <div class="flex items-center justify-end">
+          <div class="flex items-center justify-between">
+            <ComposerPrimitiveAddAttachment
+              class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+              aria-label="Add attachment"
+            >
+              <PaperclipIcon class="size-4" />
+            </ComposerPrimitiveAddAttachment>
             <AuiIf :condition="(s) => !s.thread.isRunning">
               <ComposerPrimitiveSend
                 class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
@@ -88,7 +126,7 @@ import Message from "@/components/assistant-ui/message.vue";
               </ComposerPrimitiveCancel>
             </AuiIf>
           </div>
-        </div>
+        </ComposerPrimitiveAttachmentDropzone>
       </div>
     </div>
   </div>

--- a/packages/ui/src/components/assistant-ui-vue/thread.vue
+++ b/packages/ui/src/components/assistant-ui-vue/thread.vue
@@ -103,14 +103,16 @@ import Message from "@/components/assistant-ui/message.vue";
             rows="1"
           />
           <div class="flex items-center justify-between">
-            <AuiIf :condition="(s) => s.thread.capabilities.attachments">
-              <ComposerPrimitiveAddAttachment
-                class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
-                aria-label="Add attachment"
-              >
-                <PaperclipIcon class="size-4" />
-              </ComposerPrimitiveAddAttachment>
-            </AuiIf>
+            <div class="flex items-center">
+              <AuiIf :condition="(s) => s.thread.capabilities.attachments">
+                <ComposerPrimitiveAddAttachment
+                  class="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                  aria-label="Add attachment"
+                >
+                  <PaperclipIcon class="size-4" />
+                </ComposerPrimitiveAddAttachment>
+              </AuiIf>
+            </div>
             <AuiIf :condition="(s) => !s.thread.isRunning">
               <ComposerPrimitiveSend
                 class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"


### PR DESCRIPTION
## summary

- wires the #6478 attachment primitives into the styled surface, in with-nuxt and the staged vue kit copies: the composer card is now a `ComposerPrimitiveAttachmentDropzone` (highlight ring via `data-[dragging=true]`), pending attachments render as cards (`AttachmentPrimitiveThumb` extension badge + name + remove), a paperclip `ComposerPrimitiveAddAttachment` button sits beside send, and user messages show their attachments through `MessagePrimitiveAttachments`
- zero configuration: `useAISDKRuntime` already defaults the attachments adapter to `vercelAttachmentAdapter`, so `AISDKThreads()` picks it up as-is

## test plan

### already verified

- [x] browser end to end with a real-Chrome `DataTransfer`: drag highlights the card, drop adds the attachment (`.TXT`/`.PNG` badge + name + working remove), sending a PNG completes a full streamed round trip with the attachment badge on the user message, zero console errors
- [x] `pnpm -C apps/registry test` -> 50/50 green (the emitted-SFC compile smoke covers the modified kit copies)
- [x] provider constraint exercised: OpenAI rejects `text/plain` file parts; the error renders in the message bubble (and persists for the thread since history is resent; images are the demo-safe type)

### reviewer should verify

- [ ] `pnpm -C examples/with-nuxt dev`, drag an image into the composer, send, and confirm the badge on the user message

## notes

- no changeset: only private surfaces (with-nuxt, `@assistant-ui/ui`) are touched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ucBpUGUa8kJHB2-PhdjoqVqhcFmWZmz2AuXBdJmdqp0wN-Q1JJ4n0uqtnW8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->