### PR TITLE
refactor(docs): stop sending llm traces to the auix backend

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -27,10 +27,6 @@ AXIOM_DOMAIN=
 # fetching repo stats, releases, contributors, and stargazers (lib/github.ts).
 GITHUB_TOKEN=
 
-# Optional. AUI-X Prism tracing key (lib/prism-server.ts). Leave unset to
-# disable Prism tracing.
-AUIX_PRISM_API_KEY=
-
 # Public assistant protection. Generate the signing secret with
 # `openssl rand -base64 32`. The limits are intentionally generous and can be
 # lowered without a code change. Upstash Redis credentials are required in

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -1,5 +1,4 @@
 import { getDistinctId } from "@/lib/posthog-server";
-import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
 import {
   injectQuoteContext,
   unstable_injectInteractableContext as injectInteractableContext,
@@ -76,14 +75,6 @@ export async function POST(req: Request) {
 
     const baseModel = getModel(config?.modelName);
     const distinctId = getDistinctId(req);
-    const prismTracer = createPrismTracer();
-
-    const prism = prismTracer
-      ? prismAISDK(prismTracer, baseModel, {
-          name: "general_chat",
-          endUserId: distinctId,
-        })
-      : null;
 
     const prunedMessages = pruneMessages({
       messages: await convertToModelMessages(
@@ -93,7 +84,7 @@ export async function POST(req: Request) {
     });
 
     const result = streamText({
-      model: prism?.model ?? baseModel,
+      model: baseModel,
       ...(system ? { system } : {}),
       messages: prunedMessages,
       maxOutputTokens: 4096,
@@ -104,15 +95,8 @@ export async function POST(req: Request) {
         spanName: "general_chat",
         source: "general_chat",
       }),
-      onFinish: async () => {
-        await prism?.end();
-      },
-      onError: async ({ error }) => {
+      onError: ({ error }) => {
         console.error(error);
-        await prism?.end({ status: "error" });
-      },
-      onAbort: async () => {
-        await prism?.end();
       },
     });
 

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -1,6 +1,5 @@
 import { getLLMText } from "@/lib/get-llm-text";
 import { getDistinctId } from "@/lib/posthog-server";
-import { createPrismTracer, prismAISDK } from "@/lib/prism-server";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { injectQuoteContext } from "@assistant-ui/ai-sdk";
@@ -375,19 +374,11 @@ export async function POST(req: Request): Promise<Response> {
 
     const baseModel = getModel(config?.modelName);
     const distinctId = getDistinctId(req);
-    const prismTracer = createPrismTracer();
-
-    const prism = prismTracer
-      ? prismAISDK(prismTracer, baseModel, {
-          name: "docs_assistant",
-          endUserId: distinctId,
-        })
-      : null;
 
     const repoTools = createRepoTools();
 
     const result = streamText({
-      model: prism?.model ?? baseModel,
+      model: baseModel,
       system: [SYSTEM_PROMPT, pageContext].filter(Boolean).join("\n\n"),
       messages: prunedMessages,
       maxOutputTokens: 8192,
@@ -493,15 +484,8 @@ export async function POST(req: Request): Promise<Response> {
           },
         }),
       },
-      onFinish: async () => {
-        await prism?.end();
-      },
-      onError: async ({ error }) => {
+      onError: ({ error }) => {
         console.error(error);
-        await prism?.end({ status: "error" });
-      },
-      onAbort: async () => {
-        await prism?.end();
       },
     });
 

--- a/apps/docs/lib/prism-server.ts
+++ b/apps/docs/lib/prism-server.ts
@@ -1,8 +1,6 @@
 import { AuixPrism, prismAISDK as prismAISDKBase } from "@aui-x/prism";
 import type { TraceEvent } from "@aui-x/prism";
 
-const apiKey = process.env.AUIX_PRISM_API_KEY;
-
 type PrismTracerOptions = {
   evalRunId?: string | null;
   localTraceUrl?: string | null;
@@ -44,6 +42,13 @@ async function postLocalTraceEvents(
   });
 }
 
+/**
+ * Traces agent-eval runs to the harness's own localhost endpoint.
+ *
+ * Production LLM telemetry goes to Axiom and PostHog through the
+ * OpenTelemetry pipeline in `instrumentation.ts`; this tracer no longer
+ * reaches a hosted backend, so it yields null outside an eval run.
+ */
 export function createPrismTracer(
   options: PrismTracerOptions = {},
 ): AuixPrism | null {
@@ -51,17 +56,13 @@ export function createPrismTracer(
     process.env.XULUX_EVAL_MODE === "1"
       ? getLocalTraceUrl(options.localTraceUrl)
       : null;
-  if (!apiKey && !localTraceUrl) return null;
+  if (!localTraceUrl) return null;
 
   return new AuixPrism({
-    apiKey: apiKey ?? "local-agent-eval",
+    apiKey: "local-agent-eval",
     project: "assistant-ui-docs",
-    ...(localTraceUrl
-      ? {
-          transport: (events: TraceEvent[]) =>
-            postLocalTraceEvents(localTraceUrl, options.evalRunId, events),
-        }
-      : {}),
+    transport: (events: TraceEvent[]) =>
+      postLocalTraceEvents(localTraceUrl, options.evalRunId, events),
   });
 }
 


### PR DESCRIPTION
## summary

#6533 added axiom as an llm trace destination, and it carries the per-application and per-user dimensions that the posthog otel path drops. verified on the deployed build: spans arrive with `gen_ai.agent.name` naming the application, the distinct id under `attributes.custom`, plus `gen_ai.provider.name`, token counts and the deployment sha,,several of which the auix leg never populated.

that leaves the auix prism leg supplying nothing the pipeline is missing, so this removes it.

## what changes

- `lib/prism-server.ts` no longer reads `AUIX_PRISM_API_KEY` or talks to a hosted backend. `createPrismTracer` keeps the localhost transport that agent-eval runs post to, and returns null everywhere else.
- `app/api/chat/route.ts` and `app/api/doc/chat/route.ts` drop the wrapper, the `prism?.model ?? baseModel` fallback, and the lifecycle callbacks that existed only to call `prism.end()`.
- `app/api/xulux/chat/handler.ts` is untouched,,its `createPrismTracer` call already yields null outside `XULUX_EVAL_MODE`, so it behaves like the other two without an edit.
- `AUIX_PRISM_API_KEY` is removed from `.env.example`.

## why the eval path stays

eval-mode traces post to the harness's own localhost endpoint rather than a hosted backend, so nothing in this repo or in the backend's data records whether that path is still exercised,,and no code here sends the `x-agent-eval-run-id` / `x-agent-eval-trace-url` headers that trigger it, which puts the harness outside this repo.

removing it would have been a bet on an assumption i can't check from here. cutting the hosted leg alone achieves the goal (nothing in this app reaches that backend any more) at the cost of keeping the `@aui-x/prism` dependency. happy to delete the rest in a follow-up once someone confirms the harness is retired.

## test plan

- [x] `tsc --noEmit` clean for all four touched files
- [x] `vitest run` in `apps/docs` matches the baseline on `main` exactly (8 failed / 47 passed files, 4 failed / 417 passed tests, all pre-existing and unrelated)
- [x] `AUIX_PRISM_API_KEY` has no remaining references in the repo

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eRZ9sWBcawTOUpkQ0xpF9C7yytLc2pbIz5jLw9DPr9nBuB9JhAHglPRf1sI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->