### PR TITLE
fix(ci): run changeset semver checker from the PR base

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -25,6 +25,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Checkout PR base checker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .changeset-checker-base
+
       - name: Setup pnpm and node.js
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # ratchet:pnpm/setup@v2.1.0
         with:
@@ -32,10 +38,12 @@ jobs:
           install: false
 
       - name: Test the changeset checker
-        run: node --test scripts/check-changesets.test.mjs
+        run: node --test .changeset-checker-base/scripts/check-changesets.test.mjs
 
       - name: Verify changesets only name releasable packages
-        run: node scripts/check-changesets.mjs
+        env:
+          CHANGESET_CHECK_ROOT: ${{ github.workspace }}
+        run: node .changeset-checker-base/scripts/check-changesets.mjs
 
       - name: Check changeset bump types against package versions
         id: check

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -250,4 +256,68 @@ test("the executable reports the offending line and exits 1", () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+function readSemverWorkflow() {
+  return readFileSync(
+    path.join(repoRoot, ".github/workflows/changeset-semver-check.yaml"),
+    "utf8",
+  );
+}
+
+function checkerRunCommands(workflow) {
+  return [...workflow.matchAll(/^[ \t]+run:[ \t]*(.+)$/gm)]
+    .map((match) => match[1].trim())
+    .filter((command) => command.includes("check-changesets"));
+}
+
+test("CI checks out the PR base so older branches still have the checker", () => {
+  const workflow = readSemverWorkflow();
+  assert.match(
+    workflow,
+    /ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+  );
+  assert.match(
+    workflow,
+    /fetch-depth:\s*0/,
+    "the semver git diff needs the PR-head history",
+  );
+  assert.match(
+    workflow,
+    /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
+    "scripts must come from the base so a branch forked before the checker still runs",
+  );
+});
+
+test("CI runs the base checker against PR-head data, not the PR's own copy", () => {
+  const workflow = readSemverWorkflow();
+  const commands = checkerRunCommands(workflow);
+  assert.ok(
+    commands.some((command) => command.includes("check-changesets.test.mjs")),
+  );
+  assert.ok(
+    commands.some(
+      (command) =>
+        /check-changesets\.mjs/.test(command) && !command.includes(".test.mjs"),
+    ),
+  );
+
+  for (const command of commands) {
+    assert.doesNotMatch(
+      command,
+      /(?:^|\s)node(?:\s+--test)?\s+scripts\/check-changesets/,
+      `must not execute the PR-head copy of the checker: ${command}`,
+    );
+    assert.match(
+      command,
+      /(?:^|\s)node(?:\s+--test)?\s+\S+\/scripts\/check-changesets/,
+      `must invoke the checker from the base checkout: ${command}`,
+    );
+  }
+
+  assert.match(
+    workflow,
+    /CHANGESET_CHECK_ROOT:\s*(?:\$GITHUB_WORKSPACE|\$\{\{\s*github\.workspace\s*\}\})/,
+    "the base checker must scan the PR-head workspace",
+  );
 });


### PR DESCRIPTION
## Summary
Changeset Semver Check was checking out the PR head and running `scripts/check-changesets.*` from that tree. Branches forked before the checker was added fail with a missing-file error, and a PR can rewrite the validator that is supposed to gate it.

This keeps the full-depth PR-head checkout for changeset files and `git diff`, checks out the PR base into `.changeset-checker-base`, and runs the base checker against the PR-head workspace via `CHANGESET_CHECK_ROOT`.

Fixes #6582

## Test plan
- [x] `node --test scripts/check-changesets.test.mjs` (Node >= 24) — 15 pass, including two new workflow-contract tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.e1hsyD3kHHkAKS57hs84Un5zqUocqGPAyOZwXo-IB7IungTOAEKgW-Tz9o8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->