### PR TITLE
fix(elevenlabs): harden Scribe token issuance

### DIFF
--- a/apps/docs/content/docs/guides/dictation.mdx
+++ b/apps/docs/content/docs/guides/dictation.mdx
@@ -291,7 +291,11 @@ npx assistant-ui create my-app -e with-elevenlabs-scribe
 
 Cumulative transcript services should set `disableInputDuringDictation: true` so interim text does not fight the user's keyboard.
 
-The example keeps the ElevenLabs API key server-side and rejects cross-origin browser requests. Before deploying its token endpoint, require your application session and apply a durable rate limit so anonymous callers cannot consume transcription capacity.
+The example keeps the ElevenLabs API key server-side, and its token route accepts a request only when `Sec-Fetch-Site` is `same-origin` or `none`, falling back to comparing the `Origin` header against the request URL for clients that omit Fetch Metadata.
+
+<Callout type="warn">
+  A request-context check is not authentication. Before deploying, require your application session in the token route and apply a durable rate limit, so anonymous callers cannot consume transcription capacity.
+</Callout>
 
 ## Related guides
 

--- a/apps/docs/content/docs/guides/dictation.mdx
+++ b/apps/docs/content/docs/guides/dictation.mdx
@@ -291,6 +291,8 @@ npx assistant-ui create my-app -e with-elevenlabs-scribe
 
 Cumulative transcript services should set `disableInputDuringDictation: true` so interim text does not fight the user's keyboard.
 
+The example keeps the ElevenLabs API key server-side and rejects cross-origin browser requests. Before deploying its token endpoint, require your application session and apply a durable rate limit so anonymous callers cannot consume transcription capacity.
+
 ## Related guides
 
 - [Realtime Voice](/docs/guides/voice): duplex voice sessions (`RealtimeVoiceAdapter`, `createVoiceSession`, voice UI component).

--- a/examples/with-elevenlabs-scribe/.env.example
+++ b/examples/with-elevenlabs-scribe/.env.example
@@ -1,5 +1,2 @@
 # https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=
-
-# Fetch Metadata fallback. Must be an absolute HTTP(S) origin when set.
-APP_ORIGIN=

--- a/examples/with-elevenlabs-scribe/.env.example
+++ b/examples/with-elevenlabs-scribe/.env.example
@@ -1,2 +1,5 @@
 # https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=
+
+# Externally visible app origin. Set this when a reverse proxy rewrites the URL.
+APP_ORIGIN=

--- a/examples/with-elevenlabs-scribe/.env.example
+++ b/examples/with-elevenlabs-scribe/.env.example
@@ -1,5 +1,5 @@
 # https://elevenlabs.io/app/settings/api-keys
 ELEVENLABS_API_KEY=
 
-# Externally visible app origin. Set this when a reverse proxy rewrites the URL.
+# Fetch Metadata fallback. Must be an absolute HTTP(S) origin when set.
 APP_ORIGIN=

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,7 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint rejects browser requests marked cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint rejects browser requests marked cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,6 +26,8 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
+The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+
 ## Features
 
 - ElevenLabs Scribe voice-to-text integration

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,7 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. If a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,7 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, if a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint rejects browser requests marked cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,7 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. If a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint accepts same-origin browser requests so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, if a reverse proxy rewrites the request URL, set `APP_ORIGIN` to the externally visible origin, such as `https://chat.example.com`. Origin checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,7 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint rejects browser requests marked cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint rejects browser requests marked same-site or cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/README.md
+++ b/examples/with-elevenlabs-scribe/README.md
@@ -26,7 +26,9 @@ ELEVENLABS_API_KEY=sk-...
 npm run dev
 ```
 
-The token endpoint rejects browser requests marked same-site or cross-site so the example can create short-lived Scribe sessions without exposing `ELEVENLABS_API_KEY`. For clients without Fetch Metadata, reverse proxies must preserve the public scheme and host in the request URL for the `Origin` fallback. Request-context checks are not user authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
+The token endpoint keeps `ELEVENLABS_API_KEY` server-side and accepts a request only when `Sec-Fetch-Site` is `same-origin` or `none`, so a `same-site` request from another subdomain is rejected as well. For clients that omit Fetch Metadata it falls back to comparing the `Origin` header against the request URL, which behind a reverse proxy needs the public scheme and host preserved there.
+
+A request-context check is not authentication. Before deploying, require your application session in `app/api/scribe-token/route.ts` and apply a durable rate limit.
 
 ## Features
 

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
-function tokenRequest(origin = "https://app.example") {
+function tokenRequest(fetchSite = "same-origin") {
   return new Request("https://app.example/api/scribe-token", {
     method: "POST",
-    headers: { origin },
+    headers: { "sec-fetch-site": fetchSite },
   });
 }
 
@@ -15,13 +15,11 @@ afterEach(() => {
 });
 
 describe("ElevenLabs token route", () => {
-  it("rejects cross-origin browser requests before contacting ElevenLabs", async () => {
+  it("rejects cross-site browser requests before contacting ElevenLabs", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const request = tokenRequest("https://attacker.example");
-    request.headers.set("sec-fetch-site", "cross-site");
-    const response = await POST(request);
+    const response = await POST(tokenRequest("cross-site"));
 
     expect(response.status).toBe(403);
     expect(fetchMock).not.toHaveBeenCalled();

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -60,6 +60,24 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("accepts matching origins when Fetch Metadata is unavailable", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ token: "single-use-token" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new Request("https://app.example/api/scribe-token", {
+        method: "POST",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("fails closed when the API key is missing", async () => {
     vi.stubEnv("ELEVENLABS_API_KEY", "");
     const fetchMock = vi.fn();

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -25,6 +25,21 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects foreign origins when Fetch Metadata is unavailable", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new Request("https://app.example/api/scribe-token", {
+        method: "POST",
+        headers: { origin: "https://attacker.example" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fails closed when the API key is missing", async () => {
     vi.stubEnv("ELEVENLABS_API_KEY", "");
     const fetchMock = vi.fn();

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 function tokenRequest(origin = "https://app.example") {
@@ -7,6 +7,10 @@ function tokenRequest(origin = "https://app.example") {
     headers: { origin },
   });
 }
+
+beforeEach(() => {
+  vi.stubEnv("APP_ORIGIN", "");
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -25,14 +25,25 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects cross-scheme origins when Fetch Metadata is unavailable", async () => {
-    const fetchMock = vi.fn();
+  it("accepts a public origin when a proxy uses an internal URL", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ token: "single-use-token" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const response = await POST(tokenRequest("http://app.example"));
+    const response = await POST(
+      new Request("http://app.internal/api/scribe-token", {
+        method: "POST",
+        headers: {
+          host: "app.example",
+          origin: "https://app.example",
+        },
+      }),
+    );
 
-    expect(response.status).toBe(403);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("rejects requests marked cross-site by the browser", async () => {

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
-function tokenRequest(fetchSite = "same-origin") {
+function tokenRequest(fetchSite: string | null = "same-origin") {
+  const headers = new Headers();
+  if (fetchSite !== null) headers.set("sec-fetch-site", fetchSite);
   return new Request("https://app.example/api/scribe-token", {
     method: "POST",
-    headers: { "sec-fetch-site": fetchSite },
+    headers,
   });
 }
 
@@ -15,14 +17,32 @@ afterEach(() => {
 });
 
 describe("ElevenLabs token route", () => {
-  it("rejects cross-site browser requests before contacting ElevenLabs", async () => {
+  it.each(["same-site", "cross-site"])(
+    "rejects %s browser requests before contacting ElevenLabs",
+    async (fetchSite) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await POST(tokenRequest(fetchSite));
+
+      expect(response.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { label: "missing", fetchSite: null },
+    { label: "none", fetchSite: "none" },
+  ])("allows $label Fetch Metadata context", async ({ fetchSite }) => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
     const fetchMock = vi.fn();
+    fetchMock.mockResolvedValue(Response.json({ token: "single-use-token" }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const response = await POST(tokenRequest("cross-site"));
+    const response = await POST(tokenRequest(fetchSite));
 
-    expect(response.status).toBe(403);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("rejects foreign origins when Fetch Metadata is unavailable", async () => {

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -25,6 +25,16 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects cross-scheme origins when Fetch Metadata is unavailable", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(tokenRequest("http://app.example"));
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects requests marked cross-site by the browser", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+function tokenRequest(origin = "https://app.example") {
+  return new Request("https://app.example/api/scribe-token", {
+    method: "POST",
+    headers: { origin },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("ElevenLabs token route", () => {
+  it("rejects cross-origin browser requests before contacting ElevenLabs", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(tokenRequest("https://attacker.example"));
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the API key is missing", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(500);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a non-cacheable token for same-origin requests", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ token: "single-use-token" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      token: "single-use-token",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(new Headers(init.headers).get("xi-api-key")).toBe("secret-key");
+  });
+
+  it("rejects malformed provider responses", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({})));
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(502);
+  });
+
+  it("rejects non-JSON provider responses", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("invalid")));
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -33,10 +33,10 @@ describe("ElevenLabs token route", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const response = await POST(
-      new Request("http://app.internal/api/scribe-token", {
+      new Request("http://app.example/api/scribe-token", {
         method: "POST",
         headers: {
-          host: "app.example",
+          host: "app.internal",
           origin: "https://app.example",
         },
       }),

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 function tokenRequest(origin = "https://app.example") {
@@ -7,10 +7,6 @@ function tokenRequest(origin = "https://app.example") {
     headers: { origin },
   });
 }
-
-beforeEach(() => {
-  vi.stubEnv("APP_ORIGIN", "");
-});
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -23,68 +19,7 @@ describe("ElevenLabs token route", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const response = await POST(tokenRequest("https://attacker.example"));
-
-    expect(response.status).toBe(403);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects cross-scheme origins without a configured public origin", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const response = await POST(tokenRequest("http://app.example"));
-
-    expect(response.status).toBe(403);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("accepts a configured public origin behind a proxy", async () => {
-    vi.stubEnv("APP_ORIGIN", "https://app.example");
-    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(Response.json({ token: "single-use-token" }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    const response = await POST(
-      new Request("http://app.internal/api/scribe-token", {
-        method: "POST",
-        headers: {
-          host: "app.internal",
-          origin: "https://app.example",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledOnce();
-  });
-
-  it("reports an invalid configured public origin", async () => {
-    vi.stubEnv("APP_ORIGIN", "app.example");
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const response = await POST(
-      new Request("http://app.internal/api/scribe-token", {
-        method: "POST",
-        headers: { origin: "https://app.example" },
-      }),
-    );
-
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      error: "APP_ORIGIN must be an absolute HTTP(S) origin.",
-    });
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects requests marked cross-site by the browser", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const request = tokenRequest();
+    const request = tokenRequest("https://attacker.example");
     request.headers.set("sec-fetch-site", "cross-site");
     const response = await POST(request);
 

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -44,7 +44,7 @@ describe("ElevenLabs token route", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const response = await POST(
-      new Request("http://app.example/api/scribe-token", {
+      new Request("http://app.internal/api/scribe-token", {
         method: "POST",
         headers: {
           host: "app.internal",

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -11,6 +11,7 @@ function tokenRequest(origin = "https://app.example") {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("ElevenLabs token route", () => {
@@ -24,7 +25,20 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects requests marked cross-site by the browser", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = tokenRequest();
+    request.headers.set("sec-fetch-site", "cross-site");
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fails closed when the API key is missing", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "");
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -60,6 +74,37 @@ describe("ElevenLabs token route", () => {
     const response = await POST(tokenRequest());
 
     expect(response.status).toBe(502);
+  });
+
+  it("rejects empty provider tokens", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({ token: " " })),
+    );
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(502);
+  });
+
+  it("logs provider errors without exposing them to the client", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
+    const providerResponse = new Response("invalid API key", { status: 401 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(providerResponse));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unable to create a transcription session.",
+    });
+    expect(providerResponse.bodyUsed).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "ElevenLabs token request failed (401):",
+      "invalid API key",
+    );
   });
 
   it("rejects non-JSON provider responses", async () => {

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -61,6 +61,25 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it("reports an invalid configured public origin", async () => {
+    vi.stubEnv("APP_ORIGIN", "app.example");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(
+      new Request("http://app.internal/api/scribe-token", {
+        method: "POST",
+        headers: { origin: "https://app.example" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "APP_ORIGIN must be an absolute HTTP(S) origin.",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects requests marked cross-site by the browser", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.test.ts
@@ -25,7 +25,18 @@ describe("ElevenLabs token route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("accepts a public origin when a proxy uses an internal URL", async () => {
+  it("rejects cross-scheme origins without a configured public origin", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(tokenRequest("http://app.example"));
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a configured public origin behind a proxy", async () => {
+    vi.stubEnv("APP_ORIGIN", "https://app.example");
     vi.stubEnv("ELEVENLABS_API_KEY", "secret-key");
     const fetchMock = vi
       .fn()

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -2,22 +2,63 @@
  * Generate a single-use token for ElevenLabs Scribe v2 Realtime
  * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
  */
-export async function POST() {
+export async function POST(request: Request) {
+  if (request.headers.get("sec-fetch-site") === "cross-site") {
+    return Response.json(
+      { error: "Cross-origin requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  const origin = request.headers.get("origin");
+  if (origin !== null && origin !== new URL(request.url).origin) {
+    return Response.json(
+      { error: "Cross-origin requests are not allowed." },
+      { status: 403 },
+    );
+  }
+
+  const apiKey = process.env.ELEVENLABS_API_KEY?.trim();
+  if (!apiKey) {
+    return Response.json(
+      { error: "ELEVENLABS_API_KEY must be set." },
+      { status: 500 },
+    );
+  }
+
   const response = await fetch(
     "https://api.elevenlabs.io/v1/single-use-token/realtime_scribe",
     {
       method: "POST",
       headers: {
-        "xi-api-key": process.env.ELEVENLABS_API_KEY!,
+        "xi-api-key": apiKey,
       },
+      signal: request.signal,
     },
   );
 
   if (!response.ok) {
-    const error = await response.text();
-    return new Response(error, { status: response.status });
+    return Response.json(
+      { error: "Unable to create a transcription session." },
+      { status: 502 },
+    );
   }
 
-  const data = await response.json();
-  return Response.json({ token: data.token });
+  const data: unknown = await response.json().catch(() => null);
+  if (
+    !data ||
+    typeof data !== "object" ||
+    !("token" in data) ||
+    typeof data.token !== "string"
+  ) {
+    return Response.json(
+      { error: "ElevenLabs returned an invalid token response." },
+      { status: 502 },
+    );
+  }
+
+  return Response.json(
+    { token: data.token },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -2,16 +2,30 @@
  * Generate a single-use token for ElevenLabs Scribe v2 Realtime
  * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
  */
-export async function POST(request: Request) {
-  if (request.headers.get("sec-fetch-site") === "cross-site") {
-    return Response.json(
-      { error: "Cross-origin requests are not allowed." },
-      { status: 403 },
-    );
+function isSameOriginRequest(request: Request) {
+  const fetchSite = request.headers.get("sec-fetch-site");
+  if (fetchSite !== null) {
+    return fetchSite === "same-origin" || fetchSite === "none";
   }
 
   const origin = request.headers.get("origin");
-  if (origin !== null && origin !== new URL(request.url).origin) {
+  if (origin === null) return true;
+
+  try {
+    const forwardedHost = request.headers
+      .get("x-forwarded-host")
+      ?.split(",")[0]
+      ?.trim();
+    const expectedHost =
+      forwardedHost || request.headers.get("host") || new URL(request.url).host;
+    return new URL(origin).host === expectedHost;
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(request: Request) {
+  if (!isSameOriginRequest(request)) {
     return Response.json(
       { error: "Cross-origin requests are not allowed." },
       { status: 403 },
@@ -38,6 +52,11 @@ export async function POST(request: Request) {
   );
 
   if (!response.ok) {
+    const providerError = await response.text().catch(() => "");
+    console.error(
+      `ElevenLabs token request failed (${response.status}):`,
+      providerError,
+    );
     return Response.json(
       { error: "Unable to create a transcription session." },
       { status: 502 },
@@ -49,7 +68,8 @@ export async function POST(request: Request) {
     !data ||
     typeof data !== "object" ||
     !("token" in data) ||
-    typeof data.token !== "string"
+    typeof data.token !== "string" ||
+    !data.token.trim()
   ) {
     return Response.json(
       { error: "ElevenLabs returned an invalid token response." },
@@ -58,7 +78,7 @@ export async function POST(request: Request) {
   }
 
   return Response.json(
-    { token: data.token },
+    { token: data.token.trim() },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -1,18 +1,34 @@
-function isSameOriginRequest(request: Request) {
+type OriginCheck = "allowed" | "forbidden" | "misconfigured";
+
+function checkRequestOrigin(request: Request): OriginCheck {
   const fetchSite = request.headers.get("sec-fetch-site");
   if (fetchSite !== null) {
-    return fetchSite === "same-origin" || fetchSite === "none";
+    return fetchSite === "same-origin" || fetchSite === "none"
+      ? "allowed"
+      : "forbidden";
   }
 
   const origin = request.headers.get("origin");
-  if (origin === null) return true;
+  if (origin === null) return "allowed";
+
+  const configuredOrigin = process.env.APP_ORIGIN?.trim();
+  let expectedOrigin = new URL(request.url).origin;
+  if (configuredOrigin) {
+    try {
+      const url = new URL(configuredOrigin);
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        return "misconfigured";
+      }
+      expectedOrigin = url.origin;
+    } catch {
+      return "misconfigured";
+    }
+  }
 
   try {
-    const expectedOrigin =
-      process.env.APP_ORIGIN?.trim() || new URL(request.url).origin;
-    return new URL(origin).origin === new URL(expectedOrigin).origin;
+    return new URL(origin).origin === expectedOrigin ? "allowed" : "forbidden";
   } catch {
-    return false;
+    return "forbidden";
   }
 }
 
@@ -21,7 +37,14 @@ function isSameOriginRequest(request: Request) {
  * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
  */
 export async function POST(request: Request) {
-  if (!isSameOriginRequest(request)) {
+  const originCheck = checkRequestOrigin(request);
+  if (originCheck === "misconfigured") {
+    return Response.json(
+      { error: "APP_ORIGIN must be an absolute HTTP(S) origin." },
+      { status: 500 },
+    );
+  }
+  if (originCheck === "forbidden") {
     return Response.json(
       { error: "Cross-origin requests are not allowed." },
       { status: 403 },

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -8,7 +8,9 @@ function isSameOriginRequest(request: Request) {
   if (origin === null) return true;
 
   try {
-    return new URL(origin).host === new URL(request.url).host;
+    const expectedOrigin =
+      process.env.APP_ORIGIN?.trim() || new URL(request.url).origin;
+    return new URL(origin).origin === new URL(expectedOrigin).origin;
   } catch {
     return false;
   }

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -1,35 +1,8 @@
-type OriginCheck = "allowed" | "forbidden" | "misconfigured";
-
-function checkRequestOrigin(request: Request): OriginCheck {
+function isAllowedRequestContext(request: Request) {
   const fetchSite = request.headers.get("sec-fetch-site");
-  if (fetchSite !== null) {
-    return fetchSite === "same-origin" || fetchSite === "none"
-      ? "allowed"
-      : "forbidden";
-  }
-
-  const origin = request.headers.get("origin");
-  if (origin === null) return "allowed";
-
-  const configuredOrigin = process.env.APP_ORIGIN?.trim();
-  let expectedOrigin = new URL(request.url).origin;
-  if (configuredOrigin) {
-    try {
-      const url = new URL(configuredOrigin);
-      if (url.protocol !== "http:" && url.protocol !== "https:") {
-        return "misconfigured";
-      }
-      expectedOrigin = url.origin;
-    } catch {
-      return "misconfigured";
-    }
-  }
-
-  try {
-    return new URL(origin).origin === expectedOrigin ? "allowed" : "forbidden";
-  } catch {
-    return "forbidden";
-  }
+  return (
+    fetchSite === null || fetchSite === "same-origin" || fetchSite === "none"
+  );
 }
 
 /**
@@ -37,14 +10,7 @@ function checkRequestOrigin(request: Request): OriginCheck {
  * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
  */
 export async function POST(request: Request) {
-  const originCheck = checkRequestOrigin(request);
-  if (originCheck === "misconfigured") {
-    return Response.json(
-      { error: "APP_ORIGIN must be an absolute HTTP(S) origin." },
-      { status: 500 },
-    );
-  }
-  if (originCheck === "forbidden") {
+  if (!isAllowedRequestContext(request)) {
     return Response.json(
       { error: "Cross-origin requests are not allowed." },
       { status: 403 },

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -1,8 +1,17 @@
 function isAllowedRequestContext(request: Request) {
   const fetchSite = request.headers.get("sec-fetch-site");
-  return (
-    fetchSite === null || fetchSite === "same-origin" || fetchSite === "none"
-  );
+  if (fetchSite !== null) {
+    return fetchSite === "same-origin" || fetchSite === "none";
+  }
+
+  const origin = request.headers.get("origin");
+  if (origin === null) return true;
+
+  try {
+    return new URL(origin).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -8,9 +8,7 @@ function isSameOriginRequest(request: Request) {
   if (origin === null) return true;
 
   try {
-    const requestHost =
-      request.headers.get("host") ?? new URL(request.url).host;
-    return new URL(origin).host === requestHost.toLowerCase();
+    return new URL(origin).host === new URL(request.url).host;
   } catch {
     return false;
   }

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -16,9 +16,21 @@ function isSameOriginRequest(request: Request) {
       .get("x-forwarded-host")
       ?.split(",")[0]
       ?.trim();
+    const forwardedProto = request.headers
+      .get("x-forwarded-proto")
+      ?.split(",")[0]
+      ?.trim();
+    const requestUrl = new URL(request.url);
     const expectedHost =
-      forwardedHost || request.headers.get("host") || new URL(request.url).host;
-    return new URL(origin).host === expectedHost;
+      forwardedHost || request.headers.get("host") || requestUrl.host;
+    const expectedProtocol = (forwardedProto || requestUrl.protocol)
+      .replace(/:$/, "")
+      .toLowerCase();
+    if (expectedProtocol !== "http" && expectedProtocol !== "https")
+      return false;
+    const expectedOrigin = new URL(`${expectedProtocol}://${expectedHost}`)
+      .origin;
+    return new URL(origin).origin === expectedOrigin;
   } catch {
     return false;
   }

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -1,7 +1,3 @@
-/**
- * Generate a single-use token for ElevenLabs Scribe v2 Realtime
- * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
- */
 function isSameOriginRequest(request: Request) {
   const fetchSite = request.headers.get("sec-fetch-site");
   if (fetchSite !== null) {
@@ -12,30 +8,16 @@ function isSameOriginRequest(request: Request) {
   if (origin === null) return true;
 
   try {
-    const forwardedHost = request.headers
-      .get("x-forwarded-host")
-      ?.split(",")[0]
-      ?.trim();
-    const forwardedProto = request.headers
-      .get("x-forwarded-proto")
-      ?.split(",")[0]
-      ?.trim();
-    const requestUrl = new URL(request.url);
-    const expectedHost =
-      forwardedHost || request.headers.get("host") || requestUrl.host;
-    const expectedProtocol = (forwardedProto || requestUrl.protocol)
-      .replace(/:$/, "")
-      .toLowerCase();
-    if (expectedProtocol !== "http" && expectedProtocol !== "https")
-      return false;
-    const expectedOrigin = new URL(`${expectedProtocol}://${expectedHost}`)
-      .origin;
-    return new URL(origin).origin === expectedOrigin;
+    return new URL(origin).origin === new URL(request.url).origin;
   } catch {
     return false;
   }
 }
 
+/**
+ * Generate a single-use token for ElevenLabs Scribe v2 Realtime
+ * @see https://elevenlabs.io/docs/cookbooks/speech-to-text/streaming
+ */
 export async function POST(request: Request) {
   if (!isSameOriginRequest(request)) {
     return Response.json(

--- a/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
+++ b/examples/with-elevenlabs-scribe/app/api/scribe-token/route.ts
@@ -8,7 +8,9 @@ function isSameOriginRequest(request: Request) {
   if (origin === null) return true;
 
   try {
-    return new URL(origin).origin === new URL(request.url).origin;
+    const requestHost =
+      request.headers.get("host") ?? new URL(request.url).host;
+    return new URL(origin).host === requestHost.toLowerCase();
   } catch {
     return false;
   }

--- a/examples/with-elevenlabs-scribe/package.json
+++ b/examples/with-elevenlabs-scribe/package.json
@@ -33,7 +33,7 @@
     "@types/react-dom": "^19.2.5",
     "tw-animate-css": "^1.4.0",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "scripts": {
     "dev": "next dev",

--- a/examples/with-elevenlabs-scribe/package.json
+++ b/examples/with-elevenlabs-scribe/package.json
@@ -32,11 +32,13 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1532,7 +1532,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vitest:
-        specifier: ^4.1.10
+        specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   examples/with-eve:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1531,6 +1531,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   examples/with-eve:
     dependencies:


### PR DESCRIPTION
## What changed

- reject cross-origin browser requests before contacting ElevenLabs
- fail closed when the server API key is missing
- validate the provider token response and handle invalid JSON
- avoid returning provider error bodies to clients
- mark issued token responses as non-cacheable
- add focused regression tests and deployment guidance

## Why

The example token route could be called from another website and would mint a Scribe session using the deployment API key. It also forwarded provider error bodies and trusted the response shape without validation.

Same-origin use remains unchanged. Origin validation limits browser abuse but is not user authentication, so production deployments still need application auth and durable rate limiting.

## Reproduction

Before this change, a POST with a foreign `Origin` still contacted the ElevenLabs token API. The new tests verify that request is rejected before fetch and cover missing credentials, malformed provider responses, and the successful token path.

## Verification

- `pnpm --filter with-elevenlabs-scribe test`
- `pnpm exec turbo build --filter=with-elevenlabs-scribe...`
- repository lint and changed-file formatting checks

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2-6WGSZh5j18Wbd2UI8-uKzyYhzIJJGcjBLG_zSlRjAeKKPuxPXq1tIbYCQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->