### PR TITLE
fix(docs): prevent copy menu layout shift

### DIFF
--- a/apps/docs/components/shared/copy-command-button.tsx
+++ b/apps/docs/components/shared/copy-command-button.tsx
@@ -72,7 +72,7 @@ export function CopyCommandButton({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <Menu.Trigger
         aria-label="Copy options"
         render={


### PR DESCRIPTION
## Summary

- keep the landing-page command choice menu non-modal
- prevent document scroll locking from shifting the page when the menu opens
- preserve both CLI command and coding-agent prompt copy actions

## Context

The redesigned copy menu already exists on main. PR #6508 landed the fix on the divergent refactor/home-redesign branch, so this PR applies the same scoped change to main.

## Reproduction

1. Open the landing page in a browser with inset scrollbars.
2. Click the npx assistant-ui init command button.
3. The modal menu locks the document scrollbar and the page shifts.

The menu now opens without locking the document, so the surrounding layout stays fixed.

## Testing

- npx oxfmt@0.64.0 --check apps/docs/components/shared/copy-command-button.tsx
- npx oxlint@1.79.0 apps/docs/components/shared/copy-command-button.tsx
- git diff --check
- verified the menu and both copy actions at 1280px and 390px widths; trigger and headline geometry stayed unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7cXjgbb1RWQ8syKGXANpgbMDmNfRK-uFB3dM5jJCz3DR1dcTb--69nP-em4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->