### PR TITLE
fix: preserve thread list item identity

### DIFF
--- a/.changeset/calm-threads-remember.md
+++ b/.changeset/calm-threads-remember.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve thread list item state when preceding threads are removed

--- a/packages/core/src/react/primitives/threadList/ThreadListItems.test.tsx
+++ b/packages/core/src/react/primitives/threadList/ThreadListItems.test.tsx
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadListItemState } from "../../../store/scopes/thread-list-item";
+
+const mocks = vi.hoisted(() => ({
+  threadItems: [] as ThreadListItemState[],
+  archivedThreadItems: [] as ThreadListItemState[],
+  aui: {
+    threads: {
+      item: ({ index, archived }: { index: number; archived?: boolean }) => ({
+        getState: () =>
+          archived
+            ? mocks.archivedThreadItems[index]
+            : mocks.threadItems[index],
+      }),
+    },
+  },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({
+      threads: {
+        threadIds: mocks.threadItems.map((item) => item.id),
+        archivedThreadIds: mocks.archivedThreadItems.map((item) => item.id),
+      },
+    }),
+  RenderChildrenWithAccessor: ({
+    getItemState,
+    children,
+  }: {
+    getItemState: (aui: typeof mocks.aui) => ThreadListItemState;
+    children: (getItem: () => ThreadListItemState) => ReactNode;
+  }) => children(() => getItemState(mocks.aui)),
+}));
+
+vi.mock("../../providers/ThreadListItemByIndexProvider", () => ({
+  ThreadListItemByIndexProvider: ({ children }: { children: ReactNode }) =>
+    children,
+}));
+
+import { ThreadListPrimitiveItems } from "./ThreadListItems";
+
+const threadItem = (id: string, title: string): ThreadListItemState => ({
+  id,
+  remoteId: id,
+  externalId: undefined,
+  title,
+  status: "regular",
+  isRunning: false,
+});
+
+const StatefulThreadItem = ({
+  threadListItem,
+}: {
+  threadListItem: ThreadListItemState;
+}) => {
+  const [initialTitle] = useState(threadListItem.title);
+  return <span>{initialTitle}</span>;
+};
+
+describe("ThreadListPrimitiveItems", () => {
+  it("does not reuse component state for a different thread", () => {
+    mocks.threadItems = [
+      threadItem("first", "First thread"),
+      threadItem("second", "Second thread"),
+    ];
+
+    const view = render(
+      <ThreadListPrimitiveItems>
+        {({ threadListItem }) => (
+          <StatefulThreadItem threadListItem={threadListItem} />
+        )}
+      </ThreadListPrimitiveItems>,
+    );
+
+    mocks.threadItems = [mocks.threadItems[1]!];
+    view.rerender(
+      <ThreadListPrimitiveItems>
+        {({ threadListItem }) => (
+          <StatefulThreadItem threadListItem={threadListItem} />
+        )}
+      </ThreadListPrimitiveItems>,
+    );
+
+    expect(screen.queryByText("Second thread")).not.toBeNull();
+    expect(screen.queryByText("First thread")).toBeNull();
+  });
+});

--- a/packages/core/src/react/primitives/threadList/ThreadListItems.test.tsx
+++ b/packages/core/src/react/primitives/threadList/ThreadListItems.test.tsx
@@ -38,10 +38,16 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   }) => children(() => getItemState(mocks.aui)),
 }));
 
-vi.mock("../../providers/ThreadListItemByIndexProvider", () => ({
-  ThreadListItemByIndexProvider: ({ children }: { children: ReactNode }) =>
-    children,
-}));
+vi.mock(
+  "../../providers/ThreadListItemByIndexProvider",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("../../providers/ThreadListItemByIndexProvider")
+    >()),
+    ThreadListItemByIndexProvider: ({ children }: { children: ReactNode }) =>
+      children,
+  }),
+);
 
 import { ThreadListPrimitiveItems } from "./ThreadListItems";
 

--- a/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
+++ b/packages/core/src/react/primitives/threadList/ThreadListItems.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
 } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import type { ThreadListItemState } from "../../../store/scopes/thread-list-item";
 import { ThreadListItemByIndexProvider } from "../../providers/ThreadListItemByIndexProvider";
 
@@ -64,15 +65,17 @@ const ThreadListPrimitiveItemsInner: FC<{
   archived: boolean;
   children: (value: { threadListItem: ThreadListItemState }) => ReactNode;
 }> = ({ archived, children }) => {
-  const contentLength = useAuiState((s) =>
-    archived ? s.threads.archivedThreadIds.length : s.threads.threadIds.length,
+  const threadIds = useAuiState(
+    useShallowSelector((s) =>
+      archived ? s.threads.archivedThreadIds : s.threads.threadIds,
+    ),
   );
 
   return useMemo(
     () =>
-      Array.from({ length: contentLength }, (_, index) => (
+      threadIds.map((threadId, index) => (
         <ThreadListItemByIndexProvider
-          key={index}
+          key={threadId}
           index={index}
           archived={archived}
         >
@@ -91,7 +94,7 @@ const ThreadListPrimitiveItemsInner: FC<{
           </RenderChildrenWithAccessor>
         </ThreadListItemByIndexProvider>
       )),
-    [contentLength, archived, children],
+    [threadIds, archived, children],
   );
 };
 

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -16,6 +16,7 @@ import {
   ThreadListPrimitiveItems,
   ThreadListPrimitiveNew,
 } from "../primitives/threadList";
+import { useAuiState } from "../useAuiState";
 
 type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
 type DemoThread = { id: string; title: string; messages: DemoMessage[] };
@@ -72,7 +73,14 @@ const createMultiThreadRuntime = () => {
   const core = new ExternalStoreRuntimeCore(makeAdapter());
   const runtime = new AssistantRuntimeImpl(core);
   const sync = () => core.setAdapter(makeAdapter());
-  return { runtime, onSwitchToThread, onSwitchToNewThread };
+  const removeThread = (threadId: string) => {
+    threads = threads.filter((thread) => thread.id !== threadId);
+    if (!threads.some((thread) => thread.id === currentId)) {
+      currentId = threads[0]!.id;
+    }
+    sync();
+  };
+  return { runtime, onSwitchToThread, onSwitchToNewThread, removeThread };
 };
 
 const SidebarView = defineComponent({
@@ -120,6 +128,40 @@ describe("thread list primitives", () => {
     expect(
       [...el.querySelectorAll("button.item")].map((item) => item.textContent),
     ).toEqual(["First thread", "Second thread"]);
+
+    unmount();
+  });
+
+  it("keeps component state with a thread after an earlier row is removed", async () => {
+    const { runtime, removeThread } = createMultiThreadRuntime();
+    const useStatefulItem = () => {
+      const initialTitle = useAuiState((s) => s.threadListItem.title).value;
+      return () => h("span", { class: "stateful-item" }, initialTitle);
+    };
+    const StatefulItem = defineComponent({
+      setup: useStatefulItem,
+    });
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadListPrimitiveItems, null, {
+          default: () => h(StatefulItem),
+        }),
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll(".stateful-item")).toHaveLength(2);
+    });
+
+    removeThread("t1");
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll(".stateful-item")).toHaveLength(1);
+    });
+    expect(el.querySelector(".stateful-item")!.textContent).toBe(
+      "Second thread",
+    );
 
     unmount();
   });

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -94,16 +94,14 @@ export const ThreadListPrimitiveItems = defineComponent({
   },
   slots: Object as SlotsType<{ default?: () => VNodeChild[] }>,
   setup(props, { slots }) {
-    const count = useAuiState((s) =>
-      props.archived
-        ? s.threads.archivedThreadIds.length
-        : s.threads.threadIds.length,
+    const threadIds = useAuiState((s) =>
+      props.archived ? s.threads.archivedThreadIds : s.threads.threadIds,
     );
     return () =>
-      Array.from({ length: count.value }, (_, index) =>
+      threadIds.value.map((threadId, index) =>
         h(
           ThreadListItemByIndexProvider,
-          { index, archived: props.archived, key: index },
+          { index, archived: props.archived, key: threadId },
           { default: () => slots.default?.() },
         ),
       );


### PR DESCRIPTION
## Problem

`ThreadListPrimitive.Items` keyed rows by their array index in both the core React primitive and the Vue primitive. Deleting or archiving an earlier thread could therefore move mounted row state, such as an inline rename value or open menu, onto a different thread. This is the thread-list slice of #6570.

## Root cause

The positional key described where a row was, while the index provider resolved whichever thread currently occupied that position. After removing index `0`, React or Vue could retain the old component instance at index `0` but scope it to the former index `1` thread.

## Change

Select the regular or archived thread ID list, key each row provider by its thread ID, and continue passing the current index for lookup. The same behavior now applies to the core React and Vue primitives. Suggestions and ID-less message parts still need the identity decision described in #6570 and remain out of scope.

## Reproduction

The React and Vue regressions render thread rows through stateful children, remove the leading thread, and assert that the surviving row retains the second thread's state. With `key={index}`, the surviving row displays the removed first thread's captured state.

## Verification

- `@assistant-ui/core`: 153 test files and 1,555 tests passed
- `@assistant-ui/core` build passed
- `@assistant-ui/vue`: 19 test files and 107 tests passed
- `@assistant-ui/vue` build passed
- focused oxlint and oxfmt checks passed
- patch changeset for `@assistant-ui/core` included; `@assistant-ui/vue` is private

## Public surface

No exports, props, or lookup semantics change. The behavior change is limited to component reconciliation identity. A locally-created remote thread can still change from its local ID to its server ID during a full list replacement; stabilizing that transition requires a store-level render identity and is intentionally deferred.