### PR TITLE
feat(docs): concise ask ai answers with doc sources and code collapse

### DIFF
--- a/apps/docs/app/api/doc/chat/route.test.ts
+++ b/apps/docs/app/api/doc/chat/route.test.ts
@@ -162,9 +162,17 @@ describe("withReadDocSources", () => {
         toolCallId: "b",
         output: { url: "/repo" },
       },
+      {
+        type: "message-metadata",
+        messageMetadata: { custom: { usage: { totalTokens: 42 } } },
+      },
     ] as UIMessageChunk[]);
 
     expect(out.filter((chunk) => chunk.type === "source-url")).toEqual([]);
-    expect(out).toHaveLength(4);
+    expect(out).toHaveLength(5);
+    expect(out).toContainEqual({
+      type: "message-metadata",
+      messageMetadata: { custom: { usage: { totalTokens: 42 } } },
+    });
   });
 });

--- a/apps/docs/app/api/doc/chat/route.test.ts
+++ b/apps/docs/app/api/doc/chat/route.test.ts
@@ -40,7 +40,8 @@ vi.mock("@/lib/source", () => {
   };
 });
 
-import { POST } from "./route";
+import type { UIMessageChunk } from "ai";
+import { POST, withReadDocSources } from "./route";
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -84,5 +85,86 @@ describe("POST /api/doc/chat access boundary", () => {
       "session_1234567890",
     );
     expect(mocks.getModel).not.toHaveBeenCalled();
+  });
+});
+
+describe("withReadDocSources", () => {
+  const run = async (chunks: UIMessageChunk[]) => {
+    const out: UIMessageChunk[] = [];
+    for await (const chunk of withReadDocSources(
+      (async function* () {
+        yield* chunks;
+      })(),
+    )) {
+      out.push(chunk);
+    }
+    return out;
+  };
+
+  it("emits one source-url per distinct readDoc result", async () => {
+    const out = await run([
+      {
+        type: "tool-input-available",
+        toolCallId: "a",
+        toolName: "readDoc",
+        input: {},
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "a",
+        output: { title: "Thread", url: "/docs/ui/thread" },
+      },
+      {
+        type: "tool-input-available",
+        toolCallId: "b",
+        toolName: "readDoc",
+        input: {},
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "b",
+        output: { title: "Thread", url: "/docs/ui/thread" },
+      },
+    ] as UIMessageChunk[]);
+
+    expect(out.filter((chunk) => chunk.type === "source-url")).toEqual([
+      {
+        type: "source-url",
+        sourceId: "a",
+        url: "/docs/ui/thread",
+        title: "Thread",
+      },
+    ]);
+    expect(out).toHaveLength(5);
+  });
+
+  it("ignores error results and non-readDoc tools", async () => {
+    const out = await run([
+      {
+        type: "tool-input-available",
+        toolCallId: "a",
+        toolName: "readDoc",
+        input: {},
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "a",
+        output: { error: "Page not found: nope" },
+      },
+      {
+        type: "tool-input-available",
+        toolCallId: "b",
+        toolName: "bash",
+        input: {},
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "b",
+        output: { url: "/repo" },
+      },
+    ] as UIMessageChunk[]);
+
+    expect(out.filter((chunk) => chunk.type === "source-url")).toEqual([]);
+    expect(out).toHaveLength(4);
   });
 });

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -28,7 +28,7 @@ import {
   zodSchema,
 } from "ai";
 import type * as PageTree from "fumadocs-core/page-tree";
-import type { UIMessage } from "ai";
+import type { UIMessage, UIMessageChunk } from "ai";
 import z from "zod";
 
 const SOURCE_SNAPSHOT_PATH = path.join(
@@ -181,6 +181,37 @@ export async function prepareDocChatMessages(messages: readonly UIMessage[]) {
     messages: modelMessages,
     ...DOC_CHAT_PRUNE_OPTIONS,
   });
+}
+
+export async function* withReadDocSources(
+  chunks: AsyncIterable<UIMessageChunk>,
+): AsyncGenerator<UIMessageChunk> {
+  const toolNameByCall = new Map<string, string>();
+  const sourceUrls = new Set<string>();
+
+  for await (const chunk of chunks) {
+    yield chunk;
+
+    if (chunk.type === "tool-input-available") {
+      toolNameByCall.set(chunk.toolCallId, chunk.toolName);
+    }
+
+    if (
+      chunk.type === "tool-output-available" &&
+      toolNameByCall.get(chunk.toolCallId) === "readDoc"
+    ) {
+      const output = chunk.output as { title?: unknown; url?: unknown };
+      if (typeof output.url === "string" && !sourceUrls.has(output.url)) {
+        sourceUrls.add(output.url);
+        yield {
+          type: "source-url",
+          sourceId: chunk.toolCallId,
+          url: output.url,
+          ...(typeof output.title === "string" ? { title: output.title } : {}),
+        };
+      }
+    }
+  }
 }
 
 function createRepoTools() {
@@ -476,45 +507,22 @@ export async function POST(req: Request): Promise<Response> {
 
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
-        const toolNameByCall = new Map<string, string>();
-        const sourceUrls = new Set<string>();
-
-        for await (const chunk of result.toUIMessageStream({
-          originalMessages: messages,
-          // gets usage and modelId for internal telemetry
-          messageMetadata: ({ part }) => {
-            if (part.type === "finish-step") {
-              return { modelId: part.response.modelId };
-            }
-            if (part.type === "finish") {
-              return { custom: { usage: part.totalUsage } };
-            }
-            return undefined;
-          },
-        })) {
+        for await (const chunk of withReadDocSources(
+          result.toUIMessageStream({
+            originalMessages: messages,
+            // gets usage and modelId for internal telemetry
+            messageMetadata: ({ part }) => {
+              if (part.type === "finish-step") {
+                return { modelId: part.response.modelId };
+              }
+              if (part.type === "finish") {
+                return { custom: { usage: part.totalUsage } };
+              }
+              return undefined;
+            },
+          }),
+        )) {
           writer.write(chunk);
-
-          if (chunk.type === "tool-input-available") {
-            toolNameByCall.set(chunk.toolCallId, chunk.toolName);
-          }
-
-          if (
-            chunk.type === "tool-output-available" &&
-            toolNameByCall.get(chunk.toolCallId) === "readDoc"
-          ) {
-            const output = chunk.output as { title?: unknown; url?: unknown };
-            if (typeof output.url === "string" && !sourceUrls.has(output.url)) {
-              sourceUrls.add(output.url);
-              writer.write({
-                type: "source-url",
-                sourceId: chunk.toolCallId,
-                url: output.url,
-                ...(typeof output.title === "string"
-                  ? { title: output.title }
-                  : {}),
-              });
-            }
-          }
         }
       },
     });

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -19,6 +19,8 @@ import { frontendTools } from "@assistant-ui/ai-sdk";
 import { createBashTool } from "bash-tool";
 import {
   convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
   pruneMessages,
   stepCountIs,
   streamText,
@@ -245,7 +247,6 @@ assistant-ui is a React library for building AI chat interfaces. It provides:
 - Friendly, concise, developer-focused
 - Answer the actual question - don't list documentation sections
 - Use emoji sparingly (👋 for greetings, ✅ for success, etc.)
-- Provide code snippets when they help clarify
 - Link to relevant docs naturally within answers
 </personality>
 
@@ -302,6 +303,15 @@ You also have tools for exploring the actual assistant-ui source code:
 - Prefer not linking over linking to a potentially non-existent page
 - Admit uncertainty rather than guessing
 </answering>
+
+<answer_style>
+- Default to a direct answer in 3 to 5 sentences; expand only when the question genuinely needs it
+- Include code only when the user asks for code, or when a snippet under 15 lines replaces a paragraph of explanation
+- Show only the lines that matter (the prop, the hook call, the config entry), never whole files or complete documentation examples
+- When a full example already exists in the docs, link to it instead of pasting it: "Full example: [Thread](/docs/ui/thread)"
+- The pages you read are listed automatically as clickable sources under your reply, so do not append a link list at the end
+- For multi-step setups, give short prose steps with links, and expand code for at most the step the user is currently on
+</answer_style>
 
 <formatting>
 Use inline code (\`backticks\`) for:
@@ -464,19 +474,52 @@ export async function POST(req: Request): Promise<Response> {
       },
     });
 
-    return result.toUIMessageStreamResponse({
-      originalMessages: messages,
-      // gets usage and modelId for internal telemetry
-      messageMetadata: ({ part }) => {
-        if (part.type === "finish-step") {
-          return { modelId: part.response.modelId };
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        const toolNameByCall = new Map<string, string>();
+        const sourceUrls = new Set<string>();
+
+        for await (const chunk of result.toUIMessageStream({
+          originalMessages: messages,
+          // gets usage and modelId for internal telemetry
+          messageMetadata: ({ part }) => {
+            if (part.type === "finish-step") {
+              return { modelId: part.response.modelId };
+            }
+            if (part.type === "finish") {
+              return { custom: { usage: part.totalUsage } };
+            }
+            return undefined;
+          },
+        })) {
+          writer.write(chunk);
+
+          if (chunk.type === "tool-input-available") {
+            toolNameByCall.set(chunk.toolCallId, chunk.toolName);
+          }
+
+          if (
+            chunk.type === "tool-output-available" &&
+            toolNameByCall.get(chunk.toolCallId) === "readDoc"
+          ) {
+            const output = chunk.output as { title?: unknown; url?: unknown };
+            if (typeof output.url === "string" && !sourceUrls.has(output.url)) {
+              sourceUrls.add(output.url);
+              writer.write({
+                type: "source-url",
+                sourceId: chunk.toolCallId,
+                url: output.url,
+                ...(typeof output.title === "string"
+                  ? { title: output.title }
+                  : {}),
+              });
+            }
+          }
         }
-        if (part.type === "finish") {
-          return { custom: { usage: part.totalUsage } };
-        }
-        return undefined;
       },
     });
+
+    return createUIMessageStreamResponse({ stream });
   } catch (e) {
     console.error("[api/doc/chat]", e);
     return new Response("Request failed", { status: 500 });

--- a/apps/docs/components/pages/docs/assistant/markdown.tsx
+++ b/apps/docs/components/pages/docs/assistant/markdown.tsx
@@ -81,7 +81,6 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
     });
 
     observer.observe(content);
-    for (const child of content.children) observer.observe(child);
     setOverflowing(content.scrollHeight > 320);
 
     return () => observer.disconnect();

--- a/apps/docs/components/pages/docs/assistant/markdown.tsx
+++ b/apps/docs/components/pages/docs/assistant/markdown.tsx
@@ -11,7 +11,15 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
-import { type CSSProperties, type FC, memo } from "react";
+import {
+  type CSSProperties,
+  type FC,
+  type ReactNode,
+  memo,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ShikiHighlighter from "react-shiki";
@@ -24,6 +32,7 @@ const MarkdownTextImpl = () => {
       remarkPlugins={[remarkGfm]}
       className="aui-md-assistant"
       components={markdownComponents}
+      defer
     />
   );
 };
@@ -57,27 +66,95 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   );
 };
 
+const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const observer = new ResizeObserver(() => {
+      setOverflowing(content.scrollHeight > 320);
+    });
+
+    observer.observe(content);
+    for (const child of content.children) observer.observe(child);
+    setOverflowing(content.scrollHeight > 320);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(overflowing && !expanded && "relative")}
+    >
+      <div
+        ref={contentRef}
+        className={cn(overflowing && !expanded && "max-h-64 overflow-hidden")}
+      >
+        {children}
+      </div>
+      {overflowing && !expanded && (
+        <>
+          <div className="from-background pointer-events-none absolute inset-x-0 bottom-0 h-16 rounded-b-lg bg-gradient-to-t to-transparent" />
+          <div className="absolute inset-x-0 bottom-2 flex justify-center">
+            <button
+              type="button"
+              aria-expanded={false}
+              onClick={() => setExpanded(true)}
+              className="text-muted-foreground hover:text-foreground bg-background/90 pointer-events-auto rounded-full border px-3 py-1 text-xs backdrop-blur"
+            >
+              Show more
+            </button>
+          </div>
+        </>
+      )}
+      {overflowing && expanded && (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            aria-expanded={true}
+            onClick={() => {
+              setExpanded(false);
+              containerRef.current?.scrollIntoView({ block: "nearest" });
+            }}
+            className="text-muted-foreground hover:text-foreground bg-background/90 mt-1 rounded-full border px-3 py-1 text-xs backdrop-blur"
+          >
+            Show less
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
   return (
-    <ShikiHighlighter
-      language={language}
-      theme={{ dark: "github-dark-default", light: "github-light-default" }}
-      addDefaultStyles={false}
-      showLanguage={false}
-      showLineNumbers
-      defaultColor={false}
-      className="[&_pre]:border-border/50 [&_pre]:bg-muted/30 [&_pre]:scrollbar-none [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-lg [&_pre]:border [&_pre]:border-t-0 [&_pre]:py-3 [&_pre]:pr-3 [&_pre]:pl-1 [&_pre]:text-xs [&_pre]:leading-relaxed"
-      style={
-        {
-          "--line-numbers-foreground": "var(--color-muted-foreground)",
-          "--line-numbers-width": "2ch",
-          "--line-numbers-padding-left": "0",
-          "--line-numbers-padding-right": "1ch",
-        } as CSSProperties
-      }
-    >
-      {code.trim()}
-    </ShikiHighlighter>
+    <CollapsibleCode>
+      <ShikiHighlighter
+        language={language}
+        theme={{ dark: "github-dark-default", light: "github-light-default" }}
+        addDefaultStyles={false}
+        showLanguage={false}
+        showLineNumbers
+        defaultColor={false}
+        className="[&_pre]:border-border/50 [&_pre]:bg-muted/30 [&_pre]:scrollbar-none [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-lg [&_pre]:border [&_pre]:border-t-0 [&_pre]:py-3 [&_pre]:pr-3 [&_pre]:pl-1 [&_pre]:text-xs [&_pre]:leading-relaxed"
+        style={
+          {
+            "--line-numbers-foreground": "var(--color-muted-foreground)",
+            "--line-numbers-width": "2ch",
+            "--line-numbers-padding-left": "0",
+            "--line-numbers-padding-right": "1ch",
+          } as CSSProperties
+        }
+      >
+        {code.trim()}
+      </ShikiHighlighter>
+    </CollapsibleCode>
   );
 };
 
@@ -231,14 +308,18 @@ const markdownComponents = memoizeMarkdownComponents({
     />
   ),
   tr: (props) => <tr {...props} />,
-  pre: ({ className, ...props }) => (
-    <pre
-      className={cn(
-        "border-border/50 bg-muted/30 overflow-x-auto rounded-t-none rounded-b-lg border border-t-0 p-3 text-xs leading-relaxed",
-        className,
-      )}
-      {...props}
-    />
+  pre: ({ className, children, ...props }) => (
+    <CollapsibleCode>
+      <pre
+        className={cn(
+          "border-border/50 bg-muted/30 overflow-x-auto rounded-t-none rounded-b-lg border border-t-0 p-3 text-xs leading-relaxed",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </pre>
+    </CollapsibleCode>
   ),
   code: function Code({ className, ...props }) {
     const isCodeBlock = useIsMarkdownCodeBlock();

--- a/apps/docs/components/pages/docs/assistant/markdown.tsx
+++ b/apps/docs/components/pages/docs/assistant/markdown.tsx
@@ -17,6 +17,7 @@ import {
   type ReactNode,
   memo,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -71,6 +72,7 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
   const [overflowing, setOverflowing] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const contentId = useId();
 
   useEffect(() => {
     const content = contentRef.current;
@@ -93,6 +95,7 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
     >
       <div
         ref={contentRef}
+        id={contentId}
         className={cn(overflowing && !expanded && "max-h-64 overflow-hidden")}
       >
         {children}
@@ -104,6 +107,7 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
             <button
               type="button"
               aria-expanded={false}
+              aria-controls={contentId}
               onClick={() => setExpanded(true)}
               className="text-muted-foreground hover:text-foreground bg-background/90 pointer-events-auto rounded-full border px-3 py-1 text-xs backdrop-blur"
             >
@@ -117,6 +121,7 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
           <button
             type="button"
             aria-expanded={true}
+            aria-controls={contentId}
             onClick={() => {
               setExpanded(false);
               containerRef.current?.scrollIntoView({ block: "nearest" });

--- a/apps/docs/components/pages/docs/assistant/messages.tsx
+++ b/apps/docs/components/pages/docs/assistant/messages.tsx
@@ -1,14 +1,18 @@
 "use client";
 
+import Link from "next/link";
 import { AssistantActionBar } from "./assistant-action-bar";
 import { MarkdownText } from "./markdown";
 import {
   ErrorPrimitive,
   MessagePrimitive,
+  type SourceMessagePartProps,
   type ToolCallMessagePartProps,
+  useAuiState,
 } from "@assistant-ui/react";
 import { type ComponentType, type ReactNode } from "react";
 import { Reasoning } from "@/components/assistant-ui/reasoning";
+import { Sources } from "@/components/assistant-ui/sources";
 import {
   TraceLine,
   formatDuration,
@@ -46,6 +50,7 @@ export function AssistantMessage({
             return null;
           }}
         </MessagePrimitive.Parts>
+        <SourcesFooter />
         <MessageError />
       </div>
       <AssistantActionBar />
@@ -103,18 +108,57 @@ function ToolCall({
   toolName,
   args,
   status,
+  result,
 }: ToolCallMessagePartProps): ReactNode {
   const isRunning = status?.type === "running";
   const { label, detail } = getToolDisplay(toolName, args, isRunning);
   const duration = useToolDuration(isRunning);
+  const url =
+    toolName === "readDoc" &&
+    result &&
+    typeof result === "object" &&
+    "url" in result &&
+    typeof result.url === "string"
+      ? result.url
+      : undefined;
 
-  return (
+  const traceLine = (
     <TraceLine
       live={isRunning}
       label={label}
       detail={detail}
       {...(duration !== null ? { meta: formatDuration(duration) } : {})}
     />
+  );
+
+  if (url) return <Link href={url}>{traceLine}</Link>;
+
+  return traceLine;
+}
+
+function SourcesFooter(): ReactNode {
+  const parts = useAuiState((s) => s.message.parts);
+  const sources = new Map<string, SourceMessagePartProps>();
+
+  for (const part of parts) {
+    if (
+      part.type === "source" &&
+      part.sourceType === "url" &&
+      !sources.has(part.url)
+    ) {
+      sources.set(part.url, part);
+    }
+  }
+
+  if (sources.size === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      <span className="text-muted-foreground text-xs">Sources</span>
+      {[...sources.values()].map((source) => (
+        <Sources key={source.url} {...source} />
+      ))}
+    </div>
   );
 }
 

--- a/apps/docs/components/pages/docs/assistant/messages.tsx
+++ b/apps/docs/components/pages/docs/assistant/messages.tsx
@@ -11,6 +11,7 @@ import {
   useAuiState,
 } from "@assistant-ui/react";
 import { type ComponentType, type ReactNode } from "react";
+import { FileTextIcon } from "lucide-react";
 import { Reasoning } from "@/components/assistant-ui/reasoning";
 import { Sources } from "@/components/assistant-ui/sources";
 import {
@@ -131,14 +132,22 @@ function ToolCall({
     />
   );
 
-  if (url) return <Link href={url}>{traceLine}</Link>;
+  if (url)
+    return (
+      <Link href={url} className="hover:underline focus-visible:underline">
+        {traceLine}
+      </Link>
+    );
 
   return traceLine;
 }
 
 function SourcesFooter(): ReactNode {
   const parts = useAuiState((s) => s.message.parts);
-  const sources = new Map<string, SourceMessagePartProps>();
+  const sources = new Map<
+    string,
+    Extract<SourceMessagePartProps, { sourceType: "url" }>
+  >();
 
   for (const part of parts) {
     if (
@@ -156,7 +165,10 @@ function SourcesFooter(): ReactNode {
     <div className="mt-2 flex flex-wrap items-center gap-1.5">
       <span className="text-muted-foreground text-xs">Sources</span>
       {[...sources.values()].map((source) => (
-        <Sources key={source.url} {...source} />
+        <Sources.Root key={source.url} href={source.url}>
+          <FileTextIcon className="size-3 shrink-0" />
+          <Sources.Title>{source.title ?? source.url}</Sources.Title>
+        </Sources.Root>
       ))}
     </div>
   );


### PR DESCRIPTION
## summary

- the docs ask ai widget now answers short by contract: the system prompt gains an answer_style block (3 to 5 sentence default, code only when asked or when a snippet under 15 lines replaces a paragraph, link to full examples instead of pasting them)
- every doc page the assistant reads is cited: the chat route forwards the ui message stream through createUIMessageStream and synthesizes a deduplicated source-url part per successful readDoc result, and the widget renders them as a sources footer of clickable chips reusing the Sources kit component; the readDoc trace line now links to the page it read
- long code blocks in the widget collapse: blocks taller than 320px cap at 256px with a gradient fade and a show more / show less toggle that tracks streaming growth via ResizeObserver; the widget's MarkdownTextPrimitive now passes defer like the shared markdown-text already does

## test plan

### already verified

- [x] `pnpm -C apps/docs exec tsc --noEmit` -> error set identical to the baseline before the change (5 pre-existing environment errors, none in the touched files)
- [x] `pnpm -C apps/docs test` -> 269/269 green
- [x] `pnpm lint` -> oxlint and oxfmt clean on the touched files
- [x] full browser pass against a local mock openai-compatible endpoint: readDoc trace renders as a link, a 3 line block renders without chrome, a 48 line block collapses to 256px and expands to full height with correct aria-expanded, collapsing restores the fade and scroll position, the sources footer shows one deduplicated chip linking to /docs/ui/thread, no new console errors

### reviewer should verify

- [ ] with real model credentials, ask the widget a question that triggers readDoc and confirm the sources footer lists the pages read and answers trend shorter with doc links instead of pasted examples

## notes

- source chips open in a new tab (the Sources kit component default) so the conversation stays intact; the readDoc trace line does a client-side navigation instead and the panel stays open
- the prompt contract can only be judged against real models; the mock verifies the wiring, not answer length

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.e6sYv339bYVrPLzH6rSoqVLa_SvcKFbvplFn0HRmzJNTKOuWN0If9sQOr6U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->