### PR TITLE
fix: create cli for LangGraph and TanStack examples build

### DIFF
--- a/.changeset/cli-example-import-layout.md
+++ b/.changeset/cli-example-import-layout.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: reconcile legacy component imports with the elements layout the registry installs, so created examples build

--- a/packages/cli/src/lib/create-project.test.ts
+++ b/packages/cli/src/lib/create-project.test.ts
@@ -41,6 +41,26 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
+  it("rewrites a legacy import to a bare elements file without the .aui segment", () => {
+    write(
+      "app/MyThread.tsx",
+      'import { MarkdownText } from "@/components/assistant-ui/markdown-text";\n' +
+        'import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";\n',
+    );
+    write("components/assistant-ui/elements/markdown-text.tsx", "export {};");
+    write(
+      "components/assistant-ui/elements/tooltip-icon-button.tsx",
+      "export {};",
+    );
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/MyThread.tsx")).toBe(
+      'import { MarkdownText } from "@/components/assistant-ui/elements/markdown-text";\n' +
+        'import { TooltipIconButton } from "@/components/assistant-ui/elements/tooltip-icon-button";\n',
+    );
+  });
+
   it("supports the src/ project layout", () => {
     write(
       "src/routes/index.tsx",

--- a/packages/cli/src/lib/create-project.test.ts
+++ b/packages/cli/src/lib/create-project.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { reconcileAssistantUIImportLayout } from "./create-project";
+
+describe("reconcileAssistantUIImportLayout", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "aui-cli-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  const write = (file: string, content: string) => {
+    const fullPath = path.join(projectDir, file);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  };
+
+  const read = (file: string) =>
+    fs.readFileSync(path.join(projectDir, file), "utf8");
+
+  it("rewrites a legacy import when only the elements layout exists", () => {
+    write(
+      "app/page.tsx",
+      'import { Thread } from "@/components/assistant-ui/thread";\n' +
+        'import { ThreadList } from "@/components/assistant-ui/thread-list";\n',
+    );
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+    write("components/assistant-ui/elements/thread-list.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(
+      'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n' +
+        'import { ThreadList } from "@/components/assistant-ui/elements/thread-list.aui";\n',
+    );
+  });
+
+  it("supports the src/ project layout", () => {
+    write(
+      "src/routes/index.tsx",
+      'import { Thread } from "@/components/assistant-ui/thread";\n',
+    );
+    write("src/components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("src/routes/index.tsx")).toBe(
+      'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n',
+    );
+  });
+
+  it("leaves imports alone when the legacy file exists", () => {
+    const source =
+      'import { Thread } from "@/components/assistant-ui/thread";\n';
+    write("app/page.tsx", source);
+    write("components/assistant-ui/thread.tsx", "export {};");
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(source);
+  });
+
+  it("leaves imports alone when neither layout has the file", () => {
+    const source =
+      'import { Custom } from "@/components/assistant-ui/custom-part";\n';
+    write("app/page.tsx", source);
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(source);
+  });
+
+  it("leaves elements imports untouched", () => {
+    const source =
+      'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n';
+    write("app/page.tsx", source);
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(source);
+  });
+});

--- a/packages/cli/src/lib/create-project.test.ts
+++ b/packages/cli/src/lib/create-project.test.ts
@@ -61,6 +61,21 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
+  it("prefers the .aui variant when both variants share a basename", () => {
+    write(
+      "app/page.tsx",
+      'import { Reasoning } from "@/components/assistant-ui/reasoning";\n',
+    );
+    write("components/assistant-ui/elements/reasoning.tsx", "export {};");
+    write("components/assistant-ui/elements/reasoning.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(
+      'import { Reasoning } from "@/components/assistant-ui/elements/reasoning.aui";\n',
+    );
+  });
+
   it("supports the src/ project layout", () => {
     write(
       "src/routes/index.tsx",

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -456,7 +456,16 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
       if (!normalized.includes("/")) continue;
       const specifier = normalized.replace(/\.[cm]?[tj]sx?$/, "");
       const name = path.posix.basename(specifier).replace(/\.aui$/, "");
-      if (!installedByName.has(name)) installedByName.set(name, specifier);
+      // A flat legacy import maps to the registry's `<name>` item, which is
+      // the `.aui` file; a colliding bare file with the same basename belongs
+      // to the distinct `elements-<name>` item, so the `.aui` variant wins.
+      const existing = installedByName.get(name);
+      if (
+        existing === undefined ||
+        (!existing.endsWith(".aui") && specifier.endsWith(".aui"))
+      ) {
+        installedByName.set(name, specifier);
+      }
     }
   }
   if (installedByName.size === 0) return;

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -233,6 +233,7 @@ export async function transformProject(
       pm,
     );
     if (failure) return { registryInstallFailure: failure };
+    reconcileAssistantUIImportLayout(projectDir);
   }
   return {};
 }
@@ -421,6 +422,49 @@ function toAssistantUIItem(specifier: string): string | null {
   return inElements && !BARE_ELEMENT_ITEMS.has(name)
     ? `elements-${name}`
     : name;
+}
+
+/**
+ * Example snapshots are downloaded at a release tag while the shadcn registry
+ * is live, so a snapshot may import components at the legacy flat path
+ * (`@/components/assistant-ui/<name>`) after the registry has moved the file
+ * to `components/assistant-ui/elements/<name>.aui.tsx`. Resolve each legacy
+ * specifier against the files the registry actually installed and rewrite it
+ * only when the legacy path is absent and the elements layout has it.
+ */
+export function reconcileAssistantUIImportLayout(projectDir: string): void {
+  const componentRoots = ["components", "src/components"]
+    .map((dir) => path.join(projectDir, dir, "assistant-ui"))
+    .filter((dir) => fs.existsSync(dir));
+  if (componentRoots.length === 0) return;
+
+  const resolvesAtLegacyPath = (name: string) =>
+    componentRoots.some((root) =>
+      [".tsx", ".ts", "/index.tsx", "/index.ts"].some((suffix) =>
+        fs.existsSync(path.join(root, `${name}${suffix}`)),
+      ),
+    );
+  const resolvesInElements = (name: string) =>
+    componentRoots.some((root) =>
+      fs.existsSync(path.join(root, "elements", `${name}.aui.tsx`)),
+    );
+
+  for (const { fullPath, content } of readProjectFiles("**/*.{ts,tsx}", {
+    cwd: projectDir,
+    ignore: LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES,
+  })) {
+    const next = content.replace(
+      /(from\s+["'])@\/components\/assistant-ui\/([^"'/]+)(["'])/g,
+      (match, prefix, specifier, suffix) => {
+        const name = stripImportExtension(specifier);
+        if (resolvesAtLegacyPath(name) || !resolvesInElements(name)) {
+          return match;
+        }
+        return `${prefix}@/components/assistant-ui/elements/${name}.aui${suffix}`;
+      },
+    );
+    if (next !== content) fs.writeFileSync(fullPath, next);
+  }
 }
 
 function scanRequiredComponents(projectDir: string): RequiredComponents {

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -444,10 +444,22 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
         fs.existsSync(path.join(root, `${name}${suffix}`)),
       ),
     );
-  const resolvesInElements = (name: string) =>
-    componentRoots.some((root) =>
-      fs.existsSync(path.join(root, "elements", `${name}.aui.tsx`)),
-    );
+
+  // Index the installed tree by import name so the rewrite follows whatever
+  // layout the registry delivered — some items install as
+  // elements/<name>.aui.tsx, others as elements/<name>.tsx, and a future
+  // layout move should not require new knowledge here.
+  const installedByName = new Map<string, string>();
+  for (const root of componentRoots) {
+    for (const { file } of readProjectFiles("**/*.{ts,tsx}", { cwd: root })) {
+      const normalized = file.split(path.sep).join("/");
+      if (!normalized.includes("/")) continue;
+      const specifier = normalized.replace(/\.[cm]?[tj]sx?$/, "");
+      const name = path.posix.basename(specifier).replace(/\.aui$/, "");
+      if (!installedByName.has(name)) installedByName.set(name, specifier);
+    }
+  }
+  if (installedByName.size === 0) return;
 
   for (const { fullPath, content } of readProjectFiles("**/*.{ts,tsx}", {
     cwd: projectDir,
@@ -457,10 +469,11 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
       /(from\s+["'])@\/components\/assistant-ui\/([^"'/]+)(["'])/g,
       (match, prefix, specifier, suffix) => {
         const name = stripImportExtension(specifier);
-        if (resolvesAtLegacyPath(name) || !resolvesInElements(name)) {
+        const installed = installedByName.get(name);
+        if (resolvesAtLegacyPath(name) || installed === undefined) {
           return match;
         }
-        return `${prefix}@/components/assistant-ui/elements/${name}.aui${suffix}`;
+        return `${prefix}@/components/assistant-ui/${installed}${suffix}`;
       },
     );
     if (next !== content) fs.writeFileSync(fullPath, next);


### PR DESCRIPTION
Fixes #6503

## Summary

`create` downloads the example at the latest release tag while `shadcn add` installs from the live registry, so the two can skew. That is exactly what happened here: the latest release tag (2026-08-27) still has `with-langgraph` / `with-tanstack` importing `@/components/assistant-ui/thread`, the examples migrated to the elements layout on `main` a day later (#6499), and the live registry now writes `components/assistant-ui/elements/thread.aui.tsx` — so the created project imports files that were never created, `create` exits 0, and `npm run build` fails with `Module not found`.

After a successful registry install, `transformProject` now reconciles legacy flat-path imports against the files the registry actually delivered: the installed `components/assistant-ui/` tree is indexed by import name (covering both `elements/<name>.aui.tsx` and bare `elements/<name>.tsx` items — `markdown-text`, `tooltip-icon-button`, etc.), and a legacy specifier is rewritten to the indexed path only when the legacy file is absent. This also covers `with-chain-of-thought`, `with-livekit`, and `with-elevenlabs-conversational`, which import bare-element items at the current tag. Both root-level (`components/`) and `src/` layouts are handled.

## Why reconcile in the CLI rather than fix the skew at its source

The example ref and the registry are independently-moving sources; pinning the registry to the example's tag would mean versioning and serving the registry per release, a much larger change to the publishing pipeline. Reconciling against the installed tree keeps `create` correct under any skew in the flat→nested direction without hardcoded layout knowledge — a future layout move re-resolves automatically because the index is built from what the registry actually wrote. Known limitation: the rewrite only fires for flat legacy specifiers; an old tag that imports `elements/…` after a hypothetical move away from that layout would need the inverse mapping. That direction has no occurrence today.

## Validation

- Verified the skew end to end: the example at the latest release tag imports the legacy paths (confirmed via the tagged file contents), and a fresh `apps/registry` build emits `components/assistant-ui/elements/thread.aui.tsx` for the `thread` item and `elements/markdown-text.tsx` for the bare items.
- Colocated tests: rewrites to `.aui` element files, rewrites to bare element files (fails before the second commit), `src/` layout, and no-ops when the legacy file exists, when nothing matches, and when the import already targets elements.
- Full `assistant-ui` CLI suite: 311/311 passing; `tsc --noEmit` output unchanged from `main` (pre-existing codemod errors only).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Sgn5ljySehMar2J4C1ltfH5abr0uelI3CQQ6PJ6z05JogtdP2zhKpw2_zb0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->