### PR TITLE
fix(docs): prevent copy menu layout shift

### DIFF
--- a/apps/docs/components/shared/copy-command-button.tsx
+++ b/apps/docs/components/shared/copy-command-button.tsx
@@ -72,7 +72,7 @@ export function CopyCommandButton({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <Menu.Trigger
         aria-label="Copy options"
         render={


### PR DESCRIPTION
## Summary

- keep the landing-page command choice menu non-modal
- prevent document scroll locking from shifting the page when the menu opens
- preserve both CLI command and coding-agent prompt copy actions

## Reproduction

1. Open the redesigned landing page in a browser with inset scrollbars.
2. Click the npx assistant-ui init command button.
3. The modal menu locks the document scrollbar and the page shifts.

The menu now opens without locking the document, so the surrounding layout stays fixed.

## Testing

- pnpm --filter @assistant-ui/docs exec tsc --noEmit
- pnpm exec oxlint apps/docs/components/shared/copy-command-button.tsx
- pnpm exec oxfmt --check apps/docs/components/shared/copy-command-button.tsx
- verified the menu and both copy actions at 1280px and 390px widths; trigger and headline geometry stayed unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BcCmOe6YBKKr_A207TRS2Nwsw4n1X0CbmhCLPxA70IFyCKxHo16Wi5Qu0aE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->