### PR TITLE
feat(vue): chain-of-thought primitives

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -14,6 +14,8 @@ export {
   MessagePrimitiveParts,
   type ToolUIProps,
 } from "./primitives/MessagePrimitiveParts";
+export { ChainOfThoughtPrimitiveParts } from "./primitives/ChainOfThoughtPrimitiveParts";
+export { ChainOfThoughtPrimitiveAccordionTrigger } from "./primitives/ChainOfThoughtPrimitiveAccordionTrigger";
 export { ComposerPrimitiveInput } from "./primitives/ComposerPrimitiveInput";
 export { ComposerPrimitiveSend } from "./primitives/ComposerPrimitiveSend";
 export { ComposerPrimitiveCancel } from "./primitives/ComposerPrimitiveCancel";

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.test.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import {
+  ChainOfThoughtClient,
+  type ChainOfThoughtPart,
+} from "@assistant-ui/core/store";
+import { AuiProvider } from "../AuiProvider";
+import { useAuiState } from "../useAuiState";
+import { ChainOfThoughtPrimitiveAccordionTrigger } from "./ChainOfThoughtPrimitiveAccordionTrigger";
+
+const parts: readonly ChainOfThoughtPart[] = [
+  { type: "reasoning", text: "thinking", status: { type: "complete" } },
+];
+
+const StateProbe = defineComponent({
+  setup() {
+    const collapsed = useAuiState((s) => s.chainOfThought.collapsed);
+    return () => h("span", { class: "collapsed" }, String(collapsed.value));
+  },
+});
+
+const mountTrigger = (props: Record<string, unknown> = {}) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              chainOfThought: ChainOfThoughtClient({
+                parts,
+                getMessagePart: () => {
+                  throw new Error("Part access is not needed by this test.");
+                },
+              }),
+            }),
+          },
+          {
+            default: () =>
+              h("div", [
+                h(ChainOfThoughtPrimitiveAccordionTrigger, props, {
+                  default: () => "Toggle",
+                }),
+                h(StateProbe),
+              ]),
+          },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+describe("ChainOfThoughtPrimitiveAccordionTrigger", () => {
+  it("toggles the collapsed state", async () => {
+    const { el, unmount } = mountTrigger();
+    const button = el.querySelector<HTMLButtonElement>("button")!;
+
+    expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+    button.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.collapsed")?.textContent).toBe("false");
+    });
+    button.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+    });
+
+    unmount();
+  });
+
+  it("respects caller vetoes", async () => {
+    const { el, unmount } = mountTrigger({
+      onClick: (event: MouseEvent) => event.preventDefault(),
+    });
+
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    await nextTick();
+    expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+
+    unmount();
+  });
+
+  it("stays disabled when the disabled attribute is set", async () => {
+    const { el, unmount } = mountTrigger({ disabled: true });
+    const button = el.querySelector<HTMLButtonElement>("button")!;
+
+    expect(button.disabled).toBe(true);
+    flushTapSync(() => button.click());
+    await nextTick();
+    expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+
+    button.disabled = false;
+    flushTapSync(() => button.click());
+    await nextTick();
+    expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+
+    unmount();
+  });
+});

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
@@ -9,6 +9,9 @@ import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
 import { isAttrDisabled } from "./attrDisabled";
 
+/**
+ * A button that toggles the collapsed state of the chain of thought accordion.
+ */
 export const ChainOfThoughtPrimitiveAccordionTrigger = defineComponent({
   name: "ChainOfThoughtPrimitiveAccordionTrigger",
   inheritAttrs: false,

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
@@ -1,0 +1,34 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { isAttrDisabled } from "./attrDisabled";
+
+export const ChainOfThoughtPrimitiveAccordionTrigger = defineComponent({
+  name: "ChainOfThoughtPrimitiveAccordionTrigger",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const collapsed = useAuiState((s) => s.chainOfThought.collapsed);
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+      aui.chainOfThought.setCollapsed(!collapsed.value);
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveAccordionTrigger.ts
@@ -11,6 +11,7 @@ import { isAttrDisabled } from "./attrDisabled";
 
 /**
  * A button that toggles the collapsed state of the chain of thought accordion.
+ * Caller listeners run first and can veto the toggle via `preventDefault`.
  */
 export const ChainOfThoughtPrimitiveAccordionTrigger = defineComponent({
   name: "ChainOfThoughtPrimitiveAccordionTrigger",

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.test.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.test.ts
@@ -46,6 +46,28 @@ const createReasoningRuntime = (initial: readonly string[]) => {
   return { runtime, setTexts };
 };
 
+const CollapsedProbe = defineComponent({
+  setup() {
+    const collapsed = useAuiState((s) => s.chainOfThought.collapsed);
+    return () => h("span", { class: "collapsed" }, String(collapsed.value));
+  },
+});
+
+const ExpandButton = defineComponent({
+  setup() {
+    const aui = useAui();
+    return () =>
+      h(
+        "button",
+        {
+          class: "expand",
+          onClick: () => aui.chainOfThought.setCollapsed(false),
+        },
+        "expand",
+      );
+  },
+});
+
 const ChainOfThoughtHost = defineComponent({
   setup(_, { slots }) {
     const aui = useAui();
@@ -81,7 +103,7 @@ const mountParts = (initial: readonly string[]) => {
                 h(ThreadPrimitiveMessages, null, {
                   default: () =>
                     h(ChainOfThoughtHost, null, {
-                      default: () =>
+                      default: () => [
                         h(ChainOfThoughtPrimitiveParts, null, {
                           default: ({ part }: { part: PartState }) => [
                             h(
@@ -91,6 +113,9 @@ const mountParts = (initial: readonly string[]) => {
                             ),
                           ],
                         }),
+                        h(CollapsedProbe),
+                        h(ExpandButton),
+                      ],
                     }),
                 }),
               ]),
@@ -122,11 +147,19 @@ describe("ChainOfThoughtPrimitiveParts", () => {
     unmount();
   });
 
-  it("renders while collapsed, matching the React primitive", async () => {
+  it("renders regardless of the collapsed state, matching the React primitive", async () => {
     const { el, unmount } = mountParts(["alpha"]);
 
     await vi.waitFor(async () => {
       await nextTick();
+      expect(el.querySelector("span.collapsed")?.textContent).toBe("true");
+      expect(partTexts(el)).toEqual(["alpha"]);
+    });
+
+    el.querySelector<HTMLButtonElement>("button.expand")!.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.collapsed")?.textContent).toBe("false");
       expect(partTexts(el)).toEqual(["alpha"]);
     });
 
@@ -153,6 +186,14 @@ describe("ChainOfThoughtPrimitiveParts", () => {
       await nextTick();
       expect(partTexts(el)).toEqual(["alpha", "gamma"]);
     });
+
+    const logged = error.mock.calls.map((call) => call.map(String).join(" "));
+    for (const message of logged) {
+      expect(message).toContain("(ignore if recovered)");
+    }
+    expect(logged.join("\n")).not.toContain(
+      "ChainOfThoughtPartByIndexProvider",
+    );
 
     unmount();
     error.mockRestore();

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.test.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computed, createApp, defineComponent, h, nextTick } from "vue";
+import { AuiConfig } from "@assistant-ui/store/client";
+import {
+  ChainOfThoughtClient,
+  RuntimeAdapter,
+  type ChainOfThoughtPart,
+  type PartState,
+} from "@assistant-ui/core/store";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { ThreadPrimitiveMessages } from "./ThreadPrimitiveMessages";
+import { ChainOfThoughtPrimitiveParts } from "./ChainOfThoughtPrimitiveParts";
+
+type DemoMessage = { id: string; texts: readonly string[] };
+
+const convertDemoMessage = (message: DemoMessage) => ({
+  id: message.id,
+  role: "assistant" as const,
+  content: message.texts.map((text) => ({
+    type: "reasoning" as const,
+    text,
+  })),
+});
+
+const createReasoningRuntime = (initial: readonly string[]) => {
+  let messages: DemoMessage[] = [{ id: "a0", texts: initial }];
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    isRunning: false,
+    convertMessage: convertDemoMessage,
+    onNew: async () => {},
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const setTexts = (texts: readonly string[]) => {
+    messages = [{ id: "a0", texts }];
+    core.setAdapter(makeAdapter());
+  };
+  return { runtime, setTexts };
+};
+
+const ChainOfThoughtHost = defineComponent({
+  setup(_, { slots }) {
+    const aui = useAui();
+    const parts = useAuiState((s) => s.message.parts);
+    const config = computed(() =>
+      AuiConfig({
+        chainOfThought: ChainOfThoughtClient({
+          parts: parts.value as readonly ChainOfThoughtPart[],
+          getMessagePart: ({ index }) => aui.message.part({ index }),
+        }),
+      }),
+    );
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});
+
+const mountParts = (initial: readonly string[]) => {
+  const { runtime, setTexts } = createReasoningRuntime(initial);
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          {
+            default: () =>
+              h("ul", [
+                h(ThreadPrimitiveMessages, null, {
+                  default: () =>
+                    h(ChainOfThoughtHost, null, {
+                      default: () =>
+                        h(ChainOfThoughtPrimitiveParts, null, {
+                          default: ({ part }: { part: PartState }) => [
+                            h(
+                              "li",
+                              { class: "part" },
+                              part.type === "reasoning" ? part.text : part.type,
+                            ),
+                          ],
+                        }),
+                    }),
+                }),
+              ]),
+          },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, setTexts, unmount: () => app.unmount() };
+};
+
+const partTexts = (el: HTMLElement) =>
+  [...el.querySelectorAll("li.part")].map((li) => li.textContent);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ChainOfThoughtPrimitiveParts", () => {
+  it("renders one slot invocation per part with its state", async () => {
+    const { el, unmount } = mountParts(["alpha", "beta"]);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(partTexts(el)).toEqual(["alpha", "beta"]);
+    });
+
+    unmount();
+  });
+
+  it("renders while collapsed, matching the React primitive", async () => {
+    const { el, unmount } = mountParts(["alpha"]);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(partTexts(el)).toEqual(["alpha"]);
+    });
+
+    unmount();
+  });
+
+  it("follows a parts shrink and regrowth without crashing", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { el, setTexts, unmount } = mountParts(["alpha", "beta"]);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(partTexts(el)).toEqual(["alpha", "beta"]);
+    });
+
+    setTexts(["alpha"]);
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(partTexts(el)).toEqual(["alpha"]);
+    });
+
+    setTexts(["alpha", "gamma"]);
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(partTexts(el)).toEqual(["alpha", "gamma"]);
+    });
+
+    unmount();
+    error.mockRestore();
+  });
+});

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.ts
@@ -46,6 +46,9 @@ const ChainOfThoughtPartByIndexProvider = defineComponent({
         part: Derived({
           source: "chainOfThought",
           query: { type: "index", index },
+          // chainOfThought.part() delegates to a userland getMessagePart, so
+          // validity is not decided by parts.length alone; a lookup throw is
+          // absorbed into the stale cache like an invalid index.
           get: (aui) => {
             const valid = index < aui.chainOfThought.getState().parts.length;
             try {
@@ -79,6 +82,13 @@ const ChainOfThoughtPartView = defineComponent({
   },
 });
 
+/**
+ * Renders the parts within a chain of thought through the default slot, one
+ * invocation per entry of `s.chainOfThought.parts`.
+ *
+ * Rendering is not gated on `s.chainOfThought.collapsed`; gate visibility in
+ * the caller (for example with `AuiIf`), matching the React primitive.
+ */
 export const ChainOfThoughtPrimitiveParts = defineComponent({
   name: "ChainOfThoughtPrimitiveParts",
   slots: Object as SlotsType<ChainOfThoughtPartsSlots>,

--- a/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.ts
+++ b/packages/vue/src/primitives/ChainOfThoughtPrimitiveParts.ts
@@ -1,0 +1,99 @@
+import {
+  computed,
+  defineComponent,
+  h,
+  onScopeDispose,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import type { PartMethods, PartState } from "@assistant-ui/core/store";
+import { AuiConfig, Derived } from "@assistant-ui/store/client";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { createLastValidCache, createStaleReporter } from "./lastValidCache";
+
+type ChainOfThoughtPartsSlots = {
+  default?: (props: { part: PartState }) => VNodeChild[];
+};
+
+const ChainOfThoughtPartByIndexProvider = defineComponent({
+  name: "ChainOfThoughtPartByIndexProvider",
+  props: {
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(props, { slots }) {
+    const aui = useAui();
+    let disposed = false;
+    onScopeDispose(() => {
+      disposed = true;
+    });
+    const config = computed(() => {
+      const index = props.index;
+      const cache = createLastValidCache<PartMethods>(
+        createStaleReporter({
+          name: "ChainOfThoughtPartByIndexProvider",
+          index,
+          isCurrent: () => !disposed && index === props.index,
+          isValid: () => index < aui.chainOfThought.getState().parts.length,
+        }),
+      );
+      return AuiConfig({
+        part: Derived({
+          source: "chainOfThought",
+          query: { type: "index", index },
+          get: (aui) => {
+            const valid = index < aui.chainOfThought.getState().parts.length;
+            try {
+              return cache.resolve(valid, () =>
+                aui.chainOfThought.part({ index }),
+              );
+            } catch (error) {
+              return cache.resolve(false, () => {
+                throw error;
+              });
+            }
+          },
+        }),
+      });
+    });
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});
+
+const ChainOfThoughtPartView = defineComponent({
+  name: "ChainOfThoughtPartView",
+  slots: Object as SlotsType<ChainOfThoughtPartsSlots>,
+  setup(_, { slots }) {
+    const part = useAuiState((s) => s.part);
+    return () => slots.default?.({ part: part.value });
+  },
+});
+
+export const ChainOfThoughtPrimitiveParts = defineComponent({
+  name: "ChainOfThoughtPrimitiveParts",
+  slots: Object as SlotsType<ChainOfThoughtPartsSlots>,
+  setup(_, { slots }) {
+    const count = useAuiState((s) => s.chainOfThought.parts.length);
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          ChainOfThoughtPartByIndexProvider,
+          { index, key: index },
+          {
+            default: () =>
+              h(ChainOfThoughtPartView, null, { default: slots.default }),
+          },
+        ),
+      );
+  },
+});


### PR DESCRIPTION
## what

ports the chainOfThought primitives to the vue face: `ChainOfThoughtPrimitiveParts` (per-part slot rendering over the chainOfThought scope) and `ChainOfThoughtPrimitiveAccordionTrigger` (collapse toggle).

## how

- `Parts` mirrors the core react implementation: one per-index provider per entry of `s.chainOfThought.parts`, each backed by `Derived({ source: "chainOfThought", query: { type: "index", index } })` and guarded with the shared lastValidCache pattern so a parts shrink serves the stale scope until the next tick instead of crashing; the default slot receives the part state (react's deprecated `components` config leg is not ported).
- `AccordionTrigger` follows the action-bar button idiom: `inheritAttrs: false` + `mergeProps` so caller listeners run first and can veto via `preventDefault`, attr-driven disabled semantics.
- tests cover trigger toggle/veto/disabled (including the handler-level disabled guard with the dom attribute flipped off), per-part slot rendering through a real external-store runtime with reasoning parts, collapsed-state parity, and shrink/regrow stability.

## deliberately not ported

- `ChainOfThoughtPrimitiveRoot`: a bare passthrough div on the react side; this repo does not ship inert pieces (same ruling as the earlier structural batch).
- `useScrollLock`: a dom utility hook; the vue composable surface is capped at useAui/useAuiState/useAuiEvent, so it lands with the styled kit component that needs it.
- a `ChainOfThoughtByIndicesProvider` equivalent: the scope stays constructible from userland config (`ChainOfThoughtClient` is framework-neutral and the parts test demonstrates the wiring); the grouped-parts host follows with the reasoning styled surface.

verified: vue 93/93, tsc error count unchanged vs main.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZGCo820vYdvlANLebNaSff7aXiJUpSsIOa_Wt-gtHqnNlHX6K4F-rNKptqA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->