### PR TITLE
ci: include workspace protocol edges in the semver cascade graph

### DIFF
--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -175,8 +175,9 @@ jobs:
                 if (!pkgMap.has(depName)) continue;
                 // `workspace:^` publishes as `^<the dependency version>`, so it
                 // constrains consumers exactly like the literal range a sibling
-                // writes by hand. Left raw it fails the caret test below and the
-                // edge never reaches the graph.
+                // writes by hand. Only this form is handled because
+                // scripts/check-workspace-ranges.mjs rejects every other
+                // protocol spelling in a published dependency field.
                 const range =
                   rawRange === "workspace:^"
                     ? `^${pkgMap.get(depName).version}`

--- a/.github/workflows/changeset-semver-check.yaml
+++ b/.github/workflows/changeset-semver-check.yaml
@@ -170,9 +170,18 @@ jobs:
                 ...pkgJson.dependencies,
                 ...pkgJson.peerDependencies,
               };
-              for (const [depName, range] of Object.entries(allDeps)) {
-                if (typeof range !== "string" || !range.startsWith("^")) continue;
+              for (const [depName, rawRange] of Object.entries(allDeps)) {
+                if (typeof rawRange !== "string") continue;
                 if (!pkgMap.has(depName)) continue;
+                // `workspace:^` publishes as `^<the dependency version>`, so it
+                // constrains consumers exactly like the literal range a sibling
+                // writes by hand. Left raw it fails the caret test below and the
+                // edge never reaches the graph.
+                const range =
+                  rawRange === "workspace:^"
+                    ? `^${pkgMap.get(depName).version}`
+                    : rawRange;
+                if (!range.startsWith("^")) continue;
                 if (!revDeps.has(depName)) revDeps.set(depName, []);
                 revDeps.get(depName).push({
                   name: pkgJson.name,


### PR DESCRIPTION
## Problem

The Changeset Semver Check posts a Cascade Impact table saying which packages a bump forces a downstream release on. That table is incomplete, and for some packages it is empty when it should not be.

A changeset bumping `@assistant-ui/agent-launcher` reports no cascade at all today, so the table reads as "nothing downstream is affected". `assistant-ui` depends on it and `create-assistant-ui` depends on `assistant-ui`, and both break their consumers' caret ranges when it moves.

## Root cause

`.github/workflows/changeset-semver-check.yaml:173-174` builds the reverse dependency graph from raw manifest values:

```js
if (typeof range !== "string" || !range.startsWith("^")) continue;
if (!pkgMap.has(depName)) continue;
```

`workspace:^` does not start with `^`, so the edge is dropped before it reaches `pkgMap` and never lands in `revDeps`. `computeCascade` cannot walk what is not in the graph.

Eleven internal dependencies are declared through the protocol: `@assistant-ui/react-mcp`, `@assistant-ui/react-o11y`, `@assistant-ui/cloud-ai-sdk`, `assistant-ui`, `create-assistant-ui`, `@assistant-ui/next`, and `@assistant-ui/vite`, against `@assistant-ui/core`, `@assistant-ui/store`, `@assistant-ui/tap`, `assistant-stream`, `assistant-cloud`, `@assistant-ui/agent-launcher`, and `@assistant-ui/x-generative-compiler`.

This predates #6631 and is unchanged by it. That PR moved five packages from `workspace:*` to `workspace:^`, and both spellings fail this filter identically.

## Change

Resolve the protocol against `pkgMap` before the caret test, at graph build time:

```js
const range =
  rawRange === "workspace:^"
    ? `^${pkgMap.get(depName).version}`
    : rawRange;
```

pnpm publishes `workspace:^` as `^<the dependency version>`, so the resolved edge is identical to the literal `^0.3.16` a sibling like `@assistant-ui/react` writes by hand, and the two are indistinguishable to the rest of the analysis. The `pkgMap.has` guard moves above the caret test because the version comes from it; `pkgMap` is fully built by the preceding loop, so it is available.

Normalizing here rather than at the read site means `computeCascade`'s `dep.range.replace(/^\^/, "")` parser at `:89-91` needs no change: it receives a literal caret range as it always did. One site, not two.

Only `workspace:^` is handled, because `scripts/check-workspace-ranges.mjs` (added in #6631) rejects every other protocol form in a published package, and this workflow reads the same set of non-private `packages/*` manifests. A general protocol parser here would be a branch with no caller.

## Verification

The workflow's logic is inlined in YAML, so it was exercised by extracting the shipped `script:` block and running it against a fixture holding one changeset (`agent-launcher` minor, `store` minor, `assistant-cloud` minor, `x-generative-compiler` patch) and the repository's real manifests. Before and after are the same block from `main` and from this branch:

| | cascade packages |
| --- | --- |
| before | 16 |
| after | **23** |

The seven the table missed:

| package | flagged |
| --- | --- |
| `assistant-ui` | ⛔ `^0.0.113` breaks |
| `@assistant-ui/next` | ⛔ `^0.0.18` breaks |
| `@assistant-ui/vite` | ⛔ `^0.0.15` breaks |
| `@assistant-ui/react-o11y` | ⛔ `^0.0.42` breaks |
| `create-assistant-ui` | ⛔ `^0.0.76` breaks |
| `@assistant-ui/react-mcp` | ✅ no |
| `@assistant-ui/cloud-ai-sdk` | ✅ no |

Two of those are transitive: `create-assistant-ui` is only reachable once `assistant-ui` enters the graph, and `next` and `vite` only once `x-generative-compiler`'s edges do. The fix restores whole subtrees, not just direct edges.

The workflow file parses and the embedded script body is valid JS after the edit (`yaml.parse`, then `AsyncFunction` over the extracted block).

## Public surface

None. One CI workflow; no package, export, or manifest changes, so no changeset.

Closes #6632

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.E9FIR-oj6N2El_1BDTR6yDNgSedEprF-JEuhgFEcXo0agbuN20cK1Q5Jqbk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->