### PR TITLE
fix(docs): budget the toc height against its own top offset

### DIFF
--- a/apps/docs/components/pages/docs/layout/table-of-contents.tsx
+++ b/apps/docs/components/pages/docs/layout/table-of-contents.tsx
@@ -164,7 +164,7 @@ export function TableOfContents({
 
   return (
     <div className="docs-toc w-56 max-xl:hidden">
-      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh-3.5rem)] flex-col pe-4 pt-4 pb-2">
+      <div className="sticky top-[calc(var(--docs-header-height)_+_1rem)] flex max-h-[calc(100vh_-_var(--docs-header-height)_-_1rem)] flex-col pe-4 pt-4 pb-2">
         <p className="text-muted-foreground/70 mb-3 shrink-0 text-xs">
           On this page
         </p>


### PR DESCRIPTION
## Problem

The docs table of contents can extend past the bottom of the viewport, putting its last entries out of reach. It needs a long enough page and a short enough window to show, which is why it survived the css cleanup that produced it.

## Root cause

`table-of-contents.tsx:167` positions the sticky panel and budgets its height with two expressions that disagree:

```
top:        calc(var(--docs-header-height) + 1rem)   →  64px
max-height: calc(100vh - 3.5rem)                     →  100vh - 56px
```

So the panel starts 64px down but is allowed to be tall enough for a 56px offset, and its bottom lands at `100vh + 8px`. #6616 moved `top` onto the variable as part of the fumadocs-ui cleanup and left `max-h` on the literal it was written against, so the mismatch is a leftover from that change rather than an original bug.

## Change

One line: `max-h` uses the same expression as `top`, so the budget follows the header height variable instead of a literal that has to be kept in sync by hand.

## Verification

Measured on `/docs/tools/tool-ui` at 1440x500, scrolled to 800px, on `main` at `ed825d4fd`:

| | `max-height` | panel bottom | viewport | overflow |
| --- | --- | --- | --- | --- |
| before | 444px | 508px | 500px | **8px** |
| after | 436px | 500px | 500px | **0** |

The panel now ends exactly at the viewport edge. `--docs-header-height` reads 48px, so `top` is 64px in both cases and only the budget moves.

`oxlint` and `oxfmt` clean.

## Public surface

None. `apps/docs` is private, so no changeset.

Closes #6576


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4w0m8QzjylZxJqndaoq3vyv8ZwQYRsSz9gFkripU2XgX5H9yFv1Ayrb4-p4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->