### PR TITLE
fix(core): keep cloud thread adapter options commit-safe

### DIFF
--- a/.changeset/cloud-thread-adapter-commit-safety.md
+++ b/.changeset/cloud-thread-adapter-commit-safety.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep Cloud thread adapter options scoped to committed renders

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -1,6 +1,6 @@
 declare const process: { env: Record<string, string | undefined> };
 
-import { useMemo, useState } from "react";
+import { type RefObject, useMemo, useState } from "react";
 import { AssistantCloud } from "assistant-cloud";
 import type {
   RemoteThreadListAdapter,
@@ -31,6 +31,22 @@ const baseUrl =
 export const autoCloud = baseUrl
   ? new AssistantCloud({ baseUrl, anonymous: true })
   : undefined;
+
+export const useCloudRuntimeAdapters = (
+  cloudRef: RefObject<AssistantCloud>,
+): RuntimeAdapters => {
+  const history = useAssistantCloudThreadHistoryAdapter(cloudRef);
+  const [attachments] = useState(
+    () => new CloudFileAttachmentAdapter(() => cloudRef.current),
+  );
+  return useMemo(
+    () => ({
+      history,
+      attachments,
+    }),
+    [history, attachments],
+  );
+};
 
 const CLOUD_THREAD_PAGE_SIZE = 20;
 
@@ -82,22 +98,11 @@ export const createCloudThreadListAdapter = (
   const getOptions = typeof options === "function" ? options : () => options;
 
   const unstable_useAdapters = function useCloudAdapters(): RuntimeAdapters {
-    const history = useAssistantCloudThreadHistoryAdapter({
+    return useCloudRuntimeAdapters({
       get current() {
         return getOptions().cloud ?? autoCloud!;
       },
     });
-    const [attachments] = useState(
-      () =>
-        new CloudFileAttachmentAdapter(() => getOptions().cloud ?? autoCloud!),
-    );
-    return useMemo(
-      () => ({
-        history,
-        attachments,
-      }),
-      [history, attachments],
-    );
   };
 
   const cloud = getOptions().cloud ?? autoCloud;

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -1,8 +1,15 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
+import {
+  startTransition,
+  Suspense,
+  useInsertionEffect,
+  type ReactNode,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
+import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
 import { useCloudThreadListAdapter } from "./useCloudThreadListAdapter";
 
 const makeThread = (id: string) => ({
@@ -18,7 +25,89 @@ const makeThread = (id: string) => ({
   workspace_id: "workspace-1",
 });
 
+const Suspend = ({ pending }: { pending: Promise<never> }) => {
+  throw pending;
+};
+
 describe("useCloudThreadListAdapter", () => {
+  it("keeps operations scoped to the committed Cloud options", async () => {
+    const deleteA = vi.fn(async () => {});
+    const deleteB = vi.fn(async () => {});
+    const cloudDeleteA = vi.fn(async () => {});
+    const cloudDeleteB = vi.fn(async () => {});
+    const cloudA = {
+      threads: { delete: cloudDeleteA },
+    } as unknown as AssistantCloud;
+    const cloudB = {
+      threads: { delete: cloudDeleteB },
+    } as unknown as AssistantCloud;
+    const committed: { current: RemoteThreadListAdapter | null } = {
+      current: null,
+    };
+    const renderB = vi.fn();
+    let suspend = false;
+    const pending = new Promise<never>(() => {});
+
+    const App = ({
+      cloud,
+      onDelete,
+    }: {
+      cloud: AssistantCloud;
+      onDelete: (threadId: string) => Promise<void>;
+    }) => {
+      const adapter = useCloudThreadListAdapter({
+        cloud,
+        delete: onDelete,
+      });
+      if (cloud === cloudB) renderB();
+      useInsertionEffect(() => {
+        committed.current = adapter;
+      }, [adapter]);
+      return null;
+    };
+    const Boundary = ({ children }: { children: ReactNode }) => (
+      <Suspense fallback={null}>
+        {children}
+        {suspend ? <Suspend pending={pending} /> : null}
+      </Suspense>
+    );
+    const view = render(
+      <Boundary>
+        <App cloud={cloudA} onDelete={deleteA} />
+      </Boundary>,
+    );
+
+    act(() => {
+      suspend = true;
+      startTransition(() => {
+        view.rerender(
+          <Boundary>
+            <App cloud={cloudB} onDelete={deleteB} />
+          </Boundary>,
+        );
+      });
+    });
+    expect(renderB).toHaveBeenCalled();
+
+    await committed.current!.delete!("thread-1");
+
+    expect(deleteA).toHaveBeenCalledWith("thread-1");
+    expect(deleteB).not.toHaveBeenCalled();
+    expect(cloudDeleteA).toHaveBeenCalledWith("thread-1");
+    expect(cloudDeleteB).not.toHaveBeenCalled();
+
+    suspend = false;
+    view.rerender(
+      <Boundary>
+        <App cloud={cloudB} onDelete={deleteB} />
+      </Boundary>,
+    );
+    await committed.current!.delete!("thread-2");
+
+    expect(deleteB).toHaveBeenCalledWith("thread-2");
+    expect(cloudDeleteB).toHaveBeenCalledWith("thread-2");
+  });
+
   it("loads archived Cloud threads alongside regular threads", async () => {
     const activeThreads = [makeThread("active-1")];
     const archivedThreads = [

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -1,34 +1,46 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useInsertionEffect, useMemo, useRef } from "react";
 import type { RemoteThreadListAdapter } from "../../../runtimes/remote-thread-list/types";
-import type { RuntimeAdapters } from "../RuntimeAdapterProvider";
 import {
   autoCloud,
   createCloudThreadListAdapter,
   type CloudThreadListAdapterOptions,
+  useCloudRuntimeAdapters,
 } from "./createCloudThreadListAdapter";
 
 export const useCloudThreadListAdapter = (
   adapter: CloudThreadListAdapterOptions,
 ): RemoteThreadListAdapter => {
-  // Synced during render, not in an effect: the memo below recreates the
-  // adapter in the same render a cloud swap arrives, and the factory pins the
-  // cloud instance it reads at creation.
   const adapterRef = useRef(adapter);
-  adapterRef.current = adapter;
+  useInsertionEffect(() => {
+    adapterRef.current = adapter;
+  }, [adapter]);
 
   const cloud = adapter.cloud ?? autoCloud;
   const base = useMemo(
-    () => createCloudThreadListAdapter(() => adapterRef.current),
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory branches on the cloud instance; other options are read through the ref
+    () =>
+      createCloudThreadListAdapter(() => ({
+        ...adapterRef.current,
+        cloud,
+      })),
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the factory pins the cloud instance; changing callbacks are read from the committed ref
     [cloud],
   );
 
-  const baseRef = useRef(base);
-  baseRef.current = base;
+  const cloudRef = useMemo(
+    () => ({
+      get current() {
+        return adapterRef.current.cloud ?? autoCloud!;
+      },
+    }),
+    [],
+  );
 
-  const unstable_useAdapters = useCallback(function useCloudAdapters() {
-    return baseRef.current.unstable_useAdapters!() as RuntimeAdapters;
-  }, []);
+  const unstable_useAdapters = useCallback(
+    function useCloudAdapters() {
+      return useCloudRuntimeAdapters(cloudRef);
+    },
+    [cloudRef],
+  );
 
   return useMemo<RemoteThreadListAdapter>(() => {
     if (base.unstable_useAdapters === undefined) return base;


### PR DESCRIPTION
## Summary

- publish changing Cloud adapter options only after React commits their render
- keep list operations bound to the Cloud instance from the adapter render that created them
- keep history and attachment adapters reading the latest committed Cloud instance

## Why

`useCloudThreadListAdapter` updated shared refs during render. If React rendered a workspace B update and then abandoned it, the still-committed workspace A adapter could read B's callbacks and runtime adapters.

A focused reproduction kept A committed, suspended a B transition, and then deleted an A thread. Before this fix, B's custom delete callback ran while the backend deletion still went through A's Cloud client. History and attachment adapters shared the same unsafe publication path.

This is an uncovered Cloud-specific instance of the interrupted-render problem tracked in #6486. PR #6493 addresses other runtime hooks but does not touch this adapter.

## Testing

- `pnpm --filter @assistant-ui/core test` (1,554 tests)
- `pnpm --filter @assistant-ui/core test:react-compiler` (9 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm exec oxlint`
- `pnpm exec oxfmt --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nxM8YyDPLXbiyM_hTAy2C1r61eOWWCiLkyJe23LlDn6ldBFTxxVUrtqPhDM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->