### PR TITLE
fix(livekit): isolate and shorten voice tokens

### DIFF
--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -297,7 +297,11 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects browser requests marked same-site or cross-site. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The token route accepts a request only when `Sec-Fetch-Site` is `same-origin` or `none`, and falls back to comparing the `Origin` header against the request URL for clients that omit Fetch Metadata. Behind a reverse proxy, that fallback needs the public scheme and host preserved in the request URL.
+
+<Callout type="warn">
+  A request-context check is not authentication. Before deploying, require your application session in the token route and apply a durable rate limit, so anonymous callers cannot consume voice capacity.
+</Callout>
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -297,7 +297,7 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects browser requests marked cross-site. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The example rejects browser requests marked same-site or cross-site. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -297,7 +297,7 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects cross-origin browser requests. For clients without Fetch Metadata, if a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The example rejects browser requests marked cross-site, but request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -272,7 +272,7 @@ See the [Orb page](/elements/orb) for anatomy, variants, and state samples.
 The [`with-livekit`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-livekit) example shows the full wiring:
 
 1. **Adapter** (`examples/with-livekit/lib/livekit-voice-adapter.ts`): `LiveKitVoiceAdapter` implements `RealtimeVoiceAdapter`. `connect` calls `createVoiceSession`, connects a LiveKit `Room`, enables the local microphone, attaches remote audio tracks, and maps room events to helpers (`setStatus`, `end`, `emitMode`, `emitVolume`, `emitTranscript`).
-2. **Token route** (`examples/with-livekit/app/api/livekit-token/route.ts`): mints a short-lived room token server-side so secrets stay off the client.
+2. **Token route** (`examples/with-livekit/app/api/livekit-token/route.ts`): mints a ten-minute token for an isolated room so secrets stay off the client.
 3. **Agent worker** (`examples/with-livekit/agent/`): a Python LiveKit Agents process that joins the room and runs the voice pipeline.
 
 Minimal runtime wiring:
@@ -295,6 +295,8 @@ const runtime = useChatRuntime({
 ```
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
+
+The example rejects cross-origin browser requests, but origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -297,7 +297,7 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects browser requests marked cross-site, but request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The example rejects browser requests marked cross-site. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -297,7 +297,7 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects cross-origin browser requests. If a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The example rejects cross-origin browser requests. For clients without Fetch Metadata, if a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -286,6 +286,7 @@ const runtime = useChatRuntime({
       url: process.env.NEXT_PUBLIC_LIVEKIT_URL!,
       token: async () => {
         const res = await fetch("/api/livekit-token", { method: "POST" });
+        if (!res.ok) throw new Error("Failed to create a LiveKit session");
         const { token } = await res.json();
         return token;
       },
@@ -296,7 +297,7 @@ const runtime = useChatRuntime({
 
 Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
 
-The example rejects cross-origin browser requests, but origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
+The example rejects cross-origin browser requests. If a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in the token route and apply a durable rate limit so anonymous callers cannot consume voice capacity.
 
 You can also scaffold it with the CLI:
 

--- a/examples/with-livekit/.env.example
+++ b/examples/with-livekit/.env.example
@@ -1,6 +1,7 @@
 # LiveKit Configuration
 LIVEKIT_API_KEY=your-api-key
 LIVEKIT_API_SECRET=your-api-secret
+# Prefix for isolated per-session room names.
 LIVEKIT_ROOM_NAME=assistant-room
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880
 

--- a/examples/with-livekit/.env.example
+++ b/examples/with-livekit/.env.example
@@ -1,6 +1,8 @@
 # LiveKit Configuration
 LIVEKIT_API_KEY=your-api-key
 LIVEKIT_API_SECRET=your-api-secret
+# Externally visible app origin. Set this when a reverse proxy rewrites the URL.
+APP_ORIGIN=
 # Prefix for isolated per-session room names.
 LIVEKIT_ROOM_NAME=assistant-room
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880

--- a/examples/with-livekit/.env.example
+++ b/examples/with-livekit/.env.example
@@ -1,8 +1,6 @@
 # LiveKit Configuration
 LIVEKIT_API_KEY=your-api-key
 LIVEKIT_API_SECRET=your-api-secret
-# Fetch Metadata fallback. Must be an absolute HTTP(S) origin when set.
-APP_ORIGIN=
 # Prefix for isolated per-session room names.
 LIVEKIT_ROOM_NAME=assistant-room
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880

--- a/examples/with-livekit/.env.example
+++ b/examples/with-livekit/.env.example
@@ -1,7 +1,7 @@
 # LiveKit Configuration
 LIVEKIT_API_KEY=your-api-key
 LIVEKIT_API_SECRET=your-api-secret
-# Externally visible app origin. Set this when a reverse proxy rewrites the URL.
+# Fetch Metadata fallback. Must be an absolute HTTP(S) origin when set.
 APP_ORIGIN=
 # Prefix for isolated per-session room names.
 LIVEKIT_ROOM_NAME=assistant-room

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 type LiveKitClaims = {
@@ -30,10 +30,6 @@ async function createToken() {
   return { response, claims: decodeClaims(body.token) };
 }
 
-beforeEach(() => {
-  vi.stubEnv("APP_ORIGIN", "");
-});
-
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -43,64 +39,8 @@ describe("LiveKit token route", () => {
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {
         method: "POST",
-        headers: { origin: "https://attacker.example" },
-      }),
-    );
-
-    expect(response.status).toBe(403);
-  });
-
-  it("rejects cross-scheme origins without a configured public origin", async () => {
-    const response = await POST(
-      new Request("https://app.example/api/livekit-token", {
-        method: "POST",
-        headers: { origin: "http://app.example" },
-      }),
-    );
-
-    expect(response.status).toBe(403);
-  });
-
-  it("accepts a configured public origin behind a proxy", async () => {
-    vi.stubEnv("APP_ORIGIN", "https://app.example");
-    vi.stubEnv("LIVEKIT_API_KEY", "api-key");
-    vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
-
-    const response = await POST(
-      new Request("http://app.internal/api/livekit-token", {
-        method: "POST",
         headers: {
-          host: "app.internal",
-          origin: "https://app.example",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(200);
-  });
-
-  it("reports an invalid configured public origin", async () => {
-    vi.stubEnv("APP_ORIGIN", "app.example");
-
-    const response = await POST(
-      new Request("http://app.internal/api/livekit-token", {
-        method: "POST",
-        headers: { origin: "https://app.example" },
-      }),
-    );
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      error: "APP_ORIGIN must be an absolute HTTP(S) origin.",
-    });
-  });
-
-  it("rejects requests marked cross-site by the browser", async () => {
-    const response = await POST(
-      new Request("https://app.example/api/livekit-token", {
-        method: "POST",
-        headers: {
-          origin: "https://app.example",
+          origin: "https://attacker.example",
           "sec-fetch-site": "cross-site",
         },
       }),

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -46,6 +46,20 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
+  it("rejects requests marked cross-site by the browser", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: {
+          origin: "https://app.example",
+          "sec-fetch-site": "cross-site",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it("issues short-lived tokens for isolated rooms", async () => {
     vi.stubEnv("LIVEKIT_API_KEY", "api-key");
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
@@ -64,10 +78,14 @@ describe("LiveKit token route", () => {
       roomJoin: true,
     });
     expect(first.claims.video.room).toMatch(/^assistant-room-[0-9a-f-]{36}$/);
+    expect(second.claims.sub).not.toBe(first.claims.sub);
     expect(second.claims.video.room).not.toBe(first.claims.video.room);
   });
 
   it("fails closed when the server credentials are missing", async () => {
+    vi.stubEnv("LIVEKIT_API_KEY", "");
+    vi.stubEnv("LIVEKIT_API_SECRET", "");
+
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {
         method: "POST",

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 type LiveKitClaims = {
@@ -29,6 +29,10 @@ async function createToken() {
   const body = (await response.json()) as { token: string };
   return { response, claims: decodeClaims(body.token) };
 }
+
+beforeEach(() => {
+  vi.stubEnv("APP_ORIGIN", "");
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -98,13 +98,9 @@ describe("LiveKit token route", () => {
     vi.stubEnv("LIVEKIT_API_SECRET", "");
 
     const response = await POST(
-      new Request("http://app.internal/api/livekit-token", {
+      new Request("https://app.example/api/livekit-token", {
         method: "POST",
-        headers: {
-          origin: "https://app.example",
-          "x-forwarded-host": "app.example",
-          "x-forwarded-proto": "https",
-        },
+        headers: { origin: "https://app.example" },
       }),
     );
 

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -51,10 +51,10 @@ describe("LiveKit token route", () => {
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
 
     const response = await POST(
-      new Request("http://app.internal/api/livekit-token", {
+      new Request("http://app.example/api/livekit-token", {
         method: "POST",
         headers: {
-          host: "app.example",
+          host: "app.internal",
           origin: "https://app.example",
         },
       }),

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -46,6 +46,17 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
+  it("rejects foreign origins when Fetch Metadata is unavailable", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "https://attacker.example" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it("issues short-lived tokens for isolated rooms", async () => {
     vi.stubEnv("LIVEKIT_API_KEY", "api-key");
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -46,15 +46,21 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
-  it("rejects cross-scheme origins when Fetch Metadata is unavailable", async () => {
+  it("accepts a public origin when a proxy uses an internal URL", async () => {
+    vi.stubEnv("LIVEKIT_API_KEY", "api-key");
+    vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
+
     const response = await POST(
-      new Request("https://app.example/api/livekit-token", {
+      new Request("http://app.internal/api/livekit-token", {
         method: "POST",
-        headers: { origin: "http://app.example" },
+        headers: {
+          host: "app.example",
+          origin: "https://app.example",
+        },
       }),
     );
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(200);
   });
 
   it("rejects requests marked cross-site by the browser", async () => {

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -63,7 +63,7 @@ describe("LiveKit token route", () => {
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
 
     const response = await POST(
-      new Request("http://app.example/api/livekit-token", {
+      new Request("http://app.internal/api/livekit-token", {
         method: "POST",
         headers: {
           host: "app.internal",

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -46,7 +46,19 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
-  it("accepts a public origin when a proxy uses an internal URL", async () => {
+  it("rejects cross-scheme origins without a configured public origin", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "http://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("accepts a configured public origin behind a proxy", async () => {
+    vi.stubEnv("APP_ORIGIN", "https://app.example");
     vi.stubEnv("LIVEKIT_API_KEY", "api-key");
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
 

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -79,6 +79,22 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(200);
   });
 
+  it("reports an invalid configured public origin", async () => {
+    vi.stubEnv("APP_ORIGIN", "app.example");
+
+    const response = await POST(
+      new Request("http://app.internal/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "APP_ORIGIN must be an absolute HTTP(S) origin.",
+    });
+  });
+
   it("rejects requests marked cross-site by the browser", async () => {
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -46,6 +46,17 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
+  it("rejects cross-scheme origins when Fetch Metadata is unavailable", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "http://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
   it("rejects requests marked cross-site by the browser", async () => {
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {
@@ -87,9 +98,13 @@ describe("LiveKit token route", () => {
     vi.stubEnv("LIVEKIT_API_SECRET", "");
 
     const response = await POST(
-      new Request("https://app.example/api/livekit-token", {
+      new Request("http://app.internal/api/livekit-token", {
         method: "POST",
-        headers: { origin: "https://app.example" },
+        headers: {
+          origin: "https://app.example",
+          "x-forwarded-host": "app.example",
+          "x-forwarded-proto": "https",
+        },
       }),
     );
 

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+type LiveKitClaims = {
+  exp: number;
+  nbf: number;
+  sub: string;
+  video: {
+    canPublish: boolean;
+    canSubscribe: boolean;
+    room: string;
+    roomJoin: boolean;
+  };
+};
+
+function decodeClaims(token: string): LiveKitClaims {
+  const payload = token.split(".")[1];
+  if (!payload) throw new Error("Token payload is missing");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+}
+
+async function createToken() {
+  const response = await POST(
+    new Request("https://app.example/api/livekit-token", {
+      method: "POST",
+      headers: { origin: "https://app.example" },
+    }),
+  );
+  const body = (await response.json()) as { token: string };
+  return { response, claims: decodeClaims(body.token) };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("LiveKit token route", () => {
+  it("rejects cross-origin browser requests", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "https://attacker.example" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("issues short-lived tokens for isolated rooms", async () => {
+    vi.stubEnv("LIVEKIT_API_KEY", "api-key");
+    vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
+    vi.stubEnv("LIVEKIT_ROOM_NAME", "assistant-room");
+
+    const first = await createToken();
+    const second = await createToken();
+
+    expect(first.response.status).toBe(200);
+    expect(first.response.headers.get("cache-control")).toBe("no-store");
+    expect(first.claims.exp - first.claims.nbf).toBe(600);
+    expect(first.claims.sub).toMatch(/^user-[0-9a-f-]{36}$/);
+    expect(first.claims.video).toMatchObject({
+      canPublish: true,
+      canSubscribe: true,
+      roomJoin: true,
+    });
+    expect(first.claims.video.room).toMatch(/^assistant-room-[0-9a-f-]{36}$/);
+    expect(second.claims.video.room).not.toBe(first.claims.video.room);
+  });
+
+  it("fails closed when the server credentials are missing", async () => {
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -57,6 +57,20 @@ describe("LiveKit token route", () => {
     expect(response.status).toBe(403);
   });
 
+  it("accepts matching origins when Fetch Metadata is unavailable", async () => {
+    vi.stubEnv("LIVEKIT_API_KEY", "api-key");
+    vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");
+
+    const response = await POST(
+      new Request("https://app.example/api/livekit-token", {
+        method: "POST",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("issues short-lived tokens for isolated rooms", async () => {
     vi.stubEnv("LIVEKIT_API_KEY", "api-key");
     vi.stubEnv("LIVEKIT_API_SECRET", "secret-key-that-is-long-enough");

--- a/examples/with-livekit/app/api/livekit-token/route.test.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.test.ts
@@ -23,7 +23,7 @@ async function createToken() {
   const response = await POST(
     new Request("https://app.example/api/livekit-token", {
       method: "POST",
-      headers: { origin: "https://app.example" },
+      headers: { "sec-fetch-site": "same-origin" },
     }),
   );
   const body = (await response.json()) as { token: string };
@@ -35,14 +35,11 @@ afterEach(() => {
 });
 
 describe("LiveKit token route", () => {
-  it("rejects cross-origin browser requests", async () => {
+  it("rejects cross-site browser requests", async () => {
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {
         method: "POST",
-        headers: {
-          origin: "https://attacker.example",
-          "sec-fetch-site": "cross-site",
-        },
+        headers: { "sec-fetch-site": "cross-site" },
       }),
     );
 
@@ -78,7 +75,7 @@ describe("LiveKit token route", () => {
     const response = await POST(
       new Request("https://app.example/api/livekit-token", {
         method: "POST",
-        headers: { origin: "https://app.example" },
+        headers: { "sec-fetch-site": "same-origin" },
       }),
     );
 

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -3,26 +3,49 @@ import { NextResponse } from "next/server";
 
 const TOKEN_TTL = "10m";
 
-function isSameOriginRequest(req: Request) {
+type OriginCheck = "allowed" | "forbidden" | "misconfigured";
+
+function checkRequestOrigin(req: Request): OriginCheck {
   const fetchSite = req.headers.get("sec-fetch-site");
   if (fetchSite !== null) {
-    return fetchSite === "same-origin" || fetchSite === "none";
+    return fetchSite === "same-origin" || fetchSite === "none"
+      ? "allowed"
+      : "forbidden";
   }
 
   const origin = req.headers.get("origin");
-  if (origin === null) return true;
+  if (origin === null) return "allowed";
+
+  const configuredOrigin = process.env.APP_ORIGIN?.trim();
+  let expectedOrigin = new URL(req.url).origin;
+  if (configuredOrigin) {
+    try {
+      const url = new URL(configuredOrigin);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return "misconfigured";
+      }
+      expectedOrigin = url.origin;
+    } catch {
+      return "misconfigured";
+    }
+  }
 
   try {
-    const expectedOrigin =
-      process.env.APP_ORIGIN?.trim() || new URL(req.url).origin;
-    return new URL(origin).origin === new URL(expectedOrigin).origin;
+    return new URL(origin).origin === expectedOrigin ? "allowed" : "forbidden";
   } catch {
-    return false;
+    return "forbidden";
   }
 }
 
 export async function POST(req: Request) {
-  if (!isSameOriginRequest(req)) {
+  const originCheck = checkRequestOrigin(req);
+  if (originCheck === "misconfigured") {
+    return NextResponse.json(
+      { error: "APP_ORIGIN must be an absolute HTTP(S) origin." },
+      { status: 500 },
+    );
+  }
+  if (originCheck === "forbidden") {
     return NextResponse.json(
       { error: "Cross-origin requests are not allowed." },
       { status: 403 },

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -13,7 +13,8 @@ function isSameOriginRequest(req: Request) {
   if (origin === null) return true;
 
   try {
-    return new URL(origin).origin === new URL(req.url).origin;
+    const requestHost = req.headers.get("host") ?? new URL(req.url).host;
+    return new URL(origin).host === requestHost.toLowerCase();
   } catch {
     return false;
   }

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -13,7 +13,9 @@ function isSameOriginRequest(req: Request) {
   if (origin === null) return true;
 
   try {
-    return new URL(origin).host === new URL(req.url).host;
+    const expectedOrigin =
+      process.env.APP_ORIGIN?.trim() || new URL(req.url).origin;
+    return new URL(origin).origin === new URL(expectedOrigin).origin;
   } catch {
     return false;
   }

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -13,25 +13,7 @@ function isSameOriginRequest(req: Request) {
   if (origin === null) return true;
 
   try {
-    const forwardedHost = req.headers
-      .get("x-forwarded-host")
-      ?.split(",")[0]
-      ?.trim();
-    const forwardedProto = req.headers
-      .get("x-forwarded-proto")
-      ?.split(",")[0]
-      ?.trim();
-    const requestUrl = new URL(req.url);
-    const expectedHost =
-      forwardedHost || req.headers.get("host") || requestUrl.host;
-    const expectedProtocol = (forwardedProto || requestUrl.protocol)
-      .replace(/:$/, "")
-      .toLowerCase();
-    if (expectedProtocol !== "http" && expectedProtocol !== "https")
-      return false;
-    const expectedOrigin = new URL(`${expectedProtocol}://${expectedHost}`)
-      .origin;
-    return new URL(origin).origin === expectedOrigin;
+    return new URL(origin).origin === new URL(req.url).origin;
   } catch {
     return false;
   }

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -17,9 +17,21 @@ function isSameOriginRequest(req: Request) {
       .get("x-forwarded-host")
       ?.split(",")[0]
       ?.trim();
+    const forwardedProto = req.headers
+      .get("x-forwarded-proto")
+      ?.split(",")[0]
+      ?.trim();
+    const requestUrl = new URL(req.url);
     const expectedHost =
-      forwardedHost || req.headers.get("host") || new URL(req.url).host;
-    return new URL(origin).host === expectedHost;
+      forwardedHost || req.headers.get("host") || requestUrl.host;
+    const expectedProtocol = (forwardedProto || requestUrl.protocol)
+      .replace(/:$/, "")
+      .toLowerCase();
+    if (expectedProtocol !== "http" && expectedProtocol !== "https")
+      return false;
+    const expectedOrigin = new URL(`${expectedProtocol}://${expectedHost}`)
+      .origin;
+    return new URL(origin).origin === expectedOrigin;
   } catch {
     return false;
   }

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -4,10 +4,25 @@ import { NextResponse } from "next/server";
 const TOKEN_TTL = "10m";
 
 function isSameOriginRequest(req: Request) {
-  if (req.headers.get("sec-fetch-site") === "cross-site") return false;
+  const fetchSite = req.headers.get("sec-fetch-site");
+  if (fetchSite !== null) {
+    return fetchSite === "same-origin" || fetchSite === "none";
+  }
 
   const origin = req.headers.get("origin");
-  return origin === null || origin === new URL(req.url).origin;
+  if (origin === null) return true;
+
+  try {
+    const forwardedHost = req.headers
+      .get("x-forwarded-host")
+      ?.split(",")[0]
+      ?.trim();
+    const expectedHost =
+      forwardedHost || req.headers.get("host") || new URL(req.url).host;
+    return new URL(origin).host === expectedHost;
+  } catch {
+    return false;
+  }
 }
 
 export async function POST(req: Request) {

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -5,9 +5,18 @@ const TOKEN_TTL = "10m";
 
 function isAllowedRequestContext(req: Request) {
   const fetchSite = req.headers.get("sec-fetch-site");
-  return (
-    fetchSite === null || fetchSite === "same-origin" || fetchSite === "none"
-  );
+  if (fetchSite !== null) {
+    return fetchSite === "same-origin" || fetchSite === "none";
+  }
+
+  const origin = req.headers.get("origin");
+  if (origin === null) return true;
+
+  try {
+    return new URL(origin).origin === new URL(req.url).origin;
+  } catch {
+    return false;
+  }
 }
 
 export async function POST(req: Request) {

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -1,10 +1,25 @@
 import { AccessToken } from "livekit-server-sdk";
 import { NextResponse } from "next/server";
 
-export async function POST() {
+const TOKEN_TTL = "10m";
+
+function isSameOriginRequest(req: Request) {
+  if (req.headers.get("sec-fetch-site") === "cross-site") return false;
+
+  const origin = req.headers.get("origin");
+  return origin === null || origin === new URL(req.url).origin;
+}
+
+export async function POST(req: Request) {
+  if (!isSameOriginRequest(req)) {
+    return NextResponse.json(
+      { error: "Cross-origin requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
   const apiKey = process.env.LIVEKIT_API_KEY;
   const apiSecret = process.env.LIVEKIT_API_SECRET;
-  const roomName = process.env.LIVEKIT_ROOM_NAME ?? "assistant-room";
 
   if (!apiKey || !apiSecret) {
     return NextResponse.json(
@@ -13,10 +28,13 @@ export async function POST() {
     );
   }
 
-  const participantIdentity = `user-${Date.now()}`;
+  const participantIdentity = `user-${crypto.randomUUID()}`;
+  const roomPrefix = process.env.LIVEKIT_ROOM_NAME?.trim() || "assistant-room";
+  const roomName = `${roomPrefix}-${crypto.randomUUID()}`;
 
   const at = new AccessToken(apiKey, apiSecret, {
     identity: participantIdentity,
+    ttl: TOKEN_TTL,
   });
   at.addGrant({
     roomJoin: true,
@@ -27,5 +45,8 @@ export async function POST() {
 
   const token = await at.toJwt();
 
-  return NextResponse.json({ token });
+  return NextResponse.json(
+    { token },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -3,49 +3,15 @@ import { NextResponse } from "next/server";
 
 const TOKEN_TTL = "10m";
 
-type OriginCheck = "allowed" | "forbidden" | "misconfigured";
-
-function checkRequestOrigin(req: Request): OriginCheck {
+function isAllowedRequestContext(req: Request) {
   const fetchSite = req.headers.get("sec-fetch-site");
-  if (fetchSite !== null) {
-    return fetchSite === "same-origin" || fetchSite === "none"
-      ? "allowed"
-      : "forbidden";
-  }
-
-  const origin = req.headers.get("origin");
-  if (origin === null) return "allowed";
-
-  const configuredOrigin = process.env.APP_ORIGIN?.trim();
-  let expectedOrigin = new URL(req.url).origin;
-  if (configuredOrigin) {
-    try {
-      const url = new URL(configuredOrigin);
-      if (url.protocol !== "http:" && url.protocol !== "https:") {
-        return "misconfigured";
-      }
-      expectedOrigin = url.origin;
-    } catch {
-      return "misconfigured";
-    }
-  }
-
-  try {
-    return new URL(origin).origin === expectedOrigin ? "allowed" : "forbidden";
-  } catch {
-    return "forbidden";
-  }
+  return (
+    fetchSite === null || fetchSite === "same-origin" || fetchSite === "none"
+  );
 }
 
 export async function POST(req: Request) {
-  const originCheck = checkRequestOrigin(req);
-  if (originCheck === "misconfigured") {
-    return NextResponse.json(
-      { error: "APP_ORIGIN must be an absolute HTTP(S) origin." },
-      { status: 500 },
-    );
-  }
-  if (originCheck === "forbidden") {
+  if (!isAllowedRequestContext(req)) {
     return NextResponse.json(
       { error: "Cross-origin requests are not allowed." },
       { status: 403 },

--- a/examples/with-livekit/app/api/livekit-token/route.ts
+++ b/examples/with-livekit/app/api/livekit-token/route.ts
@@ -13,8 +13,7 @@ function isSameOriginRequest(req: Request) {
   if (origin === null) return true;
 
   try {
-    const requestHost = req.headers.get("host") ?? new URL(req.url).host;
-    return new URL(origin).host === requestHost.toLowerCase();
+    return new URL(origin).host === new URL(req.url).host;
   } catch {
     return false;
   }

--- a/examples/with-livekit/app/page.tsx
+++ b/examples/with-livekit/app/page.tsx
@@ -12,6 +12,7 @@ export default function Home() {
         url: process.env.NEXT_PUBLIC_LIVEKIT_URL ?? "ws://localhost:7880",
         token: async () => {
           const res = await fetch("/api/livekit-token", { method: "POST" });
+          if (!res.ok) throw new Error("Failed to create a LiveKit session");
           const { token } = await res.json();
           return token;
         },

--- a/examples/with-livekit/package.json
+++ b/examples/with-livekit/package.json
@@ -33,11 +33,13 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   }
 }

--- a/examples/with-livekit/package.json
+++ b/examples/with-livekit/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "^19.2.5",
     "tw-animate-css": "^1.4.0",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "scripts": {
     "dev": "next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2434,6 +2434,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   examples/with-mcp:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2435,7 +2435,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
+        specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   examples/with-mcp:


### PR DESCRIPTION
## What changed

- reject cross-origin browser requests to the LiveKit token route
- issue ten-minute tokens instead of relying on the longer SDK default
- create a unique room and participant identity for each voice session
- mark token responses as non-cacheable and surface token request failures in the client
- add real JWT regression tests and deployment guidance

## Why

The example previously minted publish and subscribe credentials for one shared room. Anonymous callers could consume voice capacity, and unrelated sessions could receive credentials for the same room.

The example still supports the same voice flow: the configured room name is now a prefix, while the LiveKit agent is dispatched to each isolated room. Origin validation limits browser abuse but production deployments still need application auth and durable rate limiting.

## Reproduction

Before this change, two calls to `/api/livekit-token` produced credentials for the same configured room. The regression test decodes real generated JWTs and verifies a ten-minute lifetime, publish and subscribe grants, and different room names per session.

## Verification

- `pnpm --filter with-livekit test`
- `pnpm exec turbo build --filter=with-livekit...`
- repository lint and changed-file formatting checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.xkN0WLbYXy7aUjBB8D2zUaStc8o1PPVHoOCyXUuoFUG23dMt9MGo6wyFzz8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->