### PR TITLE
feat(vue): measure viewport footers into the scroll inset

### DIFF
--- a/.changeset/vue-viewport-footer-inset.md
+++ b/.changeset/vue-viewport-footer-inset.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: accept a content inset in the shared viewport scroll helpers

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -296,7 +296,7 @@ declare const isUserScrollUp: (previous: {
   scrollHeight: number;
 }, current: ViewportMetrics) => boolean;
 
-declare const isViewportAtBottom: (metrics: ViewportMetrics) => boolean;
+declare const isViewportAtBottom: (metrics: ViewportMetrics, contentInset?: number) => boolean;
 
 declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {
   scope: AssistantEventScope<TEvent>;
@@ -380,6 +380,6 @@ declare const useShallowSelector: <TState, TResult extends object>(select: (stat
 
 declare const useShallowStable: <T extends object>(value: T) => T;
 
-declare const viewportOverflows: (metrics: ViewportMetrics) => boolean;
+declare const viewportOverflows: (metrics: ViewportMetrics, contentInset?: number) => boolean;
 
 export { entry_client_exports as entry_client, entry_internal_exports as entry_internal, entry_root_exports as entry_root };

--- a/packages/store/src/utils/viewport-scroll.test.ts
+++ b/packages/store/src/utils/viewport-scroll.test.ts
@@ -44,6 +44,18 @@ describe("viewport scroll metrics", () => {
     ).toBe(false);
   });
 
+  it("accounts for a bottom content inset when requested", () => {
+    const metrics = {
+      scrollTop: 350,
+      scrollHeight: 500,
+      clientHeight: 100,
+    };
+
+    expect(isViewportAtBottom(metrics)).toBe(false);
+    expect(isViewportAtBottom(metrics, 50)).toBe(true);
+    expect(viewportOverflows(metrics, 450)).toBe(false);
+  });
+
   it("distinguishes user scroll-up from content-driven shifts", () => {
     expect(
       isUserScrollUp(

--- a/packages/store/src/utils/viewport-scroll.ts
+++ b/packages/store/src/utils/viewport-scroll.ts
@@ -4,6 +4,11 @@ export type ViewportMetrics = {
   clientHeight: number;
 };
 
+/**
+ * With a content inset, positions within `contentInset` of the native bottom
+ * count as at bottom: content that close is only obscured by the inset
+ * element itself, so the viewport is still treated as pinned.
+ */
 export const isViewportAtBottom = (
   metrics: ViewportMetrics,
   contentInset = 0,

--- a/packages/store/src/utils/viewport-scroll.ts
+++ b/packages/store/src/utils/viewport-scroll.ts
@@ -4,12 +4,37 @@ export type ViewportMetrics = {
   clientHeight: number;
 };
 
-export const isViewportAtBottom = (metrics: ViewportMetrics): boolean =>
-  Math.abs(metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight) <=
-    1 || metrics.scrollHeight <= metrics.clientHeight;
+export const isViewportAtBottom = (
+  metrics: ViewportMetrics,
+  contentInset = 0,
+): boolean => {
+  if (contentInset === 0) {
+    return (
+      Math.abs(
+        metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight,
+      ) <= 1 || metrics.scrollHeight <= metrics.clientHeight
+    );
+  }
 
-export const viewportOverflows = (metrics: ViewportMetrics): boolean =>
-  metrics.scrollHeight > metrics.clientHeight + 1;
+  return (
+    metrics.scrollHeight -
+      contentInset -
+      metrics.scrollTop -
+      metrics.clientHeight <=
+      1 || metrics.scrollHeight - contentInset <= metrics.clientHeight
+  );
+};
+
+export const viewportOverflows = (
+  metrics: ViewportMetrics,
+  contentInset = 0,
+): boolean => {
+  if (contentInset === 0) {
+    return metrics.scrollHeight > metrics.clientHeight + 1;
+  }
+
+  return metrics.scrollHeight - contentInset > metrics.clientHeight + 1;
+};
 
 // scrollHeight equality rules out content-driven shifts being misread as a
 // user scroll up.

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -21,6 +21,7 @@ import { AuiProvider } from "../AuiProvider";
 import { useAuiState } from "../useAuiState";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
+import { ThreadPrimitiveViewportFooter } from "../primitives/ThreadPrimitiveViewportFooter";
 import {
   ThreadPrimitiveScrollToBottom,
   clearScrollToBottomWarningForTesting,
@@ -542,6 +543,186 @@ describe("ThreadPrimitiveViewport", () => {
     });
 
     unmount();
+  });
+
+  it("updates at-bottom state when a footer height changes", async () => {
+    const observers = new Set<ResizeObserverMock>();
+    class ResizeObserverMock {
+      element: Element | null = null;
+
+      constructor(private readonly callback: ResizeObserverCallback) {
+        observers.add(this);
+      }
+
+      observe(element: Element) {
+        this.element = element;
+      }
+
+      unobserve() {}
+
+      disconnect() {
+        observers.delete(this);
+      }
+
+      takeRecords() {
+        return [];
+      }
+
+      trigger() {
+        this.callback([], this);
+      }
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+    const { runtime } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              h(ThreadPrimitiveViewportFooter, { class: "footer" }),
+              h(
+                ThreadPrimitiveScrollToBottom,
+                { class: "jump" },
+                { default: () => "Jump" },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    const footer = el.querySelector<HTMLElement>("div.footer")!;
+    let scrollTop = 350;
+    let footerHeight = 0;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => 500,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    Object.defineProperty(div, "scrollTop", {
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(footer, "offsetHeight", {
+      get: () => footerHeight,
+      configurable: true,
+    });
+
+    try {
+      await nextTick();
+      expect(
+        [...observers].some((observer) => observer.element === footer),
+      ).toBe(true);
+      scrollTop = 0;
+      div.dispatchEvent(new Event("scroll"));
+      scrollTop = 350;
+      div.dispatchEvent(new Event("scroll"));
+      await nextTick();
+      expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+        false,
+      );
+
+      footerHeight = 50;
+      expect(footer.offsetHeight).toBe(50);
+      for (const observer of observers) {
+        if (observer.element === footer) observer.trigger();
+      }
+      await nextTick();
+      expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+        true,
+      );
+
+      footerHeight = 0;
+      for (const observer of observers) {
+        if (observer.element === footer) observer.trigger();
+      }
+      await nextTick();
+      expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+        false,
+      );
+    } finally {
+      Reflect.deleteProperty(div, "scrollHeight");
+      Reflect.deleteProperty(div, "clientHeight");
+      Reflect.deleteProperty(div, "scrollTop");
+      Reflect.deleteProperty(footer, "offsetHeight");
+      unmount();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps MutationObserver content observation when ResizeObserver is unavailable", async () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const { runtime } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              h(ThreadPrimitiveViewportFooter, { class: "footer" }),
+              h("p", "content"),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    let scrollHeight = 500;
+    let scrollTop = 400;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => scrollHeight,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    Object.defineProperty(div, "scrollTop", {
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+      configurable: true,
+    });
+    const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scrollTop = Math.max(0, Math.min(top ?? 0, scrollHeight - 100));
+      div.dispatchEvent(new Event("scroll"));
+    });
+    Object.defineProperty(div, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    });
+
+    try {
+      await nextTick();
+      expect(el.querySelector("div.footer")).not.toBeNull();
+      div.dispatchEvent(new Event("scroll"));
+      scrollHeight = 600;
+      div.append(document.createElement("span"));
+      await vi.waitFor(() => {
+        expect(scrollTo).toHaveBeenCalledWith({
+          top: 600,
+          behavior: "instant",
+        });
+      });
+    } finally {
+      Reflect.deleteProperty(div, "scrollHeight");
+      Reflect.deleteProperty(div, "clientHeight");
+      Reflect.deleteProperty(div, "scrollTop");
+      Reflect.deleteProperty(div, "scrollTo");
+      unmount();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("renders scroll-to-bottom disabled outside a viewport and warns in dev", () => {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -9,6 +9,7 @@ export { MessageByIdProvider } from "./primitives/MessageByIdProvider";
 export { PartByIndexProvider } from "./primitives/PartByIndexProvider";
 export { ThreadPrimitiveMessages } from "./primitives/ThreadPrimitiveMessages";
 export { ThreadPrimitiveViewport } from "./primitives/ThreadPrimitiveViewport";
+export { ThreadPrimitiveViewportFooter } from "./primitives/ThreadPrimitiveViewportFooter";
 export { ThreadPrimitiveScrollToBottom } from "./primitives/ThreadPrimitiveScrollToBottom";
 export {
   MessagePrimitiveParts,

--- a/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
@@ -5,6 +5,7 @@ import {
   mergeProps,
   type PropType,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { isDevelopment } from "@assistant-ui/core/store/internal";
 import { isAttrDisabled } from "./attrDisabled";
@@ -30,7 +31,7 @@ export const ThreadPrimitiveScrollToBottom = defineComponent({
       default: "auto",
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { attrs, slots }) {
     const viewport = inject(viewportInjectionKey, null);
     if (isDevelopment && !viewport && !warnedOutsideViewport) {

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -7,6 +7,7 @@ import {
   shallowRef,
   watch,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import type {} from "@assistant-ui/core/store";
 import { useAuiEvent } from "../useAuiEvent";
@@ -50,9 +51,11 @@ export const ThreadPrimitiveViewport = defineComponent({
       default: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const divRef = shallowRef<HTMLElement | null>(null);
+    const contentInset = shallowRef(0);
+    const contentInsetEntries = new Map<symbol, number>();
     let intent: ScrollBehavior | null = null;
     const isAtBottom = shallowRef(true);
     let lastScrollTop = 0;
@@ -65,7 +68,7 @@ export const ThreadPrimitiveViewport = defineComponent({
       const div = divRef.value;
       if (!div) return;
       intent = behavior;
-      div.scrollTo?.({ top: div.scrollHeight, behavior });
+      div.scrollTo?.({ top: div.scrollHeight - contentInset.value, behavior });
     };
 
     const scheduleScrollToBottom = (behavior: ScrollBehavior) => {
@@ -84,13 +87,13 @@ export const ThreadPrimitiveViewport = defineComponent({
       const div = divRef.value;
       if (!div) return;
 
-      const newIsAtBottom = isViewportAtBottom(div);
+      const newIsAtBottom = isViewportAtBottom(div, contentInset.value);
       const inFlightDownward = !newIsAtBottom && lastScrollTop < div.scrollTop;
       if (!inFlightDownward) {
         if (newIsAtBottom) {
           // At-bottom is ambiguous while the viewport does not overflow; keep
           // the intent alive until content can actually scroll.
-          if (viewportOverflows(div)) intent = null;
+          if (viewportOverflows(div, contentInset.value)) intent = null;
         } else if (
           isUserScrollUp(
             { scrollTop: lastScrollTop, scrollHeight: lastScrollHeight },
@@ -104,6 +107,31 @@ export const ThreadPrimitiveViewport = defineComponent({
 
       lastScrollTop = div.scrollTop;
       lastScrollHeight = div.scrollHeight;
+    };
+
+    const updateContentInset = () => {
+      let total = 0;
+      for (const height of contentInsetEntries.values()) total += height;
+      if (contentInset.value === total) return;
+      contentInset.value = total;
+      handleScroll();
+    };
+
+    const registerContentInset = () => {
+      const id = Symbol();
+      contentInsetEntries.set(id, 0);
+
+      return {
+        setHeight: (height: number) => {
+          if (contentInsetEntries.get(id) === height) return;
+          contentInsetEntries.set(id, height);
+          updateContentInset();
+        },
+        unregister: () => {
+          if (!contentInsetEntries.delete(id)) return;
+          updateContentInset();
+        },
+      };
     };
 
     const onContentResize = () => {
@@ -181,6 +209,7 @@ export const ThreadPrimitiveViewport = defineComponent({
       isAtBottom,
       scrollToBottom: (behavior: ScrollBehavior = "auto") =>
         scrollToBottom(behavior),
+      registerContentInset,
     });
 
     return () =>

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -68,7 +68,7 @@ export const ThreadPrimitiveViewport = defineComponent({
       const div = divRef.value;
       if (!div) return;
       intent = behavior;
-      div.scrollTo?.({ top: div.scrollHeight - contentInset.value, behavior });
+      div.scrollTo?.({ top: div.scrollHeight, behavior });
     };
 
     const scheduleScrollToBottom = (behavior: ScrollBehavior) => {
@@ -113,7 +113,18 @@ export const ThreadPrimitiveViewport = defineComponent({
       let total = 0;
       for (const height of contentInsetEntries.values()) total += height;
       if (contentInset.value === total) return;
+      const grew = total > contentInset.value;
       contentInset.value = total;
+      // A growing inset obscures content a pinned viewport was showing, so it
+      // follows like a content resize; a shrinking inset reveals content and
+      // must not move the viewport.
+      if (grew) {
+        if (intent) {
+          scrollToBottom(intent);
+        } else if (props.autoScroll && isAtBottom.value) {
+          scrollToBottom("instant");
+        }
+      }
       handleScroll();
     };
 

--- a/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.test.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.test.ts
@@ -168,23 +168,20 @@ describe("ThreadPrimitiveViewportFooter", () => {
     observers.trigger(footer);
     await nextTick();
 
-    el.querySelector<HTMLButtonElement>("button.jump")!.click();
-    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
-      top: 450,
-      behavior: "auto",
-    });
+    geometry.setScrollTop(355);
+    div.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      true,
+    );
 
     showFooter.value = false;
     await nextTick();
-    geometry.setScrollTop(0);
     div.dispatchEvent(new Event("scroll"));
     await nextTick();
-
-    el.querySelector<HTMLButtonElement>("button.jump")!.click();
-    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
-      top: 500,
-      behavior: "auto",
-    });
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      false,
+    );
 
     Reflect.deleteProperty(footer, "offsetHeight");
     unmount();
@@ -192,6 +189,7 @@ describe("ThreadPrimitiveViewportFooter", () => {
 
   it("sums the heights of multiple footers", async () => {
     const observers = installResizeObserver();
+    const showSecond = ref(true);
     const View = defineComponent({
       setup: () => () =>
         h(
@@ -200,7 +198,9 @@ describe("ThreadPrimitiveViewportFooter", () => {
           {
             default: () => [
               h(ThreadPrimitiveViewportFooter, { class: "first-footer" }),
-              h(ThreadPrimitiveViewportFooter, { class: "second-footer" }),
+              showSecond.value
+                ? h(ThreadPrimitiveViewportFooter, { class: "second-footer" })
+                : null,
               h(
                 ThreadPrimitiveScrollToBottom,
                 { class: "jump" },
@@ -228,14 +228,76 @@ describe("ThreadPrimitiveViewportFooter", () => {
     observers.trigger(secondFooter);
     await nextTick();
 
-    el.querySelector<HTMLButtonElement>("button.jump")!.click();
-    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
-      top: 450,
-      behavior: "auto",
-    });
+    geometry.setScrollTop(355);
+    div.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      true,
+    );
+
+    showSecond.value = false;
+    await nextTick();
+    div.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      false,
+    );
 
     Reflect.deleteProperty(firstFooter, "offsetHeight");
     Reflect.deleteProperty(secondFooter, "offsetHeight");
+    unmount();
+  });
+
+  it("follows a footer growth while pinned at the bottom", async () => {
+    const observers = installResizeObserver();
+    let footerHeight = 50;
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              h(ThreadPrimitiveViewportFooter, { class: "footer" }),
+              h(
+                ThreadPrimitiveScrollToBottom,
+                { class: "jump" },
+                { default: () => "Jump" },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(createTestRuntime(), View);
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    const geometry = installViewportGeometry(div);
+    const footer = el.querySelector<HTMLElement>("div.footer")!;
+    Object.defineProperty(footer, "offsetHeight", {
+      get: () => footerHeight,
+      configurable: true,
+    });
+    geometry.setScrollTop(400);
+    div.dispatchEvent(new Event("scroll"));
+    observers.trigger(footer);
+    await nextTick();
+    expect(geometry.scrollTo).toHaveBeenCalledWith({
+      top: 500,
+      behavior: "instant",
+    });
+
+    geometry.scrollTo.mockClear();
+    footerHeight = 80;
+    observers.trigger(footer);
+    await nextTick();
+    expect(geometry.scrollTo).toHaveBeenCalledWith({
+      top: 500,
+      behavior: "instant",
+    });
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      true,
+    );
+
+    Reflect.deleteProperty(footer, "offsetHeight");
     unmount();
   });
 });

--- a/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.test.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  type Component,
+} from "vue";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { ThreadPrimitiveScrollToBottom } from "./ThreadPrimitiveScrollToBottom";
+import { ThreadPrimitiveViewport } from "./ThreadPrimitiveViewport";
+import { ThreadPrimitiveViewportFooter } from "./ThreadPrimitiveViewportFooter";
+
+const geometryElements = new Set<HTMLElement>();
+
+const createTestRuntime = () =>
+  new AssistantRuntimeImpl(
+    new ExternalStoreRuntimeCore({
+      messages: [],
+      convertMessage: () => ({ role: "user", content: [] }),
+      onNew: async () => {},
+    }),
+  );
+
+const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(view) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+const installViewportGeometry = (div: HTMLElement) => {
+  let scrollHeight = 500;
+  let scrollTop = 0;
+  const clientHeight = 100;
+  geometryElements.add(div);
+  Object.defineProperty(div, "scrollHeight", {
+    get: () => scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(div, "clientHeight", {
+    get: () => clientHeight,
+    configurable: true,
+  });
+  Object.defineProperty(div, "scrollTop", {
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+    configurable: true,
+  });
+  const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+    scrollTop = Math.max(0, Math.min(top ?? 0, scrollHeight - clientHeight));
+    div.dispatchEvent(new Event("scroll"));
+  });
+  Object.defineProperty(div, "scrollTo", {
+    value: scrollTo,
+    configurable: true,
+  });
+  return {
+    scrollTo,
+    setScrollHeight: (value: number) => {
+      scrollHeight = value;
+    },
+    setScrollTop: (value: number) => {
+      scrollTop = value;
+    },
+  };
+};
+
+const installResizeObserver = () => {
+  const observers = new Set<ResizeObserverMock>();
+  class ResizeObserverMock {
+    element: Element | null = null;
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+      observers.add(this);
+    }
+
+    observe(element: Element) {
+      this.element = element;
+    }
+
+    unobserve() {}
+
+    disconnect() {
+      observers.delete(this);
+    }
+
+    takeRecords() {
+      return [];
+    }
+
+    trigger() {
+      this.callback([], this);
+    }
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  return {
+    trigger: (element: Element) => {
+      for (const observer of observers) {
+        if (observer.element === element) observer.trigger();
+      }
+    },
+  };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  for (const element of geometryElements) {
+    Reflect.deleteProperty(element, "scrollHeight");
+    Reflect.deleteProperty(element, "clientHeight");
+    Reflect.deleteProperty(element, "scrollTop");
+    Reflect.deleteProperty(element, "scrollTo");
+  }
+  geometryElements.clear();
+});
+
+describe("ThreadPrimitiveViewportFooter", () => {
+  it("registers its height and unregisters it when removed", async () => {
+    const observers = installResizeObserver();
+    const showFooter = ref(true);
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              showFooter.value
+                ? h(ThreadPrimitiveViewportFooter, { class: "footer" })
+                : null,
+              h(
+                ThreadPrimitiveScrollToBottom,
+                { class: "jump" },
+                { default: () => "Jump" },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(createTestRuntime(), View);
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    const geometry = installViewportGeometry(div);
+    const footer = el.querySelector<HTMLElement>("div.footer")!;
+    Object.defineProperty(footer, "offsetHeight", {
+      get: () => 50,
+      configurable: true,
+    });
+    div.dispatchEvent(new Event("scroll"));
+    observers.trigger(footer);
+    await nextTick();
+
+    el.querySelector<HTMLButtonElement>("button.jump")!.click();
+    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
+      top: 450,
+      behavior: "auto",
+    });
+
+    showFooter.value = false;
+    await nextTick();
+    geometry.setScrollTop(0);
+    div.dispatchEvent(new Event("scroll"));
+    await nextTick();
+
+    el.querySelector<HTMLButtonElement>("button.jump")!.click();
+    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
+      top: 500,
+      behavior: "auto",
+    });
+
+    Reflect.deleteProperty(footer, "offsetHeight");
+    unmount();
+  });
+
+  it("sums the heights of multiple footers", async () => {
+    const observers = installResizeObserver();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              h(ThreadPrimitiveViewportFooter, { class: "first-footer" }),
+              h(ThreadPrimitiveViewportFooter, { class: "second-footer" }),
+              h(
+                ThreadPrimitiveScrollToBottom,
+                { class: "jump" },
+                { default: () => "Jump" },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(createTestRuntime(), View);
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    const geometry = installViewportGeometry(div);
+    const firstFooter = el.querySelector<HTMLElement>("div.first-footer")!;
+    const secondFooter = el.querySelector<HTMLElement>("div.second-footer")!;
+    Object.defineProperty(firstFooter, "offsetHeight", {
+      get: () => 20,
+      configurable: true,
+    });
+    Object.defineProperty(secondFooter, "offsetHeight", {
+      get: () => 30,
+      configurable: true,
+    });
+    div.dispatchEvent(new Event("scroll"));
+    observers.trigger(firstFooter);
+    observers.trigger(secondFooter);
+    await nextTick();
+
+    el.querySelector<HTMLButtonElement>("button.jump")!.click();
+    expect(geometry.scrollTo).toHaveBeenLastCalledWith({
+      top: 450,
+      behavior: "auto",
+    });
+
+    Reflect.deleteProperty(firstFooter, "offsetHeight");
+    Reflect.deleteProperty(secondFooter, "offsetHeight");
+    unmount();
+  });
+});

--- a/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.ts
@@ -11,6 +11,12 @@ import {
 } from "vue";
 import { viewportInjectionKey } from "./viewportContext";
 
+/**
+ * A footer container that measures its height into the viewport's content
+ * inset. Positions within the summed inset of the native bottom count as at
+ * bottom, and a growing inset re-follows a pinned viewport. Multiple footers
+ * sum. Typically used with `class="sticky bottom-0"`.
+ */
 export const ThreadPrimitiveViewportFooter = defineComponent({
   name: "ThreadPrimitiveViewportFooter",
   inheritAttrs: false,

--- a/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewportFooter.ts
@@ -1,0 +1,54 @@
+import {
+  defineComponent,
+  h,
+  inject,
+  mergeProps,
+  onMounted,
+  onScopeDispose,
+  shallowRef,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { viewportInjectionKey } from "./viewportContext";
+
+export const ThreadPrimitiveViewportFooter = defineComponent({
+  name: "ThreadPrimitiveViewportFooter",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const viewport = inject(viewportInjectionKey, null);
+    const divRef = shallowRef<HTMLElement | null>(null);
+    let dispose: (() => void) | undefined;
+
+    onMounted(() => {
+      const div = divRef.value;
+      if (!div || !viewport) return;
+
+      const contentInset = viewport.registerContentInset();
+      const updateHeight = () => {
+        const marginTop =
+          Number.parseFloat(getComputedStyle(div).marginTop) || 0;
+        contentInset.setHeight(div.offsetHeight + marginTop);
+      };
+      updateHeight();
+
+      let resizeObserver: ResizeObserver | undefined;
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(updateHeight);
+        resizeObserver.observe(div);
+      }
+
+      dispose = () => {
+        resizeObserver?.disconnect();
+        contentInset.unregister();
+      };
+    });
+
+    onScopeDispose(() => {
+      dispose?.();
+    });
+
+    return () =>
+      h("div", mergeProps(attrs, { ref: divRef }), slots.default?.());
+  },
+});

--- a/packages/vue/src/primitives/viewportContext.ts
+++ b/packages/vue/src/primitives/viewportContext.ts
@@ -1,8 +1,14 @@
 import type { InjectionKey, ShallowRef } from "vue";
 
+export type ViewportContentInsetHandle = {
+  setHeight: (height: number) => void;
+  unregister: () => void;
+};
+
 export type ViewportContext = {
   isAtBottom: ShallowRef<boolean>;
   scrollToBottom: (behavior?: ScrollBehavior) => void;
+  registerContentInset: () => ViewportContentInsetHandle;
 };
 
 export const viewportInjectionKey: InjectionKey<ViewportContext> = Symbol(


### PR DESCRIPTION
## what

ports `ThreadPrimitive.ViewportFooter` to the vue face: a footer container that measures its own height into the viewport scroll machinery, so a sticky composer overlapping the message list no longer breaks at-bottom detection and auto-follow.

## how

- the shared helpers in `store/src/utils/viewport-scroll.ts` accept an optional `contentInset` (default 0 keeps the current behavior byte-for-byte for the svelte consumer; with an inset, being scrolled past `bottom - inset` counts as at bottom, which is the physically correct reading under a sticky footer).
- `ThreadPrimitiveViewport` gains a registration channel mirroring react's `createSizeRegistry`: symbol-keyed entries, heights summed, dedupe on unchanged values, re-evaluation on every change.
- new `ThreadPrimitiveViewportFooter` registers via that channel with a ResizeObserver, unregisters on unmount, multiple footers sum. the observer mounts independently of MutationObserver availability so an SSR-ish environment cannot take one down with the other.
- a growing inset obscures content a pinned viewport was showing, so it follows like a content resize; a shrinking inset reveals content and never moves the viewport. scroll-to-bottom targets the native bottom (the browser clamp already lands there), matching react.
- slot typings on the touched viewport files tightened from `() => unknown` to `VNodeChild[]` (the package-wide sweep class).

## notes

react currently only registers `height.inset` (`registerContentInset`) without a consumer wired into its at-bottom math; the vue face consumes it, which is what makes the footer a behavioral component rather than an inert one. registration semantics match react exactly, so wiring react's consumer later needs no contract change.

verified: vue 91/91, store 186/186, svelte 57/57, vue tsc error count unchanged vs main.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.d1sE0NVQs8BcHXYp7uatBWgCpEFqdd_St24d_VCgiyxwBnO-Sg9d1EkeZi0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->