### PR TITLE
fix(assistant-stream): preserve valid generic file parts

### DIFF
--- a/.changeset/quiet-files-smile.md
+++ b/.changeset/quiet-files-smile.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: preserve zero-byte files in generic messages
+fix: preserve valid files with empty payload or MIME values

--- a/.changeset/quiet-files-smile.md
+++ b/.changeset/quiet-files-smile.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: preserve zero-byte files in generic messages

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -147,7 +147,10 @@ describe("toGenericMessages", () => {
       ]);
     });
 
-    it("falls back when a file MIME type is empty", () => {
+    it.each([
+      { label: "empty", mimeType: "" },
+      { label: "missing", mimeType: undefined },
+    ])("falls back when a file MIME type is $label", ({ mimeType }) => {
       const result = toGenericMessages([
         {
           role: "user",
@@ -155,7 +158,7 @@ describe("toGenericMessages", () => {
             {
               type: "file",
               data: "https://cdn.example.com/untyped-file",
-              mimeType: "",
+              ...(mimeType !== undefined && { mimeType }),
               filename: "untyped-file",
             },
           ],
@@ -194,6 +197,29 @@ describe("toGenericMessages", () => {
               type: "file",
               data: new URL(data),
               mediaType: "text/plain",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("does not infer a MIME type from a malformed data URL", () => {
+      const data = "data:text/plain";
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [{ type: "file", data, mimeType: "" }],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: new URL(data),
+              mediaType: "application/octet-stream",
             },
           ],
         },
@@ -289,7 +315,6 @@ describe("toGenericMessages", () => {
           content: [
             { type: "text", text: "Valid" },
             { type: "image" }, // missing image property
-            { type: "file", data: "some-data" }, // missing mimeType
             { type: "unknown" },
           ],
         },

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -130,7 +130,7 @@ describe("toGenericMessages", () => {
             },
           ],
         },
-      ] as never);
+      ]);
 
       expect(result).toEqual([
         {
@@ -141,6 +141,59 @@ describe("toGenericMessages", () => {
               data: "",
               mediaType: "text/plain",
               filename: "empty.txt",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("falls back when a file MIME type is empty", () => {
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: "https://cdn.example.com/untyped-file",
+              mimeType: "",
+              filename: "untyped-file",
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: new URL("https://cdn.example.com/untyped-file"),
+              mediaType: "application/octet-stream",
+              filename: "untyped-file",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("uses the data URL MIME type when the file MIME type is empty", () => {
+      const data = "data:text/plain;base64,";
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [{ type: "file", data, mimeType: "" }],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: new URL(data),
+              mediaType: "text/plain",
             },
           ],
         },

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -315,6 +315,7 @@ describe("toGenericMessages", () => {
           content: [
             { type: "text", text: "Valid" },
             { type: "image" }, // missing image property
+            { type: "file", data: null } as never,
             { type: "unknown" },
           ],
         },

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -117,6 +117,36 @@ describe("toGenericMessages", () => {
       ]);
     });
 
+    it("preserves zero-byte file parts", () => {
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: "",
+              mimeType: "text/plain",
+              filename: "empty.txt",
+            },
+          ],
+        },
+      ] as never);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: "",
+              mediaType: "text/plain",
+              filename: "empty.txt",
+            },
+          ],
+        },
+      ]);
+    });
+
     it("handles attachments", () => {
       const result = toGenericMessages([
         {

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -223,7 +223,7 @@ function convertUserMessage(
       });
     } else if (
       part.type === "file" &&
-      part.data !== undefined &&
+      typeof part.data === "string" &&
       part.mimeType
     ) {
       content.push({

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -107,7 +107,7 @@ const IMAGE_MEDIA_TYPES: Record<string, string> = {
 };
 
 function getDataUrlMediaType(value: string): string | undefined {
-  return value.match(/^data:([^;,]+)/i)?.[1]?.toLowerCase();
+  return value.match(/^data:([^;,]+)(?:[;,])/i)?.[1]?.toLowerCase();
 }
 
 function inferImageMediaType(url: string): string {
@@ -223,16 +223,12 @@ function convertUserMessage(
         mediaType: inferImageMediaType(part.image),
         ...(part.filename && { filename: part.filename }),
       });
-    } else if (
-      part.type === "file" &&
-      typeof part.data === "string" &&
-      typeof part.mimeType === "string"
-    ) {
+    } else if (part.type === "file" && typeof part.data === "string") {
       content.push({
         type: "file",
         data: toUrlOrString(part.data),
         mediaType:
-          part.mimeType ||
+          (typeof part.mimeType === "string" && part.mimeType) ||
           getDataUrlMediaType(part.data) ||
           "application/octet-stream",
         ...(part.filename && { filename: part.filename }),

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -221,7 +221,11 @@ function convertUserMessage(
         mediaType: inferImageMediaType(part.image),
         ...(part.filename && { filename: part.filename }),
       });
-    } else if (part.type === "file" && part.data && part.mimeType) {
+    } else if (
+      part.type === "file" &&
+      part.data !== undefined &&
+      part.mimeType
+    ) {
       content.push({
         type: "file",
         data: toUrlOrString(part.data),

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -112,8 +112,10 @@ function getDataUrlMediaType(value: string): string | undefined {
 
 function inferImageMediaType(url: string): string {
   // Handle data URLs: data:[<mediatype>][;base64],<data>
-  const dataUrlMediaType = getDataUrlMediaType(url);
-  if (dataUrlMediaType) return dataUrlMediaType;
+  if (/^data:/i.test(url)) {
+    const match = url.match(/^data:([^;,]+)/i);
+    if (match?.[1]) return match[1].toLowerCase();
+  }
 
   // Extract extension from URL path, ignoring query string and hash
   const [pathWithoutParams = ""] = url.split(/[?#]/);

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -106,12 +106,14 @@ const IMAGE_MEDIA_TYPES: Record<string, string> = {
   heif: "image/heif",
 };
 
+function getDataUrlMediaType(value: string): string | undefined {
+  return value.match(/^data:([^;,]+)/i)?.[1]?.toLowerCase();
+}
+
 function inferImageMediaType(url: string): string {
   // Handle data URLs: data:[<mediatype>][;base64],<data>
-  if (/^data:/i.test(url)) {
-    const match = url.match(/^data:([^;,]+)/i);
-    if (match?.[1]) return match[1].toLowerCase();
-  }
+  const dataUrlMediaType = getDataUrlMediaType(url);
+  if (dataUrlMediaType) return dataUrlMediaType;
 
   // Extract extension from URL path, ignoring query string and hash
   const [pathWithoutParams = ""] = url.split(/[?#]/);
@@ -224,12 +226,15 @@ function convertUserMessage(
     } else if (
       part.type === "file" &&
       typeof part.data === "string" &&
-      part.mimeType
+      typeof part.mimeType === "string"
     ) {
       content.push({
         type: "file",
         data: toUrlOrString(part.data),
-        mediaType: part.mimeType,
+        mediaType:
+          part.mimeType ||
+          getDataUrlMediaType(part.data) ||
+          "application/octet-stream",
         ...(part.filename && { filename: part.filename }),
       });
     }


### PR DESCRIPTION
## Summary

- preserve raw empty payloads supplied by custom runtimes or external message history
- preserve file parts with empty or missing MIME metadata by using the data URL declaration or `application/octet-stream`
- keep malformed parts with non-string data filtered
- add regression coverage for zero-byte, untyped, missing-MIME, and malformed-data-URL cases

## Why

`toGenericMessages` accepts structural thread messages from custom runtimes and external history. An empty base64 payload is a valid zero-byte file, but the previous truthiness check discarded it. Built-in local uploads normally wrap zero-byte files in a non-empty data URL, so the raw empty-payload case primarily protects externally supplied messages.

There is also a producer-backed case in the built-in Cloud attachment adapter. It copies `File.type`, which browsers may return as an empty string when the file type is unknown. Custom or non-spec history can omit the optional MIME field entirely. The previous guard discarded either file part and could remove a file-only user message entirely.

The converter now requires file data to be a string and follows the existing media-type policy for empty, missing, or non-string MIME metadata: use a valid data URL declaration when available, then fall back to `application/octet-stream`. Malformed file data URL prefixes do not count as declarations; image inference is unchanged by this PR.

## Testing

- `pnpm --filter assistant-stream exec vitest run src/core/converters/toGenericMessages.test.ts` (45 passed)
- `pnpm --filter assistant-stream test` (both peer matrices: 504 passed, 20 skipped each)
- `pnpm --filter assistant-stream build`
- `pnpm exec oxfmt --check packages/assistant-stream/src/core/converters/toGenericMessages.ts packages/assistant-stream/src/core/converters/toGenericMessages.test.ts .changeset/quiet-files-smile.md`
- `pnpm exec oxlint packages/assistant-stream/src/core/converters/toGenericMessages.ts packages/assistant-stream/src/core/converters/toGenericMessages.test.ts`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.G5l-xdM5gzXbhId1vhcSYuQPrLnCMaiTC7-lLSLsDMf_V0AdvOxV6efqmN0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->