### PR TITLE
fix(core): preserve composer queue item identity

### DIFF
--- a/.changeset/calm-queues-remain.md
+++ b/.changeset/calm-queues-remain.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve composer queue item component identity after removals

--- a/packages/core/src/react/primitives/composer/ComposerQueue.test.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerQueue.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { QueueItemState } from "../../../runtime/queue/queue-item";
+
+const mocks = vi.hoisted(() => ({
+  queue: [] as QueueItemState[],
+  aui: {
+    composer: {
+      queueItem: ({ index }: { index: number }) => ({
+        getState: () => mocks.queue[index],
+      }),
+    },
+  },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({ composer: { queue: mocks.queue } }),
+  RenderChildrenWithAccessor: ({
+    getItemState,
+    children,
+  }: {
+    getItemState: (aui: typeof mocks.aui) => QueueItemState;
+    children: (getItem: () => QueueItemState) => ReactNode;
+  }) => children(() => getItemState(mocks.aui)),
+}));
+
+vi.mock("../../providers/QueueItemByIndexProvider", () => ({
+  QueueItemByIndexProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ComposerPrimitiveQueue } from "./ComposerQueue";
+
+const queueItem = (id: string, prompt: string): QueueItemState => ({
+  id,
+  prompt,
+  parts: [{ type: "text", text: prompt }],
+});
+
+const StatefulQueueItem = ({ queueItem }: { queueItem: QueueItemState }) => {
+  const [initialPrompt] = useState(queueItem.prompt);
+  return <span>{initialPrompt}</span>;
+};
+
+describe("ComposerPrimitiveQueue", () => {
+  it("does not reuse component state for a different queue item", () => {
+    mocks.queue = [
+      queueItem("first", "first message"),
+      queueItem("second", "second message"),
+    ];
+
+    const view = render(
+      <ComposerPrimitiveQueue>
+        {({ queueItem }) => <StatefulQueueItem queueItem={queueItem} />}
+      </ComposerPrimitiveQueue>,
+    );
+
+    mocks.queue = [mocks.queue[1]!];
+    view.rerender(
+      <ComposerPrimitiveQueue>
+        {({ queueItem }) => <StatefulQueueItem queueItem={queueItem} />}
+      </ComposerPrimitiveQueue>,
+    );
+
+    expect(screen.queryByText("second message")).not.toBeNull();
+    expect(screen.queryByText("first message")).toBeNull();
+  });
+});

--- a/packages/core/src/react/primitives/composer/ComposerQueue.tsx
+++ b/packages/core/src/react/primitives/composer/ComposerQueue.tsx
@@ -1,5 +1,6 @@
 import { type FC, type ReactNode, memo, useMemo } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import type { QueueItemState } from "../../../store/scopes/queue-item";
 import { QueueItemByIndexProvider } from "../../providers/QueueItemByIndexProvider";
 
@@ -13,12 +14,14 @@ export namespace ComposerPrimitiveQueue {
 const ComposerPrimitiveQueueInner: FC<{
   children: (value: { queueItem: QueueItemState }) => ReactNode;
 }> = ({ children }) => {
-  const queue = useAuiState((s) => s.composer.queue.length);
+  const queueItemIds = useAuiState(
+    useShallowSelector((s) => s.composer.queue.map((item) => item.id)),
+  );
 
   return useMemo(
     () =>
-      Array.from({ length: queue }, (_, index) => (
-        <QueueItemByIndexProvider key={index} index={index}>
+      queueItemIds.map((queueItemId, index) => (
+        <QueueItemByIndexProvider key={queueItemId} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.composer.queueItem({ index }).getState()}
           >
@@ -32,7 +35,7 @@ const ComposerPrimitiveQueueInner: FC<{
           </RenderChildrenWithAccessor>
         </QueueItemByIndexProvider>
       )),
-    [queue, children],
+    [queueItemIds, children],
   );
 };
 

--- a/packages/react-ink/src/tests/QueueItem.test.tsx
+++ b/packages/react-ink/src/tests/QueueItem.test.tsx
@@ -158,7 +158,11 @@ describe("ComposerPrimitive.Queue", () => {
   it("renders children once per queued item with the queueItem state", () => {
     mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
       selector({
-        composer: { queue: { length: 3 } },
+        composer: {
+          queue: Array.from({ length: 3 }, (_, index) => ({
+            id: `queue-item-${index}`,
+          })),
+        },
         queueItem: { prompt: "p" },
       } as never),
     );
@@ -187,7 +191,7 @@ describe("ComposerPrimitive.Queue", () => {
   it("does not call children when the queue is empty", () => {
     mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
       selector({
-        composer: { queue: { length: 0 } },
+        composer: { queue: [] },
         queueItem: { prompt: "" },
       } as never),
     );


### PR DESCRIPTION
## Summary

- key composer queue item renderers by stable queue item IDs instead of array indices
- retain the index-based provider for resolving each item's current position
- add a regression that removes the first queued message while the rendered child holds local state

## Why

`ComposerPrimitive.Queue` keyed removable queue items by their array index. Removing an item before another caused React to reuse the removed item's component instance for the surviving message. Local component state could therefore be displayed or applied to the wrong queued message.

Queue items already have stable IDs and all move/remove operations use those IDs. Using the ID as the React key preserves component identity without changing the existing positional lookup contract.

## Verification

- regression fails on current `main` and passes with this change
- `packages/core`: 150 test files, 1,549 tests passed
- `packages/core`: `aui-build` passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UXvuLCjnaBV07hehz-468Mahb1HpX9yzAm_shoDLrTvOnkTjW-V6BYpartQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->