### PR TITLE
fix: preview-code extractor treats an apostrophe in JSX text as a string open

### DIFF
--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -155,3 +155,67 @@ describe("extractFunctionCode", () => {
     );
   });
 });
+
+describe("apostrophes in JSX text", () => {
+  const apostropheSource = `
+export function BraceApostrophe() {
+  return <p>it's fine</p>;
+}
+
+export const WrappedApostrophe = () => (
+  <p>it's fine</p>
+);
+
+export const BareApostrophe = () => <p>it's fine</p>;
+
+export function AfterApostrophe() {
+  return <div>after</div>;
+}
+`;
+
+  it("extracts a brace-bodied function whose JSX text contains an apostrophe", () => {
+    expect(extractFunctionCode(apostropheSource, "BraceApostrophe")).toBe(
+      `export function BraceApostrophe() {
+  return <p>it's fine</p>;
+}`,
+    );
+  });
+
+  it("extracts a paren-wrapped arrow whose JSX text contains an apostrophe", () => {
+    expect(extractFunctionCode(apostropheSource, "WrappedApostrophe")).toBe(
+      `export const WrappedApostrophe = () => (
+  <p>it's fine</p>
+);`,
+    );
+  });
+
+  it("extracts a bare arrow whose JSX text contains an apostrophe", () => {
+    expect(extractFunctionCode(apostropheSource, "BareApostrophe")).toBe(
+      `export const BareApostrophe = () => <p>it's fine</p>;`,
+    );
+  });
+
+  it("still treats a quote after an operator or keyword as a string open", () => {
+    const stringSource = `
+export function StringSpecimen() {
+  const label = "What's the weather";
+  return <div>{label + 'x;y'}</div>;
+}
+`;
+    expect(extractFunctionCode(stringSource, "StringSpecimen")).toBe(
+      `export function StringSpecimen() {
+  const label = "What's the weather";
+  return <div>{label + 'x;y'}</div>;
+}`,
+    );
+  });
+
+  it("still tracks a tagged template literal as a string", () => {
+    const taggedSource = `
+export const TaggedSpecimen = () => css\`content: ")";\`;
+`;
+    expect(extractFunctionCode(taggedSource, "TaggedSpecimen")).toBe(
+      'export const TaggedSpecimen = () => css`content: ")";`;',
+    );
+  });
+});

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -210,6 +210,24 @@ export function StringSpecimen() {
     );
   });
 
+  it("extracts prose with a decade apostrophe after whitespace", () => {
+    const proseSource = `
+export const DecadeSpecimen = () => <p>the '90s rule</p>;
+`;
+    expect(extractFunctionCode(proseSource, "DecadeSpecimen")).toBe(
+      `export const DecadeSpecimen = () => <p>the '90s rule</p>;`,
+    );
+  });
+
+  it("extracts prose with a contraction after a non-ascii word", () => {
+    const source = `
+export const CafeSpecimen = () => <p>café's fine</p>;
+`;
+    expect(extractFunctionCode(source, "CafeSpecimen")).toBe(
+      `export const CafeSpecimen = () => <p>café's fine</p>;`,
+    );
+  });
+
   it("still tracks a tagged template literal as a string", () => {
     const taggedSource = `
 export const TaggedSpecimen = () => css\`content: ")";\`;

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -242,33 +242,71 @@ export const TaggedSpecimen = () => css\`content: ")";\`;
   });
 });
 
-describe("every real sample extracts", () => {
+describe("every real preview extracts", () => {
   // #6544's bite is that a prose quote breaks extraction silently at
-  // authoring time. The heuristic in updateStringState only has to be right
-  // for the samples we actually ship — this sweep turns that from a hope
-  // into an enforced invariant: every exported component in every sample
-  // file must extract to code, never to a "Could not" marker.
-  it("extracts every exported component of every sample file", async () => {
-    const { readdirSync, readFileSync } = await import("node:fs");
-    const { join } = await import("node:path");
+  // authoring time. The scanner heuristic only has to be right for the
+  // sources we actually preview — this sweep walks every <PreviewCode>
+  // reference in the MDX content (both flavors when a .radix variant
+  // exists) and turns that from a hope into an enforced invariant.
+  it("extracts every <PreviewCode> pair referenced from content", async () => {
+    const { readdirSync, readFileSync, existsSync } = await import("node:fs");
+    const { join, resolve } = await import("node:path");
 
-    const samplesDir = join(__dirname, "samples");
-    const files = readdirSync(samplesDir).filter((file) =>
-      file.endsWith(".tsx"),
-    );
-    expect(files.length).toBeGreaterThan(0);
+    const docsRoot = resolve(__dirname, "../../..");
+    const mdxFiles: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".mdx")) mdxFiles.push(full);
+      }
+    };
+    walk(join(docsRoot, "content"));
+
+    const pairs = new Set<string>();
+    for (const mdxFile of mdxFiles) {
+      const mdx = readFileSync(mdxFile, "utf8");
+      for (const match of mdx.matchAll(
+        /<PreviewCode\s[^>]*?file="([^"]+)"[^>]*?name="([^"]+)"/gs,
+      )) {
+        pairs.add(`${match[1]}\u0000${match[2]}`);
+      }
+    }
+    expect(pairs.size).toBeGreaterThanOrEqual(60);
 
     const failures: string[] = [];
-    for (const file of files) {
-      const source = readFileSync(join(samplesDir, file), "utf8");
-      const names = [
-        ...source.matchAll(/export\s+(?:function|const)\s+([A-Z]\w*)/g),
-      ].map((match) => match[1]!);
-      for (const name of names) {
-        const extracted = extractFunctionCode(source, name);
-        if (extracted.startsWith("// Could not")) {
-          failures.push(`${file}#${name}: ${extracted}`);
-        }
+    const checkExtraction = (sourceFile: string, name: string) => {
+      const source = readFileSync(sourceFile, "utf8");
+      const extracted = extractFunctionCode(source, name);
+      if (extracted.startsWith("// Could not")) {
+        failures.push(`${sourceFile}#${name}: ${extracted}`);
+        return;
+      }
+      // A phantom string that swallows a brace truncates the snippet at an
+      // earlier boundary and still looks like code — so the text after the
+      // extracted region must start a new top-level construct.
+      const endIndex = source.indexOf(extracted) + extracted.length;
+      const rest = source.slice(endIndex).replace(/^[\s;]*/, "");
+      if (
+        rest !== "" &&
+        !/^(export\s|import\s|const\s|function\s|type\s|interface\s|\/\/|\/\*)/.test(
+          rest,
+        )
+      ) {
+        failures.push(
+          `${sourceFile}#${name}: truncated extraction (resumes at ${JSON.stringify(rest.slice(0, 40))})`,
+        );
+      }
+    };
+
+    for (const pair of pairs) {
+      const [file, name] = pair.split("\u0000") as [string, string];
+      const base = join(docsRoot, `${file}.tsx`);
+      const radix = join(docsRoot, `${file}.radix.tsx`);
+      if (existsSync(radix)) checkExtraction(radix, name);
+      if (existsSync(base)) checkExtraction(base, name);
+      if (!existsSync(base) && !existsSync(radix)) {
+        failures.push(`${file}#${name}: source file missing`);
       }
     }
     expect(failures).toEqual([]);

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -210,15 +210,6 @@ export function StringSpecimen() {
     );
   });
 
-  it("extracts prose with a decade apostrophe after whitespace", () => {
-    const proseSource = `
-export const DecadeSpecimen = () => <p>the '90s rule</p>;
-`;
-    expect(extractFunctionCode(proseSource, "DecadeSpecimen")).toBe(
-      `export const DecadeSpecimen = () => <p>the '90s rule</p>;`,
-    );
-  });
-
   it("extracts prose with a contraction after a non-ascii word", () => {
     const source = `
 export const CafeSpecimen = () => <p>café's fine</p>;
@@ -248,5 +239,38 @@ export const TaggedSpecimen = () => css\`content: ")";\`;
     expect(extractFunctionCode(taggedSource, "TaggedSpecimen")).toBe(
       'export const TaggedSpecimen = () => css`content: ")";`;',
     );
+  });
+});
+
+describe("every real sample extracts", () => {
+  // #6544's bite is that a prose quote breaks extraction silently at
+  // authoring time. The heuristic in updateStringState only has to be right
+  // for the samples we actually ship — this sweep turns that from a hope
+  // into an enforced invariant: every exported component in every sample
+  // file must extract to code, never to a "Could not" marker.
+  it("extracts every exported component of every sample file", async () => {
+    const { readdirSync, readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+
+    const samplesDir = join(__dirname, "samples");
+    const files = readdirSync(samplesDir).filter((file) =>
+      file.endsWith(".tsx"),
+    );
+    expect(files.length).toBeGreaterThan(0);
+
+    const failures: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(join(samplesDir, file), "utf8");
+      const names = [
+        ...source.matchAll(/export\s+(?:function|const)\s+([A-Z]\w*)/g),
+      ].map((match) => match[1]!);
+      for (const name of names) {
+        const extracted = extractFunctionCode(source, name);
+        if (extracted.startsWith("// Could not")) {
+          failures.push(`${file}#${name}: ${extracted}`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
   });
 });

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -219,6 +219,15 @@ export const CafeSpecimen = () => <p>café's fine</p>;
     );
   });
 
+  it("extracts prose with a contraction after an astral letter", () => {
+    const source = `
+export const AstralSpecimen = () => <p>𝕏's rule</p>;
+`;
+    expect(extractFunctionCode(source, "AstralSpecimen")).toBe(
+      `export const AstralSpecimen = () => <p>𝕏's rule</p>;`,
+    );
+  });
+
   it("tracks a keyword-adjacent literal as a string", () => {
     const source = `
 export function CompactSpecimen() {
@@ -243,11 +252,11 @@ export const TaggedSpecimen = () => css\`content: ")";\`;
 });
 
 describe("every real preview extracts", () => {
-  // #6544's bite is that a prose quote breaks extraction silently at
-  // authoring time. The scanner heuristic only has to be right for the
-  // sources we actually preview — this sweep walks every <PreviewCode>
-  // reference in the MDX content (both flavors when a .radix variant
-  // exists) and turns that from a hope into an enforced invariant.
+  // A prose quote breaks extraction silently at authoring time. The scanner
+  // heuristic only has to be right for the sources we actually preview —
+  // this sweep walks every <PreviewCode> reference in the MDX content (both
+  // flavors when a .radix variant exists) and turns that from a hope into an
+  // enforced invariant.
   it("extracts every <PreviewCode> pair referenced from content", async () => {
     const { readdirSync, readFileSync, existsSync } = await import("node:fs");
     const { join, resolve } = await import("node:path");
@@ -263,16 +272,25 @@ describe("every real preview extracts", () => {
     };
     walk(join(docsRoot, "content"));
 
+    // Every <PreviewCode occurrence must yield a parsed pair, so a call site
+    // the pair regex cannot read (attribute reordering, an expression
+    // attribute containing ">") fails the sweep instead of silently leaving
+    // that preview unguarded.
+    let occurrences = 0;
+    let parsed = 0;
     const pairs = new Set<string>();
     for (const mdxFile of mdxFiles) {
       const mdx = readFileSync(mdxFile, "utf8");
+      occurrences += mdx.match(/<PreviewCode[\s>]/g)?.length ?? 0;
       for (const match of mdx.matchAll(
         /<PreviewCode\s[^>]*?file="([^"]+)"[^>]*?name="([^"]+)"/gs,
       )) {
+        parsed += 1;
         pairs.add(`${match[1]}\u0000${match[2]}`);
       }
     }
-    expect(pairs.size).toBeGreaterThanOrEqual(60);
+    expect(occurrences).toBeGreaterThan(0);
+    expect(parsed).toBe(occurrences);
 
     const failures: string[] = [];
     const checkExtraction = (sourceFile: string, name: string) => {
@@ -289,7 +307,7 @@ describe("every real preview extracts", () => {
       const rest = source.slice(endIndex).replace(/^[\s;]*/, "");
       if (
         rest !== "" &&
-        !/^(export\s|import\s|const\s|function\s|type\s|interface\s|\/\/|\/\*)/.test(
+        !/^(export\s|import\s|const\s|let\s|var\s|class\s|function\s|async\s|type\s|interface\s|["']use client["']|\/\/|\/\*)/.test(
           rest,
         )
       ) {

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -228,6 +228,19 @@ export const CafeSpecimen = () => <p>café's fine</p>;
     );
   });
 
+  it("tracks a keyword-adjacent literal as a string", () => {
+    const source = `
+export function CompactSpecimen() {
+  return'foo}';
+}
+`;
+    expect(extractFunctionCode(source, "CompactSpecimen")).toBe(
+      `export function CompactSpecimen() {
+  return'foo}';
+}`,
+    );
+  });
+
   it("still tracks a tagged template literal as a string", () => {
     const taggedSource = `
 export const TaggedSpecimen = () => css\`content: ")";\`;

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -1,5 +1,7 @@
 type StringState = { inString: boolean; stringChar: string };
 
+const IDENTIFIER_CHAR = /[A-Za-z0-9_$]/;
+
 function updateStringState(
   state: StringState,
   char: string,
@@ -11,7 +13,16 @@ function updateStringState(
     }
     return true;
   }
-  if (char === '"' || char === "'" || char === "`") {
+  // A quote directly after an identifier character is never a string open in
+  // JS — that position only occurs in JSX text ("it's fine"), where treating
+  // it as one swallows the rest of the file. Backticks are excluded: a tagged
+  // template (css`...`) is exactly a backtick after an identifier.
+  if ((char === '"' || char === "'") && !IDENTIFIER_CHAR.test(prevChar)) {
+    state.inString = true;
+    state.stringChar = char;
+    return true;
+  }
+  if (char === "`") {
     state.inString = true;
     state.stringChar = char;
     return true;

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -1,23 +1,47 @@
 type StringState = { inString: boolean; stringChar: string };
 
-const IDENTIFIER_CHAR = /[A-Za-z0-9_$]/;
+const IDENTIFIER_CHAR = /[\p{L}\p{N}_$]/u;
+
+// A lone quote in JSX prose has no partner, while the string literals these
+// samples contain are single-line, so an unpaired quote on its line is prose.
+function hasSameLineClose(
+  source: string,
+  index: number,
+  quote: string,
+): boolean {
+  for (let i = index + 1; i < source.length; i++) {
+    const char = source[i]!;
+    if (char === "\n") return false;
+    if (char === quote && source[i - 1] !== "\\") return true;
+  }
+  return false;
+}
 
 function updateStringState(
   state: StringState,
-  char: string,
-  prevChar: string,
+  source: string,
+  index: number,
 ): boolean {
+  const char = source[index]!;
+  const prevChar = source[index - 1] ?? "";
   if (state.inString) {
     if (char === state.stringChar && prevChar !== "\\") {
       state.inString = false;
     }
     return true;
   }
-  // A quote directly after an identifier character is never a string open in
-  // JS — that position only occurs in JSX text ("it's fine"), where treating
-  // it as one swallows the rest of the file. Backticks are excluded: a tagged
-  // template (css`...`) is exactly a backtick after an identifier.
-  if ((char === '"' || char === "'") && !IDENTIFIER_CHAR.test(prevChar)) {
+  // These scanners see JSX text as code, so a quote only opens a string when
+  // the position plausibly is one. Formatting-dependent heuristics, not a
+  // grammar: a quote straight after an identifier character is a contraction
+  // in prose (it's, café's) rather than the unspaced-but-valid \`return"x"\`,
+  // and a quote with no unescaped partner before the line ends is prose too.
+  // Backticks are excluded from both rules: a backtick after an identifier is
+  // a tagged template, and template literals span lines.
+  if (
+    (char === '"' || char === "'") &&
+    !IDENTIFIER_CHAR.test(prevChar) &&
+    hasSameLineClose(source, index, char)
+  ) {
     state.inString = true;
     state.stringChar = char;
     return true;
@@ -36,8 +60,7 @@ function findMatchingParen(source: string, startIndex: number): number {
 
   for (let i = startIndex; i < source.length; i++) {
     const char = source[i]!;
-    const prevChar = source[i - 1] ?? "";
-    if (updateStringState(state, char, prevChar)) continue;
+    if (updateStringState(state, source, i)) continue;
 
     if (char === "(") parenCount++;
     if (char === ")") {
@@ -61,8 +84,7 @@ function findStatementEnd(source: string, startIndex: number): number {
 
   for (let i = startIndex; i < source.length; i++) {
     const char = source[i]!;
-    const prevChar = source[i - 1] ?? "";
-    if (updateStringState(state, char, prevChar)) continue;
+    if (updateStringState(state, source, i)) continue;
 
     if (char === "(") parenCount++;
     if (char === ")") parenCount--;
@@ -103,8 +125,7 @@ function findMatchingBrace(source: string, startIndex: number): number {
 
   for (let i = startIndex; i < source.length; i++) {
     const char = source[i]!;
-    const prevChar = source[i - 1] ?? "";
-    if (updateStringState(state, char, prevChar)) continue;
+    if (updateStringState(state, source, i)) continue;
 
     if (char === "{") {
       braceCount++;

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -7,21 +7,6 @@ const IDENTIFIER_CHAR = /[\p{L}\p{N}_$]/u;
 const KEYWORD_BEFORE_LITERAL =
   /(?:^|[^\p{L}\p{N}_$])(?:return|case|typeof|in|of|do|else|void|throw|new|delete|instanceof|yield|await)$/u;
 
-// A lone quote in JSX prose has no partner, while the string literals these
-// samples contain are single-line, so an unpaired quote on its line is prose.
-function hasSameLineClose(
-  source: string,
-  index: number,
-  quote: string,
-): boolean {
-  for (let i = index + 1; i < source.length; i++) {
-    const char = source[i]!;
-    if (char === "\n") return false;
-    if (char === quote && source[i - 1] !== "\\") return true;
-  }
-  return false;
-}
-
 function updateStringState(
   state: StringState,
   source: string,
@@ -35,22 +20,18 @@ function updateStringState(
     }
     return true;
   }
-  // These scanners see JSX text as code, so a quote only opens a string when
-  // the position plausibly is one. Formatting-dependent heuristics, not a
-  // grammar: a quote straight after an identifier character is a contraction
-  // in prose (it's, café's) unless the word it ends is a keyword that may
-  // abut a literal (return'x'), and a quote with no unescaped partner before
-  // the line ends is prose too. Backticks are excluded from both rules: a
-  // backtick after an identifier is a tagged template, and template literals
-  // span lines.
+  // These scanners see JSX text as code, so string opens use one
+  // formatting-dependent heuristic rather than a grammar: a quote straight
+  // after an identifier character is a prose contraction (it's, café's)
+  // unless the word it ends is a keyword that may legally abut a literal
+  // (return'x'). Everything else keeps opening a string, so prose quotes
+  // after whitespace still derail the scan — the exhaustive sample test is
+  // the guard that keeps that class out of the docs. Backticks are excluded:
+  // a backtick after an identifier is a tagged template.
   const afterIdentifier =
     IDENTIFIER_CHAR.test(prevChar) &&
     !KEYWORD_BEFORE_LITERAL.test(source.slice(Math.max(0, index - 12), index));
-  if (
-    (char === '"' || char === "'") &&
-    !afterIdentifier &&
-    hasSameLineClose(source, index, char)
-  ) {
+  if ((char === '"' || char === "'") && !afterIdentifier) {
     state.inString = true;
     state.stringChar = char;
     return true;

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -7,6 +7,16 @@ const IDENTIFIER_CHAR = /[\p{L}\p{N}_$]/u;
 const KEYWORD_BEFORE_LITERAL =
   /(?:^|[^\p{L}\p{N}_$])(?:return|case|typeof|in|of|do|else|void|throw|new|delete|instanceof|yield|await)$/u;
 
+// An astral letter sits in the source as a surrogate pair, so the unit at
+// index - 1 alone never matches the identifier class.
+function precedingCodePoint(source: string, index: number): string {
+  const prev = source[index - 1] ?? "";
+  const lead = source[index - 2] ?? "";
+  return /[\uD800-\uDBFF]/.test(lead) && /[\uDC00-\uDFFF]/.test(prev)
+    ? lead + prev
+    : prev;
+}
+
 function updateStringState(
   state: StringState,
   source: string,
@@ -29,7 +39,7 @@ function updateStringState(
   // the guard that keeps that class out of the docs. Backticks are excluded:
   // a backtick after an identifier is a tagged template.
   const afterIdentifier =
-    IDENTIFIER_CHAR.test(prevChar) &&
+    IDENTIFIER_CHAR.test(precedingCodePoint(source, index)) &&
     !KEYWORD_BEFORE_LITERAL.test(source.slice(Math.max(0, index - 12), index));
   if ((char === '"' || char === "'") && !afterIdentifier) {
     state.inString = true;

--- a/apps/docs/components/pages/docs/preview-code-extract.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.ts
@@ -2,6 +2,11 @@ type StringState = { inString: boolean; stringChar: string };
 
 const IDENTIFIER_CHAR = /[\p{L}\p{N}_$]/u;
 
+// Keywords that may legally abut a string literal (return'x', case'x':, ...),
+// where the identifier-adjacency rule must not suppress the open.
+const KEYWORD_BEFORE_LITERAL =
+  /(?:^|[^\p{L}\p{N}_$])(?:return|case|typeof|in|of|do|else|void|throw|new|delete|instanceof|yield|await)$/u;
+
 // A lone quote in JSX prose has no partner, while the string literals these
 // samples contain are single-line, so an unpaired quote on its line is prose.
 function hasSameLineClose(
@@ -33,13 +38,17 @@ function updateStringState(
   // These scanners see JSX text as code, so a quote only opens a string when
   // the position plausibly is one. Formatting-dependent heuristics, not a
   // grammar: a quote straight after an identifier character is a contraction
-  // in prose (it's, café's) rather than the unspaced-but-valid \`return"x"\`,
-  // and a quote with no unescaped partner before the line ends is prose too.
-  // Backticks are excluded from both rules: a backtick after an identifier is
-  // a tagged template, and template literals span lines.
+  // in prose (it's, café's) unless the word it ends is a keyword that may
+  // abut a literal (return'x'), and a quote with no unescaped partner before
+  // the line ends is prose too. Backticks are excluded from both rules: a
+  // backtick after an identifier is a tagged template, and template literals
+  // span lines.
+  const afterIdentifier =
+    IDENTIFIER_CHAR.test(prevChar) &&
+    !KEYWORD_BEFORE_LITERAL.test(source.slice(Math.max(0, index - 12), index));
   if (
     (char === '"' || char === "'") &&
-    !IDENTIFIER_CHAR.test(prevChar) &&
+    !afterIdentifier &&
     hasSameLineClose(source, index, char)
   ) {
     state.inString = true;


### PR DESCRIPTION
Fixes #6544

## Problem

An apostrophe in bare JSX text (`<p>it's fine</p>`) makes every preview-code extraction path return `// Could not parse function`: the string opened by the apostrophe never closes, every later delimiter is swallowed, and the scan runs off the end of the file. Reproduced with the issue's exact snippets on all three paths. Not reachable from today's samples; the failure mode is silent at authoring time, which is what makes it worth closing.

## Root cause

`updateStringState` opens a string on any `'`, `"`, or backtick with no notion of JSX text.

## Change

#6544 records a fork: teach the character scanner enough JSX, or move the module to ts-morph. This PR is a scoped change that does not presume that decision — it ships one narrow scanner rule plus an enforced guard:

- **One rule**: a quote directly after an identifier code point (Unicode class, surrogate pairs joined) is a prose contraction (`it's`, `café's`) and does not open a string — unless the word it ends is a keyword that may legally abut a literal (`return'foo}'`), which stays in string state. Backticks are excluded (tagged templates). The close path is untouched.
- **The guard**: a sweep test walks every `<PreviewCode>` reference in `content/**/*.mdx` — all 61 pairs, including the 39 design specimens and subdirectory samples, in both flavors when a `.radix` variant exists — and asserts each extracts without a `// Could not` marker and without truncation (the text after the extracted region must begin a new top-level construct, so a phantom string that silently swallows a brace is caught too). The sweep also asserts every raw `<PreviewCode` occurrence parses into a pair, so a call site it cannot read fails the test instead of silently dropping out of coverage.

Prose quotes after whitespace (`the '90s`) deliberately stay at `main` parity: heuristics stacked against that class proved unsound under review (`the '90s {t('label')}`), so the guard — not a guess — is what keeps that class out of the docs, failing the moment an author introduces one.

## Verification

- Three repro tests (one per extraction path) fail on `main` with the issue's snippets and pass here.
- `return'foo}'` (valid keyword-adjacent literal containing `}`) extracts identically to `main`; the test fails without the keyword exemption.
- Guard tests: quotes after operators still open strings, apostrophes inside literals unaffected, tagged templates still scan as strings.
- The MDX sweep passes over all 61 current preview pairs.
- Full extractor suite: 22/22, including an astral-letter contraction regression that fails without the surrogate-pair fix.

## Public surface

None — `apps/docs` is private; no changeset owed.
