### PR TITLE
fix(react-mcp): serialize OAuth state across provider instances

### DIFF
--- a/.changeset/stable-mcp-storage-oauth-persistence.md
+++ b/.changeset/stable-mcp-storage-oauth-persistence.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: keep MCP storage resources stable across re-renders and serialize OAuth state persistence across provider instances

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -318,6 +318,24 @@ describe("createOAuthProvider persistence across provider instances", () => {
     });
   });
 
+  it("does not leak static client information to a dynamic provider", async () => {
+    const { storage } = createStorage();
+    const staticProvider = createOAuthProvider({
+      serverId: "docs",
+      config: { type: "oauth", clientId: "client-a" },
+      storage,
+      redirectUri: "http://localhost/callback",
+      onAuthorizationUrl: () => {},
+    });
+    await expect(staticProvider.clientInformation()).resolves.toEqual({
+      client_id: "client-a",
+      redirect_uris: ["http://localhost/callback"],
+    });
+
+    const dynamicProvider = createProvider(storage);
+    await expect(dynamicProvider.clientInformation()).resolves.toBeUndefined();
+  });
+
   it("keeps a provider built while the clear is in flight usable", async () => {
     const { storage, getState } = createStorage();
     let releaseClear: (() => void) | undefined;

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -2,7 +2,10 @@ import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
 import type { MCPStorage } from "../resources/storage/types";
 import type { MCPPersistedAuthState } from "./types";
-import { createOAuthProvider } from "./createOAuthProvider";
+import {
+  clearOAuthProviderAuthState,
+  createOAuthProvider,
+} from "./createOAuthProvider";
 
 const discoveryState: OAuthDiscoveryState = {
   authorizationServerUrl: "https://auth.example.com",
@@ -196,5 +199,122 @@ describe("createOAuthProvider persistence", () => {
       tokens: { access_token: "access-token", token_type: "bearer" },
       codeVerifier: "pkce-verifier",
     });
+  });
+});
+
+describe("createOAuthProvider persistence across provider instances", () => {
+  it("shares one auth state load across provider instances", async () => {
+    let resolveLoad!: (value: MCPPersistedAuthState | null) => void;
+    const loadAuthState = vi.fn(
+      () =>
+        new Promise<MCPPersistedAuthState | null>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const { storage } = createStorage();
+    storage.loadAuthState = loadAuthState;
+    const provider = createProvider(storage);
+    const replacementProvider = createProvider(storage);
+
+    const tokens = provider.tokens();
+    const clientInformation = replacementProvider.clientInformation();
+
+    expect(loadAuthState).toHaveBeenCalledTimes(1);
+    resolveLoad(null);
+    await Promise.all([tokens, clientInformation]);
+  });
+
+  it("serializes writes across provider instances", async () => {
+    const { storage } = createStorage();
+    const pendingWrites: Array<() => void> = [];
+    let persisted: MCPPersistedAuthState | null = null;
+    storage.saveAuthState = async (_serverId, next) => {
+      await new Promise<void>((resolve) => pendingWrites.push(resolve));
+      persisted = next;
+    };
+    const provider = createProvider(storage);
+    const replacementProvider = createProvider(storage);
+    await Promise.all([provider.tokens(), replacementProvider.tokens()]);
+
+    const tokenSave = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+
+    const verifierSave = replacementProvider.saveCodeVerifier("pkce-verifier");
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(pendingWrites).toHaveLength(1);
+
+    pendingWrites.shift()!();
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+    pendingWrites.shift()!();
+    await Promise.all([tokenSave, verifierSave]);
+
+    expect(persisted).toEqual({
+      tokens: { access_token: "access-token", token_type: "bearer" },
+      codeVerifier: "pkce-verifier",
+    });
+  });
+
+  it("clears after a pending write and fences the discarded provider", async () => {
+    const { storage, getState } = createStorage();
+    const pendingWrites: Array<() => void> = [];
+    const saveAuthState = storage.saveAuthState;
+    storage.saveAuthState = async (serverId, next) => {
+      await new Promise<void>((resolve) => pendingWrites.push(resolve));
+      await saveAuthState(serverId, next);
+    };
+    const clearAuthState = vi.spyOn(storage, "clearAuthState");
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const save = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+
+    const clear = clearOAuthProviderAuthState(storage, "docs");
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(clearAuthState).not.toHaveBeenCalled();
+
+    pendingWrites.shift()!();
+    await expect(save).resolves.toBeUndefined();
+    await clear;
+    expect(clearAuthState).toHaveBeenCalledTimes(1);
+    expect(getState()).toBeNull();
+
+    storage.saveAuthState = saveAuthState;
+    await provider.saveCodeVerifier("late-verifier");
+    expect(getState()).toBeNull();
+  });
+
+  it("keeps a provider built while the clear is in flight usable", async () => {
+    const { storage, getState } = createStorage();
+    let releaseClear: (() => void) | undefined;
+    const clearAuthState = storage.clearAuthState;
+    storage.clearAuthState = async (serverId) => {
+      await new Promise<void>((resolve) => {
+        releaseClear = resolve;
+      });
+      await clearAuthState(serverId);
+    };
+    const provider = createProvider(storage);
+    await provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+
+    const clear = clearOAuthProviderAuthState(storage, "docs");
+    await vi.waitFor(() => expect(releaseClear).toBeTypeOf("function"));
+
+    const replacementProvider = createProvider(storage);
+    releaseClear!();
+    await clear;
+    expect(getState()).toBeNull();
+
+    await replacementProvider.saveCodeVerifier("new-verifier");
+    expect(getState()).toEqual({ codeVerifier: "new-verifier" });
   });
 });

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -290,6 +290,34 @@ describe("createOAuthProvider persistence across provider instances", () => {
     expect(getState()).toBeNull();
   });
 
+  it("re-derives static client information for a replacement provider", async () => {
+    const { storage } = createStorage();
+    const provider = createOAuthProvider({
+      serverId: "docs",
+      config: { type: "oauth", clientId: "client-a" },
+      storage,
+      redirectUri: "http://localhost/callback",
+      onAuthorizationUrl: () => {},
+    });
+    await expect(provider.clientInformation()).resolves.toEqual({
+      client_id: "client-a",
+      redirect_uris: ["http://localhost/callback"],
+    });
+
+    const replacementProvider = createOAuthProvider({
+      serverId: "docs",
+      config: { type: "oauth", clientId: "client-b", clientSecret: "secret-b" },
+      storage,
+      redirectUri: "http://localhost/callback-2",
+      onAuthorizationUrl: () => {},
+    });
+    await expect(replacementProvider.clientInformation()).resolves.toEqual({
+      client_id: "client-b",
+      client_secret: "secret-b",
+      redirect_uris: ["http://localhost/callback-2"],
+    });
+  });
+
   it("keeps a provider built while the clear is in flight usable", async () => {
     const { storage, getState } = createStorage();
     let releaseClear: (() => void) | undefined;

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -57,6 +57,78 @@ export type CreateOAuthProviderOptions = {
   onAuthorizationUrl: (url: URL) => void;
 };
 
+type OAuthProviderCache = {
+  tokens?: OAuthTokens | undefined;
+  clientInformation?: OAuthClientInformationFull | undefined;
+  codeVerifier?: string | undefined;
+  discoveryState?: OAuthDiscoveryState | undefined;
+};
+
+type OAuthProviderPersistence = {
+  cached: OAuthProviderCache | null;
+  cachePromise: Promise<OAuthProviderCache> | null;
+  queue: Promise<void>;
+  invalidated: boolean;
+};
+
+// McpServerResource builds a fresh provider for every transport, so the cache,
+// the in-flight load, and the write queue have to outlive any one provider.
+// saveAuthState replaces the whole record, so two providers writing their own
+// snapshots concurrently would drop whichever field the loser had added.
+const persistenceByStorage = new WeakMap<
+  MCPStorage,
+  Map<string, OAuthProviderPersistence>
+>();
+
+const getPersistence = (
+  storage: MCPStorage,
+  serverId: string,
+): OAuthProviderPersistence => {
+  let byServerId = persistenceByStorage.get(storage);
+  if (!byServerId) {
+    byServerId = new Map();
+    persistenceByStorage.set(storage, byServerId);
+  }
+
+  let persistence = byServerId.get(serverId);
+  if (!persistence) {
+    persistence = {
+      cached: null,
+      cachePromise: null,
+      queue: Promise.resolve(),
+      invalidated: false,
+    };
+    byServerId.set(serverId, persistence);
+  }
+  return persistence;
+};
+
+/**
+ * Clears persisted OAuth state after the in-flight load and every queued write
+ * for that server have settled, so a discarded provider cannot recreate the
+ * record it was mid-save on.
+ */
+export const clearOAuthProviderAuthState = async (
+  storage: MCPStorage,
+  serverId: string,
+): Promise<void> => {
+  const byServerId = persistenceByStorage.get(storage);
+  const persistence = byServerId?.get(serverId);
+  if (!byServerId || !persistence) {
+    await storage.clearAuthState(serverId);
+    return;
+  }
+
+  // Detaching the entry before awaiting keeps a provider built during the clear
+  // on a fresh generation instead of inheriting the fenced one.
+  persistence.invalidated = true;
+  byServerId.delete(serverId);
+  if (byServerId.size === 0) persistenceByStorage.delete(storage);
+
+  await Promise.allSettled([persistence.cachePromise, persistence.queue]);
+  await storage.clearAuthState(serverId);
+};
+
 /**
  * Builds an OAuthClientProvider for the MCP SDK, backed by MCPStorage.
  * Token refresh and DCR are handled by the SDK; this provider only mediates
@@ -66,24 +138,15 @@ export function createOAuthProvider(
   opts: CreateOAuthProviderOptions,
 ): OAuthClientProvider {
   const { serverId, config, storage, redirectUri, onAuthorizationUrl } = opts;
+  const persistence = getPersistence(storage, serverId);
 
-  type Cache = {
-    tokens?: OAuthTokens | undefined;
-    clientInformation?: OAuthClientInformationFull | undefined;
-    codeVerifier?: string | undefined;
-    discoveryState?: OAuthDiscoveryState | undefined;
-  };
-  let cached: Cache | null = null;
-  let cachePromise: Promise<Cache> | null = null;
-  let persistenceQueue = Promise.resolve();
+  const loadCache = (): Promise<OAuthProviderCache> => {
+    if (persistence.cached) return Promise.resolve(persistence.cached);
+    if (persistence.cachePromise) return persistence.cachePromise;
 
-  const loadCache = (): Promise<Cache> => {
-    if (cached) return Promise.resolve(cached);
-    if (cachePromise) return cachePromise;
-
-    cachePromise = storage.loadAuthState(serverId).then(
+    persistence.cachePromise = storage.loadAuthState(serverId).then(
       (persisted) => {
-        const initial: Cache = {};
+        const initial: OAuthProviderCache = {};
         if (persisted?.tokens) initial.tokens = persisted.tokens;
         if (config.clientId) {
           const ci: OAuthClientInformationFull = {
@@ -99,20 +162,21 @@ export function createOAuthProvider(
           initial.codeVerifier = persisted.codeVerifier;
         if (persisted?.discoveryState)
           initial.discoveryState = persisted.discoveryState;
-        cached = initial;
+        persistence.cached = initial;
         return initial;
       },
       (error) => {
-        cachePromise = null;
+        persistence.cachePromise = null;
         throw error;
       },
     );
-    return cachePromise;
+    return persistence.cachePromise;
   };
 
   const persist = () => {
-    const task = persistenceQueue.then(async () => {
-      const c = cached;
+    const task = persistence.queue.then(async () => {
+      if (persistence.invalidated) return;
+      const c = persistence.cached;
       if (!c) return;
       const next: Parameters<typeof storage.saveAuthState>[1] = {};
       if (c.tokens) next.tokens = c.tokens;
@@ -121,7 +185,7 @@ export function createOAuthProvider(
       if (c.discoveryState) next.discoveryState = c.discoveryState;
       await storage.saveAuthState(serverId, next);
     });
-    persistenceQueue = task.catch(() => {});
+    persistence.queue = task.catch(() => {});
     return task;
   };
 

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -140,24 +140,36 @@ export function createOAuthProvider(
   const { serverId, config, storage, redirectUri, onAuthorizationUrl } = opts;
   const persistence = getPersistence(storage, serverId);
 
+  // The cache outlives the provider, so a statically configured client is
+  // re-derived on every read: a transport rebuilt for a changed clientId,
+  // clientSecret or redirectUri must not inherit the previous registration.
+  const applyStaticClientInformation = (
+    cache: OAuthProviderCache,
+  ): OAuthProviderCache => {
+    if (!config.clientId) return cache;
+    const ci: OAuthClientInformationFull = {
+      client_id: config.clientId,
+      redirect_uris: [redirectUri],
+    };
+    if (config.clientSecret) ci.client_secret = config.clientSecret;
+    cache.clientInformation = ci;
+    return cache;
+  };
+
   const loadCache = (): Promise<OAuthProviderCache> => {
-    if (persistence.cached) return Promise.resolve(persistence.cached);
-    if (persistence.cachePromise) return persistence.cachePromise;
+    if (persistence.cached) {
+      return Promise.resolve(applyStaticClientInformation(persistence.cached));
+    }
+    if (persistence.cachePromise) {
+      return persistence.cachePromise.then(applyStaticClientInformation);
+    }
 
     persistence.cachePromise = storage.loadAuthState(serverId).then(
       (persisted) => {
         const initial: OAuthProviderCache = {};
         if (persisted?.tokens) initial.tokens = persisted.tokens;
-        if (config.clientId) {
-          const ci: OAuthClientInformationFull = {
-            client_id: config.clientId,
-            redirect_uris: [redirectUri],
-          };
-          if (config.clientSecret) ci.client_secret = config.clientSecret;
-          initial.clientInformation = ci;
-        } else if (persisted?.clientInformation) {
+        if (persisted?.clientInformation)
           initial.clientInformation = persisted.clientInformation;
-        }
         if (persisted?.codeVerifier)
           initial.codeVerifier = persisted.codeVerifier;
         if (persisted?.discoveryState)
@@ -170,7 +182,7 @@ export function createOAuthProvider(
         throw error;
       },
     );
-    return persistence.cachePromise;
+    return persistence.cachePromise.then(applyStaticClientInformation);
   };
 
   const persist = () => {

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -140,29 +140,25 @@ export function createOAuthProvider(
   const { serverId, config, storage, redirectUri, onAuthorizationUrl } = opts;
   const persistence = getPersistence(storage, serverId);
 
-  // The cache outlives the provider, so a statically configured client is
-  // re-derived on every read: a transport rebuilt for a changed clientId,
-  // clientSecret or redirectUri must not inherit the previous registration.
-  const applyStaticClientInformation = (
-    cache: OAuthProviderCache,
-  ): OAuthProviderCache => {
-    if (!config.clientId) return cache;
+  // The cache is shared with every other provider for this (storage, serverId),
+  // so a statically configured client stays a read-time overlay owned by this
+  // provider. Writing it into the cache would leak this provider's registration
+  // to a replacement built for a different, or absent, clientId.
+  const staticClientInformation = (():
+    | OAuthClientInformationFull
+    | undefined => {
+    if (!config.clientId) return undefined;
     const ci: OAuthClientInformationFull = {
       client_id: config.clientId,
       redirect_uris: [redirectUri],
     };
     if (config.clientSecret) ci.client_secret = config.clientSecret;
-    cache.clientInformation = ci;
-    return cache;
-  };
+    return ci;
+  })();
 
   const loadCache = (): Promise<OAuthProviderCache> => {
-    if (persistence.cached) {
-      return Promise.resolve(applyStaticClientInformation(persistence.cached));
-    }
-    if (persistence.cachePromise) {
-      return persistence.cachePromise.then(applyStaticClientInformation);
-    }
+    if (persistence.cached) return Promise.resolve(persistence.cached);
+    if (persistence.cachePromise) return persistence.cachePromise;
 
     persistence.cachePromise = storage.loadAuthState(serverId).then(
       (persisted) => {
@@ -182,7 +178,7 @@ export function createOAuthProvider(
         throw error;
       },
     );
-    return persistence.cachePromise.then(applyStaticClientInformation);
+    return persistence.cachePromise;
   };
 
   const persist = () => {
@@ -228,7 +224,7 @@ export function createOAuthProvider(
     },
     async clientInformation() {
       const c = await loadCache();
-      return c.clientInformation;
+      return staticClientInformation ?? c.clientInformation;
     },
     async saveClientInformation(info) {
       const c = await loadCache();

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -9,6 +9,7 @@ import {
 import { useAssistantScopeEffect } from "@assistant-ui/store/client";
 import { ModelContext } from "@assistant-ui/core/store";
 import { createMcpId } from "../utils/createMcpId";
+import { clearOAuthProviderAuthState } from "../auth/createOAuthProvider";
 import type { Tool } from "assistant-stream";
 import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
@@ -303,7 +304,7 @@ const useMcpManagerResource = (
       try {
         await lookup.get({ key: id }).remove();
       } catch {
-        await storage.clearAuthState(id);
+        await clearOAuthProviderAuthState(storage, id);
         setCustomServers((prev) => prev.filter((s) => s.id !== id));
       }
     },

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -10,7 +10,10 @@ import {
   type ElicitResult,
   type StreamableHTTPClientTransportOptions,
 } from "@modelcontextprotocol/client";
-import { createOAuthProvider } from "../auth/createOAuthProvider";
+import {
+  clearOAuthProviderAuthState,
+  createOAuthProvider,
+} from "../auth/createOAuthProvider";
 import { buildHeaders } from "../auth/buildHeaders";
 import { assertValidServerId } from "../utils/serverId";
 import { validateElicitationContent } from "./validateElicitationContent";
@@ -597,7 +600,7 @@ const useMcpServerResourceInstance = (
     remove: async () => {
       await doDisconnect();
       try {
-        await props.storage.clearAuthState(props.id);
+        await clearOAuthProviderAuthState(props.storage, props.id);
         await props.onRemove();
       } catch (err) {
         setLastError({

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -1,8 +1,10 @@
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, resource, useResource } from "@assistant-ui/tap";
+import { useState } from "react";
 import { auth, type FetchLike } from "@modelcontextprotocol/client";
 import { describe, expect, it } from "vitest";
 import { createOAuthProvider } from "../../auth/createOAuthProvider";
 
+import type { MCPStorage } from "./types";
 import {
   McpLocalStorage,
   normalizeCustomServerRecords,
@@ -416,5 +418,33 @@ describe("McpLocalStorage auth state", () => {
     ).resolves.toMatchObject({
       tokens: { access_token: "access-token" },
     });
+  });
+});
+
+describe("McpLocalStorage instance identity", () => {
+  it("returns the same instance across re-renders", () => {
+    const backing = createStorage();
+    const seen: MCPStorage[] = [];
+    let rerender!: () => void;
+
+    const useHost = () => {
+      const [, setTick] = useState(0);
+      rerender = () => setTick((n) => n + 1);
+      const storage = useResource(
+        McpLocalStorage({ keyPrefix: "test-mcp", storage: backing }),
+      );
+      seen.push(storage);
+      return storage;
+    };
+    const Host = resource(useHost);
+
+    createTapRoot(function McpStorageIdentityRoot() {
+      return useResource(Host());
+    });
+    rerender();
+    rerender();
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(new Set(seen).size).toBe(1);
   });
 });

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -1,4 +1,5 @@
 import { resource } from "@assistant-ui/tap";
+import { useMemo } from "react";
 import {
   OAuthMetadataSchema,
   OAuthClientInformationFullSchema,
@@ -208,54 +209,59 @@ export const normalizePersistedAuthState = (
 
 const useMcpLocalStorage = (opts: McpLocalStorageOptions = {}): MCPStorage => {
   const prefix = opts.keyPrefix ?? "aui-mcp";
-  const customServersKey = `${prefix}:custom-servers`;
-  const authKey = (id: string) => `${prefix}:auth:${id}`;
   const storage = resolveStorage(opts);
 
-  const read = <T>(key: string, fallback: T): T => {
-    if (!storage) return fallback;
-    try {
-      const raw = storage.getItem(key);
-      if (raw == null) return fallback;
-      return JSON.parse(raw) as T;
-    } catch {
-      return fallback;
-    }
-  };
+  // Callers key per-server coordination state on this instance, so it has to
+  // stay referentially stable for as long as the underlying store does.
+  return useMemo(() => {
+    const customServersKey = `${prefix}:custom-servers`;
+    const authKey = (id: string) => `${prefix}:auth:${id}`;
 
-  const write = (key: string, value: unknown): void => {
-    if (!storage) return;
-    try {
-      storage.setItem(key, JSON.stringify(value));
-    } catch {
-      // quota or serialization failure — silently drop
-    }
-  };
+    const read = <T>(key: string, fallback: T): T => {
+      if (!storage) return fallback;
+      try {
+        const raw = storage.getItem(key);
+        if (raw == null) return fallback;
+        return JSON.parse(raw) as T;
+      } catch {
+        return fallback;
+      }
+    };
 
-  const remove = (key: string): void => {
-    if (!storage) return;
-    try {
-      storage.removeItem(key);
-    } catch {
-      // ignore
-    }
-  };
+    const write = (key: string, value: unknown): void => {
+      if (!storage) return;
+      try {
+        storage.setItem(key, JSON.stringify(value));
+      } catch {
+        // quota or serialization failure — silently drop
+      }
+    };
 
-  return {
-    loadCustomServers: async () =>
-      normalizeCustomServerRecords(read<unknown>(customServersKey, [])),
-    saveCustomServers: async (records) => {
-      write(customServersKey, records);
-    },
-    loadAuthState: async (id) =>
-      normalizePersistedAuthState(read<unknown>(authKey(id), null)),
-    saveAuthState: async (id, state) => {
-      write(authKey(id), state);
-    },
-    clearAuthState: async (id) => {
-      remove(authKey(id));
-    },
-  };
+    const remove = (key: string): void => {
+      if (!storage) return;
+      try {
+        storage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    };
+
+    return {
+      loadCustomServers: async () =>
+        normalizeCustomServerRecords(read<unknown>(customServersKey, [])),
+      saveCustomServers: async (records) => {
+        write(customServersKey, records);
+      },
+      loadAuthState: async (id) =>
+        normalizePersistedAuthState(read<unknown>(authKey(id), null)),
+      saveAuthState: async (id, state) => {
+        write(authKey(id), state);
+      },
+      clearAuthState: async (id) => {
+        remove(authKey(id));
+      },
+    };
+  }, [prefix, storage]);
 };
 
 export const McpLocalStorage = resource(useMcpLocalStorage);

--- a/packages/react-mcp/src/resources/storage/McpMemoryStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpMemoryStorage.test.ts
@@ -1,0 +1,69 @@
+import { createTapRoot, resource, useResource } from "@assistant-ui/tap";
+import { describe, expect, it } from "vitest";
+import { useState } from "react";
+import type { MCPStorage } from "./types";
+import { McpMemoryStorage } from "./McpMemoryStorage";
+
+const mountWithRerender = () => {
+  const seen: MCPStorage[] = [];
+  let setTick!: (update: (value: number) => number) => void;
+
+  const useHost = () => {
+    const [, setValue] = useState(0);
+    setTick = setValue;
+    const storage = useResource(McpMemoryStorage());
+    seen.push(storage);
+    return storage;
+  };
+  const Host = resource(useHost);
+
+  createTapRoot(function MemoryStorageRoot() {
+    return useResource(Host());
+  });
+
+  return {
+    seen,
+    latest: () => seen[seen.length - 1]!,
+    rerender: () => setTick((value) => value + 1),
+  };
+};
+
+describe("McpMemoryStorage", () => {
+  it("returns the same instance across re-renders", () => {
+    const { seen, rerender } = mountWithRerender();
+
+    rerender();
+    rerender();
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(new Set(seen).size).toBe(1);
+  });
+
+  it("keeps persisted auth state across re-renders", async () => {
+    const { seen, latest, rerender } = mountWithRerender();
+    await seen[0]!.saveAuthState("docs", { codeVerifier: "pkce-verifier" });
+
+    rerender();
+
+    await expect(latest().loadAuthState("docs")).resolves.toEqual({
+      codeVerifier: "pkce-verifier",
+    });
+  });
+
+  it("keeps custom servers across re-renders", async () => {
+    const { seen, latest, rerender } = mountWithRerender();
+    await seen[0]!.saveCustomServers([
+      {
+        id: "docs",
+        name: "Docs",
+        url: "https://docs.example.com/mcp",
+        auth: { type: "none" },
+        createdAt: 1,
+      },
+    ]);
+
+    rerender();
+
+    await expect(latest().loadCustomServers()).resolves.toHaveLength(1);
+  });
+});

--- a/packages/react-mcp/src/resources/storage/McpMemoryStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpMemoryStorage.ts
@@ -1,24 +1,26 @@
 import { resource } from "@assistant-ui/tap";
+import { useMemo } from "react";
 import type { MCPCustomServerRecord } from "../../mcp-scope";
 import type { MCPPersistedAuthState } from "../../auth/types";
 import type { MCPStorage } from "./types";
 
-const useMcpMemoryStorage = (): MCPStorage => {
-  let servers: MCPCustomServerRecord[] = [];
-  const auth = new Map<string, MCPPersistedAuthState>();
-  return {
-    loadCustomServers: async () => [...servers],
-    saveCustomServers: async (records) => {
-      servers = [...records];
-    },
-    loadAuthState: async (id) => auth.get(id) ?? null,
-    saveAuthState: async (id, state) => {
-      auth.set(id, state);
-    },
-    clearAuthState: async (id) => {
-      auth.delete(id);
-    },
-  };
-};
+const useMcpMemoryStorage = (): MCPStorage =>
+  useMemo(() => {
+    let servers: MCPCustomServerRecord[] = [];
+    const auth = new Map<string, MCPPersistedAuthState>();
+    return {
+      loadCustomServers: async () => [...servers],
+      saveCustomServers: async (records) => {
+        servers = [...records];
+      },
+      loadAuthState: async (id) => auth.get(id) ?? null,
+      saveAuthState: async (id, state) => {
+        auth.set(id, state);
+      },
+      clearAuthState: async (id) => {
+        auth.delete(id);
+      },
+    };
+  }, []);
 
 export const McpMemoryStorage = resource(useMcpMemoryStorage);


### PR DESCRIPTION
## what

`McpServerResource.buildTransport` builds a fresh OAuth provider for every transport, and `doConnect` and `doCompleteAuth` both build replacement ones. `MCPStorage.saveAuthState` replaces the whole record, so two providers each writing their own full snapshot can interleave and drop whichever field the loser had added. #6469 serialized this within one provider; across providers it was still unserialized, which is what #6484 tracks.

This moves the cache, the in-flight load and the write queue to module level keyed by `(storage, serverId)`, and routes removal through a new `clearOAuthProviderAuthState` that waits for hydration and queued writes before clearing, so a discarded provider's queued write cannot recreate the record it was mid-save on.

## the part that made the first attempt not work

That coordination keys on the `MCPStorage` instance, and the storage resources did not keep one. React Compiler bails on `useMcpLocalStorage` and `useMcpMemoryStorage` (compile them and the bodies come back untouched, while `useMcpManagerResource` in the same package gets its `_c()` cache), so every re-render returned a brand new facade object. Keying anything on that identity silently coordinates nothing.

`McpMemoryStorage` was worse off: `let servers` and `new Map()` live in the body, so a re-render also threw away everything it held. Any app using it lost its custom servers and OAuth state on the next render.

Both storages now memoize the instance they return, so the facade and its backing store survive re-renders. `McpCustomStorage` already returns the caller's object unchanged and needs nothing.

## how it is checked

Both directions, on `@assistant-ui/react-mcp`:

- the 8 new tests fail against the unfixed sources and pass here (147 tests total, 12 files)
- `McpMemoryStorage` and `McpLocalStorage` each gained an instance-identity test driven through `createTapRoot` + `useResource`, so a future regression of the identity invariant fails at the storage seam rather than silently disabling the OAuth coordination
- `McpMemoryStorage` gained tests that auth state and custom servers survive a re-render
- `pnpm --filter @assistant-ui/react-mcp build`, `pnpm check:resource-memo`, targeted `oxlint` (6 warnings, all present on main for the same files) and `oxfmt --check` all pass
- checked the built output, not just the source: `dist/resources/storage/McpMemoryStorage.js` keeps its `useMemo`, and `dist/resources/storage/McpLocalStorage.js` now carries React Compiler cache slots

Supersedes #6488, which took the same module-level approach but kept the identity keying that does not hold, and whose fence also trapped any provider built while a clear was in flight.

Fixes #6484


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4FbHozcDRJrS6fWivt0TR-Qm2G7TEigvLbnJqHYn_U-W-FM5_z04ZLCllnc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->