### PR TITLE
test(x-performance): store notification and thread token-cost contracts

### DIFF
--- a/packages/x-performance/package.json
+++ b/packages/x-performance/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@assistant-ui/core": "workspace:*",
+    "@assistant-ui/store": "workspace:*",
     "@assistant-ui/tap": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.18",

--- a/packages/x-performance/src/cli.mjs
+++ b/packages/x-performance/src/cli.mjs
@@ -159,7 +159,9 @@ const ensureRefWorktree = (ref) => {
   const marker = `${wt}.built`;
   if (!existsSync(wt)) {
     if (existsSync(marker)) rmSync(marker);
-    execFileSync("git", ["worktree", "prune"], { cwd: repoRoot });
+    execFileSync("git", ["worktree", "prune", "--expire", "now"], {
+      cwd: repoRoot,
+    });
     console.log(`creating ref worktree for ${ref} (${sha}) at ${wt}`);
     execFileSync("git", ["worktree", "add", "--detach", wt, sha], {
       cwd: repoRoot,
@@ -225,7 +227,8 @@ const trace = async (targets, seconds) => {
   const results = [];
   for (const target of targets) {
     const arg = /^https?:/.test(target) ? target : resolve(target);
-    const hint = basename(new URL(arg, "file:///").pathname);
+    const url = new URL(arg, "file:///");
+    const hint = basename(url.pathname) || url.hostname || arg;
     console.log(`tracing ${hint} for ${seconds}s...`);
     const events = await captureTrace(arg, seconds);
     results.push({

--- a/packages/x-performance/src/ref-packages.mjs
+++ b/packages/x-performance/src/ref-packages.mjs
@@ -1,5 +1,6 @@
 export const REF_PACKAGE_DIRS = {
   "@assistant-ui/tap": "packages/tap",
   "@assistant-ui/core": "packages/core",
+  "@assistant-ui/store": "packages/store",
   "assistant-stream": "packages/assistant-stream",
 };

--- a/packages/x-performance/src/store-notifications.test.tsx
+++ b/packages/x-performance/src/store-notifications.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { createElement, useState, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { resource, flushTapSync } from "@assistant-ui/tap";
+import {
+  AuiConfig,
+  AuiProvider,
+  useAui,
+  useAuiState,
+} from "@assistant-ui/store";
+import { createRenderCounter } from "./render-counter";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = false;
+
+const Slice = resource(() => {
+  const [count, setCount] = useState(0);
+  return { getState: () => ({ count }), setCount };
+});
+
+describe("store notification granularity", () => {
+  it("one slice write re-renders only that slice's subscriber", () => {
+    const counter = createRenderCounter();
+    let aui!: ReturnType<typeof useAui>;
+
+    const SubscriberA = () => {
+      counter.useRender("subscriber-a");
+      const value = useAuiState(
+        (s) => (s as unknown as { a: { count: number } }).a.count,
+      );
+      return createElement("span", null, value);
+    };
+    const SubscriberB = () => {
+      counter.useRender("subscriber-b");
+      const value = useAuiState(
+        (s) => (s as unknown as { b: { count: number } }).b.count,
+      );
+      return createElement("span", null, value);
+    };
+    const Grab = () => {
+      aui = useAui();
+      return null;
+    };
+
+    const config = AuiConfig({
+      a: Slice(),
+      b: Slice(),
+    } as unknown as AuiConfig.Input);
+
+    const App = (): ReactNode => (
+      <AuiProvider config={config}>
+        <Grab />
+        <SubscriberA />
+        <SubscriberB />
+      </AuiProvider>
+    );
+
+    const root = createRoot(document.createElement("div"));
+    flushSync(() => root.render(createElement(App)));
+
+    expect(counter.renders("subscriber-a")).toBe(1);
+    expect(counter.renders("subscriber-b")).toBe(1);
+
+    const client = aui as unknown as {
+      a: { setCount: (n: number) => void };
+      subscribe: (fn: () => void) => () => void;
+    };
+    let notifications = 0;
+    client.subscribe(() => {
+      notifications += 1;
+    });
+
+    flushSync(() => flushTapSync(() => client.a.setCount(1)));
+
+    expect(notifications).toBe(1);
+    expect(counter.renders("subscriber-a")).toBe(2);
+    expect(counter.renders("subscriber-b")).toBe(1);
+
+    flushSync(() => flushTapSync(() => client.a.setCount(1)));
+
+    expect(counter.renders("subscriber-a")).toBe(2);
+    expect(counter.renders("subscriber-b")).toBe(1);
+
+    flushSync(() => root.unmount());
+  });
+});

--- a/packages/x-performance/src/thread-token-cost.test.tsx
+++ b/packages/x-performance/src/thread-token-cost.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { createElement, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { useAuiState } from "@assistant-ui/store";
+import type { ThreadMessageLike } from "@assistant-ui/core";
+import {
+  AssistantRuntimeProvider,
+  MessagePrimitiveParts,
+  ThreadPrimitiveMessages,
+  useExternalStoreRuntime,
+} from "@assistant-ui/core/react";
+import { createRenderCounter } from "./render-counter";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = false;
+
+type Msg = { id: string; role: "user" | "assistant"; text: string };
+
+const convertMessage = (m: Msg): ThreadMessageLike => ({
+  id: m.id,
+  role: m.role,
+  content: [{ type: "text", text: m.text }],
+});
+
+const counter = createRenderCounter();
+
+const Text = ({ text }: { text: string }) => {
+  counter.useRender("text");
+  return createElement("span", null, text);
+};
+
+const Message = () => {
+  const role = useAuiState((s) => s.message.role);
+  counter.useRender(`message:${role}`);
+  return createElement(MessagePrimitiveParts, { components: { Text } });
+};
+
+const COMPONENTS = { Message };
+
+describe("thread token cost", () => {
+  it("appending a token re-renders only the streaming message's text part", () => {
+    counter.reset();
+    let setMessages!: (updater: (prev: Msg[]) => Msg[]) => void;
+
+    const App = () => {
+      const [messages, set] = useState<Msg[]>([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "" },
+      ]);
+      setMessages = set;
+      const runtime = useExternalStoreRuntime<Msg>({
+        messages,
+        convertMessage,
+        onNew: async () => {},
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {counter.wrapCommits(
+            "thread",
+            <ThreadPrimitiveMessages components={COMPONENTS} />,
+          )}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const root = createRoot(document.createElement("div"));
+    flushSync(() => root.render(createElement(App)));
+
+    const mounted = counter.snapshot();
+
+    const TOKENS = 20;
+    for (let i = 0; i < TOKENS; i++) {
+      flushSync(() =>
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === "a1" ? { ...m, text: `${m.text}tok ` } : m,
+          ),
+        ),
+      );
+    }
+
+    const after = counter.snapshot();
+    const delta = Object.fromEntries(
+      Object.entries(after).map(([k, v]) => [k, v - (mounted[k] ?? 0)]),
+    );
+
+    expect(delta["renders:text"]).toBe(TOKENS);
+    expect(delta["renders:message:assistant"] ?? 0).toBe(0);
+    expect(delta["renders:message:user"] ?? 0).toBe(0);
+    expect(delta["commits:thread"]).toBe(2 * TOKENS);
+
+    expect(mounted).toEqual({
+      "renders:text": 1,
+      "renders:message:assistant": 1,
+      "renders:message:user": 1,
+      "commits:thread": 1,
+    });
+
+    flushSync(() => root.unmount());
+  });
+});

--- a/packages/x-performance/vitest.config.ts
+++ b/packages/x-performance/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       deps: {
         // Benches import built packages; serve dist as plain Node modules so
         // vitest's evaluator doesn't skew numbers.
-        external: [/\/packages\/(tap|core|assistant-stream)\/dist\//],
+        external: [/\/packages\/(tap|core|store|assistant-stream)\/dist\//],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5427,6 +5427,9 @@ importers:
       '@assistant-ui/core':
         specifier: workspace:*
         version: link:../core
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../store
       '@assistant-ui/tap':
         specifier: workspace:*
         version: link:../tap


### PR DESCRIPTION
## summary

- adds the first two deterministic performance contracts, written as ordinary vitest tests asserting exact integers so they can gate CI with zero timing noise
- store granularity contract: two `resource` slices under `AuiProvider config=`, one `flushSync(flushTapSync(...))` write produces exactly 1 synchronous notification, re-renders only that slice's subscriber (2 vs 1), and a same-value write re-renders nothing
- thread token-cost contract (the flagship): an external-store runtime with `ThreadPrimitiveMessages` and a headless core `Text` slot, 20 `flushSync` token appends produce exactly +20 `Text` renders, +0 renders for both message wrappers (a role selector does not fire on content changes), and +40 React commits; the 2-commits-per-token pipeline shape (host setState commit, then the passive-effect adapter push into the runtime triggering a second synchronous store-notification commit) is now pinned, so collapsing it to 1 shows up as an improvement and a third commit shows up red
- wires `@assistant-ui/store` into the measured set: devDependency, `server.deps.external` (an inlined duplicate would split the assistant context and `useAui` would not see the provider), and `REF_PACKAGE_DIRS` so `--ref` runs resolve the store from the ref worktree too; also lands the two papercuts deferred from #6584 (URL trace targets fall back to hostname for the label, `worktree prune --expire now` so a tmp-reaped ref worktree cannot stay registered and block the next add)

## test plan

### already verified

- [x] `pnpm exec vitest run` -> 5 files / 10 tests green, including both new contracts with exact-integer assertions
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` -> clean, oxlint/oxfmt -> clean
- [x] contracts run against built dists (store/core/tap/assistant-stream externalized), mount snapshot pinned (empty assistant message renders no text part)

### reviewer should verify

- [ ] `pnpm -C packages/x-performance test` on a fresh checkout after `pnpm turbo run build --filter=@assistant-ui/store --filter=@assistant-ui/core --filter=@assistant-ui/tap --filter=assistant-stream` -> 10/10

## notes

- the 2-commits-per-token shape is documented behavior of the external-store pipeline, not a bug being asserted as good; the contract exists so a change in either direction is visible
- remaining roadmap item after this: a CI informational job for the wall-time benches

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.t4Zu6RpXfo40N40bbO47NdOXG78ssITsW3_mzl5tfRxKktRal1j2vx4P_tI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->