### PR TITLE
feat(react-ag-ui): attribute AG-UI subagent lifecycle into ToolCallMessagePart.messages

### DIFF
--- a/.changeset/ag-ui-subagent-attribution.md
+++ b/.changeset/ag-ui-subagent-attribution.md
@@ -2,4 +2,6 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-feat: attribute AG-UI subagent lifecycle events (SUBAGENT_STARTED/FINISHED/ERROR, subagentRunId) into nested ToolCallMessagePart.messages instead of flattening or dropping them as RAW
+feat: model the AG-UI subagent protocol. `SUBAGENT_STARTED` / `SUBAGENT_FINISHED` / `SUBAGENT_ERROR` are parsed instead of falling through to `RAW` and being dropped, `subagentRunId` is read off the events that carry it, and each subagent run is grouped into one nested assistant message attached to its spawning tool call as `ToolCallMessagePart.messages`. a subagent with no reachable spawning call renders in the parent thread rather than being dropped.
+
+behavior change: a subagent's frontend-executed tool call is no longer reachable by `getPendingToolCalls()`, so it does not execute. previously these calls landed in the parent thread and ran, because subagent attribution did not exist. the run now reports `incomplete` / `tool-calls` instead of claiming it finished. see the subagents section of the react-ag-ui README and #6612.

--- a/.changeset/ag-ui-subagent-attribution.md
+++ b/.changeset/ag-ui-subagent-attribution.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: attribute AG-UI subagent lifecycle events (SUBAGENT_STARTED/FINISHED/ERROR, subagentRunId) into nested ToolCallMessagePart.messages instead of flattening or dropping them as RAW

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -33,6 +33,17 @@ export function Provider({ children }: { children: React.ReactNode }) {
 }
 ```
 
+## Subagents
+
+An AG-UI backend that runs subagents (the agents-as-tools pattern) emits `SUBAGENT_STARTED` / `SUBAGENT_FINISHED` / `SUBAGENT_ERROR` plus a `subagentRunId` on the events each subagent produces. This adapter groups that activity into one nested assistant message per subagent run and attaches it to the spawning tool call as `ToolCallMessagePart.messages`, joined on `SUBAGENT_STARTED.parentToolCallId`. `PartPrimitive.Messages` renders it without extra wiring, and the subagent's name, description, result, and error code ride on that message's `agui` metadata.
+
+A subagent that names no reachable spawning call (`parentToolCallId` is optional, may name a call this run never saw, or two runs may name each other) has nowhere to nest, so its output renders in the parent thread instead of being dropped. This matches the downgrade the protocol's own pre-subagent compatibility middleware performs.
+
+Two limitations are worth knowing before you rely on this:
+
+- **A subagent cannot run frontend-executed tools.** A tool call inside a nested message is not reachable by `getPendingToolCalls()`, so it is never handed to a frontend tool and never resolved. The run reports `{ type: "incomplete", reason: "tool-calls" }` rather than claiming it finished, but the call does not execute. Before subagent attribution existed these calls landed in the parent thread and did run, so this is a behavior change for a backend that pairs subagents with frontend tools. Tracked in [#6612](https://github.com/assistant-ui/assistant-ui/issues/6612).
+- **Nested human-in-the-loop is not wired up.** A `SUBAGENT_FINISHED` with a `suspended` outcome marks the nested message `requires-action`, and its `interruptIds` are preserved on the message metadata, but there is no resume path that answers them yet.
+
 ## See also
 
 - `@assistant-ui/react-a2a` for the A2A v1.0 protocol.

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
@@ -102,29 +102,12 @@ describe("RunAggregator tool approval projection", () => {
   });
 
   /**
-   * `boundToolCallIds` decides whether the whole interrupt batch is
-   * projectable at all: a gate naming a tool call the message never renders
-   * makes the batch bespoke for everyone in it, including the root gate's
-   * sibling. A subagent-scoped tool call has no interactive UI anywhere
-   * (buildParts always passes an empty approvals map for subagent scope), so
-   * it must not count as "rendered" when the root scope decides whether its
-   * batch is bound.
-   *
-   * Before this fix, `boundToolCallIds` was built from every tool call
-   * (`this.toolCalls.keys()`), so the subagent's own tool call counted as
-   * "rendered" and the batch was wrongly treated as fully bound: the root
-   * gate projected an approval that looked actionable, but
-   * `buildToolApprovalResume`/`AgUiThreadRuntimeCore.respondToToolApproval`
-   * still require a recorded decision for *every* interrupt in the batch —
-   * including the subagent's, which no UI can ever produce — so clicking it
-   * would record a local decision and then resume forever. Filtering
-   * `boundToolCallIds` to root-scoped tool calls only makes the subagent gate
-   * correctly unbound, which — per `projectAgUiToolApprovals`'s own
-   * "batch mixing a gate with anything unrenderable projects nothing" rule —
-   * collapses the *whole* batch to `EMPTY_APPROVALS`. That is the safe
-   * outcome: no button is shown that can never actually complete, and the
-   * interrupts stay on the message's metadata for the bespoke hooks to
-   * handle instead.
+   * `boundToolCallIds` names the calls that render at root scope. A gate on a
+   * call nested inside a subagent message is therefore unbound, and
+   * `projectAgUiToolApprovals` collapses the whole batch rather than
+   * projecting the root gate alone: resuming requires a decision for every
+   * interrupt in the batch, and no UI can produce one for the nested gate. The
+   * interrupts stay on the message metadata for the bespoke hooks.
    */
   it("collapses the whole batch to unbound, rather than showing an unresolvable root approval, when a subagent-scoped tool call shares the interrupt batch", () => {
     const emitted: ChatModelRunResult[] = [];

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
@@ -100,4 +100,135 @@ describe("RunAggregator tool approval projection", () => {
         ?.interrupts,
     ).toEqual([GATE]);
   });
+
+  /**
+   * `boundToolCallIds` decides whether the whole interrupt batch is
+   * projectable at all: a gate naming a tool call the message never renders
+   * makes the batch bespoke for everyone in it, including the root gate's
+   * sibling. A subagent-scoped tool call has no interactive UI anywhere
+   * (buildParts always passes an empty approvals map for subagent scope), so
+   * it must not count as "rendered" when the root scope decides whether its
+   * batch is bound.
+   *
+   * Before this fix, `boundToolCallIds` was built from every tool call
+   * (`this.toolCalls.keys()`), so the subagent's own tool call counted as
+   * "rendered" and the batch was wrongly treated as fully bound: the root
+   * gate projected an approval that looked actionable, but
+   * `buildToolApprovalResume`/`AgUiThreadRuntimeCore.respondToToolApproval`
+   * still require a recorded decision for *every* interrupt in the batch —
+   * including the subagent's, which no UI can ever produce — so clicking it
+   * would record a local decision and then resume forever. Filtering
+   * `boundToolCallIds` to root-scoped tool calls only makes the subagent gate
+   * correctly unbound, which — per `projectAgUiToolApprovals`'s own
+   * "batch mixing a gate with anything unrenderable projects nothing" rule —
+   * collapses the *whole* batch to `EMPTY_APPROVALS`. That is the safe
+   * outcome: no button is shown that can never actually complete, and the
+   * interrupts stay on the message's metadata for the bespoke hooks to
+   * handle instead.
+   */
+  it("collapses the whole batch to unbound, rather than showing an unresolvable root approval, when a subagent-scoped tool call shares the interrupt batch", () => {
+    const emitted: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: false,
+      logger: noopLogger,
+      emit: (result) => {
+        emitted.push(result);
+      },
+    });
+
+    const ROOT_GATE: AgUiInterrupt = {
+      id: "int-root",
+      reason: "tool_call",
+      toolCallId: "tc-root",
+      message: "Delete /tmp/root?",
+    };
+    const SUBAGENT_GATE: AgUiInterrupt = {
+      id: "int-sub",
+      reason: "tool_call",
+      toolCallId: "tc-sub",
+      message: "Delete /tmp/sub?",
+    };
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "run-1" });
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-root",
+      toolCallName: "delete_file",
+    });
+    aggregator.handle({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "tc-root",
+      delta: '{"path":"/tmp/root"}',
+    });
+    aggregator.handle({ type: "TOOL_CALL_END", toolCallId: "tc-root" });
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "cleanup",
+      parentToolCallId: "tc-root",
+    } as any);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-sub",
+      toolCallName: "delete_file",
+      subagentRunId: "sub-1",
+    } as any);
+    aggregator.handle({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "tc-sub",
+      delta: '{"path":"/tmp/sub"}',
+      subagentRunId: "sub-1",
+    } as any);
+    aggregator.handle({
+      type: "TOOL_CALL_END",
+      toolCallId: "tc-sub",
+      subagentRunId: "sub-1",
+    } as any);
+    aggregator.handle({
+      type: "RUN_FINISHED",
+      runId: "run-1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [ROOT_GATE, SUBAGENT_GATE],
+      },
+    } as any);
+
+    const result = emitted[emitted.length - 1]!;
+    expect(result.status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    // Neither gate renders — the batch is bespoke as a whole, not just the
+    // subagent's unrenderable half of it.
+    expect(approvalOf(result)).toBeUndefined();
+    // The interrupts survive on the message metadata so the app's bespoke
+    // interrupt hooks (useAgUiSubmitInterruptResponses / steerAway) can still
+    // resolve the batch.
+    expect(
+      (result.metadata?.custom as Record<string, any> | undefined)?.agui
+        ?.interrupts,
+    ).toEqual([ROOT_GATE, SUBAGENT_GATE]);
+  });
+
+  it("still projects a root gate whose batch is entirely root-scoped, even while an unrelated subagent tool call is in flight", () => {
+    const { aggregator, last } = gatedAggregator();
+
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "cleanup",
+    } as any);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tc-unrelated",
+      toolCallName: "noop",
+      subagentRunId: "sub-1",
+    } as any);
+
+    expect(last().status).toMatchObject({
+      type: "requires-action",
+      reason: "interrupt",
+    });
+    expect(approvalOf(last())).toEqual({ id: "int-1" });
+  });
 });

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -6,6 +6,7 @@ import {
   type MessageStatus,
   type MessageTiming,
   type ThreadAssistantMessagePart,
+  type ThreadMessage,
   type ToolCallMessagePart,
   type ToolModelContentPart,
 } from "@assistant-ui/core";
@@ -794,16 +795,163 @@ export class RunAggregator {
     this.lastResolvedToolCallId = id;
   }
 
-  private emit(): void {
+  private subagentsByParentToolCallId(): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    for (const run of this.subagentRuns.values()) {
+      if (!run.parentToolCallId) continue;
+      const list = map.get(run.parentToolCallId) ?? [];
+      list.push(run.subagentRunId);
+      map.set(run.parentToolCallId, list);
+    }
+    return map;
+  }
+
+  private materializeSubagentMessage(
+    subagentRunId: string,
+    depth: number,
+  ): ThreadMessage | undefined {
+    const run = this.subagentRuns.get(subagentRunId);
+    if (!run || depth > 16) return undefined;
+    const content = this.buildParts(subagentRunId, depth + 1);
+    return {
+      id: run.subagentRunId,
+      role: "assistant",
+      createdAt: run.createdAt,
+      status: run.status,
+      content,
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {
+          [AG_UI_METADATA_NAMESPACE]: {
+            name: run.name,
+            ...(run.description !== undefined
+              ? { description: run.description }
+              : {}),
+            ...(run.parentSubagentRunId !== undefined
+              ? { parentSubagentRunId: run.parentSubagentRunId }
+              : {}),
+          },
+        },
+      },
+    } as ThreadMessage;
+  }
+
+  private buildParts(scope: string, depth = 0): ThreadAssistantMessagePart[] {
     const snapshot: ThreadAssistantMessagePart[] = [];
-    // A run that ended incomplete can no longer be resumed, so a gate left over
-    // from an earlier interrupt outcome is unanswerable and must not stay
-    // projected. The interrupts themselves are kept on the message, since the
-    // bespoke hooks read that payload.
-    const approvals = projectAgUiToolApprovals(
-      this.status?.type === "requires-action" ? this.interrupts : undefined,
-      new Set(this.toolCalls.keys()),
-    );
+    const approvals =
+      scope === ROOT_SCOPE
+        ? projectAgUiToolApprovals(
+            this.status?.type === "requires-action"
+              ? this.interrupts
+              : undefined,
+            new Set(this.toolCalls.keys()),
+          )
+        : new Map();
+    const subagentsByParentToolCallId = this.subagentsByParentToolCallId();
+
+    for (const part of this.partOrder) {
+      if (part.kind === "tool-call") {
+        const entry = this.toolCalls.get(part.toolCallId);
+        if (!entry || (entry.subagentRunId ?? ROOT_SCOPE) !== scope) continue;
+        const approval = approvals.get(entry.toolCallId);
+        const nestedSubagentRunIds = subagentsByParentToolCallId.get(
+          entry.toolCallId,
+        );
+        const nestedMessages = nestedSubagentRunIds
+          ?.map((id) => this.materializeSubagentMessage(id, depth))
+          .filter((m): m is ThreadMessage => m !== undefined);
+        const toolPart: ToolCallMessagePart = {
+          type: "tool-call",
+          toolCallId: entry.toolCallId,
+          toolName: entry.toolCallName,
+          args: (entry.parsedArgs ?? {}) as any,
+          argsText: entry.argsText,
+          ...(approval ? { approval } : {}),
+          ...(entry.result !== undefined ? { result: entry.result } : {}),
+          ...(entry.modelContent !== undefined
+            ? { modelContent: entry.modelContent }
+            : {}),
+          ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
+          ...(entry.mcpAppResourceUri
+            ? {
+                mcp: {
+                  app: {
+                    resourceUri: entry.mcpAppResourceUri,
+                    ...(entry.mcpAppServerId
+                      ? { serverId: entry.mcpAppServerId }
+                      : {}),
+                  },
+                },
+              }
+            : {}),
+          ...(entry.parentMessageId ? { parentId: entry.parentMessageId } : {}),
+          ...(entry.toolMessageId
+            ? { unstable_toolMessageId: entry.toolMessageId }
+            : {}),
+          ...(nestedMessages && nestedMessages.length > 0
+            ? { messages: nestedMessages }
+            : {}),
+        } as ToolCallMessagePart & { unstable_toolMessageId?: string };
+        snapshot.push(toolPart);
+        continue;
+      }
+
+      const partScope =
+        "subagentRunId" in part
+          ? (part.subagentRunId ?? ROOT_SCOPE)
+          : ROOT_SCOPE;
+      if (partScope !== scope) continue;
+
+      if (part.kind === "reasoning") {
+        if (this.showThinking) {
+          const buffer = this.reasoningParts.get(part.key) ?? "";
+          const isActive =
+            this.activeReasoningKeyByScope.get(scope) === part.key;
+          if (buffer.length > 0 || isActive) {
+            const encryptedValue = this.reasoningSignatures.get(part.key);
+            const reasoningId = this.reasoningMessageIds.get(part.key);
+            const meta = {
+              ...(reasoningId !== undefined ? { reasoningId } : {}),
+              ...(encryptedValue !== undefined ? { encryptedValue } : {}),
+            };
+            snapshot.push({
+              type: "reasoning",
+              text: buffer,
+              ...(Object.keys(meta).length > 0
+                ? { providerMetadata: { [AG_UI_METADATA_NAMESPACE]: meta } }
+                : {}),
+            } as const);
+          }
+        }
+        continue;
+      }
+
+      if (part.kind === "text") {
+        const entry = this.textParts.get(part.key);
+        if (entry && entry.buffer.trim().length > 0) {
+          snapshot.push({ type: "text", text: entry.buffer } as const);
+        }
+        continue;
+      }
+
+      if (part.kind === "data" && scope === ROOT_SCOPE) {
+        snapshot.push({
+          type: "data",
+          name: part.name,
+          data: part.value,
+        });
+        continue;
+      }
+    }
+
+    return snapshot;
+  }
+
+  private emit(): void {
+    const snapshot = this.buildParts(ROOT_SCOPE);
 
     const opaqueCandidates: (AgUiOpaqueReasoning & { anchor: number })[] =
       Array.from(this.hiddenSignatures, ([id, encryptedValue]) => ({
@@ -812,40 +960,28 @@ export class RunAggregator {
         anchor: this.hiddenSignatureAnchors.get(id)!,
       }));
 
-    let currentIndex = -1;
     let lastMaterializedIndex = -1;
-    const pushSnapshotPart = (part: (typeof snapshot)[number]) => {
-      snapshot.push(part);
-      lastMaterializedIndex = currentIndex;
-    };
-
     for (const [index, part] of this.partOrder.entries()) {
-      currentIndex = index;
+      if (part.kind === "tool-call") {
+        const entry = this.toolCalls.get(part.toolCallId);
+        if (!entry || (entry.subagentRunId ?? ROOT_SCOPE) !== ROOT_SCOPE)
+          continue;
+        lastMaterializedIndex = index;
+        continue;
+      }
+      const partScope =
+        "subagentRunId" in part
+          ? (part.subagentRunId ?? ROOT_SCOPE)
+          : ROOT_SCOPE;
+      if (partScope !== ROOT_SCOPE) continue;
       if (part.kind === "reasoning") {
         if (this.showThinking) {
           const buffer = this.reasoningParts.get(part.key) ?? "";
-          const scope = part.subagentRunId ?? ROOT_SCOPE;
-          if (
-            buffer.length > 0 ||
-            this.activeReasoningKeyByScope.get(scope) === part.key
-          ) {
-            const encryptedValue = this.reasoningSignatures.get(part.key);
-            const reasoningId = this.reasoningMessageIds.get(part.key);
-            const meta = {
-              ...(reasoningId !== undefined ? { reasoningId } : {}),
-              ...(encryptedValue !== undefined ? { encryptedValue } : {}),
-            };
-            pushSnapshotPart({
-              type: "reasoning",
-              text: buffer,
-              ...(Object.keys(meta).length > 0
-                ? { providerMetadata: { [AG_UI_METADATA_NAMESPACE]: meta } }
-                : {}),
-            } as const);
+          const isActive =
+            this.activeReasoningKeyByScope.get(ROOT_SCOPE) === part.key;
+          if (buffer.length > 0 || isActive) {
+            lastMaterializedIndex = index;
           } else {
-            // A retracted empty block still carries transport state: without
-            // a part to live on, its signature rides the message metadata,
-            // matching the shape a snapshot reload produces.
             const encryptedValue = this.reasoningSignatures.get(part.key);
             const id = this.reasoningSignatureIds.get(part.key);
             if (id?.trim() && encryptedValue?.trim()) {
@@ -855,57 +991,14 @@ export class RunAggregator {
         }
         continue;
       }
-
       if (part.kind === "text") {
         const entry = this.textParts.get(part.key);
-        if (entry && entry.buffer.trim().length > 0) {
-          pushSnapshotPart({ type: "text", text: entry.buffer } as const);
-        }
+        if (entry && entry.buffer.trim().length > 0)
+          lastMaterializedIndex = index;
         continue;
       }
-
-      if (part.kind === "data") {
-        pushSnapshotPart({
-          type: "data",
-          name: part.name,
-          data: part.value,
-        });
-        continue;
-      }
-
-      const entry = this.toolCalls.get(part.toolCallId);
-      if (!entry) continue;
-      const approval = approvals.get(entry.toolCallId);
-      const toolPart: ToolCallMessagePart = {
-        type: "tool-call",
-        toolCallId: entry.toolCallId,
-        toolName: entry.toolCallName,
-        args: (entry.parsedArgs ?? {}) as any,
-        argsText: entry.argsText,
-        ...(approval ? { approval } : {}),
-        ...(entry.result !== undefined ? { result: entry.result } : {}),
-        ...(entry.modelContent !== undefined
-          ? { modelContent: entry.modelContent }
-          : {}),
-        ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
-        ...(entry.mcpAppResourceUri
-          ? {
-              mcp: {
-                app: {
-                  resourceUri: entry.mcpAppResourceUri,
-                  ...(entry.mcpAppServerId
-                    ? { serverId: entry.mcpAppServerId }
-                    : {}),
-                },
-              },
-            }
-          : {}),
-        ...(entry.parentMessageId ? { parentId: entry.parentMessageId } : {}),
-        ...(entry.toolMessageId
-          ? { unstable_toolMessageId: entry.toolMessageId }
-          : {}),
-      } as ToolCallMessagePart & { unstable_toolMessageId?: string };
-      pushSnapshotPart(toolPart);
+      // data parts always materialize when in scope.
+      lastMaterializedIndex = index;
     }
 
     // An anonymous claim promotes the signature's entityId to a wire message

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -908,6 +908,10 @@ export class RunAggregator {
     return reachable;
   }
 
+  // Nested messages rather than a discovery hook (the shape react-langchain
+  // uses): ToolCallMessagePart.messages is the contract core consumers already
+  // walk, and SUBAGENT_STARTED.parentToolCallId names the spawning call
+  // outright, so the join needs no namespace scheme of its own.
   private materializeSubagentMessage(
     subagentRunId: string,
     depth: number,

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -188,7 +188,7 @@ export class RunAggregator {
 
         this.interrupts = undefined;
         const hasUnresolvedToolCalls = Array.from(this.toolCalls.values()).some(
-          (tc) => tc.result === undefined,
+          (tc) => tc.subagentRunId === undefined && tc.result === undefined,
         );
 
         this.status = hasUnresolvedToolCalls
@@ -279,9 +279,10 @@ export class RunAggregator {
         break;
       case "REASONING_ENCRYPTED_VALUE":
         if (event.subtype === "message") {
+          const scope = this.scopeOf(event);
           // entityId names any message, not necessarily a reasoning one, so an
           // unmatched id may only claim a block that has no id to contradict it.
-          const active = this.activeReasoningKeyByScope.get(ROOT_SCOPE);
+          const active = this.activeReasoningKeyByScope.get(scope);
           const key = this.showThinking
             ? this.reasoningParts.has(event.entityId)
               ? event.entityId
@@ -295,6 +296,9 @@ export class RunAggregator {
             this.emit();
           } else if (
             !this.showThinking &&
+            // Hidden-reasoning bookkeeping stays root-only for this task — a
+            // subagent's opaque/hidden reasoning signatures are not preserved.
+            scope === ROOT_SCOPE &&
             event.entityId.trim().length > 0 &&
             event.encryptedValue.trim().length > 0 &&
             (this.hiddenReasoningIds.has(event.entityId) ||
@@ -860,7 +864,11 @@ export class RunAggregator {
             this.status?.type === "requires-action"
               ? this.interrupts
               : undefined,
-            new Set(this.toolCalls.keys()),
+            new Set(
+              Array.from(this.toolCalls.entries())
+                .filter(([, entry]) => entry.subagentRunId === undefined)
+                .map(([id]) => id),
+            ),
           )
         : new Map();
 

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -3,6 +3,7 @@
 import {
   isMcpAppUri,
   type ChatModelRunResult,
+  type MessageStatus,
   type MessageTiming,
   type ThreadAssistantMessagePart,
   type ToolCallMessagePart,
@@ -20,6 +21,19 @@ import type { AgUiEvent, AgUiInterrupt } from "../types";
 import type { Logger } from "../logger";
 
 export const AG_UI_METADATA_NAMESPACE = "agui";
+
+const ROOT_SCOPE = "";
+
+type SubagentRunState = {
+  subagentRunId: string;
+  name: string;
+  description?: string;
+  parentSubagentRunId?: string;
+  parentToolCallId?: string;
+  parentMessageId?: string;
+  createdAt: Date;
+  status: MessageStatus;
+};
 
 export type AgUiOpaqueReasoning = {
   id: string;
@@ -50,6 +64,7 @@ type ToolCallState = {
   mcpAppServerId?: string;
   modelContent?: ToolModelContentPart[];
   snapshotResultApplied: boolean;
+  subagentRunId?: string;
 };
 
 export const MCP_APPS_ACTIVITY_TYPE = "mcp-apps";
@@ -91,7 +106,7 @@ export class RunAggregator {
   private status: ChatModelRunResult["status"] | undefined;
   private interrupts: AgUiInterrupt[] | undefined;
   private readonly textParts = new Map<string, { buffer: string }>();
-  private activeTextMessageId: string | undefined;
+  private readonly activeTextMessageIdByScope = new Map<string, string>();
   private readonly reasoningParts = new Map<string, string>(); // key → buffer
   private readonly reasoningSignatures = new Map<string, string>();
   private readonly reasoningSignatureIds = new Map<string, string>();
@@ -109,15 +124,16 @@ export class RunAggregator {
   private readonly loggedDroppedOpaqueIds = new Set<string>();
   private readonly reasoningMessageIds = new Map<string, string>();
   private readonly anonymousReasoningKeys = new Set<string>();
-  private activeReasoningKey: string | undefined;
+  private readonly activeReasoningKeyByScope = new Map<string, string>();
+  private readonly subagentRuns = new Map<string, SubagentRunState>();
   private reasoningPartCounter = 0;
   private readonly toolCalls = new Map<string, ToolCallState>();
   private readonly a2uiBuckets = new Map<string, A2uiState>();
   private readonly a2uiToolCallIds = new Set<string>();
   private lastResolvedToolCallId: string | undefined;
   private readonly partOrder: (
-    | { kind: "text"; key: string }
-    | { kind: "reasoning"; key: string }
+    | { kind: "text"; key: string; subagentRunId?: string }
+    | { kind: "reasoning"; key: string; subagentRunId?: string }
     | { kind: "tool-call"; toolCallId: string }
     | { kind: "data"; name: string; value: unknown }
   )[] = [];
@@ -192,38 +208,51 @@ export class RunAggregator {
       }
 
       case "TEXT_MESSAGE_START": {
-        this.beginDistinctTextMessage(event.messageId);
-        this.reportServerMessageId(event.messageId);
-        this.startTextMessage(event.messageId);
-        if (event.messageId) this.lastTextMessageId = event.messageId;
+        const scope = this.scopeOf(event);
+        if (scope === ROOT_SCOPE) {
+          this.beginDistinctTextMessage(event.messageId);
+          this.reportServerMessageId(event.messageId);
+          if (event.messageId) this.lastTextMessageId = event.messageId;
+        }
+        this.startTextMessage(scope, event.messageId);
         this.emit();
         break;
       }
       case "TEXT_MESSAGE_CONTENT":
       case "TEXT_MESSAGE_CHUNK": {
         const incomingId = "messageId" in event ? event.messageId : undefined;
-        this.beginDistinctTextMessage(incomingId);
-        this.reportServerMessageId(incomingId);
-        if (incomingId) this.lastTextMessageId = incomingId;
+        const scope =
+          event.type === "TEXT_MESSAGE_CONTENT"
+            ? this.scopeOf(event)
+            : ROOT_SCOPE;
+        if (scope === ROOT_SCOPE) {
+          this.beginDistinctTextMessage(incomingId);
+          this.reportServerMessageId(incomingId);
+          if (incomingId) this.lastTextMessageId = incomingId;
+        }
         if (!event.delta) break;
         this.recordFirstToken();
-        const id = this.resolveTextMessageId(incomingId);
+        const id = this.resolveTextMessageId(scope, incomingId);
         this.appendText(id, event.delta);
         this.totalChunks++;
         this.emit();
         break;
       }
       case "TEXT_MESSAGE_END": {
-        this.reportServerMessageId(event.messageId);
-        if (event.messageId && this.activeTextMessageId === event.messageId) {
-          this.activeTextMessageId = undefined;
+        const scope = this.scopeOf(event);
+        if (scope === ROOT_SCOPE) this.reportServerMessageId(event.messageId);
+        if (
+          event.messageId &&
+          this.activeTextMessageIdByScope.get(scope) === event.messageId
+        ) {
+          this.activeTextMessageIdByScope.delete(scope);
         }
         this.emit();
         break;
       }
 
       case "CUSTOM": {
-        this.activeTextMessageId = undefined;
+        this.activeTextMessageIdByScope.delete(ROOT_SCOPE);
         this.partOrder.push({
           kind: "data",
           name: event.name,
@@ -238,6 +267,7 @@ export class RunAggregator {
       case "REASONING_START":
       case "REASONING_MESSAGE_START":
         this.handleReasoningStart(
+          this.scopeOf("subagentRunId" in event ? event : {}),
           "messageId" in event ? event.messageId : undefined,
           event.type === "REASONING_MESSAGE_START",
         );
@@ -246,7 +276,7 @@ export class RunAggregator {
         if (event.subtype === "message") {
           // entityId names any message, not necessarily a reasoning one, so an
           // unmatched id may only claim a block that has no id to contradict it.
-          const active = this.activeReasoningKey;
+          const active = this.activeReasoningKeyByScope.get(ROOT_SCOPE);
           const key = this.showThinking
             ? this.reasoningParts.has(event.entityId)
               ? event.entityId
@@ -277,12 +307,13 @@ export class RunAggregator {
         }
         break;
       case "THINKING_TEXT_MESSAGE_CONTENT":
-        this.handleReasoningContent(event.delta);
+        this.handleReasoningContent(ROOT_SCOPE, event.delta);
         this.totalChunks++;
         this.recordFirstToken();
         break;
       case "REASONING_MESSAGE_CONTENT":
         this.handleReasoningContent(
+          this.scopeOf(event),
           event.delta,
           "messageId" in event ? event.messageId : undefined,
           true,
@@ -292,14 +323,20 @@ export class RunAggregator {
         break;
       case "THINKING_TEXT_MESSAGE_END":
       case "THINKING_END":
+        this.handleReasoningEnd(ROOT_SCOPE);
+        break;
       case "REASONING_MESSAGE_END":
       case "REASONING_END":
-        this.handleReasoningEnd();
+        this.handleReasoningEnd(this.scopeOf(event));
         break;
 
       case "TOOL_CALL_START": {
-        this.reportServerMessageId(event.parentMessageId);
+        const scope = this.scopeOf(event);
+        if (scope === ROOT_SCOPE) {
+          this.reportServerMessageId(event.parentMessageId);
+        }
         this.startToolCall(
+          scope,
           event.toolCallId,
           event.toolCallName,
           event.parentMessageId,
@@ -323,6 +360,7 @@ export class RunAggregator {
       }
       case "TOOL_CALL_RESULT": {
         this.finishToolCall(
+          this.scopeOf(event),
           event.toolCallId,
           event.content ?? "",
           typeof event.mcpResult?.isError === "boolean"
@@ -387,6 +425,52 @@ export class RunAggregator {
           }
           this.emit();
         }
+        break;
+      }
+
+      case "SUBAGENT_STARTED": {
+        this.subagentRuns.set(event.subagentRunId, {
+          subagentRunId: event.subagentRunId,
+          name: event.name,
+          ...(event.description !== undefined
+            ? { description: event.description }
+            : {}),
+          ...(event.parentSubagentRunId !== undefined
+            ? { parentSubagentRunId: event.parentSubagentRunId }
+            : {}),
+          ...(event.parentToolCallId !== undefined
+            ? { parentToolCallId: event.parentToolCallId }
+            : {}),
+          ...(event.parentMessageId !== undefined
+            ? { parentMessageId: event.parentMessageId }
+            : {}),
+          createdAt: new Date(),
+          status: { type: "running" },
+        });
+        this.emit();
+        break;
+      }
+      case "SUBAGENT_FINISHED": {
+        const run = this.subagentRuns.get(event.subagentRunId);
+        if (run) {
+          run.status =
+            event.outcome?.type === "suspended"
+              ? { type: "requires-action", reason: "interrupt" }
+              : { type: "complete", reason: "unknown" };
+        }
+        this.emit();
+        break;
+      }
+      case "SUBAGENT_ERROR": {
+        const run = this.subagentRuns.get(event.subagentRunId);
+        if (run) {
+          run.status = {
+            type: "incomplete",
+            reason: "error",
+            ...(event.message !== undefined ? { error: event.message } : {}),
+          };
+        }
+        this.emit();
         break;
       }
 
@@ -491,7 +575,8 @@ export class RunAggregator {
     this.hiddenActiveReasoning = "none";
     this.loggedDroppedOpaqueIds.clear();
     this.anonymousReasoningKeys.clear();
-    this.activeReasoningKey = undefined;
+    this.activeReasoningKeyByScope.clear();
+    this.subagentRuns.clear();
     this.reasoningPartCounter = 0;
     this.toolCalls.clear();
     this.a2uiBuckets.clear();
@@ -499,8 +584,12 @@ export class RunAggregator {
     this.lastResolvedToolCallId = undefined;
     this.partOrder.length = 0;
     this.textPartCounter = 0;
-    this.activeTextMessageId = undefined;
+    this.activeTextMessageIdByScope.clear();
     this.reportedServerMessageId = undefined;
+  }
+
+  private scopeOf(event: { subagentRunId?: string }): string {
+    return event.subagentRunId ?? ROOT_SCOPE;
   }
 
   private beginDistinctTextMessage(messageId: string | undefined): void {
@@ -521,57 +610,68 @@ export class RunAggregator {
     return `text-${this.textPartCounter}`;
   }
 
-  private startTextMessage(messageId?: string): string {
+  private startTextMessage(scope: string, messageId?: string): string {
     const id = messageId ?? this.generateTextKey();
-    this.ensureTextPart(id);
-    this.activeTextMessageId = id;
+    this.ensureTextPart(id, scope);
+    this.activeTextMessageIdByScope.set(scope, id);
     return id;
   }
 
-  private resolveTextMessageId(messageId?: string): string {
+  private resolveTextMessageId(scope: string, messageId?: string): string {
     if (messageId) {
-      this.ensureTextPart(messageId);
-      this.activeTextMessageId = messageId;
+      this.ensureTextPart(messageId, scope);
+      this.activeTextMessageIdByScope.set(scope, messageId);
       return messageId;
     }
 
-    if (this.activeTextMessageId) {
-      return this.activeTextMessageId;
+    const active = this.activeTextMessageIdByScope.get(scope);
+    if (active) {
+      return active;
     }
 
     const generated = this.generateTextKey();
-    this.ensureTextPart(generated);
-    this.activeTextMessageId = generated;
+    this.ensureTextPart(generated, scope);
+    this.activeTextMessageIdByScope.set(scope, generated);
     return generated;
   }
 
-  private ensureTextPart(id: string): void {
+  private ensureTextPart(id: string, scope: string): void {
     if (!this.textParts.has(id)) {
       this.textParts.set(id, { buffer: "" });
       if (
         !this.partOrder.some((part) => part.kind === "text" && part.key === id)
       ) {
-        this.partOrder.push({ kind: "text", key: id });
+        this.partOrder.push(
+          scope === ROOT_SCOPE
+            ? { kind: "text", key: id }
+            : { kind: "text", key: id, subagentRunId: scope },
+        );
       }
     }
   }
 
   private appendText(id: string, delta: string): void {
-    this.ensureTextPart(id);
+    // The id has always already been ensured by resolveTextMessageId/
+    // startTextMessage before appendText runs, so the scope passed here is
+    // never actually used to create a new part.
+    this.ensureTextPart(id, ROOT_SCOPE);
     const entry = this.textParts.get(id);
     if (!entry) return;
     entry.buffer += delta;
   }
 
   private startToolCall(
+    scope: string,
     id: string | undefined,
     name?: string,
     parentMessageId?: string,
   ) {
     if (!id) return;
     // A new tool call acts as a boundary: any anonymous text that arrives
-    // after it should be a new part, not appended to the pre-tool text.
-    this.activeTextMessageId = undefined;
+    // after it should be a new part, not appended to the pre-tool text —
+    // scoped, so a subagent's tool call doesn't break the root run's text
+    // and vice versa.
+    this.activeTextMessageIdByScope.delete(scope);
     if (
       !this.partOrder.some(
         (part) => part.kind === "tool-call" && part.toolCallId === id,
@@ -590,6 +690,9 @@ export class RunAggregator {
     };
     if (parentMessageId) {
       state.parentMessageId = parentMessageId;
+    }
+    if (scope !== ROOT_SCOPE) {
+      state.subagentRunId = scope;
     }
     this.toolCalls.set(id, state);
   }
@@ -640,6 +743,7 @@ export class RunAggregator {
   }
 
   private finishToolCall(
+    scope: string,
     id: string,
     content: string,
     isError?: boolean,
@@ -657,6 +761,7 @@ export class RunAggregator {
         result: undefined,
         isError: undefined,
         snapshotResultApplied: false,
+        ...(scope !== ROOT_SCOPE ? { subagentRunId: scope } : {}),
       };
       this.toolCalls.set(id, entry);
     }
@@ -723,7 +828,11 @@ export class RunAggregator {
       if (part.kind === "reasoning") {
         if (this.showThinking) {
           const buffer = this.reasoningParts.get(part.key) ?? "";
-          if (buffer.length > 0 || this.activeReasoningKey === part.key) {
+          const scope = part.subagentRunId ?? ROOT_SCOPE;
+          if (
+            buffer.length > 0 ||
+            this.activeReasoningKeyByScope.get(scope) === part.key
+          ) {
             const encryptedValue = this.reasoningSignatures.get(part.key);
             const reasoningId = this.reasoningMessageIds.get(part.key);
             const meta = {
@@ -905,8 +1014,15 @@ export class RunAggregator {
     };
   }
 
-  private handleReasoningStart(messageId?: string, isMessageId = false): void {
+  private handleReasoningStart(
+    scope: string,
+    messageId?: string,
+    isMessageId = false,
+  ): void {
     if (!this.showThinking) {
+      // Hidden-reasoning bookkeeping stays root-only for this task — a
+      // subagent's opaque/hidden reasoning signatures are not preserved.
+      if (scope !== ROOT_SCOPE) return;
       const anchor = this.partOrder.length;
       if (messageId === undefined) {
         this.hiddenActiveReasoning = "anonymous";
@@ -919,8 +1035,8 @@ export class RunAggregator {
       return;
     }
     // A reasoning block acts as a boundary: anonymous text arriving after it
-    // should be a new part, not appended to any pre-reasoning text.
-    this.activeTextMessageId = undefined;
+    // should be a new part, not appended to any pre-reasoning text — scoped.
+    this.activeTextMessageIdByScope.delete(scope);
     const key = messageId ?? `__auto-reasoning-${++this.reasoningPartCounter}`;
     // Two different questions: which id may be replayed as a ReasoningMessage.id
     // (only the message-scoped aliases carry one), and which block an unmatched
@@ -932,13 +1048,18 @@ export class RunAggregator {
     }
     if (!this.reasoningParts.has(key)) {
       this.reasoningParts.set(key, "");
-      this.partOrder.push({ kind: "reasoning", key });
+      this.partOrder.push(
+        scope === ROOT_SCOPE
+          ? { kind: "reasoning", key }
+          : { kind: "reasoning", key, subagentRunId: scope },
+      );
     }
-    this.activeReasoningKey = key;
+    this.activeReasoningKeyByScope.set(scope, key);
     this.emit();
   }
 
   private handleReasoningContent(
+    scope: string,
     delta: string,
     messageId?: string,
     isMessageId = false,
@@ -947,27 +1068,28 @@ export class RunAggregator {
     if (!this.showThinking) {
       // Content without a preceding START still names the block (the visible
       // path opens it lazily); register it so a signature can claim it.
+      if (scope !== ROOT_SCOPE) return;
       if (this.hiddenActiveReasoning === "none") {
-        this.handleReasoningStart(messageId, isMessageId);
+        this.handleReasoningStart(scope, messageId, isMessageId);
       }
       return;
     }
-    if (!this.activeReasoningKey) {
+    if (!this.activeReasoningKeyByScope.has(scope)) {
       // Content arrived without a preceding START — create the slot lazily.
-      this.handleReasoningStart(messageId, isMessageId);
+      this.handleReasoningStart(scope, messageId, isMessageId);
     }
-    const key = this.activeReasoningKey;
+    const key = this.activeReasoningKeyByScope.get(scope);
     if (!key) return;
     this.reasoningParts.set(key, (this.reasoningParts.get(key) ?? "") + delta);
     this.emit();
   }
 
-  private handleReasoningEnd(): void {
+  private handleReasoningEnd(scope: string): void {
     if (!this.showThinking) {
-      this.hiddenActiveReasoning = "none";
+      if (scope === ROOT_SCOPE) this.hiddenActiveReasoning = "none";
       return;
     }
-    this.activeReasoningKey = undefined;
+    this.activeReasoningKeyByScope.delete(scope);
     this.emit();
   }
 }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -158,6 +158,15 @@ export class RunAggregator {
   private readonly anonymousReasoningKeys = new Set<string>();
   private readonly activeReasoningKeyByScope = new Map<string, string>();
   private readonly subagentRuns = new Map<string, SubagentRunState>();
+  // The nesting graph only moves when a run is announced or a tool call is
+  // created, which is rare next to emit(), so it is derived once per change
+  // rather than per streamed delta.
+  private nestingMemo:
+    | {
+        subagentsByParentToolCallId: Map<string, string[]>;
+        reachable: Set<string>;
+      }
+    | undefined;
   private reasoningPartCounter = 0;
   private readonly toolCalls = new Map<string, ToolCallState>();
   private readonly a2uiBuckets = new Map<string, A2uiState>();
@@ -209,9 +218,7 @@ export class RunAggregator {
         }
 
         this.interrupts = undefined;
-        const reachable = this.reachableSubagentRunIds(
-          this.subagentsByParentToolCallId(),
-        );
+        const { reachable } = this.nesting();
         // Classified by the scope a call actually renders in: one flattened to
         // root is reachable by getPendingToolCalls and therefore answerable,
         // while one nested inside a subagent message is not.
@@ -232,6 +239,7 @@ export class RunAggregator {
           : hasUnresolvedSubagentToolCalls
             ? { type: "incomplete", reason: "tool-calls" }
             : { type: "complete", reason: "unknown" };
+        this.closeOpenSubagentRuns(this.status);
         this.emit();
         break;
       }
@@ -241,11 +249,13 @@ export class RunAggregator {
           reason: "error",
           ...(event.message !== undefined ? { error: event.message } : {}),
         };
+        this.closeOpenSubagentRuns(this.status);
         this.emit();
         break;
       }
       case "RUN_CANCELLED": {
         this.status = { type: "incomplete", reason: "cancelled" };
+        this.closeOpenSubagentRuns(this.status);
         this.emit();
         break;
       }
@@ -494,6 +504,7 @@ export class RunAggregator {
           this.emit();
           break;
         }
+        this.nestingMemo = undefined;
         this.subagentRuns.set(event.subagentRunId, {
           subagentRunId: event.subagentRunId,
           name: event.name,
@@ -600,12 +611,14 @@ export class RunAggregator {
       if (!this.toolCalls.has(toolCallId)) {
         this.partOrder.push({ kind: "tool-call", toolCallId });
       }
+      this.nestingMemo = undefined;
       this.toolCalls.set(toolCallId, entry);
       this.a2uiToolCallIds.add(toolCallId);
     }
 
     for (const toolCallId of this.a2uiToolCallIds) {
       if (activeToolCallIds.has(toolCallId)) continue;
+      this.nestingMemo = undefined;
       this.toolCalls.delete(toolCallId);
       const partIndex = this.partOrder.findIndex(
         (part) => part.kind === "tool-call" && part.toolCallId === toolCallId,
@@ -645,6 +658,7 @@ export class RunAggregator {
     this.loggedDroppedOpaqueIds.clear();
     this.anonymousReasoningKeys.clear();
     this.activeReasoningKeyByScope.clear();
+    this.nestingMemo = undefined;
     this.subagentRuns.clear();
     this.reasoningPartCounter = 0;
     this.toolCalls.clear();
@@ -655,6 +669,14 @@ export class RunAggregator {
     this.textPartCounter = 0;
     this.activeTextMessageIdByScope.clear();
     this.reportedServerMessageId = undefined;
+  }
+
+  // A subagent only ever reports its own terminal, so a run that ends while
+  // one is still streaming would leave that nested message spinning forever.
+  private closeOpenSubagentRuns(status: MessageStatus): void {
+    for (const run of this.subagentRuns.values()) {
+      if (run.status.type === "running") run.status = status;
+    }
   }
 
   private scopeOf(event: { subagentRunId?: string }): string {
@@ -767,6 +789,7 @@ export class RunAggregator {
     if (scope !== ROOT_SCOPE) {
       state.subagentRunId = scope;
     }
+    this.nestingMemo = undefined;
     this.toolCalls.set(id, state);
   }
 
@@ -837,6 +860,7 @@ export class RunAggregator {
         snapshotResultApplied: false,
         ...(scope !== ROOT_SCOPE ? { subagentRunId: scope } : {}),
       };
+      this.nestingMemo = undefined;
       this.toolCalls.set(id, entry);
     }
     if (
@@ -870,6 +894,20 @@ export class RunAggregator {
       entry.toolMessageId = toolMessageId;
     }
     this.lastResolvedToolCallIdByScope.set(scope, id);
+  }
+
+  private nesting(): {
+    subagentsByParentToolCallId: Map<string, string[]>;
+    reachable: Set<string>;
+  } {
+    if (!this.nestingMemo) {
+      const subagentsByParentToolCallId = this.subagentsByParentToolCallId();
+      this.nestingMemo = {
+        subagentsByParentToolCallId,
+        reachable: this.reachableSubagentRunIds(subagentsByParentToolCallId),
+      };
+    }
+    return this.nestingMemo;
   }
 
   private subagentsByParentToolCallId(): Map<string, string[]> {
@@ -1078,7 +1116,7 @@ export class RunAggregator {
   }
 
   private emit(): void {
-    const subagentsByParentToolCallId = this.subagentsByParentToolCallId();
+    const { subagentsByParentToolCallId, reachable } = this.nesting();
     const root = {
       opaqueCandidates: Array.from(
         this.hiddenSignatures,
@@ -1090,7 +1128,6 @@ export class RunAggregator {
       ) as (AgUiOpaqueReasoning & { anchor: number })[],
       lastMaterializedIndex: -1,
     };
-    const reachable = this.reachableSubagentRunIds(subagentsByParentToolCallId);
     // A run that ended incomplete can no longer be resumed, so a gate left over
     // from an earlier interrupt outcome is unanswerable and must not stay
     // projected. The interrupts themselves are kept on the message, since the

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -45,10 +45,19 @@ type SubagentRunState = {
 
 type ToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
 
+type PartOrderEntry =
+  | { kind: "text"; key: string; subagentRunId?: string }
+  | { kind: "reasoning"; key: string; subagentRunId?: string }
+  | { kind: "tool-call"; toolCallId: string }
+  | { kind: "data"; name: string; value: unknown };
+
 type BuildContext = {
   subagentsByParentToolCallId: Map<string, string[]>;
   reachable: Set<string>;
   approvals: ReadonlyMap<string, ToolApproval>;
+  // partOrder bucketed by the scope each part renders in, so one emit walks
+  // every part once however many subagents the run spawned.
+  partsByScope: Map<string, { index: number; part: PartOrderEntry }[]>;
   // Present only for the root walk: the pass that builds the snapshot is also
   // the one that decides where a retracted reasoning signature anchors, so the
   // two can never disagree about what materialized.
@@ -154,12 +163,7 @@ export class RunAggregator {
   private readonly a2uiBuckets = new Map<string, A2uiState>();
   private readonly a2uiToolCallIds = new Set<string>();
   private readonly lastResolvedToolCallIdByScope = new Map<string, string>();
-  private readonly partOrder: (
-    | { kind: "text"; key: string; subagentRunId?: string }
-    | { kind: "reasoning"; key: string; subagentRunId?: string }
-    | { kind: "tool-call"; toolCallId: string }
-    | { kind: "data"; name: string; value: unknown }
-  )[] = [];
+  private readonly partOrder: PartOrderEntry[] = [];
   private textPartCounter = 0;
   private serverMessageIdReported = false;
   private reportedServerMessageId: string | undefined;
@@ -205,12 +209,22 @@ export class RunAggregator {
         }
 
         this.interrupts = undefined;
-        const toolCallValues = Array.from(this.toolCalls.values());
-        const hasUnresolvedRootToolCalls = toolCallValues.some(
-          (tc) => tc.subagentRunId === undefined && tc.result === undefined,
+        const reachable = this.reachableSubagentRunIds(
+          this.subagentsByParentToolCallId(),
         );
-        const hasUnresolvedSubagentToolCalls = toolCallValues.some(
-          (tc) => tc.subagentRunId !== undefined && tc.result === undefined,
+        // Classified by the scope a call actually renders in: one flattened to
+        // root is reachable by getPendingToolCalls and therefore answerable,
+        // while one nested inside a subagent message is not.
+        const unresolved = Array.from(this.toolCalls.values()).filter(
+          (tc) => tc.result === undefined,
+        );
+        const hasUnresolvedRootToolCalls = unresolved.some(
+          (tc) =>
+            tc.subagentRunId === undefined || !reachable.has(tc.subagentRunId),
+        );
+        const hasUnresolvedSubagentToolCalls = unresolved.some(
+          (tc) =>
+            tc.subagentRunId !== undefined && reachable.has(tc.subagentRunId),
         );
 
         this.status = hasUnresolvedRootToolCalls
@@ -269,7 +283,8 @@ export class RunAggregator {
         if (scope === ROOT_SCOPE) this.reportServerMessageId(event.messageId);
         if (
           event.messageId &&
-          this.activeTextMessageIdByScope.get(scope) === event.messageId
+          this.activeTextMessageIdByScope.get(scope) ===
+            this.partKey(scope, event.messageId)
         ) {
           this.activeTextMessageIdByScope.delete(scope);
         }
@@ -304,9 +319,10 @@ export class RunAggregator {
           // entityId names any message, not necessarily a reasoning one, so an
           // unmatched id may only claim a block that has no id to contradict it.
           const active = this.activeReasoningKeyByScope.get(scope);
+          const entityKey = this.partKey(scope, event.entityId);
           const key = this.showThinking
-            ? this.reasoningParts.has(event.entityId)
-              ? event.entityId
+            ? this.reasoningParts.has(entityKey)
+              ? entityKey
               : active !== undefined && this.anonymousReasoningKeys.has(active)
                 ? active
                 : undefined
@@ -465,6 +481,19 @@ export class RunAggregator {
       }
 
       case "SUBAGENT_STARTED": {
+        // A suspended subagent is re-announced with the same id on resume, so
+        // a repeat is a continuation: it may refresh the descriptive fields
+        // and reopen the status, but re-parenting an established run would
+        // move its already-rendered output to a different tool call.
+        const existing = this.subagentRuns.get(event.subagentRunId);
+        if (existing) {
+          existing.name = event.name;
+          if (event.description !== undefined)
+            existing.description = event.description;
+          existing.status = { type: "running" };
+          this.emit();
+          break;
+        }
         this.subagentRuns.set(event.subagentRunId, {
           subagentRunId: event.subagentRunId,
           name: event.name,
@@ -632,6 +661,13 @@ export class RunAggregator {
     return event.subagentRunId ?? ROOT_SCOPE;
   }
 
+  // Nothing in the AG-UI schema makes a messageId unique across subagent runs,
+  // so the accumulators key on the scope too. Root keys stay bare, which is
+  // what the wire-id collision checks against reported message ids compare on.
+  private partKey(scope: string, id: string): string {
+    return scope === ROOT_SCOPE ? id : `${scope}\u0000${id}`;
+  }
+
   private beginDistinctTextMessage(messageId: string | undefined): void {
     if (
       !messageId ||
@@ -652,16 +688,16 @@ export class RunAggregator {
 
   private startTextMessage(scope: string, messageId?: string): string {
     const id = messageId ?? this.generateTextKey();
-    this.ensureTextPart(scope, id);
-    this.activeTextMessageIdByScope.set(scope, id);
-    return id;
+    const key = this.ensureTextPart(scope, id);
+    this.activeTextMessageIdByScope.set(scope, key);
+    return key;
   }
 
   private resolveTextMessageId(scope: string, messageId?: string): string {
     if (messageId) {
-      this.ensureTextPart(scope, messageId);
-      this.activeTextMessageIdByScope.set(scope, messageId);
-      return messageId;
+      const key = this.ensureTextPart(scope, messageId);
+      this.activeTextMessageIdByScope.set(scope, key);
+      return key;
     }
 
     const active = this.activeTextMessageIdByScope.get(scope);
@@ -669,25 +705,26 @@ export class RunAggregator {
       return active;
     }
 
-    const generated = this.generateTextKey();
-    this.ensureTextPart(scope, generated);
-    this.activeTextMessageIdByScope.set(scope, generated);
-    return generated;
+    const key = this.ensureTextPart(scope, this.generateTextKey());
+    this.activeTextMessageIdByScope.set(scope, key);
+    return key;
   }
 
-  private ensureTextPart(scope: string, id: string): void {
-    if (!this.textParts.has(id)) {
-      this.textParts.set(id, { buffer: "" });
+  private ensureTextPart(scope: string, id: string): string {
+    const key = this.partKey(scope, id);
+    if (!this.textParts.has(key)) {
+      this.textParts.set(key, { buffer: "" });
       if (
-        !this.partOrder.some((part) => part.kind === "text" && part.key === id)
+        !this.partOrder.some((part) => part.kind === "text" && part.key === key)
       ) {
         this.partOrder.push(
           scope === ROOT_SCOPE
-            ? { kind: "text", key: id }
-            : { kind: "text", key: id, subagentRunId: scope },
+            ? { kind: "text", key }
+            : { kind: "text", key, subagentRunId: scope },
         );
       }
     }
+    return key;
   }
 
   private appendText(id: string, delta: string): void {
@@ -870,14 +907,6 @@ export class RunAggregator {
     return reachable;
   }
 
-  // Parts belonging to a subagent that has no nesting site fall back to the
-  // root scope rather than disappearing, which is also how the protocol's own
-  // pre-subagent downgrade renders them.
-  private effectiveScope(rawScope: string, ctx: BuildContext): string {
-    if (rawScope === ROOT_SCOPE) return ROOT_SCOPE;
-    return ctx.reachable.has(rawScope) ? rawScope : ROOT_SCOPE;
-  }
-
   private materializeSubagentMessage(
     subagentRunId: string,
     depth: number,
@@ -927,7 +956,7 @@ export class RunAggregator {
     const snapshot: ThreadAssistantMessagePart[] = [];
     const isRoot = scope === ROOT_SCOPE;
 
-    for (const [index, part] of this.partOrder.entries()) {
+    for (const { index, part } of ctx.partsByScope.get(scope) ?? []) {
       const materialized = () => {
         if (isRoot && ctx.root) ctx.root.lastMaterializedIndex = index;
       };
@@ -935,10 +964,6 @@ export class RunAggregator {
       if (part.kind === "tool-call") {
         const entry = this.toolCalls.get(part.toolCallId);
         if (!entry) continue;
-        if (
-          this.effectiveScope(entry.subagentRunId ?? ROOT_SCOPE, ctx) !== scope
-        )
-          continue;
         const approval = ctx.approvals.get(entry.toolCallId);
         const nestedMessages = (
           ctx.subagentsByParentToolCallId.get(entry.toolCallId) ?? []
@@ -985,7 +1010,6 @@ export class RunAggregator {
         "subagentRunId" in part
           ? (part.subagentRunId ?? ROOT_SCOPE)
           : ROOT_SCOPE;
-      if (this.effectiveScope(rawScope, ctx) !== scope) continue;
 
       if (part.kind === "reasoning") {
         if (this.showThinking) {
@@ -1069,9 +1093,29 @@ export class RunAggregator {
     // render at root scope, which is also exactly what getPendingToolCalls can
     // reach: a call nested inside a subagent message is unanswerable, so the
     // projector collapses the batch rather than showing half of it.
+    const partsByScope = new Map<
+      string,
+      { index: number; part: PartOrderEntry }[]
+    >();
+    for (const [index, part] of this.partOrder.entries()) {
+      const rawScope =
+        part.kind === "tool-call"
+          ? (this.toolCalls.get(part.toolCallId)?.subagentRunId ?? ROOT_SCOPE)
+          : "subagentRunId" in part
+            ? (part.subagentRunId ?? ROOT_SCOPE)
+            : ROOT_SCOPE;
+      const bucketScope =
+        rawScope === ROOT_SCOPE || reachable.has(rawScope)
+          ? rawScope
+          : ROOT_SCOPE;
+      const bucket = partsByScope.get(bucketScope);
+      if (bucket) bucket.push({ index, part });
+      else partsByScope.set(bucketScope, [{ index, part }]);
+    }
     const ctx: BuildContext = {
       subagentsByParentToolCallId,
       reachable,
+      partsByScope,
       approvals: projectAgUiToolApprovals(
         this.status?.type === "requires-action" ? this.interrupts : undefined,
         new Set(
@@ -1214,7 +1258,10 @@ export class RunAggregator {
     // A reasoning block acts as a boundary: anonymous text arriving after it
     // should be a new part, not appended to any pre-reasoning text — scoped.
     this.activeTextMessageIdByScope.delete(scope);
-    const key = messageId ?? `__auto-reasoning-${++this.reasoningPartCounter}`;
+    const key = this.partKey(
+      scope,
+      messageId ?? `__auto-reasoning-${++this.reasoningPartCounter}`,
+    );
     // Two different questions: which id may be replayed as a ReasoningMessage.id
     // (only the message-scoped aliases carry one), and which block an unmatched
     // signature may claim (any block opened without an id at all).

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -38,6 +38,24 @@ type SubagentRunState = {
   parentMessageId?: string;
   createdAt: Date;
   status: MessageStatus;
+  result?: unknown;
+  interruptIds?: string[];
+  errorCode?: string;
+};
+
+type ToolApproval = NonNullable<ToolCallMessagePart["approval"]>;
+
+type BuildContext = {
+  subagentsByParentToolCallId: Map<string, string[]>;
+  reachable: Set<string>;
+  approvals: ReadonlyMap<string, ToolApproval>;
+  // Present only for the root walk: the pass that builds the snapshot is also
+  // the one that decides where a retracted reasoning signature anchors, so the
+  // two can never disagree about what materialized.
+  root?: {
+    opaqueCandidates: (AgUiOpaqueReasoning & { anchor: number })[];
+    lastMaterializedIndex: number;
+  };
 };
 
 export type AgUiOpaqueReasoning = {
@@ -135,7 +153,7 @@ export class RunAggregator {
   private readonly toolCalls = new Map<string, ToolCallState>();
   private readonly a2uiBuckets = new Map<string, A2uiState>();
   private readonly a2uiToolCallIds = new Set<string>();
-  private lastResolvedToolCallId: string | undefined;
+  private readonly lastResolvedToolCallIdByScope = new Map<string, string>();
   private readonly partOrder: (
     | { kind: "text"; key: string; subagentRunId?: string }
     | { kind: "reasoning"; key: string; subagentRunId?: string }
@@ -232,10 +250,7 @@ export class RunAggregator {
       case "TEXT_MESSAGE_CONTENT":
       case "TEXT_MESSAGE_CHUNK": {
         const incomingId = "messageId" in event ? event.messageId : undefined;
-        const scope =
-          event.type === "TEXT_MESSAGE_CONTENT"
-            ? this.scopeOf(event)
-            : ROOT_SCOPE;
+        const scope = this.scopeOf(event);
         if (scope === ROOT_SCOPE) {
           this.beginDistinctTextMessage(incomingId);
           this.reportServerMessageId(incomingId);
@@ -361,7 +376,10 @@ export class RunAggregator {
       }
       case "TOOL_CALL_ARGS":
       case "TOOL_CALL_CHUNK": {
-        if (event.type === "TOOL_CALL_CHUNK") {
+        if (
+          event.type === "TOOL_CALL_CHUNK" &&
+          this.scopeOf(event) === ROOT_SCOPE
+        ) {
           this.reportServerMessageId(event.parentMessageId);
         }
         if (!event.delta) break;
@@ -395,12 +413,15 @@ export class RunAggregator {
           break;
         }
         if (event.activityType !== MCP_APPS_ACTIVITY_TYPE) break;
+        const activityScope = this.scopeOf(event);
         const toolCallId = event.content.toolCallId;
+        const fallbackId =
+          this.lastResolvedToolCallIdByScope.get(activityScope);
         const entry =
           typeof toolCallId === "string"
             ? this.toolCalls.get(toolCallId)
-            : this.lastResolvedToolCallId
-              ? this.toolCalls.get(this.lastResolvedToolCallId)
+            : fallbackId
+              ? this.toolCalls.get(fallbackId)
               : undefined;
         const resourceUri = event.content.resourceUri;
         if (
@@ -472,6 +493,9 @@ export class RunAggregator {
             event.outcome?.type === "suspended"
               ? { type: "requires-action", reason: "interrupt" }
               : { type: "complete", reason: "unknown" };
+          if (event.result !== undefined) run.result = event.result;
+          if (event.outcome?.type === "suspended" && event.outcome.interruptIds)
+            run.interruptIds = event.outcome.interruptIds;
         }
         this.emit();
         break;
@@ -484,6 +508,7 @@ export class RunAggregator {
             reason: "error",
             ...(event.message !== undefined ? { error: event.message } : {}),
           };
+          if (event.code !== undefined) run.errorCode = event.code;
         }
         this.emit();
         break;
@@ -596,7 +621,7 @@ export class RunAggregator {
     this.toolCalls.clear();
     this.a2uiBuckets.clear();
     this.a2uiToolCallIds.clear();
-    this.lastResolvedToolCallId = undefined;
+    this.lastResolvedToolCallIdByScope.clear();
     this.partOrder.length = 0;
     this.textPartCounter = 0;
     this.activeTextMessageIdByScope.clear();
@@ -806,7 +831,7 @@ export class RunAggregator {
     if (toolMessageId) {
       entry.toolMessageId = toolMessageId;
     }
-    this.lastResolvedToolCallId = id;
+    this.lastResolvedToolCallIdByScope.set(scope, id);
   }
 
   private subagentsByParentToolCallId(): Map<string, string[]> {
@@ -820,18 +845,47 @@ export class RunAggregator {
     return map;
   }
 
+  // A subagent nests under its spawning tool call only when that call is itself
+  // reachable from the root scope. A run with no parentToolCallId, one naming a
+  // call this run never saw, or one in a cycle has nowhere to hang; the visited
+  // set also keeps a malformed chain to one visit per run instead of branching
+  // at every level.
+  private reachableSubagentRunIds(
+    subagentsByParentToolCallId: Map<string, string[]>,
+  ): Set<string> {
+    const reachable = new Set<string>();
+    const walk = (scope: string, depth: number): void => {
+      if (depth > MAX_SUBAGENT_DEPTH) return;
+      for (const entry of this.toolCalls.values()) {
+        if ((entry.subagentRunId ?? ROOT_SCOPE) !== scope) continue;
+        for (const id of subagentsByParentToolCallId.get(entry.toolCallId) ??
+          []) {
+          if (reachable.has(id)) continue;
+          reachable.add(id);
+          walk(id, depth + 1);
+        }
+      }
+    };
+    walk(ROOT_SCOPE, 0);
+    return reachable;
+  }
+
+  // Parts belonging to a subagent that has no nesting site fall back to the
+  // root scope rather than disappearing, which is also how the protocol's own
+  // pre-subagent downgrade renders them.
+  private effectiveScope(rawScope: string, ctx: BuildContext): string {
+    if (rawScope === ROOT_SCOPE) return ROOT_SCOPE;
+    return ctx.reachable.has(rawScope) ? rawScope : ROOT_SCOPE;
+  }
+
   private materializeSubagentMessage(
     subagentRunId: string,
     depth: number,
-    subagentsByParentToolCallId: Map<string, string[]>,
+    ctx: BuildContext,
   ): ThreadMessage | undefined {
     const run = this.subagentRuns.get(subagentRunId);
     if (!run || depth > MAX_SUBAGENT_DEPTH) return undefined;
-    const content = this.buildParts(
-      subagentRunId,
-      depth + 1,
-      subagentsByParentToolCallId,
-    );
+    const content = this.buildParts(subagentRunId, depth + 1, ctx);
     return {
       id: run.subagentRunId,
       role: "assistant",
@@ -852,6 +906,13 @@ export class RunAggregator {
             ...(run.parentSubagentRunId !== undefined
               ? { parentSubagentRunId: run.parentSubagentRunId }
               : {}),
+            ...(run.result !== undefined ? { result: run.result } : {}),
+            ...(run.interruptIds !== undefined
+              ? { interruptIds: run.interruptIds }
+              : {}),
+            ...(run.errorCode !== undefined
+              ? { errorCode: run.errorCode }
+              : {}),
           },
         },
       },
@@ -861,39 +922,29 @@ export class RunAggregator {
   private buildParts(
     scope: string,
     depth: number,
-    subagentsByParentToolCallId: Map<string, string[]>,
+    ctx: BuildContext,
   ): ThreadAssistantMessagePart[] {
     const snapshot: ThreadAssistantMessagePart[] = [];
-    const approvals =
-      scope === ROOT_SCOPE
-        ? projectAgUiToolApprovals(
-            this.status?.type === "requires-action"
-              ? this.interrupts
-              : undefined,
-            new Set(
-              Array.from(this.toolCalls.entries())
-                .filter(([, entry]) => entry.subagentRunId === undefined)
-                .map(([id]) => id),
-            ),
-          )
-        : new Map();
+    const isRoot = scope === ROOT_SCOPE;
 
-    for (const part of this.partOrder) {
+    for (const [index, part] of this.partOrder.entries()) {
+      const materialized = () => {
+        if (isRoot && ctx.root) ctx.root.lastMaterializedIndex = index;
+      };
+
       if (part.kind === "tool-call") {
         const entry = this.toolCalls.get(part.toolCallId);
-        if (!entry || (entry.subagentRunId ?? ROOT_SCOPE) !== scope) continue;
-        const approval = approvals.get(entry.toolCallId);
-        const nestedSubagentRunIds = subagentsByParentToolCallId.get(
-          entry.toolCallId,
-        );
-        const nestedMessages = nestedSubagentRunIds
-          ?.map((id) =>
-            this.materializeSubagentMessage(
-              id,
-              depth,
-              subagentsByParentToolCallId,
-            ),
-          )
+        if (!entry) continue;
+        if (
+          this.effectiveScope(entry.subagentRunId ?? ROOT_SCOPE, ctx) !== scope
+        )
+          continue;
+        const approval = ctx.approvals.get(entry.toolCallId);
+        const nestedMessages = (
+          ctx.subagentsByParentToolCallId.get(entry.toolCallId) ?? []
+        )
+          .filter((id) => ctx.reachable.has(id))
+          .map((id) => this.materializeSubagentMessage(id, depth, ctx))
           .filter((m): m is ThreadMessage => m !== undefined);
         const toolPart: ToolCallMessagePart = {
           type: "tool-call",
@@ -923,25 +974,24 @@ export class RunAggregator {
           ...(entry.toolMessageId
             ? { unstable_toolMessageId: entry.toolMessageId }
             : {}),
-          ...(nestedMessages && nestedMessages.length > 0
-            ? { messages: nestedMessages }
-            : {}),
+          ...(nestedMessages.length > 0 ? { messages: nestedMessages } : {}),
         } as ToolCallMessagePart & { unstable_toolMessageId?: string };
         snapshot.push(toolPart);
+        materialized();
         continue;
       }
 
-      const partScope =
+      const rawScope =
         "subagentRunId" in part
           ? (part.subagentRunId ?? ROOT_SCOPE)
           : ROOT_SCOPE;
-      if (partScope !== scope) continue;
+      if (this.effectiveScope(rawScope, ctx) !== scope) continue;
 
       if (part.kind === "reasoning") {
         if (this.showThinking) {
           const buffer = this.reasoningParts.get(part.key) ?? "";
           const isActive =
-            this.activeReasoningKeyByScope.get(scope) === part.key;
+            this.activeReasoningKeyByScope.get(rawScope) === part.key;
           if (buffer.length > 0 || isActive) {
             const encryptedValue = this.reasoningSignatures.get(part.key);
             const reasoningId = this.reasoningMessageIds.get(part.key);
@@ -956,6 +1006,20 @@ export class RunAggregator {
                 ? { providerMetadata: { [AG_UI_METADATA_NAMESPACE]: meta } }
                 : {}),
             } as const);
+            materialized();
+          } else if (isRoot && ctx.root) {
+            // A retracted empty block still carries transport state: without
+            // a part to live on, its signature rides the message metadata,
+            // matching the shape a snapshot reload produces.
+            const encryptedValue = this.reasoningSignatures.get(part.key);
+            const id = this.reasoningSignatureIds.get(part.key);
+            if (id?.trim() && encryptedValue?.trim()) {
+              ctx.root.opaqueCandidates.push({
+                id,
+                encryptedValue,
+                anchor: index + 1,
+              });
+            }
           }
         }
         continue;
@@ -965,6 +1029,7 @@ export class RunAggregator {
         const entry = this.textParts.get(part.key);
         if (entry && entry.buffer.trim().length > 0) {
           snapshot.push({ type: "text", text: entry.buffer } as const);
+          materialized();
         }
         continue;
       }
@@ -975,6 +1040,7 @@ export class RunAggregator {
           name: part.name,
           data: part.value,
         });
+        materialized();
         continue;
       }
     }
@@ -983,59 +1049,45 @@ export class RunAggregator {
   }
 
   private emit(): void {
-    const snapshot = this.buildParts(
-      ROOT_SCOPE,
-      0,
-      this.subagentsByParentToolCallId(),
-    );
-
-    const opaqueCandidates: (AgUiOpaqueReasoning & { anchor: number })[] =
-      Array.from(this.hiddenSignatures, ([id, encryptedValue]) => ({
-        id,
-        encryptedValue,
-        anchor: this.hiddenSignatureAnchors.get(id)!,
-      }));
-
-    let lastMaterializedIndex = -1;
-    for (const [index, part] of this.partOrder.entries()) {
-      if (part.kind === "tool-call") {
-        const entry = this.toolCalls.get(part.toolCallId);
-        if (!entry || (entry.subagentRunId ?? ROOT_SCOPE) !== ROOT_SCOPE)
-          continue;
-        lastMaterializedIndex = index;
-        continue;
-      }
-      const partScope =
-        "subagentRunId" in part
-          ? (part.subagentRunId ?? ROOT_SCOPE)
-          : ROOT_SCOPE;
-      if (partScope !== ROOT_SCOPE) continue;
-      if (part.kind === "reasoning") {
-        if (this.showThinking) {
-          const buffer = this.reasoningParts.get(part.key) ?? "";
-          const isActive =
-            this.activeReasoningKeyByScope.get(ROOT_SCOPE) === part.key;
-          if (buffer.length > 0 || isActive) {
-            lastMaterializedIndex = index;
-          } else {
-            const encryptedValue = this.reasoningSignatures.get(part.key);
-            const id = this.reasoningSignatureIds.get(part.key);
-            if (id?.trim() && encryptedValue?.trim()) {
-              opaqueCandidates.push({ id, encryptedValue, anchor: index + 1 });
-            }
-          }
-        }
-        continue;
-      }
-      if (part.kind === "text") {
-        const entry = this.textParts.get(part.key);
-        if (entry && entry.buffer.trim().length > 0)
-          lastMaterializedIndex = index;
-        continue;
-      }
-      // data parts always materialize when in scope.
-      lastMaterializedIndex = index;
-    }
+    const subagentsByParentToolCallId = this.subagentsByParentToolCallId();
+    const root = {
+      opaqueCandidates: Array.from(
+        this.hiddenSignatures,
+        ([id, encryptedValue]) => ({
+          id,
+          encryptedValue,
+          anchor: this.hiddenSignatureAnchors.get(id)!,
+        }),
+      ) as (AgUiOpaqueReasoning & { anchor: number })[],
+      lastMaterializedIndex: -1,
+    };
+    const reachable = this.reachableSubagentRunIds(subagentsByParentToolCallId);
+    // A run that ended incomplete can no longer be resumed, so a gate left over
+    // from an earlier interrupt outcome is unanswerable and must not stay
+    // projected. The interrupts themselves are kept on the message, since the
+    // bespoke hooks read that payload. Bound ids are exactly the calls that
+    // render at root scope, which is also exactly what getPendingToolCalls can
+    // reach: a call nested inside a subagent message is unanswerable, so the
+    // projector collapses the batch rather than showing half of it.
+    const ctx: BuildContext = {
+      subagentsByParentToolCallId,
+      reachable,
+      approvals: projectAgUiToolApprovals(
+        this.status?.type === "requires-action" ? this.interrupts : undefined,
+        new Set(
+          Array.from(this.toolCalls.values())
+            .filter(
+              (entry) =>
+                entry.subagentRunId === undefined ||
+                !reachable.has(entry.subagentRunId),
+            )
+            .map((entry) => entry.toolCallId),
+        ),
+      ),
+      root,
+    };
+    const snapshot = this.buildParts(ROOT_SCOPE, 0, ctx);
+    const { opaqueCandidates, lastMaterializedIndex } = root;
 
     // An anonymous claim promotes the signature's entityId to a wire message
     // id; when that id actually names a text message or the adopted assistant

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -612,14 +612,14 @@ export class RunAggregator {
 
   private startTextMessage(scope: string, messageId?: string): string {
     const id = messageId ?? this.generateTextKey();
-    this.ensureTextPart(id, scope);
+    this.ensureTextPart(scope, id);
     this.activeTextMessageIdByScope.set(scope, id);
     return id;
   }
 
   private resolveTextMessageId(scope: string, messageId?: string): string {
     if (messageId) {
-      this.ensureTextPart(messageId, scope);
+      this.ensureTextPart(scope, messageId);
       this.activeTextMessageIdByScope.set(scope, messageId);
       return messageId;
     }
@@ -630,12 +630,12 @@ export class RunAggregator {
     }
 
     const generated = this.generateTextKey();
-    this.ensureTextPart(generated, scope);
+    this.ensureTextPart(scope, generated);
     this.activeTextMessageIdByScope.set(scope, generated);
     return generated;
   }
 
-  private ensureTextPart(id: string, scope: string): void {
+  private ensureTextPart(scope: string, id: string): void {
     if (!this.textParts.has(id)) {
       this.textParts.set(id, { buffer: "" });
       if (
@@ -651,10 +651,6 @@ export class RunAggregator {
   }
 
   private appendText(id: string, delta: string): void {
-    // The id has always already been ensured by resolveTextMessageId/
-    // startTextMessage before appendText runs, so the scope passed here is
-    // never actually used to create a new part.
-    this.ensureTextPart(id, ROOT_SCOPE);
     const entry = this.textParts.get(id);
     if (!entry) return;
     entry.buffer += delta;

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -25,6 +25,10 @@ export const AG_UI_METADATA_NAMESPACE = "agui";
 
 const ROOT_SCOPE = "";
 
+// Defensive guard against a malformed or cyclic parentToolCallId /
+// parentSubagentRunId chain, not a realistic nesting depth.
+const MAX_SUBAGENT_DEPTH = 16;
+
 type SubagentRunState = {
   subagentRunId: string;
   name: string;
@@ -809,10 +813,15 @@ export class RunAggregator {
   private materializeSubagentMessage(
     subagentRunId: string,
     depth: number,
+    subagentsByParentToolCallId: Map<string, string[]>,
   ): ThreadMessage | undefined {
     const run = this.subagentRuns.get(subagentRunId);
-    if (!run || depth > 16) return undefined;
-    const content = this.buildParts(subagentRunId, depth + 1);
+    if (!run || depth > MAX_SUBAGENT_DEPTH) return undefined;
+    const content = this.buildParts(
+      subagentRunId,
+      depth + 1,
+      subagentsByParentToolCallId,
+    );
     return {
       id: run.subagentRunId,
       role: "assistant",
@@ -839,7 +848,11 @@ export class RunAggregator {
     } as ThreadMessage;
   }
 
-  private buildParts(scope: string, depth = 0): ThreadAssistantMessagePart[] {
+  private buildParts(
+    scope: string,
+    depth: number,
+    subagentsByParentToolCallId: Map<string, string[]>,
+  ): ThreadAssistantMessagePart[] {
     const snapshot: ThreadAssistantMessagePart[] = [];
     const approvals =
       scope === ROOT_SCOPE
@@ -850,7 +863,6 @@ export class RunAggregator {
             new Set(this.toolCalls.keys()),
           )
         : new Map();
-    const subagentsByParentToolCallId = this.subagentsByParentToolCallId();
 
     for (const part of this.partOrder) {
       if (part.kind === "tool-call") {
@@ -861,7 +873,13 @@ export class RunAggregator {
           entry.toolCallId,
         );
         const nestedMessages = nestedSubagentRunIds
-          ?.map((id) => this.materializeSubagentMessage(id, depth))
+          ?.map((id) =>
+            this.materializeSubagentMessage(
+              id,
+              depth,
+              subagentsByParentToolCallId,
+            ),
+          )
           .filter((m): m is ThreadMessage => m !== undefined);
         const toolPart: ToolCallMessagePart = {
           type: "tool-call",
@@ -937,7 +955,7 @@ export class RunAggregator {
         continue;
       }
 
-      if (part.kind === "data" && scope === ROOT_SCOPE) {
+      if (part.kind === "data") {
         snapshot.push({
           type: "data",
           name: part.name,
@@ -951,7 +969,11 @@ export class RunAggregator {
   }
 
   private emit(): void {
-    const snapshot = this.buildParts(ROOT_SCOPE);
+    const snapshot = this.buildParts(
+      ROOT_SCOPE,
+      0,
+      this.subagentsByParentToolCallId(),
+    );
 
     const opaqueCandidates: (AgUiOpaqueReasoning & { anchor: number })[] =
       Array.from(this.hiddenSignatures, ([id, encryptedValue]) => ({

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -750,7 +750,7 @@ export class RunAggregator {
         (part) => part.kind === "tool-call" && part.toolCallId === id,
       )
     ) {
-      this.insertToolPart(id, parentMessageId);
+      this.insertToolPart(scope, id, parentMessageId);
     }
     const state: ToolCallState = {
       toolCallId: id,
@@ -772,11 +772,12 @@ export class RunAggregator {
 
   // The message and tool-call channels are unordered on the wire, so anchor a
   // tool call under its parentMessageId text part instead of appending it.
-  private insertToolPart(id: string, parentMessageId?: string) {
+  private insertToolPart(scope: string, id: string, parentMessageId?: string) {
     const entry = { kind: "tool-call", toolCallId: id } as const;
     if (parentMessageId) {
+      const parentKey = this.partKey(scope, parentMessageId);
       const parentIndex = this.partOrder.findIndex(
-        (part) => part.kind === "text" && part.key === parentMessageId,
+        (part) => part.kind === "text" && part.key === parentKey,
       );
       if (parentIndex !== -1) {
         let insertAt = parentIndex + 1;

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -187,13 +187,19 @@ export class RunAggregator {
         }
 
         this.interrupts = undefined;
-        const hasUnresolvedToolCalls = Array.from(this.toolCalls.values()).some(
+        const toolCallValues = Array.from(this.toolCalls.values());
+        const hasUnresolvedRootToolCalls = toolCallValues.some(
           (tc) => tc.subagentRunId === undefined && tc.result === undefined,
         );
+        const hasUnresolvedSubagentToolCalls = toolCallValues.some(
+          (tc) => tc.subagentRunId !== undefined && tc.result === undefined,
+        );
 
-        this.status = hasUnresolvedToolCalls
+        this.status = hasUnresolvedRootToolCalls
           ? { type: "requires-action", reason: "tool-calls" }
-          : { type: "complete", reason: "unknown" };
+          : hasUnresolvedSubagentToolCalls
+            ? { type: "incomplete", reason: "tool-calls" }
+            : { type: "complete", reason: "unknown" };
         this.emit();
         break;
       }

--- a/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/subscriber.ts
@@ -34,6 +34,9 @@ type Subscriber = {
   onMessagesSnapshotEvent?: (payload: { event: unknown }) => void;
   onCustomEvent?: (payload: { event: unknown }) => void;
   onRawEvent?: (payload: { event: unknown }) => void;
+  onSubagentStartedEvent?: (payload: { event: unknown }) => void;
+  onSubagentFinishedEvent?: (payload: { event: unknown }) => void;
+  onSubagentErrorEvent?: (payload: { event: unknown }) => void;
   onRunFinishedEvent?: (payload: { event: unknown }) => void;
   onRunErrorEvent?: (payload: { event: unknown }) => void;
   onRunFinalized?: () => void;
@@ -146,6 +149,12 @@ export const createAgUiSubscriber = (
       dispatchIfValid(event, "MESSAGES_SNAPSHOT"),
     onCustomEvent: ({ event }) => dispatchIfValid(event, "CUSTOM"),
     onRawEvent: ({ event }) => dispatchIfValid(event, "RAW"),
+    onSubagentStartedEvent: ({ event }) =>
+      dispatchIfValid(event, "SUBAGENT_STARTED"),
+    onSubagentFinishedEvent: ({ event }) =>
+      dispatchIfValid(event, "SUBAGENT_FINISHED"),
+    onSubagentErrorEvent: ({ event }) =>
+      dispatchIfValid(event, "SUBAGENT_ERROR"),
     onRunFinishedEvent: ({ event }) => {
       if (runFinishedDispatched) return;
       const parsed = ensureEvent(event, "RUN_FINISHED", logger);

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -154,7 +154,10 @@ export const parseAgUiEvent = (
       const delta = getString("delta") ?? "";
       return withOptional(
         { type: "TEXT_MESSAGE_CHUNK" as const, delta },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     }
     case "THINKING_START":
@@ -212,15 +215,16 @@ export const parseAgUiEvent = (
       const subtype = getString("subtype");
       if (!entityId || !encryptedValue) return null;
       if (subtype !== "message" && subtype !== "tool-call") return null;
-      return withOptional(
-        {
-          type: "REASONING_ENCRYPTED_VALUE" as const,
-          subtype,
-          entityId,
-          encryptedValue,
-        },
-        { subagentRunId: getString("subagentRunId") },
-      );
+      // Spread rather than withOptional: routing the narrowed `subtype` through
+      // a generic helper widens it back to string.
+      const subagentRunId = getString("subagentRunId");
+      return {
+        type: "REASONING_ENCRYPTED_VALUE" as const,
+        subtype,
+        entityId,
+        encryptedValue,
+        ...(subagentRunId !== undefined ? { subagentRunId } : {}),
+      };
     }
     case "REASONING_END":
       return withOptional(
@@ -267,6 +271,7 @@ export const parseAgUiEvent = (
           toolCallName: getString("toolCallName"),
           parentMessageId: getString("parentMessageId"),
           delta: getString("delta"),
+          subagentRunId: getString("subagentRunId"),
         },
       );
     case "TOOL_CALL_RESULT": {
@@ -314,6 +319,7 @@ export const parseAgUiEvent = (
           messageId: getString("messageId"),
           replace:
             typeof payload.replace === "boolean" ? payload.replace : undefined,
+          subagentRunId: getString("subagentRunId"),
         },
       );
     }
@@ -364,7 +370,7 @@ export const parseAgUiEvent = (
       }
       return withOptional(
         { type: "SUBAGENT_FINISHED" as const, subagentRunId },
-        { outcome },
+        { result: payload.result, outcome },
       );
     }
     case "SUBAGENT_ERROR": {

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -1,4 +1,9 @@
-import type { AgUiEvent, AgUiInterrupt, AgUiRunFinishedOutcome } from "./types";
+import type {
+  AgUiEvent,
+  AgUiInterrupt,
+  AgUiRunFinishedOutcome,
+  AgUiSubagentFinishedOutcome,
+} from "./types";
 import type { Logger } from "./logger";
 import { parseMcpToolCallResult } from "./mcp-tool-result";
 import { withRawResponseSchema } from "./interrupt-internals";
@@ -121,20 +126,29 @@ export const parseAgUiEvent = (
     case "TEXT_MESSAGE_START":
       return withOptional(
         { type: "TEXT_MESSAGE_START" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "TEXT_MESSAGE_CONTENT": {
       const delta = getString("delta");
       if (!isNonEmptyString(delta)) return null;
       return withOptional(
         { type: "TEXT_MESSAGE_CONTENT" as const, delta },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     }
     case "TEXT_MESSAGE_END":
       return withOptional(
         { type: "TEXT_MESSAGE_END" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "TEXT_MESSAGE_CHUNK": {
       const delta = getString("delta") ?? "";
@@ -161,24 +175,36 @@ export const parseAgUiEvent = (
     case "REASONING_START":
       return withOptional(
         { type: "REASONING_START" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "REASONING_MESSAGE_START":
       return withOptional(
         { type: "REASONING_MESSAGE_START" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "REASONING_MESSAGE_CONTENT": {
       const delta = getString("delta") ?? "";
       return withOptional(
         { type: "REASONING_MESSAGE_CONTENT" as const, delta },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     }
     case "REASONING_MESSAGE_END":
       return withOptional(
         { type: "REASONING_MESSAGE_END" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "REASONING_ENCRYPTED_VALUE": {
       const entityId = getString("entityId");
@@ -196,7 +222,10 @@ export const parseAgUiEvent = (
     case "REASONING_END":
       return withOptional(
         { type: "REASONING_END" as const },
-        { messageId: getString("messageId") },
+        {
+          messageId: getString("messageId"),
+          subagentRunId: getString("subagentRunId"),
+        },
       );
     case "TOOL_CALL_START": {
       const toolCallId = getString("toolCallId");
@@ -206,6 +235,7 @@ export const parseAgUiEvent = (
         {
           toolCallName: getString("toolCallName"),
           parentMessageId: getString("parentMessageId"),
+          subagentRunId: getString("subagentRunId"),
         },
       );
     }
@@ -213,11 +243,18 @@ export const parseAgUiEvent = (
       const toolCallId = getString("toolCallId");
       if (!toolCallId) return null;
       const delta = getString("delta") ?? "";
-      return { type: "TOOL_CALL_ARGS", toolCallId, delta };
+      return withOptional(
+        { type: "TOOL_CALL_ARGS" as const, toolCallId, delta },
+        { subagentRunId: getString("subagentRunId") },
+      );
     }
     case "TOOL_CALL_END": {
       const toolCallId = getString("toolCallId");
-      return toolCallId ? { type: "TOOL_CALL_END", toolCallId } : null;
+      if (!toolCallId) return null;
+      return withOptional(
+        { type: "TOOL_CALL_END" as const, toolCallId },
+        { subagentRunId: getString("subagentRunId") },
+      );
     }
     case "TOOL_CALL_CHUNK":
       return withOptional(
@@ -243,6 +280,7 @@ export const parseAgUiEvent = (
           messageId: getString("messageId"),
           role: payload.role === "tool" ? "tool" : undefined,
           mcpResult: parseMcpToolCallResult(payload, content),
+          subagentRunId: getString("subagentRunId"),
         },
       );
     }
@@ -285,6 +323,53 @@ export const parseAgUiEvent = (
       const name = getString("name");
       if (!name) return null;
       return { type: "CUSTOM", name, value: payload.value };
+    }
+    case "SUBAGENT_STARTED": {
+      const subagentRunId = getString("subagentRunId");
+      const name = getString("name");
+      if (!subagentRunId || !name) return null;
+      return withOptional(
+        { type: "SUBAGENT_STARTED" as const, subagentRunId, name },
+        {
+          description: getString("description"),
+          parentSubagentRunId: getString("parentSubagentRunId"),
+          parentToolCallId: getString("parentToolCallId"),
+          parentMessageId: getString("parentMessageId"),
+        },
+      );
+    }
+    case "SUBAGENT_FINISHED": {
+      const subagentRunId = getString("subagentRunId");
+      if (!subagentRunId) return null;
+      const rawOutcome = payload.outcome;
+      let outcome: AgUiSubagentFinishedOutcome | undefined;
+      if (isPlainObject(rawOutcome) && rawOutcome.type === "success") {
+        outcome = { type: "success" as const };
+      } else if (isPlainObject(rawOutcome) && rawOutcome.type === "suspended") {
+        outcome = withOptional(
+          { type: "suspended" as const },
+          {
+            interruptIds: Array.isArray(rawOutcome.interruptIds)
+              ? (rawOutcome.interruptIds as unknown[]).filter(isString)
+              : undefined,
+          },
+        );
+      } else {
+        outcome = undefined;
+      }
+      return withOptional(
+        { type: "SUBAGENT_FINISHED" as const, subagentRunId },
+        { outcome },
+      );
+    }
+    case "SUBAGENT_ERROR": {
+      const subagentRunId = getString("subagentRunId");
+      const message = getString("message");
+      if (!subagentRunId || !message) return null;
+      return withOptional(
+        { type: "SUBAGENT_ERROR" as const, subagentRunId, message },
+        { code: getString("code") },
+      );
     }
     default:
       return withOptional(

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -212,12 +212,15 @@ export const parseAgUiEvent = (
       const subtype = getString("subtype");
       if (!entityId || !encryptedValue) return null;
       if (subtype !== "message" && subtype !== "tool-call") return null;
-      return {
-        type: "REASONING_ENCRYPTED_VALUE" as const,
-        subtype,
-        entityId,
-        encryptedValue,
-      };
+      return withOptional(
+        {
+          type: "REASONING_ENCRYPTED_VALUE" as const,
+          subtype,
+          entityId,
+          encryptedValue,
+        },
+        { subagentRunId: getString("subagentRunId") },
+      );
     }
     case "REASONING_END":
       return withOptional(

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -343,9 +343,11 @@ export const parseAgUiEvent = (
       if (!subagentRunId) return null;
       const rawOutcome = payload.outcome;
       let outcome: AgUiSubagentFinishedOutcome | undefined;
-      if (isPlainObject(rawOutcome) && rawOutcome.type === "success") {
+      if (!isPlainObject(rawOutcome)) {
+        outcome = undefined;
+      } else if (rawOutcome.type === "success") {
         outcome = { type: "success" as const };
-      } else if (isPlainObject(rawOutcome) && rawOutcome.type === "suspended") {
+      } else if (rawOutcome.type === "suspended") {
         outcome = withOptional(
           { type: "suspended" as const },
           {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -176,6 +176,7 @@ export type AgUiEvent =
       subtype: "message" | "tool-call";
       entityId: string;
       encryptedValue: string;
+      subagentRunId?: string;
     }
   | { type: "REASONING_END"; messageId?: string; subagentRunId?: string }
   | {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -148,7 +148,12 @@ export type AgUiEvent =
       subagentRunId?: string;
     }
   | { type: "TEXT_MESSAGE_END"; messageId?: string; subagentRunId?: string }
-  | { type: "TEXT_MESSAGE_CHUNK"; delta: string }
+  | {
+      type: "TEXT_MESSAGE_CHUNK";
+      messageId?: string;
+      delta: string;
+      subagentRunId?: string;
+    }
   | { type: "THINKING_START"; title?: string }
   | { type: "THINKING_TEXT_MESSAGE_START" }
   | { type: "THINKING_TEXT_MESSAGE_CONTENT"; delta: string }
@@ -199,6 +204,7 @@ export type AgUiEvent =
       toolCallName?: string;
       parentMessageId?: string;
       delta?: string;
+      subagentRunId?: string;
     }
   | {
       type: "TOOL_CALL_RESULT";
@@ -215,6 +221,7 @@ export type AgUiEvent =
       content: Record<string, unknown>;
       messageId?: string;
       replace?: boolean;
+      subagentRunId?: string;
     }
   | { type: "RAW"; event: any; source?: string }
   | { type: "CUSTOM"; name: string; value: any }
@@ -233,6 +240,7 @@ export type AgUiEvent =
   | {
       type: "SUBAGENT_FINISHED";
       subagentRunId: string;
+      result?: unknown;
       outcome?: AgUiSubagentFinishedOutcome;
     }
   | {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -127,6 +127,10 @@ export type AgUiRunFinishedOutcome =
   | { type: "success" }
   | { type: "interrupt"; interrupts: AgUiInterrupt[] };
 
+export type AgUiSubagentFinishedOutcome =
+  | { type: "success" }
+  | { type: "suspended"; interruptIds?: string[] };
+
 export type AgUiEvent =
   | { type: "RUN_STARTED"; runId: string }
   | {
@@ -136,34 +140,58 @@ export type AgUiEvent =
     }
   | { type: "RUN_CANCELLED"; runId?: string }
   | { type: "RUN_ERROR"; message?: string; code?: string }
-  | { type: "TEXT_MESSAGE_START"; messageId?: string }
-  | { type: "TEXT_MESSAGE_CONTENT"; messageId?: string; delta: string }
-  | { type: "TEXT_MESSAGE_END"; messageId?: string }
+  | { type: "TEXT_MESSAGE_START"; messageId?: string; subagentRunId?: string }
+  | {
+      type: "TEXT_MESSAGE_CONTENT";
+      messageId?: string;
+      delta: string;
+      subagentRunId?: string;
+    }
+  | { type: "TEXT_MESSAGE_END"; messageId?: string; subagentRunId?: string }
   | { type: "TEXT_MESSAGE_CHUNK"; delta: string }
   | { type: "THINKING_START"; title?: string }
   | { type: "THINKING_TEXT_MESSAGE_START" }
   | { type: "THINKING_TEXT_MESSAGE_CONTENT"; delta: string }
   | { type: "THINKING_TEXT_MESSAGE_END" }
   | { type: "THINKING_END" }
-  | { type: "REASONING_START"; messageId?: string }
-  | { type: "REASONING_MESSAGE_START"; messageId?: string }
-  | { type: "REASONING_MESSAGE_CONTENT"; messageId?: string; delta: string }
-  | { type: "REASONING_MESSAGE_END"; messageId?: string }
+  | { type: "REASONING_START"; messageId?: string; subagentRunId?: string }
+  | {
+      type: "REASONING_MESSAGE_START";
+      messageId?: string;
+      subagentRunId?: string;
+    }
+  | {
+      type: "REASONING_MESSAGE_CONTENT";
+      messageId?: string;
+      delta: string;
+      subagentRunId?: string;
+    }
+  | {
+      type: "REASONING_MESSAGE_END";
+      messageId?: string;
+      subagentRunId?: string;
+    }
   | {
       type: "REASONING_ENCRYPTED_VALUE";
       subtype: "message" | "tool-call";
       entityId: string;
       encryptedValue: string;
     }
-  | { type: "REASONING_END"; messageId?: string }
+  | { type: "REASONING_END"; messageId?: string; subagentRunId?: string }
   | {
       type: "TOOL_CALL_START";
       toolCallId: string;
       toolCallName?: string;
       parentMessageId?: string;
+      subagentRunId?: string;
     }
-  | { type: "TOOL_CALL_ARGS"; toolCallId: string; delta: string }
-  | { type: "TOOL_CALL_END"; toolCallId: string }
+  | {
+      type: "TOOL_CALL_ARGS";
+      toolCallId: string;
+      delta: string;
+      subagentRunId?: string;
+    }
+  | { type: "TOOL_CALL_END"; toolCallId: string; subagentRunId?: string }
   | {
       type: "TOOL_CALL_CHUNK";
       toolCallId?: string;
@@ -178,6 +206,7 @@ export type AgUiEvent =
       content: string;
       role?: "tool";
       mcpResult?: McpToolCallResult;
+      subagentRunId?: string;
     }
   | {
       type: "ACTIVITY_SNAPSHOT";
@@ -190,4 +219,24 @@ export type AgUiEvent =
   | { type: "CUSTOM"; name: string; value: any }
   | { type: "STATE_SNAPSHOT"; snapshot: any }
   | { type: "STATE_DELTA"; delta: any[] }
-  | { type: "MESSAGES_SNAPSHOT"; messages: any[] };
+  | { type: "MESSAGES_SNAPSHOT"; messages: any[] }
+  | {
+      type: "SUBAGENT_STARTED";
+      subagentRunId: string;
+      name: string;
+      description?: string;
+      parentSubagentRunId?: string;
+      parentToolCallId?: string;
+      parentMessageId?: string;
+    }
+  | {
+      type: "SUBAGENT_FINISHED";
+      subagentRunId: string;
+      outcome?: AgUiSubagentFinishedOutcome;
+    }
+  | {
+      type: "SUBAGENT_ERROR";
+      subagentRunId: string;
+      message: string;
+      code?: string;
+    };

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -301,6 +301,64 @@ describe("parseAgUiEvent", () => {
     });
   });
 
+  it("parses subagentRunId on the chunk variants and ACTIVITY_SNAPSHOT", () => {
+    expect(
+      parseAgUiEvent({
+        type: "TEXT_MESSAGE_CHUNK",
+        messageId: "m1",
+        delta: "hi",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TEXT_MESSAGE_CHUNK",
+      messageId: "m1",
+      delta: "hi",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TOOL_CALL_CHUNK",
+        toolCallId: "t1",
+        delta: "{}",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TOOL_CALL_CHUNK",
+      toolCallId: "t1",
+      delta: "{}",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "ACTIVITY_SNAPSHOT",
+        activityType: "mcp-apps",
+        content: { resourceUri: "ui://s/a.html" },
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://s/a.html" },
+      subagentRunId: "sub-1",
+    });
+  });
+
+  it("parses SUBAGENT_FINISHED result alongside its outcome", () => {
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_FINISHED",
+        subagentRunId: "sub-1",
+        result: { summary: "done" },
+        outcome: { type: "suspended", interruptIds: ["int-1"] },
+      }),
+    ).toEqual({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+      result: { summary: "done" },
+      outcome: { type: "suspended", interruptIds: ["int-1"] },
+    });
+  });
+
   it("parses subagentRunId on TOOL_CALL_START/ARGS/END/RESULT", () => {
     expect(
       parseAgUiEvent({

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -244,4 +244,183 @@ describe("parseAgUiEvent", () => {
     expect(debug).toHaveBeenCalledTimes(1);
     expect(debug.mock.calls[0][0]).toMatch(/no valid interrupts/);
   });
+
+  it("parses subagentRunId on TEXT_MESSAGE_START/CONTENT/END", () => {
+    expect(
+      parseAgUiEvent({
+        type: "TEXT_MESSAGE_START",
+        messageId: "m1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TEXT_MESSAGE_START",
+      messageId: "m1",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TEXT_MESSAGE_CONTENT",
+        messageId: "m1",
+        delta: "hi",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: "hi",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TEXT_MESSAGE_END",
+        messageId: "m1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TEXT_MESSAGE_END",
+      messageId: "m1",
+      subagentRunId: "sub-1",
+    });
+  });
+
+  it("parses subagentRunId on TOOL_CALL_START/ARGS/END/RESULT", () => {
+    expect(
+      parseAgUiEvent({
+        type: "TOOL_CALL_START",
+        toolCallId: "t1",
+        toolCallName: "explore",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TOOL_CALL_START",
+      toolCallId: "t1",
+      toolCallName: "explore",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "t1",
+        delta: "{}",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "t1",
+      delta: "{}",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TOOL_CALL_END",
+        toolCallId: "t1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TOOL_CALL_END",
+      toolCallId: "t1",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "t1",
+        content: "ok",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t1",
+      content: "ok",
+      subagentRunId: "sub-1",
+    });
+  });
+
+  it("parses subagentRunId on REASONING_START/MESSAGE_START/MESSAGE_CONTENT/MESSAGE_END/END", () => {
+    expect(
+      parseAgUiEvent({
+        type: "REASONING_START",
+        messageId: "r1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_START",
+      messageId: "r1",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "REASONING_END",
+        messageId: "r1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_END",
+      messageId: "r1",
+      subagentRunId: "sub-1",
+    });
+  });
+
+  it("parses SUBAGENT_STARTED", () => {
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_STARTED",
+        subagentRunId: "sub-1",
+        name: "investigate",
+        description: "digs into the incident",
+        parentToolCallId: "t1",
+        parentMessageId: "m1",
+      }),
+    ).toEqual({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+      description: "digs into the incident",
+      parentToolCallId: "t1",
+      parentMessageId: "m1",
+    });
+  });
+
+  it("SUBAGENT_STARTED requires subagentRunId and name", () => {
+    expect(parseAgUiEvent({ type: "SUBAGENT_STARTED", name: "x" })).toBeNull();
+    expect(
+      parseAgUiEvent({ type: "SUBAGENT_STARTED", subagentRunId: "sub-1" }),
+    ).toBeNull();
+  });
+
+  it("parses SUBAGENT_FINISHED with success and suspended outcomes", () => {
+    expect(
+      parseAgUiEvent({ type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" }),
+    ).toEqual({ type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" });
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_FINISHED",
+        subagentRunId: "sub-1",
+        outcome: { type: "suspended", interruptIds: ["i1"] },
+      }),
+    ).toEqual({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+      outcome: { type: "suspended", interruptIds: ["i1"] },
+    });
+  });
+
+  it("parses SUBAGENT_ERROR", () => {
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_ERROR",
+        subagentRunId: "sub-1",
+        message: "boom",
+        code: "E1",
+      }),
+    ).toEqual({
+      type: "SUBAGENT_ERROR",
+      subagentRunId: "sub-1",
+      message: "boom",
+      code: "E1",
+    });
+    expect(
+      parseAgUiEvent({ type: "SUBAGENT_ERROR", message: "boom" }),
+    ).toBeNull();
+  });
 });

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -350,6 +350,41 @@ describe("parseAgUiEvent", () => {
     });
     expect(
       parseAgUiEvent({
+        type: "REASONING_MESSAGE_START",
+        messageId: "r1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_MESSAGE_START",
+      messageId: "r1",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "REASONING_MESSAGE_CONTENT",
+        messageId: "r1",
+        delta: "thinking",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_MESSAGE_CONTENT",
+      messageId: "r1",
+      delta: "thinking",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
+        type: "REASONING_MESSAGE_END",
+        messageId: "r1",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_MESSAGE_END",
+      messageId: "r1",
+      subagentRunId: "sub-1",
+    });
+    expect(
+      parseAgUiEvent({
         type: "REASONING_END",
         messageId: "r1",
         subagentRunId: "sub-1",
@@ -396,7 +431,43 @@ describe("parseAgUiEvent", () => {
       parseAgUiEvent({
         type: "SUBAGENT_FINISHED",
         subagentRunId: "sub-1",
+        outcome: { type: "success" },
+      }),
+    ).toEqual({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+      outcome: { type: "success" },
+    });
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_FINISHED",
+        subagentRunId: "sub-1",
         outcome: { type: "suspended", interruptIds: ["i1"] },
+      }),
+    ).toEqual({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+      outcome: { type: "suspended", interruptIds: ["i1"] },
+    });
+  });
+
+  it("requires subagentRunId for SUBAGENT_FINISHED", () => {
+    expect(parseAgUiEvent({ type: "SUBAGENT_FINISHED" })).toBeNull();
+  });
+
+  it("drops a malformed SUBAGENT_FINISHED outcome and filters non-string interruptIds", () => {
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_FINISHED",
+        subagentRunId: "sub-1",
+        outcome: { type: "bogus" },
+      }),
+    ).toEqual({ type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" });
+    expect(
+      parseAgUiEvent({
+        type: "SUBAGENT_FINISHED",
+        subagentRunId: "sub-1",
+        outcome: { type: "suspended", interruptIds: ["i1", 42, null] },
       }),
     ).toEqual({
       type: "SUBAGENT_FINISHED",
@@ -421,6 +492,9 @@ describe("parseAgUiEvent", () => {
     });
     expect(
       parseAgUiEvent({ type: "SUBAGENT_ERROR", message: "boom" }),
+    ).toBeNull();
+    expect(
+      parseAgUiEvent({ type: "SUBAGENT_ERROR", subagentRunId: "sub-1" }),
     ).toBeNull();
   });
 });

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -34,6 +34,24 @@ describe("parseAgUiEvent", () => {
     });
   });
 
+  it("parses a reasoning encrypted value event's subagentRunId", () => {
+    expect(
+      parseAgUiEvent({
+        type: "REASONING_ENCRYPTED_VALUE",
+        subtype: "message",
+        entityId: "r-1",
+        encryptedValue: "signed-blob",
+        subagentRunId: "sub-1",
+      }),
+    ).toEqual({
+      type: "REASONING_ENCRYPTED_VALUE",
+      subtype: "message",
+      entityId: "r-1",
+      encryptedValue: "signed-blob",
+      subagentRunId: "sub-1",
+    });
+  });
+
   it("rejects a reasoning encrypted value event with an unusable discriminator", () => {
     for (const subtype of [undefined, "", "Message", "other"]) {
       expect(

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1313,6 +1313,36 @@ describe("RunAggregator", () => {
     });
   });
 
+  it("does not force root requires-action status from a dangling subagent-scoped tool call", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "search",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "tool1",
+      delta: '{"q":"x"}',
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
+    });
+  });
+
   it("sets complete status when all tool calls have results at RUN_FINISHED", () => {
     const aggregator = createAggregator(false);
 
@@ -2957,6 +2987,79 @@ describe("RunAggregator", () => {
     expect(rootText).toMatchObject({ text: "root-a-root-b" });
   });
 
+  it("claims a subagent's own anonymous reasoning block with its own encrypted signature, not the root's", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-investigate",
+      toolCallName: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+      parentToolCallId: "t-investigate",
+    } as AgUiEvent);
+    aggregator.handle({ type: "REASONING_START" } as AgUiEvent); // root, anonymous
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      delta: "root thought",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_START",
+      subagentRunId: "sub-1",
+    } as AgUiEvent); // subagent, anonymous
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      delta: "subagent thought",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    // entityId matches no known block, so this can only be claimed by the
+    // open anonymous block of the scope it names — the subagent's, not root's.
+    aggregator.handle({
+      type: "REASONING_ENCRYPTED_VALUE",
+      subtype: "message",
+      entityId: "sig-owner",
+      encryptedValue: "sub-sig",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "REASONING_END" } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_END",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-investigate",
+      content: "done",
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const rootReasoning = last.content.find(
+      (p) => p.type === "reasoning",
+    ) as any;
+    expect(rootReasoning).toMatchObject({ text: "root thought" });
+    expect(
+      rootReasoning?.providerMetadata?.agui?.encryptedValue,
+    ).toBeUndefined();
+
+    const toolPart = last.content.find((p) => p.type === "tool-call") as any;
+    const nested = toolPart.messages[0];
+    const nestedReasoning = nested.content.find(
+      (p: any) => p.type === "reasoning",
+    );
+    expect(nestedReasoning).toMatchObject({ text: "subagent thought" });
+    expect(nestedReasoning?.providerMetadata?.agui?.encryptedValue).toBe(
+      "sub-sig",
+    );
+  });
+
   it("nests a subagent's activity under the spawning tool call's messages, not flattened into the parent run", () => {
     const results: ChatModelRunResult[] = [];
     const aggregator = new RunAggregator({
@@ -3043,6 +3146,116 @@ describe("RunAggregator", () => {
     });
     const nestedToolPart = nested.content[1] as any;
     expect(nestedToolPart.type).toBe("tool-call");
+    expect(nestedToolPart.toolCallId).toBe("t-explore");
+    expect(nestedToolPart.result).toEqual({ p99: 420 });
+  });
+
+  it("resolves nested subagent tool-call messages from raw wire-shaped JSON, through the subscriber's dispatch, not just hand-typed AgUiEvent objects", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+    const subscriber = createAgUiSubscriber({
+      dispatch: (evt) => aggregator.handle(evt),
+      runId: "r1",
+    });
+
+    // Plain, untyped objects with string `type` fields — the shape a JSON.parse
+    // of a network frame would produce, not a hand-typed AgUiEvent literal.
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "t-investigate",
+        toolCallName: "investigate",
+      },
+    });
+    subscriber.onToolCallArgsEvent?.({
+      event: {
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "t-investigate",
+        delta: '{"topic":"latency"}',
+      },
+    });
+    subscriber.onSubagentStartedEvent?.({
+      event: {
+        type: "SUBAGENT_STARTED",
+        subagentRunId: "sub-1",
+        name: "investigate",
+        parentToolCallId: "t-investigate",
+      },
+    });
+    subscriber.onTextMessageStartEvent?.({
+      event: {
+        type: "TEXT_MESSAGE_START",
+        messageId: "sub-msg-1",
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: "TEXT_MESSAGE_CONTENT",
+        messageId: "sub-msg-1",
+        delta: "checking dashboards",
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onTextMessageEndEvent?.({
+      event: {
+        type: "TEXT_MESSAGE_END",
+        messageId: "sub-msg-1",
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "t-explore",
+        toolCallName: "explore",
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onToolCallArgsEvent?.({
+      event: {
+        type: "TOOL_CALL_ARGS",
+        toolCallId: "t-explore",
+        delta: '{"path":"/metrics"}',
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onToolCallResultEvent?.({
+      event: {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "t-explore",
+        content: '{"p99":420}',
+        subagentRunId: "sub-1",
+      },
+    });
+    subscriber.onSubagentFinishedEvent?.({
+      event: { type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" },
+    });
+    subscriber.onToolCallResultEvent?.({
+      event: {
+        type: "TOOL_CALL_RESULT",
+        toolCallId: "t-investigate",
+        content: '{"summary":"p99 elevated"}',
+      },
+    });
+
+    const last = results[results.length - 1]!;
+    const parentToolPart = last.content[0] as any;
+    expect(parentToolPart.type).toBe("tool-call");
+    expect(parentToolPart.toolCallId).toBe("t-investigate");
+    expect(parentToolPart.messages).toHaveLength(1);
+    const nested = parentToolPart.messages[0];
+    expect(nested.id).toBe("sub-1");
+    expect(nested.content[0]).toMatchObject({
+      type: "text",
+      text: "checking dashboards",
+    });
+    const nestedToolPart = nested.content[1] as any;
     expect(nestedToolPart.toolCallId).toBe("t-explore");
     expect(nestedToolPart.result).toEqual({ p99: 420 });
   });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -3176,4 +3176,102 @@ describe("RunAggregator", () => {
       text: "partial progress",
     });
   });
+
+  it("nests two subagents that both claim the same parentToolCallId, in SUBAGENT_STARTED order", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-fanout",
+      toolCallName: "fanout",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-a",
+      name: "agent-a",
+      parentToolCallId: "t-fanout",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-b",
+      name: "agent-b",
+      parentToolCallId: "t-fanout",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "from a",
+      subagentRunId: "sub-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "from b",
+      subagentRunId: "sub-b",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-b",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-fanout",
+      content: "done",
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const toolPart = last.content[0] as any;
+    expect(toolPart.messages).toHaveLength(2);
+    expect(toolPart.messages.map((m: any) => m.id)).toEqual(["sub-a", "sub-b"]);
+    expect(toolPart.messages[0].content[0]).toMatchObject({
+      type: "text",
+      text: "from a",
+    });
+    expect(toolPart.messages[1].content[0]).toMatchObject({
+      type: "text",
+      text: "from b",
+    });
+  });
+
+  it("silently drops an orphaned subagent whose parentToolCallId matches no tool call, instead of flattening it into root", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-orphan",
+      name: "orphan-agent",
+      parentToolCallId: "t-does-not-exist",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "orphaned progress",
+      subagentRunId: "sub-orphan",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-orphan",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    expect(last.content).toHaveLength(0);
+    const orphanedText = last.content.find(
+      (p: any) => p.type === "text" && p.text === "orphaned progress",
+    );
+    expect(orphanedText).toBeUndefined();
+  });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -2899,7 +2899,7 @@ describe("RunAggregator", () => {
     expect(secondSurface.result).toBeDefined();
   });
 
-  it("does not crash on SUBAGENT_STARTED/FINISHED/ERROR and keeps emitting", () => {
+  it("emits no phantom parts for a subagent lifecycle that carries no content, and ignores a terminal for an unknown run", () => {
     const aggregator = createAggregator(true);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -2918,7 +2918,125 @@ describe("RunAggregator", () => {
       message: "boom",
     } as AgUiEvent);
 
-    expect(results.length).toBeGreaterThan(0);
+    expect(results.at(-1)?.content).toEqual([]);
+  });
+
+  it("attributes TEXT_MESSAGE_CHUNK to its subagent, the same as TEXT_MESSAGE_CONTENT", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-spawn",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CHUNK",
+      messageId: "m-sub",
+      delta: "chunked subagent text",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1)!;
+    const toolPart = last.content[0] as any;
+    expect(toolPart.messages[0].content).toEqual([
+      { type: "text", text: "chunked subagent text" },
+    ]);
+    expect(last.content.some((p: any) => p.type === "text")).toBe(false);
+  });
+
+  it("routes an MCP-apps activity to the call resolved in its own scope, not whichever call resolved last", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-root",
+      toolCallName: "render",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-root",
+      content: "root done",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-root",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-sub",
+      toolCallName: "inner",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    // Resolves after the root call, so an unscoped "last resolved" pointer
+    // would hand the root activity below to the subagent's call.
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-sub",
+      content: "inner done",
+      role: "tool",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1)!;
+    const rootTool = last.content[0] as any;
+    expect(rootTool.toolCallId).toBe("t-root");
+    expect(rootTool.mcp).toEqual({
+      app: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },
+    });
+    expect(rootTool.messages[0].content[0].mcp).toBeUndefined();
+  });
+
+  it("surfaces SUBAGENT_FINISHED.result and a suspended outcome's interruptIds on the nested message", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-spawn",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+      result: { summary: "found 3 files" },
+      outcome: { type: "suspended", interruptIds: ["int-1"] },
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const nested = (results.at(-1)!.content[0] as any).messages[0];
+    expect(nested.metadata.custom.agui).toMatchObject({
+      name: "worker",
+      result: { summary: "found 3 files" },
+      interruptIds: ["int-1"],
+    });
+    expect(nested.status).toEqual({
+      type: "requires-action",
+      reason: "interrupt",
+    });
   });
 
   it("does not merge anonymous text deltas across a subagent scope and the root scope", () => {
@@ -3498,7 +3616,7 @@ describe("RunAggregator", () => {
     });
   });
 
-  it("silently drops an orphaned subagent whose parentToolCallId matches no tool call, instead of flattening it into root", () => {
+  it("flattens a subagent with no nesting site into the root scope rather than dropping its output", () => {
     const results: ChatModelRunResult[] = [];
     const aggregator = new RunAggregator({
       showThinking: true,
@@ -3525,10 +3643,84 @@ describe("RunAggregator", () => {
     aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
 
     const last = results[results.length - 1]!;
-    expect(last.content).toHaveLength(0);
-    const orphanedText = last.content.find(
-      (p: any) => p.type === "text" && p.text === "orphaned progress",
-    );
-    expect(orphanedText).toBeUndefined();
+    expect(last.content).toEqual([{ type: "text", text: "orphaned progress" }]);
+  });
+
+  it("flattens a subagent that declares no parentToolCallId, which the schema allows", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-free",
+      name: "free-agent",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "unattributed progress",
+      subagentRunId: "sub-free",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    expect(last.content).toEqual([
+      { type: "text", text: "unattributed progress" },
+    ]);
+  });
+
+  it("keeps a cyclic parentToolCallId chain from materializing a subagent twice", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-root",
+      toolCallName: "spawn",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-a",
+      name: "a",
+      parentToolCallId: "t-root",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-a",
+      toolCallName: "spawn",
+      subagentRunId: "sub-a",
+    } as AgUiEvent);
+    // sub-a is reachable from t-root and also claims to be spawned by its own
+    // descendant call; the cycle must not re-enter it.
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-b",
+      name: "b",
+      parentToolCallId: "t-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "deep",
+      subagentRunId: "sub-b",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const rootTool = last.content[0] as any;
+    expect(rootTool.messages.map((m: any) => m.id)).toEqual(["sub-a"]);
+    const nestedTool = rootTool.messages[0].content[0];
+    expect(nestedTool.messages.map((m: any) => m.id)).toEqual(["sub-b"]);
+    expect(nestedTool.messages[0].content).toEqual([
+      { type: "text", text: "deep" },
+    ]);
   });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -2879,4 +2879,72 @@ describe("RunAggregator", () => {
     const rootText = last.content.find((p) => p.type === "text");
     expect(rootText).toMatchObject({ text: "root-a-root-b" });
   });
+
+  it("scopes tool-call boundary-clearing to the subagent that started it", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({ type: "TEXT_MESSAGE_START" } as AgUiEvent); // root, anonymous
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "root-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-explore",
+      toolCallName: "explore",
+      subagentRunId: "sub-1",
+    } as AgUiEvent); // subagent tool call — must NOT clear root's activeTextMessageIdByScope
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "-root-b",
+    } as AgUiEvent); // still anonymous, root scope — must still append to "root-a"
+
+    const last = results[results.length - 1]!;
+    const rootText = last.content.find((p) => p.type === "text");
+    expect(rootText).toMatchObject({ text: "root-a-root-b" });
+
+    const toolPart = last.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-explore",
+    );
+    expect(toolPart).toMatchObject({ toolName: "explore" });
+  });
+
+  it("scopes reasoning-start boundary-clearing to the subagent that started it", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({ type: "TEXT_MESSAGE_START" } as AgUiEvent); // root, anonymous
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "root-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "REASONING_START",
+      subagentRunId: "sub-1",
+    } as AgUiEvent); // subagent reasoning — must NOT clear root's activeTextMessageIdByScope
+    aggregator.handle({
+      type: "REASONING_MESSAGE_CONTENT",
+      delta: "sub-thought",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "-root-b",
+    } as AgUiEvent); // still anonymous, root scope — must still append to "root-a"
+
+    const last = results[results.length - 1]!;
+    const rootText = last.content.find((p) => p.type === "text");
+    expect(rootText).toMatchObject({ text: "root-a-root-b" });
+  });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -2884,6 +2884,11 @@ describe("RunAggregator", () => {
     const aggregator = createAggregator(true);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-outer",
+      toolCallName: "outer",
+    } as AgUiEvent);
     aggregator.handle({ type: "TEXT_MESSAGE_START" } as AgUiEvent); // root, anonymous
     aggregator.handle({
       type: "TEXT_MESSAGE_CONTENT",
@@ -2893,6 +2898,7 @@ describe("RunAggregator", () => {
       type: "SUBAGENT_STARTED",
       subagentRunId: "sub-1",
       name: "investigate",
+      parentToolCallId: "t-outer",
     } as AgUiEvent);
     aggregator.handle({
       type: "TOOL_CALL_START",
@@ -2909,10 +2915,13 @@ describe("RunAggregator", () => {
     const rootText = last.content.find((p) => p.type === "text");
     expect(rootText).toMatchObject({ text: "root-a-root-b" });
 
-    const toolPart = last.content.find(
-      (p) => p.type === "tool-call" && p.toolCallId === "t-explore",
+    const outerToolPart = last.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-outer",
+    ) as any;
+    const nestedToolPart = outerToolPart?.messages?.[0]?.content?.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "t-explore",
     );
-    expect(toolPart).toMatchObject({ toolName: "explore" });
+    expect(nestedToolPart).toMatchObject({ toolName: "explore" });
   });
 
   it("scopes reasoning-start boundary-clearing to the subagent that started it", () => {
@@ -2946,5 +2955,225 @@ describe("RunAggregator", () => {
     const last = results[results.length - 1]!;
     const rootText = last.content.find((p) => p.type === "text");
     expect(rootText).toMatchObject({ text: "root-a-root-b" });
+  });
+
+  it("nests a subagent's activity under the spawning tool call's messages, not flattened into the parent run", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-investigate",
+      toolCallName: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "t-investigate",
+      delta: '{"topic":"latency"}',
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+      parentToolCallId: "t-investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      messageId: "sub-msg-1",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "sub-msg-1",
+      delta: "checking dashboards",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_END",
+      messageId: "sub-msg-1",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-explore",
+      toolCallName: "explore",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "t-explore",
+      delta: '{"path":"/metrics"}',
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-explore",
+      content: '{"p99":420}',
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-investigate",
+      content: '{"summary":"p99 elevated"}',
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    expect(last.content).toHaveLength(1);
+    const parentToolPart = last.content[0] as any;
+    expect(parentToolPart.type).toBe("tool-call");
+    expect(parentToolPart.toolCallId).toBe("t-investigate");
+    expect(parentToolPart.messages).toHaveLength(1);
+    const nested = parentToolPart.messages[0];
+    expect(nested.role).toBe("assistant");
+    expect(nested.id).toBe("sub-1");
+    expect(nested.status).toEqual({ type: "complete", reason: "unknown" });
+    expect(nested.content).toHaveLength(2);
+    expect(nested.content[0]).toMatchObject({
+      type: "text",
+      text: "checking dashboards",
+    });
+    const nestedToolPart = nested.content[1] as any;
+    expect(nestedToolPart.type).toBe("tool-call");
+    expect(nestedToolPart.toolCallId).toBe("t-explore");
+    expect(nestedToolPart.result).toEqual({ p99: 420 });
+  });
+
+  it("recurses for a subagent-of-subagent (parentSubagentRunId chain)", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-outer",
+      toolCallName: "outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-outer",
+      name: "outer-agent",
+      parentToolCallId: "t-outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-inner",
+      toolCallName: "inner",
+      subagentRunId: "sub-outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-inner",
+      name: "inner-agent",
+      parentToolCallId: "t-inner",
+      parentSubagentRunId: "sub-outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      subagentRunId: "sub-inner",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "deep result",
+      subagentRunId: "sub-inner",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-inner",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-inner",
+      content: "done",
+      subagentRunId: "sub-outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-outer",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-outer",
+      content: "done",
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const outerToolPart = last.content[0] as any;
+    const outerNested = outerToolPart.messages[0];
+    expect(outerNested.id).toBe("sub-outer");
+    const innerToolPart = outerNested.content[0] as any;
+    expect(innerToolPart.toolCallId).toBe("t-inner");
+    expect(innerToolPart.messages).toHaveLength(1);
+    const innerNested = innerToolPart.messages[0];
+    expect(innerNested.id).toBe("sub-inner");
+    expect(innerNested.content[0]).toMatchObject({
+      type: "text",
+      text: "deep result",
+    });
+  });
+
+  it("keeps whatever a subagent accumulated when SUBAGENT_ERROR fires instead of dropping it", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t1",
+      toolCallName: "risky",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "risky-agent",
+      parentToolCallId: "t1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "partial progress",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_ERROR",
+      subagentRunId: "sub-1",
+      message: "tool crashed",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t1",
+      content: "failed",
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const toolPart = last.content[0] as any;
+    expect(toolPart.messages).toHaveLength(1);
+    expect(toolPart.messages[0].status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      error: "tool crashed",
+    });
+    expect(toolPart.messages[0].content[0]).toMatchObject({
+      type: "text",
+      text: "partial progress",
+    });
   });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -3805,7 +3805,7 @@ describe("RunAggregator", () => {
     ]);
   });
 
-  it("terminates on a mutually cyclic parentToolCallId graph and flattens both runs", () => {
+  it("flattens a pair of subagents that name each other's tool calls as their parent", () => {
     const results: ChatModelRunResult[] = [];
     const aggregator = new RunAggregator({
       showThinking: true,
@@ -3815,8 +3815,11 @@ describe("RunAggregator", () => {
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
     // sub-x is spawned by a call inside sub-y, and sub-y by a call inside
-    // sub-x. Neither is reachable from the root, so a walk without a visited
-    // set would not terminate.
+    // sub-x. A run's parentToolCallId is fixed at its first announcement, so a
+    // mutual pair like this can never be entered from the root at all: both
+    // stay unreachable and flatten. The visited set and depth cap in
+    // reachableSubagentRunIds are defensive against a malformed registry
+    // rather than a graph this API can produce.
     aggregator.handle({
       type: "SUBAGENT_STARTED",
       subagentRunId: "sub-x",

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1313,7 +1313,15 @@ describe("RunAggregator", () => {
     });
   });
 
-  it("does not force root requires-action status from a dangling subagent-scoped tool call", () => {
+  it("reports incomplete/tool-calls (not requires-action, not complete) for a dangling subagent-scoped tool call", () => {
+    // This adapter cannot surface a subagent-scoped tool call through
+    // getPendingToolCalls (it only walks top-level content, not nested
+    // .messages), so it cannot honestly claim "requires-action": there is
+    // no path for a caller to resolve it. Reporting "complete" would be
+    // worse — it would tell the app the run finished cleanly while an
+    // AG-UI backend still waits on a TOOL_CALL_RESULT that never arrives.
+    // "incomplete"/"tool-calls" (the same status core's local runtime uses
+    // when it deliberately stops resolving tool calls) says neither.
     const aggregator = createAggregator(false);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -1338,8 +1346,44 @@ describe("RunAggregator", () => {
 
     const last = results.at(-1);
     expect(last?.status).toMatchObject({
-      type: "complete",
-      reason: "unknown",
+      type: "incomplete",
+      reason: "tool-calls",
+    });
+  });
+
+  it("still reports requires-action/tool-calls when a root tool call is unresolved alongside a resolved subagent-scoped one", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "root-tool",
+      toolCallName: "search",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+      parentToolCallId: "root-tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "sub-tool",
+      toolCallName: "search",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "sub-tool",
+      content: '"done"',
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "requires-action",
+      reason: "tool-calls",
     });
   });
 

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1326,9 +1326,21 @@ describe("RunAggregator", () => {
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
     aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "t-spawn",
+      content: "spawned",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
       type: "SUBAGENT_STARTED",
       subagentRunId: "sub-1",
       name: "investigate",
+      parentToolCallId: "t-spawn",
     } as AgUiEvent);
     aggregator.handle({
       type: "TOOL_CALL_START",
@@ -1347,6 +1359,33 @@ describe("RunAggregator", () => {
     const last = results.at(-1);
     expect(last?.status).toMatchObject({
       type: "incomplete",
+      reason: "tool-calls",
+    });
+  });
+
+  it("reports requires-action for a dangling tool call belonging to a subagent that flattened to root", () => {
+    // The nesting-site rule above decides both where a call renders and
+    // whether it is answerable: a flattened call is top-level content, so
+    // getPendingToolCalls reaches it and the run is genuinely resumable.
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-free",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "search",
+      subagentRunId: "sub-free",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1);
+    expect(last?.status).toMatchObject({
+      type: "requires-action",
       reason: "tool-calls",
     });
   });
@@ -2921,6 +2960,46 @@ describe("RunAggregator", () => {
     expect(results.at(-1)?.content).toEqual([]);
   });
 
+  it("keeps a messageId reused by the root run and a subagent in separate buffers", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-spawn",
+    } as AgUiEvent);
+    // The schema does not make messageId unique across subagent runs.
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m-1",
+      delta: "root text",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m-1",
+      delta: "subagent text",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1)!;
+    const rootText = last.content.filter((p: any) => p.type === "text");
+    expect(rootText).toEqual([{ type: "text", text: "root text" }]);
+    const toolPart = last.content.find(
+      (p: any) => p.type === "tool-call",
+    ) as any;
+    expect(toolPart.messages[0].content).toEqual([
+      { type: "text", text: "subagent text" },
+    ]);
+  });
+
   it("attributes TEXT_MESSAGE_CHUNK to its subagent, the same as TEXT_MESSAGE_CONTENT", () => {
     const aggregator = createAggregator(true);
 
@@ -3699,13 +3778,25 @@ describe("RunAggregator", () => {
       toolCallName: "spawn",
       subagentRunId: "sub-a",
     } as AgUiEvent);
-    // sub-a is reachable from t-root and also claims to be spawned by its own
-    // descendant call; the cycle must not re-enter it.
     aggregator.handle({
       type: "SUBAGENT_STARTED",
       subagentRunId: "sub-b",
       name: "b",
       parentToolCallId: "t-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-b",
+      toolCallName: "spawn",
+      subagentRunId: "sub-b",
+    } as AgUiEvent);
+    // Closes the loop: sub-a claims to be spawned by a call inside its own
+    // descendant, so a walk with no visited set would re-enter it forever.
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-a",
+      name: "a",
+      parentToolCallId: "t-b",
     } as AgUiEvent);
     aggregator.handle({
       type: "TEXT_MESSAGE_CONTENT",
@@ -3717,10 +3808,15 @@ describe("RunAggregator", () => {
     const last = results[results.length - 1]!;
     const rootTool = last.content[0] as any;
     expect(rootTool.messages.map((m: any) => m.id)).toEqual(["sub-a"]);
-    const nestedTool = rootTool.messages[0].content[0];
-    expect(nestedTool.messages.map((m: any) => m.id)).toEqual(["sub-b"]);
-    expect(nestedTool.messages[0].content).toEqual([
-      { type: "text", text: "deep" },
-    ]);
+    const subATool = rootTool.messages[0].content[0];
+    expect(subATool.toolCallId).toBe("t-a");
+    expect(subATool.messages.map((m: any) => m.id)).toEqual(["sub-b"]);
+    const subBContent = subATool.messages[0].content;
+    expect(subBContent.map((p: any) => p.type)).toEqual(["tool-call", "text"]);
+    // The loop closes here: t-b lives inside sub-b and claims to spawn sub-a,
+    // which is already materialized further up. It must not be re-entered.
+    expect(subBContent[0].toolCallId).toBe("t-b");
+    expect(subBContent[0].messages).toBeUndefined();
+    expect(subBContent[1]).toEqual({ type: "text", text: "deep" });
   });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -3053,6 +3053,38 @@ describe("RunAggregator", () => {
     ]);
   });
 
+  it("closes a subagent still streaming when the run itself is cancelled", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-spawn",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "half a thought",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    // No SUBAGENT_FINISHED: a subagent only ever reports its own terminal.
+    aggregator.handle({ type: "RUN_CANCELLED", runId: "r1" } as AgUiEvent);
+
+    const last = results.at(-1)!;
+    expect(last.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+    const nested = (last.content[0] as any).messages[0];
+    expect(nested.status).toEqual({ type: "incomplete", reason: "cancelled" });
+  });
+
   it("attributes TEXT_MESSAGE_CHUNK to its subagent, the same as TEXT_MESSAGE_CONTENT", () => {
     const aggregator = createAggregator(true);
 

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -2957,7 +2957,60 @@ describe("RunAggregator", () => {
       message: "boom",
     } as AgUiEvent);
 
+    // Each lifecycle event emits, so ignoring them would leave fewer snapshots.
+    expect(results).toHaveLength(4);
+    // sub-1 never nests (no parentToolCallId) and carries no content, so it
+    // contributes no parts; the terminal for an unknown run is a no-op.
     expect(results.at(-1)?.content).toEqual([]);
+  });
+
+  it("anchors a subagent tool call under its own scoped parent message", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-spawn",
+      toolCallName: "task",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "worker",
+      parentToolCallId: "t-spawn",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m-sub",
+      delta: "before",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m-later",
+      delta: "after",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    // Arrives last on the wire but belongs under m-sub, so it must be spliced
+    // in rather than appended after the later text.
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-inner",
+      toolCallName: "search",
+      parentMessageId: "m-sub",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const nested = (
+      results.at(-1)!.content.find((p: any) => p.type === "tool-call") as any
+    ).messages[0];
+    expect(nested.content.map((p: any) => p.type)).toEqual([
+      "text",
+      "tool-call",
+      "text",
+    ]);
+    expect(nested.content[1].toolCallId).toBe("t-inner");
   });
 
   it("keeps a messageId reused by the root run and a subagent in separate buffers", () => {
@@ -3752,7 +3805,61 @@ describe("RunAggregator", () => {
     ]);
   });
 
-  it("keeps a cyclic parentToolCallId chain from materializing a subagent twice", () => {
+  it("terminates on a mutually cyclic parentToolCallId graph and flattens both runs", () => {
+    const results: ChatModelRunResult[] = [];
+    const aggregator = new RunAggregator({
+      showThinking: true,
+      logger: makeLogger(),
+      emit: (r) => results.push(r),
+    });
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    // sub-x is spawned by a call inside sub-y, and sub-y by a call inside
+    // sub-x. Neither is reachable from the root, so a walk without a visited
+    // set would not terminate.
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-x",
+      name: "x",
+      parentToolCallId: "t-y",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-y",
+      name: "y",
+      parentToolCallId: "t-x",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-x",
+      toolCallName: "spawn",
+      subagentRunId: "sub-x",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "t-y",
+      toolCallName: "spawn",
+      subagentRunId: "sub-y",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "from x",
+      subagentRunId: "sub-x",
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    expect(last.content.map((p: any) => p.type)).toEqual([
+      "tool-call",
+      "tool-call",
+      "text",
+    ]);
+    for (const part of last.content as any[]) {
+      expect(part.messages).toBeUndefined();
+    }
+  });
+
+  it("nests a multi-level parentToolCallId chain without re-entering an established run", () => {
     const results: ChatModelRunResult[] = [];
     const aggregator = new RunAggregator({
       showThinking: true,

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -2824,4 +2824,59 @@ describe("RunAggregator", () => {
     });
     expect(secondSurface.result).toBeDefined();
   });
+
+  it("does not crash on SUBAGENT_STARTED/FINISHED/ERROR and keeps emitting", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_FINISHED",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_ERROR",
+      subagentRunId: "does-not-exist",
+      message: "boom",
+    } as AgUiEvent);
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("does not merge anonymous text deltas across a subagent scope and the root scope", () => {
+    const aggregator = createAggregator(true);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({ type: "TEXT_MESSAGE_START" } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "root-a",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "SUBAGENT_STARTED",
+      subagentRunId: "sub-1",
+      name: "investigate",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_START",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "sub-a",
+      subagentRunId: "sub-1",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TEXT_MESSAGE_CONTENT",
+      delta: "-root-b",
+    } as AgUiEvent);
+
+    const last = results[results.length - 1]!;
+    const rootText = last.content.find((p) => p.type === "text");
+    expect(rootText).toMatchObject({ text: "root-a-root-b" });
+  });
 });

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -261,4 +261,50 @@ describe("createAgUiSubscriber", () => {
       delta: "think",
     });
   });
+
+  it("dispatches SUBAGENT_STARTED via the typed callback", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (event) => events.push(event),
+      runId: "run-1",
+    });
+    subscriber.onSubagentStartedEvent?.({
+      event: {
+        type: "SUBAGENT_STARTED",
+        subagentRunId: "sub-1",
+        name: "investigate",
+        parentToolCallId: "t1",
+      },
+    });
+    expect(events).toEqual([
+      {
+        type: "SUBAGENT_STARTED",
+        subagentRunId: "sub-1",
+        name: "investigate",
+        parentToolCallId: "t1",
+      },
+    ]);
+  });
+
+  it("dispatches SUBAGENT_FINISHED and SUBAGENT_ERROR via typed callbacks", () => {
+    const events: AgUiEvent[] = [];
+    const subscriber = createAgUiSubscriber({
+      dispatch: (event) => events.push(event),
+      runId: "run-1",
+    });
+    subscriber.onSubagentFinishedEvent?.({
+      event: { type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" },
+    });
+    subscriber.onSubagentErrorEvent?.({
+      event: {
+        type: "SUBAGENT_ERROR",
+        subagentRunId: "sub-1",
+        message: "boom",
+      },
+    });
+    expect(events).toEqual([
+      { type: "SUBAGENT_FINISHED", subagentRunId: "sub-1" },
+      { type: "SUBAGENT_ERROR", subagentRunId: "sub-1", message: "boom" },
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

Closes (or at least gives a concrete starting point for) #6529. `packages/react-ag-ui` doesn't model `@ag-ui/client@0.0.59+`'s subagent protocol: `SUBAGENT_STARTED`/`SUBAGENT_FINISHED`/`SUBAGENT_ERROR` events and the `subagentRunId` attribution field carried on most other events. `event-parser.ts`'s `default` branch folds all three into a `RAW` event, and `run-aggregator.ts` logs and drops `RAW`. A backend that runs subagents (the "agents-as-tools" pattern, e.g. deepagents' `task` tool) produces output with no lifecycle boundaries and no attribution — a subagent's own tool calls and text render as flat siblings of the parent run, with no way to know which activity belongs to which subagent.

## Root cause

The adapter's event model (`AgUiEvent` in `types.ts`) and its aggregator (`RunAggregator`) predate the subagent protocol addition and never had a concept of "this event belongs to a nested agent run" — every accumulator (`textParts`, `reasoningParts`, `toolCalls`, `partOrder`) was single-scope by construction, and events with an unmodeled `type` fall through to a defensive `RAW` catch-all that's dropped at debug level.

## Change

**Protocol facts** (confirmed against a fresh clone of `ag-ui-protocol/ag-ui`, not guessed or taken from minified dist — the issue posed the correlation mechanism as an open question, so this is worth stating precisely):
- `SUBAGENT_STARTED` carries `subagentRunId`, `name`, `description?`, `parentSubagentRunId?`, and **`parentToolCallId?`/`parentMessageId?`** — the correlation back to the spawning tool call is explicit on the event itself, not inferred from ordering. `parentToolCallId` is what this PR's nesting join actually keys on; `parentSubagentRunId` is stored and surfaced as descriptive metadata on the synthesized nested message but doesn't drive the join itself (nesting depth is driven entirely by `parentToolCallId` chains).
- `SUBAGENT_FINISHED` has `outcome?: {type:"success"} | {type:"suspended", interruptIds?}`, mirroring `RUN_FINISHED.outcome` one level down. `SUBAGENT_ERROR` has `message`/`code?`.
- `subagentRunId?` is on nearly every event schema; `@ag-ui/client`'s own reducer only tags it flatly onto the `Message`/`ToolCall` objects it builds — it does **not** nest or group anything. Grouping is left to the consumer, by design.
- Cross-runtime precedent: `@assistant-ui/react-langchain`'s current (v1-era) subagent support is discovery-only (`useLangChainSubagents()` returns a namespace-keyed map; fetching the actual messages is left to the caller via LangChain's own `useMessages`). The **earlier** legacy-runtime pattern (assistant-ui#2574/#2580/#2583) is the one that actually built and attached `ToolCallMessagePart.messages` — whoever converts a protocol's events into `ThreadMessage[]` is responsible for using that protocol's own correlating concept and assigning the array directly. AG-UI's explicit `parentToolCallId` makes this more precise than LangChain's namespace scheme, so this PR follows that established core contract rather than inventing a parallel mechanism — and doesn't add a discovery-hook API, since the nested `.messages` tree already is the discovery mechanism here.

**Implementation**, scoped to `packages/react-ag-ui`, no `@assistant-ui/core` changes needed (`ToolCallMessagePart.messages` and its consumers — `PartPrimitive.Messages`, `ToolInvocationTracker`, `external-store-thread-runtime-core`'s identity walk — already handle nested `ThreadMessage[]` generically):

1. `types.ts` — `subagentRunId?: string` added to the `AgUiEvent` variants that need it for attribution (text/reasoning/tool-call events, including `REASONING_ENCRYPTED_VALUE`); three new variants for the lifecycle events.
2. `event-parser.ts` — parses all of the above instead of falling through to `RAW`.
3. `subscriber.ts` — three new typed `AgentSubscriber` callbacks (matching `@ag-ui/client`'s real `onSubagentStartedEvent`/`onSubagentFinishedEvent`/`onSubagentErrorEvent` names).
4. `run-aggregator.ts` — the core of the change. `RunAggregator`'s existing flat accumulators are reused as-is (ids are unique per run regardless of subagent depth, per the protocol schema), but every entry is tagged with an optional `subagentRunId` scope as it's created, and a `subagentRuns` registry tracks each run's lifecycle/metadata. `emit()`'s snapshot construction became a recursive `buildParts(scope, depth, ...)`: root-scope parts assemble as before; any tool-call part whose `toolCallId` matches a subagent's `parentToolCallId` gets that subagent's own parts (rebuilt live on every emit, so nesting streams in incrementally rather than only appearing after `SUBAGENT_FINISHED`) materialized into a synthetic `ThreadAssistantMessage` and attached via `.messages` — recursing for subagent-of-subagent chains, with a depth cap as a defensive (not expected-case) guard against malformed cycles.

Two correctness issues surfaced and fixed along the way, both from a previously-single-scope collection quietly becoming multi-scoped:
- The aggregator previously tracked "which buffer should an anonymous (no explicit `messageId`) delta append to" via two single scalar fields. Once subagent-tagged events can interleave with the top-level run (or with each other, if a backend runs subagents concurrently), a shared scalar would misattribute anonymous deltas across scopes. Replaced with `Map<scope, ...>` keyed by `subagentRunId ?? ""`.
- Tool-approval projection (`projectAgUiToolApprovals`'s `boundToolCallIds` set, in the pre-existing `tool-approval.ts` seam added in #5902) was being passed `this.toolCalls.keys()` unfiltered by scope. Once subagent-scoped tool calls exist, a `RUN_FINISHED` interrupt batch mixing a root-level approval gate with a subagent-scoped one would get miscategorized as "fully bound" by the projection call, when the subagent's gate actually has no UI anywhere to answer it — and `buildToolApprovalResume`'s existing all-or-nothing contract means the run could never resume once a mismatched approval keeps a batch open. Fixed by scoping `boundToolCallIds` to root-only tool calls, which correctly lets `tool-approval.ts`'s existing "a batch containing an unbound id projects nothing" rule apply to the whole mixed batch (matching its pre-existing documented contract) rather than silently misrendering it as actionable.

## Verification

- `pnpm --filter @assistant-ui/react-ag-ui test` — 498/498 passing (all pre-existing tests green with zero regressions, plus new coverage: subagent event parsing incl. edge cases and `REASONING_ENCRYPTED_VALUE` attribution, subscriber dispatch, scoped anonymous-delta attribution, single-level nesting, two-level subagent-of-subagent recursion, `SUBAGENT_ERROR` preserving partial accumulated content instead of dropping it, duplicate-`parentToolCallId` ordering, an orphaned-subagent (unmatched `parentToolCallId`) non-crash case, mixed-scope approval-batch collapsing correctly, a dangling subagent-scoped tool call reporting `incomplete`/`tool-calls` rather than `requires-action` or a silent `complete`, a root-scoped unresolved tool call still correctly reporting `requires-action`/`tool-calls` alongside an already-resolved subagent-scoped one, and one true end-to-end test driving raw wire-shaped JSON through `createAgUiSubscriber` → `parseAgUiEvent` → `RunAggregator` → nested `.messages`).
- `pnpm --filter @assistant-ui/react-ag-ui build` — clean.
- `pnpm lint` — clean (repo-wide warnings present are pre-existing and unrelated to this change).

## Public surface

- `@assistant-ui/react-ag-ui`: additive only. `AgUiEvent` gains `subagentRunId?` on several variants and three new discriminated variants (`SUBAGENT_STARTED`/`FINISHED`/`ERROR`); `Subscriber` gains three new optional callbacks. `ToolCallMessagePart.messages` (existing `@assistant-ui/core` field) is now populated by this adapter for the first time — no type change there.
- Changeset added (patch).
- No documentation/api-reference changes — nothing here is part of the generated API reference surface (internal adapter types), and I didn't see an existing docs page describing react-ag-ui's event coverage to update; happy to add one if maintainers want it.

## Explicitly deferred / open questions for maintainers

Per the issue's own framing ("requires maintainer decisions", "not scoped for automation"), I'm not presenting this as a finished, settled design — flagging what I deliberately left out or am least sure about:

- **Scope, stated explicitly rather than silently:** one `ThreadMessage` per subagent run (not per distinct wire `messageId` within it — a subagent's entire output is one nested message, even if the subagent itself emits multiple `TEXT_MESSAGE_START` boundaries). `CUSTOM`/`STATE_SNAPSHOT`/`STATE_DELTA` don't carry attribution in this PR even though the protocol schema has `subagentRunId` on all of them; the scope is what the text/reasoning/tool-call/reasoning-signature attribution path needs.

  **Corrected in a follow-up commit on this branch.** An earlier revision of this section said `ACTIVITY_SNAPSHOT` "carries no `subagentRunId` at all" and left MCP-apps routing root-scope-only on that basis. That was wrong: `ActivitySnapshotEventSchema` and `ActivityDeltaEventSchema` both declare `subagentRunId` in `@ag-ui/core@0.0.59`, and upstream's own reducer (`apply/default.ts`) implements ownership semantics for it. `ACTIVITY_SNAPSHOT`, `TEXT_MESSAGE_CHUNK` and `TOOL_CALL_CHUNK` now parse the field, and the MCP-apps fallback resolves through a per-scope pointer.
- **`SUBAGENT_FINISHED`'s `result` and a suspended outcome's `interruptIds`** are now kept on the synthesized nested message's `agui` metadata rather than discarded, but nothing consumes them yet.
- **`SUBAGENT_FINISHED`'s `suspended` outcome** maps onto `MessageStatus`'s existing `requires-action`/`interrupt` shape, but I haven't built any nested-HITL resume UX on top of it — happy to hear whether that's wanted here or is a separate follow-up.
- **No discovery-hook API** (mirroring react-langchain's `useLangChainSubagents()`) was added — reasoning above is that the nested `.messages` structure already answers "does this tool call have subagent activity," but if there's a UX reason to want pre-completion discoverability before any content streams in, that's an easy addition on top of the existing `subagentRuns` registry.
- **A subagent with no nesting site flattens into the root scope** rather than being dropped. `parentToolCallId` is optional in the schema, so dropping silently discarded every token from a producer that never sets it; flattening is also what the protocol's own pre-subagent compatibility middleware does.
- **Known, not fixed in this PR:** `AgUiThreadRuntimeCore.findMessageIdForToolCall` only scans top-level `message.content`, not nested `.messages` — a subagent's own tool call resolving asynchronously across a run boundary (the cross-run `TOOL_CALL_RESULT`/MCP-apps `ACTIVITY_SNAPSHOT` paths) won't find it in a historical nested subagent message. Likely rare in practice; flagging as a probable follow-up rather than expanding this PR's surface further.
- **Subagent-scoped client-side (frontend-executed) tool calls are not resolvable by this adapter.** The protocol allows a subagent to call a tool from `RunAgentInput.tools`, the same as the root run — nothing in the schema restricts frontend tools to the root agent. But `AgUiThreadRuntimeCore.getPendingToolCalls()`/`findMessageIdForToolCall()` only walk a message's top-level `content`, not nested `.messages`, so a subagent's own unresolved tool call can never be surfaced to `addToolResult`/resumed — reaching it would mean extending the pending-tool-call and resume paths to walk the nested tree, which is a real feature in its own right and out of scope here. Given that ceiling, `RUN_FINISHED` deliberately does **not** report `requires-action`/`tool-calls` for a run whose only unresolved tool calls are subagent-scoped (there would be no way for a caller to act on it), but it also does not report `complete` (that would silently tell the app the run finished successfully while an AG-UI backend may still be blocked waiting on a `TOOL_CALL_RESULT` that will never come). It reports `{ type: "incomplete", reason: "tool-calls" }` instead — the same status `@assistant-ui/core`'s local runtime already uses when it deliberately stops resolving tool calls (`local-thread-runtime-core.ts`'s `maxSteps` cutoff) — so the failure is visible and honestly labeled rather than either silently swallowed or falsely reported as resumable. Full nested tool-call execution support is a natural follow-up if subagent-owned frontend tools turn out to be a real pattern maintainers want supported.

Open to feedback on any of the above, or on the overall "one nested message per subagent run" shape if there's a different design maintainers would prefer.

