### PR TITLE
fix: agent-generated canvas title is dropped when persisting the xulux canvas

### DIFF
--- a/apps/docs/components/xulux/runtime/canvas-snapshot.test.ts
+++ b/apps/docs/components/xulux/runtime/canvas-snapshot.test.ts
@@ -68,6 +68,34 @@ describe("toCanvasSnapshot", () => {
     expect(toCanvasSnapshot(canvas, undefined).status).toBe("empty");
   });
 
+  it("keeps the canvas title when the caller supplies none", () => {
+    const canvas: XuluxCanvasState = {
+      status: "ready",
+      url: "/templates/preview",
+      source: "agent_template",
+      error: null,
+      title: "Generated dashboard",
+    };
+
+    expect(toCanvasSnapshot(canvas, undefined).title).toBe(
+      "Generated dashboard",
+    );
+  });
+
+  it("prefers the supplied title over the canvas title", () => {
+    const canvas: XuluxCanvasState = {
+      status: "ready",
+      url: "/templates/preview",
+      source: "agent_template",
+      error: null,
+      title: "Generated dashboard",
+    };
+
+    expect(toCanvasSnapshot(canvas, "Support agent").title).toBe(
+      "Support agent",
+    );
+  });
+
   it("omits absent optional fields and takes the supplied title", () => {
     const canvas: XuluxCanvasState = {
       status: "ready",

--- a/apps/docs/components/xulux/runtime/canvas-snapshot.test.ts
+++ b/apps/docs/components/xulux/runtime/canvas-snapshot.test.ts
@@ -82,7 +82,7 @@ describe("toCanvasSnapshot", () => {
     );
   });
 
-  it("prefers the supplied title over the canvas title", () => {
+  it("prefers the canvas title over the supplied title", () => {
     const canvas: XuluxCanvasState = {
       status: "ready",
       url: "/templates/preview",
@@ -92,7 +92,7 @@ describe("toCanvasSnapshot", () => {
     };
 
     expect(toCanvasSnapshot(canvas, "Support agent").title).toBe(
-      "Support agent",
+      "Generated dashboard",
     );
   });
 

--- a/apps/docs/components/xulux/runtime/canvas-snapshot.ts
+++ b/apps/docs/components/xulux/runtime/canvas-snapshot.ts
@@ -24,10 +24,7 @@ export function toCanvasSnapshot(
   canvas: XuluxCanvasState,
   title: string | undefined,
 ): XuluxCanvasSnapshot {
-  // A selected template's title wins; the canvas's own title (set when an
-  // agent template populated the canvas) is the fallback so it survives
-  // persistence when no template is selected.
-  const resolvedTitle = title ?? canvas.title;
+  const resolvedTitle = canvas.title ?? title;
   return {
     status: canvas.status === "loading" ? "empty" : canvas.status,
     url: canvas.url,

--- a/apps/docs/components/xulux/runtime/canvas-snapshot.ts
+++ b/apps/docs/components/xulux/runtime/canvas-snapshot.ts
@@ -24,6 +24,10 @@ export function toCanvasSnapshot(
   canvas: XuluxCanvasState,
   title: string | undefined,
 ): XuluxCanvasSnapshot {
+  // A selected template's title wins; the canvas's own title (set when an
+  // agent template populated the canvas) is the fallback so it survives
+  // persistence when no template is selected.
+  const resolvedTitle = title ?? canvas.title;
   return {
     status: canvas.status === "loading" ? "empty" : canvas.status,
     url: canvas.url,
@@ -33,7 +37,7 @@ export function toCanvasSnapshot(
     ...(canvas.previewFrame ? { previewFrame: canvas.previewFrame } : {}),
     ...(canvas.templateId ? { templateId: canvas.templateId } : {}),
     ...(canvas.versionId ? { versionId: canvas.versionId } : {}),
-    ...(title ? { title } : {}),
+    ...(resolvedTitle ? { title: resolvedTitle } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem

On current `main`, an agent-generated canvas title can be replaced by a stale selected-template title after persistence and restore:

1. Select the `Support agent` template.
2. Let the agent open a preview titled `Generated dashboard`.
3. Persist and restore the thread.
4. The live header shows `Generated dashboard`, but the restored canvas shows `Support agent`.

Cloneable regression reproduction:

```bash
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git fetch origin pull/6624/head:pr-6624
git switch pr-6624
git checkout 109baab14 -- apps/docs/components/xulux/runtime/canvas-snapshot.ts
pnpm -C apps/docs exec vitest run components/xulux/runtime/canvas-snapshot.test.ts
```

The canvas-title precedence test fails with `Support agent` received instead of `Generated dashboard`. Restoring the PR version of `canvas-snapshot.ts` makes the same test pass.

Fixes #6512.

## Root cause

The render path treats `canvas.title` as authoritative, but `toCanvasSnapshot` previously preferred the caller-supplied selected-template title. Because template selection state remains populated after an agent preview replaces the canvas, persistence could serialize the stale template title instead of the title currently shown to the user.

## Change

Resolve the snapshot title as `canvas.title ?? title`, matching the existing render precedence. The live canvas title wins when both values exist; the supplied template title remains the fallback for canvases that do not carry their own title. Tests cover the no-template fallback, both-title precedence, ordinary template persistence, and restoration.

## Verification

- The `prefers the canvas title over the supplied title` regression test fails on the previous PR implementation and passes with this change.
- `cd apps/docs && vitest run components/xulux/runtime/canvas-snapshot.test.ts` — 8/8 tests pass.
- `oxlint apps/docs/components/xulux/runtime/canvas-snapshot.ts apps/docs/components/xulux/runtime/canvas-snapshot.test.ts` — passes.
- GitHub Code Quality, changed-package tests/builds, API-reference drift, template sync, semver, Claude, Rupic, CodeQL, and Vercel checks pass.

## Public surface

None. `apps/docs` is private; there are no package exports, API-reference pages, templates, or changesets affected.