### PR TITLE
refactor(core): generate composer attachment IDs with the shared ID utility

### DIFF
--- a/.changeset/generate-composer-attachment-ids.md
+++ b/.changeset/generate-composer-attachment-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+refactor: generate composer attachment IDs with the shared ID utility

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -49,6 +49,7 @@ import {
   drainAttachmentAdd,
 } from "../../runtime/utils/attachment-add-operations";
 import { toMessagePartStatus } from "../../utils/normalizePartStatus";
+import { generateId } from "../../utils/id";
 import { ModelContext } from "./model-context-client";
 import { ThreadSuggestions } from "./suggestions";
 import { Tools } from "../../react/client/Tools";
@@ -632,7 +633,7 @@ const useComposerClientResource = ({
         }
       } else if (!isCreateAttachment(fileOrAttachment)) {
         const newAttachment: Attachment = {
-          id: Math.random().toString(36).substring(7),
+          id: generateId(),
           type: "file",
           name: fileOrAttachment.name,
           contentType: fileOrAttachment.type,
@@ -643,7 +644,7 @@ const useComposerClientResource = ({
         setAttachments((prev) => [...prev, newAttachment]);
       } else {
         const newAttachment: Attachment = {
-          id: fileOrAttachment.id ?? Math.random().toString(36).substring(7),
+          id: fileOrAttachment.id ?? generateId(),
           type: fileOrAttachment.type ?? "document",
           name: fileOrAttachment.name,
           contentType: fileOrAttachment.contentType,

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
 import type {
   ExternalThreadMessage,
@@ -13,6 +13,18 @@ import type {
   CompleteAttachment,
   PendingAttachment,
 } from "../types/attachment";
+
+const mockGenerateId = vi.hoisted(() => vi.fn(() => "generated-id"));
+
+vi.mock("../utils/id", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/id")>()),
+  generateId: mockGenerateId,
+}));
+
+beforeEach(() => {
+  mockGenerateId.mockReset();
+  mockGenerateId.mockReturnValue("generated-id");
+});
 
 const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
   const captured: { aui?: ReturnType<typeof useAui> } = {};
@@ -57,6 +69,45 @@ const renderThread = () => {
 };
 
 describe("ExternalThread attachments", () => {
+  it("uses generated IDs unless a prepared attachment supplies one", async () => {
+    const aui = renderThread();
+    mockGenerateId
+      .mockReturnValueOnce("generated-file-id")
+      .mockReturnValueOnce("generated-prepared-id");
+
+    await act(async () => {
+      await aui()
+        .thread()
+        .composer()
+        .addAttachment(new File(["data"], "photo.png", { type: "image/png" }));
+      await aui()
+        .thread()
+        .composer()
+        .addAttachment({
+          name: "notes.txt",
+          contentType: "text/plain",
+          content: [{ type: "text", text: "hello" }],
+        });
+      await aui().thread().composer().addAttachment({
+        id: "provided-id",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        content: [],
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        aui()
+          .thread()
+          .composer()
+          .getState()
+          .attachments.map((attachment) => attachment.id),
+      ).toEqual(["generated-file-id", "generated-prepared-id", "provided-id"]);
+    });
+    expect(mockGenerateId).toHaveBeenCalledTimes(2);
+  });
+
   it("adds prepared attachments when File is unavailable", async () => {
     const aui = renderThread();
     const fileConstructor = globalThis.File;

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -114,17 +114,15 @@ describe("ExternalThread attachments", () => {
     expect(mockGenerateId).toHaveBeenCalledTimes(2);
   });
 
-  it("generates distinct seven-character IDs for attachments without one", async () => {
+  it("generates distinct IDs for attachments without one", async () => {
     const aui = renderThread();
 
     await act(async () => {
       await aui()
-        .thread()
-        .composer()
+        .thread.composer()
         .addAttachment(new File(["data"], "photo.png", { type: "image/png" }));
       await aui()
-        .thread()
-        .composer()
+        .thread.composer()
         .addAttachment({
           name: "notes.txt",
           contentType: "text/plain",
@@ -136,14 +134,10 @@ describe("ExternalThread attachments", () => {
       expect(aui().thread.composer().getState().attachments).toHaveLength(2),
     );
     const ids = aui()
-      .thread()
-      .composer()
+      .thread.composer()
       .getState()
       .attachments.map((attachment) => attachment.id);
-    expect(ids).toEqual([
-      expect.stringMatching(/^[0-9A-Za-z]{7}$/),
-      expect.stringMatching(/^[0-9A-Za-z]{7}$/),
-    ]);
+    expect(ids.every((id) => id.length > 0)).toBe(true);
     expect(new Set(ids).size).toBe(2);
   });
 

--- a/packages/core/src/tests/external-thread-attachments.test.tsx
+++ b/packages/core/src/tests/external-thread-attachments.test.tsx
@@ -14,16 +14,22 @@ import type {
   PendingAttachment,
 } from "../types/attachment";
 
-const mockGenerateId = vi.hoisted(() => vi.fn(() => "generated-id"));
+const { mockGenerateId, realGenerateId } = vi.hoisted(() => {
+  const realGenerateId = { current: (): string => "" };
+  return {
+    realGenerateId,
+    mockGenerateId: vi.fn(() => realGenerateId.current()),
+  };
+});
 
-vi.mock("../utils/id", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../utils/id")>()),
-  generateId: mockGenerateId,
-}));
+vi.mock("../utils/id", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../utils/id")>();
+  realGenerateId.current = actual.generateId;
+  return { ...actual, generateId: mockGenerateId };
+});
 
 beforeEach(() => {
   mockGenerateId.mockReset();
-  mockGenerateId.mockReturnValue("generated-id");
 });
 
 const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
@@ -106,6 +112,39 @@ describe("ExternalThread attachments", () => {
       ).toEqual(["generated-file-id", "generated-prepared-id", "provided-id"]);
     });
     expect(mockGenerateId).toHaveBeenCalledTimes(2);
+  });
+
+  it("generates distinct seven-character IDs for attachments without one", async () => {
+    const aui = renderThread();
+
+    await act(async () => {
+      await aui()
+        .thread()
+        .composer()
+        .addAttachment(new File(["data"], "photo.png", { type: "image/png" }));
+      await aui()
+        .thread()
+        .composer()
+        .addAttachment({
+          name: "notes.txt",
+          contentType: "text/plain",
+          content: [{ type: "text", text: "hello" }],
+        });
+    });
+
+    await waitFor(() =>
+      expect(aui().thread.composer().getState().attachments).toHaveLength(2),
+    );
+    const ids = aui()
+      .thread()
+      .composer()
+      .getState()
+      .attachments.map((attachment) => attachment.id);
+    expect(ids).toEqual([
+      expect.stringMatching(/^[0-9A-Za-z]{7}$/),
+      expect.stringMatching(/^[0-9A-Za-z]{7}$/),
+    ]);
+    expect(new Set(ids).size).toBe(2);
   });
 
   it("adds prepared attachments when File is unavailable", async () => {


### PR DESCRIPTION
## Problem

`ExternalThread`'s composer minted attachment ids with `Math.random().toString(36).substring(7)` in two places: the plain `File` branch and the `CreateAttachment` fallback. the `.substring(7)` cuts a fixed offset out of a float's base36 text, so the id length is whatever happens to be left over (1 to 10 characters, concentrated at 5 and 6).

per #6415 this is a consistency cleanup, not a live collision bug: the ids are scoped to one composer's attachment list, and simulated collision probability stays at 0 through n=100.

## Root cause

the tap composer in `packages/core/src/store/clients/external-thread.ts` was written with an inline generator instead of the shared helper core already ships at `packages/core/src/utils/id.ts`. the legacy composer (`packages/core/src/runtime/base/base-composer-runtime-core.ts:425`) already calls `generateId()`, so the two runtimes disagreed on id shape. #6400 collapsed the same idiom in react-mcp and react-opencode; these two sites were what remained, inside the package that owns the helper.

## Change

both sites now call `generateId()`. attachment ids pick up the same uniform 7-character shape as every other id in core, and the tap composer matches the legacy one. caller-supplied ids on prepared attachments still take precedence, unchanged.

## Verification

`pnpm -C packages/core exec vitest run src/tests/external-thread-attachments.test.tsx`, 19 passed. reverting only `external-thread.ts` to the merge base fails both new tests with the old shape (`['7nny3', 'qi9eeh', 'provided-id']`), so the coverage pins both sites instead of passing either way.

added to `packages/core/src/tests/external-thread-attachments.test.tsx`:

- generated ids on the `File` branch and on the prepared-attachment branch, with a caller-supplied id taking precedence over both
- generated ids match the shared generator's 7-character alphabet and stay distinct

the file's `generateId` mock now delegates to the real generator by default, so the rest of the file keeps production ids instead of one fixed string.

## Public surface

none. no export changes; `generateId` was already public from `@assistant-ui/core`. changeset: patch for `@assistant-ui/core`.
