### PR TITLE
fix(runtime): publish adapter refs after commit

### DIFF
--- a/.changeset/committed-adapter-refs.md
+++ b/.changeset/committed-adapter-refs.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: keep adapter callbacks scoped to committed renders

--- a/.changeset/stable-adk-approval-converter.md
+++ b/.changeset/stable-adk-approval-converter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: preserve message conversion caches while approval state is unchanged

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3736,6 +3736,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   __internal_subscribeRuntimeReplaced(callback: () => void): Unsubscribe$1;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
+  __internal_republishRuntimeHook(): void;
   __internal_setDefaultAdapters(adapters: RuntimeAdapters | null): void;
   __internal_setThreadAdapters(threadId: string, adapters: RuntimeAdapters | null): void;
   __internal_dispose(): void;
@@ -3788,6 +3789,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   getLoadThreadsPromise(): Promise<void>;
   loadMore(): Promise<void>;
   constructor(options: RemoteThreadListOptions, contextProvider: ModelContextProvider);
+  __internal_republishRuntimeHook(): void;
   __internal_setOptions(options: RemoteThreadListOptions): void;
   __internal_load(): void;
   reloadMainThread(): Promise<void>;

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   UIMessage,
   useChat,
@@ -142,9 +148,11 @@ const useGeneratedSuggestions = (
   const controllerRef = useRef<AbortController | null>(null);
   const wasRunningRef = useRef(false);
   const messagesRef = useRef(messages);
-  messagesRef.current = messages;
   const adapterRef = useRef(suggestionAdapter);
-  adapterRef.current = suggestionAdapter;
+  useInsertionEffect(() => {
+    messagesRef.current = messages;
+    adapterRef.current = suggestionAdapter;
+  }, [messages, suggestionAdapter]);
   const hasAdapter = suggestionAdapter != null;
 
   useEffect(() => {
@@ -563,7 +571,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   });
 
   const setMessagesRef = useRef(chatHelpers.setMessages);
-  setMessagesRef.current = chatHelpers.setMessages;
+  useInsertionEffect(() => {
+    setMessagesRef.current = chatHelpers.setMessages;
+  }, [chatHelpers.setMessages]);
 
   useEffect(() => {
     if (hasSeededRepositoryRef.current) return;

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -46,6 +46,7 @@ type AdapterSnapshot = {
 type HostSnapshot = {
   threads: readonly { id: string; generation: number }[];
   hookEpoch: number;
+  renderEpoch: number;
 };
 
 const ProviderRenderDetector: FC<{
@@ -66,6 +67,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   private readonly hostStore = create<HostSnapshot>(() => ({
     threads: [],
     hookEpoch: 0,
+    renderEpoch: 0,
   }));
   private readonly pendingThreadAdapters = new Map<
     string,
@@ -227,6 +229,13 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     this.runtimeHook = newRuntimeHook;
     this.hostStore.setState(
       (state) => ({ ...state, hookEpoch: state.hookEpoch + 1 }),
+      true,
+    );
+  }
+
+  public __internal_republishRuntimeHook() {
+    this.hostStore.setState(
+      (state) => ({ ...state, renderEpoch: state.renderEpoch + 1 }),
       true,
     );
   }

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -277,6 +277,10 @@ export class RemoteThreadListThreadListRuntimeCore
   private _initialThreadLoaded = false;
   private useProvider;
 
+  public __internal_republishRuntimeHook() {
+    this._hookManager.__internal_republishRuntimeHook();
+  }
+
   public __internal_setOptions(options: RemoteThreadListOptions) {
     if (this._options === options) return;
 

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.nested.test.tsx
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.nested.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import { makeAdapter } from "../../tests/remote-thread-list-test-helpers";
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => ({ threadListItem: { source: {} } }),
+}));
+
+import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+
+describe("useRemoteThreadListRuntime nested runtime", () => {
+  it("evaluates the render-local runtime hook on rerender", () => {
+    const runtimeA = { marker: "A" } as unknown as AssistantRuntime;
+    const runtimeB = { marker: "B" } as unknown as AssistantRuntime;
+    const adapter = makeAdapter();
+    const hookA = () => runtimeA;
+    const hookB = () => runtimeB;
+
+    const { result, rerender } = renderHook(
+      ({ runtimeHook }) =>
+        useRemoteThreadListRuntime({
+          adapter,
+          allowNesting: true,
+          runtimeHook,
+        }),
+      { initialProps: { runtimeHook: hookA } },
+    );
+    expect(result.current).toBe(runtimeA);
+
+    rerender({ runtimeHook: hookB });
+
+    expect(result.current).toBe(runtimeB);
+  });
+});

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.republish.test.tsx
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.republish.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
+import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import { makeAdapter } from "../../tests/remote-thread-list-test-helpers";
+
+describe("useRemoteThreadListRuntime runtime hook republication", () => {
+  it("renders thread runtimes through the latest committed runtime hook", async () => {
+    const adapter = makeAdapter();
+    const onNew = vi.fn(async () => {});
+    const rendered: string[] = [];
+
+    const makeRuntimeHook = (label: string) => () => {
+      rendered.push(label);
+      return useExternalStoreRuntime({ messages: [], onNew });
+    };
+    const hookA = makeRuntimeHook("A");
+    const hookB = makeRuntimeHook("B");
+
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    const App = ({ runtimeHook }: { runtimeHook: () => AssistantRuntime }) => {
+      const runtime = useRemoteThreadListRuntime({ adapter, runtimeHook });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const { rerender } = render(<App runtimeHook={hookA} />);
+    await waitFor(() => {
+      expect(runtimeRef.current?.threads.mainItem.getState().id).toBeDefined();
+    });
+    expect(rendered).toContain("A");
+
+    rendered.length = 0;
+    rerender(<App runtimeHook={hookB} />);
+
+    await waitFor(() => {
+      expect(rendered).toContain("B");
+    });
+  });
+});

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -5,6 +5,7 @@ import {
   useRef,
   useCallback,
   useEffectEvent,
+  useInsertionEffect,
 } from "react";
 import { BaseAssistantRuntimeCore } from "../../runtime/base/base-assistant-runtime-core";
 import { AssistantRuntimeImpl } from "../../runtime/api/assistant-runtime";
@@ -49,7 +50,9 @@ export const useRemoteThreadListRuntime = (
   options: RemoteThreadListOptions,
 ): AssistantRuntime => {
   const runtimeHookRef = useRef(options.runtimeHook);
-  runtimeHookRef.current = options.runtimeHook;
+  useInsertionEffect(() => {
+    runtimeHookRef.current = options.runtimeHook;
+  }, [options.runtimeHook]);
 
   const initialThreadIdRef = useRef(options.initialThreadId);
 
@@ -91,7 +94,7 @@ export const useRemoteThreadListRuntime = (
 
     // If allowNesting is true and already inside a thread list context,
     // just call the runtimeHook directly (no-op behavior)
-    return stableRuntimeHook();
+    return options.runtimeHook();
   }
 
   const runtime = useRemoteThreadListRuntimeImpl(stableOptions);

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffectEvent,
   useInsertionEffect,
+  useLayoutEffect,
 } from "react";
 import { BaseAssistantRuntimeCore } from "../../runtime/base/base-assistant-runtime-core";
 import { AssistantRuntimeImpl } from "../../runtime/api/assistant-runtime";
@@ -36,12 +37,20 @@ class RemoteThreadListRuntimeCore
 
 const useRemoteThreadListRuntimeImpl = (
   options: RemoteThreadListOptions,
+  sourceRuntimeHook: RemoteThreadListOptions["runtimeHook"],
 ): AssistantRuntime => {
   const [runtime] = useState(() => new RemoteThreadListRuntimeCore(options));
+  const sourceRuntimeHookRef = useRef(sourceRuntimeHook);
   useEffect(() => {
     runtime.threads.__internal_setOptions(options);
     runtime.threads.__internal_load();
   }, [runtime, options]);
+
+  useLayoutEffect(() => {
+    if (sourceRuntimeHookRef.current === sourceRuntimeHook) return;
+    sourceRuntimeHookRef.current = sourceRuntimeHook;
+    runtime.threads.__internal_republishRuntimeHook();
+  }, [runtime, sourceRuntimeHook]);
 
   return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };
@@ -97,7 +106,10 @@ export const useRemoteThreadListRuntime = (
     return options.runtimeHook();
   }
 
-  const runtime = useRemoteThreadListRuntimeImpl(stableOptions);
+  const runtime = useRemoteThreadListRuntimeImpl(
+    stableOptions,
+    options.runtimeHook,
+  );
 
   return runtime;
 };

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -1,4 +1,11 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { generateId } from "@assistant-ui/core";
 import { useAui } from "@assistant-ui/store";
 import { invokeUserCallback } from "@assistant-ui/core/internal";
@@ -61,13 +68,21 @@ export const useAdkMessages = ({
   >(new Map());
   const lastTransferToAgentRef = useRef<string | undefined>(undefined);
   const messagesRef = useRef(messages);
-  messagesRef.current = messages;
+  useInsertionEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
   const stateDeltaRef = useRef(stateDelta);
-  stateDeltaRef.current = stateDelta;
+  useInsertionEffect(() => {
+    stateDeltaRef.current = stateDelta;
+  }, [stateDelta]);
   const artifactDeltaRef = useRef(artifactDelta);
-  artifactDeltaRef.current = artifactDelta;
+  useInsertionEffect(() => {
+    artifactDeltaRef.current = artifactDelta;
+  }, [artifactDelta]);
   const messageMetadataRef = useRef(messageMetadata);
-  messageMetadataRef.current = messageMetadata;
+  useInsertionEffect(() => {
+    messageMetadataRef.current = messageMetadata;
+  }, [messageMetadata]);
 
   const setMessagesImmediate = useCallback((msgs: AdkMessage[]) => {
     messagesRef.current = msgs;

--- a/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntime.refetch.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, render, renderHook, waitFor } from "@testing-library/react";
-import { type FC, type ReactNode } from "react";
+import {
+  startTransition,
+  Suspense,
+  type FC,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
 import type {
@@ -115,6 +121,79 @@ describe("useAdkRuntime refetch", () => {
     expect(
       withoutLoad.capture.runtime!.thread.getState().capabilities.refetchThread,
     ).toBe(false);
+  });
+
+  it("keeps refetches scoped to the committed load callback", async () => {
+    const loadA = vi.fn(async () => ({
+      messages: [aiMessage("m-a", "workspace A")],
+    }));
+    const loadB = vi.fn(async () => ({
+      messages: [aiMessage("m-b", "workspace B")],
+    }));
+    const streamMock = vi.fn(async function* () {});
+    const sessionAdapter = makeThreadListAdapter();
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+    const interruptedRender = vi.fn();
+    const pending = new Promise<never>(() => {});
+    let blocked = false;
+    const Blocker = () => {
+      if (blocked) {
+        interruptedRender();
+        throw pending;
+      }
+      return null;
+    };
+    const Wrapper = ({ children }: PropsWithChildren) => (
+      <Suspense fallback={null}>
+        {children}
+        <Blocker />
+      </Suspense>
+    );
+    const Probe = ({ load }: { load: typeof loadA }) => {
+      const runtime = useAdkRuntime({
+        stream: streamMock as never,
+        load: load as never,
+        sessionAdapter,
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const view = render(<Probe load={loadA} />, { wrapper: Wrapper });
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("adk-1");
+    });
+    await waitFor(() => expect(loadA).toHaveBeenCalledOnce());
+
+    act(() => {
+      blocked = true;
+      startTransition(() => view.rerender(<Probe load={loadB} />));
+    });
+    expect(interruptedRender).toHaveBeenCalled();
+
+    await act(async () => {
+      await capture.runtime!.threads.reloadMainThread();
+    });
+
+    expect(loadA).toHaveBeenCalledTimes(2);
+    expect(loadB).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(capture.runtime!.thread.getState().messages),
+    ).toContain("workspace A");
+
+    await act(async () => {
+      await capture.runtime!.threads.reloadMainThread();
+    });
+
+    expect({
+      loadA: loadA.mock.calls.length,
+      loadB: loadB.mock.calls.length,
+    }).toEqual({ loadA: 3, loadB: 0 });
+    view.unmount();
   });
 
   it("refetches in place, keeping the composer draft and the runtime", async () => {

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -194,7 +194,8 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
       toolApprovalsKey === ""
         ? convertAdkMessage
         : createAdkMessageConverter(toolApprovals),
-    [toolApprovals, toolApprovalsKey],
+    // oxlint-disable-next-line react/exhaustive-deps -- toolApprovalsKey is the canonical decision identity; depending on equivalent fresh Maps invalidates the full conversion cache
+    [toolApprovalsKey],
   );
 
   const threadMessages = useExternalMessageConverter({

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   pickExternalStoreSharedOptions,
   type AttachmentAdapter,
@@ -135,10 +142,14 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   });
 
   const loadRef = useRef(load);
-  loadRef.current = load;
+  useInsertionEffect(() => {
+    loadRef.current = load;
+  }, [load]);
   const loadController = useMemo(createAbortableThreadLoad, []);
   const messagesRef = useRef(messages);
-  messagesRef.current = messages;
+  useInsertionEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
   const [isLoadingThread, setIsLoadingThread] = useState(
     () =>
       load !== undefined && aui.threadListItem.getState().externalId != null,
@@ -153,7 +164,9 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   );
   const effectiveIsRunning = isRunning || hasExecutingTools;
   const isRunningRef = useRef(effectiveIsRunning);
-  isRunningRef.current = effectiveIsRunning;
+  useInsertionEffect(() => {
+    isRunningRef.current = effectiveIsRunning;
+  }, [effectiveIsRunning]);
 
   const handleSendMessage = async (
     msgs: AdkMessage[],
@@ -167,17 +180,21 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     }
   };
 
-  const { approvals: toolApprovals, key: toolApprovalsKey } =
-    projectAdkToolApprovals(messages);
+  const { approvals: toolApprovals, key: toolApprovalsKey } = useMemo(
+    () => projectAdkToolApprovals(messages),
+    [messages],
+  );
   const toolApprovalsRef = useRef(toolApprovals);
-  toolApprovalsRef.current = toolApprovals;
+  useInsertionEffect(() => {
+    toolApprovalsRef.current = toolApprovals;
+  }, [toolApprovals]);
 
   const messageConverter = useMemo(
     () =>
       toolApprovalsKey === ""
         ? convertAdkMessage
-        : createAdkMessageConverter(toolApprovalsRef.current),
-    [toolApprovalsKey],
+        : createAdkMessageConverter(toolApprovals),
+    [toolApprovals, toolApprovalsKey],
   );
 
   const threadMessages = useExternalMessageConverter({
@@ -187,10 +204,14 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   });
 
   const threadMessagesRef = useRef(threadMessages);
-  threadMessagesRef.current = threadMessages;
+  useInsertionEffect(() => {
+    threadMessagesRef.current = threadMessages;
+  }, [threadMessages]);
 
   const adkMessagesRef = useRef(messages);
-  adkMessagesRef.current = messages;
+  useInsertionEffect(() => {
+    adkMessagesRef.current = messages;
+  }, [messages]);
 
   const stagedMessagesRef = useRef(
     new Map<

--- a/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntimeApproval.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   adapters: [] as unknown[],
   sendMessage: vi.fn().mockResolvedValue(undefined),
   messages: [] as AdkMessage[],
+  convertCalls: 0,
 }));
 
 vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
@@ -34,6 +35,23 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
     },
   }),
 }));
+
+vi.mock("./convertAdkMessages", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./convertAdkMessages")>();
+  return {
+    ...original,
+    createAdkMessageConverter: (
+      approvals: Parameters<typeof original.createAdkMessageConverter>[0],
+    ) => {
+      const convert = original.createAdkMessageConverter(approvals);
+      return (...args: Parameters<typeof convert>) => {
+        mocks.convertCalls++;
+        return convert(...args);
+      };
+    },
+  };
+});
 
 vi.mock("./useAdkMessages", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./useAdkMessages")>()),
@@ -97,6 +115,7 @@ const approvalPart = () =>
 afterEach(() => {
   mocks.adapters.length = 0;
   mocks.messages = [];
+  mocks.convertCalls = 0;
   vi.clearAllMocks();
 });
 
@@ -163,6 +182,47 @@ describe("useAdkRuntime tool approvals", () => {
         approved: true,
       }),
     ).rejects.toThrow("No pending ADK tool confirmation");
+  });
+
+  it("keeps conversion cached until the approval decision key changes", () => {
+    mocks.messages = [
+      { id: "u-1", type: "human", content: "delete the file" },
+      makeConfirmationRequest(),
+    ];
+
+    const { rerender } = renderHook(() => useAdkRuntime({ stream: vi.fn() }));
+    const cachedUser = latestAdapter().messages[0];
+    expect(mocks.convertCalls).toBe(2);
+
+    mocks.messages = [
+      ...mocks.messages,
+      { id: "ai-progress", type: "ai", content: "still working" },
+    ];
+    rerender();
+
+    expect(mocks.convertCalls).toBe(3);
+    expect(latestAdapter().messages[0]).toBe(cachedUser);
+    expect(approvalPart()).toMatchObject({
+      approval: { id: CONFIRMATION_CALL },
+    });
+
+    mocks.messages = [
+      ...mocks.messages,
+      {
+        id: "tool-1",
+        type: "tool",
+        tool_call_id: CONFIRMATION_CALL,
+        name: "adk_request_confirmation",
+        content: JSON.stringify({ confirmed: false }),
+        status: "success",
+      },
+    ];
+    rerender();
+
+    expect(mocks.convertCalls).toBe(7);
+    expect(approvalPart()).toMatchObject({
+      approval: { id: CONFIRMATION_CALL, approved: false },
+    });
   });
 
   it("keeps a gate answered by an unreadable reply retryable at the runtime seam", async () => {


### PR DESCRIPTION
## Summary

- publish changing runtime adapter refs from committed renders instead of during render
- keep nested remote-thread runtimes on their render-local hook while hosted runtimes use a committed stable callback
- preserve Google ADK staged, edited, and immediate message ref updates
- add interrupted-render regressions for nested runtime changes and repeated ADK reloads

Closes #6486

## Testing

- `pnpm --filter @assistant-ui/core test` (1522 tests)
- `pnpm --filter @assistant-ui/ai-sdk test` (254 tests)
- `pnpm --filter @assistant-ui/react-google-adk test` (324 tests)
- core and AI SDK React Compiler tests
- core, AI SDK, and Google ADK package builds
- full lint/format, scoped checks, changeset validation, and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jlt39ESb6Y5OXst4HoviexF6zJjzviWV6fLH-FlOw0l37D_u3DKAprlWVFI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->