### PR TITLE
fix: drop private @assistant-ui/vue from the core changeset

### DIFF
--- a/.changeset/quiet-files-remain.md
+++ b/.changeset/quiet-files-remain.md
@@ -1,6 +1,5 @@
 ---
 "@assistant-ui/core": patch
-"@assistant-ui/vue": patch
 ---
 
 fix: preserve composer attachment component identity after removals

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -25,6 +25,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Verify changesets only name releasable packages
+        run: node scripts/check-changesets.mjs
+
       - name: Check changeset bump types against package versions
         id: check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9.0.0

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -25,6 +25,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Setup pnpm and node.js
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # ratchet:pnpm/setup@v2.1.0
+        with:
+          runtime: node@24
+          install: false
+
       - name: Verify changesets only name releasable packages
         run: node scripts/check-changesets.mjs
 

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -31,6 +31,9 @@ jobs:
           runtime: node@24
           install: false
 
+      - name: Test the changeset checker
+        run: node --test scripts/check-changesets.test.mjs
+
       - name: Verify changesets only name releasable packages
         run: node scripts/check-changesets.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Every publishable package builds with `aui-build` (`@assistant-ui/x-buildutils`)
 
 Run `pnpm check:resource-memo` when bumping `@babel/core`, `babel-plugin-react-compiler`, or `react-compiler`; a green build does not prove the compiler toolchain is intact. A package the published dist imports at runtime belongs in `dependencies`, not `devDependencies`, so the bundler externalizes it (a devDep gets inlined and drags unresolvable transitive imports into consumer builds). A registry item must be self-contained: enumerate every `@/components/*` import and CSS `@import` as `registryDependencies`, so `shadcn add` never lands a file with an unresolvable import.
 
-Every PR that changes a published package needs a changeset. Always use **patch**; minor and major require maintainer approval. Private packages (`private: true` in package.json) are exempt.
+Every PR that changes a published package needs a changeset. Always use **patch**; minor and major require maintainer approval. Private packages (`private: true` in package.json) are exempt, and must never be named in a changeset: `privatePackages.version` is false, so a changeset that mixes a private package with a published one aborts `changeset version` and blocks every release. `pnpm changesets:check` enforces this.
 
 ```md
 ---

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*'",
     "api-surface:check": "node scripts/check-api-surface.mjs",
     "api-surface:test": "node --test scripts/generate-api-surface.test.mjs scripts/lib/workspace.test.mjs",
+    "changesets:check": "node scripts/check-changesets.mjs",
     "declarations:check": "node scripts/check-built-declarations.mjs",
     "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "api-surface:check": "node scripts/check-api-surface.mjs",
     "api-surface:test": "node --test scripts/generate-api-surface.test.mjs scripts/lib/workspace.test.mjs",
     "changesets:check": "node scripts/check-changesets.mjs",
+    "changesets:test": "node --test scripts/check-changesets.test.mjs",
     "declarations:check": "node scripts/check-built-declarations.mjs",
     "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -2,6 +2,7 @@
 import { globSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { isExecutedAsMain } from "./check-built-declarations.mjs";
 import { readJson } from "./lib/workspace.mjs";
 
 const repoRoot = path.resolve(
@@ -44,9 +45,9 @@ export function parseBumpLine(line) {
   return { name: entry[1] ?? entry[2] ?? entry[3], bump };
 }
 
-function readWorkspacePackages() {
+function readWorkspacePackages(root) {
   const globs = parseWorkspaceGlobs(
-    readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8"),
+    readFileSync(path.join(root, "pnpm-workspace.yaml"), "utf8"),
   );
   if (globs.length === 0) {
     throw new Error("pnpm-workspace.yaml declares no `packages:` entries.");
@@ -54,9 +55,9 @@ function readWorkspacePackages() {
   const byName = new Map();
   for (const glob of globs) {
     for (const manifest of globSync(`${glob}/package.json`, {
-      cwd: repoRoot,
+      cwd: root,
     })) {
-      const pkg = readJson(path.join(repoRoot, manifest));
+      const pkg = readJson(path.join(root, manifest));
       if (typeof pkg.name !== "string") continue;
       byName.set(pkg.name, {
         manifest: manifest.replaceAll("\\", "/"),
@@ -67,8 +68,8 @@ function readWorkspacePackages() {
   return byName;
 }
 
-function readChangesetBumps() {
-  const changesetDir = path.join(repoRoot, ".changeset");
+function readChangesetBumps(root) {
+  const changesetDir = path.join(root, ".changeset");
   const bumps = [];
   for (const file of readdirSync(changesetDir).sort()) {
     if (!file.endsWith(".md") || file === "README.md") continue;
@@ -106,9 +107,16 @@ export function findUnreleasablePackages(packages, bumps) {
   return problems;
 }
 
+export function runCheck(root = repoRoot) {
+  const packages = readWorkspacePackages(root);
+  return {
+    packageCount: packages.size,
+    problems: findUnreleasablePackages(packages, readChangesetBumps(root)),
+  };
+}
+
 function main() {
-  const packages = readWorkspacePackages();
-  const problems = findUnreleasablePackages(packages, readChangesetBumps());
+  const { packageCount, problems } = runCheck();
 
   if (problems.length > 0) {
     console.error("Changesets name packages that cannot be released:\n");
@@ -127,8 +135,8 @@ function main() {
   }
 
   console.log(
-    `All changeset bumps name releasable workspace packages. (${packages.size} packages scanned)`,
+    `All changeset bumps name releasable workspace packages. (${packageCount} packages scanned)`,
   );
 }
 
-if (import.meta.main) main();
+if (isExecutedAsMain(import.meta.url, process.argv[1])) main();

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -86,17 +86,36 @@ function readChangesetBumps(root) {
   return bumps;
 }
 
-export function findUnreleasablePackages(packages, bumps) {
+export function readSkipRules(config) {
+  const privatePackages = config.privatePackages;
+  const versionsPrivate =
+    typeof privatePackages === "object" && privatePackages !== null
+      ? privatePackages.version === true
+      : privatePackages === true;
+  return {
+    ignored: new Set(config.ignore ?? []),
+    skipsPrivate: !versionsPrivate,
+  };
+}
+
+export function findUnreleasablePackages(packages, bumps, rules) {
   const problems = [];
   for (const { file, name } of bumps) {
     const pkg = packages.get(name);
-    if (!pkg) {
+    if (rules.ignored.has(name)) {
+      problems.push({
+        file,
+        name,
+        reason:
+          "is in `ignore` in .changeset/config.json and is never versioned",
+      });
+    } else if (!pkg) {
       problems.push({
         file,
         name,
         reason: "is not a workspace package (misspelled or renamed?)",
       });
-    } else if (pkg.isPrivate) {
+    } else if (pkg.isPrivate && rules.skipsPrivate) {
       problems.push({
         file,
         name,
@@ -109,14 +128,21 @@ export function findUnreleasablePackages(packages, bumps) {
 
 export function runCheck(root = repoRoot) {
   const packages = readWorkspacePackages(root);
+  const rules = readSkipRules(
+    readJson(path.join(root, ".changeset", "config.json")),
+  );
   return {
     packageCount: packages.size,
-    problems: findUnreleasablePackages(packages, readChangesetBumps(root)),
+    problems: findUnreleasablePackages(
+      packages,
+      readChangesetBumps(root),
+      rules,
+    ),
   };
 }
 
 function main() {
-  const { packageCount, problems } = runCheck();
+  const { packageCount, problems } = runCheck(process.env.CHANGESET_CHECK_ROOT);
 
   if (problems.length > 0) {
     console.error("Changesets name packages that cannot be released:\n");
@@ -124,12 +150,11 @@ function main() {
       console.error(`  .changeset/${file}: "${name}" ${reason}`);
     }
     console.error(
-      "\n`privatePackages.version` is false, so changesets skips private packages.",
+      "\nA changeset mixing a package changesets skips with a released one aborts",
     );
     console.error(
-      "A changeset mixing a skipped package with a released one aborts `changeset version`,",
+      "`changeset version`, which blocks every release until the line is removed.",
     );
-    console.error("which blocks every release until the line is removed.");
     console.error("\nDrop the offending line from the changeset frontmatter.");
     process.exit(1);
   }

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { globSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readJson } from "./lib/workspace.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const BUMP_LINE =
+  /^(?:"([^"]+)"|'([^']+)'|([^\s'":][^:]*?))\s*:\s*(patch|minor|major)\s*$/;
+
+function readWorkspaceGlobs() {
+  const source = readFileSync(
+    path.join(repoRoot, "pnpm-workspace.yaml"),
+    "utf8",
+  );
+  const globs = [];
+  let inPackages = false;
+  for (const line of source.split("\n")) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    const entry = line.match(/^\s+-\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
+    if (!entry) break;
+    globs.push(entry[1] ?? entry[2] ?? entry[3]);
+  }
+  if (globs.length === 0) {
+    throw new Error("pnpm-workspace.yaml declares no `packages:` entries.");
+  }
+  return globs;
+}
+
+function readWorkspacePackages() {
+  const byName = new Map();
+  for (const glob of readWorkspaceGlobs()) {
+    for (const manifest of globSync(`${glob}/package.json`, {
+      cwd: repoRoot,
+    })) {
+      const pkg = readJson(path.join(repoRoot, manifest));
+      if (typeof pkg.name !== "string") continue;
+      byName.set(pkg.name, {
+        manifest: manifest.replaceAll("\\", "/"),
+        isPrivate: pkg.private === true,
+      });
+    }
+  }
+  return byName;
+}
+
+function readChangesetBumps() {
+  const changesetDir = path.join(repoRoot, ".changeset");
+  const bumps = [];
+  for (const file of readdirSync(changesetDir).sort()) {
+    if (!file.endsWith(".md") || file === "README.md") continue;
+    const frontmatter = readFileSync(
+      path.join(changesetDir, file),
+      "utf8",
+    ).match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!frontmatter) continue;
+    for (const line of frontmatter[1].split("\n")) {
+      const bump = line.trim().match(BUMP_LINE);
+      if (!bump) continue;
+      bumps.push({ file, name: bump[1] ?? bump[2] ?? bump[3] });
+    }
+  }
+  return bumps;
+}
+
+const packages = readWorkspacePackages();
+const problems = [];
+
+for (const { file, name } of readChangesetBumps()) {
+  const pkg = packages.get(name);
+  if (!pkg) {
+    problems.push({
+      file,
+      name,
+      reason: "is not a workspace package (misspelled or renamed?)",
+    });
+  } else if (pkg.isPrivate) {
+    problems.push({
+      file,
+      name,
+      reason: `is private (${pkg.manifest}) and is never versioned`,
+    });
+  }
+}
+
+if (problems.length > 0) {
+  console.error("Changesets name packages that cannot be released:\n");
+  for (const { file, name, reason } of problems) {
+    console.error(`  .changeset/${file}: "${name}" ${reason}`);
+  }
+  console.error(
+    "\n`privatePackages.version` is false, so changesets skips private packages.",
+  );
+  console.error(
+    "A changeset mixing a skipped package with a released one aborts `changeset version`,",
+  );
+  console.error("which blocks every release until the line is removed.");
+  console.error("\nDrop the offending line from the changeset frontmatter.");
+  process.exit(1);
+}
+
+console.log(
+  `All changeset bumps name releasable workspace packages. (${packages.size} packages scanned)`,
+);

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -150,10 +150,10 @@ function main() {
       console.error(`  .changeset/${file}: "${name}" ${reason}`);
     }
     console.error(
-      "\nA changeset mixing a package changesets skips with a released one aborts",
+      "\nChangesets refuses a changeset that mixes a skipped package with a released one,",
     );
     console.error(
-      "`changeset version`, which blocks every release until the line is removed.",
+      "so `changeset version` aborts and every release stays blocked until the line is removed.",
     );
     console.error("\nDrop the offending line from the changeset frontmatter.");
     process.exit(1);

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -9,14 +9,9 @@ const repoRoot = path.resolve(
   "..",
 );
 
-const BUMP_LINE =
-  /^(?:"([^"]+)"|'([^']+)'|([^\s'":][^:]*?))\s*:\s*(patch|minor|major)\s*$/;
+const BUMP_VALUES = new Set(["patch", "minor", "major"]);
 
-function readWorkspaceGlobs() {
-  const source = readFileSync(
-    path.join(repoRoot, "pnpm-workspace.yaml"),
-    "utf8",
-  );
+export function parseWorkspaceGlobs(source) {
   const globs = [];
   let inPackages = false;
   for (const line of source.split("\n")) {
@@ -25,19 +20,39 @@ function readWorkspaceGlobs() {
       continue;
     }
     if (!inPackages) continue;
-    const entry = line.match(/^\s+-\s*(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/);
+    if (/^\s*(?:#.*)?$/.test(line)) continue;
+    const entry = line.match(
+      /^\s+-\s*(?:"([^"]*)"|'([^']*)'|([^\s#]+))\s*(?:#.*)?$/,
+    );
     if (!entry) break;
     globs.push(entry[1] ?? entry[2] ?? entry[3]);
-  }
-  if (globs.length === 0) {
-    throw new Error("pnpm-workspace.yaml declares no `packages:` entries.");
   }
   return globs;
 }
 
+export function parseBumpLine(line) {
+  const entry = line
+    .trim()
+    .match(/^(?:"([^"]*)"|'([^']*)'|([^#:][^:]*?))\s*:\s*(.*)$/);
+  if (!entry) return null;
+  const value = entry[4].match(
+    /^(?:"([^"]*)"|'([^']*)'|([^\s#]*))\s*(?:#.*)?$/,
+  );
+  if (!value) return null;
+  const bump = value[1] ?? value[2] ?? value[3];
+  if (!BUMP_VALUES.has(bump)) return null;
+  return { name: entry[1] ?? entry[2] ?? entry[3], bump };
+}
+
 function readWorkspacePackages() {
+  const globs = parseWorkspaceGlobs(
+    readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8"),
+  );
+  if (globs.length === 0) {
+    throw new Error("pnpm-workspace.yaml declares no `packages:` entries.");
+  }
   const byName = new Map();
-  for (const glob of readWorkspaceGlobs()) {
+  for (const glob of globs) {
     for (const manifest of globSync(`${glob}/package.json`, {
       cwd: repoRoot,
     })) {
@@ -63,50 +78,57 @@ function readChangesetBumps() {
     ).match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!frontmatter) continue;
     for (const line of frontmatter[1].split("\n")) {
-      const bump = line.trim().match(BUMP_LINE);
-      if (!bump) continue;
-      bumps.push({ file, name: bump[1] ?? bump[2] ?? bump[3] });
+      const bump = parseBumpLine(line);
+      if (bump) bumps.push({ file, name: bump.name });
     }
   }
   return bumps;
 }
 
-const packages = readWorkspacePackages();
-const problems = [];
-
-for (const { file, name } of readChangesetBumps()) {
-  const pkg = packages.get(name);
-  if (!pkg) {
-    problems.push({
-      file,
-      name,
-      reason: "is not a workspace package (misspelled or renamed?)",
-    });
-  } else if (pkg.isPrivate) {
-    problems.push({
-      file,
-      name,
-      reason: `is private (${pkg.manifest}) and is never versioned`,
-    });
+export function findUnreleasablePackages(packages, bumps) {
+  const problems = [];
+  for (const { file, name } of bumps) {
+    const pkg = packages.get(name);
+    if (!pkg) {
+      problems.push({
+        file,
+        name,
+        reason: "is not a workspace package (misspelled or renamed?)",
+      });
+    } else if (pkg.isPrivate) {
+      problems.push({
+        file,
+        name,
+        reason: `is private (${pkg.manifest}) and is never versioned`,
+      });
+    }
   }
+  return problems;
 }
 
-if (problems.length > 0) {
-  console.error("Changesets name packages that cannot be released:\n");
-  for (const { file, name, reason } of problems) {
-    console.error(`  .changeset/${file}: "${name}" ${reason}`);
+function main() {
+  const packages = readWorkspacePackages();
+  const problems = findUnreleasablePackages(packages, readChangesetBumps());
+
+  if (problems.length > 0) {
+    console.error("Changesets name packages that cannot be released:\n");
+    for (const { file, name, reason } of problems) {
+      console.error(`  .changeset/${file}: "${name}" ${reason}`);
+    }
+    console.error(
+      "\n`privatePackages.version` is false, so changesets skips private packages.",
+    );
+    console.error(
+      "A changeset mixing a skipped package with a released one aborts `changeset version`,",
+    );
+    console.error("which blocks every release until the line is removed.");
+    console.error("\nDrop the offending line from the changeset frontmatter.");
+    process.exit(1);
   }
-  console.error(
-    "\n`privatePackages.version` is false, so changesets skips private packages.",
+
+  console.log(
+    `All changeset bumps name releasable workspace packages. (${packages.size} packages scanned)`,
   );
-  console.error(
-    "A changeset mixing a skipped package with a released one aborts `changeset version`,",
-  );
-  console.error("which blocks every release until the line is removed.");
-  console.error("\nDrop the offending line from the changeset frontmatter.");
-  process.exit(1);
 }
 
-console.log(
-  `All changeset bumps name releasable workspace packages. (${packages.size} packages scanned)`,
-);
+if (import.meta.main) main();

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -155,15 +155,15 @@ test("runCheck rejects a changeset naming a private package", () => {
   }
 });
 
-test("the executable reports success against this repo", () => {
+test("the executable runs main() instead of exiting silently", () => {
   const result = spawnSync(
     process.execPath,
     [path.join(repoRoot, "scripts", "check-changesets.mjs")],
     { encoding: "utf8" },
   );
-  assert.equal(result.status, 0, result.stderr);
   assert.match(
-    result.stdout,
-    /All changeset bumps name releasable workspace packages\./,
+    result.stdout + result.stderr,
+    /All changeset bumps name releasable workspace packages\.|Changesets name packages that cannot be released:/,
+    "the guard produced no verdict, so main() never ran",
   );
 });

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -1,10 +1,38 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   findUnreleasablePackages,
   parseBumpLine,
   parseWorkspaceGlobs,
+  runCheck,
 } from "./check-changesets.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function createWorkspace(changeset) {
+  const root = mkdtempSync(path.join(tmpdir(), "aui-changesets-"));
+  writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    "packages:\n  - packages/*\n\nlinkWorkspacePackages: true\n",
+  );
+  for (const [dir, manifest] of [
+    ["published", { name: "@fixture/published", version: "1.0.0" }],
+    ["internal", { name: "@fixture/internal", private: true }],
+  ]) {
+    mkdirSync(path.join(root, "packages", dir), { recursive: true });
+    writeFileSync(
+      path.join(root, "packages", dir, "package.json"),
+      JSON.stringify(manifest),
+    );
+  }
+  mkdirSync(path.join(root, ".changeset"));
+  writeFileSync(path.join(root, ".changeset", "entry.md"), changeset);
+  return root;
+}
 
 test("parseBumpLine reads every quoting style changesets accepts", () => {
   for (const line of [
@@ -100,4 +128,42 @@ test("findUnreleasablePackages flags private and unknown names", () => {
     /is private \(packages\/vue\/package\.json\)/,
   );
   assert.match(problems[1].reason, /is not a workspace package/);
+});
+
+test("runCheck accepts a workspace whose changesets are all releasable", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: something\n',
+  );
+  try {
+    assert.deepEqual(runCheck(root), { packageCount: 2, problems: [] });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCheck rejects a changeset naming a private package", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n"@fixture/internal": "patch" # slipped past the old matcher\n---\n\nfix: something\n',
+  );
+  try {
+    const { problems } = runCheck(root);
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].name, "@fixture/internal");
+    assert.match(problems[0].reason, /is private/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the executable reports success against this repo", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "check-changesets.mjs")],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /All changeset bumps name releasable workspace packages\./,
+  );
 });

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findUnreleasablePackages,
+  parseBumpLine,
+  parseWorkspaceGlobs,
+} from "./check-changesets.mjs";
+
+test("parseBumpLine reads every quoting style changesets accepts", () => {
+  for (const line of [
+    '"@assistant-ui/vue": patch',
+    "'@assistant-ui/vue': patch",
+    "@assistant-ui/vue: patch",
+    '"@assistant-ui/vue": "patch"',
+    "\"@assistant-ui/vue\": 'patch'",
+    '"@assistant-ui/vue": patch # keeps the release train moving',
+    '"@assistant-ui/vue": "patch" # keeps the release train moving',
+    '  "@assistant-ui/vue": patch  ',
+  ]) {
+    assert.deepEqual(
+      parseBumpLine(line),
+      { name: "@assistant-ui/vue", bump: "patch" },
+      line,
+    );
+  }
+});
+
+test("parseBumpLine ignores lines that are not bumps", () => {
+  for (const line of [
+    "",
+    "---",
+    '# "@assistant-ui/vue": patch',
+    '"@assistant-ui/vue": prerelease',
+    '"@assistant-ui/vue"',
+  ]) {
+    assert.equal(parseBumpLine(line), null, line);
+  }
+});
+
+test("parseBumpLine keeps every bump level", () => {
+  assert.equal(parseBumpLine('"a": minor')?.bump, "minor");
+  assert.equal(parseBumpLine('"a": major')?.bump, "major");
+});
+
+test("parseWorkspaceGlobs survives comments and blank lines", () => {
+  assert.deepEqual(
+    parseWorkspaceGlobs(
+      [
+        "packages:",
+        "  - api-surface",
+        "",
+        "  # the published libraries",
+        "  - packages/*",
+        '  - "apps/*"',
+        "  - templates/* # starters",
+        "",
+        "linkWorkspacePackages: true",
+        "  - never/reached",
+      ].join("\n"),
+    ),
+    ["api-surface", "packages/*", "apps/*", "templates/*"],
+  );
+});
+
+test("parseWorkspaceGlobs matches the repo's own workspace file", () => {
+  assert.deepEqual(
+    parseWorkspaceGlobs(
+      "packages:\n  - api-surface\n  - packages/*\n  - examples/*\n  - apps/*\n  - templates/*\n\nlinkWorkspacePackages: true\n",
+    ),
+    ["api-surface", "packages/*", "examples/*", "apps/*", "templates/*"],
+  );
+});
+
+test("findUnreleasablePackages flags private and unknown names", () => {
+  const packages = new Map([
+    [
+      "@assistant-ui/core",
+      { manifest: "packages/core/package.json", isPrivate: false },
+    ],
+    [
+      "@assistant-ui/vue",
+      { manifest: "packages/vue/package.json", isPrivate: true },
+    ],
+  ]);
+
+  assert.deepEqual(
+    findUnreleasablePackages(packages, [
+      { file: "a.md", name: "@assistant-ui/core" },
+    ]),
+    [],
+  );
+
+  const problems = findUnreleasablePackages(packages, [
+    { file: "a.md", name: "@assistant-ui/vue" },
+    { file: "a.md", name: "@assistant-ui/nope" },
+  ]);
+  assert.equal(problems.length, 2);
+  assert.match(
+    problems[0].reason,
+    /is private \(packages\/vue\/package\.json\)/,
+  );
+  assert.match(problems[1].reason, /is not a workspace package/);
+});

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -8,12 +8,13 @@ import {
   findUnreleasablePackages,
   parseBumpLine,
   parseWorkspaceGlobs,
+  readSkipRules,
   runCheck,
 } from "./check-changesets.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function createWorkspace(changeset) {
+function createWorkspace(changeset, config = {}) {
   const root = mkdtempSync(path.join(tmpdir(), "aui-changesets-"));
   writeFileSync(
     path.join(root, "pnpm-workspace.yaml"),
@@ -30,6 +31,10 @@ function createWorkspace(changeset) {
     );
   }
   mkdirSync(path.join(root, ".changeset"));
+  writeFileSync(
+    path.join(root, ".changeset", "config.json"),
+    JSON.stringify({ privatePackages: { version: false }, ...config }),
+  );
   writeFileSync(path.join(root, ".changeset", "entry.md"), changeset);
   return root;
 }
@@ -111,17 +116,25 @@ test("findUnreleasablePackages flags private and unknown names", () => {
     ],
   ]);
 
+  const rules = { ignored: new Set(), skipsPrivate: true };
+
   assert.deepEqual(
-    findUnreleasablePackages(packages, [
-      { file: "a.md", name: "@assistant-ui/core" },
-    ]),
+    findUnreleasablePackages(
+      packages,
+      [{ file: "a.md", name: "@assistant-ui/core" }],
+      rules,
+    ),
     [],
   );
 
-  const problems = findUnreleasablePackages(packages, [
-    { file: "a.md", name: "@assistant-ui/vue" },
-    { file: "a.md", name: "@assistant-ui/nope" },
-  ]);
+  const problems = findUnreleasablePackages(
+    packages,
+    [
+      { file: "a.md", name: "@assistant-ui/vue" },
+      { file: "a.md", name: "@assistant-ui/nope" },
+    ],
+    rules,
+  );
   assert.equal(problems.length, 2);
   assert.match(
     problems[0].reason,
@@ -155,15 +168,86 @@ test("runCheck rejects a changeset naming a private package", () => {
   }
 });
 
-test("the executable runs main() instead of exiting silently", () => {
-  const result = spawnSync(
+test("readSkipRules follows .changeset/config.json", () => {
+  assert.deepEqual(readSkipRules({}), {
+    ignored: new Set(),
+    skipsPrivate: true,
+  });
+  assert.deepEqual(readSkipRules({ privatePackages: { version: true } }), {
+    ignored: new Set(),
+    skipsPrivate: false,
+  });
+  assert.deepEqual(readSkipRules({ privatePackages: true }), {
+    ignored: new Set(),
+    skipsPrivate: false,
+  });
+  assert.deepEqual(readSkipRules({ ignore: ["@fixture/held"] }), {
+    ignored: new Set(["@fixture/held"]),
+    skipsPrivate: true,
+  });
+});
+
+test("runCheck rejects a published package listed in `ignore`", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: something\n',
+    { ignore: ["@fixture/published"] },
+  );
+  try {
+    const { problems } = runCheck(root);
+    assert.equal(problems.length, 1);
+    assert.match(problems[0].reason, /is in `ignore`/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCheck allows a private package when the config versions it", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/internal": patch\n---\n\nfix: something\n',
+    { privatePackages: { version: true } },
+  );
+  try {
+    assert.deepEqual(runCheck(root).problems, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runExecutable(root) {
+  return spawnSync(
     process.execPath,
     [path.join(repoRoot, "scripts", "check-changesets.mjs")],
-    { encoding: "utf8" },
+    { encoding: "utf8", env: { ...process.env, CHANGESET_CHECK_ROOT: root } },
   );
-  assert.match(
-    result.stdout + result.stderr,
-    /All changeset bumps name releasable workspace packages\.|Changesets name packages that cannot be released:/,
-    "the guard produced no verdict, so main() never ran",
+}
+
+test("the executable reports success and exits 0", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n---\n\nfix: something\n',
   );
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      result.stdout,
+      /All changeset bumps name releasable workspace packages\./,
+      "the guard produced no verdict, so main() never ran",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the executable reports the offending line and exits 1", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/published": patch\n"@fixture/internal": patch\n---\n\nfix: something\n',
+  );
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /"@fixture\/internal" is private/);
+    assert.match(result.stderr, /entry\.md/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## what

`.changeset/quiet-files-remain.md` listed `@assistant-ui/vue` next to `@assistant-ui/core`. `packages/vue` is `private: true`, and `.changeset/config.json` sets `privatePackages.version: false`, so changesets skips it. a changeset that mixes a skipped package with a released one is rejected outright:

```
$ pnpm exec changeset status
Error: Found mixed changeset quiet-files-remain
Found ignored packages: @assistant-ui/vue
Found not ignored packages: @assistant-ui/core
Mixed changesets that contain both ignored and not ignored packages are not allowed
    at getRelevantChangesets (@changesets/assemble-release-plan/dist/index.mjs:326)
```

that is the same call `changeset version` makes, so main currently cannot cut a release at all. dropping the line restores it; `changeset status` prints the full release plan again.

## why it got through

`Changeset Semver Check` already reads every changeset frontmatter, but it builds its package map from non-private entries under `packages/` and then does `if (!pkgInfo) continue`. private and misspelled package names are silently ignored, which is exactly the class of line that breaks the release.

## how

`scripts/check-changesets.mjs` resolves the workspace from `pnpm-workspace.yaml` and fails when a changeset names a package that is private or not a workspace package at all:

```
Changesets name packages that cannot be released:

  .changeset/quiet-files-remain.md: "@assistant-ui/vue" is private (packages/vue/package.json) and is never versioned
```

it uses node builtins only, so the workflow runs it right after checkout with no install step, and `Changeset Semver Check` has no `paths:` filter so it gates every PR into main. it runs before the semver script because a changeset naming a skipped package makes that summary misleading. also wired as `pnpm changesets:check` for local use, and the rule is written down in AGENTS.md next to the existing "private packages are exempt" line.

## verification

- guard red on this changeset, and on a probe naming a private package plus a nonexistent one; green after the fix
- `pnpm exec changeset status` errors before the fix, prints the release plan after
- oxlint clean, oxfmt formatted

no changeset here: nothing under a published package's source changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ms7-tYQ87GYbrnEDUfLyBWL253LV6-oPy-hg2hRL7SsmvQCOZWa1DG0B1Uw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->