### PR TITLE
chore(eve): move the eve devDependency to 0.47.3

### DIFF
--- a/.changeset/eve-0-47-3.md
+++ b/.changeset/eve-0-47-3.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+chore: move the eve devDependency to 0.47.3

--- a/api-surface/package.json
+++ b/api-surface/package.json
@@ -22,7 +22,7 @@
     "@standard-schema/spec": "^1.1.0",
     "ai": "^7.0.83",
     "denque": "^2.1.0",
-    "eve": "^0.44.4",
+    "eve": "^0.47.3",
     "ink": "^7.1.1",
     "ink-spinner": "^5.0.0",
     "lexical": "^0.49.0",

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -15,7 +15,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.44.4",
+    "eve": "^0.47.3",
     "lucide-react": "^1.34.0",
     "next": "^16.3.3",
     "react": "^19.2.8",

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -51,7 +51,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.3",
     "@types/react": "^19.2.18",
-    "eve": "^0.44.4",
+    "eve": "^0.47.3",
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -1376,6 +1376,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents.slice(0, 3),
           {
             type: "reasoning.appended",
+            meta: eventMeta(2),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1386,6 +1387,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "actions.requested",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1425,6 +1427,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents.slice(0, 3),
           {
             type: "reasoning.appended",
+            meta: eventMeta(2),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1435,6 +1438,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "actions.requested",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1451,6 +1455,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "reasoning.completed",
+            meta: eventMeta(4),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1485,6 +1490,7 @@ describe("convertEveMessages", () => {
           ...midStreamEvents.slice(0, 3),
           {
             type: "message.appended",
+            meta: eventMeta(2),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1495,6 +1501,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "message.completed",
+            meta: eventMeta(3),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1505,6 +1512,7 @@ describe("convertEveMessages", () => {
           },
           {
             type: "step.completed",
+            meta: eventMeta(4),
             data: {
               turnId: "turn_1",
               stepIndex: 0,
@@ -1514,10 +1522,17 @@ describe("convertEveMessages", () => {
           },
           {
             type: "step.started",
-            data: { turnId: "turn_1", stepIndex: 1, sequence: 5 },
+            meta: eventMeta(5),
+            data: {
+              turnId: "turn_1",
+              stepIndex: 1,
+              sequence: 5,
+              modelId: "test-model",
+            },
           },
           {
             type: "message.appended",
+            meta: eventMeta(6),
             data: {
               turnId: "turn_1",
               stepIndex: 1,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       eve:
-        specifier: ^0.44.4
-        version: 0.44.4(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.47.3
+        version: 0.47.3(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       ink:
         specifier: ^7.1.1
         version: 7.1.1(@types/react@19.2.18)(react-devtools-core@6.1.5)(react@19.2.8)
@@ -1663,8 +1663,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.44.4
-        version: 0.44.4(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.47.3
+        version: 0.47.3(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.34.0
         version: 1.34.0(react@19.2.8)
@@ -4008,8 +4008,8 @@ importers:
         specifier: ^19.2.18
         version: 19.2.18
       eve:
-        specifier: ^0.44.4
-        version: 0.44.4(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.47.3
+        version: 0.47.3(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -5671,8 +5671,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.44.4
-        version: 0.44.4(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: ^0.47.3
+        version: 0.47.3(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.34.0
         version: 1.34.0(react@19.2.8)
@@ -14621,8 +14621,8 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eve@0.44.4:
-    resolution: {integrity: sha512-juaOffL+doGo8z1gfB5FrO750dZKMaY5G3Qm96N+bASs5nHBwhkGfqHKEyTFGZmXaxBWJpnDRnEgL4rAKtQPcw==}
+  eve@0.47.3:
+    resolution: {integrity: sha512-CFj/CW+7mg9/r2thFDJ07r9kzy6qxyfHzMDDHOOCDCMGIY/EXkl4EbsmO2Z+4SY/JMJ7Ywh6KELnXf3AQD+z/w==}
     engines: {node: '>=24'}
     hasBin: true
     peerDependencies:
@@ -31307,7 +31307,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.44.4(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
+  eve@0.47.3(@azure/identity@4.13.2(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(ai@7.0.83(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(just-bash@3.4.2(supports-color@10.2.2))(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.83(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.2(supports-color@10.2.2))(@upstash/redis@1.38.3)(@vercel/blob@2.8.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.4.0))(rollup@4.63.0)(sqlite3@5.1.7(supports-color@10.2.2))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))

--- a/templates/eve/package.json
+++ b/templates/eve/package.json
@@ -22,7 +22,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.44.4",
+    "eve": "^0.47.3",
     "lucide-react": "^1.34.0",
     "next": "^16.3.3",
     "react": "^19.2.8",


### PR DESCRIPTION
## summary

- moves `eve` from `^0.44.4` to `^0.47.3` in all four declarers, which move in lockstep: `packages/eve`, `api-surface`, `examples/with-eve` and `templates/eve`. `packages/eve`'s published peer floor stays `>=0.32.0`.
- eve has been held out of ordinary dependency chores because its 0.x minors ship breaking type changes, so taze's proposal is reverted every run. this is that hold being paid down deliberately rather than ridden along in a chore.
- the whole product surface already compiled against 0.47.3. the only work was in test fixtures, and there are two distinct causes:
  - `EventActions` and the stream events now carry a required `readonly meta: MessageStreamEventMeta` (`{ at, id }`), from the 0.47.3 changeset that added the internal versioned protocol. ten inline event literals in `convertEveMessages.test.ts` predate it. the file already had an `eventMeta(sequence)` helper that `midStreamEvents` uses, so each gained `meta: eventMeta(<its own data.sequence>)`.
  - `step.started`'s `data` now requires `modelId`. one literal was written without it, and it is the only site: the file's other `step.started` fixtures already pass `modelId: "test-model"`, which is what this one now matches.

no product code changed. `git diff --name-only -- packages/eve/src` outside the test file is empty.

## test plan

### already verified

- [x] `tsc --noEmit` in `packages/eve` -> 0 errors, down from 13 `TS2322`
- [x] `pnpm test` in `packages/eve` -> 150/150 across 4 files
- [x] `pnpm api-surface:check --skip-build` -> 40 files unchanged, so the published surface does not move
- [x] `CI=true pnpm install --frozen-lockfile` -> clean
- [x] `pnpm lint` -> clean
- [x] lockfile: zero package version-set changes, only eve's own specifier
- [x] the whole gate re-run after rebasing onto current main (`2b87a9638`)

### reviewer should verify

- [ ] the converter is covered by its own suite, but nothing here exercises a live eve agent turn.

## notes

- worth recording for the next person: a first `tsc` in a fresh worktree reported 37 errors across 9 files, including `Cannot find module '@assistant-ui/core'` in product code. that is the missing-`dist` trap, not eve. `pnpm exec turbo run build --filter='@assistant-ui/eve...'` first, and the count drops to the 13 that are actually about this upgrade.
- 0.45.0 also moved built-in tool definitions from `eve/tools/defaults` to `eve/tools/<name>` and removed the `defineBashTool` / `defineReadFileTool` / `defineWriteFileTool` / `defineGlobTool` / `defineGrepTool` factories. `packages/eve` imports only `eve/client` and `eve/react`, so none of that reaches us.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2dSGIX_7ghDqSevO4MwFm2K6Pc0aTOcMII4BoUes0qsJcdF-cVowmYB1u0I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->