### PR TITLE
fix(ci): check out the pr merge ref in changeset semver check

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -19,10 +19,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 2
     steps:
-      - name: Checkout PR head
+      - name: Checkout PR merge ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup pnpm and node.js


### PR DESCRIPTION
## Problem

`Changeset Semver Check` goes red on every open PR whose branch forked before #6574, with `Could not find 'scripts/check-changesets.test.mjs'`. #6581 hit it; the only way out was `gh pr update-branch`. the failure has nothing to do with the PR being checked, so it reads as a broken repo to the author.

closes #6582.

## Root cause

the job pinned the checkout to the PR head:

```yaml
- name: Checkout PR head
  uses: actions/checkout@...
  with:
    ref: ${{ github.event.pull_request.head.sha }}
    fetch-depth: 0
```

and then ran `node --test scripts/check-changesets.test.mjs` and `node scripts/check-changesets.mjs` out of that tree. those files landed in `dc90e7739`, so any branch forked earlier simply does not have them.

this is also the only `pull_request` job in the repo that pins a ref. all four jobs in `code-quality.yaml` use a bare `actions/checkout`, which resolves to `refs/pull/N/merge`.

## Change

drop the `ref:` line and let `actions/checkout` take the default merge ref. the merged tree carries the base's `scripts/` and the PR's `.changeset/` at once, so the checker always exists no matter how old the branch is.

nothing else in the job needed adjusting:

- `git diff BASE_SHA HEAD_SHA -- .changeset/*.md` still resolves. both commits are ancestors of the merge commit and `fetch-depth: 0` fetches them, including for fork PRs (the `Build Changed Packages` job already relies on the same property for `...[origin/main]`).
- `packages/*/package.json` is now read post-merge, which is the version set the bump types are actually compared against.
- `node --test scripts/check-changesets.test.mjs` now exercises the merged checker rather than the head's copy, which is the version that will exist after merge.

the second half of #6582, that a PR is validated by its own copy of the checker, is not addressed and is not addressable this way: for `pull_request`, GitHub runs the workflow file from the merge commit, so a PR can rewrite `changeset-semver-check.yaml` itself. the base checkout buys no tamper resistance while the workflow is head-controlled. the guard that actually matters is the test step, and it keeps running on every PR.

supersedes #6588, which fixed the same bug by adding a second checkout of the base into `.changeset-checker-base` and running the checker from there. that pointed the test step at the base's own test file, so it became base-tests-base and a PR breaking `scripts/check-changesets.mjs` would have merged green.

## Verification

- `node --test scripts/check-changesets.test.mjs` — 13 pass
- `node scripts/check-changesets.mjs` — clean
- the reproduction is this workflow file itself: on any branch forked before `dc90e7739` the job fails at the test step before the fix, and resolves the checker from the merged tree after it.

## Public surface

None. CI workflow only, no published package touched, no changeset needed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Js0DWC2ZzAqPYhS19I8E-gOXzZDekRRM_rwOlWeIBnb_291cAwj3RZvX5m0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->