### PR TITLE
fix(cli): fail the upgrade when a codemod exits nonzero (#6456)

### DIFF
--- a/.changeset/cli-codemod-exit-status.md
+++ b/.changeset/cli-codemod-exit-status.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: fail the upgrade when a codemod exits nonzero

--- a/packages/cli/src/lib/transform.test.ts
+++ b/packages/cli/src/lib/transform.test.ts
@@ -41,6 +41,31 @@ describe("transform", () => {
     );
   });
 
+  it("fails a progress-enabled codemod that exits nonzero", async () => {
+    mocks.runSpawnCapture.mockResolvedValue({
+      code: 7,
+      signal: null,
+      stdout: "Processing file app.tsx\n",
+      stderr: "SyntaxError: Broken input\n",
+    });
+    const onProgress = vi.fn();
+
+    const failure = transform(
+      "v0-8/ui-package-split",
+      "/tmp/project",
+      { dry: true },
+      {
+        logStatus: false,
+        onProgress,
+        relevantFiles: ["/tmp/project/app.tsx"],
+      },
+    );
+
+    await expect(failure).rejects.toBeInstanceOf(SpawnExitError);
+    await expect(failure).rejects.toThrow("SyntaxError: Broken input");
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
   it("surfaces the codemod's stderr when it exits nonzero", async () => {
     mocks.runSpawnCapture.mockResolvedValue({
       code: 1,

--- a/packages/cli/src/lib/transform.ts
+++ b/packages/cli/src/lib/transform.ts
@@ -137,7 +137,7 @@ export async function transform(
   if (result.signal !== null) {
     throw new SpawnSignalError(result.signal, false);
   }
-  if (!options.onProgress && result.code !== 0) {
+  if (result.code !== 0) {
     throw new SpawnExitError(result.code || 1, result.stderr);
   }
 

--- a/packages/cli/test/lib/upgrade.test.ts
+++ b/packages/cli/test/lib/upgrade.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   transform: vi.fn(() => []),
   installEdgeLib: vi.fn(),
   installAiSdkLib: vi.fn(),
+  loggerSuccess: vi.fn(),
 }));
 
 vi.mock("../../src/lib/transform", async (importOriginal) => ({
@@ -35,6 +36,11 @@ vi.mock("cli-progress", async (importOriginal) => ({
   },
 }));
 
+vi.mock("../../src/lib/utils/logger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/utils/logger")>()),
+  logger: { info: vi.fn(), success: mocks.loggerSuccess },
+}));
+
 vi.mock("debug", async (importOriginal) => ({
   ...(await importOriginal<typeof import("debug")>()),
   default: () => () => {},
@@ -61,5 +67,19 @@ describe("upgrade", () => {
     ]);
     expect(mocks.installEdgeLib).toHaveBeenCalledOnce();
     expect(mocks.installAiSdkLib).toHaveBeenCalledOnce();
+  });
+
+  it("stops at a failed codemod without installing dependencies", async () => {
+    const failure = new Error("Process exited with code 7");
+    mocks.transform.mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    await expect(upgrade({ dry: true })).rejects.toBe(failure);
+
+    expect(mocks.transform).toHaveBeenCalledOnce();
+    expect(mocks.installEdgeLib).not.toHaveBeenCalled();
+    expect(mocks.installAiSdkLib).not.toHaveBeenCalled();
+    expect(mocks.loggerSuccess).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #6456. Supersedes #6457, which was written against the synchronous `transform` that #6452 has since replaced.

## Problem

`transform()` skipped the exit-status check whenever a progress callback was supplied:

```ts
if (!options.onProgress && result.code !== 0) {
  throw new SpawnExitError(result.code || 1, result.stderr);
}
```

`upgrade` supplies `onProgress` for every codemod in the bundle, so that branch is the one it always takes. A codemod that exited nonzero returned no errors, advanced the progress bar, and let `upgrade` continue into dependency installation and `logger.success`.

Measured on `main` before the change, with a child exiting 7 and `SyntaxError: Broken input` on stderr:

```
threw: false | returned: [] | onProgress calls: 1
```

## Change

One line: the exit-status check now runs on both paths. The non-progress path already failed this way, so the two agree rather than diverging on whether the caller asked for progress. `onProgress` accounting sits below the check, so it no longer runs for a failed child.

`upgrade` needs no change. It has no `catch`, so the throw stops the bundle before dependency installation, and `bar.stop()` already sits in a `finally` from #6452.

## Scope

jscodeshift runs with `--fail-on-error=false` here, so a parse error on its own still exits 0 and continues to be reported through `parseErrors`. This guard covers a child that actually exits nonzero. #6456's repro line ("a parse error in a matched file is enough") does not hold for that reason; the underlying report does.

## Verification

- `pnpm --filter assistant-ui test` (26 files, 305 tests)
- both new tests are non-vacuous: restoring `!options.onProgress &&` fails the transform test, and giving `upgrade` a swallowing `catch` fails the upgrade test; each fails on its own mutation and on nothing else
- `pnpm --filter assistant-ui build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.E4r2GSklK1udNlfU4-raqCnrot7hP5-ZnEvHojiUyLAIPWGIlLiA7g5TdWA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->