### PR TITLE
fix(cloud): deduplicate concurrent message appends

### DIFF
--- a/.changeset/fuzzy-taxis-persist.md
+++ b/.changeset/fuzzy-taxis-persist.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: deduplicate concurrent message appends while parent persistence is pending

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -39,32 +39,36 @@ export class CloudMessagePersistence {
     content: ReadonlyJSONObject,
   ): Promise<void> {
     const cloud = this.getCloud();
-    // Resolve parent's remote ID if it exists (may be a promise if concurrent)
-    const resolvedParentId = parentId
-      ? ((await this.idMapping[parentId]) ?? parentId)
-      : null;
+    const existing = this.idMapping[messageId];
+    if (existing instanceof Promise) {
+      await existing;
+      return;
+    }
 
-    const task = cloud.threads.messages
-      .create(threadId, {
+    const task = (async () => {
+      const resolvedParentId = parentId
+        ? ((await this.idMapping[parentId]) ?? parentId)
+        : null;
+      const { message_id } = await cloud.threads.messages.create(threadId, {
         parent_id: resolvedParentId,
         format,
         content,
-      })
-      .then(({ message_id }) => {
-        this.idMapping[messageId] = message_id;
-        return message_id;
-      })
-      .catch((err) => {
-        // Only delete if we're still the active task (avoids clobbering a retry)
-        if (this.idMapping[messageId] === task) {
-          delete this.idMapping[messageId];
-        }
-        throw err;
       });
+      return message_id;
+    })();
 
-    // Store the promise immediately so concurrent appends can await it
     this.idMapping[messageId] = task;
-    return task.then(() => {});
+    try {
+      const remoteId = await task;
+      if (this.idMapping[messageId] === task) {
+        this.idMapping[messageId] = remoteId;
+      }
+    } catch (err) {
+      if (this.idMapping[messageId] === task) {
+        delete this.idMapping[messageId];
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -108,6 +108,57 @@ describe("CloudMessagePersistence", () => {
     });
   });
 
+  it("deduplicates concurrent child appends while the parent is pending", async () => {
+    let resolveParent!: (value: { message_id: string }) => void;
+    vi.mocked(cloud.threads.messages.create)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveParent = resolve;
+          }),
+      )
+      .mockResolvedValue({ message_id: "remote-child" });
+
+    const parent = persistence.append("thread-1", "parent", null, "aui/v0", {
+      text: "parent",
+    });
+    const firstChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+    const secondChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+
+    resolveParent({ message_id: "remote-parent" });
+    await Promise.all([parent, firstChild, secondChild]);
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-appends a message after its mapping has settled", async () => {
+    vi.mocked(cloud.threads.messages.create)
+      .mockResolvedValueOnce({ message_id: "remote-1" })
+      .mockResolvedValueOnce({ message_id: "remote-2" });
+
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "first",
+    });
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "second",
+    });
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+    expect(await persistence.getRemoteId("local-1")).toBe("remote-2");
+  });
+
   it("loaded messages are marked as persisted and not re-created", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: [

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -137,10 +137,52 @@ describe("CloudMessagePersistence", () => {
       { text: "child" },
     );
 
+    expect(persistence.isPersisted("child")).toBe(true);
     resolveParent({ message_id: "remote-parent" });
     await Promise.all([parent, firstChild, secondChild]);
 
     expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves remote IDs throughout a concurrent message chain", async () => {
+    let resolveParent!: (value: { message_id: string }) => void;
+    vi.mocked(cloud.threads.messages.create)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveParent = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ message_id: "remote-child" })
+      .mockResolvedValueOnce({ message_id: "remote-grandchild" });
+
+    const parent = persistence.append("thread-1", "parent", null, "aui/v0", {
+      text: "parent",
+    });
+    const child = persistence.append("thread-1", "child", "parent", "aui/v0", {
+      text: "child",
+    });
+    const grandchild = persistence.append(
+      "thread-1",
+      "grandchild",
+      "child",
+      "aui/v0",
+      { text: "grandchild" },
+    );
+
+    resolveParent({ message_id: "remote-parent" });
+    await Promise.all([parent, child, grandchild]);
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledWith("thread-1", {
+      parent_id: "remote-parent",
+      format: "aui/v0",
+      content: { text: "child" },
+    });
+    expect(cloud.threads.messages.create).toHaveBeenCalledWith("thread-1", {
+      parent_id: "remote-child",
+      format: "aui/v0",
+      content: { text: "grandchild" },
+    });
   });
 
   it("re-appends a message after its mapping has settled", async () => {


### PR DESCRIPTION
## Problem

Two persistence passes can append the same child message while its parent is still being created. This creates duplicate Cloud rows. A chain of three new messages can also send a local child ID as the grandchild's remote `parent_id`.

This was previously addressed in #5811, but that PR merged into `fix/cloud-message-id-scope`. Its parent PR #5606 closed without merging, so the change never reached `main`.

## Root cause

`append()` awaited the parent mapping before registering the child in `idMapping`. During that wait, `isPersisted(childId)` remained false and another persistence pass could start the same append. A grandchild also had no in-flight child mapping to await.

## Change

- register each append promise before resolving its parent
- join an existing in-flight append for the same local message ID
- commit or remove a mapping only while that task still owns the slot
- preserve the existing behavior that allows a new append after a mapping has settled
- cover the in-flight persistence gate, duplicate child race, and a three-message remote-ID chain

## Reproduction

The regression test is executable from a clean clone:

```bash
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
gh pr checkout 6626
git checkout origin/main -- packages/cloud/src/CloudMessagePersistence.ts
pnpm install
pnpm --filter assistant-cloud exec vitest run src/tests/CloudMessagePersistence.test.ts
```

Against `main`, the duplicate test records three creates instead of two, and the chain test receives the local `child` ID instead of `remote-child`. Restore the PR implementation and both pass:

```bash
git restore packages/cloud/src/CloudMessagePersistence.ts
pnpm --filter assistant-cloud exec vitest run src/tests/CloudMessagePersistence.test.ts
```

## Public surface

No API or type changes. This is a behavior-only patch to internal Cloud message persistence.

## Verification

- `pnpm --filter assistant-cloud test` (14 files, 108 tests)
- `pnpm --filter assistant-cloud build`
- `pnpm lint`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.3hUFmUSOl0YD_rLuJ_eI8Zts-BB4zGR1IUIr-owKoU-aM587KZ2qmDAmITc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->