### PR TITLE
fix(react-devtools): tolerate throwing runtime properties

### DIFF
--- a/.changeset/react-devtools-throwing-properties.md
+++ b/.changeset/react-devtools-throwing-properties.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: tolerate unreadable runtime properties in DevTools snapshots

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -87,6 +87,21 @@ describe("sanitizeForMessage", () => {
 
     expect(sanitizeForMessage(value)).toBe("[Unserializable]");
   });
+
+  it("preserves readable array entries when an indexed getter throws", () => {
+    const value = ["first", "second", "third"];
+    Object.defineProperty(value, 1, {
+      get: () => {
+        throw new Error("getter failed");
+      },
+    });
+
+    expect(sanitizeForMessage(value)).toEqual([
+      "first",
+      "[Unserializable]",
+      "third",
+    ]);
+  });
 });
 
 describe("redactSensitive", () => {

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -59,6 +59,34 @@ describe("sanitizeForMessage", () => {
   it("sanitizes invalid dates without throwing", () => {
     expect(sanitizeForMessage(new Date(Number.NaN))).toBe("Invalid Date");
   });
+
+  it("preserves readable properties when an enumerable getter throws", () => {
+    const value = { readable: "value" };
+    Object.defineProperty(value, "broken", {
+      enumerable: true,
+      get: () => {
+        throw new Error("getter failed");
+      },
+    });
+
+    expect(sanitizeForMessage(value)).toEqual({
+      readable: "value",
+      broken: "[Unserializable]",
+    });
+  });
+
+  it("handles proxies that reject key enumeration", () => {
+    const value = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("enumeration failed");
+        },
+      },
+    );
+
+    expect(sanitizeForMessage(value)).toBe("[Unserializable]");
+  });
 });
 
 describe("redactSensitive", () => {

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -102,6 +102,18 @@ describe("sanitizeForMessage", () => {
       "third",
     ]);
   });
+
+  it("snapshots proxy array length before reading entries", () => {
+    let lengthReads = 0;
+    const value = new Proxy(["first", "second"], {
+      get: (target, property, receiver) => {
+        if (property === "length") return lengthReads++ === 0 ? 2 : 0;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(sanitizeForMessage(value)).toEqual(["first", "second"]);
+  });
 });
 
 describe("redactSensitive", () => {

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -45,9 +45,17 @@ export const sanitizeForMessage = (
         );
       }
       if (Array.isArray(value)) {
-        return value
-          .map((entry) => sanitizeForMessage(entry, seen))
-          .filter((item) => item !== undefined);
+        const result: unknown[] = [];
+        for (let index = 0; index < value.length; index++) {
+          try {
+            if (!(index in value)) continue;
+            const item = sanitizeForMessage(value[index], seen);
+            if (item !== undefined) result.push(item);
+          } catch {
+            result.push(UNSERIALIZABLE);
+          }
+        }
+        return result;
       }
 
       const result: Record<string, unknown> = {};

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -46,7 +46,8 @@ export const sanitizeForMessage = (
       }
       if (Array.isArray(value)) {
         const result: unknown[] = [];
-        for (let index = 0; index < value.length; index++) {
+        const length = value.length;
+        for (let index = 0; index < length; index++) {
           try {
             if (!(index in value)) continue;
             const item = sanitizeForMessage(value[index], seen);

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -2,6 +2,8 @@ import type { ModelContext } from "@assistant-ui/react";
 import type { SerializedModelContext } from "../types";
 import { normalizeToolList, type NormalizedTool } from "./toolNormalization";
 
+const UNSERIALIZABLE = "[Unserializable]";
+
 export const sanitizeForMessage = (
   value: unknown,
   seen = new WeakSet<object>(),
@@ -21,48 +23,50 @@ export const sanitizeForMessage = (
   if (typeof value === "function") {
     return "[Function]";
   }
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? String(value) : value.toISOString();
-  }
-  if (value instanceof Map) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const result: Record<string, unknown> = {};
-    for (const [key, entry] of value.entries()) {
-      result[String(key)] = sanitizeForMessage(entry, seen);
-    }
-    seen.delete(value);
-    return result;
-  }
-  if (value instanceof Set) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const result = Array.from(value).map((entry) =>
-      sanitizeForMessage(entry, seen),
-    );
-    seen.delete(value);
-    return result;
-  }
-  if (Array.isArray(value)) {
-    if (seen.has(value as unknown as object)) return "[Circular]";
-    seen.add(value as unknown as object);
-    const result = value
-      .map((entry) => sanitizeForMessage(entry, seen))
-      .filter((item) => item !== undefined);
-    seen.delete(value as unknown as object);
-    return result;
-  }
   if (typeof value === "object") {
-    if (seen.has(value as object)) return "[Circular]";
-    seen.add(value as object);
-    const result: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(
-      value as Record<string, unknown>,
-    )) {
-      result[key] = sanitizeForMessage(entry, seen);
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    try {
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime())
+          ? String(value)
+          : value.toISOString();
+      }
+      if (value instanceof Map) {
+        const result: Record<string, unknown> = {};
+        for (const [key, entry] of value.entries()) {
+          result[String(key)] = sanitizeForMessage(entry, seen);
+        }
+        return result;
+      }
+      if (value instanceof Set) {
+        return Array.from(value).map((entry) =>
+          sanitizeForMessage(entry, seen),
+        );
+      }
+      if (Array.isArray(value)) {
+        return value
+          .map((entry) => sanitizeForMessage(entry, seen))
+          .filter((item) => item !== undefined);
+      }
+
+      const result: Record<string, unknown> = {};
+      for (const key of Object.keys(value)) {
+        try {
+          result[key] = sanitizeForMessage(
+            (value as Record<string, unknown>)[key],
+            seen,
+          );
+        } catch {
+          result[key] = UNSERIALIZABLE;
+        }
+      }
+      return result;
+    } catch {
+      return UNSERIALIZABLE;
+    } finally {
+      seen.delete(value);
     }
-    seen.delete(value as object);
-    return result;
   }
   return value;
 };


### PR DESCRIPTION
## Summary

- preserve readable DevTools snapshot fields when an enumerable runtime getter throws
- replace inaccessible properties and wholly uninspectable objects with a stable `[Unserializable]` marker
- clean up cycle tracking even when object inspection fails

## Why

DevTools serializes application-owned runtime values before projecting snapshots and events, and `Object.entries()` invokes enumerable getters. one throwing getter aborted `sanitizeForMessage` for the whole projection; a proxy that rejects key enumeration failed the same way.

the panel itself never broke, because `createInProcessClient.rebuild()` already wraps `projectApi` in a try/catch and skips an api that fails to project. the cost of that catch is the granularity: the entire api entry disappears from the panel, taking state, scopes, logs and model context with it, because one property somewhere in the tree was unreadable. this change moves the recovery down to the property that actually failed, so the api keeps every readable field and only the unreadable one renders as `[Unserializable]`.

recovery is per property for plain objects and per entry for arrays; an object that cannot be enumerated at all still degrades to a single `[Unserializable]`. `finally { seen.delete(value) }` keeps cycle tracking correct on the new failure paths, so a shared reference that follows a failed one is still serialized rather than reported as `[Circular]`.

the model context path in front of the serializer (`serializeModelContext` reading `system` and `tools`, `mapToNormalizedTool` reading each tool field) is still all-or-nothing, as is a `Map` whose key `toString` throws. those are pre-existing, already degrade rather than crash, and are tracked separately in #6558.

## Tests

the first three new cases fail on `main` with the original getter and proxy errors and pass with this change. the fourth (`snapshots proxy array length before reading entries`) passes on `main` too: it is a non-regression guard for the hand-rolled array loop, which reads `length` itself instead of inheriting the single read `Array.prototype.map` performs.

## Validation

- `pnpm --filter @assistant-ui/react-devtools test` (115 tests)
- `pnpm --filter @assistant-ui/react-devtools build`
- oxlint on the changed TypeScript files
- oxfmt check on all changed files
- differential run of the existing suite against both versions of `sanitizeForMessage`: identical output on shared references, object and array cycles, sparse arrays, `Map`, `Set`, `Date`, symbol keys, inherited and non-enumerable properties

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FBX1bSyaS2-zpx3jnA50H4-mTts__7vv-9ps4p99lpLev-UekisEwo4Lrbw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
