### PR TITLE
test(ui): mount the react thread list element in jsdom

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/thread-list.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/thread-list.aui.test.tsx
@@ -1,0 +1,360 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resource } from "@assistant-ui/tap";
+import {
+  AuiConfig,
+  AuiProvider,
+  RemoteThreadList,
+  type RemoteThreadListAdapter,
+} from "@assistant-ui/react";
+import type { RemoteThreadMetadata } from "@assistant-ui/core";
+
+import { ThreadList } from "./thread-list.aui";
+
+const STUB_COMPOSER = { getState: () => ({}) };
+const STUB_SUGGESTIONS = { getState: () => ({ suggestions: [] }) };
+const STUB_THREAD_STATE = { isRunning: false, messages: [] };
+
+const useStubThread = () => ({
+  getState: () => STUB_THREAD_STATE,
+  composer: () => STUB_COMPOSER,
+  suggestions: () => STUB_SUGGESTIONS,
+});
+const StubThread = resource(useStubThread);
+
+type ThreadFixture = {
+  remoteId: string;
+  title?: string | undefined;
+  lastMessageAt?: Date | undefined;
+};
+
+const makeAdapter = (
+  threads: readonly ThreadFixture[],
+  overrides: Partial<RemoteThreadListAdapter> = {},
+): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({
+    threads: threads.map((thread): RemoteThreadMetadata => ({
+      status: "regular",
+      ...thread,
+    })),
+  })),
+  initialize: vi.fn(async (threadId: string) => ({
+    remoteId: `remote-${threadId}`,
+    externalId: undefined,
+  })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(async () => new ReadableStream() as never),
+  fetch: vi.fn(async (remoteId: string) => ({
+    status: "regular" as const,
+    remoteId,
+    externalId: undefined,
+  })),
+  ...overrides,
+});
+
+const renderThreadList = (adapter: RemoteThreadListAdapter) =>
+  render(
+    <AuiProvider
+      config={AuiConfig({
+        threads: RemoteThreadList({
+          adapter,
+          thread: () => StubThread({}) as never,
+        }),
+      })}
+    >
+      <ThreadList />
+    </AuiProvider>,
+  );
+
+const slots = (root: ParentNode, name: string) => [
+  ...root.querySelectorAll<HTMLElement>(
+    `[data-slot="aui_thread-list-${name}"]`,
+  ),
+];
+
+const texts = (root: ParentNode, name: string) =>
+  slots(root, name).map((node) => node.textContent?.trim());
+
+const searchFor = (root: ParentNode, value: string) => {
+  const input = root.querySelector<HTMLInputElement>('input[type="search"]')!;
+  fireEvent.change(input, { target: { value } });
+};
+
+const withTitles = (...titles: string[]) =>
+  titles.map((title, index) => ({ remoteId: `t${index}`, title }));
+
+const freezeClockAtMidday = () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-08-31T12:00:00Z"));
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe("ThreadList", () => {
+  it("renders one row per thread and no group labels when no thread has a date", async () => {
+    const { container } = renderThreadList(
+      makeAdapter(withTitles("First thread", "Second thread")),
+    );
+
+    await waitFor(() =>
+      expect(texts(container, "item-title")).toEqual([
+        "First thread",
+        "Second thread",
+      ]),
+    );
+    expect(slots(container, "group-label")).toHaveLength(0);
+  });
+
+  it("titles an untitled thread with the New Chat fallback", async () => {
+    const { container } = renderThreadList(
+      makeAdapter([{ remoteId: "t0" }, { remoteId: "t1", title: "Named" }]),
+    );
+
+    await waitFor(() =>
+      expect(texts(container, "item-title")).toEqual(["New Chat", "Named"]),
+    );
+  });
+
+  it("hides the search box until the list has threads", async () => {
+    const { container } = renderThreadList(makeAdapter([]));
+
+    await waitFor(() => expect(slots(container, "new")).toHaveLength(1));
+    expect(slots(container, "search")).toHaveLength(0);
+  });
+
+  it("matches titles case-insensitively and ignores surrounding whitespace", async () => {
+    const { container } = renderThreadList(
+      makeAdapter(withTitles("Trip planning", "Budget review")),
+    );
+
+    await waitFor(() => expect(slots(container, "item-title")).toHaveLength(2));
+
+    searchFor(container, "  TRIP  ");
+    expect(texts(container, "item-title")).toEqual(["Trip planning"]);
+  });
+
+  it("matches the New Chat fallback rather than the missing title", async () => {
+    const { container } = renderThreadList(
+      makeAdapter([{ remoteId: "t0" }, { remoteId: "t1", title: "Named" }]),
+    );
+
+    await waitFor(() => expect(slots(container, "item-title")).toHaveLength(2));
+
+    searchFor(container, "new ch");
+    expect(texts(container, "item-title")).toEqual(["New Chat"]);
+  });
+
+  it("renders the empty state when the query matches nothing", async () => {
+    const { container } = renderThreadList(
+      makeAdapter(withTitles("Trip planning")),
+    );
+
+    await waitFor(() => expect(slots(container, "item-title")).toHaveLength(1));
+
+    searchFor(container, "budget");
+    expect(texts(container, "empty")).toEqual(["No threads found"]);
+    expect(slots(container, "item")).toHaveLength(0);
+  });
+
+  it("shows skeleton rows while the list loads and drops them once it resolves", async () => {
+    let resolveList!: (response: { threads: RemoteThreadMetadata[] }) => void;
+    const { container } = renderThreadList(
+      makeAdapter([], {
+        list: () =>
+          new Promise((resolve) => {
+            resolveList = resolve;
+          }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(slots(container, "skeleton-wrapper")).toHaveLength(5),
+    );
+    expect(
+      slots(container, "skeleton-wrapper").every(
+        (row) =>
+          row.getAttribute("role") === "status" &&
+          row.getAttribute("aria-label") === "Loading threads",
+      ),
+    ).toBe(true);
+    expect(slots(container, "item")).toHaveLength(0);
+
+    resolveList({
+      threads: [{ status: "regular", remoteId: "t0", title: "Loaded thread" }],
+    });
+
+    await waitFor(() =>
+      expect(texts(container, "item-title")).toEqual(["Loaded thread"]),
+    );
+    expect(slots(container, "skeleton-wrapper")).toHaveLength(0);
+  });
+
+  it("groups threads by day, newest first, and coalesces a repeated label", async () => {
+    const startOfToday = freezeClockAtMidday();
+    const { container } = renderThreadList(
+      makeAdapter([
+        {
+          remoteId: "t0",
+          title: "Last week",
+          lastMessageAt: new Date(startOfToday - 6 * 86_400_000),
+        },
+        {
+          remoteId: "t1",
+          title: "Earlier today",
+          lastMessageAt: new Date(startOfToday + 1_000),
+        },
+        {
+          remoteId: "t2",
+          title: "Just now",
+          lastMessageAt: new Date(startOfToday + 60_000),
+        },
+        {
+          remoteId: "t3",
+          title: "Late yesterday",
+          lastMessageAt: new Date(startOfToday - 1_000),
+        },
+      ]),
+    );
+
+    await waitFor(() => expect(slots(container, "item-title")).toHaveLength(4));
+    expect(texts(container, "group-label")).toEqual([
+      "Today",
+      "Yesterday",
+      "Earlier",
+    ]);
+    expect(texts(container, "item-title")).toEqual([
+      "Just now",
+      "Earlier today",
+      "Late yesterday",
+      "Last week",
+    ]);
+  });
+
+  it("groups a dateless thread under Today once any thread carries a date", async () => {
+    const startOfToday = freezeClockAtMidday();
+    const { container } = renderThreadList(
+      makeAdapter([
+        { remoteId: "t0", title: "No date" },
+        {
+          remoteId: "t1",
+          title: "Last week",
+          lastMessageAt: new Date(startOfToday - 6 * 86_400_000),
+        },
+      ]),
+    );
+
+    await waitFor(() => expect(slots(container, "item-title")).toHaveLength(2));
+    expect(texts(container, "group-label")).toEqual(["Today", "Earlier"]);
+    expect(texts(container, "item-title")).toEqual(["No date", "Last week"]);
+  });
+
+  it("opens the item menu and archives through the menu item", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"));
+    const { container } = renderThreadList(adapter);
+
+    await waitFor(() => expect(slots(container, "item-more")).toHaveLength(1));
+
+    fireEvent.keyDown(slots(container, "item-more")[0]!, { key: "Enter" });
+    await waitFor(() =>
+      expect(texts(document.body, "item-more-item")).toEqual([
+        "Rename",
+        "Archive",
+        "Delete",
+      ]),
+    );
+
+    fireEvent.click(slots(document.body, "item-more-item")[1]!);
+    await waitFor(() => expect(adapter.archive).toHaveBeenCalledWith("t0"));
+  });
+});
+
+const openRename = async (container: HTMLElement) => {
+  await waitFor(() => expect(slots(container, "item-more")).toHaveLength(1));
+  fireEvent.keyDown(slots(container, "item-more")[0]!, { key: "Enter" });
+  await waitFor(() =>
+    expect(slots(document.body, "item-more-item")[0]).toBeDefined(),
+  );
+  fireEvent.click(slots(document.body, "item-more-item")[0]!);
+  await waitFor(() => expect(slots(container, "item-rename")).toHaveLength(1));
+  return slots(container, "item-rename")[0] as HTMLInputElement;
+};
+
+describe("ThreadList rename", () => {
+  it("seeds the rename input with the current title and commits the trimmed value", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"));
+    const { container } = renderThreadList(adapter);
+
+    const input = await openRename(container);
+    expect(input.value).toBe("Trip planning");
+
+    fireEvent.change(input, { target: { value: "  Trip notes  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(adapter.rename).toHaveBeenCalledWith("t0", "Trip notes"),
+    );
+    await waitFor(() =>
+      expect(slots(container, "item-rename")).toHaveLength(0),
+    );
+  });
+
+  it("leaves the title alone when the value is unchanged or blank", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"));
+    const { container } = renderThreadList(adapter);
+
+    const blank = await openRename(container);
+    fireEvent.change(blank, { target: { value: "   " } });
+    fireEvent.keyDown(blank, { key: "Enter" });
+    await waitFor(() =>
+      expect(slots(container, "item-rename")).toHaveLength(0),
+    );
+
+    const unchanged = await openRename(container);
+    fireEvent.keyDown(unchanged, { key: "Enter" });
+    await waitFor(() =>
+      expect(slots(container, "item-rename")).toHaveLength(0),
+    );
+
+    expect(adapter.rename).not.toHaveBeenCalled();
+  });
+
+  it("discards the edit on escape", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"));
+    const { container } = renderThreadList(adapter);
+
+    const input = await openRename(container);
+    fireEvent.change(input, { target: { value: "Discarded" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(slots(container, "item-rename")).toHaveLength(0),
+    );
+    expect(adapter.rename).not.toHaveBeenCalled();
+    expect(texts(container, "item-title")).toEqual(["Trip planning"]);
+  });
+
+  it("keeps the editor open when the rename is rejected", async () => {
+    const adapter = makeAdapter(withTitles("Trip planning"), {
+      rename: vi.fn(async () => {
+        throw new Error("rename failed");
+      }),
+    });
+    const { container } = renderThreadList(adapter);
+
+    const input = await openRename(container);
+    fireEvent.change(input, { target: { value: "Trip notes" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(adapter.rename).toHaveBeenCalled());
+    expect(slots(container, "item-rename")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
closes #6617

## Problem

`packages/ui/src/components/react/assistant-ui/elements/thread-list.aui.tsx` carries the branches its vue port does — search normalization gated on `hasThreads`, the `"New Chat"` untitled fallback inside the filter predicate, the `No threads found` no-match state, `AuiIf`-gated skeleton rows, and `Today` / `Yesterday` / `Earlier` grouping with newest-first sorting and label coalescing — and none of them were mounted.

the elements dir only carried `thread.aui.test.tsx`, `tool-fallback.aui.test.tsx` and `follow-up-suggestions.aui.test.tsx`; `elements.test.tsx` renders the props-only `thread-list.tsx`, not the runtime-bound one. after #6618 that left the react original less covered than its vue port, so a divergence between the two would surface only on the vue side.

`ThreadListItemRename` was uncovered too, and it holds the most delicate logic in the file: a `settledRef` guard, a deliberately deferred `Promise.resolve().then(...)` so a synchronous throw lands on the rejection path, and a revert that reopens the editor.

## Change

one suite mirroring `packages/ui/src/components/vue/assistant-ui/thread-list.test.ts`, so the two ports are asserted against the same expectations and a divergence fails on both sides.

it drives the same `RemoteThreadList` client the vue suite does. that choice is forced the same way: `ExternalStoreThreadData` carries no `lastMessageAt`, so the date-group branch is unreachable from an external store runtime and only a remote thread list can exercise it. `@assistant-ui/react` already re-exports `AuiProvider`, `AuiConfig` and `RemoteThreadList`, so the harness needs no new dependency.

the menu opens with `keyDown` `Enter` on the trigger rather than a click, matching how `ThreadListKeyboardNav.test.tsx` drives the same radix dropdown under jsdom.

rename coverage goes beyond the issue's list because the harness reaches it one click away and it is the riskiest untested code in the file: the trimmed commit, the unchanged and blank no-ops, the escape discard, and the editor staying open when the rename rejects.

## Verification

`pnpm turbo test --filter=@assistant-ui/ui` — 15 files, 408 passed, 15 skipped. `pnpm lint` clean.

the 14 tests were checked for discriminating power by mutating the component and confirming each intended test fails:

- list branches (9): dropping `.trim()`, dropping `.toLowerCase()`, replacing the `"New Chat"` fallback, reversing the sort comparator, disabling group coalescing, changing the skeleton count from 5 to 3, ungating the skeleton from `isLoading`, removing the no-match branch, rendering the search box unconditionally.
- rename (4): dropping the `.trim()` on commit, removing the unchanged/blank guard, closing the editor on rejection, committing instead of cancelling on escape.

all 13 were caught by the intended test.

the date-group tests pin the clock and derive `startOfToday` the way the component does, so they do not depend on the runner timezone; verified under `TZ=Pacific/Auckland` and `TZ=Pacific/Midway`.

## Public surface

none. test-only addition to the private `@assistant-ui/ui`, so no changeset; no component, export or dependency changed.

not covered: the `isRunning` spinner on an item, which needs per-thread run state (`unstable_isThreadRunning`) that the stub thread does not model.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.StKTqaaOlJE0w_lzcvtBPA_BRkYxLB1Fe7uPcyU2VExQqSO7SQDbkriHjM0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

