### PR TITLE
feat(docs): surface the hosted status page in the nav and footer

### DIFF
--- a/apps/docs/app/api/status/route.ts
+++ b/apps/docs/app/api/status/route.ts
@@ -1,0 +1,16 @@
+import { getStatusState } from "@/lib/status";
+
+export const revalidate = 300;
+
+export async function GET() {
+  const state = await getStatusState();
+  return Response.json(
+    { state },
+    {
+      headers: {
+        "Cache-Control":
+          "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
+      },
+    },
+  );
+}

--- a/apps/docs/app/api/status/route.ts
+++ b/apps/docs/app/api/status/route.ts
@@ -1,9 +1,10 @@
 import { getStatusState } from "@/lib/status";
 
-export const revalidate = 300;
-
 export async function GET() {
   const state = await getStatusState();
+  if (state === null) {
+    return Response.json({ error: "status unavailable" }, { status: 503 });
+  }
   return Response.json(
     { state },
     {

--- a/apps/docs/app/api/status/route.ts
+++ b/apps/docs/app/api/status/route.ts
@@ -8,10 +8,7 @@ export async function GET() {
   return Response.json(
     { state },
     {
-      headers: {
-        "Cache-Control":
-          "public, max-age=60, s-maxage=300, stale-while-revalidate=600",
-      },
+      headers: { "Cache-Control": "public, max-age=60, s-maxage=300" },
     },
   );
 }

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -2,6 +2,7 @@ import type { FC, ReactNode } from "react";
 import Link from "next/link";
 import { DiscordIcon } from "@/components/icons/discord";
 import { GitHubIcon } from "@/components/icons/github";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
 
 type FooterLinkItem = {
@@ -86,42 +87,45 @@ export function Footer(): React.ReactElement {
             <span aria-hidden>·</span>
             <FooterLink href="/terms-of-service">Terms</FooterLink>
           </div>
-          <div className="flex flex-wrap items-center gap-1.5">
-            <a
-              href="https://x.com/assistantui"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
-              aria-label="X (Twitter)"
-            >
-              <svg
-                aria-hidden="true"
-                className="size-4"
-                viewBox="0 0 24 24"
-                fill="currentColor"
+          <div className="flex flex-wrap items-center gap-4">
+            <StatusBadge />
+            <div className="flex flex-wrap items-center gap-1.5">
+              <a
+                href="https://x.com/assistantui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
+                aria-label="X (Twitter)"
               >
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-            </a>
-            <a
-              href="https://github.com/assistant-ui/assistant-ui"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
-              aria-label="GitHub"
-            >
-              <GitHubIcon className="size-4" />
-            </a>
-            <a
-              href="https://discord.gg/S9dwgCNEFs"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
-              aria-label="Discord"
-            >
-              <DiscordIcon className="size-4" />
-            </a>
-            <ThemeToggle className="hover:text-foreground" />
+                <svg
+                  aria-hidden="true"
+                  className="size-4"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
+              </a>
+              <a
+                href="https://github.com/assistant-ui/assistant-ui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
+                aria-label="GitHub"
+              >
+                <GitHubIcon className="size-4" />
+              </a>
+              <a
+                href="https://discord.gg/S9dwgCNEFs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-foreground flex size-7 items-center justify-center transition-colors"
+                aria-label="Discord"
+              >
+                <DiscordIcon className="size-4" />
+              </a>
+              <ThemeToggle className="hover:text-foreground" />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/docs/components/shared/nav-glyph.tsx
+++ b/apps/docs/components/shared/nav-glyph.tsx
@@ -326,6 +326,18 @@ function GlyphTraction() {
   );
 }
 
+function GlyphStatus() {
+  return (
+    <span className="flex h-6 items-center gap-[3px]">
+      <span className="bg-foreground/15 h-[3px] w-[4px]" />
+      <span className="bg-foreground/15 h-[3px] w-[4px]" />
+      <span className={cn("bg-foreground/40 h-[16px] w-[4px]", ACCENT)} />
+      <span className="bg-foreground/25 h-[8px] w-[4px]" />
+      <span className="bg-foreground/15 h-[3px] w-[4px]" />
+    </span>
+  );
+}
+
 const GLYPHS: Record<NavGlyphKind, () => React.ReactNode> = {
   elements: GlyphElements,
   design: GlyphDesign,
@@ -349,6 +361,7 @@ const GLYPHS: Record<NavGlyphKind, () => React.ReactNode> = {
   blog: GlyphBlog,
   careers: GlyphCareers,
   brand: GlyphBrand,
+  status: GlyphStatus,
 };
 
 export function NavGlyph({

--- a/apps/docs/components/shared/status-badge.test.tsx
+++ b/apps/docs/components/shared/status-badge.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StatusBadge } from "./status-badge";
+
+const respondWith = (body: unknown, ok = true) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve({ ok, json: () => Promise.resolve(body) })),
+  );
+};
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("StatusBadge", () => {
+  it("renders the plain link until the state resolves", () => {
+    respondWith(new Promise(() => {}));
+    render(<StatusBadge />);
+
+    const link = screen.getByRole("link");
+    expect(link.textContent).toBe("Status");
+    expect(link.querySelector("span")).toBeNull();
+  });
+
+  it.each([
+    ["operational", "All systems operational", "bg-emerald-500"],
+    ["degraded", "Degraded performance", "bg-amber-500"],
+    ["downtime", "Service disruption", "bg-red-500"],
+    ["maintenance", "Under maintenance", "bg-blue-500"],
+  ])("labels %s with its own dot", async (state, label, dot) => {
+    respondWith({ state });
+    render(<StatusBadge />);
+
+    const link = await screen.findByRole("link", { name: label });
+    expect(link.querySelector("span")?.className).toContain(dot);
+  });
+
+  it("keeps the plain link when the route reports the state unavailable", async () => {
+    respondWith({ error: "status unavailable" }, false);
+    render(<StatusBadge />);
+    await settle();
+
+    const link = screen.getByRole("link");
+    expect(link.textContent).toBe("Status");
+    expect(link.querySelector("span")).toBeNull();
+  });
+
+  it("keeps the plain link when the state is unrecognized", async () => {
+    respondWith({ state: null });
+    render(<StatusBadge />);
+    await settle();
+
+    expect(screen.getByRole("link").textContent).toBe("Status");
+  });
+});

--- a/apps/docs/components/shared/status-badge.test.tsx
+++ b/apps/docs/components/shared/status-badge.test.tsx
@@ -20,9 +20,13 @@ afterEach(() => {
 });
 
 describe("StatusBadge", () => {
-  it("renders the plain link until the state resolves", () => {
-    respondWith(new Promise(() => {}));
+  it("renders the plain link while the request is still in flight", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
     render(<StatusBadge />);
+    await settle();
 
     const link = screen.getByRole("link");
     expect(link.textContent).toBe("Status");
@@ -52,8 +56,8 @@ describe("StatusBadge", () => {
     expect(link.querySelector("span")).toBeNull();
   });
 
-  it("keeps the plain link when the state is unrecognized", async () => {
-    respondWith({ state: null });
+  it("keeps the plain link for a state it has no presentation for", async () => {
+    respondWith({ state: "unknown_state" });
     render(<StatusBadge />);
     await settle();
 

--- a/apps/docs/components/shared/status-badge.test.tsx
+++ b/apps/docs/components/shared/status-badge.test.tsx
@@ -61,6 +61,8 @@ describe("StatusBadge", () => {
     render(<StatusBadge />);
     await settle();
 
-    expect(screen.getByRole("link").textContent).toBe("Status");
+    const link = screen.getByRole("link");
+    expect(link.textContent).toBe("Status");
+    expect(link.querySelector("span")).toBeNull();
   });
 });

--- a/apps/docs/components/shared/status-badge.tsx
+++ b/apps/docs/components/shared/status-badge.tsx
@@ -1,0 +1,27 @@
+import { LiveDot } from "@/components/shared/live-dot";
+import { STATUS_URL } from "@/lib/constants";
+import { getStatusState, type StatusState } from "@/lib/status";
+
+const PRESENTATION: Record<StatusState, { label: string; dot: string }> = {
+  operational: { label: "All systems operational", dot: "bg-emerald-500" },
+  degraded: { label: "Degraded performance", dot: "bg-amber-500" },
+  downtime: { label: "Service disruption", dot: "bg-red-500" },
+  maintenance: { label: "Under maintenance", dot: "bg-blue-500" },
+};
+
+export async function StatusBadge(): Promise<React.ReactElement> {
+  const state = await getStatusState();
+  const presentation = state ? PRESENTATION[state] : null;
+
+  return (
+    <a
+      href={STATUS_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-sm transition-colors"
+    >
+      {presentation ? <LiveDot className={presentation.dot} /> : null}
+      {presentation?.label ?? "Status"}
+    </a>
+  );
+}

--- a/apps/docs/components/shared/status-badge.tsx
+++ b/apps/docs/components/shared/status-badge.tsx
@@ -1,6 +1,9 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { LiveDot } from "@/components/shared/live-dot";
 import { STATUS_URL } from "@/lib/constants";
-import { getStatusState, type StatusState } from "@/lib/status";
+import type { StatusState } from "@/lib/status";
 
 const PRESENTATION: Record<StatusState, { label: string; dot: string }> = {
   operational: { label: "All systems operational", dot: "bg-emerald-500" },
@@ -9,8 +12,27 @@ const PRESENTATION: Record<StatusState, { label: string; dot: string }> = {
   maintenance: { label: "Under maintenance", dot: "bg-blue-500" },
 };
 
-export async function StatusBadge(): Promise<React.ReactElement> {
-  const state = await getStatusState();
+export function StatusBadge(): React.ReactElement {
+  const [state, setState] = useState<StatusState | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const res = await fetch("/api/status", { signal: controller.signal });
+        if (!res.ok) return;
+        const body = (await res.json()) as { state?: StatusState | null };
+        setState(body.state ?? null);
+      } catch {
+        setState(null);
+      }
+    };
+    void load();
+
+    return () => controller.abort();
+  }, []);
+
   const presentation = state ? PRESENTATION[state] : null;
 
   return (

--- a/apps/docs/components/shared/status-badge.tsx
+++ b/apps/docs/components/shared/status-badge.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { LiveDot } from "@/components/shared/live-dot";
 import { STATUS_URL } from "@/lib/constants";
-import type { StatusState } from "@/lib/status";
+import type { StatusState } from "@/lib/status-state";
 
 const PRESENTATION: Record<StatusState, { label: string; dot: string }> = {
   operational: { label: "All systems operational", dot: "bg-emerald-500" },

--- a/apps/docs/lib/constants.test.ts
+++ b/apps/docs/lib/constants.test.ts
@@ -1,4 +1,4 @@
-import { NAV_ITEMS } from "./constants";
+import { NAV_ITEMS, STATUS_URL } from "./constants";
 
 describe("NAV_ITEMS", () => {
   it("keeps Docs first and Pricing last as links", () => {
@@ -75,6 +75,20 @@ describe("NAV_ITEMS", () => {
       resources.groups
         .find((group) => group.label === "Company")
         ?.items.map((item) => item.label),
-    ).toEqual(["Blog", "Careers", "Brand", "Traction"]);
+    ).toEqual(["Blog", "Careers", "Brand", "Traction", "Status"]);
+  });
+
+  it("links Status out to the hosted status page", () => {
+    const resources = NAV_ITEMS.find(
+      (item) => item.type === "mega" && item.label === "Resources",
+    );
+    if (resources?.type !== "mega")
+      throw new Error("Resources is not a mega item");
+
+    const status = resources.groups
+      .flatMap((group) => group.items)
+      .find((item) => item.label === "Status");
+
+    expect(status).toMatchObject({ href: STATUS_URL, external: true });
   });
 });

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -2,6 +2,7 @@ import { isAiPlaygroundEnabled } from "./feature-flags";
 
 export const BASE_URL = "https://www.assistant-ui.com";
 export const CLOUD_URL = "https://cloud.assistant-ui.com";
+export const STATUS_URL = "https://status.assistant-ui.com";
 
 export const PLATFORMS = ["react", "rn", "ink"] as const;
 export type Platform = (typeof PLATFORMS)[number];
@@ -127,7 +128,8 @@ export type NavGlyphKind =
   | "traction"
   | "blog"
   | "careers"
-  | "brand";
+  | "brand"
+  | "status";
 
 export type DropdownItem = {
   label: string;
@@ -362,6 +364,13 @@ export const NAV_ITEMS: NavItem[] = [
             description: "Stars and downloads, live",
             external: false,
             glyph: "traction",
+          },
+          {
+            label: "Status",
+            href: STATUS_URL,
+            description: "Uptime and incident history",
+            external: true,
+            glyph: "status",
           },
         ],
       },

--- a/apps/docs/lib/status-state.test.ts
+++ b/apps/docs/lib/status-state.test.ts
@@ -1,4 +1,4 @@
-import { normalizeStatusState } from "./status";
+import { normalizeStatusState } from "./status-state";
 
 describe("normalizeStatusState", () => {
   it("maps the documented operational state", () => {

--- a/apps/docs/lib/status-state.ts
+++ b/apps/docs/lib/status-state.ts
@@ -1,0 +1,22 @@
+export type StatusState =
+  | "operational"
+  | "degraded"
+  | "downtime"
+  | "maintenance";
+
+/**
+ * The provider documents "operational" and leaves the abnormal states unspecified,
+ * so everything else is matched by substring: an unlisted spelling still reaches
+ * the right badge rather than reading as no incident at all.
+ */
+export function normalizeStatusState(value: unknown): StatusState | null {
+  if (typeof value !== "string") return null;
+
+  const state = value.toLowerCase();
+  if (state === "operational") return "operational";
+  if (state.includes("maintenance")) return "maintenance";
+  if (state.includes("degraded") || state.includes("partial"))
+    return "degraded";
+  if (state.includes("down") || state.includes("outage")) return "downtime";
+  return null;
+}

--- a/apps/docs/lib/status.test.ts
+++ b/apps/docs/lib/status.test.ts
@@ -1,0 +1,33 @@
+import { normalizeStatusState } from "./status";
+
+describe("normalizeStatusState", () => {
+  it("maps the documented operational state", () => {
+    expect(normalizeStatusState("operational")).toBe("operational");
+  });
+
+  it("maps the states the status page renders", () => {
+    expect(normalizeStatusState("degraded")).toBe("degraded");
+    expect(normalizeStatusState("downtime")).toBe("downtime");
+    expect(normalizeStatusState("maintenance")).toBe("maintenance");
+  });
+
+  it("maps longer provider spellings of the same states", () => {
+    expect(normalizeStatusState("under_maintenance")).toBe("maintenance");
+    expect(normalizeStatusState("degraded_performance")).toBe("degraded");
+    expect(normalizeStatusState("partial_outage")).toBe("degraded");
+    expect(normalizeStatusState("major_outage")).toBe("downtime");
+    expect(normalizeStatusState("MAJOR_OUTAGE")).toBe("downtime");
+  });
+
+  it("returns null for states that carry no incident signal", () => {
+    expect(normalizeStatusState("not_monitored")).toBeNull();
+    expect(normalizeStatusState("")).toBeNull();
+  });
+
+  it("returns null for a missing or non-string field", () => {
+    expect(normalizeStatusState(undefined)).toBeNull();
+    expect(normalizeStatusState(null)).toBeNull();
+    expect(normalizeStatusState(3)).toBeNull();
+    expect(normalizeStatusState({ aggregate_state: "operational" })).toBeNull();
+  });
+});

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -1,4 +1,3 @@
-import "server-only";
 import { STATUS_URL } from "./constants";
 import { withTimeout } from "./with-timeout";
 
@@ -10,33 +9,40 @@ export type StatusState =
   | "downtime"
   | "maintenance";
 
-const STATUS_STATES = new Set<string>([
-  "operational",
-  "degraded",
-  "downtime",
-  "maintenance",
-]);
-
 type StatusPagePayload = {
   data?: { attributes?: { aggregate_state?: unknown } };
 };
 
-/** Resolves to null whenever the status page is unreachable or reports a state we do not render. */
+/**
+ * The provider documents "operational" and leaves the abnormal states unspecified,
+ * so everything else is matched by substring: an unlisted spelling still reaches
+ * the right badge rather than reading as no incident at all.
+ */
+export function normalizeStatusState(value: unknown): StatusState | null {
+  if (typeof value !== "string") return null;
+
+  const state = value.toLowerCase();
+  if (state === "operational") return "operational";
+  if (state.includes("maintenance")) return "maintenance";
+  if (state.includes("degraded") || state.includes("partial"))
+    return "degraded";
+  if (state.includes("down") || state.includes("outage")) return "downtime";
+  return null;
+}
+
 export async function getStatusState(): Promise<StatusState | null> {
   try {
-    const res = await withTimeout(
-      fetch(`${STATUS_URL}/index.json`, {
-        headers: { Accept: "application/json" },
-        next: { revalidate: STATUS_REVALIDATE },
-      }),
+    const payload = await withTimeout(
+      (async () => {
+        const res = await fetch(`${STATUS_URL}/index.json`, {
+          headers: { Accept: "application/json" },
+          next: { revalidate: STATUS_REVALIDATE },
+        });
+        if (!res.ok) return null;
+        return (await res.json()) as StatusPagePayload;
+      })(),
     );
-    if (!res.ok) return null;
-
-    const state = ((await res.json()) as StatusPagePayload).data?.attributes
-      ?.aggregate_state;
-    return typeof state === "string" && STATUS_STATES.has(state)
-      ? (state as StatusState)
-      : null;
+    return normalizeStatusState(payload?.data?.attributes?.aggregate_state);
   } catch {
     return null;
   }

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -3,6 +3,9 @@ import { STATUS_URL } from "./constants";
 import { normalizeStatusState, type StatusState } from "./status-state";
 import { withTimeout } from "./with-timeout";
 
+/** Bounds the upstream fanout: the edge cache key includes the query string, so a request with one cannot be relied on to hit it. */
+const STATUS_REVALIDATE = 30;
+
 type StatusPagePayload = {
   data?: { attributes?: { aggregate_state?: unknown } };
 };
@@ -13,7 +16,7 @@ export async function getStatusState(): Promise<StatusState | null> {
       (async () => {
         const res = await fetch(`${STATUS_URL}/index.json`, {
           headers: { Accept: "application/json" },
-          cache: "no-store",
+          next: { revalidate: STATUS_REVALIDATE },
         });
         if (!res.ok) return null;
         return (await res.json()) as StatusPagePayload;

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -3,8 +3,6 @@ import { STATUS_URL } from "./constants";
 import { normalizeStatusState, type StatusState } from "./status-state";
 import { withTimeout } from "./with-timeout";
 
-export const STATUS_REVALIDATE = 300;
-
 type StatusPagePayload = {
   data?: { attributes?: { aggregate_state?: unknown } };
 };
@@ -15,7 +13,7 @@ export async function getStatusState(): Promise<StatusState | null> {
       (async () => {
         const res = await fetch(`${STATUS_URL}/index.json`, {
           headers: { Accept: "application/json" },
-          next: { revalidate: STATUS_REVALIDATE },
+          cache: "no-store",
         });
         if (!res.ok) return null;
         return (await res.json()) as StatusPagePayload;

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -3,7 +3,7 @@ import { STATUS_URL } from "./constants";
 import { normalizeStatusState, type StatusState } from "./status-state";
 import { withTimeout } from "./with-timeout";
 
-/** Bounds the upstream fanout: the edge cache key includes the query string, so a request with one cannot be relied on to hit it. */
+/** Bounds how often the status host is read, at the cost of a short lag in the badge. */
 const STATUS_REVALIDATE = 30;
 
 type StatusPagePayload = {

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -1,0 +1,43 @@
+import "server-only";
+import { STATUS_URL } from "./constants";
+import { withTimeout } from "./with-timeout";
+
+export const STATUS_REVALIDATE = 300;
+
+export type StatusState =
+  | "operational"
+  | "degraded"
+  | "downtime"
+  | "maintenance";
+
+const STATUS_STATES = new Set<string>([
+  "operational",
+  "degraded",
+  "downtime",
+  "maintenance",
+]);
+
+type StatusPagePayload = {
+  data?: { attributes?: { aggregate_state?: unknown } };
+};
+
+/** Resolves to null whenever the status page is unreachable or reports a state we do not render. */
+export async function getStatusState(): Promise<StatusState | null> {
+  try {
+    const res = await withTimeout(
+      fetch(`${STATUS_URL}/index.json`, {
+        headers: { Accept: "application/json" },
+        next: { revalidate: STATUS_REVALIDATE },
+      }),
+    );
+    if (!res.ok) return null;
+
+    const state = ((await res.json()) as StatusPagePayload).data?.attributes
+      ?.aggregate_state;
+    return typeof state === "string" && STATUS_STATES.has(state)
+      ? (state as StatusState)
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/docs/lib/status.ts
+++ b/apps/docs/lib/status.ts
@@ -1,34 +1,13 @@
+import "server-only";
 import { STATUS_URL } from "./constants";
+import { normalizeStatusState, type StatusState } from "./status-state";
 import { withTimeout } from "./with-timeout";
 
 export const STATUS_REVALIDATE = 300;
 
-export type StatusState =
-  | "operational"
-  | "degraded"
-  | "downtime"
-  | "maintenance";
-
 type StatusPagePayload = {
   data?: { attributes?: { aggregate_state?: unknown } };
 };
-
-/**
- * The provider documents "operational" and leaves the abnormal states unspecified,
- * so everything else is matched by substring: an unlisted spelling still reaches
- * the right badge rather than reading as no incident at all.
- */
-export function normalizeStatusState(value: unknown): StatusState | null {
-  if (typeof value !== "string") return null;
-
-  const state = value.toLowerCase();
-  if (state === "operational") return "operational";
-  if (state.includes("maintenance")) return "maintenance";
-  if (state.includes("degraded") || state.includes("partial"))
-    return "degraded";
-  if (state.includes("down") || state.includes("outage")) return "downtime";
-  return null;
-}
 
 export async function getStatusState(): Promise<StatusState | null> {
   try {


### PR DESCRIPTION
## Problem

we run a public status page at status.assistant-ui.com and nothing on the docs site points at it. a visitor hitting a failing request has no way to tell an incident from a bug in their own code, and the link is not reachable from any page.

## Change

two surfaces, one for discovery and one for the signal itself.

nav: a `Status` entry under Resources → Company in `NAV_ITEMS`, external, with its own glyph. because the docs header renders the same `NAV_ITEMS`, this reaches marketing pages, `/design`, and every docs page, plus the mobile menu.

footer: a live badge instead of a plain link. `app/api/status/route.ts` calls `getStatusState` and `StatusBadge` fetches it on mount, rendering a colored `LiveDot` with the matching label. keeping the fetch out of the page render matters twice over: `(home)` and `(design)` pages stay fully static, and the dot reflects the state at view time rather than whatever ISR captured on that page's last visit.

caching: the upstream fetch carries `next: { revalidate: 30 }` and the route responds `max-age=60, s-maxage=300`. the 30s Data Cache window bounds how often the status host is read (the edge cache alone cannot, since its key includes the query string, so a cache-busting request would reach the origin every time), and the route returns 503 with no cache headers when the state is unknown, matching `app/api/npm/downloads/route.ts`. worst case lag is roughly six minutes.

the module splits along the line that makes both halves work. `lib/status-state.ts` is the pure parser, so `lib/status-state.test.ts` imports it directly; `lib/status.ts` keeps `server-only` on the fetch, so it cannot be pulled into a client bundle later. `status-badge.tsx` imports its type from the pure module, so no client component reaches into the server one.

state matching is deliberately tolerant. the provider documents `operational` and leaves the abnormal states unspecified, so `normalizeStatusState` matches the rest by substring; an unlisted spelling (`under_maintenance`, `major_outage`) still reaches the right badge instead of falling through to a bare link that reads as no incident.

## Verification

- `pnpm -C apps/docs exec vitest run`: 57 files and 469 tests passed
- `lib/status-state.test.ts` covers every state branch, the longer provider spellings, `not_monitored`, and non-string payloads; `components/shared/status-badge.test.tsx` covers the four presentation mappings plus the in-flight, non-ok, and no-presentation fallbacks
- oxlint and oxfmt clean on the touched files
- `GET /api/status` returns `{"state":"operational"}` with `public, max-age=60, s-maxage=300`
- the served HTML for `/` contains zero occurrences of the resolved label, confirming the page render no longer embeds the status; the unresolved render is the plain `Status` link, which is also the 503 fallback
- exercised in a running dev server: badge resolves to the emerald dot after hydration, Resources dropdown shows `Status ↗` on both `/` and `/docs`, mobile menu lists it under COMPANY, checked in light and dark themes and at 390px

## Public surface

none. `apps/docs` is `private: true`, so no changeset. no published package, export, or type changes.