### PR TITLE
fix(changesets): mirror ignored package semantics

### DIFF
--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -93,23 +93,47 @@ export function readSkipRules(config) {
       ? privatePackages.version === true
       : privatePackages === true;
   return {
-    ignored: new Set(config.ignore ?? []),
+    ignored: config.ignore ?? [],
     skipsPrivate: !versionsPrivate,
   };
 }
 
+function expandPackageGlobs(packageNames, patterns) {
+  const names = [...packageNames];
+  const matches = new Set();
+  for (const rawPattern of patterns) {
+    let pattern = rawPattern;
+    let negated = false;
+    while (pattern.startsWith("!") && !pattern.startsWith("!(")) {
+      negated = !negated;
+      pattern = pattern.slice(1);
+    }
+
+    for (const name of names) {
+      if (!path.matchesGlob(name, pattern)) continue;
+      if (negated) matches.delete(name);
+      else matches.add(name);
+    }
+  }
+  return matches;
+}
+
 export function findUnreleasablePackages(packages, bumps, rules) {
+  const ignored = expandPackageGlobs(packages.keys(), rules.ignored);
+  const filesWithReleasedBumps = new Set(
+    bumps
+      .filter(({ name }) => {
+        const pkg = packages.get(name);
+        return (
+          pkg && !ignored.has(name) && (!pkg.isPrivate || !rules.skipsPrivate)
+        );
+      })
+      .map(({ file }) => file),
+  );
   const problems = [];
   for (const { file, name } of bumps) {
     const pkg = packages.get(name);
-    if (rules.ignored.has(name)) {
-      problems.push({
-        file,
-        name,
-        reason:
-          "is in `ignore` in .changeset/config.json and is never versioned",
-      });
-    } else if (!pkg) {
+    if (!pkg) {
       problems.push({
         file,
         name,
@@ -120,6 +144,13 @@ export function findUnreleasablePackages(packages, bumps, rules) {
         file,
         name,
         reason: `is private (${pkg.manifest}) and is never versioned`,
+      });
+    } else if (ignored.has(name) && filesWithReleasedBumps.has(file)) {
+      problems.push({
+        file,
+        name,
+        reason:
+          "matches `ignore` in .changeset/config.json and shares a changeset with a released package",
       });
     }
   }

--- a/scripts/check-changesets.test.mjs
+++ b/scripts/check-changesets.test.mjs
@@ -22,6 +22,7 @@ function createWorkspace(changeset, config = {}) {
   );
   for (const [dir, manifest] of [
     ["published", { name: "@fixture/published", version: "1.0.0" }],
+    ["held", { name: "@fixture/held", version: "1.0.0" }],
     ["internal", { name: "@fixture/internal", private: true }],
   ]) {
     mkdirSync(path.join(root, "packages", dir), { recursive: true });
@@ -116,7 +117,7 @@ test("findUnreleasablePackages flags private and unknown names", () => {
     ],
   ]);
 
-  const rules = { ignored: new Set(), skipsPrivate: true };
+  const rules = { ignored: [], skipsPrivate: true };
 
   assert.deepEqual(
     findUnreleasablePackages(
@@ -148,7 +149,7 @@ test("runCheck accepts a workspace whose changesets are all releasable", () => {
     '---\n"@fixture/published": patch\n---\n\nfix: something\n',
   );
   try {
-    assert.deepEqual(runCheck(root), { packageCount: 2, problems: [] });
+    assert.deepEqual(runCheck(root), { packageCount: 3, problems: [] });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -170,32 +171,59 @@ test("runCheck rejects a changeset naming a private package", () => {
 
 test("readSkipRules follows .changeset/config.json", () => {
   assert.deepEqual(readSkipRules({}), {
-    ignored: new Set(),
+    ignored: [],
     skipsPrivate: true,
   });
   assert.deepEqual(readSkipRules({ privatePackages: { version: true } }), {
-    ignored: new Set(),
+    ignored: [],
     skipsPrivate: false,
   });
   assert.deepEqual(readSkipRules({ privatePackages: true }), {
-    ignored: new Set(),
+    ignored: [],
     skipsPrivate: false,
   });
   assert.deepEqual(readSkipRules({ ignore: ["@fixture/held"] }), {
-    ignored: new Set(["@fixture/held"]),
+    ignored: ["@fixture/held"],
     skipsPrivate: true,
   });
 });
 
-test("runCheck rejects a published package listed in `ignore`", () => {
+test("runCheck allows an ignored-only changeset", () => {
   const root = createWorkspace(
-    '---\n"@fixture/published": patch\n---\n\nfix: something\n',
-    { ignore: ["@fixture/published"] },
+    '---\n"@fixture/held": patch\n---\n\nfix: something\n',
+    { ignore: ["@fixture/held"] },
+  );
+  try {
+    assert.deepEqual(runCheck(root).problems, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCheck rejects a changeset mixing ignored and released packages", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n"@fixture/published": patch\n---\n\nfix: something\n',
+    { ignore: ["@fixture/held"] },
   );
   try {
     const { problems } = runCheck(root);
     assert.equal(problems.length, 1);
-    assert.match(problems[0].reason, /is in `ignore`/);
+    assert.equal(problems[0].name, "@fixture/held");
+    assert.match(problems[0].reason, /shares a changeset/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCheck expands ordered ignore globs", () => {
+  const root = createWorkspace(
+    '---\n"@fixture/held": patch\n"@fixture/published": patch\n---\n\nfix: something\n',
+    { ignore: ["@fixture/*", "!@fixture/published"] },
+  );
+  try {
+    const { problems } = runCheck(root);
+    assert.equal(problems.length, 1);
+    assert.equal(problems[0].name, "@fixture/held");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- expand configured ignore entries as ordered package globs
- allow changesets containing only ignored packages
- reject changesets that mix ignored and releasable packages while keeping private and unknown package validation strict

Fixes #6579

## Testing

- `node --test scripts/check-changesets.test.mjs`: 15 tests
- `node scripts/check-changesets.mjs`: 102 packages scanned
- `oxlint scripts/check-changesets.mjs scripts/check-changesets.test.mjs`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tJPMdf-9S61rsql1avKpRrtDdqOHPcPcWTr7lkcb1_PXm1DPuD6gNHr6kuk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->