### PR TITLE
perf(docs): compile mdx bodies lazily via fumadocs async collections

### DIFF
--- a/apps/docs/app/(catalog)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(catalog)/elements/(detail)/[slug]/page.tsx
@@ -116,9 +116,10 @@ export default async function ElementPage({
     : null;
 
   const mdxPage = elementsDocs.getPage([slug]);
-  const MdxBody = mdxPage?.data.body;
+  const mdxData = mdxPage ? await mdxPage.data.load() : undefined;
+  const MdxBody = mdxData?.body;
   const mdxHasApi = Boolean(
-    mdxPage?.data.toc?.some(
+    mdxData?.toc.some(
       (item) =>
         /^#(api-reference|props)$/.test(String(item.url)) ||
         /api reference|^props$/i.test(tocTitle(item.title)),
@@ -137,7 +138,7 @@ export default async function ElementPage({
 
   const toc: { title: string; url: string }[] = [
     { title: "Installation", url: "#installation" },
-    ...(mdxPage?.data.toc ?? [])
+    ...(mdxData?.toc ?? [])
       .filter((item) => item.depth <= 2)
       .map((item) => ({ title: tocTitle(item.title), url: item.url })),
     ...(generativeEntry

--- a/apps/docs/app/(design)/design/components/[slug]/page.tsx
+++ b/apps/docs/app/(design)/design/components/[slug]/page.tsx
@@ -53,7 +53,8 @@ export default async function DesignComponentPage({
   const section = getDesignSectionLabel(slug);
   const mdxComponents = getMDXComponents({});
   const links = page.data.links;
-  const toc = page.data.toc.filter((item) => item.depth <= 3);
+  const { body: MdxBody, toc: fullToc } = await page.data.load();
+  const toc = fullToc.filter((item) => item.depth <= 3);
 
   return (
     <PageFrame pad="sub">
@@ -117,7 +118,7 @@ export default async function DesignComponentPage({
           </header>
 
           <article data-page-content="" className="prose mt-12 max-w-none">
-            <page.data.body components={mdxComponents} />
+            <MdxBody components={mdxComponents} />
           </article>
         </div>
 

--- a/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(docs)/docs/[[...slug]]/page.tsx
@@ -40,6 +40,7 @@ export default async function Page(props: {
     notFound();
   }
 
+  const { body: MdxBody, toc } = await page.data.load();
   const mdxComponents = getMDXComponents({
     DocsCategory,
   });
@@ -54,13 +55,13 @@ export default async function Page(props: {
 
   return (
     <DocsPage
-      toc={page.data.toc}
+      toc={toc}
       full
       tableOfContent={{
         enabled: true,
         component: (
           <TableOfContents
-            items={page.data.toc}
+            items={toc}
             githubEditUrl={githubEditUrl}
             markdownUrl={markdownUrl}
           />
@@ -111,7 +112,7 @@ export default async function Page(props: {
             </div>
           )}
         </header>
-        <page.data.body components={mdxComponents} />
+        <MdxBody components={mdxComponents} />
         <DocsFooter previous={footerPrevious} next={footerNext} />
       </DocsBody>
     </DocsPage>

--- a/apps/docs/app/(home)/examples/[slug]/page.tsx
+++ b/apps/docs/app/(home)/examples/[slug]/page.tsx
@@ -55,6 +55,7 @@ export default async function ExamplePage(props: {
 
   const demo = getDemo(EXAMPLE_TO_DEMO_SLUG[slug] ?? slug);
   const neighbors = getExampleNeighbors(slug);
+  const { body: MdxBody } = await page.data.load();
   const mdxComponents = getMDXComponents({});
   const preview = hasExamplePreview(slug);
 
@@ -131,7 +132,7 @@ export default async function ExamplePage(props: {
         data-page-content=""
         className="prose prose-blog mt-16 max-w-none"
       >
-        <page.data.body components={mdxComponents} />
+        <MdxBody components={mdxComponents} />
       </article>
 
       {neighbors.previous || neighbors.next ? (

--- a/apps/docs/app/(home)/sitemap.md/route.ts
+++ b/apps/docs/app/(home)/sitemap.md/route.ts
@@ -1,26 +1,49 @@
+import type { SitemapPage } from "@/lib/agent-discovery";
 import { buildMarkdownSitemap, createDiscoveryResponse } from "@/lib/agent-discovery";
 import { design, elementsDocs, examples, getTapDocsPages, source } from "@/lib/source";
 
 export const revalidate = false;
 
-function sitemapDocument() {
+type LazyPage = {
+  url: string;
+  data: {
+    title: string;
+    description?: string | undefined;
+    load: () => Promise<{ lastModified?: Date | undefined }>;
+  };
+};
+
+function loadPages(pages: LazyPage[]): Promise<SitemapPage[]> {
+  return Promise.all(
+    pages.map(async (page) => ({
+      url: page.url,
+      data: {
+        title: page.data.title,
+        description: page.data.description,
+        lastModified: (await page.data.load()).lastModified,
+      },
+    })),
+  );
+}
+
+async function sitemapDocument() {
   return buildMarkdownSitemap([
-    { title: "Documentation", pages: source.getPages() },
-    { title: "Tap documentation", pages: getTapDocsPages() },
-    { title: "Examples", pages: examples.getPages() },
-    { title: "Design", pages: design.getPages() },
-    { title: "Elements", pages: elementsDocs.getPages() },
+    { title: "Documentation", pages: await loadPages(source.getPages()) },
+    { title: "Tap documentation", pages: await loadPages(getTapDocsPages()) },
+    { title: "Examples", pages: await loadPages(examples.getPages()) },
+    { title: "Design", pages: await loadPages(design.getPages()) },
+    { title: "Elements", pages: await loadPages(elementsDocs.getPages()) },
   ]);
 }
 
-export function GET() {
-  return createDiscoveryResponse(sitemapDocument(), {
+export async function GET() {
+  return createDiscoveryResponse(await sitemapDocument(), {
     contentType: "text/markdown; charset=utf-8",
   });
 }
 
-export function HEAD() {
-  return createDiscoveryResponse(sitemapDocument(), {
+export async function HEAD() {
+  return createDiscoveryResponse(await sitemapDocument(), {
     contentType: "text/markdown; charset=utf-8",
     head: true,
   });

--- a/apps/docs/app/(products)/tap/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/(products)/tap/docs/[[...slug]]/page.tsx
@@ -33,6 +33,7 @@ export default async function Page(props: {
     notFound();
   }
 
+  const { body: MdxBody, toc } = await page.data.load();
   const mdxComponents = getMDXComponents({
     DocsCategory,
   });
@@ -51,13 +52,13 @@ export default async function Page(props: {
 
   return (
     <DocsPage
-      toc={page.data.toc}
+      toc={toc}
       full
       tableOfContent={{
         enabled: true,
         component: (
           <TableOfContents
-            items={page.data.toc}
+            items={toc}
             githubEditUrl={githubEditUrl}
             markdownUrl={markdownUrl}
           />
@@ -88,7 +89,7 @@ export default async function Page(props: {
             </p>
           )}
         </header>
-        <page.data.body components={mdxComponents} />
+        <MdxBody components={mdxComponents} />
         <DocsFooter previous={footerPrevious} next={footerNext} />
       </DocsBody>
     </DocsPage>

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -2,8 +2,8 @@ import { buildSearchIndex } from "@/lib/search/pages";
 
 export const revalidate = false;
 
-export function GET() {
-  return Response.json(buildSearchIndex(), {
+export async function GET() {
+  return Response.json(await buildSearchIndex(), {
     headers: {
       "X-Robots-Tag": "noindex, follow",
     },

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -5,7 +5,7 @@ import { DEMOS } from "@/lib/demos";
 import { DESIGN_COMPONENTS } from "@/components/pages/design/registry-meta";
 import { BASE_URL, PRODUCTS } from "@/lib/constants";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticPages: MetadataRoute.Sitemap = [
     { url: BASE_URL, changeFrequency: "weekly", priority: 1 },
     { url: `${BASE_URL}/blog`, changeFrequency: "weekly", priority: 0.8 },
@@ -53,19 +53,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.4,
   }));
 
-  const docsPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
-    url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
-    changeFrequency: "weekly",
-    priority: 0.9,
-  }));
+  const docsPages: MetadataRoute.Sitemap = await Promise.all(
+    source.getPages().map(async (page) => ({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: (await page.data.load()).lastModified,
+      changeFrequency: "weekly" as const,
+      priority: 0.9,
+    })),
+  );
 
-  const tapDocsPages: MetadataRoute.Sitemap = getTapDocsPages().map((page) => ({
-    url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
-    changeFrequency: "weekly",
-    priority: 0.7,
-  }));
+  const tapDocsPages: MetadataRoute.Sitemap = await Promise.all(
+    getTapDocsPages().map(async (page) => ({
+      url: `${BASE_URL}${page.url}`,
+      lastModified: (await page.data.load()).lastModified,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
+  );
 
   const blogPages: MetadataRoute.Sitemap = blog.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
@@ -74,14 +78,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }));
 
-  const examplePages: MetadataRoute.Sitemap = examples
-    .getPages()
-    .map((page) => ({
+  const examplePages: MetadataRoute.Sitemap = await Promise.all(
+    examples.getPages().map(async (page) => ({
       url: `${BASE_URL}${page.url}`,
-      lastModified: page.data.lastModified,
-      changeFrequency: "monthly",
+      lastModified: (await page.data.load()).lastModified,
+      changeFrequency: "monthly" as const,
       priority: 0.6,
-    }));
+    })),
+  );
 
   const elementPages: MetadataRoute.Sitemap = ELEMENTS.map((element) => ({
     url: `${BASE_URL}/elements/${element.slug}`,

--- a/apps/docs/app/static.json/route.ts
+++ b/apps/docs/app/static.json/route.ts
@@ -4,7 +4,7 @@ import { design, elementsDocs, source, getTapDocsPages } from "@/lib/source";
 
 export const revalidate = false;
 
-export function GET() {
+export async function GET() {
   const results: DocumentRecord[] = [];
 
   for (const page of [
@@ -15,7 +15,7 @@ export function GET() {
   ]) {
     results.push({
       _id: page.url,
-      structured: page.data.structuredData,
+      structured: await page.data.structuredData(),
       url: page.url,
       title: page.data.title,
       description: page.data.description ?? "",

--- a/apps/docs/lib/get-llm-text.tsx
+++ b/apps/docs/lib/get-llm-text.tsx
@@ -350,7 +350,7 @@ export async function getLLMText(
   page: LLMPage,
   ctx: LLMRenderContext = DEFAULT_LLM_CONTEXT,
 ) {
-  const Body = page.data.body;
+  const { body: Body } = await page.data.load();
 
   // TODO: Platform-scoped MDX currently renders with the server default
   // platform ("react"). If llms output should include React Native or Ink

--- a/apps/docs/lib/search/pages.ts
+++ b/apps/docs/lib/search/pages.ts
@@ -23,16 +23,18 @@ function headingsFrom(structuredData: {
   return headings;
 }
 
-export function buildSearchIndex(): SearchRecord[] {
-  return [
-    ...source.getPages(),
-    ...getTapDocsPages(),
-    ...design.getPages(),
-    ...elementsDocs.getPages(),
-  ].map((page) => ({
-    url: page.url,
-    title: page.data.title,
-    description: page.data.description ?? "",
-    headings: headingsFrom(page.data.structuredData),
-  }));
+export function buildSearchIndex(): Promise<SearchRecord[]> {
+  return Promise.all(
+    [
+      ...source.getPages(),
+      ...getTapDocsPages(),
+      ...design.getPages(),
+      ...elementsDocs.getPages(),
+    ].map(async (page) => ({
+      url: page.url,
+      title: page.data.title,
+      description: page.data.description ?? "",
+      headings: headingsFrom(await page.data.structuredData()),
+    })),
+  );
 }

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -40,9 +40,7 @@ export const docs = defineDocs({
         .optional(),
       platforms: z.array(platformSchema).optional(),
     }),
-    postprocess: {
-      includeProcessedMarkdown: true,
-    },
+    async: true,
   },
   meta: {
     schema: metaSchema.extend({
@@ -57,9 +55,7 @@ export const tapDocs = defineDocs({
   dir: "content/tap-docs",
   docs: {
     schema: frontmatterSchema,
-    postprocess: {
-      includeProcessedMarkdown: true,
-    },
+    async: true,
   },
   meta: {
     schema: metaSchema.extend({
@@ -72,18 +68,14 @@ export const examples = defineCollections({
   type: "doc",
   dir: "content/examples",
   schema: frontmatterSchema,
-  postprocess: {
-    includeProcessedMarkdown: true,
-  },
+  async: true,
 });
 
 export const elements = defineCollections({
   type: "doc",
   dir: "content/elements",
   schema: frontmatterSchema,
-  postprocess: {
-    includeProcessedMarkdown: true,
-  },
+  async: true,
 });
 
 export const design = defineCollections({
@@ -99,9 +91,7 @@ export const design = defineCollections({
       )
       .optional(),
   }),
-  postprocess: {
-    includeProcessedMarkdown: true,
-  },
+  async: true,
 });
 
 export const blog = defineCollections({


### PR DESCRIPTION
## summary

- turns on fumadocs-mdx `async: true` for the docs, tap-docs, examples, elements, and design collections, so `.source/server.ts` imports only `?only=frontmatter` heads eagerly and defers the 433 mdx bodies behind `import()` thunks resolved per page via `page.data.load()`
- drops `includeProcessedMarkdown` from those five collections; the only `getText("processed")` consumer is the blog llms.md route, and blog (plus careers) stays on the eager path unchanged
- adapts every consumer of the now-lazy fields: both docs pages, the design/elements/examples pages, `getLLMText`, the search index and `/static.json` (`await page.data.structuredData()`), and `sitemap.ts` plus `sitemap.md` (`lastModified` now rides the loaded body, so the dates are unchanged at a build-time-only cost)
- measured on a cold `.next`: first `/docs` hit in dev drops from 15.6s/22.1s to 13.1s/12.1s, `generate-params` from 1.9s to 2.8s down to about 280ms, warm and second-page timings unchanged, `next build` 55.8s vs 51.8s (the build still compiles all bodies for llms-full/search/sitemap, as expected), rendered docs HTML byte-identical

## test plan

### already verified

- [x] `pnpm exec tsc --noEmit` in apps/docs -> clean
- [x] `pnpm exec vitest run` in apps/docs -> 55 files / 450 tests green
- [x] `pnpm lint` + `oxfmt --check` on the touched files -> clean
- [x] live dev curls: `/docs/installation` (h1 + toc), `/tap/docs` redirect -> 200, `/elements/reasoning`, `/design/components/button`, `/api/search` records with headings, `/docs/installation.md`, `/blog/2025-01-31-changelog.md`, `/sitemap.md` (426 "Last updated" lines), `/sitemap.xml` (284 lastmod), `/static.json` structured payloads

### reviewer should verify

- [ ] open a few docs pages on the vercel preview and confirm toc, pager, and body render as on production

## notes

- after this change the remaining cold-compile cost of a docs page is the page's own component graph (transpiled kit + shiki, chrome, assistant), not content; shrinking that import graph is the next lever and a separate change

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OTAbdaJ_wsNZQBrPFIufkkAIke_fNVTPg10TkD0_RZlH6rF_n-QvuSNEK6k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

