### PR TITLE
fix(docs): scope the docs prose styles to their own class

### DIFF
--- a/apps/docs/app/(catalog)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(catalog)/elements/(detail)/[slug]/page.tsx
@@ -222,7 +222,7 @@ export default async function ElementPage({
             )}
           </Figure>
 
-          <article className="prose mt-12 max-w-none">
+          <article className="docs-prose prose mt-12 max-w-none">
             <section id="installation">
               <h2>Installation</h2>
               <div className="mt-4">

--- a/apps/docs/app/(design)/design/components/[slug]/page.tsx
+++ b/apps/docs/app/(design)/design/components/[slug]/page.tsx
@@ -117,7 +117,10 @@ export default async function DesignComponentPage({
             ) : null}
           </header>
 
-          <article data-page-content="" className="prose mt-12 max-w-none">
+          <article
+            data-page-content=""
+            className="docs-prose prose mt-12 max-w-none"
+          >
             <MdxBody components={mdxComponents} />
           </article>
         </div>

--- a/apps/docs/app/(home)/blog/[slug]/page.tsx
+++ b/apps/docs/app/(home)/blog/[slug]/page.tsx
@@ -100,7 +100,7 @@ export default function Page(props: {
       <div className="border-foreground/10 mt-12 border-t pt-12 lg:grid lg:grid-cols-[minmax(0,1fr)_24rem] lg:gap-16">
         <article
           data-page-content=""
-          className="prose prose-blog w-full max-w-[42rem] min-w-0"
+          className="docs-prose prose prose-blog w-full max-w-[42rem] min-w-0"
         >
           <page.data.body components={mdxComponents} />
         </article>

--- a/apps/docs/app/(home)/careers/[slug]/page.tsx
+++ b/apps/docs/app/(home)/careers/[slug]/page.tsx
@@ -93,7 +93,7 @@ export default function CareerRolePage({
 
       <div className="border-foreground/10 mt-12 border-t pt-12 lg:grid lg:grid-cols-[minmax(0,1fr)_24rem] lg:gap-16">
         <div className="min-w-0">
-          <article className="prose prose-blog w-full max-w-[42rem] min-w-0">
+          <article className="docs-prose prose prose-blog w-full max-w-[42rem] min-w-0">
             <role.data.body components={mdxComponents} />
           </article>
           <section

--- a/apps/docs/app/(home)/examples/[slug]/page.tsx
+++ b/apps/docs/app/(home)/examples/[slug]/page.tsx
@@ -130,7 +130,7 @@ export default async function ExamplePage(props: {
 
       <article
         data-page-content=""
-        className="prose prose-blog mt-16 max-w-none"
+        className="docs-prose prose prose-blog mt-16 max-w-none"
       >
         <MdxBody components={mdxComponents} />
       </article>

--- a/apps/docs/components/pages/docs/layout/docs-page.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-page.tsx
@@ -19,5 +19,5 @@ export function DocsPageShell({
 }
 
 export function DocsBody({ className, ...props }: ComponentProps<"article">) {
-  return <article {...props} className={cn("prose", className)} />;
+  return <article {...props} className={cn("docs-prose prose", className)} />;
 }

--- a/apps/docs/components/pages/docs/layout/table-of-contents.tsx
+++ b/apps/docs/components/pages/docs/layout/table-of-contents.tsx
@@ -164,7 +164,7 @@ export function TableOfContents({
 
   return (
     <div className="docs-toc w-56 max-xl:hidden">
-      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh-3.5rem)] flex-col pe-4 pt-4 pb-2">
+      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh_-_var(--docs-header-height)_-_1rem)] flex-col pe-4 pt-4 pb-2">
         <p className="text-muted-foreground/70 mb-3 shrink-0 text-xs">
           On this page
         </p>

--- a/apps/docs/components/pages/docs/layout/table-of-contents.tsx
+++ b/apps/docs/components/pages/docs/layout/table-of-contents.tsx
@@ -164,7 +164,7 @@ export function TableOfContents({
 
   return (
     <div className="docs-toc w-56 max-xl:hidden">
-      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh_-_var(--docs-header-height)_-_1rem)] flex-col pe-4 pt-4 pb-2">
+      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh-3.5rem)] flex-col pe-4 pt-4 pb-2">
         <p className="text-muted-foreground/70 mb-3 shrink-0 text-xs">
           On this page
         </p>

--- a/apps/docs/components/pages/docs/primitives-type-table-client.tsx
+++ b/apps/docs/components/pages/docs/primitives-type-table-client.tsx
@@ -122,7 +122,7 @@ function Item({
         )}
       >
         <div className="grid grid-cols-[1fr_3fr] gap-y-4 overflow-auto border-t p-3 text-sm">
-          <div className="prose prose-no-margin col-span-full text-sm empty:hidden">
+          <div className="docs-prose prose prose-no-margin col-span-full text-sm empty:hidden">
             {row.description}
           </div>
           {row.typeFull && (

--- a/apps/docs/styles/docs.css
+++ b/apps/docs/styles/docs.css
@@ -26,7 +26,7 @@ html:has(.docs-layout) {
   }
 }
 
-.prose {
+.docs-prose {
   font-size: 0.875rem;
   line-height: 1.7;
 
@@ -237,7 +237,7 @@ html:has(.docs-layout) {
 
 /* A Callout (or any not-prose block) inside a tab owns its own link styling.
    The tab's [&_a] color/weight would otherwise bleed in, turning callout links
-   foreground-white and medium-weight. Let them inherit, like .prose does. */
+   foreground-white and medium-weight. Let them inherit, like .docs-prose does. */
 [role="tabpanel"] :where([class~="not-prose"], [class~="not-prose"] *) a {
   color: inherit;
   font-weight: inherit;


### PR DESCRIPTION
## Problem

`apps/docs/styles/docs.css` styled `.prose`, which is Tailwind typography's own class rather than one this app owns. Every element on the site using `prose` therefore inherited documentation typography, whether or not it was documentation.

The visible case is the chat demos. `components/pages/examples/claude.tsx:288` renders its assistant messages inside `prose prose-claude`, so on `/demos/claude`, a page with no documentation on it at all, message content was picking up docs rules.

## Root cause

The rules are descendant selectors under a single class (`& :where(p)`, `& :where(table)`, and so on). Scoping them to `.prose` meant "anything Tailwind considers prose, anywhere on the site", which is a superset of "documentation prose". Nothing in the file distinguished the two, so the only thing keeping demos out was the `not-prose` escape hatch, which a demo that legitimately wants Tailwind prose cannot use.

## Change

The rule block moves to `.docs-prose`, and the seven documentation surfaces that want it opt in explicitly:

- the docs page article and its type table
- the elements and design component detail pages
- the blog, careers, and examples article bodies

`prose` stays alongside `docs-prose` at each site, so Tailwind typography still applies; only the docs-specific overrides became opt-in. `.prose-blog`, `.prose-no-margin` and `not-prose` are separate classes and are untouched.

## Verification

Measured in the browser against the dev server rather than read off the diff.

**No regression.** Across `/docs/tools/tool-ui`, `/blog/2024-07-29-hello`, `/careers/design-engineer`, `/examples/claude`, `/design/components/callout` and `/elements/thread`: each renders exactly one `.docs-prose` container, and **zero** `prose` containers are left outside one, so nothing lost the rules by being missed. Computed styles on the docs article are unchanged: container `font-size` 14px, `p` `margin-top` 20px, `h2` 20px / `margin-top` 40px, inline `code` keeps its background and padding.

**Embedded demos were already safe.** On `/docs/tools/tool-ui`, all six demo containers inside the article carry `not-prose` and showed no leaked rules before or after.

**What actually changes.** This is what #6576 item 2 recorded as broken: the docs rules are unlayered and Tailwind's `prose-<element>:` variants live in `@layer utilities`, so unlayered won and the variants were inert. Scoping the rules off these containers lets them apply. Measured on `/demos/grok` with each file's exact classes, with and without a `.docs-prose` wrapper:

| site | declared | before | after |
| --- | --- | --- | --- |
| `grok.tsx:194` | `prose-p:my-0` | `p` margin 20px | **0px** |
| `perplexity.tsx:335` | `prose-p:my-2` | `p` margin 20px | **8px** |
| `perplexity.tsx:335` | `prose-li:my-1` | `li` margin 4px | 4px (already correct) |

Chat bubbles on those pages were rendering with documentation body spacing, which is the user-visible half of the issue's plan item b.

Secondary, on demos that do not declare variants (`claude.tsx:288`), the overlap with Tailwind's own `prose` is large and only two properties move: inline `code` padding `2.4px 6.4px` to `3px`, and `table` background/radius from the docs treatment (`oklch(0.97 0.004 106)`, 12px) to Tailwind's (`oklch(0.992 0.002 106)`, 8px).

`oxlint` and `oxfmt` clean on the touched files.

## Public surface

None. `apps/docs` is private, so no changeset. No exported API, no published package.

Part of #6576, which is left open: its plan item 3, the table of contents viewport budget, ships separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.phWL6vrtd_z0j_UtVMjOVrv7RMGQBYf9e-Yjw8iaNzdVZcxd4XBI5SJphTY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

