### PR TITLE
fix(react-devtools): isolate unreadable model context fields

### DIFF
--- a/.changeset/bright-devtools-survive.md
+++ b/.changeset/bright-devtools-survive.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: preserve readable model context when individual properties throw

--- a/packages/react-devtools/src/data/projectApi.test.ts
+++ b/packages/react-devtools/src/data/projectApi.test.ts
@@ -77,6 +77,45 @@ describe("projectApi", () => {
     expect(result.modelContext).toEqual({ system: "be nice" });
   });
 
+  it("keeps readable model-context fields when others are unreadable", () => {
+    const tools = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("tools unavailable");
+        },
+      },
+    );
+    const modelContext = {
+      tools,
+      config: { model: "test-model" },
+    };
+    Object.defineProperty(modelContext, "system", {
+      get: () => {
+        throw new Error("system unavailable");
+      },
+    });
+    const thread = scope(
+      "root",
+      {},
+      {
+        getState: () => ({ messages: [], isRunning: false }),
+        getModelContext: () => modelContext,
+      },
+    );
+
+    const projected = projectApi(1, {
+      api: { thread },
+      logs: [],
+    } as unknown as Parameters<typeof projectApi>[1]);
+
+    expect(projected.modelContext).toEqual({
+      system: "[Unserializable]",
+      tools: [{ name: "[Unserializable]" }],
+      config: { model: "test-model" },
+    });
+  });
+
   it("keeps event-log timestamps as Date instances", () => {
     expect(result.logs[0]?.time).toBeInstanceOf(Date);
     expect(result.logs[0]?.event).toBe("thread.run-start");

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -121,13 +121,20 @@ describe("sanitizeForMessage", () => {
         throw new Error("key conversion failed");
       },
     };
+    const secondBrokenKey = {
+      toString: () => {
+        throw new Error("key conversion failed");
+      },
+    };
     const value = new Map<unknown, unknown>([
       [brokenKey, "broken key value"],
+      [secondBrokenKey, "second broken key value"],
       ["readable", "readable value"],
     ]);
 
     expect(sanitizeForMessage(value)).toEqual({
       "[Unserializable]": "broken key value",
+      "[Unserializable] (2)": "second broken key value",
       readable: "readable value",
     });
   });

--- a/packages/react-devtools/src/utils/serialization.test.ts
+++ b/packages/react-devtools/src/utils/serialization.test.ts
@@ -114,6 +114,23 @@ describe("sanitizeForMessage", () => {
 
     expect(sanitizeForMessage(value)).toEqual(["first", "second"]);
   });
+
+  it("preserves map entries when a key cannot be converted to a string", () => {
+    const brokenKey = {
+      toString: () => {
+        throw new Error("key conversion failed");
+      },
+    };
+    const value = new Map<unknown, unknown>([
+      [brokenKey, "broken key value"],
+      ["readable", "readable value"],
+    ]);
+
+    expect(sanitizeForMessage(value)).toEqual({
+      "[Unserializable]": "broken key value",
+      readable: "readable value",
+    });
+  });
 });
 
 describe("redactSensitive", () => {
@@ -235,5 +252,32 @@ describe("serializeModelContext", () => {
 
   it("returns undefined when there is no context", () => {
     expect(serializeModelContext(undefined)).toBeUndefined();
+  });
+
+  it("preserves readable fields when a model-context getter throws", () => {
+    const context = {
+      tools: {
+        search: { type: "frontend", description: "Search documents" },
+      },
+      config: { model: "test-model" },
+    };
+    Object.defineProperty(context, "system", {
+      enumerable: true,
+      get: () => {
+        throw new Error("system unavailable");
+      },
+    });
+
+    expect(serializeModelContext(context as never)).toEqual({
+      system: "[Unserializable]",
+      tools: [
+        {
+          name: "search",
+          type: "frontend",
+          description: "Search documents",
+        },
+      ],
+      config: { model: "test-model" },
+    });
   });
 });

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -33,6 +33,7 @@ export const sanitizeForMessage = (
       }
       if (value instanceof Map) {
         const result: Record<string, unknown> = {};
+        const nextSuffixByKey = new Map<string, number>();
         for (const [key, entry] of value.entries()) {
           let serializedKey: string;
           try {
@@ -43,11 +44,14 @@ export const sanitizeForMessage = (
 
           if (Object.hasOwn(result, serializedKey)) {
             const baseKey = serializedKey;
-            let suffix = 2;
+            let suffix = nextSuffixByKey.get(baseKey) ?? 2;
             do {
               serializedKey = `${baseKey} (${suffix})`;
               suffix += 1;
             } while (Object.hasOwn(result, serializedKey));
+            nextSuffixByKey.set(baseKey, suffix);
+          } else {
+            nextSuffixByKey.set(serializedKey, 2);
           }
 
           result[serializedKey] = sanitizeForMessage(entry, seen);

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -40,11 +40,17 @@ export const sanitizeForMessage = (
           } catch {
             serializedKey = UNSERIALIZABLE;
           }
-          try {
-            result[serializedKey] = sanitizeForMessage(entry, seen);
-          } catch {
-            result[serializedKey] = UNSERIALIZABLE;
+
+          if (Object.hasOwn(result, serializedKey)) {
+            const baseKey = serializedKey;
+            let suffix = 2;
+            do {
+              serializedKey = `${baseKey} (${suffix})`;
+              suffix += 1;
+            } while (Object.hasOwn(result, serializedKey));
           }
+
+          result[serializedKey] = sanitizeForMessage(entry, seen);
         }
         return result;
       }

--- a/packages/react-devtools/src/utils/serialization.ts
+++ b/packages/react-devtools/src/utils/serialization.ts
@@ -1,8 +1,7 @@
 import type { ModelContext } from "@assistant-ui/react";
 import type { SerializedModelContext } from "../types";
 import { normalizeToolList, type NormalizedTool } from "./toolNormalization";
-
-const UNSERIALIZABLE = "[Unserializable]";
+import { readProperty, UNSERIALIZABLE } from "./unserializable";
 
 export const sanitizeForMessage = (
   value: unknown,
@@ -35,7 +34,17 @@ export const sanitizeForMessage = (
       if (value instanceof Map) {
         const result: Record<string, unknown> = {};
         for (const [key, entry] of value.entries()) {
-          result[String(key)] = sanitizeForMessage(entry, seen);
+          let serializedKey: string;
+          try {
+            serializedKey = String(key);
+          } catch {
+            serializedKey = UNSERIALIZABLE;
+          }
+          try {
+            result[serializedKey] = sanitizeForMessage(entry, seen);
+          } catch {
+            result[serializedKey] = UNSERIALIZABLE;
+          }
         }
         return result;
       }
@@ -153,12 +162,12 @@ export const serializeModelContext = (
   const modelContext = context as Record<string, unknown>;
   const result: SerializedModelContext = {};
 
-  const systemValue = modelContext.system;
+  const systemValue = readProperty(modelContext, "system");
   if (typeof systemValue === "string" && systemValue.length > 0) {
     result.system = systemValue;
   }
 
-  const tools = normalizeToolList(modelContext.tools);
+  const tools = normalizeToolList(readProperty(modelContext, "tools"));
   if (tools.length > 0) {
     result.tools = tools.map((tool): NormalizedTool => {
       return {
@@ -180,8 +189,9 @@ export const serializeModelContext = (
     });
   }
 
-  if (modelContext.callSettings !== undefined) {
-    const callSettings = sanitizeAndRedact(modelContext.callSettings);
+  const callSettingsValue = readProperty(modelContext, "callSettings");
+  if (callSettingsValue !== undefined) {
+    const callSettings = sanitizeAndRedact(callSettingsValue);
     if (
       callSettings &&
       typeof callSettings === "object" &&
@@ -191,8 +201,9 @@ export const serializeModelContext = (
     }
   }
 
-  if (modelContext.config !== undefined) {
-    const config = sanitizeAndRedact(modelContext.config);
+  const configValue = readProperty(modelContext, "config");
+  if (configValue !== undefined) {
+    const config = sanitizeAndRedact(configValue);
     if (config && typeof config === "object" && !Array.isArray(config)) {
       result.config = config as Record<string, unknown>;
     }

--- a/packages/react-devtools/src/utils/toolNormalization.test.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.test.ts
@@ -68,4 +68,35 @@ describe("normalizeToolList", () => {
     expect(normalizeToolList(undefined)).toEqual([]);
     expect(normalizeToolList(null)).toEqual([]);
   });
+
+  it("preserves readable tool properties when another getter throws", () => {
+    const tool = { description: "Search documents" };
+    Object.defineProperty(tool, "type", {
+      enumerable: true,
+      get: () => {
+        throw new Error("type unavailable");
+      },
+    });
+
+    expect(normalizeToolList({ search: tool })).toEqual([
+      {
+        name: "search",
+        type: "[Unserializable]",
+        description: "Search documents",
+      },
+    ]);
+  });
+
+  it("represents a tool collection that rejects enumeration", () => {
+    const tools = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("enumeration unavailable");
+        },
+      },
+    );
+
+    expect(normalizeToolList(tools)).toEqual([{ name: "[Unserializable]" }]);
+  });
 });

--- a/packages/react-devtools/src/utils/toolNormalization.test.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.test.ts
@@ -68,7 +68,8 @@ describe("normalizeToolList", () => {
   it("preserves array entries around an unreadable slot", () => {
     const tools = [
       { name: "first", type: "frontend" },
-      { name: "hidden", type: "frontend" },
+      { name: "hidden-one", type: "frontend" },
+      { name: "hidden-two", type: "frontend" },
       { name: "last", type: "backend" },
     ];
     Object.defineProperty(tools, 1, {
@@ -76,9 +77,15 @@ describe("normalizeToolList", () => {
         throw new Error("tool unavailable");
       },
     });
+    Object.defineProperty(tools, 2, {
+      get: () => {
+        throw new Error("tool unavailable");
+      },
+    });
 
     expect(normalizeToolList(tools)).toEqual([
       { name: "first", type: "frontend" },
+      { name: "[Unserializable]" },
       { name: "[Unserializable]" },
       { name: "last", type: "backend" },
     ]);

--- a/packages/react-devtools/src/utils/toolNormalization.test.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.test.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { describe, expect, it } from "vitest";
 import { normalizeToolList } from "./toolNormalization";
 
@@ -62,6 +63,33 @@ describe("normalizeToolList", () => {
     ]);
     expect(tools.map((t) => t.name)).toEqual(["a", "b"]);
     expect(tools[1]?.disabled).toBe(true);
+  });
+
+  it("preserves array entries around an unreadable slot", () => {
+    const tools = [
+      { name: "first", type: "frontend" },
+      { name: "hidden", type: "frontend" },
+      { name: "last", type: "backend" },
+    ];
+    Object.defineProperty(tools, 1, {
+      get: () => {
+        throw new Error("tool unavailable");
+      },
+    });
+
+    expect(normalizeToolList(tools)).toEqual([
+      { name: "first", type: "frontend" },
+      { name: "[Unserializable]" },
+      { name: "last", type: "backend" },
+    ]);
+  });
+
+  it("keeps Zod schemas that cannot be converted to JSON Schema", () => {
+    const parameters = z.object({ when: z.date() });
+
+    expect(normalizeToolList({ schedule: { parameters } })[0]?.parameters).toBe(
+      parameters,
+    );
   });
 
   it("returns an empty list for non-objects", () => {

--- a/packages/react-devtools/src/utils/toolNormalization.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { readProperty, UNSERIALIZABLE } from "./unserializable";
 
 export type NormalizedTool = {
   name: string;
@@ -19,12 +20,12 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object";
 
 const toJsonSchema = (value: unknown): unknown => {
-  if (value instanceof z.ZodType) {
-    try {
+  try {
+    if (value instanceof z.ZodType) {
       return z.toJSONSchema(value);
-    } catch {
-      return value;
     }
+  } catch {
+    return UNSERIALIZABLE;
   }
 
   return value;
@@ -36,64 +37,86 @@ const mapToNormalizedTool = (
 ): NormalizedTool => {
   const tool: NormalizedTool = { name };
 
-  if (typeof raw.type === "string") {
-    tool.type = raw.type as string;
+  const type = readProperty(raw, "type");
+  if (typeof type === "string") {
+    tool.type = type;
   }
 
-  if (typeof raw.description === "string") {
-    tool.description = raw.description as string;
+  const description = readProperty(raw, "description");
+  if (typeof description === "string") {
+    tool.description = description;
   }
 
-  if (typeof raw.disabled === "boolean") {
-    tool.disabled = raw.disabled as boolean;
+  const disabled = readProperty(raw, "disabled");
+  if (typeof disabled === "boolean") {
+    tool.disabled = disabled;
   }
 
-  if (typeof raw.display === "string") {
-    tool.display = raw.display as string;
+  const display = readProperty(raw, "display");
+  if (typeof display === "string") {
+    tool.display = display;
   }
 
-  if (typeof raw.providerId === "string") {
-    tool.providerId = raw.providerId as string;
+  const providerId = readProperty(raw, "providerId");
+  if (typeof providerId === "string") {
+    tool.providerId = providerId;
   }
 
-  if (typeof raw.supportsDeferredResults === "boolean") {
-    tool.supportsDeferredResults = raw.supportsDeferredResults as boolean;
+  const supportsDeferredResults = readProperty(raw, "supportsDeferredResults");
+  if (typeof supportsDeferredResults === "boolean") {
+    tool.supportsDeferredResults = supportsDeferredResults;
   }
 
-  if (raw.unstable_backendDefault !== undefined) {
-    tool.backendDefault = raw.unstable_backendDefault;
+  const backendDefault = readProperty(raw, "unstable_backendDefault");
+  if (backendDefault !== undefined) {
+    tool.backendDefault = backendDefault;
   }
 
-  if (raw.providerOptions !== undefined) {
-    tool.providerOptions = raw.providerOptions;
+  const providerOptions = readProperty(raw, "providerOptions");
+  if (providerOptions !== undefined) {
+    tool.providerOptions = providerOptions;
   }
 
-  if (raw.args !== undefined) {
-    tool.providerArgs = raw.args;
+  const providerArgs = readProperty(raw, "args");
+  if (providerArgs !== undefined) {
+    tool.providerArgs = providerArgs;
   }
 
-  if (raw.server !== undefined) {
-    tool.server = raw.server;
+  const server = readProperty(raw, "server");
+  if (server !== undefined) {
+    tool.server = server;
   }
 
-  if (Object.hasOwn(raw, "parameters")) {
-    tool.parameters = toJsonSchema(raw.parameters);
+  try {
+    if (Object.hasOwn(raw, "parameters")) {
+      tool.parameters = toJsonSchema(readProperty(raw, "parameters"));
+    }
+  } catch {
+    tool.parameters = UNSERIALIZABLE;
   }
 
   return tool;
 };
 
 export const normalizeToolList = (value: unknown): NormalizedTool[] => {
+  if (value === UNSERIALIZABLE) {
+    return [{ name: UNSERIALIZABLE }];
+  }
   if (!value || typeof value !== "object") {
     return [];
   }
 
   if (Array.isArray(value)) {
     const tools: NormalizedTool[] = [];
+    const length = readProperty(value, "length");
+    if (typeof length !== "number") return [{ name: UNSERIALIZABLE }];
 
-    for (const entry of value) {
-      if (!isRecord(entry) || typeof entry.name !== "string") continue;
-      tools.push(mapToNormalizedTool(entry.name as string, entry));
+    for (let index = 0; index < length; index++) {
+      const entry = readProperty(value, index);
+      if (!isRecord(entry)) continue;
+      const name = readProperty(entry, "name");
+      if (typeof name !== "string") continue;
+      tools.push(mapToNormalizedTool(name, entry));
     }
 
     return tools;
@@ -101,8 +124,15 @@ export const normalizeToolList = (value: unknown): NormalizedTool[] => {
 
   if (isRecord(value)) {
     const tools: NormalizedTool[] = [];
+    let names: string[];
+    try {
+      names = Object.keys(value);
+    } catch {
+      return [{ name: UNSERIALIZABLE }];
+    }
 
-    for (const [name, entry] of Object.entries(value)) {
+    for (const name of names) {
+      const entry = readProperty(value, name);
       if (!isRecord(entry)) {
         tools.push({ name });
         continue;

--- a/packages/react-devtools/src/utils/toolNormalization.ts
+++ b/packages/react-devtools/src/utils/toolNormalization.ts
@@ -25,7 +25,7 @@ const toJsonSchema = (value: unknown): unknown => {
       return z.toJSONSchema(value);
     }
   } catch {
-    return UNSERIALIZABLE;
+    return value;
   }
 
   return value;
@@ -113,6 +113,10 @@ export const normalizeToolList = (value: unknown): NormalizedTool[] => {
 
     for (let index = 0; index < length; index++) {
       const entry = readProperty(value, index);
+      if (entry === UNSERIALIZABLE) {
+        tools.push({ name: UNSERIALIZABLE });
+        continue;
+      }
       if (!isRecord(entry)) continue;
       const name = readProperty(entry, "name");
       if (typeof name !== "string") continue;

--- a/packages/react-devtools/src/utils/unserializable.ts
+++ b/packages/react-devtools/src/utils/unserializable.ts
@@ -1,0 +1,9 @@
+export const UNSERIALIZABLE = "[Unserializable]";
+
+export const readProperty = (value: object, key: PropertyKey): unknown => {
+  try {
+    return Reflect.get(value, key);
+  } catch {
+    return UNSERIALIZABLE;
+  }
+};

--- a/packages/react-devtools/src/views/context/contextNodes.test.ts
+++ b/packages/react-devtools/src/views/context/contextNodes.test.ts
@@ -28,4 +28,25 @@ describe("buildContextNav", () => {
       "ctx:toolUIs",
     ]);
   });
+
+  it("assigns unique navigation IDs to tools with the same display name", () => {
+    const groups = buildContextNav({
+      id: 1,
+      state: {},
+      logs: [],
+      modelContext: {
+        tools: [
+          { name: "[Unserializable]" },
+          { name: "[Unserializable]:2" },
+          { name: "[Unserializable]" },
+        ],
+      },
+    });
+
+    expect(flattenNav(groups).map((node) => node.id)).toEqual([
+      "ctx:tool:[Unserializable]",
+      "ctx:tool:[Unserializable]:2",
+      "ctx:tool:[Unserializable]:3",
+    ]);
+  });
 });

--- a/packages/react-devtools/src/views/context/contextNodes.ts
+++ b/packages/react-devtools/src/views/context/contextNodes.ts
@@ -28,9 +28,21 @@ export const buildContextNav = (data: ApiInfo): ContextNavGroup[] => {
     });
   }
 
+  const nextToolOccurrence = new Map<string, number>();
+  const toolNodeIds = new Set<string>();
   for (const tool of model?.tools ?? []) {
+    const baseId = `ctx:tool:${tool.name}` as const;
+    let occurrence = nextToolOccurrence.get(tool.name) ?? 1;
+    let id: `ctx:tool:${string}` =
+      occurrence === 1 ? baseId : `${baseId}:${occurrence}`;
+    while (toolNodeIds.has(id)) {
+      occurrence += 1;
+      id = `${baseId}:${occurrence}`;
+    }
+    nextToolOccurrence.set(tool.name, occurrence + 1);
+    toolNodeIds.add(id);
     modelNodes.push({
-      id: `ctx:tool:${tool.name}`,
+      id,
       kind: "tool",
       tool,
     });


### PR DESCRIPTION
## Problem

DevTools can lose the entire `modelContext` block when one application-owned getter throws. Merged #6553 hardens the later sanitizer, but direct reads of `system`, `tools`, `callSettings`, `config`, and individual tool fields still happen before that recovery boundary. This is the remaining defect recorded in #6558.

## Root cause

`serializeModelContext` and `normalizeToolList` read application-owned properties directly. A throw escapes to the broad `projectApi` catch, which omits all model-context data, including readable siblings. Map key string conversion has the same all-or-nothing behavior when application-owned `toString` throws.

## Change

Guard model-context and tool properties independently, retain readable siblings, represent unreadable values with the existing `[Unserializable]` convention where the serialized shape supports it, and isolate Map key failures per entry. Cached suffix allocation keeps colliding Map keys near-linear, and duplicate fallback tool names receive unique navigation IDs without changing their displayed names. The existing fallback for Zod schemas that cannot convert to JSON Schema remains unchanged.

## Reproduction

This branch is a cloneable minimal reproduction through `packages/react-devtools/src/data/projectApi.test.ts`: the regression constructs a model context whose `system` getter throws and whose tools proxy rejects enumeration while `config` remains readable. Before the guards, `projectApi` omits `modelContext`; with this change it retains the unreadable markers and `{ model: "test-model" }`. Utility regressions also cover throwing tool getters, array slots, Map keys, unsupported Zod conversion, and duplicate navigation names.

Run from `packages/react-devtools` with:

```sh
node_modules/.bin/vitest run src/data/projectApi.test.ts src/utils/serialization.test.ts src/utils/toolNormalization.test.ts src/views/context/contextNodes.test.ts
```

## Verification

- focused reproduction: 4 files and 35 tests passed
- full `@assistant-ui/react-devtools` suite: 31 files and 125 tests passed
- package and dependency builds passed
- oxlint and oxfmt checks passed
- patch changeset included

## Public surface

No exports or public types change. `readProperty` and the sentinel helper remain internal; the behavior change is limited to more granular DevTools projection recovery and unique internal navigation identities.