### PR TITLE
fix(react-mcp): protect OAuth callbacks from auto-connect

### DIFF
--- a/.changeset/tidy-auth-callbacks.md
+++ b/.changeset/tidy-auth-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: keep saved-token auto-connect from interrupting OAuth callbacks

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -603,6 +603,51 @@ describe("McpServerResource completeAuth", () => {
     }
   });
 
+  it("resumes auto-connect when callback validation fails", async () => {
+    const pendingLoads: Array<
+      (value: { state?: string; tokens?: { access_token: string } }) => void
+    > = [];
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pendingLoads.push(resolve);
+        }),
+    );
+    const root = mount({
+      auth: { type: "oauth" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitFor(() => pendingLoads.length > 1);
+      const callbackLoadIndex = pendingLoads.length;
+      const completeAuth = root
+        .getValue()
+        .completeAuth("https://example.com/callback?code=abc&state=expected");
+      await waitFor(() => pendingLoads.length > callbackLoadIndex);
+
+      for (const resolve of pendingLoads.slice(0, callbackLoadIndex)) {
+        resolve({ tokens: { access_token: "persisted" } });
+      }
+      await flushMacrotask();
+
+      expect(mocks.StreamableHTTPClientTransport).not.toHaveBeenCalled();
+
+      pendingLoads[callbackLoadIndex]!({ state: "different" });
+      await expect(completeAuth).rejects.toThrow(
+        "OAuth state does not match the authorization request",
+      );
+      await waitFor(() => mocks.transports.length === 1);
+      await waitForResourceUpdate(
+        () => root.getValue().getState().connectionState === "connected",
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("completes auth across the StrictMode effect replay", async () => {
     const storage = createStorage();
     vi.mocked(storage.loadAuthState).mockResolvedValue({

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -559,6 +559,50 @@ describe("McpServerResource connection lifecycle", () => {
 describe("McpServerResource completeAuth", () => {
   beforeEach(resetMocks);
 
+  it("lets callback validation win over mount-time auto-connect", async () => {
+    const pendingLoads: Array<
+      (value: { state?: string; tokens?: { access_token: string } }) => void
+    > = [];
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pendingLoads.push(resolve);
+        }),
+    );
+    const root = mount({
+      auth: { type: "oauth" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitFor(() => pendingLoads.length > 1);
+      const callbackLoadIndex = pendingLoads.length;
+      const completeAuth = root
+        .getValue()
+        .completeAuth("https://example.com/callback?code=abc&state=expected");
+      await waitFor(() => pendingLoads.length > callbackLoadIndex);
+
+      for (const resolve of pendingLoads.slice(0, callbackLoadIndex)) {
+        resolve({ tokens: { access_token: "persisted" } });
+      }
+      await flushMacrotask();
+
+      expect(mocks.StreamableHTTPClientTransport).not.toHaveBeenCalled();
+
+      pendingLoads[callbackLoadIndex]!({ state: "expected" });
+      await expect(completeAuth).resolves.toBeUndefined();
+      await flushMacrotask();
+
+      expect(mocks.transports).toHaveLength(1);
+      expect(mocks.transports[0].finishAuth).toHaveBeenCalledTimes(1);
+      expect(root.getValue().getState().connectionState).toBe("connected");
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("completes auth across the StrictMode effect replay", async () => {
     const storage = createStorage();
     vi.mocked(storage.loadAuthState).mockResolvedValue({

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -505,13 +505,12 @@ const useMcpServerResourceInstance = (
     } finally {
       pendingAuthValidation.count -= 1;
       if (pendingAuthValidation.count === 0) {
-        if (pendingAuthValidationRef.current === pendingAuthValidation) {
-          pendingAuthValidationRef.current = null;
-        }
+        pendingAuthValidationRef.current = null;
         pendingAuthValidation.resolve();
       }
     }
 
+    // Claim the generation before a waiting auto-connect can resume.
     const generation = ++connectionGenerationRef.current;
     cancelPendingElicitations();
     await closePendingTransport();

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -105,7 +105,11 @@ const useMcpServerResourceInstance = (
     null,
   );
   const connectionGenerationRef = useRef(0);
-  const pendingAuthValidationCountRef = useRef(0);
+  const pendingAuthValidationRef = useRef<{
+    count: number;
+    promise: Promise<void>;
+    resolve: () => void;
+  } | null>(null);
   const elicitationResolversRef = useRef(
     new Map<
       string,
@@ -472,7 +476,16 @@ const useMcpServerResourceInstance = (
     const url = new URL(callbackUrl);
     const state = url.searchParams.get("state");
     if (!state) throw new Error('missing "state" parameter');
-    pendingAuthValidationCountRef.current += 1;
+    let pendingAuthValidation = pendingAuthValidationRef.current;
+    if (!pendingAuthValidation) {
+      let resolve!: () => void;
+      const promise = new Promise<void>((resolvePromise) => {
+        resolve = resolvePromise;
+      });
+      pendingAuthValidation = { count: 0, promise, resolve };
+      pendingAuthValidationRef.current = pendingAuthValidation;
+    }
+    pendingAuthValidation.count += 1;
     try {
       const persisted = await props.storage.loadAuthState(props.id);
       if (!isCurrentConnection(validationGeneration)) {
@@ -490,7 +503,13 @@ const useMcpServerResourceInstance = (
         throw new Error("missing authorization code in callback URL");
       }
     } finally {
-      pendingAuthValidationCountRef.current -= 1;
+      pendingAuthValidation.count -= 1;
+      if (pendingAuthValidation.count === 0) {
+        if (pendingAuthValidationRef.current === pendingAuthValidation) {
+          pendingAuthValidationRef.current = null;
+        }
+        pendingAuthValidation.resolve();
+      }
     }
 
     const generation = ++connectionGenerationRef.current;
@@ -562,7 +581,11 @@ const useMcpServerResourceInstance = (
       } else if (!persisted?.token) {
         return;
       }
-      if (pendingAuthValidationCountRef.current > 0) return;
+      const pendingAuthValidation = pendingAuthValidationRef.current;
+      if (pendingAuthValidation) {
+        await pendingAuthValidation.promise;
+        if (signal.cancelled || !isCurrentConnection(generation)) return;
+      }
       void doConnect();
     },
   );

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -105,6 +105,7 @@ const useMcpServerResourceInstance = (
     null,
   );
   const connectionGenerationRef = useRef(0);
+  const pendingAuthValidationCountRef = useRef(0);
   const elicitationResolversRef = useRef(
     new Map<
       string,
@@ -471,18 +472,25 @@ const useMcpServerResourceInstance = (
     const url = new URL(callbackUrl);
     const state = url.searchParams.get("state");
     if (!state) throw new Error('missing "state" parameter');
-    const persisted = await props.storage.loadAuthState(props.id);
-    if (!isCurrentConnection(validationGeneration)) {
-      throw createInterruptedAuthError();
-    }
-    if (!persisted?.state) {
-      throw new Error("no pending OAuth authorization request for this server");
-    }
-    if (persisted.state !== state) {
-      throw new Error("OAuth state does not match the authorization request");
-    }
-    if (!url.searchParams.get("code") && !url.searchParams.get("error")) {
-      throw new Error("missing authorization code in callback URL");
+    pendingAuthValidationCountRef.current += 1;
+    try {
+      const persisted = await props.storage.loadAuthState(props.id);
+      if (!isCurrentConnection(validationGeneration)) {
+        throw createInterruptedAuthError();
+      }
+      if (!persisted?.state) {
+        throw new Error(
+          "no pending OAuth authorization request for this server",
+        );
+      }
+      if (persisted.state !== state) {
+        throw new Error("OAuth state does not match the authorization request");
+      }
+      if (!url.searchParams.get("code") && !url.searchParams.get("error")) {
+        throw new Error("missing authorization code in callback URL");
+      }
+    } finally {
+      pendingAuthValidationCountRef.current -= 1;
     }
 
     const generation = ++connectionGenerationRef.current;
@@ -554,6 +562,7 @@ const useMcpServerResourceInstance = (
       } else if (!persisted?.token) {
         return;
       }
+      if (pendingAuthValidationCountRef.current > 0) return;
       void doConnect();
     },
   );


### PR DESCRIPTION
## Problem

A valid MCP OAuth callback could race with mount-time saved-token auto-connect. If auto-connect loaded persisted tokens first, it advanced the connection generation and caused callback completion to fail before `finishAuth`. This is the race reported in #6535.

## Root cause

Callback validation and auto-connect both read OAuth storage asynchronously during mount. Nothing represented the callback's validation window, so resolution order rather than validity determined which flow claimed the connection.

## Change

Register callback validation before its asynchronous storage read and make saved-token auto-connect wait for all pending validation. A valid callback advances the connection generation before the waiter resumes, fencing out auto-connect. A rejected callback leaves the generation unchanged, allowing the saved-token connection to continue.

## Reproduction

The added tests defer the storage reads to control their order. One resolves auto-connect while a valid callback is still validating and verifies that only callback completion connects. The mirror case supplies an invalid callback with usable persisted tokens and verifies that auto-connect resumes after validation rejects.

## Verification

- `@assistant-ui/react-mcp`: 12 test files and 161 tests passed
- package build passed
- focused formatting and lint checks passed with no new errors
- all CI checks pass
- patch changeset included

## Public surface

No exports or public types change. The behavior change is limited to coordinating the existing callback-completion and saved-token auto-connect paths.