### PR TITLE
fix(docs): polish code surfaces

### DIFF
--- a/apps/docs/app/(home)/design/page.tsx
+++ b/apps/docs/app/(home)/design/page.tsx
@@ -76,7 +76,7 @@ export default function DesignPage() {
         <Register
           index={1}
           label="Shape"
-          claim="Every shape question is answered by asking what the thing is. Ask it in order, and only the third answer reaches for a radius."
+          claim="Every shape question is answered by asking what the thing is. The page stays square, printed matter takes the smallest rounding, and only what you press reaches for the rest of the scale."
         >
           <div className="mt-8 grid gap-6 sm:grid-cols-3">
             <Plate caption="fig. 01 · the page itself">
@@ -85,7 +85,7 @@ export default function DesignPage() {
               </span>
             </Plate>
             <Plate caption="fig. 02 · matter printed on it">
-              <span className="bg-foreground/[0.04] flex h-16 w-24 flex-col justify-center gap-1.5 px-4">
+              <span className="bg-foreground/[0.04] rounded-document flex h-16 w-24 flex-col justify-center gap-1.5 px-4">
                 <span className="bg-foreground/30 block h-px w-14" />
                 <span className="bg-foreground/30 block h-px w-9" />
                 <span className="bg-foreground/30 block h-px w-12" />

--- a/apps/docs/app/(home)/design/page.tsx
+++ b/apps/docs/app/(home)/design/page.tsx
@@ -103,9 +103,9 @@ export default function DesignPage() {
               note="The page itself, and every full-bleed band on it: header, footer, section rules."
             />
             <Row
-              sample={<Corner radius="0" />}
+              sample={<Corner radius="0.375rem" />}
               name="--radius-document"
-              value="0"
+              value="6px"
               note="Anything printed on the page: a code sheet, a table, a figure plate, a specimen frame. Declared so a parent radius cannot leak in."
             />
             <Row

--- a/apps/docs/app/(home)/pricing/pricing-plan-card.tsx
+++ b/apps/docs/app/(home)/pricing/pricing-plan-card.tsx
@@ -20,7 +20,7 @@ export function PricingPlanCard({ plan }: { plan: PricingPlan }) {
   return (
     <div
       className={cn(
-        "relative flex flex-col rounded-(--radius-document) border-t pt-6",
+        "rounded-document relative flex flex-col border-t pt-6",
         plan.highlighted ? "border-foreground" : "border-foreground/10",
       )}
     >

--- a/apps/docs/components/demo/utils/canvas.ts
+++ b/apps/docs/components/demo/utils/canvas.ts
@@ -1,4 +1,4 @@
 export const demoFrameClass =
-  "border-foreground/10 flex items-center justify-center overflow-hidden rounded-(--radius-document) border";
+  "border-foreground/10 flex items-center justify-center overflow-hidden rounded-document border";
 
 export const demoCanvasClass = `${demoFrameClass} p-5 md:p-6`;

--- a/apps/docs/components/pages/design/design-gallery.tsx
+++ b/apps/docs/components/pages/design/design-gallery.tsx
@@ -61,7 +61,7 @@ function DesignCard({
         <Link
           href={`/design/components/${component.slug}`}
           aria-label={`Open ${component.name}`}
-          className="text-muted-foreground hover:text-foreground grid size-6 place-items-center rounded-(--radius-sm) opacity-0 transition-[color,opacity] group-hover:opacity-100 focus-visible:opacity-100"
+          className="text-muted-foreground hover:text-foreground grid size-6 place-items-center rounded-sm opacity-0 transition-[color,opacity] group-hover:opacity-100 focus-visible:opacity-100"
         >
           <ArrowUpRightIcon className="size-3.5" />
         </Link>

--- a/apps/docs/components/pages/design/design-rail.tsx
+++ b/apps/docs/components/pages/design/design-rail.tsx
@@ -19,7 +19,7 @@ export function DesignRail({ activeSlug }: { activeSlug?: string }): ReactNode {
                   href={`/design/components/${component.slug}`}
                   aria-current={active ? "page" : undefined}
                   className={cn(
-                    "flex h-7 items-center rounded-(--radius-control) px-2 text-[13px] transition-colors",
+                    "rounded-control flex h-7 items-center px-2 text-[13px] transition-colors",
                     active
                       ? "bg-foreground/[0.06] text-foreground"
                       : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",

--- a/apps/docs/components/pages/design/instruments.tsx
+++ b/apps/docs/components/pages/design/instruments.tsx
@@ -33,7 +33,7 @@ export function TintKnob() {
         value={tint}
         aria-label="Tint hue"
         onChange={(event) => apply(Number(event.target.value))}
-        className="bg-border [&::-moz-range-thumb]:border-foreground/40 [&::-moz-range-thumb]:bg-background [&::-webkit-slider-thumb]:border-foreground/40 [&::-webkit-slider-thumb]:bg-background h-px w-56 cursor-ew-resize appearance-none rounded-(--radius-capsule) outline-none [&::-moz-range-thumb]:size-3.5 [&::-moz-range-thumb]:rounded-(--radius-capsule) [&::-moz-range-thumb]:border [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-(--radius-capsule) [&::-webkit-slider-thumb]:border"
+        className="bg-border [&::-moz-range-thumb]:border-foreground/40 [&::-moz-range-thumb]:bg-background [&::-webkit-slider-thumb]:border-foreground/40 [&::-webkit-slider-thumb]:bg-background rounded-capsule [&::-moz-range-thumb]:rounded-capsule [&::-webkit-slider-thumb]:rounded-capsule h-px w-56 cursor-ew-resize appearance-none outline-none [&::-moz-range-thumb]:size-3.5 [&::-moz-range-thumb]:border [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:border"
       />
       <span className="text-muted-foreground w-[3ch] text-right font-mono text-[11px] tabular-nums">
         {tint}

--- a/apps/docs/components/pages/design/specimens.radix.tsx
+++ b/apps/docs/components/pages/design/specimens.radix.tsx
@@ -505,7 +505,7 @@ export function SkeletonSpecimen(): ReactNode {
 export function SkeletonCardSpecimen(): ReactNode {
   return (
     <SampleFrame className={frameClass}>
-      <div className="border-foreground/10 flex w-full max-w-72 flex-col gap-3 rounded-(--radius-surface) border p-4">
+      <div className="border-foreground/10 rounded-surface flex w-full max-w-72 flex-col gap-3 border p-4">
         <Skeleton className="h-24 w-full" />
         <Skeleton className="h-4 w-4/5" />
         <Skeleton className="h-4 w-3/5" />

--- a/apps/docs/components/pages/design/specimens.tsx
+++ b/apps/docs/components/pages/design/specimens.tsx
@@ -711,7 +711,7 @@ export function AvatarBadgeSpecimen(): ReactNode {
 export function SkeletonCardSpecimen(): ReactNode {
   return (
     <SampleFrame className={frameClass}>
-      <div className="border-foreground/10 flex w-full max-w-72 flex-col gap-3 rounded-(--radius-surface) border p-4">
+      <div className="border-foreground/10 rounded-surface flex w-full max-w-72 flex-col gap-3 border p-4">
         <Skeleton className="h-24 w-full" />
         <Skeleton className="h-4 w-4/5" />
         <Skeleton className="h-4 w-3/5" />

--- a/apps/docs/components/pages/docs/assistant/ball.tsx
+++ b/apps/docs/components/pages/docs/assistant/ball.tsx
@@ -32,7 +32,7 @@ export function AskAiBall() {
         type="button"
         onClick={toggle}
         aria-label="Ask AI"
-        className="animate-in fade-in-0 zoom-in-75 border-border/60 bg-background hover:border-border grid size-12 place-items-center rounded-(--radius-capsule) border transition-colors duration-300"
+        className="animate-in fade-in-0 zoom-in-75 border-border/60 bg-background hover:border-border rounded-capsule grid size-12 place-items-center border transition-colors duration-300"
       >
         <span
           aria-hidden
@@ -48,7 +48,7 @@ export function AskAiBall() {
           setArmed(false);
         }}
         aria-label="Dismiss Ask AI"
-        className="border-border/60 bg-background text-muted-foreground hover:text-foreground absolute -top-1.5 -right-1.5 grid size-5 place-items-center rounded-(--radius-capsule) border opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
+        className="border-border/60 bg-background text-muted-foreground hover:text-foreground rounded-capsule absolute -top-1.5 -right-1.5 grid size-5 place-items-center border opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
       >
         <XIcon className="size-3" />
       </button>

--- a/apps/docs/components/pages/docs/assistant/composer.tsx
+++ b/apps/docs/components/pages/docs/assistant/composer.tsx
@@ -130,7 +130,7 @@ export function AssistantComposer({
       onSubmit={handleSubmit}
       className={cn("pb-2.5", className)}
     >
-      <div className="border-foreground/10 bg-muted/30 focus-within:border-foreground/25 rounded-(--radius-thread) border transition-colors">
+      <div className="border-foreground/10 bg-muted/30 focus-within:border-foreground/25 rounded-thread border transition-colors">
         <ComposerPrimitive.Input asChild>
           <textarea
             placeholder={placeholder}

--- a/apps/docs/components/pages/docs/assistant/messages.tsx
+++ b/apps/docs/components/pages/docs/assistant/messages.tsx
@@ -23,7 +23,7 @@ import {
 export function UserMessage(): ReactNode {
   return (
     <MessagePrimitive.Root className="flex justify-end py-2" data-role="user">
-      <div className="bg-muted max-w-[85%] rounded-(--radius-thread) px-3.5 py-2 text-sm empty:hidden">
+      <div className="bg-muted rounded-thread max-w-[85%] px-3.5 py-2 text-sm empty:hidden">
         <MessagePrimitive.Parts />
       </div>
     </MessagePrimitive.Root>

--- a/apps/docs/components/pages/docs/assistant/thread.tsx
+++ b/apps/docs/components/pages/docs/assistant/thread.tsx
@@ -168,7 +168,7 @@ function PanelHeader(): React.ReactNode {
             aui.threads.switchToNewThread();
           }}
           aria-label="New chat"
-          className="text-muted-foreground hover:text-foreground flex h-7 items-center rounded-(--radius-control) px-2 font-mono text-[11px] font-medium tracking-wide uppercase transition-colors"
+          className="text-muted-foreground hover:text-foreground rounded-control flex h-7 items-center px-2 font-mono text-[11px] font-medium tracking-wide uppercase transition-colors"
         >
           new
         </button>
@@ -182,7 +182,7 @@ function PanelHeader(): React.ReactNode {
             setOpen(false);
           }}
           aria-label="Close chat"
-          className="text-muted-foreground hover:text-foreground flex size-7 items-center justify-center rounded-(--radius-control) transition-colors"
+          className="text-muted-foreground hover:text-foreground rounded-control flex size-7 items-center justify-center transition-colors"
         >
           <XIcon className="size-3.5" />
         </button>

--- a/apps/docs/components/pages/docs/assistant/window.tsx
+++ b/apps/docs/components/pages/docs/assistant/window.tsx
@@ -44,7 +44,7 @@ export function AskAiWindow() {
   if (!open) return null;
 
   return (
-    <div className="animate-in fade-in-0 slide-in-from-bottom-3 bg-popover md:ring-foreground/10 fixed inset-0 z-50 flex flex-col overflow-hidden duration-300 ease-out motion-reduce:animate-none md:inset-auto md:right-5 md:bottom-5 md:h-[min(42rem,calc(100vh-6rem))] md:w-[min(30rem,calc(100vw-2.5rem))] md:rounded-(--radius-xl) md:shadow-[0_16px_48px_-24px_rgb(0_0_0/0.25)] md:ring-1 dark:md:shadow-[0_16px_48px_-24px_rgb(0_0_0/0.6)]">
+    <div className="animate-in fade-in-0 slide-in-from-bottom-3 bg-popover md:ring-foreground/10 fixed inset-0 z-50 flex flex-col overflow-hidden duration-300 ease-out motion-reduce:animate-none md:inset-auto md:right-5 md:bottom-5 md:h-[min(42rem,calc(100vh-6rem))] md:w-[min(30rem,calc(100vw-2.5rem))] md:rounded-xl md:shadow-[0_16px_48px_-24px_rgb(0_0_0/0.25)] md:ring-1 dark:md:shadow-[0_16px_48px_-24px_rgb(0_0_0/0.6)]">
       <div className="min-h-0 flex-1">
         <AssistantThread />
       </div>

--- a/apps/docs/components/pages/docs/preview-code.tsx
+++ b/apps/docs/components/pages/docs/preview-code.tsx
@@ -77,7 +77,7 @@ export function PreviewCodeClient({
       {tab === "preview" ? (
         <div
           className={cn(
-            "preview-code-preview border-foreground/10 flex items-center justify-center rounded-(--radius-document) border p-6",
+            "preview-code-preview border-foreground/10 rounded-document flex items-center justify-center border p-6",
             className,
           )}
         >

--- a/apps/docs/components/pages/elements/demo-variants.tsx
+++ b/apps/docs/components/pages/elements/demo-variants.tsx
@@ -38,7 +38,7 @@ export function DemoVariants({
               aria-pressed={selected}
               onClick={() => setKey(variant.key)}
               className={cn(
-                "h-6 rounded-(--radius-sm) px-2 font-mono text-[11px] font-medium tracking-wide uppercase transition-colors motion-reduce:transition-none",
+                "h-6 rounded-sm px-2 font-mono text-[11px] font-medium tracking-wide uppercase transition-colors motion-reduce:transition-none",
                 selected
                   ? "bg-foreground/[0.06] text-foreground"
                   : "text-muted-foreground hover:text-foreground",

--- a/apps/docs/components/pages/elements/element-pager.tsx
+++ b/apps/docs/components/pages/elements/element-pager.tsx
@@ -19,8 +19,7 @@ import {
   getElement,
 } from "./registry";
 
-const stepClass =
-  "grid size-7 place-items-center rounded-(--radius-sm) transition-colors";
+const stepClass = "grid size-7 place-items-center rounded-sm transition-colors";
 
 export function ElementPager({ slug }: { slug: string }) {
   const router = useRouter();
@@ -77,7 +76,7 @@ export function ElementPager({ slug }: { slug: string }) {
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger
           aria-label="Jump to element"
-          className="text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground flex h-7 items-center rounded-(--radius-sm) px-1.5 font-mono text-[11px] tabular-nums transition-colors"
+          className="text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground flex h-7 items-center rounded-sm px-1.5 font-mono text-[11px] tabular-nums transition-colors"
         >
           {String(element.index).padStart(2, "0")}
           <span className="text-foreground/30 px-1">/</span>
@@ -114,7 +113,7 @@ export function ElementPager({ slug }: { slug: string }) {
                         aria-current={active ? "page" : undefined}
                         onClick={() => handleOpenChange(false)}
                         className={cn(
-                          "flex h-7 items-center rounded-(--radius-control) px-2 text-[13px] transition-colors",
+                          "rounded-control flex h-7 items-center px-2 text-[13px] transition-colors",
                           active
                             ? "bg-foreground/[0.06] text-foreground"
                             : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",

--- a/apps/docs/components/pages/elements/elements-sidebar.tsx
+++ b/apps/docs/components/pages/elements/elements-sidebar.tsx
@@ -71,7 +71,7 @@ export function ElementsSidebar() {
                       scroll={false}
                       aria-current={active ? "page" : undefined}
                       className={cn(
-                        "flex h-7 items-center rounded-(--radius-control) px-2 text-[13px] transition-colors",
+                        "rounded-control flex h-7 items-center px-2 text-[13px] transition-colors",
                         active
                           ? "bg-foreground/[0.06] text-foreground"
                           : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",

--- a/apps/docs/components/pages/elements/filter-input.tsx
+++ b/apps/docs/components/pages/elements/filter-input.tsx
@@ -50,7 +50,7 @@ export function FilterInput({
             onValueChange("");
             inputRef.current?.focus();
           }}
-          className="text-muted-foreground hover:text-foreground absolute end-1.5 top-1/2 grid size-5 -translate-y-1/2 place-items-center rounded-(--radius-sm) transition-colors"
+          className="text-muted-foreground hover:text-foreground absolute end-1.5 top-1/2 grid size-5 -translate-y-1/2 place-items-center rounded-sm transition-colors"
         >
           <XIcon className="size-3.5" />
         </button>

--- a/apps/docs/components/pages/elements/vocab-code-tabs.tsx
+++ b/apps/docs/components/pages/elements/vocab-code-tabs.tsx
@@ -40,7 +40,7 @@ export function VocabCodeTabs({
                 aria-pressed={selected}
                 onClick={() => setTab(entry.key)}
                 className={cn(
-                  "h-6 rounded-(--radius-sm) px-2 transition-colors motion-reduce:transition-none",
+                  "h-6 rounded-sm px-2 transition-colors motion-reduce:transition-none",
                   selected
                     ? "bg-foreground/[0.06] text-foreground"
                     : "hover:text-foreground",

--- a/apps/docs/components/pages/elements/vocabulary-toc.tsx
+++ b/apps/docs/components/pages/elements/vocabulary-toc.tsx
@@ -74,7 +74,7 @@ export function VocabularyToc({
                       href={`#${name}`}
                       aria-current={active ? "location" : undefined}
                       className={cn(
-                        "flex h-7 items-center rounded-(--radius-control) px-2 text-[13px] transition-colors",
+                        "rounded-control flex h-7 items-center px-2 text-[13px] transition-colors",
                         active
                           ? "bg-foreground/[0.06] text-foreground"
                           : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",

--- a/apps/docs/components/pages/examples/base.tsx
+++ b/apps/docs/components/pages/examples/base.tsx
@@ -803,7 +803,7 @@ const UserMessage: FC = () => {
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content peer bg-muted text-foreground rounded-(--radius-thread) px-4 py-2 wrap-break-word empty:hidden">
+        <div className="aui-user-message-content peer bg-muted text-foreground rounded-thread px-4 py-2 wrap-break-word empty:hidden">
           <MessagePrimitive.Quote>
             {(quote) => <QuoteBlock {...quote} />}
           </MessagePrimitive.Quote>

--- a/apps/docs/components/pages/home/hero.tsx
+++ b/apps/docs/components/pages/home/hero.tsx
@@ -93,7 +93,7 @@ export function Hero({
           >
             <GitHubStars stars={stars} />
           </a>
-          <span className="bg-muted-foreground/20 hidden size-1 rounded-(--radius-capsule) sm:block" />
+          <span className="bg-muted-foreground/20 rounded-capsule hidden size-1 sm:block" />
           <a
             href="https://www.npmjs.com/package/@assistant-ui/react"
             target="_blank"
@@ -102,7 +102,7 @@ export function Hero({
           >
             <NpmDownloads downloads={downloads} />
           </a>
-          <span className="bg-muted-foreground/20 hidden size-1 rounded-(--radius-capsule) sm:block" />
+          <span className="bg-muted-foreground/20 rounded-capsule hidden size-1 sm:block" />
           <a
             href="https://www.ycombinator.com/companies/assistant-ui"
             target="_blank"

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -80,7 +80,7 @@ export function HomeThread({
             type="button"
             onClick={onToggleExpanded}
             aria-label={expanded ? "Exit full screen" : "Full screen"}
-            className="text-muted-foreground hover:text-foreground ml-auto grid size-7 shrink-0 place-items-center rounded-(--radius-control) transition-colors"
+            className="text-muted-foreground hover:text-foreground rounded-control ml-auto grid size-7 shrink-0 place-items-center transition-colors"
           >
             {expanded ? (
               <Minimize2Icon className="size-3.5" />
@@ -95,7 +95,7 @@ export function HomeThread({
           <ThreadListPrimitive.New asChild>
             <button
               type="button"
-              className="border-foreground/10 bg-background hover:border-foreground/25 flex h-8 w-full shrink-0 items-center gap-2 rounded-(--radius-control) border px-2.5 text-[13px] transition-colors"
+              className="border-foreground/10 bg-background hover:border-foreground/25 rounded-control flex h-8 w-full shrink-0 items-center gap-2 border px-2.5 text-[13px] transition-colors"
             >
               <PlusIcon className="size-3.5" />
               New thread
@@ -175,7 +175,7 @@ function SidebarThreadRow(): ReactNode {
   }, [isRenaming]);
 
   return (
-    <ThreadListItemPrimitive.Root className="group data-active:bg-foreground/[0.06] hover:bg-foreground/[0.04] has-data-[state=open]:bg-foreground/[0.04] relative flex h-8 shrink-0 items-center rounded-(--radius-control) transition-colors">
+    <ThreadListItemPrimitive.Root className="group data-active:bg-foreground/[0.06] hover:bg-foreground/[0.04] has-data-[state=open]:bg-foreground/[0.04] rounded-control relative flex h-8 shrink-0 items-center transition-colors">
       {isRenaming ? (
         <SidebarThreadRename
           onDone={(restoreFocus) => {
@@ -263,7 +263,7 @@ function SidebarThreadRename({
 }
 
 const threadMenuItemClass =
-  "hover:bg-muted focus:bg-muted flex cursor-pointer items-center gap-2 rounded-(--radius-sm) px-2 py-1.5 text-[13px] outline-none select-none";
+  "hover:bg-muted focus:bg-muted flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] outline-none select-none";
 
 function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
   return (
@@ -272,7 +272,7 @@ function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
         <button
           type="button"
           aria-label="Thread actions"
-          className="text-muted-foreground hover:text-foreground absolute end-1 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-(--radius-sm) opacity-0 transition-colors group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
+          className="text-muted-foreground hover:text-foreground absolute end-1 top-1/2 grid size-6 -translate-y-1/2 place-items-center rounded-sm opacity-0 transition-colors group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
         >
           <MoreHorizontalIcon className="size-3.5" />
         </button>
@@ -281,7 +281,7 @@ function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
         side="right"
         align="start"
         sideOffset={6}
-        className="bg-popover text-popover-foreground border-foreground/10 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out z-[70] min-w-28 overflow-hidden rounded-(--radius-surface) border p-1"
+        className="bg-popover text-popover-foreground border-foreground/10 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out rounded-surface z-[70] min-w-28 overflow-hidden border p-1"
       >
         <ThreadListItemMorePrimitive.Item
           className={threadMenuItemClass}
@@ -340,13 +340,13 @@ function SpecimenThread(): ReactNode {
             className="animate-in fade-in fill-mode-both mx-auto flex w-full max-w-(--thread-max-width) flex-col gap-y-6 [animation-delay:150ms] [animation-duration:200ms]"
           >
             <span className="sr-only">Loading conversation</span>
-            <Skeleton className="ml-auto h-9 w-2/5 rounded-(--radius-thread) motion-reduce:animate-none" />
+            <Skeleton className="rounded-thread ml-auto h-9 w-2/5 motion-reduce:animate-none" />
             <div className="flex flex-col gap-y-2">
               <Skeleton className="h-4 w-11/12 motion-reduce:animate-none" />
               <Skeleton className="h-4 w-4/5 motion-reduce:animate-none" />
               <Skeleton className="h-4 w-3/5 motion-reduce:animate-none" />
             </div>
-            <Skeleton className="ml-auto h-9 w-1/3 rounded-(--radius-thread) motion-reduce:animate-none" />
+            <Skeleton className="rounded-thread ml-auto h-9 w-1/3 motion-reduce:animate-none" />
             <div className="flex flex-col gap-y-2">
               <Skeleton className="h-4 w-10/12 motion-reduce:animate-none" />
               <Skeleton className="h-4 w-2/3 motion-reduce:animate-none" />
@@ -375,7 +375,7 @@ function SpecimenThread(): ReactNode {
             <button
               type="button"
               aria-label="Scroll to bottom"
-              className="border-foreground/10 bg-background hover:border-foreground/25 absolute -top-11 z-10 grid size-8 place-items-center self-center rounded-(--radius-capsule) border transition-colors disabled:invisible"
+              className="border-foreground/10 bg-background hover:border-foreground/25 rounded-capsule absolute -top-11 z-10 grid size-8 place-items-center self-center border transition-colors disabled:invisible"
             >
               <ArrowDownIcon className="size-4" />
             </button>
@@ -419,7 +419,7 @@ function SpecimenSuggestions(): ReactNode {
           key={suggestion.prompt}
           prompt={suggestion.prompt}
           send
-          className="border-foreground/10 bg-background text-muted-foreground hover:border-foreground/25 hover:text-foreground h-8 rounded-(--radius-control) border px-3 text-[13px] transition-colors"
+          className="border-foreground/10 bg-background text-muted-foreground hover:border-foreground/25 hover:text-foreground rounded-control h-8 border px-3 text-[13px] transition-colors"
         >
           {suggestion.label}
         </ThreadPrimitive.Suggestion>
@@ -431,7 +431,7 @@ function SpecimenSuggestions(): ReactNode {
 function SpecimenComposer(): ReactNode {
   return (
     <ComposerPrimitive.Root className="w-full">
-      <div className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 flex flex-col rounded-(--radius-thread) border transition-colors">
+      <div className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 rounded-thread flex flex-col border transition-colors">
         <div className="has-[.aui-attachment-root]:px-3 has-[.aui-attachment-root]:pt-3">
           <ComposerAttachments />
         </div>
@@ -447,7 +447,7 @@ function SpecimenComposer(): ReactNode {
             <button
               type="button"
               aria-label="Add attachment"
-              className="text-muted-foreground hover:text-foreground grid size-8 place-items-center rounded-(--radius-control) transition-colors"
+              className="text-muted-foreground hover:text-foreground rounded-control grid size-8 place-items-center transition-colors"
             >
               <PlusIcon className="size-4.5" />
             </button>
@@ -489,7 +489,7 @@ function SpecimenUserMessage(): ReactNode {
       <div className="w-full has-[.aui-attachment-root]:mb-2">
         <UserMessageAttachments />
       </div>
-      <div className="bg-muted max-w-[80%] rounded-(--radius-thread) px-4 py-2 text-[15px] wrap-break-word empty:hidden">
+      <div className="bg-muted rounded-thread max-w-[80%] px-4 py-2 text-[15px] wrap-break-word empty:hidden">
         <MessagePrimitive.Parts />
       </div>
     </MessagePrimitive.Root>

--- a/apps/docs/components/pages/home/library-body.tsx
+++ b/apps/docs/components/pages/home/library-body.tsx
@@ -92,7 +92,7 @@ export function LibraryBody({
           </p>
         </div>
 
-        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-w-0 flex-col gap-7 px-6 py-8 md:px-10 md:py-10">
+        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-w-0 flex-col gap-7 rounded-(--radius-sm) px-6 py-8 md:px-10 md:py-10">
           <div className="flex flex-wrap items-center gap-3">
             <p className="font-mono text-[1.125rem] tracking-[-0.01em] break-all [font-variant-ligatures:none] md:text-[1.375rem]">
               npx assistant-ui init

--- a/apps/docs/components/pages/home/library-body.tsx
+++ b/apps/docs/components/pages/home/library-body.tsx
@@ -92,7 +92,7 @@ export function LibraryBody({
           </p>
         </div>
 
-        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-w-0 flex-col gap-7 rounded-(--radius-sm) px-6 py-8 md:px-10 md:py-10">
+        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] rounded-document flex min-w-0 flex-col gap-7 px-6 py-8 md:px-10 md:py-10">
           <div className="flex flex-wrap items-center gap-3">
             <p className="font-mono text-[1.125rem] tracking-[-0.01em] break-all [font-variant-ligatures:none] md:text-[1.375rem]">
               npx assistant-ui init

--- a/apps/docs/components/pages/home/library-showcase.tsx
+++ b/apps/docs/components/pages/home/library-showcase.tsx
@@ -233,7 +233,7 @@ function Stage() {
       </ol>
 
       <div className="flex min-w-0 flex-col gap-3">
-        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-h-[340px] flex-1 items-center justify-center overflow-hidden px-6 py-10 md:min-h-[380px] md:px-12">
+        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-h-[340px] flex-1 items-center justify-center overflow-hidden rounded-(--radius-sm) px-6 py-10 md:min-h-[380px] md:px-12">
           {cycle.visible ? (
             <div
               key={`${cycle.index}-${cycle.epoch}`}
@@ -329,7 +329,7 @@ function SetupPanel({ tabs }: { tabs: SetupTab[] }) {
         </div>
       </div>
 
-      <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] relative min-h-[22.5rem] overflow-hidden">
+      <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] relative min-h-[22.5rem] overflow-hidden rounded-(--radius-sm)">
         {brand && activeTab ? (
           <div
             key={activeTab.id}

--- a/apps/docs/components/pages/home/library-showcase.tsx
+++ b/apps/docs/components/pages/home/library-showcase.tsx
@@ -233,7 +233,7 @@ function Stage() {
       </ol>
 
       <div className="flex min-w-0 flex-col gap-3">
-        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex min-h-[340px] flex-1 items-center justify-center overflow-hidden rounded-(--radius-sm) px-6 py-10 md:min-h-[380px] md:px-12">
+        <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] rounded-document flex min-h-[340px] flex-1 items-center justify-center overflow-hidden px-6 py-10 md:min-h-[380px] md:px-12">
           {cycle.visible ? (
             <div
               key={`${cycle.index}-${cycle.epoch}`}
@@ -329,7 +329,7 @@ function SetupPanel({ tabs }: { tabs: SetupTab[] }) {
         </div>
       </div>
 
-      <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] relative min-h-[22.5rem] overflow-hidden rounded-(--radius-sm)">
+      <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] rounded-document relative min-h-[22.5rem] overflow-hidden">
         {brand && activeTab ? (
           <div
             key={activeTab.id}

--- a/apps/docs/components/pages/home/primitives-anatomy.tsx
+++ b/apps/docs/components/pages/home/primitives-anatomy.tsx
@@ -119,7 +119,7 @@ export function PrimitivesAnatomy() {
 
   return (
     <div
-      className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex flex-col gap-6 px-6 py-8 md:px-10 md:py-10"
+      className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex flex-col gap-6 rounded-(--radius-sm) px-6 py-8 md:px-10 md:py-10"
       onMouseEnter={() => setHeld(true)}
       onMouseLeave={() => setHeld(false)}
     >

--- a/apps/docs/components/pages/home/primitives-anatomy.tsx
+++ b/apps/docs/components/pages/home/primitives-anatomy.tsx
@@ -119,7 +119,7 @@ export function PrimitivesAnatomy() {
 
   return (
     <div
-      className="bg-foreground/[0.025] dark:bg-foreground/[0.04] flex flex-col gap-6 rounded-(--radius-sm) px-6 py-8 md:px-10 md:py-10"
+      className="bg-foreground/[0.025] dark:bg-foreground/[0.04] rounded-document flex flex-col gap-6 px-6 py-8 md:px-10 md:py-10"
       onMouseEnter={() => setHeld(true)}
       onMouseLeave={() => setHeld(false)}
     >
@@ -188,7 +188,7 @@ export function PrimitivesAnatomy() {
             <Region
               part="scroll"
               active={active}
-              className="border-foreground/20 bg-background mt-auto ml-auto grid size-6 place-items-center rounded-(--radius-capsule) border"
+              className="border-foreground/20 bg-background rounded-capsule mt-auto ml-auto grid size-6 place-items-center border"
             >
               <ArrowDownIcon className="text-foreground/60 size-3" />
             </Region>
@@ -199,7 +199,7 @@ export function PrimitivesAnatomy() {
             className="border-foreground/15 flex items-center justify-between border px-2.5 py-2"
           >
             <div className="bg-foreground/20 h-1.5 w-16" />
-            <div className="bg-foreground/80 size-4 rounded-(--radius-capsule)" />
+            <div className="bg-foreground/80 rounded-capsule size-4" />
           </Region>
         </Region>
       </div>

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -70,7 +70,7 @@ export function ThreadSpecimen() {
 
   return (
     <section aria-label="Thread" className="flex flex-col gap-3">
-      <div className="border-foreground/10 h-[min(52rem,88svh)] overflow-hidden rounded-(--radius-document) border">
+      <div className="border-foreground/10 h-[min(52rem,88svh)] overflow-hidden rounded-(--radius-sm) border">
         <DocsRuntimeProvider devtools={false}>
           {expanded
             ? createPortal(

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -70,7 +70,7 @@ export function ThreadSpecimen() {
 
   return (
     <section aria-label="Thread" className="flex flex-col gap-3">
-      <div className="border-foreground/10 h-[min(52rem,88svh)] overflow-hidden rounded-(--radius-sm) border">
+      <div className="border-foreground/10 rounded-document h-[min(52rem,88svh)] overflow-hidden border">
         <DocsRuntimeProvider devtools={false}>
           {expanded
             ? createPortal(

--- a/apps/docs/components/shared/copy-command-button.tsx
+++ b/apps/docs/components/shared/copy-command-button.tsx
@@ -41,7 +41,7 @@ export function CopyCommandButton({
   };
 
   const wrapperClassName =
-    "group border-border/60 bg-muted/30 hover:border-border hover:bg-muted/50 inline-flex h-8 w-fit items-center gap-1.5 rounded-(--radius-control) border px-3 font-mono text-sm transition-all";
+    "group border-border/60 bg-muted/30 hover:border-border hover:bg-muted/50 inline-flex h-8 w-fit items-center gap-1.5 rounded-control border px-3 font-mono text-sm transition-all";
 
   const copyIcon = (
     <div className="text-muted-foreground relative flex size-4 items-center justify-center">

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -50,7 +50,7 @@ const FOOTER_LINKS: Record<string, FooterLinkItem[]> = {
 
 export function Footer(): React.ReactElement {
   return (
-    <footer className="rounded-(--radius-page) py-10 md:py-16">
+    <footer className="rounded-page py-10 md:py-16">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-4">
         <div className="grid grid-cols-2 gap-x-8 gap-y-8 sm:grid-cols-3 lg:grid-cols-6">
           {Object.entries(FOOTER_LINKS).map(([category, links]) => (

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -63,7 +63,7 @@ export function Header() {
   const scrolled = useScrolled();
 
   return (
-    <header className="sticky top-0 z-50 w-full rounded-(--radius-page)">
+    <header className="rounded-page sticky top-0 z-50 w-full">
       <NavItemsRoot>
         <div
           className={headerBarClassName(

--- a/apps/docs/components/shared/nav-glyph.tsx
+++ b/apps/docs/components/shared/nav-glyph.tsx
@@ -43,10 +43,7 @@ function GlyphReact() {
       <span className="bg-foreground/25 h-[3px] w-4/5" />
       <span className="border-foreground/25 mt-[2px] flex h-[9px] items-center justify-end border px-[2px]">
         <span
-          className={cn(
-            "bg-foreground/40 size-[4px] rounded-(--radius-capsule)",
-            ACCENT,
-          )}
+          className={cn("bg-foreground/40 rounded-capsule size-[4px]", ACCENT)}
         />
       </span>
     </span>
@@ -69,8 +66,8 @@ function GlyphInk() {
   return (
     <span className="border-foreground/25 flex h-6 w-8 flex-col border">
       <span className="border-foreground/25 flex h-[6px] items-center gap-[2px] border-b px-[3px]">
-        <span className="bg-foreground/30 size-[2px] rounded-(--radius-capsule)" />
-        <span className="bg-foreground/30 size-[2px] rounded-(--radius-capsule)" />
+        <span className="bg-foreground/30 rounded-capsule size-[2px]" />
+        <span className="bg-foreground/30 rounded-capsule size-[2px]" />
       </span>
       <span className="flex flex-1 flex-col justify-center gap-[2px] px-[3px]">
         <span className="flex items-center gap-[2px]">
@@ -125,7 +122,7 @@ function GlyphGlass() {
       <span className="bg-foreground/20 h-[2px] w-full" />
       <span className="bg-foreground/20 h-[2px] w-full" />
       <span className="bg-foreground/20 h-[2px] w-full" />
-      <span className="border-foreground/40 bg-background absolute top-1/2 right-[3px] flex size-[14px] -translate-y-1/2 items-center justify-center rounded-(--radius-capsule) border">
+      <span className="border-foreground/40 bg-background rounded-capsule absolute top-1/2 right-[3px] flex size-[14px] -translate-y-1/2 items-center justify-center border">
         <span
           className={cn("bg-foreground/40 mt-[3px] h-[2px] w-[7px]", ACCENT)}
         />
@@ -228,7 +225,7 @@ function GlyphChangelog() {
         <span key={index} className="flex items-center gap-[3px]">
           <span
             className={cn(
-              "bg-foreground/30 size-[4px] rounded-(--radius-capsule)",
+              "bg-foreground/30 rounded-capsule size-[4px]",
               index === 0 && ACCENT,
             )}
           />
@@ -280,15 +277,12 @@ function GlyphCareers() {
     <span className="flex items-end gap-[4px]">
       <span className="flex flex-col items-center gap-[2px]">
         <span
-          className={cn(
-            "bg-foreground/35 size-[6px] rounded-(--radius-capsule)",
-            ACCENT,
-          )}
+          className={cn("bg-foreground/35 rounded-capsule size-[6px]", ACCENT)}
         />
         <span className="bg-foreground/20 h-[6px] w-[10px] rounded-t-[3px]" />
       </span>
       <span className="flex flex-col items-center gap-[2px]">
-        <span className="bg-foreground/25 size-[5px] rounded-(--radius-capsule)" />
+        <span className="bg-foreground/25 rounded-capsule size-[5px]" />
         <span className="bg-foreground/15 h-[5px] w-[9px] rounded-t-[3px]" />
       </span>
     </span>

--- a/apps/docs/content/design.md
+++ b/apps/docs/content/design.md
@@ -14,7 +14,7 @@ The site is the library's own book. Everything below exists so that a page drawn
 assistant-ui is drawn as a printed document, not as an application skin. Every shape question is answered by asking what the thing is:
 
 - **The page is paper.** It is square. `--radius-page` is 0.
-- **Matter printed on the page** (a code sheet, a table, a figure plate, a specimen frame, a thread specimen) is printed, not applied. It is square. `--radius-document` is 0, and it is declared explicitly so a parent radius cannot leak into it.
+- **Matter printed on the page** (a code sheet, a table, a figure plate, a specimen frame, a thread specimen) is printed, not applied. It carries the smallest rounding on the scale, nothing more: `--radius-document` is 6px, and it is declared explicitly so a parent radius cannot leak into it.
 - **An object you press or lift** (a button, a field, a menu, a dialog, a toast, a composer) is a physical control resting on the paper. It is rounded.
 
 Everything below descends from that. Hairlines instead of boxes, because a printed rule is a line and not a container. Mono eyebrows instead of tracked all-caps kickers, because a running head names its section in the typewriter's voice. `fig. NN` captions instead of floating labels, because a plate in a book is numbered. A line budget, because ink is expensive.
@@ -35,12 +35,12 @@ Honesty ranks first because this site describes software that exists. No "soon",
 
 ## Register: shape
 
-Ask the three questions in order (page, printed matter, pressed object). Only the third answer reaches for the rounded scale:
+Ask the three questions in order (page, printed matter, pressed object). The page stays square, printed matter takes `--radius-document` and nothing else, and only the third answer reaches for the rest of the rounded scale:
 
 | Token | Value | What it is |
 | --- | --- | --- |
 | `--radius-page` | 0 | the page itself |
-| `--radius-document` | 0 | anything printed on it |
+| `--radius-document` | 6px | anything printed on it |
 | `--radius-sm` | 6px | kbd, inline code, the smallest icon button |
 | `--radius-control`, `--radius-md` | 8px | button, input, header CTA |
 | `--radius-surface` | 10px | menu, popover, tooltip |

--- a/apps/docs/content/design/components/command-tabs.mdx
+++ b/apps/docs/content/design/components/command-tabs.mdx
@@ -43,7 +43,7 @@ export function Example() {
 }
 ```
 
-The command renders as plain mono text; the copy button always copies the active dialect.
+The command renders as Shiki-highlighted Bash; the copy button always copies the active dialect.
 
 ## Examples
 

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -79,7 +79,7 @@
 
   --radius-none: 0;
   --radius-page: 0;
-  --radius-document: 0;
+  --radius-document: var(--radius-sm);
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-control: 0.5rem;

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -81,7 +81,7 @@ export function CodeBlock({
   return (
     <figure
       className={cn(
-        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden border",
+        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -44,7 +44,7 @@ function CopyButton({
         setTimeout(() => setCopied(false), 1500);
       }}
       className={cn(
-        "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-(--radius-sm) transition-colors",
+        "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors",
         className,
       )}
     >
@@ -81,7 +81,7 @@ export function CodeBlock({
   return (
     <figure
       className={cn(
-        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
+        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-sm border",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -8,7 +8,7 @@ import {
   type ComponentProps,
 } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import ShikiHighlighter from "react-shiki";
+import { useShikiHighlighter } from "react-shiki";
 import { cn } from "@/lib/utils";
 
 export interface CommandTabsProps extends Omit<
@@ -87,6 +87,10 @@ export function CommandTabs({
     ? active
     : (labels[0] ?? "");
   const command = commands[activeLabel] ?? "";
+  const highlighted = useShikiHighlighter(command, "bash", {
+    light: "catppuccin-latte",
+    dark: "catppuccin-mocha",
+  });
 
   return (
     <figure
@@ -149,14 +153,11 @@ export function CommandTabs({
           "dark:[&_code_span]:[color:var(--shiki-dark)]!",
         )}
       >
-        <ShikiHighlighter
-          language="bash"
-          theme={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }}
-          addDefaultStyles={false}
-          showLanguage={false}
-        >
-          {command}
-        </ShikiHighlighter>
+        {highlighted ?? (
+          <pre>
+            <code>{command}</code>
+          </pre>
+        )}
       </div>
     </figure>
   );

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -8,6 +8,7 @@ import {
   type ComponentProps,
 } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
+import ShikiHighlighter from "react-shiki";
 import { cn } from "@/lib/utils";
 
 export interface CommandTabsProps extends Omit<
@@ -31,7 +32,7 @@ function syncEventName(storageKey: string) {
 
 /**
  * One command in several dialects: a tab per variant, the active command as
- * plain mono text, and a copy button. With a `storageKey`, picking a tab
+ * highlighted Bash, and a copy button. With a `storageKey`, picking a tab
  * switches every instance sharing that key and survives reloads.
  */
 export function CommandTabs({
@@ -90,7 +91,7 @@ export function CommandTabs({
   return (
     <figure
       className={cn(
-        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden border",
+        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
         className,
       )}
       {...props}
@@ -140,10 +141,22 @@ export function CommandTabs({
           )}
         </button>
       </div>
-      <div className="min-w-0 overflow-x-auto">
-        <pre className="w-max min-w-full px-3.5 py-4 font-mono text-[13px] leading-relaxed whitespace-pre [font-variant-ligatures:none]">
-          <code>{command}</code>
-        </pre>
+      <div
+        className={cn(
+          "min-w-0 overflow-x-auto",
+          "[&_pre]:w-max [&_pre]:min-w-full [&_pre]:bg-transparent! [&_pre]:px-3.5 [&_pre]:py-4 [&_pre]:font-mono [&_pre]:text-[13px] [&_pre]:leading-relaxed [&_pre]:whitespace-pre [&_pre]:[font-variant-ligatures:none]",
+          "[&_code_span]:[color:var(--shiki-light,inherit)]",
+          "dark:[&_code_span]:[color:var(--shiki-dark)]!",
+        )}
+      >
+        <ShikiHighlighter
+          language="bash"
+          theme={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }}
+          addDefaultStyles={false}
+          showLanguage={false}
+        >
+          {command}
+        </ShikiHighlighter>
       </div>
     </figure>
   );

--- a/packages/ui/src/components/react/ui/base/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/base/command-tabs.tsx
@@ -91,7 +91,7 @@ export function CommandTabs({
   return (
     <figure
       className={cn(
-        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
+        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-sm border",
         className,
       )}
       {...props}
@@ -132,7 +132,7 @@ export function CommandTabs({
             clearTimeout(copyTimer.current);
             copyTimer.current = setTimeout(() => setCopied(false), 1500);
           }}
-          className="text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-(--radius-sm) transition-colors"
+          className="text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors"
         >
           {copied ? (
             <CheckIcon className="size-3.5" />

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -81,7 +81,7 @@ export function CodeBlock({
   return (
     <figure
       className={cn(
-        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden border",
+        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -44,7 +44,7 @@ function CopyButton({
         setTimeout(() => setCopied(false), 1500);
       }}
       className={cn(
-        "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-(--radius-sm) transition-colors",
+        "text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors",
         className,
       )}
     >
@@ -81,7 +81,7 @@ export function CodeBlock({
   return (
     <figure
       className={cn(
-        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
+        "not-prose not-fumadocs-codeblock border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] group/code relative my-6 flex min-w-0 flex-col overflow-hidden rounded-sm border",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -8,7 +8,7 @@ import {
   type ComponentProps,
 } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import ShikiHighlighter from "react-shiki";
+import { useShikiHighlighter } from "react-shiki";
 import { cn } from "@/lib/utils";
 
 export interface CommandTabsProps extends Omit<
@@ -87,6 +87,10 @@ export function CommandTabs({
     ? active
     : (labels[0] ?? "");
   const command = commands[activeLabel] ?? "";
+  const highlighted = useShikiHighlighter(command, "bash", {
+    light: "catppuccin-latte",
+    dark: "catppuccin-mocha",
+  });
 
   return (
     <figure
@@ -149,14 +153,11 @@ export function CommandTabs({
           "dark:[&_code_span]:[color:var(--shiki-dark)]!",
         )}
       >
-        <ShikiHighlighter
-          language="bash"
-          theme={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }}
-          addDefaultStyles={false}
-          showLanguage={false}
-        >
-          {command}
-        </ShikiHighlighter>
+        {highlighted ?? (
+          <pre>
+            <code>{command}</code>
+          </pre>
+        )}
       </div>
     </figure>
   );

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -8,6 +8,7 @@ import {
   type ComponentProps,
 } from "react";
 import { CheckIcon, CopyIcon } from "lucide-react";
+import ShikiHighlighter from "react-shiki";
 import { cn } from "@/lib/utils";
 
 export interface CommandTabsProps extends Omit<
@@ -31,7 +32,7 @@ function syncEventName(storageKey: string) {
 
 /**
  * One command in several dialects: a tab per variant, the active command as
- * plain mono text, and a copy button. With a `storageKey`, picking a tab
+ * highlighted Bash, and a copy button. With a `storageKey`, picking a tab
  * switches every instance sharing that key and survives reloads.
  */
 export function CommandTabs({
@@ -90,7 +91,7 @@ export function CommandTabs({
   return (
     <figure
       className={cn(
-        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden border",
+        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
         className,
       )}
       {...props}
@@ -140,10 +141,22 @@ export function CommandTabs({
           )}
         </button>
       </div>
-      <div className="min-w-0 overflow-x-auto">
-        <pre className="w-max min-w-full px-3.5 py-4 font-mono text-[13px] leading-relaxed whitespace-pre [font-variant-ligatures:none]">
-          <code>{command}</code>
-        </pre>
+      <div
+        className={cn(
+          "min-w-0 overflow-x-auto",
+          "[&_pre]:w-max [&_pre]:min-w-full [&_pre]:bg-transparent! [&_pre]:px-3.5 [&_pre]:py-4 [&_pre]:font-mono [&_pre]:text-[13px] [&_pre]:leading-relaxed [&_pre]:whitespace-pre [&_pre]:[font-variant-ligatures:none]",
+          "[&_code_span]:[color:var(--shiki-light,inherit)]",
+          "dark:[&_code_span]:[color:var(--shiki-dark)]!",
+        )}
+      >
+        <ShikiHighlighter
+          language="bash"
+          theme={{ light: "catppuccin-latte", dark: "catppuccin-mocha" }}
+          addDefaultStyles={false}
+          showLanguage={false}
+        >
+          {command}
+        </ShikiHighlighter>
       </div>
     </figure>
   );

--- a/packages/ui/src/components/react/ui/radix/command-tabs.tsx
+++ b/packages/ui/src/components/react/ui/radix/command-tabs.tsx
@@ -91,7 +91,7 @@ export function CommandTabs({
   return (
     <figure
       className={cn(
-        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-(--radius-sm) border",
+        "not-prose border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] my-6 flex min-w-0 flex-col overflow-hidden rounded-sm border",
         className,
       )}
       {...props}
@@ -132,7 +132,7 @@ export function CommandTabs({
             clearTimeout(copyTimer.current);
             copyTimer.current = setTimeout(() => setCopied(false), 1500);
           }}
-          className="text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-(--radius-sm) transition-colors"
+          className="text-muted-foreground hover:text-foreground grid size-6 shrink-0 place-items-center rounded-sm transition-colors"
         >
           {copied ? (
             <CheckIcon className="size-3.5" />


### PR DESCRIPTION
polishes the docs code surfaces and lands the radius ruling they surfaced.

command tabs render the active command as shiki-highlighted bash (catppuccin latte/mocha, the site pair) instead of plain mono text, and the design doc claim follows. the design law changes with it: matter printed on the page now carries the smallest rounding instead of being square, so `--radius-document` is 6px (`var(--radius-sm)`) in globals.css, with design.md prose, the token table, and the /design ledger row updated in the same change. radius classes across apps/docs are spelled as the generated semantic utilities (`rounded-document`, `rounded-control`, ...) instead of `rounded-(--radius-x)` var references, and the kit code-block/command-tabs use the portable `rounded-sm`.

rebased onto main: the original base predates the elements layer and its registry fix, which is what failed the vercel build on the previous head.

verified: registry build + 51 tests, ui vitest 377, docs vitest 415, zero `rounded-(--radius-` references left, browser pass over home, /docs/installation, /design/components/command-tabs, and /elements/thread in light and dark.