### PR TITLE
fix(ai-sdk): isolate each AISDKThreads thread in its own message repository

### DIFF
--- a/.changeset/aisdkthreads-repo-isolation.md
+++ b/.changeset/aisdkthreads-repo-isolation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: isolate each AISDKThreads thread in its own message repository

--- a/.changeset/repository-instance-swap.md
+++ b/.changeset/repository-instance-swap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: adopt an externally owned message repository instance per adapter swap

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -16,6 +16,7 @@ type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Externa
     suggestion?: SuggestionAdapter | undefined;
   }) | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   cancelPendingToolCallsOnSend?: boolean | undefined;
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
@@ -785,6 +786,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1176,6 +1178,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1186,10 +1208,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;
@@ -2202,7 +2224,7 @@ declare const useAISDKError: () => Error | undefined;
 
 declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter<UI_MESSAGE>) => AssistantRuntime;
 
-declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
+declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param3?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
 
 declare function useThreadTokenUsage(): ThreadTokenUsage | undefined;
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -883,7 +883,7 @@ type BaseThreadMessage = {
 
 declare abstract class BaseThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
   #private;
-  protected readonly repository: MessageRepository;
+  protected repository: MessageRepository;
   abstract get adapters(): BaseThreadAdapters | undefined;
   abstract get isDisabled(): boolean;
   abstract get isSendDisabled(): boolean;
@@ -1735,6 +1735,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -371,6 +371,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -701,6 +702,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -711,10 +732,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -647,6 +647,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1009,6 +1010,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1019,10 +1040,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -418,6 +418,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -789,6 +790,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -799,10 +820,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -16,6 +16,7 @@ type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = Externa
     suggestion?: SuggestionAdapter | undefined;
   }) | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   cancelPendingToolCallsOnSend?: boolean | undefined;
   onResume?: ExternalStoreAdapter["onResume"];
   onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
@@ -785,6 +786,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1176,6 +1178,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1186,10 +1208,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;
@@ -2202,7 +2224,7 @@ declare const useAISDKError: () => Error | undefined;
 
 declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter<UI_MESSAGE>) => AssistantRuntime;
 
-declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
+declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param3?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
 
 declare function useThreadTokenUsage(): ThreadTokenUsage | undefined;
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1071,6 +1071,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1453,6 +1454,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1463,10 +1484,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;
@@ -2491,7 +2512,7 @@ declare const useAdkLongRunningToolIds: () => string[];
 
 declare const useAdkMessageMetadata: () => Map<string, AdkMessageMetadata>;
 
-declare const useAdkMessages: (_param2: UseAdkMessagesOptions) => {
+declare const useAdkMessages: (_param3: UseAdkMessagesOptions) => {
   messages: AdkMessage[];
   stateDelta: Record<string, unknown>;
   agentInfo: {
@@ -2511,7 +2532,7 @@ declare const useAdkMessages: (_param2: UseAdkMessagesOptions) => {
   applySnapshot: (snapshot: AdkThreadSnapshot) => void;
 };
 
-declare const useAdkRuntime: (_param3: UseAdkRuntimeOptions) => AssistantRuntime;
+declare const useAdkRuntime: (_param4: UseAdkRuntimeOptions) => AssistantRuntime;
 
 declare const useAdkSend: () => (messages: AdkMessage[], config: AdkSendMessageConfig) => Promise<void>;
 
@@ -2533,7 +2554,7 @@ declare namespace useExternalMessageConverter {
   type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
-declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {
+declare const useExternalMessageConverter: <T extends WeakKey>(_param5: {
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -700,6 +700,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1179,6 +1180,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1189,10 +1210,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;
@@ -2261,7 +2282,7 @@ declare namespace useExternalMessageConverter {
   type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
-declare const useExternalMessageConverter: <T extends WeakKey>(_param2: {
+declare const useExternalMessageConverter: <T extends WeakKey>(_param3: {
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -719,6 +719,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -1320,6 +1321,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param1: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -1330,10 +1351,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param1: {
+  submitFeedback(_param2: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param2: {
+  switchToBranch(_param3: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;
@@ -2354,7 +2375,7 @@ declare namespace entry_root_exports {
   export { CreateLangGraphStreamOptions, LangChainEvent, LangChainMessage, LangChainMessageChunk, LangChainToolCall, LangChainToolCallChunk, LangGraphCommand, LangGraphInterruptState, LangGraphMessageAccumulator, LangGraphMessagesEvent, LangGraphSendMessageConfig, LangGraphStreamCallback, LangGraphStreamClient, LangGraphTupleMetadata, OnCustomEventCallback, OnErrorEventCallback, OnInfoEventCallback, OnMessageChunkCallback, OnMetadataEventCallback, OnSubgraphErrorEventCallback, OnSubgraphUpdatesEventCallback, OnSubgraphValuesEventCallback, OnUpdatesEventCallback, OnValuesEventCallback, RemoveUIMessage, UIMessage, UseLangGraphRuntimeOptions, appendLangChainChunk, convertLangChainMessages, unstable_createLangGraphStream, useLangGraphInterruptState, useLangGraphMessageMetadata, useLangGraphMessages, useLangGraphRuntime, useLangGraphSend, useLangGraphSendCommand, useLangGraphSetState, useLangGraphState, useLangGraphStreamingTiming, useLangGraphUIMessages };
 }
 
-declare const unstable_createLangGraphStream: (_param3: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
+declare const unstable_createLangGraphStream: (_param4: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
 
 declare namespace useExternalMessageConverter {
   type Message = ExternalMessageConverterMessage;
@@ -2362,7 +2383,7 @@ declare namespace useExternalMessageConverter {
   type Callback<T> = ExternalMessageConverterCallback<T>;
 }
 
-declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {
+declare const useExternalMessageConverter: <T extends WeakKey>(_param5: {
   callback: useExternalMessageConverter.Callback<T>;
   messages: T[];
   isRunning: boolean;
@@ -2376,7 +2397,7 @@ declare const useLangGraphMessageMetadata: () => Map<string, LangGraphTupleMetad
 
 declare const useLangGraphMessages: <TMessage extends {
   id?: string;
-}>(_param5: {
+}>(_param6: {
   stream: LangGraphStreamCallback<TMessage>;
   appendMessage?: (prev: TMessage | undefined, curr: TMessage) => TMessage;
   uiStateKey?: string;
@@ -2404,16 +2425,16 @@ declare const useLangGraphMessages: <TMessage extends {
   setValues: import("react").Dispatch<import("react").SetStateAction<Record<string, unknown> | undefined>>;
   setMessages: (msgs: TMessage[]) => void;
   setUIMessages: (next: UIMessage[]) => void;
-  reconcileMessages: (serverMessages: TMessage[], messagesAtLoadStart: TMessage[], _param6?: {
+  reconcileMessages: (serverMessages: TMessage[], messagesAtLoadStart: TMessage[], _param7?: {
     snapshotIsComplete?: boolean;
   }) => void;
-  reconcileUIMessages: (serverMessages: UIMessage[], messagesAtLoadStart: UIMessage[], _param7?: {
+  reconcileUIMessages: (serverMessages: UIMessage[], messagesAtLoadStart: UIMessage[], _param8?: {
     snapshotIsComplete?: boolean;
   }) => void;
   reconcileInterrupt: (serverInterrupt: LangGraphInterruptState | undefined, interruptAtLoadStart: LangGraphInterruptState | undefined) => void;
 };
 
-declare const useLangGraphRuntime: (_param8: UseLangGraphRuntimeOptions) => AssistantRuntime;
+declare const useLangGraphRuntime: (_param9: UseLangGraphRuntimeOptions) => AssistantRuntime;
 
 declare const useLangGraphSend: () => (messages: LangChainMessage[], config: LangGraphSendMessageConfig) => Promise<void>;
 

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -442,6 +442,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -774,6 +775,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -784,10 +805,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -444,6 +444,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;
@@ -774,6 +775,26 @@ type MessagePartStreamStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
 };
 
+declare class MessageRepository {
+  #private;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param0: ExportedMessageRepository): void;
+}
+
 type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
@@ -784,10 +805,10 @@ type MessageRuntime = {
   reload(config?: ReloadConfig): void;
   speak(): void;
   stopSpeaking(): void;
-  submitFeedback(_param0: {
+  submitFeedback(_param1: {
     type: "positive" | "negative";
   }): void;
-  switchToBranch(_param1: {
+  switchToBranch(_param2: {
     position?: "previous" | "next" | undefined;
     branchId?: string | undefined;
   }): void;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2130,6 +2130,7 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;

--- a/packages/ai-sdk/src/runtime/AISDKThreads.test.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.test.ts
@@ -546,3 +546,105 @@ describe("AISDKThreads", () => {
     }
   });
 });
+
+describe("AISDKThreads branch isolation", () => {
+  const completeRound = async (
+    handle: ReturnType<typeof createAssistantClient>,
+    emit: (...chunks: never[]) => void,
+    close: () => void,
+    question: string,
+    answer: string,
+  ) => {
+    const aui = handle.getClient();
+    flushTapSync(() => aui.composer.setText(question));
+    flushTapSync(() => aui.composer.send());
+    await vi.waitFor(() => {
+      expect(aui.thread.getState().messages.length).toBeGreaterThan(0);
+    });
+    emit(...(textReply(answer) as never[]));
+    close();
+    await vi.waitFor(() => {
+      expect(handle.getClient().thread.getState().isRunning).toBe(false);
+    });
+  };
+
+  it("keeps switching between populated threads free of cross-thread branches", async () => {
+    const { transport, emit, close } = createControlledTransport();
+    const handle = createAssistantClient(
+      AuiConfig({ threads: AISDKThreads({ transport }) }),
+    );
+    handle.subscribe(() => {});
+    const aui = handle.getClient();
+
+    await completeRound(
+      handle,
+      emit as never,
+      close,
+      "thread a question",
+      "thread a answer",
+    );
+
+    flushTapSync(() => aui.threads.switchToNewThread());
+    await completeRound(
+      handle,
+      emit as never,
+      close,
+      "thread b question",
+      "thread b answer",
+    );
+
+    flushTapSync(() => aui.threads.switchToThread("main"));
+    await vi.waitFor(() => {
+      expect(threadText(handle as never)).toEqual([
+        "thread a question",
+        "thread a answer",
+      ]);
+    });
+    expect(aui.thread.message({ index: 0 }).getState().branchCount).toBe(1);
+    expect(aui.thread.message({ index: 1 }).getState().branchCount).toBe(1);
+
+    handle.destroy();
+  });
+
+  it("preserves intra-thread branches across a switch through an empty thread", async () => {
+    const { transport, emit, close } = createControlledTransport();
+    const handle = createAssistantClient(
+      AuiConfig({ threads: AISDKThreads({ transport }) }),
+    );
+    handle.subscribe(() => {});
+    const aui = handle.getClient();
+
+    await completeRound(
+      handle,
+      emit as never,
+      close,
+      "branchy question",
+      "first answer",
+    );
+
+    flushTapSync(() => aui.thread.message({ index: 1 }).reload());
+    await vi.waitFor(() => {
+      expect(handle.getClient().thread.getState().isRunning).toBe(true);
+    });
+    emit(...(textReply("second answer") as never[]));
+    close();
+    await vi.waitFor(() => {
+      expect(handle.getClient().thread.getState().isRunning).toBe(false);
+      expect(aui.thread.message({ index: 1 }).getState().branchCount).toBe(2);
+    });
+
+    flushTapSync(() => aui.threads.switchToNewThread());
+    expect(handle.getClient().thread.getState().messages).toHaveLength(0);
+
+    flushTapSync(() => handle.getClient().threads.switchToThread("main"));
+    await vi.waitFor(() => {
+      expect(threadText(handle as never)).toEqual([
+        "branchy question",
+        "second answer",
+      ]);
+    });
+    expect(aui.thread.message({ index: 1 }).getState().branchCount).toBe(2);
+
+    handle.destroy();
+  });
+});

--- a/packages/ai-sdk/src/runtime/AISDKThreads.ts
+++ b/packages/ai-sdk/src/runtime/AISDKThreads.ts
@@ -24,6 +24,7 @@ import {
   useChatThread,
   type ChatThreadOptions,
 } from "./useChatThread";
+import { MessageRepository } from "@assistant-ui/core/internal";
 import { useResourceCleanup } from "./useResourceCleanup";
 
 export type AISDKThreadsOptions<UI_MESSAGE extends UIMessage = UIMessage> =
@@ -64,6 +65,7 @@ type AISDKThreadChatOptions<UI_MESSAGE extends UIMessage = UIMessage> = Omit<
 type ChatEntry<UI_MESSAGE extends UIMessage> = {
   chat: Chat<UI_MESSAGE>;
   transport: ChatTransport<UI_MESSAGE>;
+  repository: MessageRepository;
 };
 
 const createChatEntry = <UI_MESSAGE extends UIMessage>(
@@ -84,6 +86,7 @@ const createChatEntry = <UI_MESSAGE extends UIMessage>(
   return {
     chat: new Chat<UI_MESSAGE>({ ...chatInit, id: threadId, transport }),
     transport,
+    repository: new MessageRepository(),
   };
 };
 
@@ -113,7 +116,7 @@ const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
   const [owned] = useState(() =>
     cloud ? createChatEntry(threadId, options) : undefined,
   );
-  const { chat, transport } =
+  const { chat, transport, repository } =
     owned ?? getOrCreateChatEntry(threadId, options, chats);
 
   useEffect(() => {
@@ -145,6 +148,7 @@ const useAISDKChatThread = <UI_MESSAGE extends UIMessage = UIMessage>({
             : undefined
           : fallbackItem,
       chat,
+      messageRepositoryInstance: repository,
       stopOnClientDestroy: cloud,
     },
   );

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -82,6 +82,7 @@ export type AISDKRuntimeAdapter<UI_MESSAGE extends UIMessage = UIMessage> =
         })
       | undefined;
     toCreateMessage?: CustomToCreateMessageFunction;
+    unstable_messageRepositoryInstance?: MessageRepository | undefined;
     /**
      * Whether to automatically cancel pending interactive tool calls when the user sends a new message.
      *
@@ -549,6 +550,10 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         }),
       ),
     ...pickExternalStoreSharedOptions(adapter),
+    ...(adapter.unstable_messageRepositoryInstance && {
+      unstable_messageRepositoryInstance:
+        adapter.unstable_messageRepositoryInstance,
+    }),
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
     ...(onResume && { onResume }),
     ...(onResumeToolCall && { onResumeToolCall }),

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -1,4 +1,5 @@
-"use client";
+import type { MessageRepository } from "@assistant-ui/core/internal";
+("use client");
 
 import { useChat, type Chat, type UIMessage } from "@ai-sdk/react";
 import {
@@ -60,6 +61,12 @@ export type ChatThreadEnvironment<UI_MESSAGE extends UIMessage = UIMessage> = {
    * from the instance.
    */
   chat?: Chat<UI_MESSAGE> | undefined;
+  /**
+   * An externally owned per-thread message repository. Hosts that route
+   * multiple threads through one mounting pass a distinct instance per
+   * thread so histories and branches stay isolated.
+   */
+  messageRepositoryInstance?: MessageRepository | undefined;
 };
 
 const useDynamicChatTransport = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -183,6 +190,7 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     getThreadListItem,
     stopOnClientDestroy = false,
     chat: externalChat,
+    messageRepositoryInstance,
   } = env;
 
   const defaultTransport = useMemo(() => new AssistantChatTransport(), []);
@@ -209,6 +217,9 @@ export const useChatThread = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(onResumeToolCall && { onResumeToolCall }),
     ...(joinStrategy && { joinStrategy }),
     ...(messageRepository && { messageRepository }),
+    ...(messageRepositoryInstance && {
+      unstable_messageRepositoryInstance: messageRepositoryInstance,
+    }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
   });
 

--- a/packages/ai-sdk/src/runtime/useChatThread.ts
+++ b/packages/ai-sdk/src/runtime/useChatThread.ts
@@ -1,7 +1,7 @@
-import type { MessageRepository } from "@assistant-ui/core/internal";
-("use client");
+"use client";
 
 import { useChat, type Chat, type UIMessage } from "@ai-sdk/react";
+import type { MessageRepository } from "@assistant-ui/core/internal";
 import {
   pickExternalStoreSharedOptions,
   type AssistantRuntime,

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -51,7 +51,7 @@ export abstract class BaseThreadRuntimeCore
 {
   private _isInitialized = false;
 
-  protected readonly repository = new MessageRepository();
+  protected repository = new MessageRepository();
   public abstract get adapters(): BaseThreadAdapters | undefined;
   public abstract get isDisabled(): boolean;
   public abstract get isSendDisabled(): boolean;

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -14,7 +14,10 @@ import type {
   ResumeRunConfig,
   ThreadSuggestion,
 } from "../../runtime/interfaces/thread-runtime-core";
-import type { ExportedMessageRepository } from "../../runtime/utils/message-repository";
+import type {
+  ExportedMessageRepository,
+  MessageRepository,
+} from "../../runtime/utils/message-repository";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type { ToolExecutionStatus } from "../tool-invocations/ToolInvocationTracker";
 import type { ExternalThreadQueueAdapter } from "../../runtime/queue/external-thread-queue-adapter";
@@ -105,6 +108,15 @@ type ExternalStoreAdapterBase<T> = {
   isLoading?: boolean | undefined;
   messages?: readonly T[];
   messageRepository?: ExportedMessageRepository;
+  /**
+   * An externally owned message repository instance. When provided, the
+   * thread runtime adopts it as its branch store and swaps to it atomically
+   * whenever a different instance is passed, so hosts that route multiple
+   * conversations through one runtime keep each conversation's history and
+   * branches isolated in its own instance. Omit it to keep the runtime's own
+   * repository.
+   */
+  unstable_messageRepositoryInstance?: MessageRepository | undefined;
   suggestions?: readonly ThreadSuggestion[] | undefined;
   state?: ReadonlyJSONValue | undefined;
   extras?: unknown;

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -318,7 +318,11 @@ export class ExternalStoreThreadRuntimeCore
       const headId =
         store.messageRepository.headId ?? incoming.at(-1)?.message.id ?? null;
 
-      if (oldStore && oldStore.messageRepository === store.messageRepository) {
+      if (
+        oldStore &&
+        !repositoryChanged &&
+        oldStore.messageRepository === store.messageRepository
+      ) {
         this.repository.resetHead(headId);
         messages = this.repository.getMessages();
       } else {

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -246,6 +246,15 @@ export class ExternalStoreThreadRuntimeCore
     const oldStore = this._store as ExternalStoreAdapter<any> | undefined;
     this._store = store;
     const isRunning = this._getEffectiveIsRunning(store);
+    const repositoryInstance = store.unstable_messageRepositoryInstance;
+    const repositoryChanged =
+      repositoryInstance !== undefined &&
+      repositoryInstance !== this.repository;
+    if (repositoryChanged) {
+      this.repository = repositoryInstance;
+      this._pendingDeleteEvictions.clear();
+      this._runTrackerUpdate(() => this._toolInvocations?.reset());
+    }
     if (oldStore?.queue !== store.queue) {
       this._transformedQueue = undefined;
       store.queue?.__internal_setDispatchTransform?.((message) => {
@@ -296,6 +305,7 @@ export class ExternalStoreThreadRuntimeCore
       // Handle messageRepository
       if (
         oldStore &&
+        !repositoryChanged &&
         oldStore.isRunning === store.isRunning &&
         oldStore.messageRepository === store.messageRepository &&
         previousIsRunning === isRunning
@@ -333,6 +343,7 @@ export class ExternalStoreThreadRuntimeCore
         if (oldStore.convertMessage !== store.convertMessage) {
           this._converter = new ThreadMessageConverter();
         } else if (
+          !repositoryChanged &&
           oldStore.isRunning === store.isRunning &&
           oldStore.messages === store.messages &&
           previousIsRunning === isRunning

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -253,7 +253,6 @@ export class ExternalStoreThreadRuntimeCore
     if (repositoryChanged) {
       this.repository = repositoryInstance;
       this._pendingDeleteEvictions.clear();
-      this._runTrackerUpdate(() => this._toolInvocations?.reset());
     }
     if (oldStore?.queue !== store.queue) {
       this._transformedQueue = undefined;
@@ -466,6 +465,9 @@ export class ExternalStoreThreadRuntimeCore
 
     this._messages = this.repository.getMessages();
 
+    if (repositoryChanged) {
+      this._runTrackerUpdate(() => this._toolInvocations?.reset());
+    }
     this._runTrackerUpdate(() => this._driveToolInvocations());
 
     this._notifySubscribers();

--- a/packages/core/src/tests/external-store-repository-instance.test.ts
+++ b/packages/core/src/tests/external-store-repository-instance.test.ts
@@ -136,4 +136,31 @@ describe("ExternalStoreThreadRuntimeCore repository instance swap", () => {
     expect(repoB.getMessages().map((m) => m.id)).toEqual(["s-u1"]);
     expect(core.messages.map((m) => m.id)).toEqual(["s-u1"]);
   });
+
+  it("re-imports a same-reference repository snapshot when the instance swapped", () => {
+    const repoA = new MessageRepository();
+    const repoB = new MessageRepository();
+    const snapshot = {
+      headId: "s-m1",
+      messages: [
+        { parentId: null, message: createUserMessage("s-u1") },
+        { parentId: "s-u1", message: createAssistantMessage("s-m1") },
+      ],
+    };
+
+    const core = new ExternalStoreThreadRuntimeCore(createContextProvider(), {
+      messageRepository: snapshot,
+      onNew: vi.fn(async () => {}),
+      unstable_messageRepositoryInstance: repoA,
+    });
+    expect(core.messages.map((m) => m.id)).toEqual(["s-u1", "s-m1"]);
+
+    core.__internal_setAdapter({
+      messageRepository: snapshot,
+      onNew: vi.fn(async () => {}),
+      unstable_messageRepositoryInstance: repoB,
+    });
+    expect(core.messages.map((m) => m.id)).toEqual(["s-u1", "s-m1"]);
+    expect(repoB.getMessages().map((m) => m.id)).toEqual(["s-u1", "s-m1"]);
+  });
 });

--- a/packages/core/src/tests/external-store-repository-instance.test.ts
+++ b/packages/core/src/tests/external-store-repository-instance.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import { ExternalStoreThreadRuntimeCore } from "../runtimes/external-store/external-store-thread-runtime-core";
+import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
+import type { ModelContextProvider } from "../model-context/types";
+import type { ThreadMessage } from "../types/message";
+import { MessageRepository } from "../runtime/utils/message-repository";
+
+const createContextProvider = (): ModelContextProvider => ({
+  getModelContext: () => ({}),
+});
+
+const createUserMessage = (id: string, text = "Hello"): ThreadMessage =>
+  ({
+    id,
+    role: "user" as const,
+    createdAt: new Date(),
+    content: [{ type: "text" as const, text }],
+    attachments: [],
+    metadata: {
+      custom: {},
+    },
+  }) as ThreadMessage;
+
+const createAssistantMessage = (id: string, text = "Hi there"): ThreadMessage =>
+  ({
+    id,
+    role: "assistant" as const,
+    createdAt: new Date(),
+    content: [{ type: "text" as const, text }],
+    status: { type: "complete" as const, reason: "stop" as const },
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+  }) as ThreadMessage;
+
+const createAdapter = (
+  messages: readonly ThreadMessage[],
+  repository: MessageRepository,
+): ExternalStoreAdapter<ThreadMessage> => ({
+  messages,
+  onNew: vi.fn(async () => {}),
+  unstable_messageRepositoryInstance: repository,
+});
+
+describe("ExternalStoreThreadRuntimeCore repository instance swap", () => {
+  it("keeps each conversation's history in its own repository across swaps", () => {
+    const repoA = new MessageRepository();
+    const repoB = new MessageRepository();
+    const threadA = [
+      createUserMessage("a-u1", "thread a question"),
+      createAssistantMessage("a-m1", "thread a answer"),
+    ];
+    const threadB = [
+      createUserMessage("b-u1", "thread b question"),
+      createAssistantMessage("b-m1", "thread b answer"),
+    ];
+
+    const core = new ExternalStoreThreadRuntimeCore(
+      createContextProvider(),
+      createAdapter(threadA, repoA),
+    );
+    expect(core.messages.map((m) => m.id)).toEqual(["a-u1", "a-m1"]);
+
+    core.__internal_setAdapter(createAdapter(threadB, repoB));
+    expect(core.messages.map((m) => m.id)).toEqual(["b-u1", "b-m1"]);
+    expect(core.getBranches("b-u1")).toEqual(["b-u1"]);
+
+    core.__internal_setAdapter(createAdapter(threadA, repoA));
+    expect(core.messages.map((m) => m.id)).toEqual(["a-u1", "a-m1"]);
+    expect(core.getBranches("a-u1")).toEqual(["a-u1"]);
+    expect(repoB.getMessages().map((m) => m.id)).toEqual(["b-u1", "b-m1"]);
+  });
+
+  it("preserves intra-thread branches across a swap through an empty conversation", () => {
+    const repoA = new MessageRepository();
+    const repoB = new MessageRepository();
+    const original = [
+      createUserMessage("a-u1"),
+      createAssistantMessage("a-m1"),
+    ];
+    const edited = [
+      createUserMessage("a-u2", "edited question"),
+      createAssistantMessage("a-m2", "edited answer"),
+    ];
+
+    const core = new ExternalStoreThreadRuntimeCore(
+      createContextProvider(),
+      createAdapter(original, repoA),
+    );
+    repoA.addOrUpdateMessage(null, edited[0]!);
+    repoA.addOrUpdateMessage("a-u2", edited[1]!);
+    core.__internal_setAdapter(createAdapter(edited, repoA));
+    expect(core.getBranches("a-u2")).toEqual(["a-u1", "a-u2"]);
+
+    core.__internal_setAdapter(createAdapter([], repoB));
+    expect(core.messages).toHaveLength(0);
+
+    core.__internal_setAdapter(createAdapter(edited, repoA));
+    expect(core.messages.map((m) => m.id)).toEqual(["a-u2", "a-m2"]);
+    expect(core.getBranches("a-u2")).toEqual(["a-u1", "a-u2"]);
+  });
+
+  it("does not adopt anything when the instance is omitted", () => {
+    const messages = [createUserMessage("u1")];
+    const core = new ExternalStoreThreadRuntimeCore(createContextProvider(), {
+      messages,
+      onNew: vi.fn(async () => {}),
+    });
+    expect(core.messages.map((m) => m.id)).toEqual(["u1"]);
+
+    const next = [createUserMessage("u1"), createAssistantMessage("m1")];
+    core.__internal_setAdapter({
+      messages: next,
+      onNew: vi.fn(async () => {}),
+    });
+    expect(core.messages.map((m) => m.id)).toEqual(["u1", "m1"]);
+  });
+
+  it("reconciles a same-reference messages array when only the repository swapped", () => {
+    const repoA = new MessageRepository();
+    const repoB = new MessageRepository();
+    const shared = [createUserMessage("s-u1")];
+
+    const core = new ExternalStoreThreadRuntimeCore(
+      createContextProvider(),
+      createAdapter(shared, repoA),
+    );
+    expect(repoA.getMessages().map((m) => m.id)).toEqual(["s-u1"]);
+    expect(repoB.getMessages()).toHaveLength(0);
+
+    core.__internal_setAdapter(createAdapter(shared, repoB));
+    expect(repoB.getMessages().map((m) => m.id)).toEqual(["s-u1"]);
+    expect(core.messages.map((m) => m.id)).toEqual(["s-u1"]);
+  });
+});


### PR DESCRIPTION
closes #6477

## summary

- fixes the branch-bleed defect: with `AISDKThreads`, switching threads merged every thread's history into sibling branches on the one shared `MessageRepository` (visible through the branch picker), and switching through an empty thread wiped the whole repository via `resetHead(null)`
- core gains an `unstable_messageRepositoryInstance` adapter field: when a different instance arrives, `_updateStoreSnapshot` adopts it atomically before any reconciliation, clears pending delete evictions, resets tool-invocation tracking, and bypasses the reference-equality early returns for that pass; omitting the field keeps the runtime's own repository, so every existing consumer is byte-compatible
- `AISDKThreads` keeps one `MessageRepository` per thread in its existing per-thread entry map and threads it through `useChatThread`/`useAISDKRuntime` into the adapter; thread deletion drops the entry and its repository with it

## test plan

### already verified

- [x] core suite 1525/1525, including 4 new contract tests: histories stay isolated per instance, intra-thread branches survive a switch through an empty conversation, omitted instance is a no-op, and a same-reference messages array still reconciles when only the repository swapped
- [x] ai-sdk suite 105/105, including 2 new `AISDKThreads` regressions (the exact reported repro, and edit-branch survival through an empty thread); both were red-proven by removing the wiring and watching them fail
- [x] browser end to end on with-nuxt: the original repro (send in A, new thread, send, switch back) shows no branch picker and intact per-thread content, zero console errors

### reviewer should verify

- [ ] `pnpm -C packages/ai-sdk vitest run src/runtime/AISDKThreads.test.ts`

## notes

- design adjudicated among four candidates before implementation (per-thread repository instance won over a reset hook, which would have destroyed intra-thread branches on every switch, and over per-thread runtime cores, which fixes more but restructures the adapter); the second latent defect (empty-thread `resetHead(null)` wipe) is covered by the same isolation
- an edit composer left open across a switch still resolves against the new repository and fails on submit; pre-existing behavior under the shared repository too, noted for the thread-list line

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qCFt6N1LpvDSRtuU12JgF8ZpYUZMR-3pX6LBOtYeyZpdvZ7yNnZCUzTZ-uQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->