### PR TITLE
fix(cloud): time out authentication requests

### DIFF
--- a/.changeset/timeout-cloud-auth-requests.md
+++ b/.changeset/timeout-cloud-auth-requests.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: abort Cloud authentication token requests after their deadline

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -4,6 +4,34 @@ import {
   readCloudString,
 } from "./cloudResponse";
 
+const AUTH_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+
+const fetchAuthToken = async (
+  url: string,
+  operation: string,
+  init: RequestInit,
+): Promise<Response> => {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, AUTH_TOKEN_REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (timedOut) {
+      throw new Error(
+        `Assistant Cloud ${operation} timed out after ${AUTH_TOKEN_REQUEST_TIMEOUT_MS}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
 export type AssistantCloudAuthStrategy = {
   readonly strategy: "anon" | "jwt" | "api-key";
   getAuthHeaders(): Promise<Record<string, string> | false>;
@@ -308,8 +336,9 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
       if (storedRefreshToken) {
         const refreshExpiry = new Date(storedRefreshToken.expires_at).getTime();
         if (refreshExpiry - currentTime > 30 * 1000) {
-          const response = await fetch(
+          const response = await fetchAuthToken(
             `${this.baseUrl}/v1/auth/tokens/refresh`,
+            "refresh token request",
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -345,9 +374,11 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
       }
 
       // No valid refresh token; request a new anonymous token
-      const response = await fetch(`${this.baseUrl}/v1/auth/tokens/anonymous`, {
-        method: "POST",
-      });
+      const response = await fetchAuthToken(
+        `${this.baseUrl}/v1/auth/tokens/anonymous`,
+        "anonymous token request",
+        { method: "POST" },
+      );
 
       if (!response.ok) return null;
 

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -6,11 +6,10 @@ import {
 
 const AUTH_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 
-const fetchAuthToken = async (
-  url: string,
+const withAuthTokenDeadline = async <T>(
   operation: string,
-  init: RequestInit,
-): Promise<Response> => {
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> => {
   const controller = new AbortController();
   let timedOut = false;
   const timeout = setTimeout(() => {
@@ -19,11 +18,12 @@ const fetchAuthToken = async (
   }, AUTH_TOKEN_REQUEST_TIMEOUT_MS);
 
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    return await run(controller.signal);
   } catch (error) {
     if (timedOut) {
       throw new Error(
         `Assistant Cloud ${operation} timed out after ${AUTH_TOKEN_REQUEST_TIMEOUT_MS}ms`,
+        { cause: error },
       );
     }
     throw error;
@@ -336,65 +336,79 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
       if (storedRefreshToken) {
         const refreshExpiry = new Date(storedRefreshToken.expires_at).getTime();
         if (refreshExpiry - currentTime > 30 * 1000) {
-          const response = await fetchAuthToken(
-            `${this.baseUrl}/v1/auth/tokens/refresh`,
+          const refreshedAccessToken = await withAuthTokenDeadline(
             "refresh token request",
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ refresh_token: storedRefreshToken.token }),
+            async (signal) => {
+              const response = await fetch(
+                `${this.baseUrl}/v1/auth/tokens/refresh`,
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    refresh_token: storedRefreshToken.token,
+                  }),
+                  signal,
+                },
+              );
+
+              if (response.ok) {
+                const { data, accessToken } = await readAuthTokenResponse(
+                  response,
+                  "refresh auth token response",
+                );
+                if (data.refresh_token != null) {
+                  writeRefreshToken(
+                    this.baseUrl,
+                    readRefreshTokenResponse(
+                      data.refresh_token,
+                      "refresh auth token response.refresh_token",
+                    ),
+                  );
+                }
+                return accessToken;
+              }
+
+              if (response.status === 429 || response.status >= 500) {
+                throw new Error(
+                  `Assistant Cloud token refresh failed with status ${response.status}`,
+                );
+              }
+
+              return null;
             },
           );
-
-          if (response.ok) {
-            const { data, accessToken } = await readAuthTokenResponse(
-              response,
-              "refresh auth token response",
-            );
-            if (data.refresh_token != null) {
-              writeRefreshToken(
-                this.baseUrl,
-                readRefreshTokenResponse(
-                  data.refresh_token,
-                  "refresh auth token response.refresh_token",
-                ),
-              );
-            }
-            return accessToken;
-          }
-
-          if (response.status === 429 || response.status >= 500) {
-            throw new Error(
-              `Assistant Cloud token refresh failed with status ${response.status}`,
-            );
-          }
+          if (refreshedAccessToken !== null) return refreshedAccessToken;
         } else {
           removeRefreshToken(this.baseUrl);
         }
       }
 
       // No valid refresh token; request a new anonymous token
-      const response = await fetchAuthToken(
-        `${this.baseUrl}/v1/auth/tokens/anonymous`,
+      return withAuthTokenDeadline(
         "anonymous token request",
-        { method: "POST" },
-      );
+        async (signal) => {
+          const response = await fetch(
+            `${this.baseUrl}/v1/auth/tokens/anonymous`,
+            { method: "POST", signal },
+          );
 
-      if (!response.ok) return null;
+          if (!response.ok) return null;
 
-      const { data, accessToken } = await readAuthTokenResponse(
-        response,
-        "anonymous auth token response",
-      );
+          const { data, accessToken } = await readAuthTokenResponse(
+            response,
+            "anonymous auth token response",
+          );
 
-      writeRefreshToken(
-        this.baseUrl,
-        readRefreshTokenResponse(
-          data.refresh_token,
-          "anonymous auth token response.refresh_token",
-        ),
+          writeRefreshToken(
+            this.baseUrl,
+            readRefreshTokenResponse(
+              data.refresh_token,
+              "anonymous auth token response.refresh_token",
+            ),
+          );
+          return accessToken;
+        },
       );
-      return accessToken;
     };
     this.jwtStrategy = new AssistantCloudJWTAuthStrategy(() =>
       getSharedAnonymousAuthToken(this.baseUrl, requestAuthToken),

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -43,6 +43,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     if (originalLocalStorageDescriptor) {
       Object.defineProperty(
@@ -83,7 +84,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     expect(values.get(refreshTokenKey)).toBe(JSON.stringify(nextRefreshToken));
     expect(fetchMock).toHaveBeenCalledWith(
       `${baseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
   });
 
@@ -185,7 +186,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       `${baseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
@@ -194,6 +195,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken.token }),
+        signal: expect.any(AbortSignal),
       },
     );
     expect(lockRequest).toHaveBeenCalledTimes(2);
@@ -238,6 +240,119 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
     ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts timed out shared anonymous token requests before retrying", async () => {
+    vi.useFakeTimers();
+    const values = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            requestSignal = init?.signal;
+            requestSignal?.addEventListener(
+              "abort",
+              () => reject(requestSignal?.reason),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const first = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+    const second = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    const firstRequest = expect(first.getAuthHeaders()).rejects.toThrow(
+      "Assistant Cloud anonymous token request timed out after 30000ms",
+    );
+    const secondRequest = expect(second.getAuthHeaders()).rejects.toThrow(
+      "Assistant Cloud anonymous token request timed out after 30000ms",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await Promise.all([firstRequest, secondRequest]);
+    expect(requestSignal?.aborted).toBe(true);
+    expect(values.has(refreshTokenKey)).toBe(false);
+
+    await expect(
+      new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
+    ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts timed out refresh requests without replacing the identity", async () => {
+    vi.useFakeTimers();
+    const values = new Map([[refreshTokenKey, JSON.stringify(refreshToken)]]);
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    let requestSignal: AbortSignal | null | undefined;
+    const rotatedRefreshToken = { token: "r2", expires_at: "2099-02-01" };
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            requestSignal = init?.signal;
+            requestSignal?.addEventListener(
+              "abort",
+              () => reject(requestSignal?.reason),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: accessToken,
+          refresh_token: rotatedRefreshToken,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    const request = expect(strategy.getAuthHeaders()).rejects.toThrow(
+      "Assistant Cloud refresh token request timed out after 30000ms",
+    );
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await request;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(values.get(refreshTokenKey)).toBe(JSON.stringify(refreshToken));
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(values.get(refreshTokenKey)).toBe(
+      JSON.stringify(rotatedRefreshToken),
+    );
   });
 
   it("keeps anonymous token requests independent without localStorage", async () => {
@@ -300,12 +415,12 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       `${baseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       `${secondBaseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
     expect(values.get(refreshTokenKey)).toBe(JSON.stringify(refreshToken));
     expect(values.get(`aui:refresh_token:${secondBaseUrl}`)).toBe(
@@ -358,12 +473,13 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken.token }),
+        signal: expect.any(AbortSignal),
       },
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       `${secondBaseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
     expect(values.get(refreshTokenKey)).toBe(JSON.stringify(refreshToken));
     expect(values.get(`aui:refresh_token:${secondBaseUrl}`)).toBe(
@@ -422,12 +538,13 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: scopedRefreshToken.token }),
+        signal: expect.any(AbortSignal),
       },
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       `${secondBaseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
+      { method: "POST", signal: expect.any(AbortSignal) },
     );
     expect(values.has("aui:refresh_token")).toBe(false);
     expect(values.get(`aui:refresh_token:${secondBaseUrl}`)).toBe(
@@ -622,6 +739,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: refreshToken.token }),
+        signal: expect.any(AbortSignal),
       },
     );
     expect(setItem).not.toHaveBeenCalled();
@@ -690,7 +808,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
         `${baseUrl}/v1/auth/tokens/anonymous`,
-        { method: "POST" },
+        { method: "POST", signal: expect.any(AbortSignal) },
       );
       expect(values.get(refreshTokenKey)).toBe(
         JSON.stringify(replacementRefreshToken),

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -257,16 +257,19 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     let requestSignal: AbortSignal | null | undefined;
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce(
-        (_input: RequestInfo | URL, init?: RequestInit) =>
-          new Promise<Response>((_resolve, reject) => {
-            requestSignal = init?.signal;
-            requestSignal?.addEventListener(
-              "abort",
-              () => reject(requestSignal?.reason),
-              { once: true },
-            );
-          }),
+      .mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            new Promise<never>((_resolve, reject) => {
+              requestSignal = init?.signal;
+              requestSignal?.addEventListener(
+                "abort",
+                () => reject(requestSignal?.reason),
+                { once: true },
+              );
+            }),
+        } as Response),
       )
       .mockResolvedValueOnce({
         ok: true,
@@ -285,6 +288,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     const secondRequest = expect(second.getAuthHeaders()).rejects.toThrow(
       "Assistant Cloud anonymous token request timed out after 30000ms",
     );
+    await vi.advanceTimersByTimeAsync(0);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(requestSignal).toBeInstanceOf(AbortSignal);
 


### PR DESCRIPTION
## Summary

- abort anonymous and refresh token fetches after a 30-second transport deadline
- normalize timeout failures while preserving existing non-timeout fetch errors
- keep shared auth ownership until the aborted fetch settles, then allow a non-overlapping retry
- cover anonymous shared waiters, refresh-token preservation, signal abortion, and retry behavior

## Why

Cloud token requests had no timeout or `AbortSignal`. A fetch that never settled permanently wedged one auth strategy and, after shared browser authentication was introduced, every client using the same storage/backend scope. Clearing only the coordination entry would be unsafe because the original request could later mint an identity alongside its retry.

The deadline is applied at the transport boundary instead. The actual fetch is aborted, all current waiters receive the same normalized timeout failure, and the existing settlement-based cleanup releases per-instance, in-realm, and Web Lock coordination before a later request retries. Refresh-token storage is left unchanged on timeout.

The 30-second deadline is module-private, so this fixes the hang without changing the public Cloud configuration surface or creating conflicting deadlines between clients sharing one authentication scope.

Closes #6481

## Verification

- reproduced both token fetches receiving no signal on current main
- `vitest run packages/cloud/src` (14 files, 105 tests)
- `aui-build` for `assistant-cloud`
- `oxlint` on the changed source and test
- `oxfmt --check` on the changed files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bDyR1_YTxFyMSci7igeniRwrc9_YqqxBLI7RH7WELHeuJlBMa74M_58n2Fo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->