### PR TITLE
fix(core): preserve thread message identity

### DIFF
--- a/.changeset/quiet-messages-stay.md
+++ b/.changeset/quiet-messages-stay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve message component state when thread messages are removed or reordered

--- a/packages/core/src/react/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { MessageState } from "../../../store";
+
+const mocks = vi.hoisted(() => ({
+  messages: [] as MessageState[],
+  aui: {
+    thread: {
+      message: ({ index }: { index: number }) => ({
+        getState: () => mocks.messages[index],
+      }),
+    },
+  },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({ thread: { messages: mocks.messages } }),
+  RenderChildrenWithAccessor: ({
+    getItemState,
+    children,
+  }: {
+    getItemState: (aui: typeof mocks.aui) => MessageState;
+    children: (getItem: () => MessageState) => ReactNode;
+  }) => children(() => getItemState(mocks.aui)),
+}));
+
+vi.mock("../../providers/MessageByIndexProvider", () => ({
+  MessageByIndexProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { ThreadPrimitiveMessages } from "./ThreadMessages";
+
+const message = (id: string): MessageState =>
+  ({
+    id,
+    createdAt: new Date(),
+    role: "user",
+    content: [],
+    attachments: [],
+    metadata: { custom: {} },
+  }) as unknown as MessageState;
+
+const StatefulMessage = ({ message }: { message: MessageState }) => {
+  const [initialId] = useState(message.id);
+  return <span>{initialId}</span>;
+};
+
+describe("ThreadPrimitiveMessages", () => {
+  it("does not reuse component state for a different message", () => {
+    mocks.messages = [message("first-message"), message("second-message")];
+
+    const view = render(
+      <ThreadPrimitiveMessages>
+        {({ message }) => <StatefulMessage message={message} />}
+      </ThreadPrimitiveMessages>,
+    );
+
+    mocks.messages = [mocks.messages[1]!];
+    view.rerender(
+      <ThreadPrimitiveMessages>
+        {({ message }) => <StatefulMessage message={message} />}
+      </ThreadPrimitiveMessages>,
+    );
+
+    expect(screen.queryByText("second-message")).not.toBeNull();
+    expect(screen.queryByText("first-message")).toBeNull();
+  });
+});

--- a/packages/core/src/react/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.test.tsx
@@ -29,7 +29,10 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   }) => children(() => getItemState(mocks.aui)),
 }));
 
-vi.mock("../../providers/MessageByIndexProvider", () => ({
+vi.mock("../../providers/MessageByIndexProvider", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../providers/MessageByIndexProvider")
+  >()),
   MessageByIndexProvider: ({ children }: { children: ReactNode }) => children,
 }));
 

--- a/packages/core/src/react/primitives/thread/ThreadMessages.tsx
+++ b/packages/core/src/react/primitives/thread/ThreadMessages.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
 } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import { MessageByIndexProvider } from "../../providers/MessageByIndexProvider";
 import { MessageByIdProvider } from "../../providers/MessageByIdProvider";
 import type { MessageState } from "../../../store";
@@ -241,12 +242,14 @@ ThreadPrimitiveUnstable_MessageById.displayName =
 const ThreadPrimitiveMessagesInner: FC<{
   children: (value: { message: MessageState }) => ReactNode;
 }> = ({ children }) => {
-  const messagesLength = useAuiState((s) => s.thread.messages.length);
+  const messageIds = useAuiState(
+    useShallowSelector((s) => s.thread.messages.map((message) => message.id)),
+  );
 
   return useMemo(() => {
-    if (messagesLength === 0) return null;
-    return Array.from({ length: messagesLength }, (_, index) => (
-      <MessageByIndexProvider key={index} index={index}>
+    if (messageIds.length === 0) return null;
+    return messageIds.map((messageId, index) => (
+      <MessageByIndexProvider key={messageId} index={index}>
         <RenderChildrenWithAccessor
           getItemState={(aui) => aui.thread.message({ index }).getState()}
         >
@@ -260,7 +263,7 @@ const ThreadPrimitiveMessagesInner: FC<{
         </RenderChildrenWithAccessor>
       </MessageByIndexProvider>
     ));
-  }, [messagesLength, children]);
+  }, [messageIds, children]);
 };
 
 /**


### PR DESCRIPTION
> **Draft:** the regression is valid, but wire message IDs are not a safe React identity. External-store runtimes replace optimistic placeholder/client IDs with server IDs mid-run, so the current implementation would remount assistant-message subtrees during normal streaming. This PR must not merge until the core exposes an identity that survives those ID swaps.

## Problem

`ThreadPrimitive.Messages` currently keys each message subtree by array index. Removing or reordering an earlier message can move local edit, menu, or custom component state onto a different message. This is the `ThreadPrimitive.Messages` slice of #6570.

## Root cause

Positional keys do not follow a message through removal or reordering. However, `message.id` is a wire identity rather than a stable render identity: `ExternalStoreThreadRuntimeCore` replaces generated optimistic IDs with provider/server IDs at the same position during a run. Neither index nor wire ID satisfies both required cases.

## Current experiment

The branch selects message IDs, keys providers by ID, and retains positional lookup. Its regression proves the leading-removal bug, but final review confirmed this approach remounts message children during optimistic ID swaps. The branch is retained as a tested experiment, not a merge candidate.

## Required direction

Introduce or expose a core-owned per-message render identity that survives placeholder and client-to-server ID replacement, while assigning a new identity when a branch message is genuinely replaced. Then use that identity as the key and retain the current index provider. This needs a maintainer decision at the runtime/store boundary before implementation continues.

## Verification

- leading-removal regression passes with the experimental ID key
- full `@assistant-ui/core` suite and build pass
- CI and reviewer checks pass, aside from the identified identity-design blocker

## Public surface

The current experiment changes no exports or types, but it is intentionally draft because its behavior is not safe to ship.