### PR TITLE
feat(registry): complete the staged vue thread list

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1901,7 +1901,7 @@ export const stagedVueRegistry: RegistryItem[] = [
     type: "registry:component",
     title: "Thread List",
     description:
-      "Sidebar or dropdown for switching conversations, with active selection.",
+      "Sidebar or dropdown for switching conversations, with search and active selection.",
     files: [
       {
         type: "registry:component",

--- a/packages/ui/src/components/vue/assistant-ui/thread-list.vue
+++ b/packages/ui/src/components/vue/assistant-ui/thread-list.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { computed, ref } from "vue";
 import {
+  AuiIf,
+  ThreadListItemByIndexProvider,
   ThreadListItemPrimitiveArchive,
   ThreadListItemPrimitiveDelete,
   ThreadListItemPrimitiveRoot,
   ThreadListItemPrimitiveTitle,
   ThreadListItemPrimitiveTrigger,
-  ThreadListPrimitiveItems,
   ThreadListPrimitiveNew,
   ThreadListPrimitiveRoot,
+  useAuiState,
 } from "@assistant-ui/vue";
 import {
   DropdownMenuContent,
@@ -20,8 +23,75 @@ import {
   ArchiveIcon,
   MoreHorizontalIcon,
   PlusIcon,
+  SearchIcon,
   TrashIcon,
 } from "@lucide/vue";
+
+const DAY_IN_MS = 86_400_000;
+
+const dateGroupLabel = (date: Date | undefined, startOfToday: number) => {
+  if (!date || date.getTime() >= startOfToday) return "Today";
+  if (date.getTime() >= startOfToday - DAY_IN_MS) return "Yesterday";
+  return "Earlier";
+};
+
+const search = ref("");
+const hasThreads = useAuiState((s) => s.threads.threadIds.length > 0);
+const threadIds = useAuiState((s) => s.threads.threadIds);
+const threadItems = useAuiState((s) => s.threads.threadItems);
+const query = computed(() =>
+  (hasThreads.value ? search.value : "").trim().toLowerCase(),
+);
+
+const threadListGroups = computed(() => {
+  const itemsById = new Map(threadItems.value.map((item) => [item.id, item]));
+  const dates = threadIds.value.map((id) => itemsById.get(id)?.lastMessageAt);
+  const filteredIndices = threadIds.value
+    .map((id, index) => ({ id, index }))
+    .filter(
+      ({ id }) =>
+        !query.value ||
+        (itemsById.get(id)?.title || "New Chat")
+          .toLowerCase()
+          .includes(query.value),
+    )
+    .map(({ index }) => index);
+
+  if (!filteredIndices.some((index) => dates[index])) {
+    return { filteredIndices, groups: null };
+  }
+
+  const now = new Date();
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const time = (index: number) =>
+    dates[index]?.getTime() ?? Number.MAX_SAFE_INTEGER;
+  const sorted = [...filteredIndices].sort((a, b) => time(b) - time(a));
+  const groups: { label: string; indices: number[] }[] = [];
+
+  for (const index of sorted) {
+    const label = dateGroupLabel(dates[index], startOfToday);
+    const lastGroup = groups[groups.length - 1];
+
+    if (lastGroup?.label === label) {
+      lastGroup.indices.push(index);
+    } else {
+      groups.push({ label, indices: [index] });
+    }
+  }
+
+  return { filteredIndices, groups };
+});
+
+const visibleThreadGroups = computed(
+  () =>
+    threadListGroups.value.groups ?? [
+      { label: undefined, indices: threadListGroups.value.filteredIndices },
+    ],
+);
 </script>
 
 <template>
@@ -38,62 +108,120 @@ import {
         New Thread
       </span>
     </ThreadListPrimitiveNew>
+    <div
+      v-if="hasThreads"
+      data-slot="aui_thread-list-search"
+      class="relative px-0.5 py-1"
+    >
+      <SearchIcon
+        data-slot="aui_thread-list-search-icon"
+        class="text-muted-foreground pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2"
+      />
+      <input
+        v-model="search"
+        type="search"
+        aria-label="Search threads"
+        placeholder="Search threads"
+        class="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 bg-background flex h-8 w-full rounded-md border py-1 ps-8 pe-3 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </div>
     <div data-slot="aui_thread-list-items" class="flex flex-col gap-0.5">
-      <ThreadListPrimitiveItems>
-        <ThreadListItemPrimitiveRoot
-          data-slot="aui_thread-list-item"
-          class="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted has-focus-visible:bg-muted has-data-[state=open]:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
-        >
-          <ThreadListItemPrimitiveTrigger
-            data-slot="aui_thread-list-item-trigger"
-            class="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-1"
+      <AuiIf :condition="(s) => s.threads.isLoading">
+        <div class="flex flex-col gap-0.5">
+          <div
+            v-for="index in 5"
+            :key="index"
+            role="status"
+            aria-label="Loading threads"
+            data-slot="aui_thread-list-skeleton-wrapper"
+            class="flex h-8 items-center px-2.5"
           >
-            <span
-              data-slot="aui_thread-list-item-title"
-              class="min-w-0 flex-1 truncate"
+            <div
+              data-slot="aui_thread-list-skeleton"
+              class="bg-accent h-3.5 w-full animate-pulse rounded-md"
+            />
+          </div>
+        </div>
+      </AuiIf>
+      <AuiIf :condition="(s) => !s.threads.isLoading">
+        <div
+          v-if="query && threadListGroups.filteredIndices.length === 0"
+          data-slot="aui_thread-list-empty"
+          class="text-muted-foreground px-2.5 py-4 text-sm"
+        >
+          No threads found
+        </div>
+        <template v-else>
+          <template v-for="group in visibleThreadGroups" :key="group.label">
+            <div
+              v-if="group.label"
+              data-slot="aui_thread-list-group-label"
+              class="text-muted-foreground px-2.5 pt-3 pb-1 text-xs font-medium"
             >
-              <ThreadListItemPrimitiveTitle fallback="New Chat" />
-            </span>
-          </ThreadListItemPrimitiveTrigger>
-          <DropdownMenuRoot>
-            <DropdownMenuTrigger
-              data-slot="aui_thread-list-item-more"
-              class="data-[state=open]:bg-accent focus-visible:ring-ring/50 absolute end-1.5 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md p-0 opacity-0 outline-none group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 focus-visible:ring-1 data-[state=open]:opacity-100"
-              aria-label="More options"
+              {{ group.label }}
+            </div>
+            <ThreadListItemByIndexProvider
+              v-for="index in group.indices"
+              :key="threadIds[index]"
+              :index="index"
             >
-              <MoreHorizontalIcon class="size-3.5" />
-            </DropdownMenuTrigger>
-            <DropdownMenuPortal>
-              <DropdownMenuContent
-                side="right"
-                align="start"
-                :side-offset="6"
-                data-slot="aui_thread-list-item-more-content"
-                class="bg-popover text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5"
+              <ThreadListItemPrimitiveRoot
+                data-slot="aui_thread-list-item"
+                class="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted has-focus-visible:bg-muted has-data-[state=open]:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
               >
-                <DropdownMenuItem as-child>
-                  <ThreadListItemPrimitiveArchive
-                    data-slot="aui_thread-list-item-more-item"
-                    class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                <ThreadListItemPrimitiveTrigger
+                  data-slot="aui_thread-list-item-trigger"
+                  class="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-1"
+                >
+                  <span
+                    data-slot="aui_thread-list-item-title"
+                    class="min-w-0 flex-1 truncate"
                   >
-                    <ArchiveIcon class="size-4" />
-                    Archive
-                  </ThreadListItemPrimitiveArchive>
-                </DropdownMenuItem>
-                <DropdownMenuItem as-child>
-                  <ThreadListItemPrimitiveDelete
-                    data-slot="aui_thread-list-item-more-item"
-                    class="text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                    <ThreadListItemPrimitiveTitle fallback="New Chat" />
+                  </span>
+                </ThreadListItemPrimitiveTrigger>
+                <DropdownMenuRoot>
+                  <DropdownMenuTrigger
+                    data-slot="aui_thread-list-item-more"
+                    class="data-[state=open]:bg-accent focus-visible:ring-ring/50 absolute end-1.5 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md p-0 opacity-0 outline-none group-hover:opacity-100 group-has-focus-visible:opacity-100 group-data-active:opacity-100 focus-visible:ring-1 data-[state=open]:opacity-100"
+                    aria-label="More options"
                   >
-                    <TrashIcon class="size-4" />
-                    Delete
-                  </ThreadListItemPrimitiveDelete>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenuPortal>
-          </DropdownMenuRoot>
-        </ThreadListItemPrimitiveRoot>
-      </ThreadListPrimitiveItems>
+                    <MoreHorizontalIcon class="size-3.5" />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuContent
+                      side="right"
+                      align="start"
+                      :side-offset="6"
+                      data-slot="aui_thread-list-item-more-content"
+                      class="bg-popover text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5"
+                    >
+                      <DropdownMenuItem as-child>
+                        <ThreadListItemPrimitiveArchive
+                          data-slot="aui_thread-list-item-more-item"
+                          class="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                        >
+                          <ArchiveIcon class="size-4" />
+                          Archive
+                        </ThreadListItemPrimitiveArchive>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem as-child>
+                        <ThreadListItemPrimitiveDelete
+                          data-slot="aui_thread-list-item-more-item"
+                          class="text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+                        >
+                          <TrashIcon class="size-4" />
+                          Delete
+                        </ThreadListItemPrimitiveDelete>
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenuPortal>
+                </DropdownMenuRoot>
+              </ThreadListItemPrimitiveRoot>
+            </ThreadListItemByIndexProvider>
+          </template>
+        </template>
+      </AuiIf>
     </div>
   </ThreadListPrimitiveRoot>
 </template>

--- a/packages/ui/src/components/vue/assistant-ui/thread-list.vue
+++ b/packages/ui/src/components/vue/assistant-ui/thread-list.vue
@@ -122,7 +122,7 @@ const visibleThreadGroups = computed(
         type="search"
         aria-label="Search threads"
         placeholder="Search threads"
-        class="placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 bg-muted/60 focus-visible:bg-background h-8 w-full min-w-0 rounded-lg border border-transparent px-3 ps-8 py-1 text-sm transition-colors outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-1"
+        class="placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 bg-muted/60 focus-visible:bg-background h-8 w-full min-w-0 rounded-lg border border-transparent px-3 py-1 ps-8 text-sm transition-colors outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-1"
       />
     </div>
     <div data-slot="aui_thread-list-items" class="flex flex-col gap-0.5">

--- a/packages/ui/src/components/vue/assistant-ui/thread-list.vue
+++ b/packages/ui/src/components/vue/assistant-ui/thread-list.vue
@@ -122,7 +122,7 @@ const visibleThreadGroups = computed(
         type="search"
         aria-label="Search threads"
         placeholder="Search threads"
-        class="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 bg-background flex h-8 w-full rounded-md border py-1 ps-8 pe-3 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+        class="placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 bg-muted/60 focus-visible:bg-background h-8 w-full min-w-0 rounded-lg border border-transparent px-3 ps-8 py-1 text-sm transition-colors outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-1"
       />
     </div>
     <div data-slot="aui_thread-list-items" class="flex flex-col gap-0.5">


### PR DESCRIPTION
## what

completes the staged vue `thread-list.vue` with the react kit's search, loading skeleton, and today/yesterday/earlier date grouping.

## how

- search: kit-local input state mirroring `ThreadListSearch` (icon, placeholder/aria-label, reveal only when threads exist), query normalization identical to react's.
- skeleton: `AuiIf`-gated on `s.threads.isLoading` with the react skeleton markup.
- grouping: mirrors the react helper line-for-line (`lastMessageAt` per thread item, date-descending sort, ungrouped fallback when no item carries a date), applied after the search filter exactly as react applies it.
- the staged registry item description restores the react wording now that search exists ("with search and active selection").
- everything stays in the single SFC so the staged item remains self-contained; the reka more menu and active stamps are untouched.

verified: registry build green with 70/70 tests, deployed vue index still `items: []`, the barrel exports and state fields the SFC relies on (`ThreadListItemByIndexProvider`, `threadItems`, `lastMessageAt`) confirmed against the vue and core sources.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._rUCMdYMrloUTnU--QrvS7KeF_pAvVGooppQGG0fELAVLcs-hI3fpsXUsMo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->