### PR TITLE
fix(docs): export llm traces to axiom to preserve span attributes

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -20,6 +20,8 @@ NEXT_PUBLIC_POSTHOG_API_KEY=
 # attach; leaving either blank disables only the Axiom leg.
 AXIOM_TOKEN=
 AXIOM_DATASET=
+# Optional. Defaults to api.axiom.co; set to api.eu.axiom.co for an EU org.
+AXIOM_DOMAIN=
 
 # Optional. Personal access token used to raise GitHub API rate limits when
 # fetching repo stats, releases, contributors, and stargazers (lib/github.ts).

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -16,6 +16,11 @@ NEXT_PUBLIC_APP_URL=
 # Optional. PostHog project key. When unset, analytics are disabled.
 NEXT_PUBLIC_POSTHOG_API_KEY=
 
+# Axiom OTel export for LLM traces. Both must be set for the exporter to attach;
+# leaving either blank keeps PostHog as the only destination.
+AXIOM_TOKEN=
+AXIOM_DATASET=
+
 # Optional. Personal access token used to raise GitHub API rate limits when
 # fetching repo stats, releases, contributors, and stargazers (lib/github.ts).
 GITHUB_TOKEN=

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -16,8 +16,8 @@ NEXT_PUBLIC_APP_URL=
 # Optional. PostHog project key. When unset, analytics are disabled.
 NEXT_PUBLIC_POSTHOG_API_KEY=
 
-# Axiom OTel export for LLM traces. Both must be set for the exporter to attach;
-# leaving either blank keeps PostHog as the only destination.
+# Axiom OTel export for LLM traces. Both must be set for the exporter to
+# attach; leaving either blank disables only the Axiom leg.
 AXIOM_TOKEN=
 AXIOM_DATASET=
 

--- a/apps/docs/instrumentation.test.ts
+++ b/apps/docs/instrumentation.test.ts
@@ -1,0 +1,73 @@
+import type {
+  ReadableSpan,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { describe, expect, it, vi } from "vitest";
+import { aiOnly, isAiSpan } from "./instrumentation";
+
+function span(name: string, attributes: Record<string, unknown> = {}) {
+  return { name, attributes } as unknown as ReadableSpan;
+}
+
+function recordingProcessor() {
+  return {
+    onStart: vi.fn(),
+    onEnd: vi.fn(),
+    forceFlush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  } satisfies SpanProcessor;
+}
+
+describe("isAiSpan", () => {
+  it("accepts a span whose name carries an AI prefix", () => {
+    expect(isAiSpan(span("ai.streamText"))).toBe(true);
+    expect(isAiSpan(span("gen_ai.client"))).toBe(true);
+  });
+
+  it("accepts a span whose attributes carry an AI prefix", () => {
+    expect(
+      isAiSpan(
+        span("chat gpt-5.6-luna", {
+          "ai.settings.context.posthog_distinct_id": "user_1",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops an ordinary request span", () => {
+    expect(
+      isAiSpan(
+        span("GET /docs/[[...slug]]", {
+          "http.method": "GET",
+          "next.route": "/docs/[[...slug]]",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("aiOnly", () => {
+  it("forwards AI spans and swallows the rest", () => {
+    const inner = recordingProcessor();
+    const processor = aiOnly(inner);
+
+    processor.onEnd(span("ai.streamText"));
+    processor.onEnd(span("GET /docs", { "http.method": "GET" }));
+
+    expect(inner.onEnd).toHaveBeenCalledTimes(1);
+    expect(inner.onEnd.mock.calls[0]?.[0].name).toBe("ai.streamText");
+  });
+
+  // A wrapper that forgets either one silently loses the tail batch on Vercel,
+  // where the function suspends as soon as the response is sent.
+  it("delegates forceFlush and shutdown to the inner processor", async () => {
+    const inner = recordingProcessor();
+    const processor = aiOnly(inner);
+
+    await processor.forceFlush();
+    await processor.shutdown();
+
+    expect(inner.forceFlush).toHaveBeenCalledTimes(1);
+    expect(inner.shutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/docs/instrumentation.test.ts
+++ b/apps/docs/instrumentation.test.ts
@@ -3,7 +3,7 @@ import type {
   SpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { describe, expect, it, vi } from "vitest";
-import { aiOnly, isAiSpan } from "./instrumentation";
+import { aiOnly, axiomExporterConfig, isAiSpan } from "./instrumentation";
 
 function span(name: string, attributes: Record<string, unknown> = {}) {
   return { name, attributes } as unknown as ReadableSpan;
@@ -82,5 +82,37 @@ describe("aiOnly", () => {
 
     expect(inner.forceFlush).toHaveBeenCalledTimes(1);
     expect(inner.shutdown).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("axiomExporterConfig", () => {
+  const creds = { AXIOM_TOKEN: "xaat-test", AXIOM_DATASET: "traces" };
+
+  it("returns null unless both credentials are present", () => {
+    expect(axiomExporterConfig({})).toBeNull();
+    expect(axiomExporterConfig({ AXIOM_TOKEN: "xaat-test" })).toBeNull();
+    expect(axiomExporterConfig({ AXIOM_DATASET: "traces" })).toBeNull();
+  });
+
+  it("defaults to the US host when the domain is unset or blank", () => {
+    expect(axiomExporterConfig(creds)?.url).toBe(
+      "https://api.axiom.co/v1/traces",
+    );
+    expect(axiomExporterConfig({ ...creds, AXIOM_DOMAIN: "" })?.url).toBe(
+      "https://api.axiom.co/v1/traces",
+    );
+  });
+
+  it("honours an explicit region", () => {
+    expect(
+      axiomExporterConfig({ ...creds, AXIOM_DOMAIN: "api.eu.axiom.co" })?.url,
+    ).toBe("https://api.eu.axiom.co/v1/traces");
+  });
+
+  it("carries the token and dataset headers", () => {
+    expect(axiomExporterConfig(creds)?.headers).toEqual({
+      Authorization: "Bearer xaat-test",
+      "X-Axiom-Dataset": "traces",
+    });
   });
 });

--- a/apps/docs/instrumentation.test.ts
+++ b/apps/docs/instrumentation.test.ts
@@ -58,6 +58,19 @@ describe("aiOnly", () => {
     expect(inner.onEnd.mock.calls[0]?.[0].name).toBe("ai.streamText");
   });
 
+  it("passes onStart through unfiltered", () => {
+    const inner = recordingProcessor();
+    const started = span("GET /docs", { "http.method": "GET" });
+    const context = {} as Parameters<SpanProcessor["onStart"]>[1];
+
+    aiOnly(inner).onStart(
+      started as unknown as Parameters<SpanProcessor["onStart"]>[0],
+      context,
+    );
+
+    expect(inner.onStart).toHaveBeenCalledWith(started, context);
+  });
+
   // A wrapper that forgets either one silently loses the tail batch on Vercel,
   // where the function suspends as soon as the response is sent.
   it("delegates forceFlush and shutdown to the inner processor", async () => {

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -23,16 +23,15 @@ function axiomProcessor() {
 }
 
 export function register() {
-  const posthog = new BatchSpanProcessor(
-    new PostHogTraceExporter({
-      projectToken: process.env.NEXT_PUBLIC_POSTHOG_API_KEY ?? "",
-    }),
-  );
-
   const axiom = axiomProcessor();
 
   registerOTel({
     serviceName: "assistant-ui-docs",
-    spanProcessors: axiom ? [posthog, axiom] : [posthog],
+    traceExporter: new PostHogTraceExporter({
+      projectToken: process.env.NEXT_PUBLIC_POSTHOG_API_KEY ?? "",
+    }),
+    // "auto" keeps the environment's default processors, including the Vercel
+    // tracing integration that an explicit list would otherwise replace.
+    spanProcessors: axiom ? ["auto", axiom] : ["auto"],
   });
 }

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -1,11 +1,38 @@
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { PostHogTraceExporter } from "@posthog/ai/otel";
-import { registerOTel } from "@vercel/otel";
+import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+// PostHog's OTLP ingestion drops span attributes it does not recognise, which
+// costs the per-application and per-user dimensions on the AI SDK v7 path
+// (PostHog/posthog#52442). Axiom stores every attribute verbatim, so it is
+// exported alongside rather than instead of PostHog while both are in use.
+function axiomProcessor() {
+  const token = process.env.AXIOM_TOKEN;
+  const dataset = process.env.AXIOM_DATASET;
+  if (!token || !dataset) return null;
+
+  return new BatchSpanProcessor(
+    new OTLPHttpProtoTraceExporter({
+      url: "https://api.axiom.co/v1/traces",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Axiom-Dataset": dataset,
+      },
+    }),
+  );
+}
 
 export function register() {
-  registerOTel({
-    serviceName: "assistant-ui-docs",
-    traceExporter: new PostHogTraceExporter({
+  const posthog = new BatchSpanProcessor(
+    new PostHogTraceExporter({
       projectToken: process.env.NEXT_PUBLIC_POSTHOG_API_KEY ?? "",
     }),
+  );
+
+  const axiom = axiomProcessor();
+
+  registerOTel({
+    serviceName: "assistant-ui-docs",
+    spanProcessors: axiom ? [posthog, axiom] : [posthog],
   });
 }

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -1,6 +1,35 @@
+import type {
+  ReadableSpan,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { PostHogTraceExporter } from "@posthog/ai/otel";
 import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+
+// Mirrors the prefixes PostHogTraceExporter filters on, so both legs carry the
+// same spans. Without it Axiom would also receive every request and fetch span
+// that "auto" produces for ordinary site traffic, which it bills by volume.
+const AI_SPAN_PREFIXES = ["gen_ai.", "llm.", "ai.", "traceloop."];
+
+function isAiSpan(span: ReadableSpan) {
+  return (
+    AI_SPAN_PREFIXES.some((prefix) => span.name.startsWith(prefix)) ||
+    Object.keys(span.attributes).some((key) =>
+      AI_SPAN_PREFIXES.some((prefix) => key.startsWith(prefix)),
+    )
+  );
+}
+
+function aiOnly(inner: SpanProcessor): SpanProcessor {
+  return {
+    onStart: (span, context) => inner.onStart(span, context),
+    onEnd: (span) => {
+      if (isAiSpan(span)) inner.onEnd(span);
+    },
+    forceFlush: () => inner.forceFlush(),
+    shutdown: () => inner.shutdown(),
+  };
+}
 
 // PostHog's OTLP ingestion drops span attributes it does not recognise, which
 // costs the per-application and per-user dimensions on the AI SDK v7 path
@@ -11,14 +40,16 @@ function axiomProcessor() {
   const dataset = process.env.AXIOM_DATASET;
   if (!token || !dataset) return null;
 
-  return new BatchSpanProcessor(
-    new OTLPHttpProtoTraceExporter({
-      url: "https://api.axiom.co/v1/traces",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "X-Axiom-Dataset": dataset,
-      },
-    }),
+  return aiOnly(
+    new BatchSpanProcessor(
+      new OTLPHttpProtoTraceExporter({
+        url: "https://api.axiom.co/v1/traces",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-Axiom-Dataset": dataset,
+        },
+      }),
+    ),
   );
 }
 

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -35,24 +35,29 @@ export function aiOnly(inner: SpanProcessor): SpanProcessor {
 // costs the per-application and per-user dimensions on the AI SDK v7 path
 // (PostHog/posthog#52442). Axiom stores every attribute verbatim, so it is
 // exported alongside rather than instead of PostHog while both are in use.
-function axiomProcessor() {
-  const token = process.env.AXIOM_TOKEN;
-  const dataset = process.env.AXIOM_DATASET;
+export function axiomExporterConfig(env: NodeJS.ProcessEnv) {
+  const token = env.AXIOM_TOKEN;
+  const dataset = env.AXIOM_DATASET;
   if (!token || !dataset) return null;
 
-  return aiOnly(
-    new BatchSpanProcessor(
-      new OTLPHttpProtoTraceExporter({
-        // api.axiom.co is the US domain; an EU-hosted org ingests at
-        // api.eu.axiom.co and otherwise drops batches silently.
-        url: `https://${process.env.AXIOM_DOMAIN || "api.axiom.co"}/v1/traces`,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "X-Axiom-Dataset": dataset,
-        },
-      }),
-    ),
-  );
+  return {
+    // api.axiom.co is the US domain; an EU-hosted org ingests at
+    // api.eu.axiom.co and otherwise drops batches silently. An empty value
+    // has to fall back too: a Vercel variable created ahead of its value
+    // would otherwise build https:///v1/traces.
+    url: `https://${env.AXIOM_DOMAIN || "api.axiom.co"}/v1/traces`,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Axiom-Dataset": dataset,
+    },
+  };
+}
+
+function axiomProcessor() {
+  const config = axiomExporterConfig(process.env);
+  if (!config) return null;
+
+  return aiOnly(new BatchSpanProcessor(new OTLPHttpProtoTraceExporter(config)));
 }
 
 export function register() {

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -11,7 +11,7 @@ import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
 // that "auto" produces for ordinary site traffic, which it bills by volume.
 const AI_SPAN_PREFIXES = ["gen_ai.", "llm.", "ai.", "traceloop."];
 
-function isAiSpan(span: ReadableSpan) {
+export function isAiSpan(span: ReadableSpan) {
   return (
     AI_SPAN_PREFIXES.some((prefix) => span.name.startsWith(prefix)) ||
     Object.keys(span.attributes).some((key) =>
@@ -20,7 +20,7 @@ function isAiSpan(span: ReadableSpan) {
   );
 }
 
-function aiOnly(inner: SpanProcessor): SpanProcessor {
+export function aiOnly(inner: SpanProcessor): SpanProcessor {
   return {
     onStart: (span, context) => inner.onStart(span, context),
     onEnd: (span) => {

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -45,7 +45,7 @@ function axiomProcessor() {
       new OTLPHttpProtoTraceExporter({
         // api.axiom.co is the US domain; an EU-hosted org ingests at
         // api.eu.axiom.co and otherwise drops batches silently.
-        url: `https://${process.env.AXIOM_DOMAIN ?? "api.axiom.co"}/v1/traces`,
+        url: `https://${process.env.AXIOM_DOMAIN || "api.axiom.co"}/v1/traces`,
         headers: {
           Authorization: `Bearer ${token}`,
           "X-Axiom-Dataset": dataset,

--- a/apps/docs/instrumentation.ts
+++ b/apps/docs/instrumentation.ts
@@ -43,7 +43,9 @@ function axiomProcessor() {
   return aiOnly(
     new BatchSpanProcessor(
       new OTLPHttpProtoTraceExporter({
-        url: "https://api.axiom.co/v1/traces",
+        // api.axiom.co is the US domain; an EU-hosted org ingests at
+        // api.eu.axiom.co and otherwise drops batches silently.
+        url: `https://${process.env.AXIOM_DOMAIN ?? "api.axiom.co"}/v1/traces`,
         headers: {
           Authorization: `Bearer ${token}`,
           "X-Axiom-Dataset": dataset,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -36,6 +36,7 @@
     "@hookform/resolvers": "^5.9.1",
     "@langchain/langgraph-sdk": "^1.10.0",
     "@modelcontextprotocol/server": "^2.0.0",
+    "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@posthog/ai": "^8.9.0",
     "@shikijs/transformers": "^4.4.3",
     "@upstash/ratelimit": "^2.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.1.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@posthog/ai':
         specifier: ^8.9.0
         version: 8.9.0(@ai-sdk/provider@4.0.8)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2))(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.81)(@smithy/signature-v4@5.7.3)(undici@8.10.0)(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-http@0.205.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@7.8.0(@aws-sdk/credential-provider-node@3.972.81)(@smithy/signature-v4@5.7.3)(undici@8.10.0)(ws@8.21.3)(zod@4.4.3))(posthog-node@5.51.4(rxjs@7.8.2))
@@ -1973,7 +1976,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.6.0
-        version: 1.6.0(3c75a5fb077326a9e1b54756d238cb65)
+        version: 1.6.0(6fd5759e436e9fcbe998bd01458de66c)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -23184,12 +23187,12 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(supports-color@10.2.2)':
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(supports-color@10.2.2)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
+      '@google-cloud/opentelemetry-resource-util': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
       '@google-cloud/precise-date': 4.0.0
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.0)
       google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@10.2.2)
@@ -23213,13 +23216,13 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google-cloud/opentelemetry-cloud-trace-exporter@3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)':
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
+      '@google-cloud/opentelemetry-resource-util': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.1
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.0)
       google-auth-library: 10.9.1(supports-color@10.2.2)
@@ -23240,10 +23243,10 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google-cloud/opentelemetry-resource-util@3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)':
+  '@google-cloud/opentelemetry-resource-util@3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.43.0
       gcp-metadata: 9.0.3(supports-color@10.2.2)
@@ -23303,11 +23306,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/adk@1.6.0(3c75a5fb077326a9e1b54756d238cb65)':
+  '@google/adk@1.6.0(6fd5759e436e9fcbe998bd01458de66c)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(@bufbuild/protobuf@2.14.0)(@grpc/grpc-js@1.14.4)(express@4.22.2(supports-color@10.2.2))
-      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(supports-color@10.2.2)
-      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(supports-color@10.2.2)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.1.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(supports-color@10.2.2)
       '@google-cloud/storage': 7.22.0(encoding@0.1.13)(supports-color@10.2.2)
       '@google-cloud/vertexai': 1.12.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(encoding@0.1.13)(supports-color@10.2.2)
       '@google/genai': 2.19.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)


### PR DESCRIPTION
## summary

posthog's otlp ingestion drops span attributes it does not recognise, so the ai sdk v7 path silently lost two dimensions on llm traces: which application made the call, and which user. this adds axiom as a second destination, where those attributes survive.

`telemetry.ts` already emits both. the loss happens downstream: `@ai-sdk/otel` prefixes every runtime-context key as `ai.settings.context.*`, and posthog discards attributes outside its own allowlist ([PostHog/posthog#52442](https://github.com/PostHog/posthog/issues/52442), open since march).

two symptoms confirm it, comparing the periods either side of #5893:

- `$ai_span_name` no longer carries the application name; every generation collapses to the hardcoded `chat <model>`
- the distinct person count jumps by roughly an order of magnitude while generation volume stays flat,,the signature of every call landing a fresh anonymous id rather than real growth

`gen_ai.agent.name`, `operation.name` and `service.name` were each checked as fallbacks; none carries the application.

## approach

`registerOTel` takes a `spanProcessors` array, so axiom attaches alongside posthog rather than replacing it. the list is prefixed with `"auto"` so the environment's default processors, including the vercel tracing integration, stay in place. `telemetry.ts` and the three route handlers are untouched.

the axiom processor is wrapped in the same span filter `PostHogTraceExporter` applies internally (name or attribute key starting with `gen_ai.`, `llm.`, `ai.` or `traceloop.`), so both legs carry generations rather than the whole site's request and fetch spans.

no new third-party dependency: `OTLPHttpProtoTraceExporter` ships with `@vercel/otel`, and `@opentelemetry/sdk-trace-base` was already a transitive peer,,it is only declared explicitly so pnpm's strict resolution allows the import.

## rollout

both `AXIOM_TOKEN` and `AXIOM_DATASET` must be set for the exporter to attach. with either blank the list is just `["auto"]`, which is the current pipeline, so this is safe to merge before the env vars land.

## test plan

- [x] `tsc --noEmit` clean for `instrumentation.ts` (the remaining errors are pre-existing baseline in `heat-graph` and `elements`)
- [x] oxlint and oxfmt clean via the pre-commit hook
- [ ] after deploy, confirm spans arrive in axiom carrying the application dimension,,the exact attribute path needs confirming against real data

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Aslj1wJCsefjrcIVrVlytf2eLETDZLn2V-PXPtOxdEdAaeFwlZ7stoCqqG0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
