### PR TITLE
fix: a subagent's frontend-executed tool call is unreachable once nested

### DIFF
--- a/.changeset/ag-ui-nested-frontend-tools.md
+++ b/.changeset/ag-ui-nested-frontend-tools.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: a subagent's frontend-executed tool call resolves and resumes the run

--- a/.changeset/ag-ui-nested-frontend-tools.md
+++ b/.changeset/ag-ui-nested-frontend-tools.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-fix: a subagent's frontend-executed tool call resolves and resumes the run
+fix: a subagent's frontend tool result is recorded, survives re-emits, and resumes the run

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -39,10 +39,11 @@ An AG-UI backend that runs subagents (the agents-as-tools pattern) emits `SUBAGE
 
 A subagent that names no reachable spawning call (`parentToolCallId` is optional, may name a call this run never saw, or two runs may name each other) has nowhere to nest, so its output renders in the parent thread instead of being dropped. This matches the downgrade the protocol's own pre-subagent compatibility middleware performs.
 
-A subagent's frontend-executed tool calls work the same way the root agent's do: a call nested on `ToolCallMessagePart.messages` is reachable by `getPendingToolCalls()`, resolves through `addToolResult`, and its result rides the resume as a `tool` record for the backend that is waiting on it.
+A subagent's frontend-executed tool calls work the same way the root agent's do: a call nested on `ToolCallMessagePart.messages` is reachable by `getPendingToolCalls()`, resolves through `addToolResult`, and its result rides the resume as a `tool` record on the spawning assistant record, the same flattened wire shape these calls had before subagent attribution.
 
-One limitation is worth knowing before you rely on this:
+Two limitations are worth knowing before you rely on this:
 
+- **Nested tool calls are never approval-gated.** A gate that names a subagent-scoped call collapses the whole approval batch (the projector only binds root-scope calls), so no nested part ever carries `approval`: a registered frontend tool for a nested call executes ungated and its result is exported to the backend.
 - **Nested human-in-the-loop is not wired up.** A `SUBAGENT_FINISHED` with a `suspended` outcome marks the nested message `requires-action`, and its `interruptIds` are preserved on the message metadata, but there is no resume path that answers them yet.
 
 ## See also

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -41,9 +41,10 @@ A subagent that names no reachable spawning call (`parentToolCallId` is optional
 
 A subagent's frontend-executed tool calls work the same way the root agent's do: a call nested on `ToolCallMessagePart.messages` is reachable by `getPendingToolCalls()`, resolves through `addToolResult`, and its result rides the resume as a `tool` record on the spawning assistant record, the same flattened wire shape these calls had before subagent attribution.
 
-Two limitations are worth knowing before you rely on this:
+Approval gates cover nested calls too: a gate that names a subagent-scoped call projects onto the nested part, the frontend tool stays unexecuted while the gate is open, decisions recorded through `respondToToolApproval` land on the nested part, and an undecided gate's result is never exported to the backend.
 
-- **Nested tool calls are never approval-gated.** A gate that names a subagent-scoped call collapses the whole approval batch (the projector only binds root-scope calls), so no nested part ever carries `approval`: a registered frontend tool for a nested call executes ungated and its result is exported to the backend.
+One limitation is worth knowing before you rely on this:
+
 - **Nested human-in-the-loop is not wired up.** A `SUBAGENT_FINISHED` with a `suspended` outcome marks the nested message `requires-action`, and its `interruptIds` are preserved on the message metadata, but there is no resume path that answers them yet.
 
 ## See also

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -39,9 +39,10 @@ An AG-UI backend that runs subagents (the agents-as-tools pattern) emits `SUBAGE
 
 A subagent that names no reachable spawning call (`parentToolCallId` is optional, may name a call this run never saw, or two runs may name each other) has nowhere to nest, so its output renders in the parent thread instead of being dropped. This matches the downgrade the protocol's own pre-subagent compatibility middleware performs.
 
-Two limitations are worth knowing before you rely on this:
+A subagent's frontend-executed tool calls work the same way the root agent's do: a call nested on `ToolCallMessagePart.messages` is reachable by `getPendingToolCalls()`, resolves through `addToolResult`, and its result rides the resume as a `tool` record for the backend that is waiting on it.
 
-- **A subagent cannot run frontend-executed tools.** A tool call inside a nested message is not reachable by `getPendingToolCalls()`, so it is never handed to a frontend tool and never resolved. The run reports `{ type: "incomplete", reason: "tool-calls" }` rather than claiming it finished, but the call does not execute. Before subagent attribution existed these calls landed in the parent thread and did run, so this is a behavior change for a backend that pairs subagents with frontend tools. Tracked in [#6612](https://github.com/assistant-ui/assistant-ui/issues/6612).
+One limitation is worth knowing before you rely on this:
+
 - **Nested human-in-the-loop is not wired up.** A `SUBAGENT_FINISHED` with a `suspended` outcome marks the nested message `requires-action`, and its `interruptIds` are preserved on the message metadata, but there is no resume path that answers them yet.
 
 ## See also

--- a/packages/react-ag-ui/README.md
+++ b/packages/react-ag-ui/README.md
@@ -43,7 +43,9 @@ A subagent's frontend-executed tool calls work the same way the root agent's do:
 
 Approval gates cover nested calls too: a gate that names a subagent-scoped call projects onto the nested part, the frontend tool stays unexecuted while the gate is open, decisions recorded through `respondToToolApproval` land on the nested part, and an undecided gate's result is never exported to the backend.
 
-One limitation is worth knowing before you rely on this:
+Two limitations are worth knowing before you rely on this:
+
+- **Nested structure does not survive a reload.** Thread restore reads the flattened wire shape, so a restored subagent tool call comes back as a root-level part rather than nested under its spawning call. Results and decisions are preserved; only the nesting is not.
 
 - **Nested human-in-the-loop is not wired up.** A `SUBAGENT_FINISHED` with a `suspended` outcome marks the nested message `requires-action`, and its `interruptIds` are preserved on the message metadata, but there is no resume path that answers them yet.
 

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -850,7 +850,14 @@ export class AgUiThreadRuntimeCore {
   }
 
   addToolResult(options: AddToolResultOptions): void {
-    const updated = this.session.updateMessage(options.messageId, (message) => {
+    // Core's ToolInvocationTracker resolves a nested call to the nested
+    // subagent message's id, which is not a session message; re-anchor on the
+    // top-level message that owns the tree so the update can land.
+    const sessionMessageId = this.session.tryGetMessage(options.messageId)
+      ? options.messageId
+      : this.findMessageIdForToolCall(options.toolCallId);
+    if (sessionMessageId === undefined) return;
+    const updated = this.session.updateMessage(sessionMessageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
@@ -870,7 +877,7 @@ export class AgUiThreadRuntimeCore {
 
     if (!updated) return;
     this.notifyUpdate();
-    this.maybeResumeAfterToolResults(options.messageId);
+    this.maybeResumeAfterToolResults(sessionMessageId);
   }
 
   sendA2uiAction(action: Record<string, unknown>): void {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -69,63 +69,12 @@ const optimisticPrefix = "__optimistic__";
 const generateOptimisticId = () => `${optimisticPrefix}${generateId()}`;
 const isOptimisticId = (id: string) => id.startsWith(optimisticPrefix);
 
+import { iterateToolCallParts, mapToolCallPartsDeep } from "./tool-call-tree";
+
 const isResolvedToolCall = (
   part: ThreadAssistantMessage["content"][number],
 ): boolean =>
   part.type === "tool-call" && "result" in part && part.result !== undefined;
-
-type AssistantContent = ThreadAssistantMessage["content"];
-type AssistantContentPart = AssistantContent[number];
-
-// A subagent run renders as a nested assistant message on its spawning call's
-// ToolCallMessagePart.messages, so the subagent's own tool calls live below
-// the top-level content. Every seam that resolves or inspects tool calls has
-// to walk that tree, or a subagent's frontend-executed call is unreachable.
-function* iterateToolCallParts(
-  content: AssistantContent,
-): Generator<ToolCallMessagePart> {
-  for (const part of content) {
-    if (part.type !== "tool-call") continue;
-    yield part;
-    for (const nested of part.messages ?? []) {
-      if (nested.role !== "assistant") continue;
-      yield* iterateToolCallParts((nested as ThreadAssistantMessage).content);
-    }
-  }
-}
-
-function mapToolCallPartsDeep(
-  content: AssistantContent,
-  fn: (part: ToolCallMessagePart) => ToolCallMessagePart,
-): { content: AssistantContent; changed: boolean } {
-  let changed = false;
-  const next = content.map((part): AssistantContentPart => {
-    if (part.type !== "tool-call") return part;
-    let mapped = fn(part);
-    if (mapped.messages !== undefined) {
-      let nestedChanged = false;
-      const nestedMessages = mapped.messages.map((nested) => {
-        if (nested.role !== "assistant") return nested;
-        const assistant = nested as ThreadAssistantMessage;
-        const result = mapToolCallPartsDeep(assistant.content, fn);
-        if (!result.changed) return nested;
-        nestedChanged = true;
-        return { ...assistant, content: result.content };
-      });
-      if (nestedChanged) {
-        mapped =
-          mapped === part
-            ? { ...part, messages: nestedMessages }
-            : { ...mapped, messages: nestedMessages };
-      }
-    }
-    if (mapped !== part) changed = true;
-    return mapped;
-  });
-  return changed
-    ? { content: next as AssistantContent, changed }
-    : { content, changed };
-}
 
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
 type ResumeStream = (
@@ -604,9 +553,9 @@ export class AgUiThreadRuntimeCore {
     const gated = projectAgUiToolApprovals(
       pending.interrupts,
       new Set(
-        (gatedMessage?.content ?? [])
-          .filter((part) => part.type === "tool-call")
-          .map((part) => part.toolCallId),
+        Array.from(iterateToolCallParts(gatedMessage?.content ?? [])).map(
+          (part) => part.toolCallId,
+        ),
       ),
     );
     const isGated = [...gated.values()].some(

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1649,9 +1649,8 @@ export class AgUiThreadRuntimeCore {
       const assistant = message as ThreadAssistantMessage;
       const mcpAppUri = readMcpAppResourceUri(event.mcpResult?._meta);
       let matchedToolCall = false;
-      const content = assistant.content.map((part) => {
-        if (part.type !== "tool-call" || part.toolCallId !== event.toolCallId)
-          return part;
+      const { content } = mapToolCallPartsDeep(assistant.content, (part) => {
+        if (part.toolCallId !== event.toolCallId) return part;
         matchedToolCall = true;
         // An applied activity snapshot owns part.result; a later result only
         // fills what is missing, mirroring the aggregator's finishToolCall.
@@ -1735,9 +1734,8 @@ export class AgUiThreadRuntimeCore {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
-      const content = assistant.content.map((part) => {
-        if (part.type !== "tool-call" || part.toolCallId !== toolCallId)
-          return part;
+      const { content } = mapToolCallPartsDeep(assistant.content, (part) => {
+        if (part.toolCallId !== toolCallId) return part;
         matchedToolCall = true;
         return {
           ...part,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -49,6 +49,7 @@ import {
   toAgUiTools,
 } from "./adapter/conversions";
 import { createAgUiSubscriber } from "./adapter/subscriber";
+import { iterateToolCallParts, mapToolCallPartsDeep } from "./tool-call-tree";
 import {
   buildToolApprovalResume,
   projectAgUiToolApprovals,
@@ -68,8 +69,6 @@ type RunAgentWithRunOptions = (
 const optimisticPrefix = "__optimistic__";
 const generateOptimisticId = () => `${optimisticPrefix}${generateId()}`;
 const isOptimisticId = (id: string) => id.startsWith(optimisticPrefix);
-
-import { iterateToolCallParts, mapToolCallPartsDeep } from "./tool-call-tree";
 
 const isResolvedToolCall = (
   part: ThreadAssistantMessage["content"][number],

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -74,6 +74,59 @@ const isResolvedToolCall = (
 ): boolean =>
   part.type === "tool-call" && "result" in part && part.result !== undefined;
 
+type AssistantContent = ThreadAssistantMessage["content"];
+type AssistantContentPart = AssistantContent[number];
+
+// A subagent run renders as a nested assistant message on its spawning call's
+// ToolCallMessagePart.messages, so the subagent's own tool calls live below
+// the top-level content. Every seam that resolves or inspects tool calls has
+// to walk that tree, or a subagent's frontend-executed call is unreachable.
+function* iterateToolCallParts(
+  content: AssistantContent,
+): Generator<ToolCallMessagePart> {
+  for (const part of content) {
+    if (part.type !== "tool-call") continue;
+    yield part;
+    for (const nested of part.messages ?? []) {
+      if (nested.role !== "assistant") continue;
+      yield* iterateToolCallParts((nested as ThreadAssistantMessage).content);
+    }
+  }
+}
+
+function mapToolCallPartsDeep(
+  content: AssistantContent,
+  fn: (part: ToolCallMessagePart) => ToolCallMessagePart,
+): { content: AssistantContent; changed: boolean } {
+  let changed = false;
+  const next = content.map((part): AssistantContentPart => {
+    if (part.type !== "tool-call") return part;
+    let mapped = fn(part);
+    if (mapped.messages !== undefined) {
+      let nestedChanged = false;
+      const nestedMessages = mapped.messages.map((nested) => {
+        if (nested.role !== "assistant") return nested;
+        const assistant = nested as ThreadAssistantMessage;
+        const result = mapToolCallPartsDeep(assistant.content, fn);
+        if (!result.changed) return nested;
+        nestedChanged = true;
+        return { ...assistant, content: result.content };
+      });
+      if (nestedChanged) {
+        mapped =
+          mapped === part
+            ? { ...part, messages: nestedMessages }
+            : { ...mapped, messages: nestedMessages };
+      }
+    }
+    if (mapped !== part) changed = true;
+    return mapped;
+  });
+  return changed
+    ? { content: next as AssistantContent, changed }
+    : { content, changed };
+}
+
 type RunConfig = NonNullable<AppendMessage["runConfig"]>;
 type ResumeStream = (
   options: ChatModelRunOptions,
@@ -434,8 +487,7 @@ export class AgUiThreadRuntimeCore {
     const assistant = this.findRequiresActionAssistant("tool-calls");
     if (!assistant) return null;
     const toolCallIds: string[] = [];
-    for (const part of assistant.content) {
-      if (part.type !== "tool-call") continue;
+    for (const part of iterateToolCallParts(assistant.content)) {
       if (isResolvedToolCall(part)) continue;
       toolCallIds.push(part.toolCallId);
     }
@@ -769,9 +821,8 @@ export class AgUiThreadRuntimeCore {
     for (let index = messages.length - 1; index >= 0; index--) {
       const message = messages[index];
       if (!message || message.role !== "assistant") continue;
-      for (const part of message.content) {
-        if (part.type !== "tool-call" || part.toolCallId !== toolCallId)
-          continue;
+      for (const part of iterateToolCallParts(message.content)) {
+        if (part.toolCallId !== toolCallId) continue;
         if (!isResolvedToolCall(part)) {
           return message.id;
         }
@@ -785,8 +836,8 @@ export class AgUiThreadRuntimeCore {
     const updated = this.session.updateMessage(messageId, (message) => {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
-      const content = assistant.content.map((part) => {
-        if (part.type !== "tool-call" || isResolvedToolCall(part)) return part;
+      const { content } = mapToolCallPartsDeep(assistant.content, (part) => {
+        if (isResolvedToolCall(part)) return part;
         return {
           ...part,
           result: { error: "Tool call cancelled by user" },
@@ -803,9 +854,8 @@ export class AgUiThreadRuntimeCore {
       if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
-      const content = assistant.content.map((part) => {
-        if (part.type !== "tool-call" || part.toolCallId !== options.toolCallId)
-          return part;
+      const { content } = mapToolCallPartsDeep(assistant.content, (part) => {
+        if (part.toolCallId !== options.toolCallId) return part;
         matchedToolCall = true;
         return {
           ...part,
@@ -873,9 +923,13 @@ export class AgUiThreadRuntimeCore {
     ) {
       return false;
     }
-    const allResolved = assistant.content.every(
-      (part) => part.type !== "tool-call" || isResolvedToolCall(part),
-    );
+    let allResolved = true;
+    for (const part of iterateToolCallParts(assistant.content)) {
+      if (!isResolvedToolCall(part)) {
+        allResolved = false;
+        break;
+      }
+    }
     if (!allResolved) return false;
 
     const updated = this.session.updateMessage(messageId, (current) =>
@@ -1472,19 +1526,17 @@ export class AgUiThreadRuntimeCore {
     next: ThreadAssistantMessage["content"],
   ): ThreadAssistantMessage["content"] {
     const resolved = new Map<string, ToolCallMessagePart>();
-    for (const part of previous) {
-      if (part.type === "tool-call" && isResolvedToolCall(part)) {
+    for (const part of iterateToolCallParts(previous)) {
+      if (isResolvedToolCall(part)) {
         resolved.set(part.toolCallId, part);
       }
     }
     if (resolved.size === 0) return next;
 
-    let changed = false;
-    const merged = next.map((part) => {
-      if (part.type !== "tool-call" || isResolvedToolCall(part)) return part;
+    const { content: merged, changed } = mapToolCallPartsDeep(next, (part) => {
+      if (isResolvedToolCall(part)) return part;
       const prior = resolved.get(part.toolCallId);
       if (!prior) return part;
-      changed = true;
       return {
         ...part,
         result: prior.result,
@@ -1492,7 +1544,7 @@ export class AgUiThreadRuntimeCore {
         ...(prior.isError !== undefined ? { isError: prior.isError } : {}),
       };
     });
-    return changed ? (merged as ThreadAssistantMessage["content"]) : next;
+    return changed ? merged : next;
   }
 
   private mergeAssistantMetadata(

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -108,7 +108,15 @@ type ToolCallPart = {
   unstable_toolMessageId?: string;
   mcp?: ToolCallMessagePartMcpMetadata;
   messages?: readonly ThreadMessage[];
+  approval?: CoreToolCallPartApproval;
 };
+
+type CoreToolCallPartApproval = NonNullable<
+  Extract<
+    Exclude<CoreThreadMessageLike["content"], string>[number],
+    { type: "tool-call" }
+  >["approval"]
+>;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -1087,6 +1095,13 @@ function convertAssistantMessage(
     emitToolResult(toolCallId, part, converted);
   }
   for (const { id: toolCallId, part } of nestedToolCalls) {
+    // A result recorded while the call's approval gate is still open must not
+    // reach the backend as if the gate had been decided.
+    const gateOpen =
+      part.approval != null &&
+      part.approval.approved === undefined &&
+      part.approval.resolution === undefined;
+    if (gateOpen) continue;
     emitToolResult(toolCallId, part, converted);
   }
 }
@@ -1102,7 +1117,7 @@ function collectNestedToolCalls(
       if (!isObject(nestedPart) || nestedPart.type !== "tool-call") continue;
       const nestedToolCall = nestedPart as ToolCallPart;
       if (
-        typeof nestedToolCall.toolCallId === "string" &&
+        typeof nestedToolCall.toolCallId !== "string" ||
         nestedToolCall.toolCallId.startsWith("a2ui:")
       ) {
         continue;

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -108,7 +108,15 @@ type ToolCallPart = {
   unstable_toolMessageId?: string;
   mcp?: ToolCallMessagePartMcpMetadata;
   messages?: readonly ThreadMessage[];
+  approval?: CoreToolCallPartApproval;
 };
+
+type CoreToolCallPartApproval = NonNullable<
+  Extract<
+    Exclude<CoreThreadMessageLike["content"], string>[number],
+    { type: "tool-call" }
+  >["approval"]
+>;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -1053,29 +1061,54 @@ function convertAssistantMessage(
     return;
   }
 
+  // A subagent's tool calls live on nested assistant messages. Before
+  // subagent attribution they flattened to root and went out with this
+  // assistant record as their antecedent, so the resume payload restores
+  // exactly that shape: the calls join this record's toolCalls and their
+  // results follow as tool records — never a tool record without its call.
+  // The nested assistant content itself is backend-owned state and is not
+  // re-sent.
+  const nestedToolCalls: {
+    id: string;
+    call: AgUiToolCall;
+    part: ToolCallPart;
+  }[] = [];
+  for (const { part } of toolCalls) {
+    collectNestedToolCalls(part, nestedToolCalls);
+  }
+
   converted.push({
     id: message.id,
     role: "assistant",
     content,
     ...(message.name ? { name: message.name } : {}),
-    ...(toolCalls.length > 0
-      ? { toolCalls: toolCalls.map((entry) => entry.call) }
+    ...(toolCalls.length + nestedToolCalls.length > 0
+      ? {
+          toolCalls: [...toolCalls, ...nestedToolCalls].map(
+            (entry) => entry.call,
+          ),
+        }
       : {}),
   });
 
   for (const { id: toolCallId, part } of toolCalls) {
     emitToolResult(toolCallId, part, converted);
-    // A subagent's frontend-executed call lives on the nested assistant
-    // message, and its backend waits for that call's tool record like any
-    // other; the nested assistant content itself is backend-owned state and
-    // is not re-sent.
-    emitNestedToolResults(part, converted);
+  }
+  for (const { id: toolCallId, part } of nestedToolCalls) {
+    // A result injected while an approval gate is still open must not reach
+    // the backend as if the gate had been decided.
+    const gateOpen =
+      part.approval != null &&
+      part.approval.approved === undefined &&
+      part.approval.resolution === undefined;
+    if (gateOpen) continue;
+    emitToolResult(toolCallId, part, converted);
   }
 }
 
-function emitNestedToolResults(
+function collectNestedToolCalls(
   part: ToolCallPart,
-  converted: AgUiMessage[],
+  out: { id: string; call: AgUiToolCall; part: ToolCallPart }[],
 ): void {
   for (const nested of part.messages ?? []) {
     if (!isObject(nested) || nested.role !== "assistant") continue;
@@ -1083,12 +1116,14 @@ function emitNestedToolResults(
     for (const nestedPart of nestedContent) {
       if (!isObject(nestedPart) || nestedPart.type !== "tool-call") continue;
       const nestedToolCall = nestedPart as ToolCallPart;
-      emitToolResult(
-        normalizeToolCall(nestedToolCall).id,
-        nestedToolCall,
-        converted,
-      );
-      emitNestedToolResults(nestedToolCall, converted);
+      if (
+        typeof nestedToolCall.toolCallId === "string" &&
+        nestedToolCall.toolCallId.startsWith("a2ui:")
+      ) {
+        continue;
+      }
+      out.push({ ...normalizeToolCall(nestedToolCall), part: nestedToolCall });
+      collectNestedToolCalls(nestedToolCall, out);
     }
   }
 }

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -108,15 +108,7 @@ type ToolCallPart = {
   unstable_toolMessageId?: string;
   mcp?: ToolCallMessagePartMcpMetadata;
   messages?: readonly ThreadMessage[];
-  approval?: CoreToolCallPartApproval;
 };
-
-type CoreToolCallPartApproval = NonNullable<
-  Extract<
-    Exclude<CoreThreadMessageLike["content"], string>[number],
-    { type: "tool-call" }
-  >["approval"]
->;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -1095,13 +1087,6 @@ function convertAssistantMessage(
     emitToolResult(toolCallId, part, converted);
   }
   for (const { id: toolCallId, part } of nestedToolCalls) {
-    // A result injected while an approval gate is still open must not reach
-    // the backend as if the gate had been decided.
-    const gateOpen =
-      part.approval != null &&
-      part.approval.approved === undefined &&
-      part.approval.resolution === undefined;
-    if (gateOpen) continue;
     emitToolResult(toolCallId, part, converted);
   }
 }

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -5,6 +5,7 @@ import { generateId } from "@assistant-ui/core";
 import type {
   ThreadMessageLike as CoreThreadMessageLike,
   PartProviderMetadata,
+  ThreadMessage,
   ToolCallMessagePartMcpMetadata,
   ToolModelContentPart,
 } from "@assistant-ui/core";
@@ -106,6 +107,7 @@ type ToolCallPart = {
   modelContent?: readonly ToolModelContentPart[];
   unstable_toolMessageId?: string;
   mcp?: ToolCallMessagePartMcpMetadata;
+  messages?: readonly ThreadMessage[];
 };
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
@@ -1062,23 +1064,56 @@ function convertAssistantMessage(
   });
 
   for (const { id: toolCallId, part } of toolCalls) {
-    if (part.result === undefined) continue;
-
-    const resultContent =
-      part.modelContent !== undefined
-        ? extractText(part.modelContent)
-        : typeof part.result === "string"
-          ? part.result
-          : JSON.stringify(part.result);
-
-    converted.push({
-      id: part.unstable_toolMessageId ?? `${toolCallId}:tool`,
-      role: "tool",
-      content: resultContent,
-      toolCallId,
-      ...(part.isError ? { error: resultContent } : {}),
-    });
+    emitToolResult(toolCallId, part, converted);
+    // A subagent's frontend-executed call lives on the nested assistant
+    // message, and its backend waits for that call's tool record like any
+    // other; the nested assistant content itself is backend-owned state and
+    // is not re-sent.
+    emitNestedToolResults(part, converted);
   }
+}
+
+function emitNestedToolResults(
+  part: ToolCallPart,
+  converted: AgUiMessage[],
+): void {
+  for (const nested of part.messages ?? []) {
+    if (!isObject(nested) || nested.role !== "assistant") continue;
+    const nestedContent = Array.isArray(nested.content) ? nested.content : [];
+    for (const nestedPart of nestedContent) {
+      if (!isObject(nestedPart) || nestedPart.type !== "tool-call") continue;
+      const nestedToolCall = nestedPart as ToolCallPart;
+      emitToolResult(
+        normalizeToolCall(nestedToolCall).id,
+        nestedToolCall,
+        converted,
+      );
+      emitNestedToolResults(nestedToolCall, converted);
+    }
+  }
+}
+
+function emitToolResult(
+  toolCallId: string,
+  part: ToolCallPart,
+  converted: AgUiMessage[],
+): void {
+  if (part.result === undefined) return;
+
+  const resultContent =
+    part.modelContent !== undefined
+      ? extractText(part.modelContent)
+      : typeof part.result === "string"
+        ? part.result
+        : JSON.stringify(part.result);
+
+  converted.push({
+    id: part.unstable_toolMessageId ?? `${toolCallId}:tool`,
+    role: "tool",
+    content: resultContent,
+    toolCallId,
+    ...(part.isError ? { error: resultContent } : {}),
+  });
 }
 
 function convertToolMessage(

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
@@ -102,12 +102,11 @@ describe("RunAggregator tool approval projection", () => {
   });
 
   /**
-   * `boundToolCallIds` names the calls that render at root scope. A gate on a
-   * call nested inside a subagent message is therefore unbound, and
-   * `projectAgUiToolApprovals` collapses the whole batch rather than
-   * projects onto the nested part: the approval seams walk
-   * ToolCallMessagePart.messages, so a gate naming a subagent-scoped call is
-   * answerable the same way a root gate is.
+   * `boundToolCallIds` names every call the run produced, root or nested, so a
+   * gate on a call inside a subagent message is bound and projects onto the
+   * nested part rather than collapsing the batch. The approval seams walk
+   * `ToolCallMessagePart.messages`, which is what makes a subagent-scoped gate
+   * answerable the same way a root one is.
    */
   it("projects a batch that names a subagent-scoped tool call onto both the root and nested parts", () => {
     const emitted: ChatModelRunResult[] = [];

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.approval.test.ts
@@ -105,11 +105,11 @@ describe("RunAggregator tool approval projection", () => {
    * `boundToolCallIds` names the calls that render at root scope. A gate on a
    * call nested inside a subagent message is therefore unbound, and
    * `projectAgUiToolApprovals` collapses the whole batch rather than
-   * projecting the root gate alone: resuming requires a decision for every
-   * interrupt in the batch, and no UI can produce one for the nested gate. The
-   * interrupts stay on the message metadata for the bespoke hooks.
+   * projects onto the nested part: the approval seams walk
+   * ToolCallMessagePart.messages, so a gate naming a subagent-scoped call is
+   * answerable the same way a root gate is.
    */
-  it("collapses the whole batch to unbound, rather than showing an unresolvable root approval, when a subagent-scoped tool call shares the interrupt batch", () => {
+  it("projects a batch that names a subagent-scoped tool call onto both the root and nested parts", () => {
     const emitted: ChatModelRunResult[] = [];
     const aggregator = new RunAggregator({
       showThinking: false,
@@ -181,9 +181,15 @@ describe("RunAggregator tool approval projection", () => {
       type: "requires-action",
       reason: "interrupt",
     });
-    // Neither gate renders — the batch is bespoke as a whole, not just the
-    // subagent's unrenderable half of it.
-    expect(approvalOf(result)).toBeUndefined();
+    const content = result.content ?? [];
+    const rootPart = content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "tc-root",
+    ) as any;
+    expect(rootPart?.approval).toEqual({ id: "int-root" });
+    const nestedPart = rootPart?.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "tc-sub",
+    );
+    expect(nestedPart?.approval).toEqual({ id: "int-sub" });
     // The interrupts survive on the message metadata so the app's bespoke
     // interrupt hooks (useAgUiSubmitInterruptResponses / steerAway) can still
     // resolve the batch.

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -218,27 +218,17 @@ export class RunAggregator {
         }
 
         this.interrupts = undefined;
-        const { reachable } = this.nesting();
-        // Classified by the scope a call actually renders in: one flattened to
-        // root is reachable by getPendingToolCalls and therefore answerable,
-        // while one nested inside a subagent message is not.
-        const unresolved = Array.from(this.toolCalls.values()).filter(
+        // A call nested inside a subagent message is answerable the same way
+        // a root call is: getPendingToolCalls and addToolResult walk
+        // ToolCallMessagePart.messages, so any unresolved call keeps the run
+        // resumable.
+        const hasUnresolvedToolCalls = Array.from(this.toolCalls.values()).some(
           (tc) => tc.result === undefined,
         );
-        const hasUnresolvedRootToolCalls = unresolved.some(
-          (tc) =>
-            tc.subagentRunId === undefined || !reachable.has(tc.subagentRunId),
-        );
-        const hasUnresolvedSubagentToolCalls = unresolved.some(
-          (tc) =>
-            tc.subagentRunId !== undefined && reachable.has(tc.subagentRunId),
-        );
 
-        this.status = hasUnresolvedRootToolCalls
+        this.status = hasUnresolvedToolCalls
           ? { type: "requires-action", reason: "tool-calls" }
-          : hasUnresolvedSubagentToolCalls
-            ? { type: "incomplete", reason: "tool-calls" }
-            : { type: "complete", reason: "unknown" };
+          : { type: "complete", reason: "unknown" };
         this.closeOpenSubagentRuns(this.status);
         this.emit();
         break;

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -1121,10 +1121,10 @@ export class RunAggregator {
     // A run that ended incomplete can no longer be resumed, so a gate left over
     // from an earlier interrupt outcome is unanswerable and must not stay
     // projected. The interrupts themselves are kept on the message, since the
-    // bespoke hooks read that payload. Bound ids are exactly the calls that
-    // render at root scope, which is also exactly what getPendingToolCalls can
-    // reach: a call nested inside a subagent message is unanswerable, so the
-    // projector collapses the batch rather than showing half of it.
+    // bespoke hooks read that payload. Bound ids cover every call the run
+    // produced, root or nested: the approval seams walk
+    // ToolCallMessagePart.messages, so a gate naming a subagent-scoped call is
+    // answerable and projects onto the nested part.
     const partsByScope = new Map<
       string,
       { index: number; part: PartOrderEntry }[]
@@ -1151,13 +1151,7 @@ export class RunAggregator {
       approvals: projectAgUiToolApprovals(
         this.status?.type === "requires-action" ? this.interrupts : undefined,
         new Set(
-          Array.from(this.toolCalls.values())
-            .filter(
-              (entry) =>
-                entry.subagentRunId === undefined ||
-                !reachable.has(entry.subagentRunId),
-            )
-            .map((entry) => entry.toolCallId),
+          Array.from(this.toolCalls.values()).map((entry) => entry.toolCallId),
         ),
       ),
       root,

--- a/packages/react-ag-ui/src/runtime/adapter/tool-approval.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/tool-approval.test.ts
@@ -679,3 +679,68 @@ describe("restored snapshots", () => {
     }
   });
 });
+
+describe("nested tool-call approval seams", () => {
+  const nestedContent = (
+    approval?: Record<string, unknown>,
+  ): ThreadAssistantMessagePart[] => [
+    {
+      ...(toolCall("tc-spawn") as any),
+      messages: [
+        {
+          id: "sub-1",
+          role: "assistant",
+          createdAt: new Date(),
+          status: { type: "requires-action", reason: "interrupt" },
+          content: [toolCall("tc-nested", approval ?? { id: "int-nested" })],
+          metadata: {
+            unstable_state: null,
+            unstable_annotations: [],
+            unstable_data: [],
+            steps: [],
+            custom: {},
+          },
+        },
+      ],
+    } as ThreadAssistantMessagePart,
+  ];
+
+  it("records a decision on a nested gate", () => {
+    const next = withToolApprovalDecision(nestedContent(), {
+      approvalId: "int-nested",
+      approved: true,
+    });
+    const nested = (next[0] as any).messages[0].content[0];
+    expect(nested.approval).toEqual({ id: "int-nested", approved: true });
+  });
+
+  it("reads a nested decision into the resume array", () => {
+    const decided = nestedContent({ id: "int-nested", approved: false });
+    const resume = buildToolApprovalResume(decided, [
+      {
+        id: "int-nested",
+        reason: "tool_call",
+        toolCallId: "tc-nested",
+        message: "Delete?",
+      },
+    ]);
+    expect(resume).toEqual([
+      expect.objectContaining({
+        interruptId: "int-nested",
+        status: "resolved",
+        payload: { approved: false },
+      }),
+    ]);
+  });
+
+  it("settles a nested gate that a cancellation resumes", () => {
+    const next = withSettledToolApprovals(nestedContent(), [
+      { interruptId: "int-nested", status: "cancelled" },
+    ]);
+    const nested = (next[0] as any).messages[0].content[0];
+    expect(nested.approval).toEqual({
+      id: "int-nested",
+      resolution: "cancelled",
+    });
+  });
+});

--- a/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
@@ -1,3 +1,4 @@
+import { iterateToolCallParts, mapToolCallPartsDeep } from "../tool-call-tree";
 import { buildResumeArray } from "@ag-ui/client";
 import type {
   RespondToToolApprovalOptions,
@@ -228,12 +229,9 @@ export const withToolApprovalDecision = (
   content: readonly ThreadAssistantMessagePart[],
   { approvalId, approved, reason }: RespondToToolApprovalOptions,
 ): readonly ThreadAssistantMessagePart[] => {
-  let changed = false;
-  const next = content.map((part) => {
-    if (part.type !== "tool-call") return part;
+  const { content: next, changed } = mapToolCallPartsDeep(content, (part) => {
     const approval = part.approval;
     if (approval?.id !== approvalId || !isPending(approval)) return part;
-    changed = true;
     return {
       ...part,
       approval: {
@@ -263,8 +261,7 @@ export const buildToolApprovalResume = (
   // instead of recording a response, and `constructor` or `toString` would
   // report themselves as answered while undecided.
   const responses = new Map<string, { status: "resolved"; payload: unknown }>();
-  for (const part of content) {
-    if (part.type !== "tool-call") continue;
+  for (const part of iterateToolCallParts(content)) {
     const approval = part.approval;
     if (!approval || approval.approved === undefined) continue;
     if (!open.has(approval.id)) continue;

--- a/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/tool-approval.ts
@@ -194,7 +194,9 @@ const isPending = (approval: ToolCallMessagePart["approval"]) =>
  * render can never be decided through this seam, so the batch it belongs to
  * could never be completed either: the decisions taken on its visible siblings
  * would sit on the message while the run waited for a response that no click
- * can produce. `boundToolCallIds` leaves such a batch bespoke instead.
+ * can produce. `boundToolCallIds` spans every call the run produced — root or
+ * nested on ToolCallMessagePart.messages — so only a gate naming a call the
+ * message renders nowhere leaves the batch bespoke.
  */
 export const projectAgUiToolApprovals = (
   interrupts: readonly AgUiInterrupt[] | undefined,
@@ -347,16 +349,13 @@ export const withSettledToolApprovals = (
 ): readonly ThreadAssistantMessagePart[] => {
   if (resume.length === 0) return content;
   const byId = new Map(resume.map((entry) => [entry.interruptId, entry]));
-  let changed = false;
-  const next = content.map((part) => {
-    if (part.type !== "tool-call") return part;
+  const { content: next, changed } = mapToolCallPartsDeep(content, (part) => {
     const approval = part.approval;
     if (!approval) return part;
     const entry = byId.get(approval.id);
     if (!entry) return part;
     const settled = settle(approval, entry);
     if (!settled) return part;
-    changed = true;
     return { ...part, approval: settled };
   });
   return changed ? next : content;

--- a/packages/react-ag-ui/src/runtime/tool-call-tree.ts
+++ b/packages/react-ag-ui/src/runtime/tool-call-tree.ts
@@ -1,0 +1,58 @@
+import type {
+  ThreadAssistantMessage,
+  ThreadAssistantMessagePart,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+
+type AssistantContent = readonly ThreadAssistantMessagePart[];
+
+/**
+ * A subagent run renders as a nested assistant message on its spawning call's
+ * ToolCallMessagePart.messages, so the subagent's own tool calls live below
+ * the top-level content. Every seam that resolves, inspects, gates, or
+ * exports tool calls has to walk that tree, or a subagent's call is
+ * unreachable.
+ */
+export function* iterateToolCallParts(
+  content: AssistantContent,
+): Generator<ToolCallMessagePart> {
+  for (const part of content) {
+    if (part.type !== "tool-call") continue;
+    yield part;
+    for (const nested of part.messages ?? []) {
+      if (nested.role !== "assistant") continue;
+      yield* iterateToolCallParts((nested as ThreadAssistantMessage).content);
+    }
+  }
+}
+
+export function mapToolCallPartsDeep(
+  content: AssistantContent,
+  fn: (part: ToolCallMessagePart) => ToolCallMessagePart,
+): { content: AssistantContent; changed: boolean } {
+  let changed = false;
+  const next = content.map((part): ThreadAssistantMessagePart => {
+    if (part.type !== "tool-call") return part;
+    let mapped = fn(part);
+    if (mapped.messages !== undefined) {
+      let nestedChanged = false;
+      const nestedMessages = mapped.messages.map((nested) => {
+        if (nested.role !== "assistant") return nested;
+        const assistant = nested as ThreadAssistantMessage;
+        const result = mapToolCallPartsDeep(assistant.content, fn);
+        if (!result.changed) return nested;
+        nestedChanged = true;
+        return { ...assistant, content: result.content };
+      });
+      if (nestedChanged) {
+        mapped =
+          mapped === part
+            ? { ...part, messages: nestedMessages }
+            : { ...mapped, messages: nestedMessages };
+      }
+    }
+    if (mapped !== part) changed = true;
+    return mapped;
+  });
+  return changed ? { content: next, changed } : { content, changed };
+}

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3272,6 +3272,310 @@ describe("AGUIThreadRuntimeCore", () => {
       (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
     );
     expect(nestedPart?.result).toEqual({ found: "late" });
+    expect(updated.status).toMatchObject({ type: "complete" });
+  });
+
+  it("cancels a subagent's pending tool call on steerAway", async () => {
+    let runCount = 0;
+    const runInputs: any[] = [];
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "t-spawn",
+            toolCallName: "task",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "m-spawn",
+            toolCallId: "t-spawn",
+            content: "spawned",
+            role: "tool",
+          },
+        });
+        subscriber.onSubagentStartedEvent?.({
+          event: {
+            type: "SUBAGENT_STARTED",
+            subagentRunId: "sub-1",
+            name: "investigate",
+            parentToolCallId: "t-spawn",
+          },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "nested-1",
+            toolCallName: "search",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: {
+            type: "TOOL_CALL_END",
+            toolCallId: "nested-1",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["nested-1"]);
+
+    await core.steerAway("changed my mind");
+    expect(runCount).toBe(2);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const spawn = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedPart = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedPart?.result).toEqual({
+      error: "Tool call cancelled by user",
+    });
+    expect(nestedPart?.isError).toBe(true);
+
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolMsg = run2Messages.find(
+      (m: any) => m.role === "tool" && m.toolCallId === "nested-1",
+    );
+    expect(toolMsg?.content).toContain("cancelled");
+  });
+
+  it("preserves a frontend-injected nested result across an aggregator re-emit", async () => {
+    let releaseStream!: () => void;
+    const streamGate = new Promise<void>((r) => {
+      releaseStream = r;
+    });
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onToolCallStartEvent?.({
+        event: {
+          type: "TOOL_CALL_START",
+          toolCallId: "t-spawn",
+          toolCallName: "task",
+        },
+      });
+      subscriber.onToolCallEndEvent?.({
+        event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+      });
+      subscriber.onToolCallResultEvent?.({
+        event: {
+          type: "TOOL_CALL_RESULT",
+          messageId: "m-spawn",
+          toolCallId: "t-spawn",
+          content: "spawned",
+          role: "tool",
+        },
+      });
+      subscriber.onSubagentStartedEvent?.({
+        event: {
+          type: "SUBAGENT_STARTED",
+          subagentRunId: "sub-1",
+          name: "investigate",
+          parentToolCallId: "t-spawn",
+        },
+      });
+      subscriber.onToolCallStartEvent?.({
+        event: {
+          type: "TOOL_CALL_START",
+          toolCallId: "nested-1",
+          toolCallName: "search",
+          subagentRunId: "sub-1",
+        },
+      });
+      subscriber.onToolCallEndEvent?.({
+        event: {
+          type: "TOOL_CALL_END",
+          toolCallId: "nested-1",
+          subagentRunId: "sub-1",
+        },
+      });
+      await streamGate;
+      // The aggregator regenerates the whole content from its own state on
+      // this event; a result injected meanwhile must survive.
+      subscriber.onTextMessageStartEvent?.({
+        event: { type: "TEXT_MESSAGE_START", messageId: "t1" },
+      });
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", messageId: "t1", delta: "hi" },
+      });
+      subscriber.onTextMessageEndEvent?.({
+        event: { type: "TEXT_MESSAGE_END", messageId: "t1" },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent, {
+      autoCancelPendingToolCalls: false,
+    });
+    const appendDone = core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    const messageId = core.findMessageIdForToolCall("nested-1")!;
+    core.addToolResult({
+      messageId,
+      toolCallId: "nested-1",
+      result: { found: "early" },
+    });
+    releaseStream();
+    await appendDone;
+    await new Promise((r) => setTimeout(r, 0));
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const spawn = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedPart = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedPart?.result).toEqual({ found: "early" });
+  });
+
+  it("applies a cross-run mcp activity snapshot to a nested tool call", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "t-spawn",
+            toolCallName: "task",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "m-spawn",
+            toolCallId: "t-spawn",
+            content: "spawned",
+            role: "tool",
+          },
+        });
+        subscriber.onSubagentStartedEvent?.({
+          event: {
+            type: "SUBAGENT_STARTED",
+            subagentRunId: "sub-1",
+            name: "investigate",
+            parentToolCallId: "t-spawn",
+          },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "nested-1",
+            toolCallName: "render_app",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: {
+            type: "TOOL_CALL_END",
+            toolCallId: "nested-1",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onActivitySnapshotEvent?.({
+        event: {
+          type: "ACTIVITY_SNAPSHOT",
+          activityType: "mcp-apps",
+          content: {
+            toolCallId: "nested-1",
+            resourceUri: "ui://apps/dashboard",
+            serverId: "apps",
+          },
+        },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent, {
+      autoCancelPendingToolCalls: false,
+    });
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+    const firstAssistantId = (
+      core.getMessages().find((m) => m.role === "assistant") as ThreadMessage
+    ).id;
+
+    await core.append(
+      createAppendMessage({ parentId: core.getMessages().at(-1)!.id }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runCount).toBe(2);
+
+    const updated = core
+      .getMessages()
+      .find(
+        (m) => m.role === "assistant" && m.id === firstAssistantId,
+      ) as ThreadAssistantMessage;
+    const spawn = updated.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedPart = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedPart?.mcp?.app?.resourceUri).toBe("ui://apps/dashboard");
   });
 
   it("steerAway cancels every pending client-side tool call", async () => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3153,6 +3153,124 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(nestedPart?.result).toEqual({ found: true });
   });
 
+  it("applies a cross-run TOOL_CALL_RESULT to a nested tool call from an earlier run", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "t-spawn",
+            toolCallName: "task",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "m-spawn",
+            toolCallId: "t-spawn",
+            content: "spawned",
+            role: "tool",
+          },
+        });
+        subscriber.onSubagentStartedEvent?.({
+          event: {
+            type: "SUBAGENT_STARTED",
+            subagentRunId: "sub-1",
+            name: "investigate",
+            parentToolCallId: "t-spawn",
+          },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "nested-1",
+            toolCallName: "search",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: {
+            type: "TOOL_CALL_END",
+            toolCallId: "nested-1",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      // A different run whose aggregator has never seen nested-1 delivers
+      // its result: the cross-run branch must reach the nested part.
+      subscriber.onToolCallResultEvent?.({
+        event: {
+          type: "TOOL_CALL_RESULT",
+          messageId: "m-late",
+          toolCallId: "nested-1",
+          content: JSON.stringify({ found: "late" }),
+          role: "tool",
+        },
+      });
+      subscriber.onTextMessageStartEvent?.({
+        event: { type: "TEXT_MESSAGE_START", messageId: "t2" },
+      });
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", messageId: "t2", delta: "ok" },
+      });
+      subscriber.onTextMessageEndEvent?.({
+        event: { type: "TEXT_MESSAGE_END", messageId: "t2" },
+      });
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent, {
+      autoCancelPendingToolCalls: false,
+    });
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    const firstAssistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["nested-1"]);
+
+    await core.append(
+      createAppendMessage({ parentId: core.getMessages().at(-1)!.id }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(runCount).toBe(2);
+    const updated = core
+      .getMessages()
+      .find(
+        (m) => m.role === "assistant" && m.id === firstAssistant.id,
+      ) as ThreadAssistantMessage;
+    const spawn = updated.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedPart = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedPart?.result).toEqual({ found: "late" });
+  });
+
   it("steerAway cancels every pending client-side tool call", async () => {
     const runInputs: any[] = [];
     let runCount = 0;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3126,8 +3126,11 @@ describe("AGUIThreadRuntimeCore", () => {
 
     expect(core.findMessageIdForToolCall("nested-1")).toBe(pending!.messageId);
 
+    // Core's ToolInvocationTracker path resolves a nested call to the nested
+    // subagent message's id ("sub-1"), not a session message id — the runtime
+    // must re-anchor it onto the owning top-level message.
     core.addToolResult({
-      messageId: pending!.messageId,
+      messageId: "sub-1",
       toolCallId: "nested-1",
       result: { found: true },
     });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3578,6 +3578,132 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(nestedPart?.mcp?.app?.resourceUri).toBe("ui://apps/dashboard");
   });
 
+  it("decides a nested approval gate through respondToToolApproval and resumes", async () => {
+    let runCount = 0;
+    const runInputs: any[] = [];
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "t-spawn",
+            toolCallName: "task",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "m-spawn",
+            toolCallId: "t-spawn",
+            content: "spawned",
+            role: "tool",
+          },
+        });
+        subscriber.onSubagentStartedEvent?.({
+          event: {
+            type: "SUBAGENT_STARTED",
+            subagentRunId: "sub-1",
+            name: "investigate",
+            parentToolCallId: "t-spawn",
+          },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "nested-1",
+            toolCallName: "delete_file",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: {
+            type: "TOOL_CALL_ARGS",
+            toolCallId: "nested-1",
+            delta: '{"path":"/tmp/a"}',
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: {
+            type: "TOOL_CALL_END",
+            toolCallId: "nested-1",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: {
+              type: "interrupt",
+              interrupts: [
+                {
+                  id: "int-nested",
+                  reason: "tool_call",
+                  toolCallId: "nested-1",
+                  message: "Delete /tmp/a?",
+                },
+              ],
+            },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const spawn = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedBefore = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedBefore?.approval).toEqual({ id: "int-nested" });
+
+    await core.respondToToolApproval({
+      approvalId: "int-nested",
+      approved: true,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(runCount).toBe(2);
+    expect(JSON.stringify(runInputs[1])).toContain("int-nested");
+
+    const updated = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const spawnAfter = updated.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedAfter = spawnAfter.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedAfter?.approval).toMatchObject({
+      id: "int-nested",
+      approved: true,
+    });
+  });
+
   it("steerAway cancels every pending client-side tool call", async () => {
     const runInputs: any[] = [];
     let runCount = 0;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3040,6 +3040,119 @@ describe("AGUIThreadRuntimeCore", () => {
     ).toBe(true);
   });
 
+  it("resolves a subagent's frontend tool call through addToolResult and resumes the run", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      runCount++;
+      if (runCount === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "t-spawn",
+            toolCallName: "task",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: { type: "TOOL_CALL_END", toolCallId: "t-spawn" },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            messageId: "m-spawn",
+            toolCallId: "t-spawn",
+            content: "spawned",
+            role: "tool",
+          },
+        });
+        subscriber.onSubagentStartedEvent?.({
+          event: {
+            type: "SUBAGENT_STARTED",
+            subagentRunId: "sub-1",
+            name: "investigate",
+            parentToolCallId: "t-spawn",
+          },
+        });
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "nested-1",
+            toolCallName: "search",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: {
+            type: "TOOL_CALL_ARGS",
+            toolCallId: "nested-1",
+            delta: '{"q":"x"}',
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onToolCallEndEvent?.({
+          event: {
+            type: "TOOL_CALL_END",
+            toolCallId: "nested-1",
+            subagentRunId: "sub-1",
+          },
+        });
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome: { type: "success" },
+          },
+        });
+        subscriber.onRunFinalized?.();
+        return;
+      }
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: { type: "success" },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    const pending = core.getPendingToolCalls();
+    expect(pending?.toolCallIds).toEqual(["nested-1"]);
+
+    expect(core.findMessageIdForToolCall("nested-1")).toBe(pending!.messageId);
+
+    core.addToolResult({
+      messageId: pending!.messageId,
+      toolCallId: "nested-1",
+      result: { found: true },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(runCount).toBe(2);
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolMsg = run2Messages.find(
+      (m: any) => m.role === "tool" && m.toolCallId === "nested-1",
+    );
+    expect(toolMsg?.content).toContain("found");
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    expect(assistant.status).toMatchObject({ type: "complete" });
+    const spawn = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "t-spawn",
+    ) as any;
+    const nestedPart = spawn.messages?.[0]?.content.find(
+      (p: any) => p.type === "tool-call" && p.toolCallId === "nested-1",
+    );
+    expect(nestedPart?.result).toEqual({ found: true });
+  });
+
   it("steerAway cancels every pending client-side tool call", async () => {
     const runInputs: any[] = [];
     let runCount = 0;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3687,7 +3687,13 @@ describe("AGUIThreadRuntimeCore", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(runCount).toBe(2);
-    expect(JSON.stringify(runInputs[1])).toContain("int-nested");
+    expect(runInputs[1]?.resume).toEqual([
+      expect.objectContaining({
+        interruptId: "int-nested",
+        status: "resolved",
+        payload: { approved: true },
+      }),
+    ]);
 
     const updated = core
       .getMessages()

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -58,6 +58,62 @@ describe("adapter conversions", () => {
     ]);
     const nested = toolRecords.find((m: any) => m.toolCallId === "nested-1");
     expect(nested?.content).toContain("found");
+
+    // Every tool record has its antecedent: nested calls flatten onto the
+    // spawning assistant record's toolCalls, the pre-subagent wire shape.
+    const assistantCallIds = new Set(
+      result
+        .filter((m) => m.role === "assistant")
+        .flatMap((m: any) => (m.toolCalls ?? []).map((c: any) => c.id)),
+    );
+    expect(assistantCallIds.has("t-spawn")).toBe(true);
+    expect(assistantCallIds.has("nested-1")).toBe(true);
+    for (const record of toolRecords) {
+      expect(assistantCallIds.has((record as any).toolCallId)).toBe(true);
+    }
+  });
+
+  it("does not export a nested result whose approval gate is still open", () => {
+    const result = toAgUiMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "t-spawn",
+            toolName: "task",
+            args: {},
+            result: "spawned",
+            messages: [
+              {
+                id: "sub-1",
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool-call",
+                    toolCallId: "nested-gated",
+                    toolName: "delete_file",
+                    args: { path: "/tmp/a" },
+                    result: { done: true },
+                    approval: { id: "gate-1" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const toolRecords = result.filter((m) => m.role === "tool");
+    expect(toolRecords.some((m: any) => m.toolCallId === "nested-gated")).toBe(
+      false,
+    );
+    const assistant = result.find((m) => m.role === "assistant") as any;
+    expect(assistant.toolCalls.some((c: any) => c.id === "nested-gated")).toBe(
+      true,
+    );
   });
 
   it("converts thread messages to AG-UI format", () => {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -19,6 +19,47 @@ import {
 } from "../src/runtime/adapter/conversions";
 
 describe("adapter conversions", () => {
+  it("emits tool records for resolved tool calls nested in subagent messages", () => {
+    const result = toAgUiMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "t-spawn",
+            toolName: "task",
+            args: {},
+            result: "spawned",
+            messages: [
+              {
+                id: "sub-1",
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool-call",
+                    toolCallId: "nested-1",
+                    toolName: "search",
+                    args: { q: "x" },
+                    result: { found: true },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const toolRecords = result.filter((m) => m.role === "tool");
+    expect(toolRecords.map((m: any) => m.toolCallId).sort()).toEqual([
+      "nested-1",
+      "t-spawn",
+    ]);
+    const nested = toolRecords.find((m: any) => m.toolCallId === "nested-1");
+    expect(nested?.content).toContain("found");
+  });
+
   it("converts thread messages to AG-UI format", () => {
     const result = toAgUiMessages([
       {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -73,49 +73,6 @@ describe("adapter conversions", () => {
     }
   });
 
-  it("does not export a nested result whose approval gate is still open", () => {
-    const result = toAgUiMessages([
-      {
-        id: "a1",
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "t-spawn",
-            toolName: "task",
-            args: {},
-            result: "spawned",
-            messages: [
-              {
-                id: "sub-1",
-                role: "assistant",
-                content: [
-                  {
-                    type: "tool-call",
-                    toolCallId: "nested-gated",
-                    toolName: "delete_file",
-                    args: { path: "/tmp/a" },
-                    result: { done: true },
-                    approval: { id: "gate-1" },
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    ] as any);
-
-    const toolRecords = result.filter((m) => m.role === "tool");
-    expect(toolRecords.some((m: any) => m.toolCallId === "nested-gated")).toBe(
-      false,
-    );
-    const assistant = result.find((m) => m.role === "assistant") as any;
-    expect(assistant.toolCalls.some((c: any) => c.id === "nested-gated")).toBe(
-      true,
-    );
-  });
-
   it("converts thread messages to AG-UI format", () => {
     const result = toAgUiMessages([
       {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -73,6 +73,49 @@ describe("adapter conversions", () => {
     }
   });
 
+  it("does not export a nested result whose approval gate is still open", () => {
+    const result = toAgUiMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "t-spawn",
+            toolName: "task",
+            args: {},
+            result: "spawned",
+            messages: [
+              {
+                id: "sub-1",
+                role: "assistant",
+                content: [
+                  {
+                    type: "tool-call",
+                    toolCallId: "nested-gated",
+                    toolName: "delete_file",
+                    args: { path: "/tmp/a" },
+                    result: { done: true },
+                    approval: { id: "gate-1" },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const toolRecords = result.filter((m) => m.role === "tool");
+    expect(toolRecords.some((m: any) => m.toolCallId === "nested-gated")).toBe(
+      false,
+    );
+    const assistant = result.find((m) => m.role === "assistant") as any;
+    expect(assistant.toolCalls.some((c: any) => c.id === "nested-gated")).toBe(
+      true,
+    );
+  });
+
   it("converts thread messages to AG-UI format", () => {
     const result = toAgUiMessages([
       {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1313,15 +1313,10 @@ describe("RunAggregator", () => {
     });
   });
 
-  it("reports incomplete/tool-calls (not requires-action, not complete) for a dangling subagent-scoped tool call", () => {
-    // This adapter cannot surface a subagent-scoped tool call through
-    // getPendingToolCalls (it only walks top-level content, not nested
-    // .messages), so it cannot honestly claim "requires-action": there is
-    // no path for a caller to resolve it. Reporting "complete" would be
-    // worse — it would tell the app the run finished cleanly while an
-    // AG-UI backend still waits on a TOOL_CALL_RESULT that never arrives.
-    // "incomplete"/"tool-calls" (the same status core's local runtime uses
-    // when it deliberately stops resolving tool calls) says neither.
+  it("reports requires-action/tool-calls for a dangling subagent-scoped tool call", () => {
+    // getPendingToolCalls and addToolResult walk ToolCallMessagePart.messages,
+    // so a subagent-scoped call is answerable the same way a root call is:
+    // the run stays resumable and honestly reports requires-action.
     const aggregator = createAggregator(false);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -1358,7 +1353,7 @@ describe("RunAggregator", () => {
 
     const last = results.at(-1);
     expect(last?.status).toMatchObject({
-      type: "incomplete",
+      type: "requires-action",
       reason: "tool-calls",
     });
   });


### PR DESCRIPTION
Fixes #6612

## Problem

`@assistant-ui/react-ag-ui` groups a subagent run into a nested assistant message on the spawning call's `ToolCallMessagePart.messages` (#6608). A tool call the subagent makes therefore lives below top-level `content`, where the runtime's resolution seams could not see it. Core's `ToolInvocationTracker` already recursed into nested messages, so the frontend tool *did execute* — but `addToolResult` could not find the call, the result was dropped, the run reported `incomplete`, and the backend waited forever for a `TOOL_CALL_RESULT`.

## Root cause

Every seam that resolves, inspects, gates, or exports tool calls assumed top-level `content`: `getPendingToolCalls`, `findMessageIdForToolCall`, `addToolResult` (both its lookup and its session-message anchoring — core's tracker supplies the *nested* message's id, which is not a session message), `cancelUnresolvedToolCalls`, the all-resolved completion check, `preserveToolResults`, both cross-run updaters, the approval seams (`boundToolCallIds` projection, `respondToToolApproval`'s bound check, `withToolApprovalDecision`, `buildToolApprovalResume`), and `toAgUiMessages`.

## Change

- A shared `tool-call-tree` module (`iterateToolCallParts`, `mapToolCallPartsDeep`) walks the nested message tree; all seams above use it. `addToolResult` re-anchors on the owning session message when handed a nested id. Deep `preserveToolResults` keeps a frontend-injected nested result alive across `RunAggregator` re-emits.
- Approval gates cover nested calls: the aggregator's `boundToolCallIds` includes every call the run produced, so a gate naming a subagent-scoped call projects onto the nested part (the old collapse was justified by "nested calls are unanswerable", a premise this PR removes); decisions and resume-building recurse; core's tracker suppresses execution while the gate is open; an undecided gate's result is never exported.
- `RUN_FINISHED` reports `requires-action` / `tool-calls` for an unresolved nested call instead of #6608's `incomplete` downgrade.
- `toAgUiMessages` restores the pre-#6608 wire shape for nested calls: they flatten onto the spawning assistant record's `toolCalls` (requiring a string `toolCallId`, skipping `a2ui:` ids) and their resolved results follow as `tool` records — never a tool record without its antecedent. Nested assistant content stays un-exported (backend-owned state). No live backend was exercised; the shape is pinned to what pre-subagent backends demonstrably accepted, and the conversion tests enforce the no-orphan invariant.
- The README's limitation section is replaced: frontend execution and approval gating both reach nested calls; nested `SUBAGENT_FINISHED`-suspension HITL remains the one documented gap.

## Verification

Regression tests failing on `main`:

- End-to-end: nested call detected under the top-level message id, resolved via `addToolResult` **driven with the nested subagent message id — the id core's tracker actually supplies**, run resumes with the nested `tool` record on the wire, assistant completes.
- Cross-run: a later run's `TOOL_CALL_RESULT` lands on the nested part via the deep cross-run updater, and the owning assistant reaches `complete`; a cross-run `ACTIVITY_SNAPSHOT` lands `mcp.app` on the nested part.
- Cancellation: `steerAway` stamps the nested pending call with the cancellation error and ships it on the resume wire.
- Re-emit: a frontend result injected mid-stream survives the aggregator regenerating content.
- Approval: a gate batch naming root and nested calls projects onto both parts; an undecided nested gate's result is not exported (with the antecedent no-orphan invariant test).
- Aggregator: dangling subagent-scoped call reports `requires-action` / `tool-calls`.

Full `@assistant-ui/react-ag-ui` suite: 517/517 passing; `tsc --noEmit` clean.

## Public surface

No exports added or removed. `toAgUiMessages` (public) changes behavior for messages carrying nested subagent tool calls: their calls and results appear on the wire in the pre-#6608 flattened shape. Approval projection now binds nested calls, which apps observe as `approval` on nested parts where the batch previously collapsed to bespoke handling.