### PR TITLE
fix(docs): extract typed and expression-bodied preview samples

### DIFF
--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -36,6 +36,8 @@ export const ExpressionSpecimen = () => (
 export function GuardSpecimen() {
   return <div>guard</div>;
 }
+
+export const CompoundSpecimen = () => (compose)();
 `;
 
 describe("extractFunctionCode", () => {
@@ -69,6 +71,12 @@ describe("extractFunctionCode", () => {
     expect(code).toContain("<span>expression</span>");
     expect(code.endsWith(");")).toBe(true);
     expect(code).not.toContain("GuardSpecimen");
+  });
+
+  it("reports an arrow whose parens cover only part of the body", () => {
+    expect(extractFunctionCode(source, "CompoundSpecimen")).toBe(
+      "// Could not parse function: CompoundSpecimen",
+    );
   });
 
   it("keeps imports only for identifiers the code uses as words", () => {

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./preview-code-extract";
 
 const source = `
-import type { ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 
 export function PlainSpecimen() {
   return <div>{"}"}</div>;
@@ -21,6 +21,20 @@ export function AnnotatedSpecimen(): ReactNode {
 
 export function TrailingSpecimen() {
   return <div>trailing</div>;
+}
+
+export const TypedSpecimen: FC = () => {
+  return <div>typed</div>;
+};
+
+export const ExpressionSpecimen = () => (
+  <div>
+    <span>expression</span>
+  </div>
+);
+
+export function GuardSpecimen() {
+  return <div>guard</div>;
 }
 `;
 
@@ -39,6 +53,22 @@ describe("extractFunctionCode", () => {
     expect(code).toContain("<span>ok</span>");
     expect(code.endsWith("}")).toBe(true);
     expect(code).not.toContain("TrailingSpecimen");
+  });
+
+  it("extracts a const arrow with a type annotation", () => {
+    const code = extractFunctionCode(source, "TypedSpecimen");
+    expect(code).toContain("export const TypedSpecimen: FC = () => {");
+    expect(code).toContain("<div>typed</div>");
+    expect(code.endsWith("}")).toBe(true);
+    expect(code).not.toContain("ExpressionSpecimen");
+  });
+
+  it("extracts a const arrow with a parenthesized expression body", () => {
+    const code = extractFunctionCode(source, "ExpressionSpecimen");
+    expect(code).toContain("export const ExpressionSpecimen = () => (");
+    expect(code).toContain("<span>expression</span>");
+    expect(code.endsWith(");")).toBe(true);
+    expect(code).not.toContain("GuardSpecimen");
   });
 
   it("keeps imports only for identifiers the code uses as words", () => {

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -72,7 +72,7 @@ export function extractFunctionCode(
     `export\\s+function\\s+${functionName}\\s*\\([^)]*\\)\\s*(?::[^{=]+)?\\{`,
   );
   const constRegex = new RegExp(
-    `export\\s+const\\s+${functionName}\\s*=\\s*(?:function\\s*)?\\([^)]*\\)\\s*(?::[^{=]+)?(?:=>\\s*)?\\{?`,
+    `export\\s+const\\s+${functionName}\\s*(?::[^=]+)?=\\s*(?:function\\s*)?\\([^)]*\\)\\s*(?::[^{=]+)?(?:=>\\s*)?\\{?`,
   );
 
   let match = functionRegex.exec(source);
@@ -93,7 +93,9 @@ export function extractFunctionCode(
   const searchStart = match.index + match[0].length;
 
   if (isArrowWithoutBrace) {
-    const endIndex = findMatchingParen(source, searchStart);
+    const bodyStart =
+      source[searchStart] === "(" ? searchStart + 1 : searchStart;
+    const endIndex = findMatchingParen(source, bodyStart);
     if (endIndex === -1) return `// Could not parse function: ${functionName}`;
     return source.slice(startIndex, endIndex).trim();
   }

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -40,6 +40,13 @@ function findMatchingParen(source: string, startIndex: number): number {
   return -1;
 }
 
+function endsLine(source: string, index: number): boolean {
+  const lineEnd = source.indexOf("\n", index);
+  const rest =
+    lineEnd === -1 ? source.slice(index) : source.slice(index, lineEnd);
+  return rest.trim() === "";
+}
+
 function findMatchingBrace(source: string, startIndex: number): number {
   const state: StringState = { inString: false, stringChar: "" };
   let braceCount = 0;
@@ -93,10 +100,15 @@ export function extractFunctionCode(
   const searchStart = match.index + match[0].length;
 
   if (isArrowWithoutBrace) {
-    const bodyStart =
-      source[searchStart] === "(" ? searchStart + 1 : searchStart;
-    const endIndex = findMatchingParen(source, bodyStart);
-    if (endIndex === -1) return `// Could not parse function: ${functionName}`;
+    const isWrapped = source[searchStart] === "(";
+    const endIndex = findMatchingParen(
+      source,
+      isWrapped ? searchStart + 1 : searchStart,
+    );
+    // A wrapping paren that closes mid-line covered only part of the body.
+    if (endIndex === -1 || (isWrapped && !endsLine(source, endIndex))) {
+      return `// Could not parse function: ${functionName}`;
+    }
     return source.slice(startIndex, endIndex).trim();
   }
 


### PR DESCRIPTION
closes #6526

## summary

- `extractFunctionCode` now reads `export const X: FC = () => {}` and `export const X = () => (...)`. both forms previously rendered `// Could not find function` or `// Could not parse function` into the preview code panel.
- the const regex takes an optional `(?::[^=]+)?` annotation between the name and `=`. the span is bounded by the `=` the pattern already required, so a plain `export const X = ...` matches exactly as before.
- the expression-body branch starts the paren scan one character past the body's opening `(`, so `findMatchingParen` meets that paren's closer at depth zero instead of running past it to the next unmatched `)` in the file. that offset is only taken when the closer ends its line; a paren closing mid-line (`() => (fn)()`, `() => (v) + (w)`) wrapped just part of the body, so those keep the `// Could not parse function` marker rather than extracting a truncated snippet.
- an AST parse would add parser scope to a private docs helper, and rewriting `findMatchingParen`'s contract would broaden a helper to serve its one call site, so the offset and its guard live at the caller.

## test plan

### already verified

- [x] `./node_modules/.bin/vitest run components/pages/docs/preview-code-extract.test.ts components/pages/docs/preview-code.server.test.tsx` from `apps/docs` -> 12/12 green
- [x] both directions: reverting only `preview-code-extract.ts` to origin/main and rerunning fails the two new cases with exactly `// Could not find function: TypedSpecimen` and `// Could not parse function: ExpressionSpecimen`
- [x] real samples through the patched module: `samples/speech.tsx#Thread` extracts 24 lines ending at `}`, `tap/tutorial-slideshow.tsx#TapTutorialSlideshow` extracts 3 lines ending at `);`
- [x] partial-wrap shapes through the patched module: `() => (fn)()` and `() => (v) + (w)` both return `// Could not parse function`, matching what the base module returns for them
- [x] regression sweep over all 61 `<PreviewCode>` call sites (and their `.radix` twins), base module vs patched: byte-identical output everywhere, no site sitting on a `// Could not` fallback
- [x] `oxfmt --check` and `oxlint` on both touched files: clean

## notes

- no changeset; `apps/docs` is private.
- neither form is reachable from a call site today, so no rendered page changes. the sweep above is the evidence, not an assumption.
- `export const X = () => expr;` without wrapping parens is still unsupported, unchanged from before this PR and out of scope for #6526.
- supersedes #6527, which fixed the same defect against the pre-#6522 file layout (`preview-code.server.tsx`) and so cannot merge.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CD8Kq6kjiLlLDsICkZuH4udXqks2xgbCoqSd-g1QF3hN3y4fRjo0JSIOQ80?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->