### PR TITLE
test(ui): mount the vue kit components in jsdom

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,6 +44,7 @@
     "zustand": "^5.0.15"
   },
   "devDependencies": {
+    "@assistant-ui/tap": "workspace:*",
     "@assistant-ui/vue": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@lucide/vue": "^1.34.0",
@@ -52,6 +53,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@vitejs/plugin-vue": "^6.0.8",
     "jsdom": "^30.0.1",
     "markdown-it": "^15.0.1",
     "reka-ui": "^2.10.4",

--- a/packages/ui/src/components/vue/assistant-ui/thread-list.test.ts
+++ b/packages/ui/src/components/vue/assistant-ui/thread-list.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick } from "vue";
+import { resource } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RemoteThreadList } from "@assistant-ui/core/store";
+import type {
+  RemoteThreadListAdapter,
+  RemoteThreadMetadata,
+} from "@assistant-ui/core";
+import { AuiProvider } from "@assistant-ui/vue";
+
+import ThreadList from "./thread-list.vue";
+
+const STUB_COMPOSER = { getState: () => ({}) };
+const STUB_SUGGESTIONS = { getState: () => ({ suggestions: [] }) };
+const STUB_THREAD_STATE = { isRunning: false, messages: [] };
+
+const useStubThread = () => ({
+  getState: () => STUB_THREAD_STATE,
+  composer: () => STUB_COMPOSER,
+  suggestions: () => STUB_SUGGESTIONS,
+});
+const StubThread = resource(useStubThread);
+
+type ThreadFixture = {
+  remoteId: string;
+  title?: string | undefined;
+  lastMessageAt?: Date | undefined;
+};
+
+const makeAdapter = (
+  threads: readonly ThreadFixture[],
+  overrides: Partial<RemoteThreadListAdapter> = {},
+): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({
+    threads: threads.map((thread): RemoteThreadMetadata => ({
+      status: "regular",
+      ...thread,
+    })),
+  })),
+  initialize: vi.fn(async (threadId: string) => ({
+    remoteId: `remote-${threadId}`,
+    externalId: undefined,
+  })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(async () => new ReadableStream() as never),
+  fetch: vi.fn(async (remoteId: string) => ({
+    status: "regular" as const,
+    remoteId,
+    externalId: undefined,
+  })),
+  ...overrides,
+});
+
+const mountThreadList = (adapter: RemoteThreadListAdapter) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              threads: RemoteThreadList({
+                adapter,
+                thread: () => StubThread({}) as never,
+              }),
+            }),
+          },
+          { default: () => h(ThreadList) },
+        ),
+    }),
+  );
+  const el = document.body.appendChild(document.createElement("div"));
+  app.mount(el);
+  return {
+    el,
+    unmount: () => {
+      app.unmount();
+      el.remove();
+    },
+  };
+};
+
+const slots = (root: ParentNode, name: string) => [
+  ...root.querySelectorAll<HTMLElement>(
+    `[data-slot="aui_thread-list-${name}"]`,
+  ),
+];
+
+const texts = (root: ParentNode, name: string) =>
+  slots(root, name).map((node) => node.textContent?.trim());
+
+const searchFor = async (root: ParentNode, value: string) => {
+  const input = root.querySelector<HTMLInputElement>('input[type="search"]')!;
+  input.value = value;
+  input.dispatchEvent(new Event("input"));
+  await nextTick();
+};
+
+const settle = (assert: () => void) =>
+  vi.waitFor(async () => {
+    await nextTick();
+    assert();
+  });
+
+const withTitles = (...titles: string[]) =>
+  titles.map((title, index) => ({ remoteId: `t${index}`, title }));
+
+const freezeClockAtMidday = () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-08-31T12:00:00Z"));
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.replaceChildren();
+});
+
+describe("vue thread list", () => {
+  it("renders one row per thread and no group labels when no thread has a date", async () => {
+    const { el, unmount } = mountThreadList(
+      makeAdapter(withTitles("First thread", "Second thread")),
+    );
+
+    await settle(() =>
+      expect(texts(el, "item-title")).toEqual([
+        "First thread",
+        "Second thread",
+      ]),
+    );
+    expect(slots(el, "group-label")).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("titles an untitled thread with the New Chat fallback", async () => {
+    const { el, unmount } = mountThreadList(
+      makeAdapter([{ remoteId: "t0" }, { remoteId: "t1", title: "Named" }]),
+    );
+
+    await settle(() =>
+      expect(texts(el, "item-title")).toEqual(["New Chat", "Named"]),
+    );
+
+    unmount();
+  });
+
+  it("hides the search box until the list has threads", async () => {
+    const { el, unmount } = mountThreadList(makeAdapter([]));
+
+    await settle(() => expect(slots(el, "new")).toHaveLength(1));
+    expect(slots(el, "search")).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("matches titles case-insensitively and ignores surrounding whitespace", async () => {
+    const { el, unmount } = mountThreadList(
+      makeAdapter(withTitles("Trip planning", "Budget review")),
+    );
+
+    await settle(() => expect(slots(el, "item-title")).toHaveLength(2));
+
+    await searchFor(el, "  TRIP  ");
+    expect(texts(el, "item-title")).toEqual(["Trip planning"]);
+
+    unmount();
+  });
+
+  it("matches the New Chat fallback rather than the missing title", async () => {
+    const { el, unmount } = mountThreadList(
+      makeAdapter([{ remoteId: "t0" }, { remoteId: "t1", title: "Named" }]),
+    );
+
+    await settle(() => expect(slots(el, "item-title")).toHaveLength(2));
+
+    await searchFor(el, "new ch");
+    expect(texts(el, "item-title")).toEqual(["New Chat"]);
+
+    unmount();
+  });
+
+  it("renders the empty state when the query matches nothing", async () => {
+    const { el, unmount } = mountThreadList(
+      makeAdapter(withTitles("Trip planning")),
+    );
+
+    await settle(() => expect(slots(el, "item-title")).toHaveLength(1));
+
+    await searchFor(el, "budget");
+    expect(texts(el, "empty")).toEqual(["No threads found"]);
+    expect(slots(el, "item")).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("shows skeleton rows while the list loads and drops them once it resolves", async () => {
+    let resolveList!: (response: { threads: RemoteThreadMetadata[] }) => void;
+    const { el, unmount } = mountThreadList(
+      makeAdapter([], {
+        list: () =>
+          new Promise((resolve) => {
+            resolveList = resolve;
+          }),
+      }),
+    );
+
+    await settle(() => expect(slots(el, "skeleton-wrapper")).toHaveLength(5));
+    expect(
+      slots(el, "skeleton-wrapper").every(
+        (row) =>
+          row.getAttribute("role") === "status" &&
+          row.getAttribute("aria-label") === "Loading threads",
+      ),
+    ).toBe(true);
+    expect(slots(el, "item")).toHaveLength(0);
+
+    resolveList({
+      threads: [{ status: "regular", remoteId: "t0", title: "Loaded thread" }],
+    });
+
+    await settle(() =>
+      expect(texts(el, "item-title")).toEqual(["Loaded thread"]),
+    );
+    expect(slots(el, "skeleton-wrapper")).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("groups threads by day, newest first, and coalesces a repeated label", async () => {
+    const startOfToday = freezeClockAtMidday();
+    const { el, unmount } = mountThreadList(
+      makeAdapter([
+        {
+          remoteId: "t0",
+          title: "Last week",
+          lastMessageAt: new Date(startOfToday - 6 * 86_400_000),
+        },
+        {
+          remoteId: "t1",
+          title: "Earlier today",
+          lastMessageAt: new Date(startOfToday + 1_000),
+        },
+        {
+          remoteId: "t2",
+          title: "Just now",
+          lastMessageAt: new Date(startOfToday + 60_000),
+        },
+        {
+          remoteId: "t3",
+          title: "Late yesterday",
+          lastMessageAt: new Date(startOfToday - 1_000),
+        },
+      ]),
+    );
+
+    await settle(() => expect(slots(el, "item-title")).toHaveLength(4));
+    expect(texts(el, "group-label")).toEqual(["Today", "Yesterday", "Earlier"]);
+    expect(texts(el, "item-title")).toEqual([
+      "Just now",
+      "Earlier today",
+      "Late yesterday",
+      "Last week",
+    ]);
+
+    unmount();
+  });
+
+  it("groups a dateless thread under Today once any thread carries a date", async () => {
+    const startOfToday = freezeClockAtMidday();
+    const { el, unmount } = mountThreadList(
+      makeAdapter([
+        { remoteId: "t0", title: "No date" },
+        {
+          remoteId: "t1",
+          title: "Last week",
+          lastMessageAt: new Date(startOfToday - 6 * 86_400_000),
+        },
+      ]),
+    );
+
+    await settle(() => expect(slots(el, "item-title")).toHaveLength(2));
+    expect(texts(el, "group-label")).toEqual(["Today", "Earlier"]);
+    expect(texts(el, "item-title")).toEqual(["No date", "Last week"]);
+
+    unmount();
+  });
+
+  it("opens the item menu and archives through the menu item", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"));
+    const { el, unmount } = mountThreadList(adapter);
+
+    await settle(() => expect(slots(el, "item-more")).toHaveLength(1));
+
+    slots(el, "item-more")[0]!.click();
+    await settle(() =>
+      expect(texts(document.body, "item-more-item")).toEqual([
+        "Archive",
+        "Delete",
+      ]),
+    );
+
+    slots(document.body, "item-more-item")[0]!.click();
+    await vi.waitFor(() => expect(adapter.archive).toHaveBeenCalledWith("t0"));
+
+    unmount();
+  });
+});

--- a/packages/ui/src/components/vue/assistant-ui/thread.test.ts
+++ b/packages/ui/src/components/vue/assistant-ui/thread.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick } from "vue";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type {
+  ExternalStoreAdapter,
+  ThreadMessageLike,
+} from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "@assistant-ui/vue";
+
+import Thread from "./thread.vue";
+
+const mountThread = (
+  messages: readonly ThreadMessageLike[],
+  options: { isRunning?: boolean } = {},
+) => {
+  const adapter: ExternalStoreAdapter<ThreadMessageLike> = {
+    messages: [...messages],
+    convertMessage: (message) => message,
+    onNew: async () => {},
+    ...(options.isRunning === undefined
+      ? {}
+      : { isRunning: options.isRunning }),
+  };
+  const core = new ExternalStoreRuntimeCore(adapter);
+  const runtime = new AssistantRuntimeImpl(core);
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(Thread) },
+        ),
+    }),
+  );
+  const el = document.body.appendChild(document.createElement("div"));
+  app.mount(el);
+  return {
+    el,
+    unmount: () => {
+      app.unmount();
+      el.remove();
+    },
+  };
+};
+
+const rows = (root: ParentNode) => [
+  ...root.querySelectorAll<HTMLElement>("li[data-role]"),
+];
+
+const settle = (assert: () => void) =>
+  vi.waitFor(async () => {
+    await nextTick();
+    assert();
+  });
+
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("vue thread", () => {
+  it("greets on an empty thread and composes a send-capable composer", async () => {
+    const { el, unmount } = mountThread([]);
+
+    await settle(() =>
+      expect(el.textContent).toContain("How can I help you today?"),
+    );
+    expect(el.querySelector("textarea")).not.toBeNull();
+    expect(el.querySelector('[aria-label="Send"]')).not.toBeNull();
+    expect(el.querySelector('[aria-label="Stop"]')).toBeNull();
+
+    unmount();
+  });
+
+  it("swaps send for stop while the thread runs", async () => {
+    const { el, unmount } = mountThread([], { isRunning: true });
+
+    await settle(() =>
+      expect(el.querySelector('[aria-label="Stop"]')).not.toBeNull(),
+    );
+    expect(el.querySelector('[aria-label="Send"]')).toBeNull();
+
+    unmount();
+  });
+
+  it("drops the greeting and renders a row per message role", async () => {
+    const { el, unmount } = mountThread([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ]);
+
+    await settle(() => expect(rows(el)).toHaveLength(2));
+    expect(rows(el).map((row) => row.dataset["role"])).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(el.textContent).not.toContain("How can I help you today?");
+
+    unmount();
+  });
+
+  it("renders assistant text as markdown and user text verbatim", async () => {
+    const { el, unmount } = mountThread([
+      { role: "user", content: [{ type: "text", text: "**not bold**" }] },
+      { role: "assistant", content: [{ type: "text", text: "**bold**" }] },
+    ]);
+
+    await settle(() => expect(rows(el)).toHaveLength(2));
+    const [user, assistant] = rows(el);
+    expect(assistant!.querySelector("strong")?.textContent).toBe("bold");
+    expect(user!.querySelector("strong")).toBeNull();
+    expect(user!.textContent).toContain("**not bold**");
+
+    unmount();
+  });
+
+  it("escapes raw HTML in assistant markdown instead of rendering it", async () => {
+    const { el, unmount } = mountThread([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "<img src=x onerror=alert(1)>" }],
+      },
+    ]);
+
+    await settle(() => expect(rows(el)).toHaveLength(1));
+    expect(el.querySelector("img")).toBeNull();
+    expect(el.textContent).toContain("<img src=x onerror=alert(1)>");
+
+    unmount();
+  });
+
+  it("surfaces the error of an assistant message that failed", async () => {
+    const { el, unmount } = mountThread([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "partial" }],
+        status: {
+          type: "incomplete",
+          reason: "error",
+          error: new Error("model unavailable"),
+        },
+      },
+    ]);
+
+    await settle(() => expect(el.textContent).toContain("model unavailable"));
+    expect(el.textContent).not.toContain("Error:");
+
+    unmount();
+  });
+
+  it("offers edit only on user rows and regenerate only on assistant rows", async () => {
+    const { el, unmount } = mountThread([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ]);
+
+    await settle(() => expect(rows(el)).toHaveLength(2));
+    const [user, assistant] = rows(el);
+    expect(user!.querySelector('[aria-label="Edit"]')).not.toBeNull();
+    expect(user!.querySelector('[aria-label="Regenerate"]')).toBeNull();
+    expect(
+      assistant!.querySelector('[aria-label="Regenerate"]'),
+    ).not.toBeNull();
+    expect(assistant!.querySelector('[aria-label="Edit"]')).toBeNull();
+    expect(user!.querySelector('[aria-label="Copy"]')).not.toBeNull();
+
+    unmount();
+  });
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,10 +1,12 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vitest/config";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: "jsdom",
     include: ["src/**/*.test.{ts,tsx}"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5252,6 +5252,9 @@ importers:
       '@assistant-ui/core':
         specifier: workspace:*
         version: link:../core
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../tap
       '@assistant-ui/vue':
         specifier: workspace:*
         version: link:../vue
@@ -5276,6 +5279,9 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.8
+        version: 6.0.8(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.42(typescript@7.0.2))
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1


### PR DESCRIPTION
closes #6569

## Problem

the vue kit SFCs under `packages/ui/src/components/vue/assistant-ui/` are compiled by the registry build and type-checked through with-nuxt, but nothing renders them. `packages/ui/vitest.config.ts` had no vue plugin, so a `.vue` import could not even be loaded by a test.

that left every behavior branch in `thread-list.vue` unverified: search normalization, the `"New Chat"` untitled fallback, the no-match state, skeleton gating, date grouping, and the reka menu composition. `thread.vue`, `message.vue` and `markdown-text.vue` were unmounted too.

## Root cause

not a defect, a missing harness. the registry check (`apps/registry/scripts/build-registry.test.mjs`) only parses and compile-checks the emitted SFCs, and with-nuxt's `nuxi typecheck` reaches `thread-list.vue` through the generated `components.d.ts` but never renders it (`ThreadListSidebar.vue` hand-rolls its own list from primitives).

## Change

`@vitejs/plugin-vue` in the packages/ui vitest config. the existing `include` already matched `.ts`, so no other config change was needed.

`thread-list.test.ts` drives a `RemoteThreadList` client with a stub adapter. that choice is forced: `lastMessageAt` never reaches the store through an external store runtime, because `ExternalStoreThreadData` carries no such field, so the `Today` / `Yesterday` / `Earlier` branch is unreachable from `ExternalStoreRuntimeCore` and only a remote thread list can exercise it. building the whole suite on one client keeps a single mount helper, and it is also the path a real consumer takes. that is what `@assistant-ui/tap` is for in devDependencies: `resource` builds the stub thread the client requires.

`thread.test.ts` mounts `thread.vue` (which nests `message.vue`, which nests `markdown-text.vue`) over an `ExternalStoreRuntimeCore`, so the composition is exercised with real messages and a real composer. it pins role branching, the markdown path applying to assistant text only, and markdown-it's `html: false` — `markdown-text.vue` is the one place in the kit that uses `v-html`, so raw HTML in model output must stay escaped.

the mount helper follows the pattern already used across `packages/vue`'s 19 suites (bare `createApp` plus `h` plus `AuiProvider`) instead of introducing `@vue/test-utils`, which the repo does not currently depend on.

## Verification

`pnpm turbo test --filter=@assistant-ui/ui` — 14 files, 394 passed, 15 skipped. `pnpm lint` clean.

the 17 new tests were checked for discriminating power by mutating the components and confirming each intended test fails:

- thread-list (11): dropping `.trim()`, dropping `.toLowerCase()`, replacing the `"New Chat"` fallback, reversing the sort comparator, disabling group coalescing, changing the skeleton count from 5 to 3, ungating the skeleton from `isLoading`, removing the no-match branch, showing the search box unconditionally, unwiring the archive primitive, removing the delete item.
- thread / message / markdown-text (7): `html: true`, assistant text bypassing markdown, user text routed through markdown, edit rendered on every row, error stringified instead of read from `.message`, send ungated from `isRunning`, greeting shown unconditionally.

all 18 were caught by the intended test.

the date-group suite pins the clock and derives `startOfToday` the same way the component does, so it does not depend on the runner timezone; verified under `TZ=Pacific/Auckland` and `TZ=Pacific/Midway`.

## Public surface

none. `@assistant-ui/ui` is private, so no changeset (naming it in one would abort `changeset version`); `pnpm changesets:check` passes. two devDependencies added to that private package, no runtime dependency, no export changed, no component changed.

follow-up: #6617 tracks the same missing coverage on the react `thread-list.aui.tsx`, which carries these branches and is likewise unmounted.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HZCmrOL7mH16ZJOtes-5EbpAAJVgU_Z2kM9K6sFTuGf3L1lfAOMBrDjpP6g?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->