### PR TITLE
fix(ci): pin the vercel build install command for pnpm 12

### DIFF
--- a/apps/registry/vercel.json
+++ b/apps/registry/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
+  "installCommand": "pnpm install --frozen-lockfile",
   "rewrites": [
     {
       "source": "/styles/base-:variant/:path(.+\\.json)",

--- a/examples/with-expo/vercel.json
+++ b/examples/with-expo/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
+  "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-native --filter=@assistant-ui/ai-sdk --filter=@assistant-ui/metro && cd examples/with-expo && pnpm run export:web",
   "outputDirectory": "dist",
   "framework": null

--- a/examples/with-react-ink-web/vercel.json
+++ b/examples/with-react-ink-web/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
+  "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo build --filter=@assistant-ui/react-ink --filter=@assistant-ui/react-ink-markdown --filter=@assistant-ui/ai-sdk && cd examples/with-react-ink-web && pnpm run build",
   "outputDirectory": "out",
   "framework": null,


### PR DESCRIPTION
## summary

- `Deploy Examples` has been failing on main since pnpm 12 landed (#6534), and `registry.yaml` is latently broken the same way. this adds `"installCommand": "pnpm install --frozen-lockfile"` to the three `vercel.json` files whose workflows run `vercel build` in the GitHub runner.
- root cause is upstream: `@vercel/build-utils` hardcodes `--unsafe-perm` when the package manager is pnpm.

  ```js
  // dist/fs/run-user-scripts.js:561 (14.4.0, what vercel@59.5.0 bundles)
  case "pnpm":
    commandArguments: args.filter(a => a !== "--prefer-offline").concat(["install", "--unsafe-perm"])
  ```

  pnpm 12's Rust CLI removed that flag (pnpm 11 accepted it as an npm-compat no-op), so `vercel build`'s own install step dies during argument parsing with `error: unexpected argument '--unsafe-perm' found` and exits 2.
- setting `installCommand` replaces build-utils' default install entirely, so the flag is never constructed. it is also the semantically right command: the runner already ran `pnpm install --frozen-lockfile` at the repo root before `vercel build`, making that second install redundant work.

scope: this only affects the two workflows that run `vercel build` locally and deploy with `--prebuilt`, namely `deploy-examples.yaml` (with-expo, with-react-ink-web) and `registry.yaml`. `apps/docs` is built by Vercel's own cloud builder under `ENABLE_EXPERIMENTAL_COREPACK=1`, a different code path that never reaches this argument construction, which is why the Vercel check on #6534 was green and this went unnoticed.

`registry.yaml` had not run since `a2d52c434` (before pnpm 12), so it was failing-in-waiting rather than visibly red.

two decisions worth stating:

- upgrading the Vercel CLI does not fix this. `@vercel/build-utils@14.7.0`, the current latest and what `vercel@59.10.0` bundles, still carries the same line at `:559`. vercel/vercel#14302 removed `--unsafe-perm` only from the npm branch.
- `installCommand` is an explicit command rather than an empty string. an empty value skips install entirely, which would be faster in CI but would break these projects if Vercel's own builder ever built them (a dashboard redeploy, for instance). the explicit command is correct in both environments.

## test plan

### already verified

- [x] reproduced the CI failure locally before changing anything: `pnpm exec vercel build` in `examples/with-react-ink-web` exits 1 with `Installing dependencies with pnpm 12.0.0` followed by `error: unexpected argument '--unsafe-perm' found`
- [x] with the fix, all three projects complete a real `vercel build` (exit 0, `Running "install" command: pnpm install --frozen-lockfile`, and a populated `.vercel/output`): with-react-ink-web 2.8M, registry 2.4M, with-expo 4.5M

### reviewer should verify

- [ ] neither workflow is `pull_request`-triggered, so this cannot be proven by this PR's own checks. the three local builds above are the evidence; `Deploy Examples` will run for real on the first push to main that touches its paths.

## notes

- the durable fix belongs upstream: `--unsafe-perm` should come off the pnpm branch of `getInstallCommandForPackageManager` the way #14302 took it off the npm branch. worth filing there; this change stays correct either way.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.zwYrRFcYOAq6LwDwwCh08eydTmgyyXoVQ0PVL3A_s8Bklr3hhT6tbx-V1r4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->