### PR TITLE
docs: add the vue section behind the platform gate

### DIFF
--- a/apps/docs/content/docs/vue/index.mdx
+++ b/apps/docs/content/docs/vue/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Vue
+description: Build streaming AI chat interfaces with Vue, Nuxt, and the AI SDK.
+---
+
+`@assistant-ui/vue` provides Vue components and composables for assistant-ui's runtime. Use it with Nuxt for a streaming chat route, a client-side assistant tree, and styled chat components from the assistant-ui registry.
+
+The Vue surface includes `AuiProvider` and `AuiIf`, the `useAui`, `useAuiState`, and `useAuiEvent` composables, and primitives for threads, messages, composers, thread lists, attachments, suggestions, actions, branches, errors, and chain of thought.
+
+## Start here
+
+<Cards>
+  <Card title="Five-minute quickstart" description="Add a streaming Nuxt chat with AISDKChat and the assistant-ui registry." href="/docs/vue/quickstart" />
+  <Card title="Runtimes" description="Choose a single chat, multi-thread chat, or an external-store runtime." href="/docs/vue/runtimes" />
+  <Card title="Server rendering" description="Keep assistant client state out of Vue's server-rendered scope." href="/docs/vue/ssr" />
+  <Card title="Tool UI" description="Register Vue renderers for tool calls and human-in-the-loop actions." href="/docs/vue/tool-ui" />
+</Cards>
+
+## How it fits together
+
+`AuiProvider` owns an assistant client. Its `AuiConfig` connects a runtime such as `AISDKChat()` to Vue primitives and composables. The AI SDK runtime posts messages to a Nuxt route, and the route returns the UI message stream to the browser.
+
+Use a `.client.vue` boundary for the provider and runtime. Keep model credentials and `streamText` in a Nitro route. The [quickstart](/docs/vue/quickstart) contains the complete path.

--- a/apps/docs/content/docs/vue/meta.json
+++ b/apps/docs/content/docs/vue/meta.json
@@ -1,0 +1,8 @@
+{
+  "title": "Vue",
+  "description": "Build streaming AI chat UIs with Vue and Nuxt",
+  "icon": "PanelsTopLeft",
+  "root": true,
+  "pages": ["index", "quickstart", "runtimes", "ssr", "tool-ui"],
+  "platforms": ["vue"]
+}

--- a/apps/docs/content/docs/vue/quickstart.mdx
+++ b/apps/docs/content/docs/vue/quickstart.mdx
@@ -1,0 +1,122 @@
+---
+title: Quickstart
+description: Build a streaming Nuxt chat with Vue, assistant-ui, and the AI SDK.
+---
+
+This guide adds a streaming chat to a Nuxt app in about five minutes. The runtime stays in a client-only component and the model call stays in a Nitro route.
+
+<Steps>
+  <Step>
+
+### Install the runtime
+
+Install the Vue binding, the AI SDK runtime, and an AI SDK provider:
+
+```sh
+pnpm add @assistant-ui/vue @assistant-ui/ai-sdk ai @ai-sdk/openai
+```
+
+Add your provider key to `.env`:
+
+```sh title=".env"
+OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+  </Step>
+  <Step>
+
+### Install the styled components
+
+Add the Vue assistant-ui registry once in `components.json`:
+
+```json title="components.json"
+{
+  "registries": {
+    "@assistant-ui": "https://r.assistant-ui.com/vue/{name}.json"
+  }
+}
+```
+
+Install the chat surface:
+
+```sh
+npx shadcn@latest add @assistant-ui/thread @assistant-ui/thread-list
+```
+
+This writes Vue components under `components/assistant-ui`. The registry installs their assistant-ui, Vue, and UI dependencies.
+
+  </Step>
+  <Step>
+
+### Create the assistant client
+
+Use a `.client.vue` file so the runtime is created only in the browser:
+
+```vue title="app/components/Assistant.client.vue"
+<script setup lang="ts">
+import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
+import { AISDKChat } from "@assistant-ui/ai-sdk";
+import Thread from "~/components/assistant-ui/thread.vue";
+
+const config = AuiConfig({
+  threads: AISDKChat(),
+});
+</script>
+
+<template>
+  <AuiProvider :config="config">
+    <Thread class="h-dvh" />
+  </AuiProvider>
+</template>
+```
+
+`AISDKChat()` creates one streaming thread. Its default transport sends requests to `/api/chat`.
+
+  </Step>
+  <Step>
+
+### Add the streaming route
+
+Create the Nitro route that receives UI messages and returns an AI SDK UI message stream:
+
+```ts title="server/api/chat.post.ts"
+import { openai } from "@ai-sdk/openai";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
+
+export default defineEventHandler(async (event) => {
+  const { messages, system } = await readBody<{
+    messages: UIMessage[];
+    system?: string;
+  }>(event);
+
+  const result = streamText({
+    model: openai("gpt-5.6-luna"),
+    messages: await convertToModelMessages(messages),
+    system,
+  });
+
+  return result.toUIMessageStreamResponse();
+});
+```
+
+  </Step>
+  <Step>
+
+### Render the assistant
+
+Nuxt recognizes the `.client.vue` suffix and only mounts this component in the browser:
+
+```vue title="app/pages/index.vue"
+<template>
+  <Assistant />
+</template>
+```
+
+Start the app with `pnpm dev`, then send a message. The response streams from `server/api/chat.post.ts` into the thread.
+
+  </Step>
+</Steps>
+
+## Next steps
+
+Use [AISDKThreads](/docs/vue/runtimes#aisdkthreads) when the chat needs a thread list, [server rendering](/docs/vue/ssr) to understand the `.client.vue` boundary, and [Tool UI](/docs/vue/tool-ui) to render tool calls.

--- a/apps/docs/content/docs/vue/quickstart.mdx
+++ b/apps/docs/content/docs/vue/quickstart.mdx
@@ -13,10 +13,10 @@ This guide adds a streaming chat to a Nuxt app in about five minutes. The runtim
 Install the Vue binding, the AI SDK runtime, and an AI SDK provider:
 
 ```sh
-pnpm add @assistant-ui/vue @assistant-ui/ai-sdk ai @ai-sdk/openai
+pnpm add @assistant-ui/vue @assistant-ui/ai-sdk ai @ai-sdk/openai react
 ```
 
-If you run `nuxi typecheck`, also add `@types/react` as a dev dependency: a type-only react reference rides through the core runtime types.
+`react` is the AI SDK runtime's substrate — an optional peer of `@assistant-ui/ai-sdk`, so it does not install on its own. For `nuxi typecheck`, add `@types/react` as a dev dependency: a type-only react reference rides through the core runtime types.
 
 ```bash
 pnpm add -D @types/react

--- a/apps/docs/content/docs/vue/quickstart.mdx
+++ b/apps/docs/content/docs/vue/quickstart.mdx
@@ -16,6 +16,12 @@ Install the Vue binding, the AI SDK runtime, and an AI SDK provider:
 pnpm add @assistant-ui/vue @assistant-ui/ai-sdk ai @ai-sdk/openai
 ```
 
+If you run `nuxi typecheck`, also add `@types/react` as a dev dependency: a type-only react reference rides through the core runtime types.
+
+```bash
+pnpm add -D @types/react
+```
+
 Add your provider key to `.env`:
 
 ```sh title=".env"

--- a/apps/docs/content/docs/vue/runtimes.mdx
+++ b/apps/docs/content/docs/vue/runtimes.mdx
@@ -51,6 +51,8 @@ For an in-memory list, assistant-ui retains each chat and its history across swi
 
 Use `RuntimeAdapter` and `ExternalStoreRuntimeCore` when another client store owns messages, streaming status, or thread state. The Vue echo example follows this shape: create an external-store adapter, update it whenever the store changes, then expose its runtime through `AuiConfig`.
 
+The constructors come from `@assistant-ui/core/internal`, the advanced entry for building custom runtimes; it can evolve faster than the public entries, so pin your versions when depending on it.
+
 ```ts title="app/runtime/echo.ts"
 import type { AppendMessage, ExternalStoreAdapter } from "@assistant-ui/core";
 import {

--- a/apps/docs/content/docs/vue/runtimes.mdx
+++ b/apps/docs/content/docs/vue/runtimes.mdx
@@ -1,0 +1,121 @@
+---
+title: Runtimes
+description: Choose a single AI SDK chat, a multi-thread AI SDK chat, or a custom external store.
+---
+
+A runtime connects Vue primitives to message state and actions. Put the runtime in an `AuiConfig` that is provided by a client-only `AuiProvider`.
+
+## AISDKChat
+
+`AISDKChat` is the smallest setup. It owns one client-side thread and uses `AssistantChatTransport` by default to call `/api/chat`.
+
+```vue title="app/components/Assistant.client.vue"
+<script setup lang="ts">
+import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
+import { AISDKChat } from "@assistant-ui/ai-sdk";
+
+const config = AuiConfig({
+  threads: AISDKChat(),
+});
+</script>
+
+<template>
+  <AuiProvider :config="config">
+    <slot />
+  </AuiProvider>
+</template>
+```
+
+Pass `AISDKChat({ transport })` when the endpoint or transport behavior differs. The chat id is captured when the resource first mounts, so remount the provider when a different id must create a different chat.
+
+## AISDKThreads
+
+`AISDKThreads` creates a thread list and one AI SDK chat per thread. Without a cloud option, threads and their histories stay in memory for the lifetime of the assistant client.
+
+```ts title="app/components/Assistant.client.vue"
+import { AuiConfig } from "@assistant-ui/vue";
+import { AISDKThreads } from "@assistant-ui/ai-sdk";
+
+const config = AuiConfig({
+  threads: AISDKThreads(),
+});
+```
+
+With a cloud-backed list, `AISDKThreads` opts into `backgroundThreads`. Every visited thread stays mounted with its own history, a run continues after a thread switch, each thread list item's `isRunning` state remains live, and a new thread title is generated after its initialize operation settles. This continuity uses memory proportional to the number of visited threads. Deleting a thread stops its run.
+
+Each thread captures its AI SDK options when it first mounts. Changing the `transport`, initial messages, or other per-thread options later does not reconfigure an existing chat. Create a new thread or remount the assistant client when those options need to change.
+
+For an in-memory list, assistant-ui retains each chat and its history across switches, while the currently visible thread is the mounted UI. For server-backed history, configure the cloud-backed path or own persistence in an external store. In both cases, keep this client state behind the [Nuxt client boundary](/docs/vue/ssr).
+
+## External store
+
+Use `RuntimeAdapter` and `ExternalStoreRuntimeCore` when another client store owns messages, streaming status, or thread state. The Vue echo example follows this shape: create an external-store adapter, update it whenever the store changes, then expose its runtime through `AuiConfig`.
+
+```ts title="app/runtime/echo.ts"
+import type { AppendMessage, ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+
+type EchoMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
+export const createEchoRuntime = () => {
+  let messages: EchoMessage[] = [];
+  let isRunning = false;
+  let nextId = 0;
+
+  const makeAdapter = (): ExternalStoreAdapter<EchoMessage> => ({
+    messages,
+    isRunning,
+    convertMessage: (message) => ({
+      id: message.id,
+      role: message.role,
+      content: [{ type: "text", text: message.text }],
+    }),
+    setMessages: (next) => {
+      messages = [...next];
+      sync();
+    },
+    onNew: async (message: AppendMessage) => {
+      const text = message.content
+        .map((part) => (part.type === "text" ? part.text : ""))
+        .join("");
+      messages = [
+        ...messages,
+        { id: `user-${nextId++}`, role: "user", text },
+      ];
+      isRunning = true;
+      sync();
+      messages = [
+        ...messages,
+        { id: `assistant-${nextId++}`, role: "assistant", text: `Echo: ${text}` },
+      ];
+      isRunning = false;
+      sync();
+    },
+  });
+
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const sync = () => core.setAdapter(makeAdapter());
+  return new AssistantRuntimeImpl(core);
+};
+```
+
+Connect the runtime to Vue with `RuntimeAdapter`:
+
+```ts title="app/components/Assistant.client.vue"
+import { AuiConfig } from "@assistant-ui/vue";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { createEchoRuntime } from "~/runtime/echo";
+
+const config = AuiConfig({
+  threads: RuntimeAdapter(createEchoRuntime()),
+});
+```
+
+The adapter owns conversion and mutations. Implement `onEdit`, `onReload`, `onCancel`, and thread-list methods when the external backend supports those actions.

--- a/apps/docs/content/docs/vue/ssr.mdx
+++ b/apps/docs/content/docs/vue/ssr.mdx
@@ -1,0 +1,64 @@
+---
+title: Server rendering
+description: Keep Vue assistant state in a client-only Nuxt component and stream from Nitro.
+---
+
+Place the `AuiProvider` and its runtime in a `.client.vue` component. This is required even when the surrounding Nuxt page is server-rendered.
+
+An assistant runtime owns a client tree and reactive scopes. If it renders on the server, each request creates a client tree that Vue SSR never disposes. That leaks one assistant tree per request. The `.client.vue` boundary prevents the provider, its runtime, and its scopes from being created during server rendering.
+
+```vue title="app/components/Assistant.client.vue"
+<script setup lang="ts">
+import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
+import { AISDKChat } from "@assistant-ui/ai-sdk";
+import Thread from "~/components/assistant-ui/thread.vue";
+
+const config = AuiConfig({
+  threads: AISDKChat(),
+});
+</script>
+
+<template>
+  <AuiProvider :config="config">
+    <Thread class="h-dvh" />
+  </AuiProvider>
+</template>
+```
+
+## What belongs on the server
+
+Keep provider credentials, `streamText`, and the streaming response in a Nitro route. Nitro runs `server/api/chat.post.ts` on the server, while the browser receives only the UI message stream.
+
+```ts title="server/api/chat.post.ts"
+import { openai } from "@ai-sdk/openai";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
+
+export default defineEventHandler(async (event) => {
+  const { messages, system } = await readBody<{
+    messages: UIMessage[];
+    system?: string;
+  }>(event);
+
+  const result = streamText({
+    model: openai("gpt-5.6-luna"),
+    messages: await convertToModelMessages(messages),
+    system,
+  });
+
+  return result.toUIMessageStreamResponse();
+});
+```
+
+## Nuxt wiring
+
+Server-rendered pages can include the client component normally. Nuxt resolves the `.client.vue` suffix and mounts it after hydration.
+
+```vue title="app/pages/index.vue"
+<template>
+  <main>
+    <Assistant />
+  </main>
+</template>
+```
+
+Keep only page data and ordinary server-renderable UI outside the boundary. Do not create `AuiConfig`, `AISDKChat`, `AISDKThreads`, or an `AuiProvider` in `app.vue`, a page setup block that runs during SSR, or a Nitro route.

--- a/apps/docs/content/docs/vue/tool-ui.mdx
+++ b/apps/docs/content/docs/vue/tool-ui.mdx
@@ -1,0 +1,102 @@
+---
+title: Tool UI
+description: Render AI SDK tool calls with Vue components, text descriptors, and human-in-the-loop actions.
+---
+
+`MessagePrimitiveParts` renders a registered tool UI for matching tool-call parts. A Vue tool UI receives one required `tool` prop of type `ToolUIProps`. Vue does not spread tool-call fields into the component because undeclared props fall through to the DOM. Read all tool state and callbacks from `tool` instead.
+
+## Register tool UIs in config
+
+Use `Tools({ toolkit })` when the toolkit and its renderers belong to the assistant configuration. The tools scope registers the renderers for message rendering and exposes the toolkit to model context.
+
+```ts title="app/components/Assistant.client.vue"
+import { AuiConfig } from "@assistant-ui/vue";
+import { AISDKChat } from "@assistant-ui/ai-sdk";
+import { Tools } from "@assistant-ui/core/react";
+import { toolkit } from "~/toolkit";
+
+const config = AuiConfig({
+  threads: AISDKChat(),
+  tools: Tools({ toolkit }),
+});
+```
+
+For a tool that only has status text, a toolkit entry can use `renderText`. String and number results render in Vue without a component. A descriptor that returns a React element is React-only and renders nothing in Vue.
+
+```ts title="app/toolkit.ts"
+export const toolkit = {
+  weather: {
+    type: "backend",
+    renderText: {
+      running: ({ args }: { args: { city: string } }) => `Checking ${args.city}`,
+      complete: ({ result }: { result: { temperature: number } }) => `${result.temperature}°C`,
+    },
+  },
+};
+```
+
+## Register a Vue component at runtime
+
+Use `aui.tools.setToolUI` when the renderer is local to a Vue subtree or must follow the component lifecycle. It returns an unregister function.
+
+```vue title="app/components/RegisterToolUIs.vue"
+<script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
+import { useAui } from "@assistant-ui/vue";
+import type { ToolCallMessagePartComponent } from "@assistant-ui/core/react";
+import WeatherToolUI from "./WeatherToolUI.vue";
+
+const aui = useAui();
+let unregister: (() => void) | undefined;
+
+onMounted(() => {
+  unregister = aui.tools.setToolUI(
+    "weather",
+    WeatherToolUI as unknown as ToolCallMessagePartComponent,
+  );
+});
+
+onUnmounted(() => unregister?.());
+</script>
+
+<template><slot /></template>
+```
+
+Declare the single `tool` prop in the Vue component:
+
+```vue title="app/components/WeatherToolUI.vue"
+<script setup lang="ts">
+import { computed, type PropType } from "vue";
+import type { ToolUIProps } from "@assistant-ui/vue";
+
+const props = defineProps({
+  tool: { type: Object as PropType<ToolUIProps>, required: true },
+});
+
+const city = computed(() => (props.tool.part.args as { city?: string }).city);
+const result = computed(
+  () => props.tool.part.result as { temperature: number; condition: string } | undefined,
+);
+</script>
+
+<template>
+  <p v-if="result">{{ city }}: {{ result.temperature }}°C, {{ result.condition }}</p>
+  <p v-else>Checking {{ city }}…</p>
+</template>
+```
+
+## Human-in-the-loop actions
+
+`ToolUIProps` also supplies the callbacks for a pending tool call:
+
+```ts
+tool.addResult(result);
+tool.resume(payload);
+tool.respondToApproval({ approved: true });
+```
+
+Call `addResult` to provide a tool result, `resume` to continue a paused tool call with its payload, and `respondToApproval` with the user's approval response. The runtime forwards these actions to the matching adapter callbacks.
+
+## Chain of thought
+
+`ChainOfThoughtPrimitiveParts` iterates the current chain-of-thought parts through its default slot. It does not hide itself when `s.chainOfThought.collapsed` is true. Gate the containing UI with `AuiIf` when collapsed content should be hidden. Use `MessagePrimitiveParts` for the normal message path that dispatches registered tool UIs.

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -25,7 +25,7 @@ function transformerLineNumbers(): ShikiTransformer {
 // filter content based on the user's selected platform in the header dropdown.
 // Pages / folders with no `platforms` field are universal.
 // fumadocs-mdx forbids non-collection exports here, so this is local-only.
-const platformSchema = z.enum(["react", "rn", "ink"]);
+const platformSchema = z.enum(["react", "rn", "ink", "vue"]);
 
 export const docs = defineDocs({
   docs: {


### PR DESCRIPTION
## what

adds the vue documentation section, kept out of the navigation until the publish flip.

## how

- five pages under `content/docs/vue/`: overview, quickstart (five minutes to a streaming nuxt chat: install, `.client.vue` component with `AISDKChat`, nitro route, registry components), runtimes (`AISDKChat` / `AISDKThreads` with the backgroundThreads behaviors and boundaries / external-store via `RuntimeAdapter`), ssr (why the runtime lives behind a `.client.vue` boundary), and tool-ui (`Tools({ toolkit })`, the single `tool` prop contract, `renderText`, HITL callbacks).
- hidden-but-routable: the section's `meta.json` declares `"platforms": ["vue"]` and the `platforms` frontmatter schema in `source.config.ts` gains the `"vue"` value. the sidebar and platform selector filter by the active platform (react / rn / ink), which never matches, so nothing shows anywhere in the navigation while `/docs/vue/*` urls render normally — a shareable preview until the flip. the root `meta.json` needs no entry (unlisted folders join the tree as fallback nodes and the platform filter drops them).
- revealing at flip time is three small edits: add `vue` to `PLATFORMS` and `PLATFORM_LABELS` in `lib/constants.ts` and to `platformFolders` in the platform tree config; the content wiring is already in place.

verified: full docs build green, browser-checked both ways (navigation shows no vue anywhere; `/docs/vue/quickstart` renders completely), and every runtime/primitive identifier the pages reference was checked against the real package exports — zero invented apis.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AvdzmcUKjWI18SxgcFlC-jLtWeJQN3UhArfaZBTfvGMQeuMIngdq03shGe0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->