### PR TITLE
feat(vue): thread list keyboard navigation and styled thread list

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -64,27 +64,38 @@ const createBuilt = (
     new Map(files.map(([filePath, content]) => [filePath, content])),
 });
 
-test("vue registry build emits a self-contained thread with its type-only dependency", async () => {
+test("vue registry build emits self-contained staged items", async () => {
   const { registry, stagedVueRegistry } = await import("../src/registry.ts");
   await buildRegistry(registry, stagedVueRegistry);
 
-  const [registryContent, threadContent] = await Promise.all([
-    readFile("dist/vue/registry.json", "utf8"),
-    readFile("dist/vue/thread.json", "utf8"),
-  ]);
+  const [registryContent, threadContent, threadListContent] = await Promise.all(
+    [
+      readFile("dist/vue/registry.json", "utf8"),
+      readFile("dist/vue/thread.json", "utf8"),
+      readFile("dist/vue/thread-list.json", "utf8"),
+    ],
+  );
   const vueIndex = JSON.parse(registryContent);
   const thread = JSON.parse(threadContent);
+  const threadList = JSON.parse(threadListContent);
   const threadFile = thread.files.find(
     (file) => file.path === "components/assistant-ui/thread.vue",
+  );
+  const threadListFile = threadList.files.find(
+    (file) => file.path === "components/assistant-ui/thread-list.vue",
   );
 
   assert.ok(
     threadFile,
     "vue thread registry output includes components/assistant-ui/thread.vue",
   );
+  assert.ok(
+    threadListFile,
+    "vue thread list registry output includes components/assistant-ui/thread-list.vue",
+  );
   assert.deepEqual(
     vueIndex.items.map((item) => item.name),
-    ["thread"],
+    ["thread-list", "thread"],
   );
   assert.deepEqual(thread.dependencies, [
     "@assistant-ui/core",
@@ -94,30 +105,54 @@ test("vue registry build emits a self-contained thread with its type-only depend
   ]);
   assert.deepEqual(thread.devDependencies, ["@types/markdown-it"]);
   assert.equal("target" in threadFile, false);
+  assert.deepEqual(threadList.dependencies, [
+    "@assistant-ui/vue",
+    "reka-ui",
+    "@lucide/vue",
+  ]);
+  assert.equal("target" in threadListFile, false);
   assert.match(
     threadFile.content,
     /import Message from "@\/components\/assistant-ui\/message\.vue"/,
   );
+  assert.match(threadListFile.content, /from "reka-ui"/);
 });
 
 test("emitted vue artifacts compile as SFCs and pass the vue purity gate", async () => {
   const { parse, compileScript } = await import("@vue/compiler-sfc");
-  const thread = JSON.parse(await readFile("dist/vue/thread.json", "utf8"));
-  const emitted = thread.files.map((file) => [file.path, file.content]);
-  assert.deepEqual(emitted.map(([outputPath]) => outputPath).sort(), [
+  const [thread, threadList] = await Promise.all([
+    readFile("dist/vue/thread.json", "utf8").then(JSON.parse),
+    readFile("dist/vue/thread-list.json", "utf8").then(JSON.parse),
+  ]);
+  const threadEmitted = thread.files.map((file) => [file.path, file.content]);
+  const threadListEmitted = threadList.files.map((file) => [
+    file.path,
+    file.content,
+  ]);
+  assert.deepEqual(threadEmitted.map(([outputPath]) => outputPath).sort(), [
     "components/assistant-ui/markdown-text.vue",
     "components/assistant-ui/message.vue",
     "components/assistant-ui/thread.vue",
   ]);
+  assert.deepEqual(
+    threadListEmitted.map(([outputPath]) => outputPath),
+    ["components/assistant-ui/thread-list.vue"],
+  );
 
-  for (const [outputPath, content] of emitted) {
+  for (const [outputPath, content] of [
+    ...threadEmitted,
+    ...threadListEmitted,
+  ]) {
     const { descriptor, errors } = parse(content, { filename: outputPath });
     assert.deepEqual(errors, []);
     const compiled = compileScript(descriptor, { id: outputPath });
     assert.ok(compiled.content.length > 0);
   }
 
-  validateVueFlavorContent([createBuilt("thread", emitted)]);
+  validateVueFlavorContent([
+    createBuilt("thread", threadEmitted),
+    createBuilt("thread-list", threadListEmitted),
+  ]);
 });
 
 test("the production vue registry stays empty until the publish flip", async () => {

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1897,6 +1897,22 @@ export const vueRegistry: RegistryItem[] = [];
  */
 export const stagedVueRegistry: RegistryItem[] = [
   {
+    name: "thread-list",
+    type: "registry:component",
+    title: "Thread List",
+    description:
+      "Sidebar or dropdown for switching conversations, with search and active selection.",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/thread-list.vue",
+        sourcePath:
+          "../../packages/ui/src/components/vue/assistant-ui/thread-list.vue",
+      },
+    ],
+    dependencies: ["@assistant-ui/vue", "reka-ui", "@lucide/vue"],
+  },
+  {
     name: "thread",
     type: "registry:component",
     title: "Thread",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1901,7 +1901,7 @@ export const stagedVueRegistry: RegistryItem[] = [
     type: "registry:component",
     title: "Thread List",
     description:
-      "Sidebar or dropdown for switching conversations, with search and active selection.",
+      "Sidebar or dropdown for switching conversations, with active selection.",
     files: [
       {
         type: "registry:component",

--- a/packages/ui/src/components/vue/assistant-ui/thread-list.vue
+++ b/packages/ui/src/components/vue/assistant-ui/thread-list.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import {
+  ThreadListItemPrimitiveArchive,
+  ThreadListItemPrimitiveDelete,
+  ThreadListItemPrimitiveRoot,
+  ThreadListItemPrimitiveTitle,
+  ThreadListItemPrimitiveTrigger,
+  ThreadListPrimitiveItems,
+  ThreadListPrimitiveNew,
+  ThreadListPrimitiveRoot,
+} from "@assistant-ui/vue";
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+} from "reka-ui";
+import {
+  ArchiveIcon,
+  MoreHorizontalIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@lucide/vue";
+</script>
+
+<template>
+  <ThreadListPrimitiveRoot
+    data-slot="aui_thread-list-root"
+    class="flex flex-col gap-0.5"
+  >
+    <ThreadListPrimitiveNew
+      data-slot="aui_thread-list-new"
+      class="hover:bg-muted data-active:bg-muted flex h-8 justify-start gap-2 rounded-md px-2.5 text-sm font-normal"
+    >
+      <PlusIcon data-slot="aui_thread-list-new-icon" class="size-4 shrink-0" />
+      <span data-slot="aui_thread-list-new-label" class="whitespace-nowrap">
+        New Thread
+      </span>
+    </ThreadListPrimitiveNew>
+    <div data-slot="aui_thread-list-items" class="flex flex-col gap-0.5">
+      <ThreadListPrimitiveItems>
+        <ThreadListItemPrimitiveRoot
+          data-slot="aui_thread-list-item"
+          class="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted has-focus-visible:bg-muted has-data-[state=open]:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
+        >
+          <ThreadListItemPrimitiveTrigger
+            data-slot="aui_thread-list-item-trigger"
+            class="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-1"
+          >
+            <span
+              data-slot="aui_thread-list-item-title"
+              class="min-w-0 flex-1 truncate"
+            >
+              <ThreadListItemPrimitiveTitle fallback="New Chat" />
+            </span>
+          </ThreadListItemPrimitiveTrigger>
+          <DropdownMenuRoot>
+            <DropdownMenuTrigger
+              data-slot="aui_thread-list-item-more"
+              class="data-[state=open]:bg-accent focus-visible:ring-ring/50 absolute end-1.5 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md p-0 opacity-0 outline-none group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 focus-visible:ring-1 data-[state=open]:opacity-100"
+              aria-label="More options"
+            >
+              <MoreHorizontalIcon class="size-3.5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuContent
+                side="right"
+                align="start"
+                :side-offset="6"
+                data-slot="aui_thread-list-item-more-content"
+                class="bg-popover text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5"
+              >
+                <DropdownMenuItem as-child>
+                  <ThreadListItemPrimitiveArchive
+                    data-slot="aui_thread-list-item-more-item"
+                    class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                  >
+                    <ArchiveIcon class="size-4" />
+                    Archive
+                  </ThreadListItemPrimitiveArchive>
+                </DropdownMenuItem>
+                <DropdownMenuItem as-child>
+                  <ThreadListItemPrimitiveDelete
+                    data-slot="aui_thread-list-item-more-item"
+                    class="text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                  >
+                    <TrashIcon class="size-4" />
+                    Delete
+                  </ThreadListItemPrimitiveDelete>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenuPortal>
+          </DropdownMenuRoot>
+        </ThreadListItemPrimitiveRoot>
+      </ThreadListPrimitiveItems>
+    </div>
+  </ThreadListPrimitiveRoot>
+</template>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -42,6 +42,8 @@ export {
   ThreadListItemPrimitiveTrigger,
   ThreadListItemPrimitiveTitle,
 } from "./primitives/threadList";
+export { ThreadListPrimitiveRoot } from "./primitives/ThreadListPrimitiveRoot";
+export { ThreadListItemPrimitiveRoot } from "./primitives/ThreadListItemPrimitiveRoot";
 export { AttachmentByIndexProvider } from "./primitives/AttachmentByIndexProvider";
 export {
   AttachmentPrimitiveRoot,

--- a/packages/vue/src/primitives/ThreadListItemPrimitiveRoot.ts
+++ b/packages/vue/src/primitives/ThreadListItemPrimitiveRoot.ts
@@ -1,0 +1,57 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { useAuiState } from "../useAuiState";
+import {
+  provideThreadListItemFocus,
+  useThreadListCollection,
+} from "./threadListFocusGroup";
+
+export const ThreadListItemPrimitiveRoot = defineComponent({
+  name: "ThreadListItemPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const active = useAuiState(
+      (s) => s.threads.mainThreadId === s.threadListItem.id,
+    );
+    const focus = provideThreadListItemFocus();
+    const collection = useThreadListCollection();
+    const onKeydown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      const trigger = focus.trigger.value;
+      if (
+        !trigger ||
+        event.target !== trigger ||
+        (event.key !== "ArrowDown" && event.key !== "ArrowUp")
+      ) {
+        return;
+      }
+      const triggers = collection?.getTriggers();
+      if (!triggers) return;
+      const next =
+        triggers[
+          triggers.indexOf(trigger) + (event.key === "ArrowDown" ? 1 : -1)
+        ];
+      if (!next) return;
+      next.focus();
+      event.preventDefault();
+    };
+    return () =>
+      h(
+        "div",
+        mergeProps(attrs, {
+          ...(active.value && {
+            "data-active": "true",
+            "aria-current": "true",
+          }),
+          onKeydown,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/ThreadListItemPrimitiveTrigger.ts
+++ b/packages/vue/src/primitives/ThreadListItemPrimitiveTrigger.ts
@@ -15,6 +15,13 @@ import {
   useThreadListItemFocus,
 } from "./threadListFocusGroup";
 
+/**
+ * A button that switches to the current thread-list item's thread. Carries
+ * `data-active` and `aria-current` while that thread is the main one, for
+ * standalone use; when nested under `ThreadListItemPrimitiveRoot` the root
+ * stamps them too, diverging from React's root-only pattern to keep existing
+ * standalone consumers styled.
+ */
 export const ThreadListItemPrimitiveTrigger = defineComponent({
   name: "ThreadListItemPrimitiveTrigger",
   inheritAttrs: false,

--- a/packages/vue/src/primitives/ThreadListItemPrimitiveTrigger.ts
+++ b/packages/vue/src/primitives/ThreadListItemPrimitiveTrigger.ts
@@ -1,0 +1,67 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  onScopeDispose,
+  type ComponentPublicInstance,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import {
+  useThreadListCollection,
+  useThreadListItemFocus,
+} from "./threadListFocusGroup";
+
+export const ThreadListItemPrimitiveTrigger = defineComponent({
+  name: "ThreadListItemPrimitiveTrigger",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const active = useAuiState(
+      (s) => s.threads.mainThreadId === s.threadListItem.id,
+    );
+    const collection = useThreadListCollection();
+    const focus = useThreadListItemFocus();
+    const key = Symbol();
+    let trigger: HTMLButtonElement | null = null;
+    let unregister: (() => void) | undefined;
+    const setTrigger = (element: Element | ComponentPublicInstance | null) => {
+      const next = element instanceof HTMLButtonElement ? element : null;
+      const previous = trigger;
+      if (previous === next) return;
+      unregister?.();
+      if (focus && (next || focus.trigger.value === previous)) {
+        focus.trigger.value = next;
+      }
+      trigger = next;
+      unregister = next ? collection?.registerTrigger(key, next) : undefined;
+    };
+    onScopeDispose(() => {
+      unregister?.();
+      if (focus?.trigger.value === trigger) focus.trigger.value = null;
+    });
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+      aui.threadListItem.switchTo();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          ref: setTrigger,
+          type: "button",
+          disabled: isAttrDisabled(attrs),
+          ...(active.value && {
+            "data-active": "true",
+            "aria-current": "true",
+          }),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/ThreadListKeyboardNav.test.ts
+++ b/packages/vue/src/primitives/ThreadListKeyboardNav.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  type Component,
+} from "vue";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { ThreadListItemByIndexProvider } from "./threadList";
+import { ThreadListItemPrimitiveRoot } from "./ThreadListItemPrimitiveRoot";
+import { ThreadListItemPrimitiveTrigger } from "./ThreadListItemPrimitiveTrigger";
+import { ThreadListPrimitiveRoot } from "./ThreadListPrimitiveRoot";
+
+type Message = { id: string; role: "user"; text: string };
+
+const createRuntime = () => {
+  let mainThreadId = "first";
+  let core!: ExternalStoreRuntimeCore;
+  const onSwitchToThread = vi.fn((threadId: string) => {
+    mainThreadId = threadId;
+    core.setAdapter(createAdapter());
+  });
+  const createAdapter = (): ExternalStoreAdapter<Message> => ({
+    messages: [],
+    convertMessage: (message) => ({
+      id: message.id,
+      role: message.role,
+      content: [{ type: "text", text: message.text }],
+    }),
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: mainThreadId,
+        threads: ["first", "second", "third"].map((id) => ({
+          status: "regular" as const,
+          id,
+          title: id,
+        })),
+        onSwitchToThread,
+      },
+    },
+  });
+  core = new ExternalStoreRuntimeCore(createAdapter());
+  return {
+    runtime: new AssistantRuntimeImpl(core),
+    onSwitchToThread,
+  };
+};
+
+const mount = (runtime: AssistantRuntimeImpl, view: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(view) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  document.body.append(el);
+  app.mount(el);
+  return {
+    el,
+    unmount: () => {
+      app.unmount();
+      el.remove();
+    },
+  };
+};
+
+const keydown = (element: HTMLElement, key: string) =>
+  element.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key }),
+  );
+
+const buttons = (el: HTMLElement) => [
+  ...el.querySelectorAll<HTMLButtonElement>("button"),
+];
+
+describe("thread list keyboard navigation", () => {
+  it("moves through triggers in DOM order without wrapping", async () => {
+    const { runtime } = createRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadListPrimitiveRoot,
+          { class: "list" },
+          {
+            default: () =>
+              [0, 1, 2].map((index) =>
+                h(
+                  ThreadListItemByIndexProvider,
+                  { index, key: index },
+                  {
+                    default: () =>
+                      h(
+                        ThreadListItemPrimitiveRoot,
+                        { class: "item" },
+                        {
+                          default: () =>
+                            h(ThreadListItemPrimitiveTrigger, null, {
+                              default: () => `item ${index}`,
+                            }),
+                        },
+                      ),
+                  },
+                ),
+              ),
+          },
+        ),
+    });
+    const { el, unmount } = mount(runtime, View);
+
+    await nextTick();
+    const [first, second, third] = buttons(el);
+    const list = el.querySelector<HTMLElement>(".list")!;
+    const [firstItem, , thirdItem] = el.querySelectorAll<HTMLElement>(".item");
+    list.insertBefore(thirdItem!, firstItem!);
+
+    third!.focus();
+    expect(keydown(third!, "ArrowDown")).toBe(false);
+    expect(document.activeElement).toBe(first);
+    expect(keydown(first!, "ArrowDown")).toBe(false);
+    expect(document.activeElement).toBe(second);
+    expect(keydown(second!, "ArrowDown")).toBe(true);
+    expect(document.activeElement).toBe(second);
+    expect(keydown(first!, "ArrowUp")).toBe(false);
+    expect(document.activeElement).toBe(third);
+    expect(keydown(third!, "ArrowUp")).toBe(true);
+    expect(document.activeElement).toBe(third);
+
+    unmount();
+  });
+
+  it("lets a caller veto collection navigation", async () => {
+    const { runtime } = createRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadListPrimitiveRoot, null, {
+          default: () =>
+            [0, 1].map((index) =>
+              h(
+                ThreadListItemByIndexProvider,
+                { index, key: index },
+                {
+                  default: () =>
+                    h(
+                      ThreadListItemPrimitiveRoot,
+                      {
+                        onKeydown: (event: KeyboardEvent) =>
+                          event.preventDefault(),
+                      },
+                      {
+                        default: () =>
+                          h(ThreadListItemPrimitiveTrigger, null, {
+                            default: () => `item ${index}`,
+                          }),
+                      },
+                    ),
+                },
+              ),
+            ),
+        }),
+    });
+    const { el, unmount } = mount(runtime, View);
+
+    await nextTick();
+    const [first] = buttons(el);
+    first!.focus();
+    expect(keydown(first!, "ArrowDown")).toBe(false);
+    expect(document.activeElement).toBe(first);
+
+    unmount();
+  });
+
+  it("tracks the main thread on the item root", async () => {
+    const { runtime, onSwitchToThread } = createRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadListPrimitiveRoot, null, {
+          default: () =>
+            [0, 1].map((index) =>
+              h(
+                ThreadListItemByIndexProvider,
+                { index, key: index },
+                {
+                  default: () =>
+                    h(
+                      ThreadListItemPrimitiveRoot,
+                      { class: "item" },
+                      {
+                        default: () =>
+                          h(ThreadListItemPrimitiveTrigger, null, {
+                            default: () => `item ${index}`,
+                          }),
+                      },
+                    ),
+                },
+              ),
+            ),
+        }),
+    });
+    const { el, unmount } = mount(runtime, View);
+
+    await nextTick();
+    const items = el.querySelectorAll<HTMLElement>(".item");
+    expect(items[0]!.getAttribute("data-active")).toBe("true");
+    expect(items[0]!.getAttribute("aria-current")).toBe("true");
+    buttons(el)[1]!.click();
+    await vi.waitFor(() => {
+      expect(onSwitchToThread).toHaveBeenCalledWith("second");
+      expect(items[1]!.getAttribute("data-active")).toBe("true");
+      expect(items[1]!.getAttribute("aria-current")).toBe("true");
+    });
+    expect(items[0]!.hasAttribute("data-active")).toBe(false);
+    expect(items[0]!.hasAttribute("aria-current")).toBe(false);
+
+    unmount();
+  });
+
+  it("keeps the trigger working without either root", async () => {
+    const { runtime, onSwitchToThread } = createRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        [0, 1].map((index) =>
+          h(
+            ThreadListItemByIndexProvider,
+            { index, key: index },
+            {
+              default: () =>
+                h(ThreadListItemPrimitiveTrigger, null, {
+                  default: () => `item ${index}`,
+                }),
+            },
+          ),
+        ),
+    });
+    const { el, unmount } = mount(runtime, View);
+
+    await nextTick();
+    buttons(el)[1]!.click();
+    await vi.waitFor(() => {
+      expect(onSwitchToThread).toHaveBeenCalledWith("second");
+    });
+
+    unmount();
+  });
+
+  it("unregisters a trigger when its item unmounts", async () => {
+    const { runtime } = createRuntime();
+    const showSecond = ref(true);
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadListPrimitiveRoot, null, {
+          default: () =>
+            [0, 1, 2]
+              .filter((index) => index !== 1 || showSecond.value)
+              .map((index) =>
+                h(
+                  ThreadListItemByIndexProvider,
+                  { index, key: index },
+                  {
+                    default: () =>
+                      h(ThreadListItemPrimitiveRoot, null, {
+                        default: () =>
+                          h(ThreadListItemPrimitiveTrigger, null, {
+                            default: () => `item ${index}`,
+                          }),
+                      }),
+                  },
+                ),
+              ),
+        }),
+    });
+    const { el, unmount } = mount(runtime, View);
+
+    await nextTick();
+    showSecond.value = false;
+    await nextTick();
+    const [first, third] = buttons(el);
+    first!.focus();
+    expect(keydown(first!, "ArrowDown")).toBe(false);
+    expect(document.activeElement).toBe(third);
+
+    unmount();
+  });
+});

--- a/packages/vue/src/primitives/ThreadListPrimitiveRoot.ts
+++ b/packages/vue/src/primitives/ThreadListPrimitiveRoot.ts
@@ -1,0 +1,18 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import { provideThreadListCollection } from "./threadListFocusGroup";
+
+export const ThreadListPrimitiveRoot = defineComponent({
+  name: "ThreadListPrimitiveRoot",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
+  setup(_, { attrs, slots }) {
+    provideThreadListCollection();
+    return () => h("div", mergeProps(attrs), slots.default?.());
+  },
+});

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -13,6 +13,7 @@ import { isAttrDisabled } from "./attrDisabled";
 import { createLastValidCache, createStaleReporter } from "./lastValidCache";
 import { useAui } from "../useAui";
 import { useAuiState } from "../useAuiState";
+export { ThreadListItemPrimitiveTrigger } from "./ThreadListItemPrimitiveTrigger";
 
 /**
  * Scopes the subtree to the thread-list item at `index`: descendants read it
@@ -124,38 +125,6 @@ export const ThreadListPrimitiveNew = defineComponent({
     const onClick = (event: MouseEvent) => {
       if (event.defaultPrevented || isAttrDisabled(attrs)) return;
       aui.threads.switchToNewThread();
-    };
-    return () =>
-      h(
-        "button",
-        mergeProps(attrs, {
-          type: "button",
-          disabled: isAttrDisabled(attrs),
-          ...(active.value && {
-            "data-active": "true",
-            "aria-current": "true",
-          }),
-          onClick,
-        }),
-        slots.default?.(),
-      );
-  },
-});
-
-/**
- * A button that switches to the current thread-list item's thread. Carries
- * `data-active` and `aria-current` while that thread is the main one.
- */
-export const ThreadListItemPrimitiveTrigger = defineComponent({
-  name: "ThreadListItemPrimitiveTrigger",
-  inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
-  setup(_, { attrs, slots }) {
-    const aui = useAui();
-    const active = useAuiState((s) => s.threadListItem.isMain);
-    const onClick = (event: MouseEvent) => {
-      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
-      aui.threadListItem.switchTo();
     };
     return () =>
       h(

--- a/packages/vue/src/primitives/threadListFocusGroup.ts
+++ b/packages/vue/src/primitives/threadListFocusGroup.ts
@@ -1,0 +1,56 @@
+import {
+  inject,
+  provide,
+  shallowRef,
+  type InjectionKey,
+  type ShallowRef,
+} from "vue";
+
+type ThreadListCollection = {
+  registerTrigger: (key: symbol, trigger: HTMLButtonElement) => () => void;
+  getTriggers: () => HTMLButtonElement[];
+};
+
+type ThreadListItemFocus = {
+  trigger: ShallowRef<HTMLButtonElement | null>;
+};
+
+const threadListCollectionKey: InjectionKey<ThreadListCollection> = Symbol(
+  "assistant-ui.vue.thread-list-collection",
+);
+
+const threadListItemFocusKey: InjectionKey<ThreadListItemFocus> = Symbol(
+  "assistant-ui.vue.thread-list-item-focus",
+);
+
+export const provideThreadListCollection = () => {
+  const triggers = new Map<symbol, HTMLButtonElement>();
+  const collection: ThreadListCollection = {
+    registerTrigger: (key, trigger) => {
+      triggers.set(key, trigger);
+      return () => {
+        if (triggers.get(key) === trigger) triggers.delete(key);
+      };
+    },
+    getTriggers: () =>
+      [...triggers.values()].sort((first, second) => {
+        const position = first.compareDocumentPosition(second);
+        if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+        if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+        return 0;
+      }),
+  };
+  provide(threadListCollectionKey, collection);
+};
+
+export const useThreadListCollection = () =>
+  inject(threadListCollectionKey, null);
+
+export const provideThreadListItemFocus = (): ThreadListItemFocus => {
+  const focus = { trigger: shallowRef<HTMLButtonElement | null>(null) };
+  provide(threadListItemFocusKey, focus);
+  return focus;
+};
+
+export const useThreadListItemFocus = () =>
+  inject(threadListItemFocusKey, null);


### PR DESCRIPTION
## what

returns the thread-list structural primitives to the vue face with real behavior, and adds the first styled `thread-list.vue` to the staged registry kit.

## how

- `ThreadListPrimitiveRoot` provides a provide/inject collection; `ThreadListItemPrimitiveTrigger` registers its element into it (zero behavior change when mounted standalone, which the existing examples do); `ThreadListItemPrimitiveRoot` stamps `data-active`/`aria-current` from `s.threads.mainThreadId === s.threadListItem.id` and moves focus across registered triggers with ArrowDown/ArrowUp in dom order (no wrap, preventDefault only on an actual move, caller listeners compose first and can veto). this is the behavioral return of the pieces deleted from the earlier structural batch for being inert.
- the trigger moved to its own module with a re-export from the threadList barrel; its main-thread read now uses the threads/threadListItem id comparison, which also removes a pre-existing tsc error (vue error count drops from 20 to 18).
- `thread-list.vue` mirrors the react kit component: new-thread button, items with trigger + title, and a per-item more menu on reka-ui's DropdownMenu (archive + delete wrapping the existing vue primitives via `as-child`), with the react kit's reveal-on-hover/focus/active affordances and `data-slot` naming. registered as a staged registry item (`reka-ui`, `@lucide/vue`, `@assistant-ui/vue` in item dependencies); the production vue index keeps emitting `items: []` until the publish flip.

## deliberately not ported

- the rename item: react implements it as local inline-edit state on the title; the vue title primitive has no editing mode yet.
- the message action-bar more menu: its only react item is export-as-markdown, which has no vue-face action yet; a zero-item menu is an inert component.
- ArrowRight/ArrowLeft trigger-to-more focus jump: react couples it to its in-package more primitive; the vue equivalent lands when the kit menu integrates with the focus group.
- the loading skeleton, the today/yesterday/earlier date grouping, and react's search: none is blocked by a missing vue primitive; they are staged-kit completion items and land with the pre-flip kit pass (the staged item keeps evolving until the registry serves it; the toolchain side is #6474).

verified: vue 92/92, registry build green with 70/70 tests, deployed vue index unchanged, vue tsc errors 18 (baseline 20).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.e85h2VWexgdmGHKrQ9aOwHiQAe3LwYxsOk4zrw5sCtVXOH32HGinX2yOrZs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->