### PR TITLE
test(x-performance): pin the commit-shape rationale and real subscribe type

### DIFF
--- a/packages/x-performance/src/store-notifications.test.tsx
+++ b/packages/x-performance/src/store-notifications.test.tsx
@@ -65,10 +65,9 @@ describe("store notification granularity", () => {
 
     const client = aui as unknown as {
       a: { setCount: (n: number) => void };
-      subscribe: (fn: () => void) => () => void;
     };
     let notifications = 0;
-    client.subscribe(() => {
+    aui.subscribe(() => {
       notifications += 1;
     });
 

--- a/packages/x-performance/src/thread-token-cost.test.tsx
+++ b/packages/x-performance/src/thread-token-cost.test.tsx
@@ -89,6 +89,9 @@ describe("thread token cost", () => {
     expect(delta["renders:text"]).toBe(TOKENS);
     expect(delta["renders:message:assistant"] ?? 0).toBe(0);
     expect(delta["renders:message:user"] ?? 0).toBe(0);
+    // Two commits per append: the host setState commit, then the passive-effect
+    // adapter push whose store notification React flushes inside the same
+    // discrete flushSync. A React scheduling change moves this number alone.
     expect(delta["commits:thread"]).toBe(2 * TOKENS);
 
     expect(mounted).toEqual({


### PR DESCRIPTION
## summary

- follows up on the two review threads posted to #6592 after it merged
- the 2-commits-per-token assertion now carries the mechanism as a comment (host setState commit, then the passive-effect adapter push flushed inside the same discrete flushSync), so a React scheduling change that moves the number is diagnosable without rediscovering the pipeline shape
- the store contract subscribes through the real `AssistantClient.subscribe` instead of a fabricated cast, so a signature change breaks at compile time; only the fabricated test scope stays behind the cast

no test plan, comment and type-narrowing deltas on tests only (`pnpm exec vitest run` -> 10/10, tsc clean, verified before push)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JSb9H3P3KiVd8lbg3O8Em5qpCjLy66xiw90rSIL1-zWcYqneewPwOSmIpRo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->