### PR TITLE
feat(vue): render toolkit renderText through a neutral seam

### DIFF
--- a/.changeset/neutral-tool-call-text.md
+++ b/.changeset/neutral-tool-call-text.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: resolve toolkit renderText through a framework-neutral seam

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -4,7 +4,7 @@ import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ChatInit, ChatTransport, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
 
-import { ComponentType, ReactNode } from "react";
+import { ComponentType } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
@@ -1958,10 +1958,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -2026,9 +2026,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -2037,6 +2037,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -4,7 +4,7 @@ import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ChatInit, ChatTransport, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
 
-import { ComponentType } from "react";
+import { ComponentType, ReactNode } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
@@ -1958,10 +1958,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -2026,19 +2026,19 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5362,10 +5362,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -5430,16 +5430,18 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
 
 type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
@@ -5449,8 +5451,6 @@ type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
     readonly type?: string | undefined;
   } | undefined;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -5528,7 +5528,7 @@ type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TAr
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
-  readonly renderText?: ToolCallText<any, any> | undefined;
+  readonly renderText?: ToolCallText$1<any, any, unknown> | undefined;
   readonly standalone: boolean;
 };
 
@@ -6087,7 +6087,7 @@ declare namespace entry_root_exports {
 }
 
 declare namespace entry_store_exports {
-  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, ExternalThread, ExternalThreadMessage, ExternalThreadProps, InMemoryThreadList, InMemoryThreadListProps, JoinStrategy, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, RemoteThreadList, RemoteThreadListProps, RuntimeAdapter, RuntimeExtrasBrand, SingleThreadList, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsEvents, ThreadsMethods, ThreadsState, ToolCallText, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, convertExternalMessages, createRuntimeExtrasBrand, defineMcpToolkit, defineToolkit, inMemoryThreadListTransformScopes, resolveToolCallText, runtimeAdapterTransformScopes, useExternalMessageConverter, useStreamingTiming };
+  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, ExternalThread, ExternalThreadMessage, ExternalThreadProps, InMemoryThreadList, InMemoryThreadListProps, JoinStrategy, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, RemoteThreadList, RemoteThreadListProps, RuntimeAdapter, RuntimeExtrasBrand, SingleThreadList, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsEvents, ThreadsMethods, ThreadsState, ToolCallText$1 as ToolCallText, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, convertExternalMessages, createRuntimeExtrasBrand, defineMcpToolkit, defineToolkit, inMemoryThreadListTransformScopes, resolveToolCallText, runtimeAdapterTransformScopes, useExternalMessageConverter, useStreamingTiming };
 }
 
 declare namespace entry_internal_exports {
@@ -6156,7 +6156,7 @@ declare const resolveToolApprovalResponse: (approval: {
   readonly options?: readonly ToolApprovalOption[];
 }, response: ToolApprovalResponse) => RespondToToolApprovalOptions;
 
-declare const resolveToolCallText: <TArgs extends Record<string, unknown>, TResult>(text: ToolCallText<TArgs, TResult>, part: ToolCallTextPart<TArgs, TResult>) => ToolCallTextValue;
+declare const resolveToolCallText: <TArgs extends Record<string, unknown>, TResult, TValue>(text: ToolCallText$1<TArgs, TResult, TValue>, part: ToolCallTextPart<TArgs, TResult>) => TValue | undefined | null;
 
 declare const runtimeAdapterTransformScopes: (scopes: ScopesConfig, parent: AssistantClient) => void;
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5362,10 +5362,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -5430,9 +5430,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -5441,6 +5441,16 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly status?: {
+    readonly type?: string | undefined;
+  } | undefined;
+};
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -5518,6 +5528,7 @@ type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TAr
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
+  readonly renderText?: ToolCallText<any, any> | undefined;
   readonly standalone: boolean;
 };
 
@@ -6076,7 +6087,7 @@ declare namespace entry_root_exports {
 }
 
 declare namespace entry_store_exports {
-  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, ExternalThread, ExternalThreadMessage, ExternalThreadProps, InMemoryThreadList, InMemoryThreadListProps, JoinStrategy, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, RemoteThreadList, RemoteThreadListProps, RuntimeAdapter, RuntimeExtrasBrand, SingleThreadList, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsEvents, ThreadsMethods, ThreadsState, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, convertExternalMessages, createRuntimeExtrasBrand, defineMcpToolkit, defineToolkit, inMemoryThreadListTransformScopes, runtimeAdapterTransformScopes, useExternalMessageConverter, useStreamingTiming };
+  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, ExternalThread, ExternalThreadMessage, ExternalThreadProps, InMemoryThreadList, InMemoryThreadListProps, JoinStrategy, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, RemoteThreadList, RemoteThreadListProps, RuntimeAdapter, RuntimeExtrasBrand, SingleThreadList, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsEvents, ThreadsMethods, ThreadsState, ToolCallText, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, convertExternalMessages, createRuntimeExtrasBrand, defineMcpToolkit, defineToolkit, inMemoryThreadListTransformScopes, resolveToolCallText, runtimeAdapterTransformScopes, useExternalMessageConverter, useStreamingTiming };
 }
 
 declare namespace entry_internal_exports {
@@ -6144,6 +6155,8 @@ declare const resolveToolApprovalResponse: (approval: {
   readonly id: string;
   readonly options?: readonly ToolApprovalOption[];
 }, response: ToolApprovalResponse) => RespondToToolApprovalOptions;
+
+declare const resolveToolCallText: <TArgs extends Record<string, unknown>, TResult>(text: ToolCallText<TArgs, TResult>, part: ToolCallTextPart<TArgs, TResult>) => ToolCallTextValue;
 
 declare const runtimeAdapterTransformScopes: (scopes: ScopesConfig, parent: AssistantClient) => void;
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -4,7 +4,7 @@ import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ChatInit, ChatTransport, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
 
-import { ComponentType, ReactNode } from "react";
+import { ComponentType } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
@@ -1958,10 +1958,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -2026,9 +2026,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -2037,6 +2037,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -4,7 +4,7 @@ import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { ChatInit, ChatTransport, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
 
-import { ComponentType } from "react";
+import { ComponentType, ReactNode } from "react";
 
 declare const AISDKChat: <UI_MESSAGE extends UIMessage$1 = UIMessage$1<unknown, import("ai").UIDataTypes, import("ai").UITools>>(options?: AISDKChatOptions<UI_MESSAGE> | undefined) => ResourceElement<ClientOutput<"threads">>;
 
@@ -1958,10 +1958,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -2026,19 +2026,19 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -1326,10 +1326,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -1394,9 +1394,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -1405,6 +1405,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -1326,10 +1326,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -1394,19 +1394,19 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -4154,10 +4154,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -4222,9 +4222,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallStatus = "complete" | "error" | "requires-action" | "running";
 
@@ -4235,6 +4235,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -4154,10 +4154,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -4222,21 +4222,21 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallStatus = "complete" | "error" | "requires-action" | "running";
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
 
-type ToolCallTextValue = string | undefined | null;
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
+};
 
 type ToolCallTiming = {
   readonly startedAt: number;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3711,10 +3711,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -3779,9 +3779,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -3790,6 +3790,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -3834,6 +3836,7 @@ type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TAr
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
+  readonly renderText?: ToolCallText<any, any> | undefined;
   readonly standalone: boolean;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3711,10 +3711,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -3779,19 +3779,19 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -3836,7 +3836,7 @@ type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TAr
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
-  readonly renderText?: ToolCallText<any, any> | undefined;
+  readonly renderText?: ToolCallText$1<any, any, unknown> | undefined;
   readonly standalone: boolean;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -5263,10 +5263,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -5331,19 +5331,19 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> = TValue | undefined | null | ((options: {
   args: TArgs;
-}) => ToolCallTextValue);
+}) => TValue | undefined | null);
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = ToolCallText$1<TArgs, TResult, ReactNode>;
+
+type ToolCallText$1<TArgs extends Record<string, unknown>, TResult, TValue = string> = {
+  running: ToolCallRunningText<TArgs, TValue>;
+  complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
 } | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
+  running?: ToolCallRunningText<TArgs, TValue> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult, TValue>;
 };
-
-type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -5400,7 +5400,7 @@ type ToolPartLike = Pick<ToolCallMessagePart, "mcp">;
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
-  readonly renderText?: ToolCallText<any, any> | undefined;
+  readonly renderText?: ToolCallText$1<any, any, unknown> | undefined;
   readonly standalone: boolean;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -5263,10 +5263,10 @@ interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
   forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ToolCallTextValue | ((options: {
   args: TArgs;
   result: TResult | undefined;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly type: "tool-call";
@@ -5331,9 +5331,9 @@ interface ToolCallResponseReader<TResult> {
   get: () => Promise<ToolResponse<TResult>>;
 }
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ToolCallTextValue | ((options: {
   args: TArgs;
-}) => ReactNode);
+}) => ToolCallTextValue);
 
 type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running: ToolCallRunningText<TArgs>;
@@ -5342,6 +5342,8 @@ type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
   running?: ToolCallRunningText<TArgs> | undefined;
   complete: ToolCallCompleteText<TArgs, TResult>;
 };
+
+type ToolCallTextValue = string | undefined | null;
 
 type ToolCallTiming = {
   readonly startedAt: number;
@@ -5398,6 +5400,7 @@ type ToolPartLike = Pick<ToolCallMessagePart, "mcp">;
 
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
+  readonly renderText?: ToolCallText<any, any> | undefined;
   readonly standalone: boolean;
 };
 

--- a/packages/core/src/model-context/tool-call-text.test.ts
+++ b/packages/core/src/model-context/tool-call-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolCallText } from "./tool-call-text";
+
+describe("resolveToolCallText", () => {
+  it("resolves literal text for running and complete tool calls", () => {
+    const text = {
+      running: "Searching...",
+      complete: "Done searching",
+    };
+
+    expect(
+      resolveToolCallText(text, {
+        args: {},
+        status: { type: "running" },
+      }),
+    ).toBe("Searching...");
+    expect(
+      resolveToolCallText(text, {
+        args: {},
+        status: { type: "complete" },
+      }),
+    ).toBe("Done searching");
+  });
+
+  it("passes args and results to text functions", () => {
+    const text = {
+      running: ({ args }: { args: { query: string } }) =>
+        `Searching ${args.query}...`,
+      complete: ({
+        args,
+        result,
+      }: {
+        args: { query: string };
+        result: number | undefined;
+      }) => `Found ${result ?? 0} results for ${args.query}`,
+    };
+
+    expect(
+      resolveToolCallText(text, {
+        args: { query: "docs" },
+        status: { type: "requires-action" },
+      }),
+    ).toBe("Searching docs...");
+    expect(
+      resolveToolCallText(text, {
+        args: { query: "docs" },
+        result: 3,
+        status: { type: "complete" },
+      }),
+    ).toBe("Found 3 results for docs");
+  });
+
+  it("returns null when the active status has no text", () => {
+    expect(
+      resolveToolCallText(
+        { running: "Searching..." },
+        { args: {}, status: { type: "complete" } },
+      ),
+    ).toBeNull();
+    expect(
+      resolveToolCallText(
+        { complete: "Done searching" },
+        { args: {}, status: { type: "running" } },
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/model-context/tool-call-text.ts
+++ b/packages/core/src/model-context/tool-call-text.ts
@@ -1,0 +1,49 @@
+type ToolCallTextValue = string | undefined | null;
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> =
+  | ToolCallTextValue
+  | ((options: { args: TArgs }) => ToolCallTextValue);
+
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> =
+  | ToolCallTextValue
+  | ((options: {
+      args: TArgs;
+      result: TResult | undefined;
+    }) => ToolCallTextValue);
+
+export type ToolCallText<TArgs extends Record<string, unknown>, TResult> =
+  | {
+      running: ToolCallRunningText<TArgs>;
+      complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+    }
+  | {
+      running?: ToolCallRunningText<TArgs> | undefined;
+      complete: ToolCallCompleteText<TArgs, TResult>;
+    };
+
+type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly status?: { readonly type?: string | undefined } | undefined;
+};
+
+export const resolveToolCallText = <
+  TArgs extends Record<string, unknown>,
+  TResult,
+>(
+  text: ToolCallText<TArgs, TResult>,
+  part: ToolCallTextPart<TArgs, TResult>,
+): ToolCallTextValue => {
+  const isRunning =
+    part.status?.type === "running" || part.status?.type === "requires-action";
+
+  if (!isRunning) {
+    const value = text.complete;
+    if (typeof value !== "function") return value ?? null;
+    return value({ args: part.args, result: part.result });
+  }
+
+  const value = text.running;
+  if (typeof value !== "function") return value ?? null;
+  return value({ args: part.args });
+};

--- a/packages/core/src/model-context/tool-call-text.ts
+++ b/packages/core/src/model-context/tool-call-text.ts
@@ -1,24 +1,34 @@
-type ToolCallTextValue = string | undefined | null;
+type ToolCallRunningText<TArgs extends Record<string, unknown>, TValue> =
+  | TValue
+  | undefined
+  | null
+  | ((options: { args: TArgs }) => TValue | undefined | null);
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> =
-  | ToolCallTextValue
-  | ((options: { args: TArgs }) => ToolCallTextValue);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> =
-  | ToolCallTextValue
+type ToolCallCompleteText<
+  TArgs extends Record<string, unknown>,
+  TResult,
+  TValue,
+> =
+  | TValue
+  | undefined
+  | null
   | ((options: {
       args: TArgs;
       result: TResult | undefined;
-    }) => ToolCallTextValue);
+    }) => TValue | undefined | null);
 
-export type ToolCallText<TArgs extends Record<string, unknown>, TResult> =
+export type ToolCallText<
+  TArgs extends Record<string, unknown>,
+  TResult,
+  TValue = string,
+> =
   | {
-      running: ToolCallRunningText<TArgs>;
-      complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+      running: ToolCallRunningText<TArgs, TValue>;
+      complete?: ToolCallCompleteText<TArgs, TResult, TValue> | undefined;
     }
   | {
-      running?: ToolCallRunningText<TArgs> | undefined;
-      complete: ToolCallCompleteText<TArgs, TResult>;
+      running?: ToolCallRunningText<TArgs, TValue> | undefined;
+      complete: ToolCallCompleteText<TArgs, TResult, TValue>;
     };
 
 type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
@@ -30,20 +40,28 @@ type ToolCallTextPart<TArgs extends Record<string, unknown>, TResult> = {
 export const resolveToolCallText = <
   TArgs extends Record<string, unknown>,
   TResult,
+  TValue,
 >(
-  text: ToolCallText<TArgs, TResult>,
+  text: ToolCallText<TArgs, TResult, TValue>,
   part: ToolCallTextPart<TArgs, TResult>,
-): ToolCallTextValue => {
+): TValue | undefined | null => {
   const isRunning =
     part.status?.type === "running" || part.status?.type === "requires-action";
 
   if (!isRunning) {
     const value = text.complete;
     if (typeof value !== "function") return value ?? null;
-    return value({ args: part.args, result: part.result });
+    return (
+      value as (options: {
+        args: TArgs;
+        result: TResult | undefined;
+      }) => TValue | undefined | null
+    )({ args: part.args, result: part.result });
   }
 
   const value = text.running;
   if (typeof value !== "function") return value ?? null;
-  return value({ args: part.args });
+  return (value as (options: { args: TArgs }) => TValue | undefined | null)({
+    args: part.args,
+  });
 };

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -16,6 +16,7 @@ import type { Tool } from "assistant-stream";
 import {
   isStandaloneToolDisplay,
   makeToolCallTextComponent,
+  type ToolCallText,
   type Toolkit,
 } from "../model-context/toolbox";
 import type { ToolCallMessagePartComponent } from "../types/MessagePartComponentTypes";
@@ -59,12 +60,16 @@ const useTools = ({
     (
       toolName: string,
       render: ToolCallMessagePartComponent,
-      options?: { standalone?: boolean },
+      options?: {
+        standalone?: boolean;
+        renderText?: ToolCallText<any, any> | undefined;
+      },
     ) => {
       // One registration object per call; identity is the removal key, so
       // the per-name list stays correctly ref-counted across re-registers.
       const registration = {
         render,
+        renderText: options?.renderText,
         standalone: options?.standalone ?? false,
       };
 
@@ -105,6 +110,7 @@ const useTools = ({
         unsubscribes.push(
           setToolUI(toolName, render, {
             standalone: isStandaloneToolDisplay(tool),
+            renderText: toolRenderText,
           }),
         );
       }

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -11,10 +11,13 @@ import type {
 } from "../types/MessagePartComponentTypes";
 import {
   resolveToolCallText,
-  type ToolCallText,
+  type ToolCallText as NeutralToolCallText,
 } from "../../model-context/tool-call-text";
 
-export type { ToolCallText } from "../../model-context/tool-call-text";
+export type ToolCallText<
+  TArgs extends Record<string, unknown>,
+  TResult,
+> = NeutralToolCallText<TArgs, TResult, ReactNode>;
 
 /**
  * Resolves whether a tool's UI should be presented standalone (outside the

--- a/packages/core/src/react/model-context/toolbox.ts
+++ b/packages/core/src/react/model-context/toolbox.ts
@@ -9,6 +9,12 @@ import type {
   ToolCallMessagePartComponent,
   ToolCallMessagePartProps,
 } from "../types/MessagePartComponentTypes";
+import {
+  resolveToolCallText,
+  type ToolCallText,
+} from "../../model-context/tool-call-text";
+
+export type { ToolCallText } from "../../model-context/tool-call-text";
 
 /**
  * Resolves whether a tool's UI should be presented standalone (outside the
@@ -60,42 +66,6 @@ type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (
   reader: ToolCallReader<TArgs, TResult>,
   context: ToolExecuteContext,
 ) => void;
-
-type ToolCallRunningText<TArgs extends Record<string, unknown>> =
-  | ReactNode
-  | ((options: { args: TArgs }) => ReactNode);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> =
-  | ReactNode
-  | ((options: { args: TArgs; result: TResult | undefined }) => ReactNode);
-
-export type ToolCallText<TArgs extends Record<string, unknown>, TResult> =
-  | {
-      running: ToolCallRunningText<TArgs>;
-      complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-    }
-  | {
-      running?: ToolCallRunningText<TArgs> | undefined;
-      complete: ToolCallCompleteText<TArgs, TResult>;
-    };
-
-const resolveToolCallText = <TArgs extends Record<string, unknown>, TResult>(
-  text: ToolCallText<TArgs, TResult>,
-  part: ToolCallMessagePartProps<TArgs, TResult>,
-): ReactNode => {
-  const isRunning =
-    part.status?.type === "running" || part.status?.type === "requires-action";
-
-  if (!isRunning) {
-    const value = text.complete;
-    if (typeof value !== "function") return value ?? null;
-    return value({ args: part.args, result: part.result });
-  }
-
-  const value = text.running;
-  if (typeof value !== "function") return value ?? null;
-  return value({ args: part.args });
-};
 
 export const makeToolCallTextComponent = <
   TArgs extends Record<string, unknown>,

--- a/packages/core/src/react/types/scopes/tools.ts
+++ b/packages/core/src/react/types/scopes/tools.ts
@@ -13,7 +13,7 @@ export type McpAppResourceOutput = {
  */
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
-  readonly renderText?: ToolCallText<any, any> | undefined;
+  readonly renderText?: ToolCallText<any, any, unknown> | undefined;
   /** Whether this UI renders standalone, outside the chain-of-thought trace. */
   readonly standalone: boolean;
 };

--- a/packages/core/src/react/types/scopes/tools.ts
+++ b/packages/core/src/react/types/scopes/tools.ts
@@ -1,5 +1,6 @@
 import type { ToolCallMessagePartComponent } from "../MessagePartComponentTypes";
 import type { Unsubscribe } from "../../..";
+import type { ToolCallText } from "../../../model-context/tool-call-text";
 
 export type McpAppResourceOutput = {
   readonly render: ToolCallMessagePartComponent;
@@ -12,6 +13,7 @@ export type McpAppResourceOutput = {
  */
 type ToolRegistration = {
   readonly render: ToolCallMessagePartComponent;
+  readonly renderText?: ToolCallText<any, any> | undefined;
   /** Whether this UI renders standalone, outside the chain-of-thought trace. */
   readonly standalone: boolean;
 };

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -108,6 +108,10 @@ export {
   createRuntimeExtrasBrand,
   type RuntimeExtrasBrand,
 } from "../runtime/utils/runtime-extras-brand";
+export {
+  resolveToolCallText,
+  type ToolCallText,
+} from "../model-context/tool-call-text";
 export { defineToolkit } from "../react/model-context/define-toolkit";
 export {
   defineMcpToolkit,

--- a/packages/vue/src/AuiIf.ts
+++ b/packages/vue/src/AuiIf.ts
@@ -1,4 +1,9 @@
-import { defineComponent, type PropType, type SlotsType } from "vue";
+import {
+  defineComponent,
+  type PropType,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
 import type { AssistantState } from "@assistant-ui/store/client";
 import { useAuiState } from "./useAuiState";
 
@@ -21,7 +26,7 @@ export const AuiIf = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const active = useAuiState((state) => props.condition(state));
     return () => (active.value ? slots.default?.() : null);

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -6,6 +6,7 @@ import {
   watch,
   type PropType,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import {
   createAssistantClient,
@@ -42,7 +43,7 @@ export const AuiProvider = defineComponent({
       default: undefined,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const injected = inject(auiInjectionKey, null);
     const hasExtends = props.extends !== undefined;

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -320,6 +320,46 @@ describe("MessagePrimitiveParts tool UI registry", () => {
     unmount();
   });
 
+  it("renders nothing for a react-element-valued renderText descriptor", async () => {
+    const { runtime, replace } = createTestRuntime();
+    const toolkit = {
+      weather: {
+        type: "frontend",
+        description: "Looks up the weather.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "sunny",
+        renderText: {
+          running: () => ({ reactElement: true }),
+          complete: () => ({ reactElement: true }),
+        },
+      },
+    } as unknown as Toolkit;
+    const { el, unmount } = mountChat(runtime, PartsWithToolSlot, {
+      tools: Tools({ toolkit }),
+    });
+
+    flushTapSync(() =>
+      replace({
+        role: "assistant",
+        status: { type: "running" },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "weather",
+            args: { city: "sf" },
+          },
+        ],
+      }),
+    );
+    await nextTick();
+    await nextTick();
+    expect(el.textContent ?? "").not.toContain("reactElement");
+    expect(el.textContent ?? "").not.toContain("[object");
+
+    unmount();
+  });
+
   it("renders toolkit renderText for running and complete tool calls", async () => {
     const { runtime, replace } = createTestRuntime();
     const toolkit = {

--- a/packages/vue/src/__tests__/primitives-tool-ui.test.ts
+++ b/packages/vue/src/__tests__/primitives-tool-ui.test.ts
@@ -8,6 +8,7 @@ import { createApp, defineComponent, h, nextTick, type Component } from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
 import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { Tools, type Toolkit } from "@assistant-ui/core/react";
 import type {
   ExternalStoreAdapter,
   ThreadMessageLike,
@@ -28,6 +29,7 @@ import {
 type DemoMessage = {
   role: "user" | "assistant";
   content: ThreadMessageLike["content"];
+  status?: { type: "running" } | undefined;
 };
 
 const createTestRuntime = () => {
@@ -41,6 +43,7 @@ const createTestRuntime = () => {
     convertMessage: (message) => ({
       role: message.role,
       content: message.content,
+      ...(message.status && { status: message.status }),
     }),
     onNew: async () => {},
     onAddToolResult,
@@ -53,16 +56,25 @@ const createTestRuntime = () => {
     messages = [...messages, message];
     core.setAdapter(makeAdapter());
   };
+  const replace = (message: DemoMessage) => {
+    messages = [message];
+    core.setAdapter(makeAdapter());
+  };
   return {
     runtime,
     append,
+    replace,
     onAddToolResult,
     onResumeToolCall,
     onRespondToToolApproval,
   };
 };
 
-const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+const mountChat = (
+  runtime: AssistantRuntimeImpl,
+  view: Component,
+  config: Parameters<typeof AuiConfig>[0] = {},
+) => {
   let client: any;
   const CaptureClient = defineComponent({
     setup() {
@@ -75,7 +87,9 @@ const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
       setup: () => () =>
         h(
           AuiProvider,
-          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          {
+            config: AuiConfig({ threads: RuntimeAdapter(runtime), ...config }),
+          },
           { default: () => [h(CaptureClient), h(view)] },
         ),
     }),
@@ -302,6 +316,74 @@ describe("MessagePrimitiveParts tool UI registry", () => {
       expect(el.querySelector("span.first")).not.toBeNull();
     });
     expect(el.querySelector("span.second")).toBeNull();
+
+    unmount();
+  });
+
+  it("renders toolkit renderText for running and complete tool calls", async () => {
+    const { runtime, replace } = createTestRuntime();
+    const toolkit = {
+      weather: {
+        type: "frontend",
+        description: "Looks up the weather.",
+        parameters: { type: "object", properties: {} },
+        execute: async () => "sunny",
+        renderText: {
+          running: ({ args }: { args: { city: string } }) =>
+            `Checking ${args.city}...`,
+          complete: ({
+            args,
+            result,
+          }: {
+            args: { city: string };
+            result: string | undefined;
+          }) => `${result} in ${args.city}`,
+        },
+      },
+    } as unknown as Toolkit;
+    const { el, unmount } = mountChat(runtime, PartsWithToolSlot, {
+      tools: Tools({ toolkit }),
+    });
+
+    flushTapSync(() =>
+      replace({
+        role: "assistant",
+        status: { type: "running" },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "weather",
+            args: { city: "sf" },
+          },
+        ],
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.textContent).toBe("Checking sf...");
+    });
+
+    flushTapSync(() =>
+      replace({
+        role: "assistant",
+        status: { type: "running" },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "weather",
+            args: { city: "sf" },
+            result: "sunny",
+          },
+        ],
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.textContent).toBe("sunny in sf");
+    });
+    expect(el.querySelector("span.slot")).toBeNull();
 
     unmount();
   });

--- a/packages/vue/src/primitives/AttachmentByIndexProvider.ts
+++ b/packages/vue/src/primitives/AttachmentByIndexProvider.ts
@@ -5,6 +5,7 @@ import {
   onScopeDispose,
   type PropType,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { AuiConfig, Derived } from "@assistant-ui/store/client";
 import type { AssistantClient } from "@assistant-ui/store/client";
@@ -40,7 +41,7 @@ export const AttachmentByIndexProvider = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;

--- a/packages/vue/src/primitives/ComposerPrimitiveCancel.ts
+++ b/packages/vue/src/primitives/ComposerPrimitiveCancel.ts
@@ -1,4 +1,10 @@
-import { defineComponent, h, mergeProps, type SlotsType } from "vue";
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
 import { composerCancelDisabled } from "@assistant-ui/core/store/internal";
 import { isAttrDisabled } from "./attrDisabled";
 import { useAui } from "../useAui";
@@ -12,7 +18,7 @@ import { useAuiState } from "../useAuiState";
 export const ComposerPrimitiveCancel = defineComponent({
   name: "ComposerPrimitiveCancel",
   inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
     const disabled = useAuiState(composerCancelDisabled);

--- a/packages/vue/src/primitives/ComposerPrimitiveSend.ts
+++ b/packages/vue/src/primitives/ComposerPrimitiveSend.ts
@@ -1,4 +1,10 @@
-import { defineComponent, h, mergeProps, type SlotsType } from "vue";
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
 import { isAttrDisabled } from "./attrDisabled";
 import { useComposerSendState } from "./useComposerSendState";
 
@@ -11,7 +17,7 @@ import { useComposerSendState } from "./useComposerSendState";
 export const ComposerPrimitiveSend = defineComponent({
   name: "ComposerPrimitiveSend",
   inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const { disabled, send } = useComposerSendState();
     const onClick = (event: MouseEvent) => {

--- a/packages/vue/src/primitives/MessageByIdProvider.ts
+++ b/packages/vue/src/primitives/MessageByIdProvider.ts
@@ -4,6 +4,7 @@ import {
   h,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import {
   AuiConfig,
@@ -41,7 +42,7 @@ export const MessageByIdProvider = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;

--- a/packages/vue/src/primitives/MessageByIndexProvider.ts
+++ b/packages/vue/src/primitives/MessageByIndexProvider.ts
@@ -4,6 +4,7 @@ import {
   h,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { AuiConfig, Derived } from "@assistant-ui/store/client";
 import type { ComposerMethods, MessageMethods } from "@assistant-ui/core/store";
@@ -23,7 +24,7 @@ export const MessageByIndexProvider = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,5 +1,14 @@
-import { defineComponent, h, type Component, type SlotsType } from "vue";
-import type { PartMethods } from "@assistant-ui/core/store";
+import {
+  defineComponent,
+  h,
+  type Component,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
+import {
+  resolveToolCallText,
+  type PartMethods,
+} from "@assistant-ui/core/store";
 import { isDevelopment } from "@assistant-ui/core/store/internal";
 import type { AssistantState } from "@assistant-ui/store/client";
 import { useAui } from "../useAui";
@@ -20,7 +29,8 @@ export const clearPartWarningsForTesting = () => warnedTypes.clear();
  * face bridges the seam with casts at registration and render; a genuine
  * React renderer arriving through a shared toolkit type-checks at `setToolUI`
  * and then fails when invoked as a Vue component. This type is the Vue-facing
- * contract until the scope's renderer type goes framework-generic.
+ * contract for custom components. Toolkit `renderText` descriptors are
+ * framework-neutral and render their resolved text directly.
  */
 export type ToolUIProps = {
   part: Extract<AssistantState["part"], { type: "tool-call" }>;
@@ -42,7 +52,7 @@ export type ToolUIProps = {
  */
 export const MessagePrimitiveParts = defineComponent({
   name: "MessagePrimitiveParts",
-  slots: Object as SlotsType<Record<string, (() => unknown) | undefined>>,
+  slots: Object as SlotsType<Record<string, (() => VNodeChild[]) | undefined>>,
   setup(_, { slots }) {
     const count = useAuiState((s) => s.message.parts.length);
     const PartView = defineComponent({
@@ -55,7 +65,7 @@ export const MessagePrimitiveParts = defineComponent({
         );
         const toolUI = useAuiState((s) =>
           s.part.type === "tool-call"
-            ? (s.optional.tools?.toolUIs[s.part.toolName]?.[0]?.render ?? null)
+            ? (s.optional.tools?.toolUIs[s.part.toolName]?.[0] ?? null)
             : null,
         );
         const toolPart = useAuiState((s) =>
@@ -63,10 +73,13 @@ export const MessagePrimitiveParts = defineComponent({
         );
         return () => {
           if (type.value === "tool-call") {
-            const render = toolUI.value;
+            const registration = toolUI.value;
             const part = toolPart.value;
-            if (render && part) {
-              return h(render as unknown as Component, {
+            if (registration && part) {
+              if (registration.renderText) {
+                return resolveToolCallText(registration.renderText, part);
+              }
+              return h(registration.render as unknown as Component, {
                 tool: {
                   part,
                   addResult: aui.part.addToolResult,

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -29,8 +29,9 @@ export const clearPartWarningsForTesting = () => warnedTypes.clear();
  * face bridges the seam with casts at registration and render; a genuine
  * React renderer arriving through a shared toolkit type-checks at `setToolUI`
  * and then fails when invoked as a Vue component. This type is the Vue-facing
- * contract for custom components. Toolkit `renderText` descriptors are
- * framework-neutral and render their resolved text directly.
+ * contract for custom components. Toolkit `renderText` descriptors resolve
+ * through the neutral resolver and render string or number results directly;
+ * a react-element-valued descriptor is react-only and renders nothing here.
  */
 export type ToolUIProps = {
   part: Extract<AssistantState["part"], { type: "tool-call" }>;
@@ -77,7 +78,17 @@ export const MessagePrimitiveParts = defineComponent({
             const part = toolPart.value;
             if (registration && part) {
               if (registration.renderText) {
-                return resolveToolCallText(registration.renderText, part);
+                const resolved = resolveToolCallText(
+                  registration.renderText,
+                  part,
+                );
+                if (
+                  typeof resolved === "string" ||
+                  typeof resolved === "number"
+                ) {
+                  return resolved;
+                }
+                return null;
               }
               return h(registration.render as unknown as Component, {
                 tool: {

--- a/packages/vue/src/primitives/PartByIndexProvider.ts
+++ b/packages/vue/src/primitives/PartByIndexProvider.ts
@@ -4,6 +4,7 @@ import {
   h,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { AuiConfig, Derived } from "@assistant-ui/store/client";
 import type { PartMethods } from "@assistant-ui/core/store";
@@ -23,7 +24,7 @@ export const PartByIndexProvider = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;

--- a/packages/vue/src/primitives/ThreadPrimitiveMessages.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveMessages.ts
@@ -1,4 +1,10 @@
-import { computed, defineComponent, h, type SlotsType } from "vue";
+import {
+  computed,
+  defineComponent,
+  h,
+  type SlotsType,
+  type VNodeChild,
+} from "vue";
 import type {} from "@assistant-ui/core/store";
 import { useAuiState } from "../useAuiState";
 import { MessageByIdProvider } from "./MessageByIdProvider";
@@ -21,7 +27,7 @@ import { MessageByIdProvider } from "./MessageByIdProvider";
  */
 export const ThreadPrimitiveMessages = defineComponent({
   name: "ThreadPrimitiveMessages",
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { slots }) {
     const messages = useAuiState((s) => s.thread.messages);
     let previousIds: readonly string[] = [];

--- a/packages/vue/src/primitives/actionBar.ts
+++ b/packages/vue/src/primitives/actionBar.ts
@@ -4,6 +4,7 @@ import {
   mergeProps,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
 import {
@@ -19,7 +20,7 @@ import { useAuiState } from "../useAuiState";
 export const ActionBarPrimitiveEdit = defineComponent({
   name: "ActionBarPrimitiveEdit",
   inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
     const disabled = useAuiState(actionBarEditDisabled);
@@ -49,7 +50,7 @@ export const ActionBarPrimitiveEdit = defineComponent({
 export const ActionBarPrimitiveReload = defineComponent({
   name: "ActionBarPrimitiveReload",
   inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
     const disabled = useAuiState(actionBarReloadDisabled);
@@ -93,7 +94,7 @@ export const ActionBarPrimitiveCopy = defineComponent({
       default: 3000,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { attrs, slots }) {
     const aui = useAui();
     const disabled = useAuiState(actionBarCopyDisabled);

--- a/packages/vue/src/primitives/branchPicker.ts
+++ b/packages/vue/src/primitives/branchPicker.ts
@@ -4,6 +4,7 @@ import {
   mergeProps,
   type ComputedRef,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import {
   branchPickerNextDisabled,
@@ -21,7 +22,7 @@ const branchButton = (
   defineComponent({
     name,
     inheritAttrs: false,
-    slots: Object as SlotsType<{ default?: () => unknown }>,
+    slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
     setup(_, { attrs, slots }) {
       const aui = useAui();
       const disabled = useDisabled();

--- a/packages/vue/src/primitives/messageAttachments.ts
+++ b/packages/vue/src/primitives/messageAttachments.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, type SlotsType } from "vue";
+import { defineComponent, h, type SlotsType, type VNodeChild } from "vue";
 import { useAuiState } from "../useAuiState";
 import { AttachmentByIndexProvider } from "./AttachmentByIndexProvider";
 
@@ -9,7 +9,7 @@ import { AttachmentByIndexProvider } from "./AttachmentByIndexProvider";
  */
 export const MessagePrimitiveAttachments = defineComponent({
   name: "MessagePrimitiveAttachments",
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { slots }) {
     const count = useAuiState((s) =>
       s.message.role === "user" ? (s.message.attachments?.length ?? 0) : 0,

--- a/packages/vue/src/primitives/suggestions.ts
+++ b/packages/vue/src/primitives/suggestions.ts
@@ -5,6 +5,7 @@ import {
   mergeProps,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { AuiConfig, Derived } from "@assistant-ui/store/client";
 import { flushTapSync } from "@assistant-ui/tap";
@@ -28,7 +29,7 @@ export const SuggestionByIndexProvider = defineComponent({
       required: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;
@@ -72,7 +73,7 @@ export const SuggestionByIndexProvider = defineComponent({
  */
 export const ThreadPrimitiveSuggestions = defineComponent({
   name: "ThreadPrimitiveSuggestions",
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { slots }) {
     const count = useAuiState((s) => s.suggestions.suggestions.length);
     return () =>
@@ -105,7 +106,7 @@ export const SuggestionPrimitiveTrigger = defineComponent({
       default: true,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { attrs, slots }) {
     const aui = useAui();
     const prompt = useAuiState((s) => s.suggestion.prompt);

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -5,6 +5,7 @@ import {
   mergeProps,
   onScopeDispose,
   type SlotsType,
+  type VNodeChild,
 } from "vue";
 import { AuiConfig, Derived } from "@assistant-ui/store/client";
 import type { ThreadListItemMethods } from "@assistant-ui/core/store";
@@ -31,7 +32,7 @@ export const ThreadListItemByIndexProvider = defineComponent({
       default: false,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const aui = useAui();
     let disposed = false;
@@ -91,7 +92,7 @@ export const ThreadListPrimitiveItems = defineComponent({
       default: false,
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const count = useAuiState((s) =>
       props.archived
@@ -116,7 +117,7 @@ export const ThreadListPrimitiveItems = defineComponent({
 export const ThreadListPrimitiveNew = defineComponent({
   name: "ThreadListPrimitiveNew",
   inheritAttrs: false,
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
     const active = useAuiState(
@@ -155,7 +156,7 @@ export const ThreadListItemPrimitiveTitle = defineComponent({
       default: "",
     },
   },
-  slots: Object as SlotsType<{ default?: () => unknown }>,
+  slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
     const title = useAuiState((s) => s.threadListItem.title);
     return () =>


### PR DESCRIPTION
## what

makes toolkit `renderText` entries render on the vue face, and finishes the vue slot-typing sweep.

## how

- `ToolCallText` and its resolver moved to a neutral module (`core/src/model-context/tool-call-text.ts`), exported through `@assistant-ui/core/store` per the existing seam precedent; the resolver's return type is the plain value union the logic produces, not ReactNode. react's toolbox re-exports the type and wraps the neutral resolver, so every existing react export keeps its exact name and type.
- tool registrations additively retain the original descriptor: the (file-local) toolUIs entry type gains an optional `renderText`, populated wherever a toolkit definition supplied one. the react render path is unchanged.
- vue `MessagePrimitiveParts` renders a neutrally-resolved `renderText` as a plain text vnode ahead of the react-renderer cast, closing the caveat recorded at #6470; the ToolUIProps JSDoc reflects it.
- slot sweep: every remaining `() => unknown` slot typing in packages/vue became the `VNodeChild[]` form, which removes half the package's standing tsc baseline (20 → 10, all remaining errors are unrelated test-file classes).

the third recorded api-quality item, making the tools scope renderer type framework-generic, is deliberately not here: that type is published react surface and any narrowing is breaking, so it goes through a design pass first.

verified: core 1551/1551 (new resolver unit tests), react 431/431, vue 104/104 (new toolkit renderText integration test), store 186/186, vue tsc 20 → 10 with zero new errors.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2jAAsgzGqtT1RFro6hFUVtPhpz5y-Ks9Xg7kR-ZPN9Lbh7GCI1t_n7deTWk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->