### PR TITLE
fix(core): keep remote thread adapters commit-safe

### DIFF
--- a/.changeset/remote-thread-list-committed-adapter.md
+++ b/.changeset/remote-thread-list-committed-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep remote thread actions scoped to the committed adapter

--- a/packages/core/src/react/client/RemoteThreadList.concurrent.test.tsx
+++ b/packages/core/src/react/client/RemoteThreadList.concurrent.test.tsx
@@ -15,11 +15,12 @@ import { RemoteThreadList } from "./RemoteThreadList";
 const composer = { getState: () => ({}) };
 const suggestions = { getState: () => ({ suggestions: [] }) };
 const threadState = { isRunning: false, messages: [] };
-const StubThread = resource(() => ({
+const useStubThread = () => ({
   getState: () => threadState,
   composer: () => composer,
   suggestions: () => suggestions,
-}));
+});
+const StubThread = resource(useStubThread);
 
 const makeAdapter = (): RemoteThreadListAdapter => ({
   list: vi.fn(async () => ({

--- a/packages/core/src/react/client/RemoteThreadList.concurrent.test.tsx
+++ b/packages/core/src/react/client/RemoteThreadList.concurrent.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { createRef, startTransition, Suspense } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { resource } from "@assistant-ui/tap";
+import {
+  AuiConfig,
+  AuiProvider,
+  type AssistantClient,
+} from "@assistant-ui/store";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteThreadListAdapter } from "../../runtimes/remote-thread-list/types";
+import { RemoteThreadList } from "./RemoteThreadList";
+
+const composer = { getState: () => ({}) };
+const suggestions = { getState: () => ({ suggestions: [] }) };
+const threadState = { isRunning: false, messages: [] };
+const StubThread = resource(() => ({
+  getState: () => threadState,
+  composer: () => composer,
+  suggestions: () => suggestions,
+}));
+
+const makeAdapter = (): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({
+    threads: [
+      { status: "regular" as const, remoteId: "thread-1", title: "Thread" },
+    ],
+  })),
+  initialize: vi.fn(async (threadId: string) => ({
+    remoteId: threadId,
+    externalId: undefined,
+  })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(async () => new ReadableStream()),
+  fetch: vi.fn(async (remoteId: string) => ({
+    status: "regular" as const,
+    remoteId,
+    externalId: undefined,
+    title: "Thread",
+  })),
+});
+
+describe("RemoteThreadList concurrent rendering", () => {
+  it("keeps actions scoped to the committed adapter", async () => {
+    const adapterA = makeAdapter();
+    const adapterB = makeAdapter();
+    const clientRef = createRef<AssistantClient>();
+    const never = new Promise<never>(() => {});
+    let suspend = false;
+
+    const Blocker = () => {
+      if (suspend) throw never;
+      return null;
+    };
+    const App = ({ adapter }: { adapter: RemoteThreadListAdapter }) => (
+      <Suspense fallback={null}>
+        <AuiProvider
+          ref={clientRef as never}
+          config={AuiConfig({
+            threads: RemoteThreadList({
+              adapter,
+              thread: () => StubThread() as never,
+            }),
+          })}
+        >
+          <Blocker />
+        </AuiProvider>
+      </Suspense>
+    );
+
+    const view = render(<App adapter={adapterA} />);
+    const client = clientRef.current!;
+    await act(async () => {
+      await client.threads.getLoadThreadsPromise();
+    });
+    await waitFor(() =>
+      expect(client.threads.getState().threadIds).toEqual(["thread-1"]),
+    );
+
+    act(() => {
+      suspend = true;
+      startTransition(() => view.rerender(<App adapter={adapterB} />));
+    });
+    await act(async () => {
+      await client.threads.item({ id: "thread-1" }).rename("Renamed");
+    });
+
+    expect(adapterA.rename).toHaveBeenCalledWith("thread-1", "Renamed");
+    expect(adapterB.rename).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -524,7 +524,7 @@ const useRemoteThreadList = (
   );
   useThreadSelectionEvents(mainThreadId);
   useEffect(() => {
-    // Imperative actions stay scoped to this committed adapter; explicit reload adopts its render-local adapter.
+    // Publishing after commit keeps imperative actions on the adapter the committed tree renders with; an abandoned render must not reach them.
     session.adapter = adapter;
     session.mainThreadId = mainThreadId;
     session.onThreadIdChange = onThreadIdChange;
@@ -599,7 +599,6 @@ const useRemoteThreadList = (
 
   const reload = useCallback(() => {
     const adapterChanged = adapter !== session.adapterAtLoad;
-    session.adapter = adapter;
     session.loadGeneration++;
     session.loadPromise = undefined;
     session.loadMorePromise = undefined;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -524,6 +524,7 @@ const useRemoteThreadList = (
   );
   useThreadSelectionEvents(mainThreadId);
   useEffect(() => {
+    // Imperative actions stay scoped to this committed adapter; reload receives its render-local adapter explicitly.
     session.adapter = adapter;
     session.mainThreadId = mainThreadId;
     session.onThreadIdChange = onThreadIdChange;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -524,7 +524,7 @@ const useRemoteThreadList = (
   );
   useThreadSelectionEvents(mainThreadId);
   useEffect(() => {
-    // Imperative actions stay scoped to this committed adapter; reload receives its render-local adapter explicitly.
+    // Imperative actions stay scoped to this committed adapter; explicit reload adopts its render-local adapter.
     session.adapter = adapter;
     session.mainThreadId = mainThreadId;
     session.onThreadIdChange = onThreadIdChange;
@@ -548,60 +548,58 @@ const useRemoteThreadList = (
     [session],
   );
 
-  const getLoadThreadsPromise = useCallback(
-    (adapterOverride?: RemoteThreadListAdapter) => {
-      if (session.loadPromise) return session.loadPromise;
-      const generation = session.loadGeneration;
-      const adapter = adapterOverride ?? session.adapter;
-      const statusAtRequest = statusSnapshot(store.baseValue);
-      session.loadPromise = store
-        .optimisticUpdate({
-          execute: () => adapter.list(),
-          loading: (state) => ({ ...state, isLoading: true }),
-          then: (state, page) => {
-            if (generation !== session.loadGeneration) return state;
-            session.adapterAtLoad = adapter;
-            const fresh = classifyThreads(page.threads, {
-              threadIds: [],
-              archivedThreadIds: [],
-              threadIdMap: {},
-              threadData: {},
-            });
-            const merged = {
-              ...state,
-              isLoading: false,
-              cursor: normalizeCursor(page.nextCursor),
-              threadIds: fresh.threadIds,
-              archivedThreadIds: fresh.archivedThreadIds,
-              threadIdMap: {
-                ...state.threadIdMap,
-                ...fresh.threadIdMap,
-              },
-              threadData: {
-                ...state.threadData,
-                ...fresh.threadData,
-              },
-            };
-            return preserveMidLoadTransitions(merged, state, statusAtRequest);
-          },
-        })
-        .catch((error: unknown) => {
-          if (generation !== session.loadGeneration) return;
-          console.error("[assistant-ui] thread list load failed:", error);
-          session.loadPromise = undefined;
-          store.update({
-            ...store.baseValue,
-            isLoading: false,
+  const getLoadThreadsPromise = useCallback(() => {
+    if (session.loadPromise) return session.loadPromise;
+    const generation = session.loadGeneration;
+    const adapter = session.adapter;
+    const statusAtRequest = statusSnapshot(store.baseValue);
+    session.loadPromise = store
+      .optimisticUpdate({
+        execute: () => adapter.list(),
+        loading: (state) => ({ ...state, isLoading: true }),
+        then: (state, page) => {
+          if (generation !== session.loadGeneration) return state;
+          session.adapterAtLoad = adapter;
+          const fresh = classifyThreads(page.threads, {
+            threadIds: [],
+            archivedThreadIds: [],
+            threadIdMap: {},
+            threadData: {},
           });
-        })
-        .then(() => {});
-      return session.loadPromise;
-    },
-    [session, store],
-  );
+          const merged = {
+            ...state,
+            isLoading: false,
+            cursor: normalizeCursor(page.nextCursor),
+            threadIds: fresh.threadIds,
+            archivedThreadIds: fresh.archivedThreadIds,
+            threadIdMap: {
+              ...state.threadIdMap,
+              ...fresh.threadIdMap,
+            },
+            threadData: {
+              ...state.threadData,
+              ...fresh.threadData,
+            },
+          };
+          return preserveMidLoadTransitions(merged, state, statusAtRequest);
+        },
+      })
+      .catch((error: unknown) => {
+        if (generation !== session.loadGeneration) return;
+        console.error("[assistant-ui] thread list load failed:", error);
+        session.loadPromise = undefined;
+        store.update({
+          ...store.baseValue,
+          isLoading: false,
+        });
+      })
+      .then(() => {});
+    return session.loadPromise;
+  }, [session, store]);
 
   const reload = useCallback(() => {
     const adapterChanged = adapter !== session.adapterAtLoad;
+    session.adapter = adapter;
     session.loadGeneration++;
     session.loadPromise = undefined;
     session.loadMorePromise = undefined;
@@ -621,7 +619,7 @@ const useRemoteThreadList = (
         cursor: undefined,
       });
     }
-    return getLoadThreadsPromise(adapter);
+    return getLoadThreadsPromise();
   }, [
     adapter,
     assignMainThreadId,
@@ -1236,7 +1234,7 @@ const useRemoteThreadList = (
     switchToNewThread: () => {
       handleThreadListAction("create", () => switchToNewThread());
     },
-    getLoadThreadsPromise: () => getLoadThreadsPromise(),
+    getLoadThreadsPromise,
     reload,
     reloadMainThread: () => {
       if (getThreadData(store.value, mainThreadId)?.status === "new") {

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -503,9 +503,6 @@ const useRemoteThreadList = (
     };
   });
 
-  // Config updates can invoke `reload()` in the same turn as the re-render, before the effect below runs.
-  session.adapter = adapter;
-
   const listState = useSyncExternalStore(
     (onStoreChange) => store.subscribe(onStoreChange),
     () => store.value,
@@ -550,54 +547,57 @@ const useRemoteThreadList = (
     [session],
   );
 
-  const getLoadThreadsPromise = useCallback(() => {
-    if (session.loadPromise) return session.loadPromise;
-    const generation = session.loadGeneration;
-    const adapter = session.adapter;
-    const statusAtRequest = statusSnapshot(store.baseValue);
-    session.loadPromise = store
-      .optimisticUpdate({
-        execute: () => adapter.list(),
-        loading: (state) => ({ ...state, isLoading: true }),
-        then: (state, page) => {
-          if (generation !== session.loadGeneration) return state;
-          session.adapterAtLoad = adapter;
-          const fresh = classifyThreads(page.threads, {
-            threadIds: [],
-            archivedThreadIds: [],
-            threadIdMap: {},
-            threadData: {},
-          });
-          const merged = {
-            ...state,
+  const getLoadThreadsPromise = useCallback(
+    (adapterOverride?: RemoteThreadListAdapter) => {
+      if (session.loadPromise) return session.loadPromise;
+      const generation = session.loadGeneration;
+      const adapter = adapterOverride ?? session.adapter;
+      const statusAtRequest = statusSnapshot(store.baseValue);
+      session.loadPromise = store
+        .optimisticUpdate({
+          execute: () => adapter.list(),
+          loading: (state) => ({ ...state, isLoading: true }),
+          then: (state, page) => {
+            if (generation !== session.loadGeneration) return state;
+            session.adapterAtLoad = adapter;
+            const fresh = classifyThreads(page.threads, {
+              threadIds: [],
+              archivedThreadIds: [],
+              threadIdMap: {},
+              threadData: {},
+            });
+            const merged = {
+              ...state,
+              isLoading: false,
+              cursor: normalizeCursor(page.nextCursor),
+              threadIds: fresh.threadIds,
+              archivedThreadIds: fresh.archivedThreadIds,
+              threadIdMap: {
+                ...state.threadIdMap,
+                ...fresh.threadIdMap,
+              },
+              threadData: {
+                ...state.threadData,
+                ...fresh.threadData,
+              },
+            };
+            return preserveMidLoadTransitions(merged, state, statusAtRequest);
+          },
+        })
+        .catch((error: unknown) => {
+          if (generation !== session.loadGeneration) return;
+          console.error("[assistant-ui] thread list load failed:", error);
+          session.loadPromise = undefined;
+          store.update({
+            ...store.baseValue,
             isLoading: false,
-            cursor: normalizeCursor(page.nextCursor),
-            threadIds: fresh.threadIds,
-            archivedThreadIds: fresh.archivedThreadIds,
-            threadIdMap: {
-              ...state.threadIdMap,
-              ...fresh.threadIdMap,
-            },
-            threadData: {
-              ...state.threadData,
-              ...fresh.threadData,
-            },
-          };
-          return preserveMidLoadTransitions(merged, state, statusAtRequest);
-        },
-      })
-      .catch((error: unknown) => {
-        if (generation !== session.loadGeneration) return;
-        console.error("[assistant-ui] thread list load failed:", error);
-        session.loadPromise = undefined;
-        store.update({
-          ...store.baseValue,
-          isLoading: false,
-        });
-      })
-      .then(() => {});
-    return session.loadPromise;
-  }, [session, store]);
+          });
+        })
+        .then(() => {});
+      return session.loadPromise;
+    },
+    [session, store],
+  );
 
   const reload = useCallback(() => {
     const adapterChanged = adapter !== session.adapterAtLoad;
@@ -620,7 +620,7 @@ const useRemoteThreadList = (
         cursor: undefined,
       });
     }
-    return getLoadThreadsPromise();
+    return getLoadThreadsPromise(adapter);
   }, [
     adapter,
     assignMainThreadId,
@@ -1235,7 +1235,7 @@ const useRemoteThreadList = (
     switchToNewThread: () => {
       handleThreadListAction("create", () => switchToNewThread());
     },
-    getLoadThreadsPromise,
+    getLoadThreadsPromise: () => getLoadThreadsPromise(),
     reload,
     reloadMainThread: () => {
       if (getThreadData(store.value, mainThreadId)?.status === "new") {


### PR DESCRIPTION
## Summary

- stop publishing `RemoteThreadList` adapter changes through shared session state during render
- keep thread actions bound to the last committed adapter

## Why

`RemoteThreadList` assigned `session.adapter` during render. If React started rendering workspace B and that render suspended or was abandoned, the still-committed workspace A client could immediately invoke B's adapter. A focused reproduction kept A committed, suspended B, and observed A's thread rename being sent through B.

The comment that render-phase write carried claimed `reload()` can run in the same turn as the re-render, before the effect lands. It cannot: the effect that publishes `session.adapter` runs before any child effect that can reach `reload()`, so the loader already sees the replacement adapter. An earlier revision of this PR also wrote the render-local adapter inside `reload()`; that write changes nothing observable (removing it leaves all 1540 core tests green, and neither the standalone client path nor a child passive or layout effect resolves a different adapter with it in place), so it is gone and the fix is the render-phase write alone.

This is the `RemoteThreadList` entry introduced after the scope of #6486/#6493; #6493 does not touch this implementation.

## Testing

- `pnpm --filter @assistant-ui/core exec vitest run --reporter=dot` (148 files, 1540 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.08_VfjzupW1O4WkuSsscKwl_KIt8kAeAwB0KDWiPaufLoHdNqEPCNORfN7c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
