### PR TITLE
fix(docs): close the header nav menu on click and align its row

### DIFF
--- a/apps/docs/components/shared/nav-items.tsx
+++ b/apps/docs/components/shared/nav-items.tsx
@@ -43,6 +43,7 @@ function DropdownLink({ link }: { link: DropdownItem }) {
 
   return (
     <NavigationMenuLink
+      closeOnClick
       render={
         link.external ? (
           <a
@@ -76,6 +77,7 @@ function FeaturedCard({
         {featured.label}
       </span>
       <NavigationMenuLink
+        closeOnClick
         render={
           <Link
             href={link.href}
@@ -97,6 +99,9 @@ function FeaturedCard({
     </div>
   );
 }
+
+const navItemClassName =
+  "text-muted-foreground hover:text-foreground flex items-center px-3 py-1.5 text-sm transition-colors";
 
 export function NavItemsRoot({ children }: { children: ReactNode }) {
   const [value, setValue] = useState<string | null>(null);
@@ -161,11 +166,9 @@ export function NavItems({
               value={`${instanceId}:${item.href}`}
             >
               <NavigationMenuLink
+                closeOnClick
                 render={
-                  <Link
-                    href={item.href}
-                    className="text-muted-foreground hover:text-foreground px-3 py-1.5 text-sm transition-colors"
-                  >
+                  <Link href={item.href} className={navItemClassName}>
                     {item.label}
                   </Link>
                 }
@@ -179,7 +182,12 @@ export function NavItems({
             key={item.label}
             value={`${instanceId}:${item.label}`}
           >
-            <NavigationMenuTrigger className="text-muted-foreground hover:text-foreground data-[popup-open]:text-foreground group/trigger flex cursor-pointer items-center gap-1 px-3 py-1.5 text-sm transition-colors">
+            <NavigationMenuTrigger
+              className={cn(
+                navItemClassName,
+                "data-[popup-open]:text-foreground group/trigger cursor-pointer gap-1",
+              )}
+            >
               {item.label}
               <ChevronDown className="size-3 opacity-60 transition-[rotate] duration-200 group-data-[popup-open]/trigger:rotate-180 motion-reduce:transition-none" />
             </NavigationMenuTrigger>


### PR DESCRIPTION
## summary

- clicking an item in the header mega menu left the menu (and its full-page backdrop) open on top of the page it navigated to. base UI's `NavigationMenu.Link` defaults `closeOnClick` to `false`, and `NavItemsRoot` owns the open value in state that survives a client navigation, so nothing ever closed it. every link in `nav-items.tsx` now passes `closeOnClick`.
- the plain nav links (`Docs`, `Pricing`) rendered as inline anchors while the dropdown triggers are flex boxes, so their item boxes were 24px against the triggers' 32px and their text landed half a pixel below the trigger text (a visible 1px step at 2x). link and trigger now share one `navItemClassName`, so the boxes are identical and drift is harder to reintroduce.

## test plan

### already verified

- browser A/B on the docs dev server: without `closeOnClick`, clicking Products then React leaves the popup and backdrop up for 3s+ on the same page; with it, `/docs` loads with `data-popup-open` gone and the popup unmounted. same result from the docs header instance (Products then Design lands on `/design` closed).
- measured every item in the live nav: all four now report box `y=8 h=32` and text `y=15.5`, against `y=12 h=24` / text `y=16` for the inline links before.
- `oxlint` and `oxfmt --check` clean on the touched file.

### reviewer should verify

- [ ] open the mega menu at lg+ on the marketing header and inside docs, click through to a page, and confirm the panel is gone on arrival.
- [ ] eyeball the nav row at the md to lg condensed width, where `MoreDropdown` sits beside the same items.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1gNysgprnkEOxrwxalxMUfYHdrRwhSmorUBmBRP4_pHeFcwckYuG8mNeD7I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->