### PR TITLE
fix: preserve composer attachment component identity

### DIFF
--- a/.changeset/quiet-files-remain.md
+++ b/.changeset/quiet-files-remain.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/vue": patch
+---
+
+fix: preserve composer attachment component identity after removals

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.test.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Attachment } from "../../../types/attachment";
+
+const mocks = vi.hoisted(() => ({
+  attachments: [] as Attachment[],
+  aui: {
+    composer: {
+      attachment: ({ index }: { index: number }) => ({
+        getState: () => mocks.attachments[index],
+      }),
+    },
+  },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({ composer: { attachments: mocks.attachments } }),
+  RenderChildrenWithAccessor: ({
+    getItemState,
+    children,
+  }: {
+    getItemState: (aui: typeof mocks.aui) => Attachment;
+    children: (getItem: () => Attachment) => ReactNode;
+  }) => children(() => getItemState(mocks.aui)),
+}));
+
+vi.mock("../../providers/AttachmentByIndexProvider", () => ({
+  ComposerAttachmentByIndexProvider: ({ children }: { children: ReactNode }) =>
+    children,
+}));
+
+import { ComposerPrimitiveAttachments } from "./ComposerAttachments";
+
+const attachment = (id: string, name: string): Attachment => ({
+  id,
+  name,
+  type: "file",
+  contentType: "text/plain",
+  status: { type: "complete" },
+  content: [],
+});
+
+const StatefulAttachment = ({ attachment }: { attachment: Attachment }) => {
+  const [initialName] = useState(attachment.name);
+  return <span>{initialName}</span>;
+};
+
+describe("ComposerPrimitiveAttachments", () => {
+  it("does not reuse component state for a different attachment", () => {
+    mocks.attachments = [
+      attachment("first", "first.txt"),
+      attachment("second", "second.txt"),
+    ];
+
+    const view = render(
+      <ComposerPrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </ComposerPrimitiveAttachments>,
+    );
+
+    mocks.attachments = [mocks.attachments[1]!];
+    view.rerender(
+      <ComposerPrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </ComposerPrimitiveAttachments>,
+    );
+
+    expect(screen.queryByText("second.txt")).not.toBeNull();
+    expect(screen.queryByText("first.txt")).toBeNull();
+  });
+});

--- a/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerAttachments.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
 } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import { ComposerAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
 
 type ComposerAttachmentsComponentConfig = {
@@ -91,12 +92,16 @@ ComposerPrimitiveAttachmentByIndex.displayName =
 const ComposerPrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: Attachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentsCount = useAuiState((s) => s.composer.attachments.length);
+  const attachmentIds = useAuiState(
+    useShallowSelector((s) =>
+      s.composer.attachments.map((attachment) => attachment.id),
+    ),
+  );
 
   return useMemo(
     () =>
-      Array.from({ length: attachmentsCount }, (_, index) => (
-        <ComposerAttachmentByIndexProvider key={index} index={index}>
+      attachmentIds.map((attachmentId, index) => (
+        <ComposerAttachmentByIndexProvider key={attachmentId} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) =>
               aui.composer.attachment({ index }).getState()
@@ -112,7 +117,7 @@ const ComposerPrimitiveAttachmentsInner: FC<{
           </RenderChildrenWithAccessor>
         </ComposerAttachmentByIndexProvider>
       )),
-    [attachmentsCount, children],
+    [attachmentIds, children],
   );
 };
 

--- a/packages/vue/src/__tests__/primitives-attachment.test.ts
+++ b/packages/vue/src/__tests__/primitives-attachment.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@assistant-ui/core/internal";
 import { AuiProvider } from "../AuiProvider";
 import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import {
   AttachmentPrimitiveName,
@@ -185,6 +186,43 @@ describe("composer attachment primitives", () => {
       expect(el.querySelectorAll("span.att")).toHaveLength(0);
     });
     expect(attachmentAdapter.removed).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("does not reuse component state for a different attachment", async () => {
+    const { runtime } = createTestRuntime();
+    const StatefulAttachment = defineComponent({
+      setup() {
+        const initialName = useAuiState((s) => s.attachment.name).value;
+        return () => h("span", { class: "stateful-att" }, initialName);
+      },
+    });
+    const view = defineComponent({
+      setup: () => () =>
+        h(ComposerPrimitiveAttachments, null, {
+          default: () => h(StatefulAttachment),
+        }),
+    });
+    const { el, client, unmount } = mountChat(runtime, view);
+
+    await client().composer.addAttachment(makeFile("first.txt"));
+    await client().composer.addAttachment(makeFile("second.txt"));
+    flushTapSync(() => {});
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll(".stateful-att")).toHaveLength(2);
+    });
+
+    await client().composer.attachment({ index: 0 }).remove();
+    flushTapSync(() => {});
+    await vi.waitFor(async () => {
+      await nextTick();
+      const names = [...el.querySelectorAll(".stateful-att")].map(
+        (node) => node.textContent,
+      );
+      expect(names).toEqual(["second.txt"]);
+    });
 
     unmount();
   });

--- a/packages/vue/src/primitives/composerAttachments.ts
+++ b/packages/vue/src/primitives/composerAttachments.ts
@@ -20,12 +20,12 @@ export const ComposerPrimitiveAttachments = defineComponent({
   name: "ComposerPrimitiveAttachments",
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { slots }) {
-    const count = useAuiState((s) => s.composer.attachments.length);
+    const attachments = useAuiState((s) => s.composer.attachments);
     return () =>
-      Array.from({ length: count.value }, (_, index) =>
+      attachments.value.map((attachment, index) =>
         h(
           AttachmentByIndexProvider,
-          { source: "composer", index, key: index },
+          { source: "composer", index, key: attachment.id },
           { default: () => slots.default?.() },
         ),
       );


### PR DESCRIPTION
## Summary

- key composer attachment renderers by stable attachment IDs instead of array indices
- keep React and Vue attachment primitives at behavior parity
- add regressions that remove the first of two attachments while the rendered child holds local state

## Why

The attachment primitives used the array index as the component key. Removing an attachment before another caused React or Vue to reuse the removed attachment's component instance for the surviving file. Any local preview, error, or other component state could then be displayed for the wrong attachment.

Selecting the stable attachment IDs and using them as keys preserves component identity while the index-based provider continues resolving the attachment's current position.

## Verification

- `packages/core`: 150 test files, 1,549 tests passed
- `packages/vue`: 14 test files passed, 87 tests passed, 1 existing skip
- `packages/core`: `aui-build` passed
- `packages/vue`: `aui-build` passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fHDEMZMB1e1xDvDL17XQQjXrB-5SiHVyDzD7PO3ITVaGGcENHmFX7A3bsM8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->