### PR TITLE
fix(core): preserve tool renderer hook boundaries

### DIFF
--- a/.changeset/quiet-ravens-juggle.md
+++ b/.changeset/quiet-ravens-juggle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve React hook boundaries when tool renderers change

--- a/packages/core/src/react/model-context/useInlineRender.test.tsx
+++ b/packages/core/src/react/model-context/useInlineRender.test.tsx
@@ -9,25 +9,19 @@ afterEach(() => cleanup());
 
 type Props = ToolCallMessagePartProps<any, any>;
 
-// The point of useInlineRender is a component whose identity survives a
-// changing toolUI, so inner state must not be lost when toolUI swaps.
-const makeToolUI = (label: string): FC<Props> =>
-  function Inner() {
-    const [n, setN] = useState(0);
-    return (
-      <button onClick={() => setN((v) => v + 1)}>
-        {label}:{n}
-      </button>
-    );
-  };
-
 describe("useInlineRender", () => {
-  it("follows toolUI changes without remounting the inner tree", async () => {
+  it("renders replacement components with an independent hook boundary", async () => {
     let swap!: (fc: FC<Props>) => void;
     const identities = new Set<unknown>();
 
+    const WithoutHooks = () => <div>without hooks</div>;
+    const WithHooks = () => {
+      const [n, setN] = useState(0);
+      return <button onClick={() => setN((v) => v + 1)}>{n}</button>;
+    };
+
     const Host = () => {
-      const [toolUI, setToolUI] = useState(() => makeToolUI("a"));
+      const [toolUI, setToolUI] = useState<FC<Props>>(() => WithoutHooks);
       swap = (fc) => setToolUI(() => fc);
       const ToolUI = useInlineRender(toolUI);
       identities.add(ToolUI);
@@ -35,14 +29,13 @@ describe("useInlineRender", () => {
     };
 
     render(<Host />);
-    expect(screen.getByRole("button").textContent).toBe("a:0");
+    expect(screen.getByText("without hooks")).toBeTruthy();
+
+    await act(async () => swap(WithHooks));
+    expect(screen.getByRole("button").textContent).toBe("0");
 
     await act(async () => screen.getByRole("button").click());
-    expect(screen.getByRole("button").textContent).toBe("a:1");
-
-    await act(async () => swap(makeToolUI("b")));
-    // label follows the new toolUI, counter survives => no remount
-    expect(screen.getByRole("button").textContent).toBe("b:1");
+    expect(screen.getByRole("button").textContent).toBe("1");
     expect(identities.size).toBe(1);
   });
 });

--- a/packages/core/src/react/model-context/useInlineRender.ts
+++ b/packages/core/src/react/model-context/useInlineRender.ts
@@ -1,4 +1,10 @@
-import { type FC, useCallback, useEffect, useState } from "react";
+import {
+  createElement,
+  type FC,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import type { ToolCallMessagePartProps } from "../types/MessagePartComponentTypes";
 import { WritableSubscribable } from "../../subscribable/subscribable";
 import { useSubscribable } from "../../store/runtime-clients/useSubscribable";
@@ -19,10 +25,8 @@ export const useInlineRender = <TArgs, TResult>(
 
   return useCallback(
     function ToolUI(args) {
-      // Invoked as a plain function so its hooks belong to this component,
-      // which keeps its identity while `toolUI` changes underneath.
       const currentToolUI = useSubscribable(toolUIStore);
-      return currentToolUI(args);
+      return createElement(currentToolUI, args);
     },
     [toolUIStore],
   );


### PR DESCRIPTION
## Summary

- render replacement tool UIs as React components instead of invoking them as plain functions
- preserve the stable wrapper returned by `useInlineRender`
- add a regression test for switching from a renderer with no hooks to one that uses hooks

## Why

`useInlineRender` directly invoked the current renderer inside its stable wrapper. That merged the renderer's hooks into the wrapper's hook list. Replacing a renderer with one that uses a different hook layout then caused React to throw `Rendered more hooks than during the previous render`.

Rendering the selected UI as a child component gives each renderer its own hook boundary. Replacing the renderer now follows normal React component semantics and safely initializes the replacement's state, while the wrapper identity remains stable for registration consumers.

## Testing

- `vitest run packages/core/src/react/model-context/useInlineRender.test.tsx`
- `aui-build` from `packages/core`
- `git diff --check`

The repository lint command could not be reproduced locally because the existing installed oxlint binary predates rules in the current configuration; CI will run the pinned toolchain.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.brp70uJcWOLI1_ofij47y5z8ht0S5-iijnau5u1G0d6TuYd_6tx_peYpjEM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->