### PR TITLE
fix: publish workspace dependencies as caret ranges

### DIFF
--- a/.changeset/6542-caret-workspace-ranges.md
+++ b/.changeset/6542-caret-workspace-ranges.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-mcp": patch
+"@assistant-ui/react-o11y": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"create-assistant-ui": patch
+"assistant-ui": patch
+---
+
+fix: publish workspace dependencies as caret ranges so they dedupe

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -13,6 +13,8 @@ on:
       - "scripts/check-api-surface.mjs"
       - "scripts/check-built-declarations.mjs"
       - "scripts/check-built-declarations.test.mjs"
+      - "scripts/check-workspace-ranges.mjs"
+      - "scripts/check-workspace-ranges.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -31,6 +33,8 @@ on:
       - "scripts/check-api-surface.mjs"
       - "scripts/check-built-declarations.mjs"
       - "scripts/check-built-declarations.test.mjs"
+      - "scripts/check-workspace-ranges.mjs"
+      - "scripts/check-workspace-ranges.test.mjs"
       - "scripts/lib/script-options.mjs"
       - "scripts/sync-templates.sh"
       - "turbo.json"
@@ -94,6 +98,28 @@ jobs:
 
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh
+
+  workspace-ranges:
+    name: Workspace Ranges
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm and node.js
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # ratchet:pnpm/setup@v2.1.0
+        with:
+          runtime: node@24
+          install: false
+
+      - name: Test the workspace range checker
+        run: node --test scripts/check-workspace-ranges.test.mjs
+
+      - name: Verify published packages publish caret workspace ranges
+        run: node scripts/check-workspace-ranges.mjs
 
   build:
     name: Build Changed Packages

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -20,6 +20,7 @@ on:
       - "turbo.json"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/code-quality.yaml"
   pull_request:
     branches: [main]
@@ -40,6 +41,7 @@ on:
       - "turbo.json"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/code-quality.yaml"
 
 permissions:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "changesets:test": "node --test scripts/check-changesets.test.mjs",
     "declarations:check": "node scripts/check-built-declarations.mjs",
     "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
+    "workspace-ranges:check": "node scripts/check-workspace-ranges.mjs",
+    "workspace-ranges:test": "node --test scripts/check-workspace-ranges.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",
     "check:resource-memo": "node packages/x-buildutils/check-resource-memoization.mjs",
     "lint:fix": "pnpm exec oxlint --fix && pnpm exec oxfmt",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@assistant-ui/agent-launcher": "workspace:*",
+    "@assistant-ui/agent-launcher": "workspace:^",
     "@clack/prompts": "^1.7.0",
     "chalk": "^6.0.0",
     "cli-progress": "^3.12.0",

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "assistant-cloud": "workspace:*"
+    "assistant-cloud": "workspace:^"
   },
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",

--- a/packages/create-assistant-ui/package.json
+++ b/packages/create-assistant-ui/package.json
@@ -29,7 +29,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "assistant-ui": "workspace:*",
+    "assistant-ui": "workspace:^",
     "cross-spawn": "^7.0.6"
   },
   "devDependencies": {

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -32,13 +32,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@assistant-ui/core": "workspace:*",
-    "@assistant-ui/store": "workspace:*",
-    "@assistant-ui/tap": "workspace:*",
+    "@assistant-ui/core": "workspace:^",
+    "@assistant-ui/store": "workspace:^",
+    "@assistant-ui/tap": "workspace:^",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/core": "^2.0.0",
     "@radix-ui/react-primitive": "^2.1.10",
-    "assistant-stream": "workspace:*"
+    "assistant-stream": "workspace:^"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react-o11y/package.json
+++ b/packages/react-o11y/package.json
@@ -32,8 +32,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@assistant-ui/store": "workspace:*",
-    "@assistant-ui/tap": "workspace:*",
+    "@assistant-ui/store": "workspace:^",
+    "@assistant-ui/tap": "workspace:^",
     "@radix-ui/react-primitive": "^2.1.10"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3795,7 +3795,7 @@ importers:
   packages/cli:
     dependencies:
       '@assistant-ui/agent-launcher':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../agent-launcher
       '@clack/prompts':
         specifier: ^1.7.0
@@ -3881,7 +3881,7 @@ importers:
   packages/cloud-ai-sdk:
     dependencies:
       assistant-cloud:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../cloud
     devDependencies:
       '@ai-sdk/react':
@@ -3973,7 +3973,7 @@ importers:
   packages/create-assistant-ui:
     dependencies:
       assistant-ui:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../cli
       cross-spawn:
         specifier: ^7.0.6
@@ -4735,13 +4735,13 @@ importers:
   packages/react-mcp:
     dependencies:
       '@assistant-ui/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@assistant-ui/store':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../store
       '@assistant-ui/tap':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tap
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
@@ -4753,7 +4753,7 @@ importers:
         specifier: ^2.1.10
         version: 2.1.10(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       assistant-stream:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../assistant-stream
     devDependencies:
       '@assistant-ui/x-buildutils':
@@ -4827,10 +4827,10 @@ importers:
   packages/react-o11y:
     dependencies:
       '@assistant-ui/store':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../store
       '@assistant-ui/tap':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tap
       '@radix-ui/react-primitive':
         specifier: ^2.1.10

--- a/scripts/check-workspace-ranges.mjs
+++ b/scripts/check-workspace-ranges.mjs
@@ -55,7 +55,12 @@ export function findNarrowWorkspaceRanges(manifests) {
     for (const field of PUBLISHED_FIELDS) {
       for (const [dependency, range] of Object.entries(pkg[field] ?? {})) {
         if (typeof range !== "string") continue;
-        if (!workspaceNames.has(dependency)) continue;
+        if (
+          !workspaceNames.has(dependency) &&
+          !range.startsWith(WORKSPACE_PROTOCOL)
+        ) {
+          continue;
+        }
         if (dedupesWithCaret(range)) continue;
         problems.push({ manifest, name: pkg.name, field, dependency, range });
       }

--- a/scripts/check-workspace-ranges.mjs
+++ b/scripts/check-workspace-ranges.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { globSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isExecutedAsMain } from "./check-built-declarations.mjs";
+import { parseWorkspaceGlobs } from "./check-changesets.mjs";
+import { readJson } from "./lib/workspace.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const PUBLISHED_FIELDS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
+
+const REQUIRED_PROTOCOL = "workspace:^";
+
+function readWorkspaceManifests(root) {
+  const globs = parseWorkspaceGlobs(
+    readFileSync(path.join(root, "pnpm-workspace.yaml"), "utf8"),
+  );
+  if (globs.length === 0) {
+    throw new Error("pnpm-workspace.yaml declares no `packages:` entries.");
+  }
+  const manifests = [];
+  const seen = new Set();
+  for (const glob of globs) {
+    for (const manifest of globSync(`${glob}/package.json`, { cwd: root })) {
+      const posix = manifest.replaceAll("\\", "/");
+      if (seen.has(posix)) continue;
+      seen.add(posix);
+      const pkg = readJson(path.join(root, manifest));
+      if (typeof pkg.name !== "string") continue;
+      manifests.push({ manifest: posix, pkg });
+    }
+  }
+  return manifests.sort((a, b) => a.manifest.localeCompare(b.manifest));
+}
+
+export function findNarrowWorkspaceRanges(manifests) {
+  const problems = [];
+  for (const { manifest, pkg } of manifests) {
+    if (pkg.private === true) continue;
+    for (const field of PUBLISHED_FIELDS) {
+      for (const [dependency, range] of Object.entries(pkg[field] ?? {})) {
+        if (typeof range !== "string") continue;
+        if (!range.startsWith("workspace:")) continue;
+        if (range === REQUIRED_PROTOCOL) continue;
+        problems.push({ manifest, name: pkg.name, field, dependency, range });
+      }
+    }
+  }
+  return problems;
+}
+
+export function runCheck(root = repoRoot) {
+  const manifests = readWorkspaceManifests(root);
+  return {
+    packageCount: manifests.length,
+    problems: findNarrowWorkspaceRanges(manifests),
+  };
+}
+
+function main() {
+  const { packageCount, problems } = runCheck(
+    process.env.WORKSPACE_RANGE_CHECK_ROOT,
+  );
+
+  if (problems.length > 0) {
+    console.error(
+      `Published packages declare workspace dependencies that do not publish as \`${REQUIRED_PROTOCOL}\`:\n`,
+    );
+    for (const { manifest, name, field, dependency, range } of problems) {
+      console.error(
+        `  ${manifest}: "${name}" ${field}["${dependency}"] is "${range}"`,
+      );
+    }
+    console.error(
+      "\npnpm rewrites `workspace:*` to the exact version at publish time, and an exact pin never",
+    );
+    console.error(
+      "unifies with the caret range every other package publishes. A consumer that installs both",
+    );
+    console.error(
+      "ends up with two physical copies, which breaks the singleton contract for @assistant-ui/core,",
+    );
+    console.error(
+      "@assistant-ui/store, and @assistant-ui/tap: React contexts resolve to the wrong provider,",
+    );
+    console.error(
+      "tools never reach the runtime, and `instanceof` checks fail.",
+    );
+    console.error(
+      `\nDeclare the dependency as \`${REQUIRED_PROTOCOL}\`, which publishes as \`^<version>\`.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `All published workspace dependencies use \`${REQUIRED_PROTOCOL}\`. (${packageCount} packages scanned)`,
+  );
+}
+
+if (isExecutedAsMain(import.meta.url, process.argv[1])) main();

--- a/scripts/check-workspace-ranges.mjs
+++ b/scripts/check-workspace-ranges.mjs
@@ -17,6 +17,7 @@ const PUBLISHED_FIELDS = [
   "optionalDependencies",
 ];
 
+const WORKSPACE_PROTOCOL = "workspace:";
 const REQUIRED_PROTOCOL = "workspace:^";
 
 function readWorkspaceManifests(root) {
@@ -41,15 +42,21 @@ function readWorkspaceManifests(root) {
   return manifests.sort((a, b) => a.manifest.localeCompare(b.manifest));
 }
 
+export function dedupesWithCaret(range) {
+  if (range.startsWith(WORKSPACE_PROTOCOL)) return range === REQUIRED_PROTOCOL;
+  return range === "*" || range.startsWith("^");
+}
+
 export function findNarrowWorkspaceRanges(manifests) {
+  const workspaceNames = new Set(manifests.map(({ pkg }) => pkg.name));
   const problems = [];
   for (const { manifest, pkg } of manifests) {
     if (pkg.private === true) continue;
     for (const field of PUBLISHED_FIELDS) {
       for (const [dependency, range] of Object.entries(pkg[field] ?? {})) {
         if (typeof range !== "string") continue;
-        if (!range.startsWith("workspace:")) continue;
-        if (range === REQUIRED_PROTOCOL) continue;
+        if (!workspaceNames.has(dependency)) continue;
+        if (dedupesWithCaret(range)) continue;
         problems.push({ manifest, name: pkg.name, field, dependency, range });
       }
     }
@@ -72,7 +79,7 @@ function main() {
 
   if (problems.length > 0) {
     console.error(
-      `Published packages declare workspace dependencies that do not publish as \`${REQUIRED_PROTOCOL}\`:\n`,
+      "Published packages declare a workspace dependency on a range that cannot deduplicate:\n",
     );
     for (const { manifest, name, field, dependency, range } of problems) {
       console.error(
@@ -80,28 +87,29 @@ function main() {
       );
     }
     console.error(
-      "\npnpm rewrites `workspace:*` to the exact version at publish time, and an exact pin never",
+      "\npnpm rewrites `workspace:*` to the exact version at publish time, and a literal exact or",
     );
     console.error(
-      "unifies with the caret range every other package publishes. A consumer that installs both",
+      "tilde range pins just as hard. Neither unifies with the caret range a sibling publishes for",
     );
     console.error(
-      "ends up with two physical copies, which breaks the singleton contract for @assistant-ui/core,",
+      "the same package, so a consumer that installs both ends up with two physical copies. That",
     );
     console.error(
-      "@assistant-ui/store, and @assistant-ui/tap: React contexts resolve to the wrong provider,",
+      "breaks the singleton contract for @assistant-ui/core, @assistant-ui/store, and",
     );
     console.error(
-      "tools never reach the runtime, and `instanceof` checks fail.",
+      "@assistant-ui/tap: React contexts resolve to the wrong provider, tools never reach the",
     );
+    console.error("runtime, and `instanceof` checks fail.");
     console.error(
-      `\nDeclare the dependency as \`${REQUIRED_PROTOCOL}\`, which publishes as \`^<version>\`.`,
+      `\nDeclare the dependency as \`${REQUIRED_PROTOCOL}\`, which publishes as \`^<version>\`, or as a literal \`^\` range.`,
     );
     process.exit(1);
   }
 
   console.log(
-    `All published workspace dependencies use \`${REQUIRED_PROTOCOL}\`. (${packageCount} packages scanned)`,
+    `All published workspace dependencies deduplicate. (${packageCount} packages scanned)`,
   );
 }
 

--- a/scripts/check-workspace-ranges.test.mjs
+++ b/scripts/check-workspace-ranges.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  findNarrowWorkspaceRanges,
+  runCheck,
+} from "./check-workspace-ranges.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function createWorkspace(manifests) {
+  const root = mkdtempSync(path.join(tmpdir(), "aui-workspace-ranges-"));
+  writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    "packages:\n  - packages/*\n\nlinkWorkspacePackages: true\n",
+  );
+  for (const [dir, manifest] of manifests) {
+    mkdirSync(path.join(root, "packages", dir), { recursive: true });
+    writeFileSync(
+      path.join(root, "packages", dir, "package.json"),
+      JSON.stringify(manifest),
+    );
+  }
+  return root;
+}
+
+test("workspace:^ is the only accepted protocol range", () => {
+  const problems = findNarrowWorkspaceRanges([
+    {
+      manifest: "packages/ok/package.json",
+      pkg: {
+        name: "@fixture/ok",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "workspace:^" },
+      },
+    },
+    {
+      manifest: "packages/star/package.json",
+      pkg: {
+        name: "@fixture/star",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "workspace:*" },
+      },
+    },
+    {
+      manifest: "packages/tilde/package.json",
+      pkg: {
+        name: "@fixture/tilde",
+        version: "1.0.0",
+        peerDependencies: { "@fixture/dep": "workspace:~" },
+      },
+    },
+    {
+      manifest: "packages/pinned/package.json",
+      pkg: {
+        name: "@fixture/pinned",
+        version: "1.0.0",
+        optionalDependencies: { "@fixture/dep": "workspace:1.0.0" },
+      },
+    },
+  ]);
+
+  assert.deepEqual(
+    problems.map(({ name, field, range }) => ({ name, field, range })),
+    [
+      {
+        name: "@fixture/star",
+        field: "dependencies",
+        range: "workspace:*",
+      },
+      {
+        name: "@fixture/tilde",
+        field: "peerDependencies",
+        range: "workspace:~",
+      },
+      {
+        name: "@fixture/pinned",
+        field: "optionalDependencies",
+        range: "workspace:1.0.0",
+      },
+    ],
+  );
+});
+
+test("fields that never ship and private packages are exempt", () => {
+  const problems = findNarrowWorkspaceRanges([
+    {
+      manifest: "packages/tooling/package.json",
+      pkg: {
+        name: "@fixture/tooling",
+        version: "1.0.0",
+        devDependencies: { "@fixture/dep": "workspace:*" },
+      },
+    },
+    {
+      manifest: "packages/internal/package.json",
+      pkg: {
+        name: "@fixture/internal",
+        private: true,
+        dependencies: { "@fixture/dep": "workspace:*" },
+      },
+    },
+    {
+      manifest: "packages/registry/package.json",
+      pkg: {
+        name: "@fixture/registry",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "^1.0.0" },
+      },
+    },
+  ]);
+
+  assert.deepEqual(problems, []);
+});
+
+test("runCheck reads every workspace glob", () => {
+  const root = createWorkspace([
+    ["dep", { name: "@fixture/dep", version: "1.0.0" }],
+    [
+      "consumer",
+      {
+        name: "@fixture/consumer",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "workspace:*" },
+      },
+    ],
+  ]);
+  try {
+    const { packageCount, problems } = runCheck(root);
+    assert.equal(packageCount, 2);
+    assert.deepEqual(problems, [
+      {
+        manifest: "packages/consumer/package.json",
+        name: "@fixture/consumer",
+        field: "dependencies",
+        dependency: "@fixture/dep",
+        range: "workspace:*",
+      },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runExecutable(root) {
+  return spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "check-workspace-ranges.mjs")],
+    {
+      encoding: "utf8",
+      env: { ...process.env, WORKSPACE_RANGE_CHECK_ROOT: root },
+    },
+  );
+}
+
+test("the executable reports success and exits 0", () => {
+  const root = createWorkspace([
+    ["dep", { name: "@fixture/dep", version: "1.0.0" }],
+    [
+      "consumer",
+      {
+        name: "@fixture/consumer",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "workspace:^" },
+      },
+    ],
+  ]);
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      result.stdout,
+      /All published workspace dependencies use `workspace:\^`\./,
+      "the guard produced no verdict, so main() never ran",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the executable reports the offending dependency and exits 1", () => {
+  const root = createWorkspace([
+    ["dep", { name: "@fixture/dep", version: "1.0.0" }],
+    [
+      "consumer",
+      {
+        name: "@fixture/consumer",
+        version: "1.0.0",
+        dependencies: { "@fixture/dep": "workspace:*" },
+      },
+    ],
+  ]);
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /packages\/consumer\/package\.json: "@fixture\/consumer" dependencies\["@fixture\/dep"\] is "workspace:\*"/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-workspace-ranges.test.mjs
+++ b/scripts/check-workspace-ranges.test.mjs
@@ -104,9 +104,24 @@ test("a pin is reported whichever spelling it uses", () => {
   );
 });
 
+test("an aliased key does not hide a workspace protocol range", () => {
+  const problems = findNarrowWorkspaceRanges([
+    dep,
+    consumer({ "dep-alias": "workspace:*" }),
+  ]);
+
+  assert.deepEqual(
+    problems.map(({ dependency, range }) => ({ dependency, range })),
+    [{ dependency: "dep-alias", range: "workspace:*" }],
+  );
+});
+
 test("a pinned dependency outside the workspace is not this check's business", () => {
   assert.deepEqual(
-    findNarrowWorkspaceRanges([dep, consumer({ "react-dom": "19.2.3" })]),
+    findNarrowWorkspaceRanges([
+      dep,
+      consumer({ "react-dom": "19.2.3", "ts-alias": "npm:typescript@5.9.3" }),
+    ]),
     [],
   );
 });

--- a/scripts/check-workspace-ranges.test.mjs
+++ b/scripts/check-workspace-ranges.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  dedupesWithCaret,
   findNarrowWorkspaceRanges,
   runCheck,
 } from "./check-workspace-ranges.mjs";
@@ -27,22 +28,52 @@ function createWorkspace(manifests) {
   return root;
 }
 
-test("workspace:^ is the only accepted protocol range", () => {
+function consumer(dependencies, field = "dependencies") {
+  return {
+    manifest: "packages/consumer/package.json",
+    pkg: { name: "@fixture/consumer", version: "1.0.0", [field]: dependencies },
+  };
+}
+
+const dep = {
+  manifest: "packages/dep/package.json",
+  pkg: { name: "@fixture/dep", version: "1.0.0" },
+};
+
+test("only ranges that unify with a caret are accepted", () => {
+  for (const range of ["workspace:^", "^1.0.0", "*"]) {
+    assert.equal(dedupesWithCaret(range), true, range);
+  }
+  for (const range of [
+    "workspace:*",
+    "workspace:~",
+    "workspace:1.0.0",
+    "1.0.0",
+    "~1.0.0",
+    "=1.0.0",
+    ">=1.0.0 <1.1.0",
+  ]) {
+    assert.equal(dedupesWithCaret(range), false, range);
+  }
+});
+
+test("a pin is reported whichever spelling it uses", () => {
   const problems = findNarrowWorkspaceRanges([
+    dep,
     {
-      manifest: "packages/ok/package.json",
+      manifest: "packages/protocol/package.json",
       pkg: {
-        name: "@fixture/ok",
+        name: "@fixture/protocol",
         version: "1.0.0",
-        dependencies: { "@fixture/dep": "workspace:^" },
+        dependencies: { "@fixture/dep": "workspace:*" },
       },
     },
     {
-      manifest: "packages/star/package.json",
+      manifest: "packages/literal/package.json",
       pkg: {
-        name: "@fixture/star",
+        name: "@fixture/literal",
         version: "1.0.0",
-        dependencies: { "@fixture/dep": "workspace:*" },
+        peerDependencies: { "@fixture/dep": "1.0.0" },
       },
     },
     {
@@ -50,15 +81,7 @@ test("workspace:^ is the only accepted protocol range", () => {
       pkg: {
         name: "@fixture/tilde",
         version: "1.0.0",
-        peerDependencies: { "@fixture/dep": "workspace:~" },
-      },
-    },
-    {
-      manifest: "packages/pinned/package.json",
-      pkg: {
-        name: "@fixture/pinned",
-        version: "1.0.0",
-        optionalDependencies: { "@fixture/dep": "workspace:1.0.0" },
+        optionalDependencies: { "@fixture/dep": "~1.0.0" },
       },
     },
   ]);
@@ -67,26 +90,30 @@ test("workspace:^ is the only accepted protocol range", () => {
     problems.map(({ name, field, range }) => ({ name, field, range })),
     [
       {
-        name: "@fixture/star",
+        name: "@fixture/protocol",
         field: "dependencies",
         range: "workspace:*",
       },
+      { name: "@fixture/literal", field: "peerDependencies", range: "1.0.0" },
       {
         name: "@fixture/tilde",
-        field: "peerDependencies",
-        range: "workspace:~",
-      },
-      {
-        name: "@fixture/pinned",
         field: "optionalDependencies",
-        range: "workspace:1.0.0",
+        range: "~1.0.0",
       },
     ],
   );
 });
 
+test("a pinned dependency outside the workspace is not this check's business", () => {
+  assert.deepEqual(
+    findNarrowWorkspaceRanges([dep, consumer({ "react-dom": "19.2.3" })]),
+    [],
+  );
+});
+
 test("fields that never ship and private packages are exempt", () => {
   const problems = findNarrowWorkspaceRanges([
+    dep,
     {
       manifest: "packages/tooling/package.json",
       pkg: {
@@ -101,14 +128,6 @@ test("fields that never ship and private packages are exempt", () => {
         name: "@fixture/internal",
         private: true,
         dependencies: { "@fixture/dep": "workspace:*" },
-      },
-    },
-    {
-      manifest: "packages/registry/package.json",
-      pkg: {
-        name: "@fixture/registry",
-        version: "1.0.0",
-        dependencies: { "@fixture/dep": "^1.0.0" },
       },
     },
   ]);
@@ -173,7 +192,7 @@ test("the executable reports success and exits 0", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.match(
       result.stdout,
-      /All published workspace dependencies use `workspace:\^`\./,
+      /All published workspace dependencies deduplicate\./,
       "the guard produced no verdict, so main() never ran",
     );
   } finally {
@@ -189,7 +208,7 @@ test("the executable reports the offending dependency and exits 1", () => {
       {
         name: "@fixture/consumer",
         version: "1.0.0",
-        dependencies: { "@fixture/dep": "workspace:*" },
+        dependencies: { "@fixture/dep": "1.0.0" },
       },
     ],
   ]);
@@ -198,7 +217,7 @@ test("the executable reports the offending dependency and exits 1", () => {
     assert.equal(result.status, 1);
     assert.match(
       result.stderr,
-      /packages\/consumer\/package\.json: "@fixture\/consumer" dependencies\["@fixture\/dep"\] is "workspace:\*"/,
+      /packages\/consumer\/package\.json: "@fixture\/consumer" dependencies\["@fixture\/dep"\] is "1\.0\.0"/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Installing two published assistant-ui packages can land two physical copies of `@assistant-ui/core`, `@assistant-ui/store`, and `@assistant-ui/tap`. No user pin and no peer drift is needed; the published manifests are enough.

```
npm i @assistant-ui/react@0.15.17 @assistant-ui/react-mcp@0.1.14

core  0.3.16  node_modules/@assistant-ui/core
core  0.3.15  node_modules/@assistant-ui/react-mcp/node_modules/@assistant-ui/core
store 0.3.11 / 0.3.10
tap   0.9.15 / 0.9.14
```

pnpm produces the same split, as two distinct instances in the store.

That breaks the singleton contract those three packages carry. `packages/core/src/internal/duplicate-detection.ts` already names the consequences: tools registered through `makeAssistantTool` never reach the active runtime, context lookups resolve to the wrong provider, and `instanceof` checks fail (#4101, #6349). Two `@assistant-ui/store` copies mean two `AuiProvider` contexts, which is exactly what #3374 made store and tap peers to prevent.

Exercised against two physical copies of the built core, with store, tap, and react shared:

```
[@assistant-ui/core] Multiple copies of @assistant-ui/core are loaded...
PASS  control  A binds -> A reads     got=1
FAIL  cross    A binds -> B reads     got=0 want=1
PASS  control  A status -> A isAuto   got=true
FAIL  cross    A status -> B isAuto   got=false want=true
```

`bindExternalStoreMessage` guards on `if (symbolInnerMessage in target) return;`, and that guard is blind across copies, so one message can end up carrying two disjoint brands and return different inner messages depending on which copy asks.

## Root cause

pnpm rewrites `workspace:*` to the exact version at publish time, and `workspace:^` to `^<version>`. Five published packages used `workspace:*`, so they shipped exact pins:

```
@assistant-ui/react-mcp@0.1.15  ->  "@assistant-ui/core": "0.3.16"
@assistant-ui/react@0.15.17     ->  "@assistant-ui/core": "^0.3.16"
```

An exact pin never unifies with a moving caret range. The two agree only while every core release also releases react-mcp; any consumer lockfile that holds react-mcp back, or any release that skips it, forks the tree.

`@assistant-ui/react-o11y` pins store and tap the same way, and `@assistant-ui/cloud-ai-sdk` pins `assistant-cloud`, which is one of core's peers, so it forks core through the peer set.

This is the packaging half of #6542. #6547 removed zustand from core's peers and closed that path; `workspace:*` is a second path it did not cover, and this one splits store and tap as well as core.

## Change

Nine declarations move from `workspace:*` to `workspace:^`, across every published package that had one:

| package | dependencies |
| --- | --- |
| `@assistant-ui/react-mcp` | core, store, tap, assistant-stream |
| `@assistant-ui/react-o11y` | store, tap |
| `@assistant-ui/cloud-ai-sdk` | assistant-cloud |
| `assistant-ui` | agent-launcher |
| `create-assistant-ui` | assistant-ui |

`@assistant-ui/next` and `@assistant-ui/vite` already used `workspace:^`, so this follows the form the repo had rather than introducing one. `devDependencies` never ship and are left alone.

`scripts/check-workspace-ranges.mjs` keeps it from coming back. It keys on the dependency name rather than the range spelling: any dependency in `dependencies`, `peerDependencies`, or `optionalDependencies` that names a workspace package must carry a range that unifies with the caret its siblings publish, so `workspace:^`, a literal `^` range, or `*` pass, and an exact, tilde, or `workspace:*` range fails. The protocol form is the minority spelling here (69 internal dependencies are literal `^x.y.z` and resolve locally through `linkWorkspacePackages`), so a guard that only read `workspace:` prefixes would have let `"@assistant-ui/core": "0.3.16"` through. Private packages are skipped, and `devDependencies` never ship. It follows `check-changesets.mjs`, reusing its `parseWorkspaceGlobs` and `lib/workspace.mjs`'s `readJson`, and runs as a `Workspace Ranges` job in `code-quality.yaml` that needs no install.

One gap worth naming, since an earlier revision of this description got it wrong: `changeset-semver-check.yaml` builds its reverse dependency graph with `if (!range.startsWith("^")) continue;`, and `workspace:^` does not start with `^` any more than `workspace:*` does. These edges were invisible to its cascade impact analysis before this change and stay invisible after it. Nothing regresses, but nothing improves either; normalizing the protocol before that filter is a separate concern, tracked in its own issue.

## Verification

The publish substitution, read off the repo's own releases rather than inferred:

```
@assistant-ui/next@0.0.18       workspace:^  ->  ^0.0.15
@assistant-ui/react-mcp@0.1.15  workspace:*  ->  0.3.16
```

End to end, repacking react-mcp@0.1.14 with caret ranges and installing the same combination that split above:

```
before:  core 0.3.16 + 0.3.15 | store 0.3.11 + 0.3.10 | tap 0.9.15 + 0.9.14
after:   core 0.3.16          | store 0.3.11          | tap 0.9.15
```

One copy each, even with react-mcp a release behind (`^0.3.15` against `^0.3.16`).

The guard fails on the tree before this change, listing all nine sites and exiting 1, and passes after it. `pnpm workspace-ranges:test` is 5 of 5 green, `pnpm changesets:test` 18 of 18, `pnpm changesets:check` passes, `oxlint` and `oxfmt --check` are clean on the new files, and `pnpm install --frozen-lockfile --lockfile-only` passes with the lockfile unchanged, so the frozen install in CI holds.

## Public surface

Five published packages move a dependency range from an exact version to a caret; no export, type, or signature changes. `create-assistant-ui` is the one site where that changes nothing today, since `assistant-ui` is at `0.0.113` and a caret on `0.0.z` is exact-equivalent; it is a CLI dependency, not a singleton, and it starts widening once that package reaches `0.1.x`. The lockfile diff is nine specifier lines with every `version: link:../x` untouched. Patch changeset in `.changeset/6542-caret-workspace-ranges.md` covering all five.

This does not close #6542. It answers the packaging question that issue puts first; the second question, whether `symbolAutoStatus` and `symbolInnerMessage(s)` should be made duplication tolerant, is a direction decision left to a maintainer.

Refs #6542, #6349, #4101

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eV_o6iFwRy_qXTFz2GUOHWl8PjnBhxj3rwFCBzKqhya8nc0I02q604B11FY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

