### PR TITLE
fix(react-ink): keep vertical cursor movement on grapheme boundaries

### DIFF
--- a/.changeset/gentle-pianos-smile.md
+++ b/.changeset/gentle-pianos-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: keep vertical text input movement on grapheme boundaries

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -90,6 +90,38 @@ const getLineRange = (text: string, cursorOffset: number) => {
   return { start, end };
 };
 
+const getGraphemeColumn = (
+  text: string,
+  lineStart: number,
+  cursorOffset: number,
+) => {
+  let column = 0;
+  for (const _ of graphemeSegmenter.segment(
+    text.slice(lineStart, cursorOffset),
+  )) {
+    column++;
+  }
+  return column;
+};
+
+const getOffsetAtGraphemeColumn = (
+  text: string,
+  lineStart: number,
+  lineEnd: number,
+  column: number,
+) => {
+  let offset = lineStart;
+  let currentColumn = 0;
+  for (const { segment } of graphemeSegmenter.segment(
+    text.slice(lineStart, lineEnd),
+  )) {
+    if (currentColumn >= column) break;
+    offset += segment.length;
+    currentColumn++;
+  }
+  return offset;
+};
+
 const getPreviousWordOffset = (text: string, cursorOffset: number) => {
   let result = 0;
   for (const segment of wordSegmenter.segment(text)) {
@@ -115,7 +147,8 @@ const moveVertical = (
   direction: -1 | 1,
 ) => {
   const { start, end } = getLineRange(text, cursorOffset);
-  const currentColumn = preferredColumn ?? cursorOffset - start;
+  const currentColumn =
+    preferredColumn ?? getGraphemeColumn(text, start, cursorOffset);
   const adjacentBreakIndex = direction === -1 ? start - 1 : end;
 
   if (adjacentBreakIndex < 0 || adjacentBreakIndex >= text.length) {
@@ -125,10 +158,11 @@ const moveVertical = (
   const adjacentCursorBase =
     direction === -1 ? adjacentBreakIndex : adjacentBreakIndex + 1;
   const adjacentRange = getLineRange(text, adjacentCursorBase);
-  const nextCursorOffset = clamp(
-    adjacentRange.start + currentColumn,
+  const nextCursorOffset = getOffsetAtGraphemeColumn(
+    text,
     adjacentRange.start,
     adjacentRange.end,
+    currentColumn,
   );
 
   return {

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -113,9 +113,9 @@ const getOffsetAtGraphemeColumn = (
   let offset = lineStart;
   let currentColumn = 0;
   for (const { segment } of graphemeSegmenter.segment(
-    text.slice(lineStart, lineEnd),
+    text.slice(lineStart, lineEnd + 1),
   )) {
-    if (currentColumn >= column) break;
+    if (currentColumn >= column || offset + segment.length > lineEnd) break;
     offset += segment.length;
     currentColumn++;
   }

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -92,6 +92,31 @@ describe("textBufferReducer", () => {
     expect(inserted.text).toBe("a\n😀Xb");
   });
 
+  it("preserves a grapheme column across a shorter line", () => {
+    const start = reduce(createTextBufferState("😀😀😀\nab\n😀😀😀"), {
+      type: "set-cursor",
+      cursorOffset: 16,
+    });
+    const middle = reduce(start, { type: "move-up" });
+    const top = reduce(middle, { type: "move-up" });
+    const roundTrip = reduce(top, { type: "move-down" }, { type: "move-down" });
+
+    expect(middle.cursorOffset).toBe(9);
+    expect(top.cursorOffset).toBe(6);
+    expect(roundTrip.cursorOffset).toBe(16);
+  });
+
+  it("does not move inside a CRLF line break", () => {
+    const movedDown = reduce(
+      createTextBufferState("abc\nx\r\ny"),
+      { type: "set-cursor", cursorOffset: 3 },
+      { type: "move-down" },
+    );
+
+    expect(movedDown.cursorOffset).toBe(5);
+    expect(getGraphemeAt(movedDown.text, movedDown.cursorOffset)).toBe("\r\n");
+  });
+
   it("moves by words and deletes the previous word", () => {
     const movedLeft = reduce(createTextBufferState("alpha beta gamma"), {
       type: "move-word-left",

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -80,6 +80,18 @@ describe("textBufferReducer", () => {
     expect(movedDown.cursorOffset).toBe(11);
   });
 
+  it("keeps vertical movement on grapheme boundaries", () => {
+    const movedDown = reduce(
+      createTextBufferState("a\n😀b"),
+      { type: "set-cursor", cursorOffset: 1 },
+      { type: "move-down" },
+    );
+    const inserted = reduce(movedDown, { type: "insert", text: "X" });
+
+    expect(movedDown.cursorOffset).toBe(4);
+    expect(inserted.text).toBe("a\n😀Xb");
+  });
+
   it("moves by words and deletes the previous word", () => {
     const movedLeft = reduce(createTextBufferState("alpha beta gamma"), {
       type: "move-word-left",

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -86,24 +86,32 @@ describe("textBufferReducer", () => {
       { type: "set-cursor", cursorOffset: 1 },
       { type: "move-down" },
     );
-    const inserted = reduce(movedDown, { type: "insert", text: "X" });
+    const insertedBelow = reduce(movedDown, { type: "insert", text: "X" });
+    const movedUp = reduce(
+      createTextBufferState("😀x\nabcd"),
+      { type: "set-cursor", cursorOffset: 5 },
+      { type: "move-up" },
+    );
+    const insertedAbove = reduce(movedUp, { type: "insert", text: "X" });
 
     expect(movedDown.cursorOffset).toBe(4);
-    expect(inserted.text).toBe("a\n😀Xb");
+    expect(insertedBelow.text).toBe("a\n😀Xb");
+    expect(movedUp.cursorOffset).toBe(2);
+    expect(insertedAbove.text).toBe("😀Xx\nabcd");
   });
 
   it("preserves a grapheme column across a shorter line", () => {
-    const start = reduce(createTextBufferState("😀😀😀\nab\n😀😀😀"), {
+    const start = reduce(createTextBufferState("a😀b\nxy\ncdefg"), {
       type: "set-cursor",
-      cursorOffset: 16,
+      cursorOffset: 11,
     });
     const middle = reduce(start, { type: "move-up" });
     const top = reduce(middle, { type: "move-up" });
     const roundTrip = reduce(top, { type: "move-down" }, { type: "move-down" });
 
-    expect(middle.cursorOffset).toBe(9);
-    expect(top.cursorOffset).toBe(6);
-    expect(roundTrip.cursorOffset).toBe(16);
+    expect(middle.cursorOffset).toBe(7);
+    expect(top.cursorOffset).toBe(4);
+    expect(roundTrip.cursorOffset).toBe(11);
   });
 
   it("does not move inside a CRLF line break", () => {


### PR DESCRIPTION
## Problem

React Ink text input already treats grapheme clusters as a unit for horizontal movement and deletion, but vertical movement calculates columns with UTF-16 code-unit offsets.

For `a\n😀b`, moving down from after `a` lands between the emoji's surrogate halves. Typing at that cursor position corrupts the buffer. CRLF input has the same boundary problem when a target column reaches the line break.

## Root cause

`moveVertical()` calculated a column with `cursorOffset - lineStart` and applied it as `adjacentStart + column`. Those offsets count UTF-16 code units rather than grapheme clusters, so they can point inside a multi-unit character or CRLF cluster.

## Change

- calculate preferred vertical columns in grapheme clusters
- map those columns back to complete boundaries on adjacent lines
- stop before graphemes that cross the logical line end
- retain preferred columns across shorter intervening lines

## Reproduction

The regression tests are executable from a clean clone:

```bash
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
gh pr checkout 6628
git checkout origin/main -- packages/react-ink/src/primitives/textInput/useTextBuffer.ts
pnpm install
pnpm --filter @assistant-ui/react-ink exec vitest run src/tests/useTextBuffer.test.ts
```

Against `main`, the emoji test receives offset `3` instead of `4`, and the CRLF test lands inside the line-break cluster. Restore the PR implementation and they pass:

```bash
git restore packages/react-ink/src/primitives/textInput/useTextBuffer.ts
pnpm --filter @assistant-ui/react-ink exec vitest run src/tests/useTextBuffer.test.ts
```

## Public surface

No API or type changes. The patch only corrects internal text-buffer cursor behavior.

## Verification

- `pnpm --filter @assistant-ui/react-ink test` (26 files, 259 tests)
- `pnpm --filter @assistant-ui/react-ink build`
- `pnpm lint`
