### PR TITLE
fix(docs): repair install source links and preview imports, extend the design language

### DIFF
--- a/apps/docs/components/pages/docs/fumadocs/install/install-command.tsx
+++ b/apps/docs/components/pages/docs/fumadocs/install/install-command.tsx
@@ -1,16 +1,14 @@
-import fs from "node:fs";
-import path from "node:path";
 import { Tab, Tabs } from "@/components/pages/docs/fumadocs/tabs";
 import { Flavored } from "@/components/pages/docs/contexts/flavor.server";
 import type { LLMRenderContext } from "@/lib/get-llm-text";
 import {
   resolveAllComponents,
   ComponentSourceFromFile,
-  type RegistryFlavor,
   type ResolvedComponents,
   type ResolvedFile,
   type ResolvedGroup,
 } from "@/components/pages/docs/fumadocs/install/component-source";
+import { githubSourcePath } from "@/components/pages/docs/fumadocs/install/install-source-path";
 import { SetupInstructions } from "@/components/pages/docs/fumadocs/install/setup-instructions";
 import {
   ExpoInstallTabs,
@@ -126,37 +124,6 @@ const CommandBlock = ({ command }: { command: string }) => (
     <code className="language-bash">{command}</code>
   </pre>
 );
-
-function existsInUiSource(relativePath: string): boolean {
-  return fs.existsSync(
-    path.join(process.cwd(), "../../packages/ui/src", relativePath),
-  );
-}
-
-// Registry paths name where a file lands in the consumer's project; the kit
-// stores it under components/react, with a flavor directory for the primitives.
-function githubSourcePath(filePath: string, flavor: RegistryFlavor): string {
-  const primitive = filePath.match(/^components\/ui\/(.+)$/)?.[1];
-  if (primitive) {
-    const flavored = `components/react/ui/${flavor}/${primitive}`;
-    if (existsInUiSource(flavored)) return flavored;
-    const twin = flavor === "base" ? "radix" : "base";
-    const fallback = `components/react/ui/${twin}/${primitive}`;
-    return existsInUiSource(fallback) ? fallback : filePath;
-  }
-
-  const component = filePath.match(/^components\/(.+)$/)?.[1];
-  if (component) {
-    const source = `components/react/${component}`;
-    if (flavor === "radix") {
-      const radixSource = source.replace(/\.tsx$/, ".radix.tsx");
-      if (existsInUiSource(radixSource)) return radixSource;
-    }
-    return existsInUiSource(source) ? source : filePath;
-  }
-
-  return filePath;
-}
 
 type LinkedFile = ResolvedFile & { sourcePath: string };
 

--- a/apps/docs/components/pages/docs/fumadocs/install/install-command.tsx
+++ b/apps/docs/components/pages/docs/fumadocs/install/install-command.tsx
@@ -127,14 +127,35 @@ const CommandBlock = ({ command }: { command: string }) => (
   </pre>
 );
 
-function githubSourcePath(filePath: string, flavor: RegistryFlavor): string {
-  if (flavor !== "radix") return filePath;
-  const radixPath = filePath.replace(/\.tsx$/, ".radix.tsx");
+function existsInUiSource(relativePath: string): boolean {
   return fs.existsSync(
-    path.join(process.cwd(), "../../packages/ui/src", radixPath),
-  )
-    ? radixPath
-    : filePath;
+    path.join(process.cwd(), "../../packages/ui/src", relativePath),
+  );
+}
+
+// Registry paths name where a file lands in the consumer's project; the kit
+// stores it under components/react, with a flavor directory for the primitives.
+function githubSourcePath(filePath: string, flavor: RegistryFlavor): string {
+  const primitive = filePath.match(/^components\/ui\/(.+)$/)?.[1];
+  if (primitive) {
+    const flavored = `components/react/ui/${flavor}/${primitive}`;
+    if (existsInUiSource(flavored)) return flavored;
+    const twin = flavor === "base" ? "radix" : "base";
+    const fallback = `components/react/ui/${twin}/${primitive}`;
+    return existsInUiSource(fallback) ? fallback : filePath;
+  }
+
+  const component = filePath.match(/^components\/(.+)$/)?.[1];
+  if (component) {
+    const source = `components/react/${component}`;
+    if (flavor === "radix") {
+      const radixSource = source.replace(/\.tsx$/, ".radix.tsx");
+      if (existsInUiSource(radixSource)) return radixSource;
+    }
+    return existsInUiSource(source) ? source : filePath;
+  }
+
+  return filePath;
 }
 
 type LinkedFile = ResolvedFile & { sourcePath: string };

--- a/apps/docs/components/pages/docs/fumadocs/install/install-source-path.test.ts
+++ b/apps/docs/components/pages/docs/fumadocs/install/install-source-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { githubSourcePath } from "./install-source-path";
+
+describe("githubSourcePath", () => {
+  it("resolves a primitive through its flavor directory", () => {
+    expect(githubSourcePath("components/ui/accordion.tsx", "base")).toBe(
+      "components/react/ui/base/accordion.tsx",
+    );
+    expect(githubSourcePath("components/ui/accordion.tsx", "radix")).toBe(
+      "components/react/ui/radix/accordion.tsx",
+    );
+  });
+
+  it("prefers the radix twin the registry build ships", () => {
+    expect(githubSourcePath("components/ui/direction.tsx", "radix")).toBe(
+      "components/react/ui/radix/direction.radix.tsx",
+    );
+  });
+
+  it("falls back to the other flavor for a primitive that ships in one", () => {
+    expect(githubSourcePath("components/ui/carousel.tsx", "base")).toBe(
+      "components/react/ui/radix/carousel.tsx",
+    );
+  });
+
+  it("resolves elements and icons under components/react", () => {
+    expect(
+      githubSourcePath(
+        "components/assistant-ui/elements/thread.aui.tsx",
+        "base",
+      ),
+    ).toBe("components/react/assistant-ui/elements/thread.aui.tsx");
+    expect(githubSourcePath("components/icons/github.tsx", "base")).toBe(
+      "components/react/icons/github.tsx",
+    );
+  });
+
+  it("returns paths the kit does not own untouched", () => {
+    expect(githubSourcePath("app/page.tsx", "base")).toBe("app/page.tsx");
+    expect(githubSourcePath("hooks/use-copy-to-clipboard.ts", "base")).toBe(
+      "hooks/use-copy-to-clipboard.ts",
+    );
+  });
+});

--- a/apps/docs/components/pages/docs/fumadocs/install/install-source-path.ts
+++ b/apps/docs/components/pages/docs/fumadocs/install/install-source-path.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { RegistryFlavor } from "@/components/pages/docs/fumadocs/install/component-source";
+
+const UI_SRC = path.join(process.cwd(), "../../packages/ui/src");
+
+function existsInUiSource(relativePath: string): boolean {
+  return fs.existsSync(path.join(UI_SRC, relativePath));
+}
+
+const radixVariant = (relativePath: string): string =>
+  relativePath.replace(/\.tsx$/, ".radix.tsx");
+
+// Registry paths name where a file lands in the consumer's project; the kit
+// stores it under components/react, with a flavor directory for the primitives.
+// The radix probes mirror getRadixVariantSourcePath in the registry build, which
+// prefers a .radix.tsx sibling over the file it sits next to.
+export function githubSourcePath(
+  filePath: string,
+  flavor: RegistryFlavor,
+): string {
+  const primitive = filePath.match(/^components\/ui\/(.+)$/)?.[1];
+  if (primitive) {
+    const flavored = `components/react/ui/${flavor}/${primitive}`;
+    const twin = `components/react/ui/${flavor === "base" ? "radix" : "base"}/${primitive}`;
+    const candidates =
+      flavor === "radix"
+        ? [radixVariant(flavored), flavored, radixVariant(twin), twin]
+        : [flavored, twin];
+    return candidates.find(existsInUiSource) ?? filePath;
+  }
+
+  const component = filePath.match(/^components\/(.+)$/)?.[1];
+  if (component) {
+    const source = `components/react/${component}`;
+    const candidates =
+      flavor === "radix" ? [radixVariant(source), source] : [source];
+    return candidates.find(existsInUiSource) ?? filePath;
+  }
+
+  return filePath;
+}

--- a/apps/docs/components/pages/docs/fumadocs/install/install-source-path.ts
+++ b/apps/docs/components/pages/docs/fumadocs/install/install-source-path.ts
@@ -11,10 +11,8 @@ function existsInUiSource(relativePath: string): boolean {
 const radixVariant = (relativePath: string): string =>
   relativePath.replace(/\.tsx$/, ".radix.tsx");
 
-// Registry paths name where a file lands in the consumer's project; the kit
-// stores it under components/react, with a flavor directory for the primitives.
-// The radix probes mirror getRadixVariantSourcePath in the registry build, which
-// prefers a .radix.tsx sibling over the file it sits next to.
+// Registry paths name the consumer's destination; the kit keeps the file under
+// components/react, and the radix probes mirror the build's radix variant rule.
 export function githubSourcePath(
   filePath: string,
   flavor: RegistryFlavor,

--- a/apps/docs/components/pages/docs/parameters-table.tsx
+++ b/apps/docs/components/pages/docs/parameters-table.tsx
@@ -1,6 +1,13 @@
-import { cn } from "@/lib/utils";
 import Link from "next/link";
 import type { FC, ReactNode } from "react";
+import {
+  Definition,
+  DefinitionAnnotation,
+  DefinitionDetails,
+  DefinitionList,
+  DefinitionName,
+  DefinitionTerm,
+} from "@/components/ui/definition-list";
 import { StatusBadge } from "./status-badge";
 
 const DESCRIPTION_LINK_CLASSNAME =
@@ -91,10 +98,9 @@ export function renderDescription(description: string | ReactNode): ReactNode {
   return parts;
 }
 
-const Parameter: FC<{
-  parameter: ParameterDef;
-  isNested?: boolean | undefined;
-}> = ({ parameter: partialParameter, isNested }) => {
+const Parameter: FC<{ parameter: ParameterDef }> = ({
+  parameter: partialParameter,
+}) => {
   const parameter = {
     ...COMMON_PARAMS[partialParameter.name],
     ...partialParameter,
@@ -103,43 +109,25 @@ const Parameter: FC<{
   const isOptional = !parameter.required && !parameter.default;
 
   return (
-    <div
-      className={cn(
-        "group border-border/50 border-b px-4 py-3 last:border-b-0",
-        isNested && "bg-muted/30",
-      )}
-    >
-      <dt>
-        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-          <code className="text-foreground font-mono text-sm font-semibold">
-            {parameter.name}
-          </code>
-          {parameter.deprecated && <StatusBadge variant="deprecated" />}
-          {parameter.name.startsWith("unstable_") && (
-            <StatusBadge variant="unstable" />
-          )}
-          {parameter.type && (
-            <>
-              {" "}
-              <code className="text-muted-foreground font-mono text-xs">
-                {isOptional && "?"}
-                {": "}
-                {parameter.type}
-              </code>
-            </>
-          )}
-          {parameter.default && (
-            <>
-              {" "}
-              <span className="text-muted-foreground font-mono text-xs">
-                = {parameter.default}
-              </span>
-            </>
-          )}
-        </div>
-      </dt>
-      <dd className="pt-2">
-        <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-line">
+    <Definition>
+      <DefinitionTerm>
+        <DefinitionName>
+          {parameter.name}
+          {isOptional && "?"}
+        </DefinitionName>
+        {parameter.type && (
+          <DefinitionAnnotation>{parameter.type}</DefinitionAnnotation>
+        )}
+        {parameter.default && (
+          <DefinitionAnnotation>= {parameter.default}</DefinitionAnnotation>
+        )}
+        {parameter.deprecated && <StatusBadge variant="deprecated" />}
+        {parameter.name.startsWith("unstable_") && (
+          <StatusBadge variant="unstable" />
+        )}
+      </DefinitionTerm>
+      <DefinitionDetails>
+        <p className="whitespace-pre-line">
           {renderDescription(parameter.description)}
         </p>
 
@@ -150,41 +138,26 @@ const Parameter: FC<{
         )}
 
         {parameter.children?.map((child, i) => (
-          <div key={child.type ?? i} className="mt-3">
-            <ParametersBox {...child} isNested />
-          </div>
+          <ParametersGroup key={child.type ?? i} {...child} />
         ))}
-      </dd>
-    </div>
+      </DefinitionDetails>
+    </Definition>
   );
 };
 
-const ParametersBox: FC<
-  ParametersTableProps & { isNested?: boolean | undefined }
-> = ({ type, parameters, isNested }) => {
+const ParametersGroup: FC<ParametersTableProps> = ({ type, parameters }) => {
   return (
-    <div
-      className={cn(
-        "border-border/60 overflow-hidden rounded-lg border",
-        isNested && "border-border/40",
-      )}
-    >
-      {type && !isNested && (
-        <div className="border-border/60 bg-muted/50 border-b px-4 py-2">
-          <code className="text-muted-foreground font-mono text-xs font-medium">
-            {type}
-          </code>
+    <div className="border-foreground/10 mt-3 border-s ps-4">
+      {type && (
+        <div className="text-muted-foreground mb-2 font-mono text-[11px] font-medium tracking-wide">
+          {type}
         </div>
       )}
-      <dl>
+      <DefinitionList className="border-t-0 [&>div:last-child]:border-b-0 [&>div:last-child]:pb-0">
         {parameters.map((parameter) => (
-          <Parameter
-            key={parameter.name}
-            parameter={parameter}
-            isNested={isNested}
-          />
+          <Parameter key={parameter.name} parameter={parameter} />
         ))}
-      </dl>
+      </DefinitionList>
     </div>
   );
 };
@@ -199,8 +172,17 @@ export const ParametersTable: FC<ParametersTableProps> = ({
   parameters,
 }) => {
   return (
-    <div className="not-prose my-4">
-      <ParametersBox type={type} parameters={parameters} />
+    <div className="not-prose my-6">
+      {type && (
+        <div className="text-muted-foreground mb-2 font-mono text-[11px] font-medium tracking-wide">
+          {type}
+        </div>
+      )}
+      <DefinitionList>
+        {parameters.map((parameter) => (
+          <Parameter key={parameter.name} parameter={parameter} />
+        ))}
+      </DefinitionList>
     </div>
   );
 };

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -19,9 +19,9 @@ export function AnnotatedSpecimen(): ReactNode {
   );
 }
 
-export const ArrowSpecimen = (): ReactNode => (
-  <div>arrow</div>
-);
+export function TrailingSpecimen() {
+  return <div>trailing</div>;
+}
 `;
 
 describe("extractFunctionCode", () => {
@@ -38,7 +38,7 @@ describe("extractFunctionCode", () => {
     expect(code).toContain("export function AnnotatedSpecimen(): ReactNode {");
     expect(code).toContain("<span>ok</span>");
     expect(code.endsWith("}")).toBe(true);
-    expect(code).not.toContain("ArrowSpecimen");
+    expect(code).not.toContain("TrailingSpecimen");
   });
 
   it("keeps imports only for identifiers the code uses as words", () => {
@@ -49,6 +49,19 @@ describe("extractFunctionCode", () => {
     const code = "<Table>Buttons, inputs, menu items</Table>";
     expect(filterRelevantImports(imports, code)).toEqual([
       'import { Table } from "@/components/ui/table";',
+    ]);
+  });
+
+  it("keeps an import bound under an alias or an inline type specifier", () => {
+    const imports = [
+      'import { Button as Action } from "@/components/ui/button";',
+      'import { useState, type ReactNode } from "react";',
+      'import { Table } from "@/components/ui/table";',
+    ];
+    const code = "const node: ReactNode = <Action />;";
+    expect(filterRelevantImports(imports, code)).toEqual([
+      'import { Button as Action } from "@/components/ui/button";',
+      'import { useState, type ReactNode } from "react";',
     ]);
   });
 

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractFunctionCode,
+  filterRelevantImports,
+} from "./preview-code-extract";
+
+const source = `
+import type { ReactNode } from "react";
+
+export function PlainSpecimen() {
+  return <div>{"}"}</div>;
+}
+
+export function AnnotatedSpecimen(): ReactNode {
+  return (
+    <div>
+      <span>ok</span>
+    </div>
+  );
+}
+
+export const ArrowSpecimen = (): ReactNode => (
+  <div>arrow</div>
+);
+`;
+
+describe("extractFunctionCode", () => {
+  it("extracts a plain function", () => {
+    const code = extractFunctionCode(source, "PlainSpecimen");
+    expect(code).toContain("export function PlainSpecimen()");
+    expect(code.endsWith("}")).toBe(true);
+    expect(code).toContain('{"}"}');
+    expect(code).not.toContain("AnnotatedSpecimen");
+  });
+
+  it("extracts a function with a return type annotation", () => {
+    const code = extractFunctionCode(source, "AnnotatedSpecimen");
+    expect(code).toContain("export function AnnotatedSpecimen(): ReactNode {");
+    expect(code).toContain("<span>ok</span>");
+    expect(code.endsWith("}")).toBe(true);
+    expect(code).not.toContain("ArrowSpecimen");
+  });
+
+  it("keeps imports only for identifiers the code uses as words", () => {
+    const imports = [
+      'import { Button } from "@/components/ui/button";',
+      'import { Table } from "@/components/ui/table";',
+    ];
+    const code = "<Table>Buttons, inputs, menu items</Table>";
+    expect(filterRelevantImports(imports, code)).toEqual([
+      'import { Table } from "@/components/ui/table";',
+    ]);
+  });
+
+  it("reports a missing function", () => {
+    expect(extractFunctionCode(source, "Missing")).toBe(
+      "// Could not find function: Missing",
+    );
+  });
+});

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -1,0 +1,195 @@
+type StringState = { inString: boolean; stringChar: string };
+
+function updateStringState(
+  state: StringState,
+  char: string,
+  prevChar: string,
+): boolean {
+  if (state.inString) {
+    if (char === state.stringChar && prevChar !== "\\") {
+      state.inString = false;
+    }
+    return true;
+  }
+  if (char === '"' || char === "'" || char === "`") {
+    state.inString = true;
+    state.stringChar = char;
+    return true;
+  }
+  return false;
+}
+
+function findMatchingParen(source: string, startIndex: number): number {
+  const state: StringState = { inString: false, stringChar: "" };
+  let parenCount = 0;
+
+  for (let i = startIndex; i < source.length; i++) {
+    const char = source[i]!;
+    const prevChar = source[i - 1] ?? "";
+    if (updateStringState(state, char, prevChar)) continue;
+
+    if (char === "(") parenCount++;
+    if (char === ")") {
+      if (parenCount === 0) {
+        const endIndex = i + 1;
+        return source[endIndex] === ";" ? endIndex + 1 : endIndex;
+      }
+      parenCount--;
+    }
+  }
+  return -1;
+}
+
+function findMatchingBrace(source: string, startIndex: number): number {
+  const state: StringState = { inString: false, stringChar: "" };
+  let braceCount = 0;
+  let foundFirstBrace = false;
+
+  for (let i = startIndex; i < source.length; i++) {
+    const char = source[i]!;
+    const prevChar = source[i - 1] ?? "";
+    if (updateStringState(state, char, prevChar)) continue;
+
+    if (char === "{") {
+      braceCount++;
+      foundFirstBrace = true;
+    }
+    if (char === "}") {
+      braceCount--;
+      if (foundFirstBrace && braceCount === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+export function extractFunctionCode(
+  source: string,
+  functionName: string,
+): string {
+  const functionRegex = new RegExp(
+    `export\\s+function\\s+${functionName}\\s*\\([^)]*\\)\\s*(?::[^{=]+)?\\{`,
+  );
+  const constRegex = new RegExp(
+    `export\\s+const\\s+${functionName}\\s*=\\s*(?:function\\s*)?\\([^)]*\\)\\s*(?::[^{=]+)?(?:=>\\s*)?\\{?`,
+  );
+
+  let match = functionRegex.exec(source);
+  let isArrowWithoutBrace = false;
+
+  if (!match) {
+    match = constRegex.exec(source);
+    if (match && !match[0].endsWith("{")) {
+      isArrowWithoutBrace = true;
+    }
+  }
+
+  if (!match) {
+    return `// Could not find function: ${functionName}`;
+  }
+
+  const startIndex = match.index;
+  const searchStart = match.index + match[0].length;
+
+  if (isArrowWithoutBrace) {
+    const endIndex = findMatchingParen(source, searchStart);
+    if (endIndex === -1) return `// Could not parse function: ${functionName}`;
+    return source.slice(startIndex, endIndex).trim();
+  }
+
+  const endIndex = findMatchingBrace(source, searchStart - 1);
+  if (endIndex === -1) return `// Could not parse function: ${functionName}`;
+  return source.slice(startIndex, endIndex).trim();
+}
+
+export function extractImports(source: string): string[] {
+  const imports: string[] = [];
+  const lines = source.split("\n");
+  let currentImport = "";
+  let inImport = false;
+
+  const isImportComplete = (line: string): boolean =>
+    (line.includes(" from ") && (line.includes('"') || line.includes("'"))) ||
+    line.includes('"') ||
+    line.includes("'");
+
+  for (const line of lines) {
+    if (line.trim().startsWith("import ")) {
+      inImport = true;
+      currentImport = line;
+    } else if (inImport) {
+      currentImport += `\n${line}`;
+    }
+
+    if (inImport && isImportComplete(line)) {
+      imports.push(currentImport);
+      currentImport = "";
+      inImport = false;
+    }
+  }
+  return imports;
+}
+
+export function filterRelevantImports(
+  imports: string[],
+  code: string,
+): string[] {
+  const usesName = (name: string) => new RegExp(`\\b${name}\\b`).test(code);
+
+  return imports.filter((imp) => {
+    const namedMatch = imp.match(/import\s+(?:type\s+)?\{([^}]+)\}/);
+    const defaultMatch = imp.match(/import\s+(\w+)\s+from/);
+
+    if (namedMatch?.[1]) {
+      const names = namedMatch[1]
+        .split(",")
+        .map((n) => n.trim().split(" as ")[0]?.trim())
+        .filter((name): name is string => Boolean(name));
+      return names.some(usesName);
+    }
+    if (defaultMatch?.[1]) {
+      return usesName(defaultMatch[1]);
+    }
+    return false;
+  });
+}
+
+function dedentSampleFrameContent(code: string): string {
+  const lines = code.split("\n");
+  const result: string[] = [];
+  let inSampleFrame = false;
+
+  for (const line of lines) {
+    if (line.includes("<SampleFrame")) {
+      inSampleFrame = true;
+      continue;
+    }
+    if (line.includes("</SampleFrame>")) {
+      inSampleFrame = false;
+      continue;
+    }
+    if (inSampleFrame && line.startsWith("  ")) {
+      result.push(line.slice(2));
+    } else {
+      result.push(line);
+    }
+  }
+  return result.join("\n");
+}
+
+export function cleanupCode(code: string): string {
+  return dedentSampleFrameContent(code).replace(/^export\s+/, "");
+}
+
+export function cleanupImports(imports: string[]): string[] {
+  return imports
+    .filter((imp) => !imp.includes("SampleFrame"))
+    .map((imp) =>
+      imp.replace(/(@\/components\/[\w-]+\/[\w.-]+?)\.radix(["'])/g, "$1$2"),
+    );
+}
+
+export function extractUseClientDirective(source: string): string | undefined {
+  return source.match(/^\s*(["'])use client\1;?/)?.[0].trim();
+}

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -131,6 +131,16 @@ export function extractImports(source: string): string[] {
   return imports;
 }
 
+// A specifier binds under its alias, and an inline type specifier binds under
+// the name after the keyword.
+function localBindingName(specifier: string): string {
+  return specifier
+    .replace(/^\s*type\s+/, "")
+    .split(/\s+as\s+/)
+    .pop()!
+    .trim();
+}
+
 export function filterRelevantImports(
   imports: string[],
   code: string,
@@ -144,7 +154,7 @@ export function filterRelevantImports(
     if (namedMatch?.[1]) {
       const names = namedMatch[1]
         .split(",")
-        .map((n) => n.trim().split(" as ")[0]?.trim())
+        .map((specifier) => localBindingName(specifier))
         .filter((name): name is string => Boolean(name));
       return names.some(usesName);
     }

--- a/apps/docs/components/pages/docs/preview-code.server.test.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.test.tsx
@@ -52,6 +52,16 @@ describe("PreviewCode", () => {
     expect(code).toContain("function MermaidSample()");
   });
 
+  it("keeps an import the sample binds under an inline type specifier", async () => {
+    const { code } = await getPreviewCode(
+      "components/pages/design/specimens",
+      "TooltipSpecimen",
+    );
+
+    expect(code).toContain('import { useState, type ReactNode } from "react";');
+    expect(code).toContain("): ReactNode {");
+  });
+
   it("keeps only the type import used by the preview function", async () => {
     const { code } = await getPreviewCode(
       "components/pages/docs/samples/tool-ui/custom-renderer",

--- a/apps/docs/components/pages/docs/preview-code.server.tsx
+++ b/apps/docs/components/pages/docs/preview-code.server.tsx
@@ -2,6 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ReactNode } from "react";
 import { PreviewCodeClient } from "./preview-code";
+import {
+  cleanupCode,
+  cleanupImports,
+  extractFunctionCode,
+  extractImports,
+  extractUseClientDirective,
+  filterRelevantImports,
+} from "./preview-code-extract";
 import type { LLMRenderContext } from "@/lib/get-llm-text";
 
 type PreviewCodeProps = {
@@ -14,194 +22,6 @@ type PreviewCodeProps = {
   base?: React.ReactNode;
   className?: string;
 };
-
-type StringState = { inString: boolean; stringChar: string };
-
-function updateStringState(
-  state: StringState,
-  char: string,
-  prevChar: string,
-): boolean {
-  if (state.inString) {
-    if (char === state.stringChar && prevChar !== "\\") {
-      state.inString = false;
-    }
-    return true;
-  }
-  if (char === '"' || char === "'" || char === "`") {
-    state.inString = true;
-    state.stringChar = char;
-    return true;
-  }
-  return false;
-}
-
-function findMatchingParen(source: string, startIndex: number): number {
-  const state: StringState = { inString: false, stringChar: "" };
-  let parenCount = 0;
-
-  for (let i = startIndex; i < source.length; i++) {
-    const char = source[i]!;
-    const prevChar = source[i - 1] ?? "";
-    if (updateStringState(state, char, prevChar)) continue;
-
-    if (char === "(") parenCount++;
-    if (char === ")") {
-      if (parenCount === 0) {
-        const endIndex = i + 1;
-        return source[endIndex] === ";" ? endIndex + 1 : endIndex;
-      }
-      parenCount--;
-    }
-  }
-  return -1;
-}
-
-function findMatchingBrace(source: string, startIndex: number): number {
-  const state: StringState = { inString: false, stringChar: "" };
-  let braceCount = 0;
-  let foundFirstBrace = false;
-
-  for (let i = startIndex; i < source.length; i++) {
-    const char = source[i]!;
-    const prevChar = source[i - 1] ?? "";
-    if (updateStringState(state, char, prevChar)) continue;
-
-    if (char === "{") {
-      braceCount++;
-      foundFirstBrace = true;
-    }
-    if (char === "}") {
-      braceCount--;
-      if (foundFirstBrace && braceCount === 0) {
-        return i + 1;
-      }
-    }
-  }
-  return -1;
-}
-
-function extractFunctionCode(source: string, functionName: string): string {
-  const functionRegex = new RegExp(
-    `export\\s+function\\s+${functionName}\\s*\\([^)]*\\)\\s*(?::[^{=]+)?\\{`,
-  );
-  const constRegex = new RegExp(
-    `export\\s+const\\s+${functionName}\\s*=\\s*(?:function\\s*)?\\([^)]*\\)\\s*(?::[^{=]+)?(?:=>\\s*)?\\{?`,
-  );
-
-  let match = functionRegex.exec(source);
-  let isArrowWithoutBrace = false;
-
-  if (!match) {
-    match = constRegex.exec(source);
-    if (match && !match[0].endsWith("{")) {
-      isArrowWithoutBrace = true;
-    }
-  }
-
-  if (!match) {
-    return `// Could not find function: ${functionName}`;
-  }
-
-  const startIndex = match.index;
-  const searchStart = match.index + match[0].length;
-
-  if (isArrowWithoutBrace) {
-    const endIndex = findMatchingParen(source, searchStart);
-    if (endIndex === -1) return `// Could not parse function: ${functionName}`;
-    return source.slice(startIndex, endIndex).trim();
-  }
-
-  const endIndex = findMatchingBrace(source, searchStart - 1);
-  if (endIndex === -1) return `// Could not parse function: ${functionName}`;
-  return source.slice(startIndex, endIndex).trim();
-}
-
-function extractImports(source: string): string[] {
-  const imports: string[] = [];
-  const lines = source.split("\n");
-  let currentImport = "";
-  let inImport = false;
-
-  const isImportComplete = (line: string): boolean =>
-    (line.includes(" from ") && (line.includes('"') || line.includes("'"))) ||
-    line.includes('"') ||
-    line.includes("'");
-
-  for (const line of lines) {
-    if (line.trim().startsWith("import ")) {
-      inImport = true;
-      currentImport = line;
-    } else if (inImport) {
-      currentImport += `\n${line}`;
-    }
-
-    if (inImport && isImportComplete(line)) {
-      imports.push(currentImport);
-      currentImport = "";
-      inImport = false;
-    }
-  }
-  return imports;
-}
-
-function filterRelevantImports(imports: string[], code: string): string[] {
-  return imports.filter((imp) => {
-    const namedMatch = imp.match(/import\s+(?:type\s+)?\{([^}]+)\}/);
-    const defaultMatch = imp.match(/import\s+(\w+)\s+from/);
-
-    if (namedMatch?.[1]) {
-      const names = namedMatch[1]
-        .split(",")
-        .map((n) => n.trim().split(" as ")[0]?.trim())
-        .filter((name): name is string => Boolean(name));
-      return names.some((name) => code.includes(name));
-    }
-    if (defaultMatch?.[1]) {
-      return code.includes(defaultMatch[1]);
-    }
-    return false;
-  });
-}
-
-function dedentSampleFrameContent(code: string): string {
-  const lines = code.split("\n");
-  const result: string[] = [];
-  let inSampleFrame = false;
-
-  for (const line of lines) {
-    if (line.includes("<SampleFrame")) {
-      inSampleFrame = true;
-      continue;
-    }
-    if (line.includes("</SampleFrame>")) {
-      inSampleFrame = false;
-      continue;
-    }
-    if (inSampleFrame && line.startsWith("  ")) {
-      result.push(line.slice(2));
-    } else {
-      result.push(line);
-    }
-  }
-  return result.join("\n");
-}
-
-function cleanupCode(code: string): string {
-  return dedentSampleFrameContent(code).replace(/^export\s+/, "");
-}
-
-function cleanupImports(imports: string[]): string[] {
-  return imports
-    .filter((imp) => !imp.includes("SampleFrame"))
-    .map((imp) =>
-      imp.replace(/(@\/components\/[\w-]+\/[\w.-]+?)\.radix(["'])/g, "$1$2"),
-    );
-}
-
-function extractUseClientDirective(source: string): string | undefined {
-  return source.match(/^\s*(["'])use client\1;?/)?.[0].trim();
-}
 
 function buildPreviewCode(file: string, name: string): string {
   const filePath = path.join(process.cwd(), `${file}.tsx`);

--- a/apps/docs/components/pages/docs/samples/o11y/capability-samples.tsx
+++ b/apps/docs/components/pages/docs/samples/o11y/capability-samples.tsx
@@ -13,7 +13,7 @@ import { ClientOnly } from "./client-only";
 function SpanLatency() {
   const latencyMs = useAuiState((s) => s.span.latencyMs) as number | null;
   return (
-    <span className="text-muted-foreground ml-auto pl-3 font-mono text-xs tabular-nums">
+    <span className="text-muted-foreground/70 ml-auto pl-3 font-mono text-[11px] tracking-wide tabular-nums">
       {latencyMs == null ? "" : `${latencyMs} ms`}
     </span>
   );
@@ -21,7 +21,7 @@ function SpanLatency() {
 
 function TreeSpanRow() {
   return (
-    <SpanPrimitive.Root className="hover:bg-accent/40 flex items-center rounded-md">
+    <SpanPrimitive.Root className="hover:bg-foreground/[0.03] flex items-center">
       <SpanPrimitive.Indent
         baseIndent={8}
         indentPerLevel={18}
@@ -35,9 +35,9 @@ function TreeSpanRow() {
         <AuiIf condition={(s) => !s.span.hasChildren}>
           <span className="size-4 shrink-0" />
         </AuiIf>
-        <SpanPrimitive.StatusIndicator className="size-2 shrink-0 rounded-full data-[span-status=completed]:bg-green-500 data-[span-status=failed]:bg-red-500 data-[span-status=running]:animate-pulse data-[span-status=running]:bg-yellow-500 data-[span-status=skipped]:bg-zinc-400" />
-        <SpanPrimitive.TypeBadge className="border-border text-muted-foreground shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px]" />
-        <SpanPrimitive.Name className="truncate text-sm" />
+        <SpanPrimitive.StatusIndicator className="size-1.5 shrink-0 rounded-full data-[span-status=completed]:bg-green-500 data-[span-status=failed]:bg-red-500 data-[span-status=running]:animate-pulse data-[span-status=running]:bg-yellow-500 data-[span-status=skipped]:bg-zinc-400 data-[span-status=running]:motion-reduce:animate-none" />
+        <SpanPrimitive.TypeBadge className="text-muted-foreground/70 shrink-0 font-mono text-[10px] tracking-wide" />
+        <SpanPrimitive.Name className="truncate text-[13px]" />
         <SpanLatency />
       </SpanPrimitive.Indent>
     </SpanPrimitive.Root>
@@ -48,7 +48,7 @@ function Tree({ spans }: { spans: SpanData[] }) {
   const aui = useAui({ span: SpanResource({ spans }) });
   return (
     <AuiProvider value={aui}>
-      <div className="border-border bg-background w-full max-w-md rounded-lg border p-2">
+      <div className="border-foreground/10 bg-background w-full max-w-md border p-1.5">
         <SpanPrimitive.Children components={{ Span: TreeSpanRow }} />
       </div>
     </AuiProvider>

--- a/apps/docs/components/pages/docs/samples/o11y/waterfall-bar.tsx
+++ b/apps/docs/components/pages/docs/samples/o11y/waterfall-bar.tsx
@@ -25,13 +25,14 @@ export function WaterfallBar() {
 
   return (
     <SpanPrimitive.TimelineBar
-      className={status === "running" ? "animate-pulse" : ""}
+      className={
+        status === "running" ? "animate-pulse motion-reduce:animate-none" : ""
+      }
       style={
         {
           "--span-timeline-min-width": "4px",
           top: 4,
           height: barHeight - 8,
-          borderRadius: 3,
           background: fill,
           opacity,
           boxShadow:

--- a/apps/docs/components/pages/docs/samples/o11y/waterfall-row.tsx
+++ b/apps/docs/components/pages/docs/samples/o11y/waterfall-row.tsx
@@ -16,7 +16,7 @@ export function WaterfallRow() {
       <SpanPrimitive.Indent
         baseIndent={8}
         indentPerLevel={12}
-        className="border-border bg-background group-hover:bg-accent/50 sticky left-0 z-10 flex shrink-0 items-center gap-1 overflow-hidden border-r px-2"
+        className="border-foreground/10 bg-background group-hover:bg-foreground/[0.03] sticky left-0 z-10 flex shrink-0 items-center gap-1.5 overflow-hidden border-r px-2"
         style={{ width: LABEL_WIDTH, height: barHeight }}
       >
         <AuiIf condition={(s) => s.span.hasChildren}>
@@ -34,13 +34,13 @@ export function WaterfallRow() {
         <AuiIf condition={(s) => !s.span.hasChildren}>
           <span className="w-4.5 shrink-0" />
         </AuiIf>
-        <SpanPrimitive.StatusIndicator className="size-1.5 shrink-0 rounded-full bg-current" />
-        <SpanPrimitive.TypeBadge className="border-border text-muted-foreground shrink-0 rounded border px-1 text-[10px]" />
-        <SpanPrimitive.Name className="truncate text-sm" />
+        <SpanPrimitive.StatusIndicator className="size-1.5 shrink-0 rounded-full data-[span-status=completed]:bg-green-500 data-[span-status=failed]:bg-red-500 data-[span-status=running]:animate-pulse data-[span-status=running]:bg-yellow-500 data-[span-status=skipped]:bg-zinc-400 data-[span-status=running]:motion-reduce:animate-none" />
+        <SpanPrimitive.TypeBadge className="text-muted-foreground/70 shrink-0 font-mono text-[10px] tracking-wide" />
+        <SpanPrimitive.Name className="truncate text-[13px]" />
       </SpanPrimitive.Indent>
 
       <div
-        className="group-hover:bg-accent/30 relative"
+        className="group-hover:bg-foreground/[0.02] relative"
         style={{ width: barWidth, height: barHeight }}
       >
         <WaterfallBar />

--- a/apps/docs/components/pages/docs/samples/o11y/waterfall-timeline.tsx
+++ b/apps/docs/components/pages/docs/samples/o11y/waterfall-timeline.tsx
@@ -84,13 +84,13 @@ function TimeAxisTicks({
             x2={x}
             y2={28}
             stroke="currentColor"
-            className="text-border"
+            className="text-foreground/15"
           />
           <text
             x={x}
             y={14}
             textAnchor="middle"
-            className="fill-muted-foreground text-[10px]"
+            className="fill-muted-foreground font-mono text-[9px]"
           >
             {formatTime(t)}
           </text>
@@ -198,31 +198,28 @@ export function WaterfallTimeline() {
 
   if (!hasSpans) {
     return (
-      <div className="border-border text-muted-foreground rounded-lg border py-12 text-center text-sm">
-        No spans recorded.
+      <div className="border-foreground/10 text-muted-foreground border py-12 text-center font-mono text-[12px]">
+        no spans recorded
       </div>
     );
   }
 
   return (
-    <div
-      ref={outerRef}
-      className="border-border overflow-hidden rounded-lg border"
-    >
+    <div ref={outerRef} className="border-foreground/10 overflow-hidden border">
       <div
         ref={scrollRef}
         className="overflow-auto"
         style={{ maxHeight: scrollMaxHeight }}
       >
         <div
-          className="border-border bg-background sticky top-0 z-20 flex border-b"
+          className="border-foreground/10 bg-background sticky top-0 z-20 flex border-b"
           style={{ width: contentWidth }}
         >
           <div
-            className="border-border bg-background text-muted-foreground sticky left-0 z-30 shrink-0 border-r px-2 py-1.5 text-xs"
+            className="border-foreground/10 bg-background text-muted-foreground sticky left-0 z-30 flex shrink-0 items-center border-r px-2 font-mono text-[10px] tracking-wide uppercase"
             style={{ width: LABEL_WIDTH }}
           >
-            Span
+            span
           </div>
           <div style={{ width: barWidth, height: 28 }}>
             <TimeAxisTicks timeRange={renderTimeRange} barWidth={barWidth} />
@@ -241,13 +238,10 @@ export function WaterfallTimeline() {
         </WaterfallLayoutContext.Provider>
       </div>
 
-      <div className="border-border text-muted-foreground flex items-center gap-4 border-t px-3 py-2 text-xs">
+      <div className="border-foreground/10 text-muted-foreground/70 flex flex-wrap items-center gap-x-4 gap-y-1 border-t px-3 py-2 font-mono text-[10px] tracking-wide">
         {Object.entries(TYPE_COLORS).map(([label, color]) => (
           <div key={label} className="flex items-center gap-1.5">
-            <span
-              className="size-2.5 rounded-sm"
-              style={{ background: color }}
-            />
+            <span className="size-2" style={{ background: color }} />
             <span>{label}</span>
           </div>
         ))}

--- a/apps/docs/components/pages/docs/samples/sample-frame.tsx
+++ b/apps/docs/components/pages/docs/samples/sample-frame.tsx
@@ -61,7 +61,7 @@ export function SampleFrame({ code, children, className }: SampleFrameProps) {
 
       <div
         className={cn(
-          "border-border/50 relative h-150 rounded-xl border",
+          "border-foreground/10 rounded-document relative h-150 border",
           className,
         )}
       >

--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -351,6 +351,19 @@ html:has(#nd-docs-layout) {
 .prose-blog {
   font-size: 0.9375rem !important;
   line-height: 1.75 !important;
+
+  & :where(code):not(:where(pre code)) {
+    font-size: 0.8125rem !important;
+    font-weight: 500 !important;
+    padding: 0.125rem 0.3125rem !important;
+    border-radius: var(--radius-sm) !important;
+    border: none !important;
+    background: color-mix(
+      in oklab,
+      var(--foreground) 6%,
+      transparent
+    ) !important;
+  }
 }
 
 figure.shiki {


### PR DESCRIPTION
## summary

three docs-app fixes extracted from the redesign branch, rebuilt against main's current paths.

- **install source links.** `githubSourcePath` built its GitHub links from the registry destination path, which stopped matching the kit tree when #6499 moved the components under `components/react`. 151 of the 153 registry files linked to a 404, in the manual tab and in the curl command alike. ui primitives now resolve through their flavor directory (falling back to the twin when a component ships in one flavor only), everything else through `components/react`, with the radix twin still preferred for the radix flavor.
- **preview code imports.** the import filter matched identifiers as substrings, so a specimen rendering `BreadcrumbSeparator` also carried an unused `Separator` import. eight design specimens print at least one import their snippet cannot use, and the Table specimen prints the entire `Dialog` group. it now matches on word boundaries. the parser moves into `preview-code-extract.ts` so the rule is testable without dragging the server component and its fs work into the suite; extraction output is otherwise unchanged.
- **design language.** the parameters table renders on the kit definition list instead of a bespoke bordered box, and nested parameters indent under a rule rather than nesting a box in a box (every parameters table routes through this component, generated api reference pages included). the sample frame takes the document radius and a hairline border, the o11y samples drop accent fills and boxed badges for the same hairline grammar (pulsing spans now respect reduced motion), and blog inline code becomes a tinted chip.

## test plan

### already verified

- `pnpm -C apps/docs test` -> 425/425 green, including the new `preview-code-extract` cases.
- ran the old and new extractor over all 61 `<PreviewCode>` call sites in `content/`: 0 differences in extracted code, 8 specimens shed a bogus import.
- resolved every registry file path through the new mapping against both flavors, on a registry rebuilt after #6476: unresolved drops from 151/153 to 4, and those four (`app/api/*`, `app/page.tsx`, `lib/resumable-context.ts`) are sourced from `templates/`, outside the `packages/ui/src` base url this component links against.
- docs-own `tsc --noEmit` clean, oxlint and oxfmt clean.
- browser pass on `/docs/api-reference/tools/toolkits` (parameters, nested groups), `/docs/utilities/react-o11y` (waterfall and tree), `/docs/tools/tool-ui` (30 preview blocks, no extraction errors), a blog post, and `/docs/tools/generative-ui.md` where the emitted GitHub link now points at a file that exists.

### reviewer should verify

- [ ] open a component doc's manual install tab in both flavors and follow one GitHub link.
- [ ] skim a parameters-heavy api reference page for the new definition-list rendering, nested parameters included.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iPPJKTnDBfOxQc2owmJDEs8rfRBUe67fWNbBIeFgk1TEbTVF6TOgMuoOH68?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->