### PR TITLE
chore: upgrade pnpm to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "turbo": "^2.10.12",
     "typescript": "^7.0.2"
   },
-  "packageManager": "pnpm@11.23.0",
+  "packageManager": "pnpm@12.0.0",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,jsonc}": [
       "oxlint --fix --no-error-on-unmatched-pattern",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## summary

- moves the `packageManager` pin from `pnpm@11.23.0` to `pnpm@12.0.0`. the whole change is that one line plus what pnpm 12 itself writes into the lockfile.
- the lockfile gains a `packageManagerDependencies` block recording pnpm and the 8 `@pnpm/exe.*` platform binaries with their integrity hashes. pnpm 12 emits this as a second YAML document at the top of `pnpm-lock.yaml`, so the file is now two documents (the package-manager one, then the ordinary lockfile). `lockfileVersion` stays `9.0` and not a single dependency entry moves: the install reported "Already up to date" in 157ms and only appended the new block.
- CI needs no change. `pnpm/setup` (adopted in #6531) reads the version from this pin and accepts v11 or newer, and no workflow names a pnpm version.
- locally this is also a no-op to adopt: `managePackageManagerVersions` is on by default, so `pnpm --version` inside the repo already resolves to 12.0.0 without touching any machine config.

worth writing down for the next person: from here on, **a `packageManager` bump must regenerate the lockfile in the same commit**. pnpm 11 silently rewrote the `packageManagerDependencies` block during a frozen install; pnpm 12 does not, and fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` when the pin and the lockfile disagree.

`12.0.0` released 2026-08-26 and currently sits on the `next-12` dist-tag, with `latest` still on `11.24.0`. that is why taze never proposed it. the release is real and complete, not a prerelease.

## test plan

### already verified

- [x] `CI=true pnpm install --frozen-lockfile` -> clean. this is the check pnpm 12 newly made strict, so it is the one that matters most here
- [x] `pnpm build` -> 93/93 tasks successful
- [x] `pnpm lint` (oxlint + oxfmt) -> pass
- [x] `pnpm exec turbo test --force` -> 89/89 tasks successful (`--force` so nothing is served from cache)
- [x] `pnpm test:react-compiler` -> 11/11, `pnpm check:resource-memo` -> pass
- [x] `pnpm api-surface:check --skip-build` -> 40 surface files unchanged; `pnpm declarations:check` -> pass
- [x] `bash scripts/sync-templates.sh` -> in sync
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` -> no drift
- [x] `pnpm-lock.yaml` parses as 2 YAML documents with 0 errors in each. nothing in the repo reads the lockfile's contents (the one match, `apps/docs/scripts/generate-source-snapshot.mts:11`, is an exclusion pattern), so the two-document shape reaches no parser of ours
- [x] every v12 breaking change checked against this repo: all 8 `pnpm-workspace.yaml` keys are recognized under the now-satisfied pin (v12 turns an unknown one into a hard `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS`), 0 git dependencies in the lockfile, no `engineStrict`, no `.npmrc`, no pnpmfile, no `pnpm.*` manifest field, and `strictDepBuilds` plus `allowBuilds` still run both pinned esbuild postinstalls

### reviewer should verify

- [ ] first CI run on this PR is the real proof that `pnpm/setup` provisions 12.0.0 from the pin on a clean runner, since every local run reused a warm store.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Nv_z6o0ALMRUuAjAEvgkthDs5TgcUhgc53UQgijOhmdjFdSmxw0wB6RMiqA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->