### PR TITLE
fix(core): preserve message attachment identity

### DIFF
--- a/.changeset/neat-attachments-stay.md
+++ b/.changeset/neat-attachments-stay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve attachment component state when message attachments are removed or reordered

--- a/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
@@ -97,4 +97,51 @@ describe("MessagePrimitiveAttachments", () => {
     expect(screen.queryByText("second-file")).not.toBeNull();
     expect(screen.queryByText("first-file")).toBeNull();
   });
+
+  it("keeps component state with attachments when they are reordered", () => {
+    mocks.role = "user";
+    mocks.attachments = [attachment("first-file"), attachment("second-file")];
+
+    const view = render(
+      <MessagePrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </MessagePrimitiveAttachments>,
+    );
+
+    mocks.attachments = [mocks.attachments[1]!, mocks.attachments[0]!];
+    view.rerender(
+      <MessagePrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </MessagePrimitiveAttachments>,
+    );
+
+    expect(view.container.textContent).toBe("second-filefirst-file");
+  });
+
+  it("assigns distinct React keys to duplicate attachment IDs", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.role = "user";
+    mocks.attachments = [
+      { ...attachment("duplicate"), name: "first.txt" },
+      { ...attachment("duplicate"), name: "second.txt" },
+    ];
+
+    try {
+      render(
+        <MessagePrimitiveAttachments>
+          {({ attachment }) => <span>{attachment.name}</span>}
+        </MessagePrimitiveAttachments>,
+      );
+
+      expect(screen.queryByText("first.txt")).not.toBeNull();
+      expect(screen.queryByText("second.txt")).not.toBeNull();
+      expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+        "same key",
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });

--- a/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
@@ -35,10 +35,16 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   }) => children(() => getItemState(mocks.aui)),
 }));
 
-vi.mock("../../providers/AttachmentByIndexProvider", () => ({
-  MessageAttachmentByIndexProvider: ({ children }: { children: ReactNode }) =>
-    children,
-}));
+vi.mock(
+  "../../providers/AttachmentByIndexProvider",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("../../providers/AttachmentByIndexProvider")
+    >()),
+    MessageAttachmentByIndexProvider: ({ children }: { children: ReactNode }) =>
+      children,
+  }),
+);
 
 import { MessagePrimitiveAttachments } from "./MessageAttachments";
 

--- a/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
@@ -117,31 +117,4 @@ describe("MessagePrimitiveAttachments", () => {
 
     expect(view.container.textContent).toBe("second-filefirst-file");
   });
-
-  it("assigns distinct React keys to duplicate attachment IDs", () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    mocks.role = "user";
-    mocks.attachments = [
-      { ...attachment("duplicate"), name: "first.txt" },
-      { ...attachment("duplicate"), name: "second.txt" },
-    ];
-
-    try {
-      render(
-        <MessagePrimitiveAttachments>
-          {({ attachment }) => <span>{attachment.name}</span>}
-        </MessagePrimitiveAttachments>,
-      );
-
-      expect(screen.queryByText("first.txt")).not.toBeNull();
-      expect(screen.queryByText("second.txt")).not.toBeNull();
-      expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
-        "same key",
-      );
-    } finally {
-      consoleError.mockRestore();
-    }
-  });
 });

--- a/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.test.tsx
@@ -1,50 +1,94 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import type { ReactElement } from "react";
+import type { CompleteAttachment } from "../../../types/attachment";
+
+const mocks = vi.hoisted(() => ({
+  role: "user" as "user" | "assistant",
+  attachments: undefined as CompleteAttachment[] | undefined,
+  aui: {
+    message: {
+      attachment: ({ index }: { index: number }) => ({
+        getState: () => mocks.attachments?.[index],
+      }),
+    },
+  },
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: (selector: (state: unknown) => unknown) =>
+    selector({
+      message: {
+        role: mocks.role,
+        attachments: mocks.attachments,
+      },
+    }),
+  RenderChildrenWithAccessor: ({
+    getItemState,
+    children,
+  }: {
+    getItemState: (aui: typeof mocks.aui) => CompleteAttachment;
+    children: (getItem: () => CompleteAttachment) => ReactNode;
+  }) => children(() => getItemState(mocks.aui)),
+}));
+
+vi.mock("../../providers/AttachmentByIndexProvider", () => ({
+  MessageAttachmentByIndexProvider: ({ children }: { children: ReactNode }) =>
+    children,
+}));
+
 import { MessagePrimitiveAttachments } from "./MessageAttachments";
 
-const mockUseAuiState = vi.fn();
-type UseAuiStateSelector = Parameters<
-  (typeof import("@assistant-ui/store"))["useAuiState"]
->[0];
-type AttachmentsElement = ReactElement<{ children: () => null }>;
-
-vi.mock("react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react")>();
-  return {
-    ...actual,
-    useMemo: (factory: () => unknown) => factory(),
-  };
+const attachment = (id: string): CompleteAttachment => ({
+  id,
+  type: "file",
+  name: `${id}.txt`,
+  status: { type: "complete" },
+  content: [],
 });
 
-vi.mock("@assistant-ui/store", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
-  return {
-    ...actual,
-    useAuiState: (selector: UseAuiStateSelector) => mockUseAuiState(selector),
-  };
-});
-
-const renderAttachmentsInner = () => {
-  const element = MessagePrimitiveAttachments({
-    children: () => null,
-  }) as AttachmentsElement;
-
-  const Inner = element.type as (props: typeof element.props) => unknown;
-  return Inner(element.props);
+const StatefulAttachment = ({
+  attachment,
+}: {
+  attachment: CompleteAttachment;
+}) => {
+  const [initialId] = useState(attachment.id);
+  return <span>{initialId}</span>;
 };
 
 describe("MessagePrimitiveAttachments", () => {
   it("treats missing user message attachments as empty", () => {
-    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
-      selector({
-        message: {
-          role: "user",
-          attachments: undefined,
-        },
-      } as never),
+    mocks.role = "user";
+    mocks.attachments = undefined;
+
+    const view = render(
+      <MessagePrimitiveAttachments>{() => null}</MessagePrimitiveAttachments>,
     );
 
-    expect(() => renderAttachmentsInner()).not.toThrow();
-    expect(renderAttachmentsInner()).toEqual([]);
+    expect(view.container.childElementCount).toBe(0);
+  });
+
+  it("does not reuse component state for a different attachment", () => {
+    mocks.role = "user";
+    mocks.attachments = [attachment("first-file"), attachment("second-file")];
+
+    const view = render(
+      <MessagePrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </MessagePrimitiveAttachments>,
+    );
+
+    mocks.attachments = [mocks.attachments[1]!];
+    view.rerender(
+      <MessagePrimitiveAttachments>
+        {({ attachment }) => <StatefulAttachment attachment={attachment} />}
+      </MessagePrimitiveAttachments>,
+    );
+
+    expect(screen.queryByText("second-file")).not.toBeNull();
+    expect(screen.queryByText("first-file")).toBeNull();
   });
 });

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
 } from "react";
 import { RenderChildrenWithAccessor, useAuiState } from "@assistant-ui/store";
+import { useShallowSelector } from "@assistant-ui/store/internal";
 import { MessageAttachmentByIndexProvider } from "../../providers/AttachmentByIndexProvider";
 
 type MessageAttachmentsComponentConfig = {
@@ -91,15 +92,17 @@ MessagePrimitiveAttachmentByIndex.displayName =
 const MessagePrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: CompleteAttachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentsCount = useAuiState((s) => {
-    if (s.message.role !== "user") return 0;
-    return (s.message.attachments ?? []).length;
-  });
+  const attachmentIds = useAuiState(
+    useShallowSelector((s) => {
+      if (s.message.role !== "user") return [];
+      return (s.message.attachments ?? []).map((attachment) => attachment.id);
+    }),
+  );
 
   return useMemo(
     () =>
-      Array.from({ length: attachmentsCount }, (_, index) => (
-        <MessageAttachmentByIndexProvider key={index} index={index}>
+      attachmentIds.map((attachmentId, index) => (
+        <MessageAttachmentByIndexProvider key={attachmentId} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.message.attachment({ index }).getState()}
           >
@@ -113,7 +116,7 @@ const MessagePrimitiveAttachmentsInner: FC<{
           </RenderChildrenWithAccessor>
         </MessageAttachmentByIndexProvider>
       )),
-    [attachmentsCount, children],
+    [attachmentIds, children],
   );
 };
 

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -92,17 +92,22 @@ MessagePrimitiveAttachmentByIndex.displayName =
 const MessagePrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: CompleteAttachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentIds = useAuiState(
+  const attachmentKeys = useAuiState(
     useShallowSelector((s) => {
       if (s.message.role !== "user") return [];
-      return (s.message.attachments ?? []).map((attachment) => attachment.id);
+      const occurrences = new Map<string, number>();
+      return (s.message.attachments ?? []).map((attachment) => {
+        const occurrence = occurrences.get(attachment.id) ?? 0;
+        occurrences.set(attachment.id, occurrence + 1);
+        return JSON.stringify([attachment.id, occurrence]);
+      });
     }),
   );
 
   return useMemo(
     () =>
-      attachmentIds.map((attachmentId, index) => (
-        <MessageAttachmentByIndexProvider key={attachmentId} index={index}>
+      attachmentKeys.map((attachmentKey, index) => (
+        <MessageAttachmentByIndexProvider key={attachmentKey} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.message.attachment({ index }).getState()}
           >
@@ -116,7 +121,7 @@ const MessagePrimitiveAttachmentsInner: FC<{
           </RenderChildrenWithAccessor>
         </MessageAttachmentByIndexProvider>
       )),
-    [attachmentIds, children],
+    [attachmentKeys, children],
   );
 };
 

--- a/packages/core/src/react/primitives/message/MessageAttachments.tsx
+++ b/packages/core/src/react/primitives/message/MessageAttachments.tsx
@@ -92,22 +92,17 @@ MessagePrimitiveAttachmentByIndex.displayName =
 const MessagePrimitiveAttachmentsInner: FC<{
   children: (value: { attachment: CompleteAttachment }) => ReactNode;
 }> = ({ children }) => {
-  const attachmentKeys = useAuiState(
+  const attachmentIds = useAuiState(
     useShallowSelector((s) => {
       if (s.message.role !== "user") return [];
-      const occurrences = new Map<string, number>();
-      return (s.message.attachments ?? []).map((attachment) => {
-        const occurrence = occurrences.get(attachment.id) ?? 0;
-        occurrences.set(attachment.id, occurrence + 1);
-        return JSON.stringify([attachment.id, occurrence]);
-      });
+      return (s.message.attachments ?? []).map((attachment) => attachment.id);
     }),
   );
 
   return useMemo(
     () =>
-      attachmentKeys.map((attachmentKey, index) => (
-        <MessageAttachmentByIndexProvider key={attachmentKey} index={index}>
+      attachmentIds.map((attachmentId, index) => (
+        <MessageAttachmentByIndexProvider key={attachmentId} index={index}>
           <RenderChildrenWithAccessor
             getItemState={(aui) => aui.message.attachment({ index }).getState()}
           >
@@ -121,7 +116,7 @@ const MessagePrimitiveAttachmentsInner: FC<{
           </RenderChildrenWithAccessor>
         </MessageAttachmentByIndexProvider>
       )),
-    [attachmentKeys, children],
+    [attachmentIds, children],
   );
 };
 


### PR DESCRIPTION
## Problem

`MessagePrimitive.Attachments` keys each attachment subtree by its array index. Removing or reordering an earlier attachment can therefore carry mounted component state onto a different file. This is the `MessagePrimitive.Attachments` slice of #6570.

## Root cause

React reconciles the child by its positional key while `MessageAttachmentByIndexProvider` resolves whichever attachment now occupies that position. After the leading file is removed, index `0` keeps the old component instance but resolves the former index `1` attachment.

## Change

Select attachment IDs for user messages, key each provider by that stable ID, and continue passing the current index to `MessageAttachmentByIndexProvider`. This matches the established `ComposerPrimitive.Attachments` pattern. Attachment IDs are already the runtime identity used for attachment updates and lookup, so duplicate IDs are invalid independently of React keys.

## Reproduction

The updated `MessageAttachments.test.tsx` renders files through a stateful child and covers both leading removal and reordering. With the previous `key={index}` implementation, the child state stays at its old position and both cases fail. The existing missing-attachments case remains covered.

## Verification

- focused regression: 1 file and 3 tests passed
- full `@assistant-ui/core` suite: 152 files and 1,556 tests passed
- `@assistant-ui/core` build passed
- focused oxlint and oxfmt checks passed
- patch changeset included

## Public surface

No exports, types, props, or lookup semantics change. The behavior change is limited to React reconciliation identity for existing attachment children.