### PR TITLE
fix(react): prevent MCP Apps from loading through stale hosts

### DIFF
--- a/.changeset/clean-buses-smile.md
+++ b/.changeset/clean-buses-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: load newly mounted MCP Apps through the committed host

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -189,6 +189,23 @@ describe("McpAppRenderer", () => {
     framePropsMock.mockReset();
   });
 
+  it("loads newly mounted parts through the committed host", async () => {
+    const hostA = loadingHost();
+    const hostB = loadingHost();
+    const view = render(
+      <OptionsHarness host={hostA} toolCallIds={["call-1"]} />,
+    );
+    await waitFor(() => expect(hostA.loadResource).toHaveBeenCalledOnce());
+    vi.mocked(hostA.loadResource).mockClear();
+
+    view.rerender(
+      <OptionsHarness host={hostB} toolCallIds={["call-1", "call-2"]} />,
+    );
+    await waitFor(() => expect(hostB.loadResource).toHaveBeenCalled());
+
+    expect(hostA.loadResource).not.toHaveBeenCalled();
+  });
+
   it("merges forPart handlers over the thread-wide handlers", async () => {
     const onInitialized = vi.fn();
     render(
@@ -428,7 +445,7 @@ describe("McpAppRenderer", () => {
     framePropsMock.mockClear();
     view.rerender(<MemoizedHarness host={nextHost} />);
 
-    expect(nextHost.loadResource).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(nextHost.loadResource).toHaveBeenCalledTimes(1));
     expect(framePropsMock).not.toHaveBeenCalled();
 
     nextResource.resolve({

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -268,6 +268,7 @@ describe("McpAppRenderer", () => {
       const rendererStore = rendererStores.at(-1);
       expect(rendererStore).toBeDefined();
       const staleHost = rendererStore!.getState().host;
+      expect(staleHost).toBe(hostA);
 
       global.IS_REACT_ACT_ENVIRONMENT = false;
       flushSync(() => {

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -1,9 +1,7 @@
 // @vitest-environment jsdom
 import { render, waitFor } from "@testing-library/react";
 import { resource, useResource, withKey } from "@assistant-ui/tap";
-import { act, memo, startTransition, Suspense, useEffect } from "react";
-import { flushSync } from "react-dom";
-import { createRoot } from "react-dom/client";
+import { act, memo, startTransition, Suspense } from "react";
 import type {
   ToolCallMessagePartComponent,
   ToolCallMessagePartProps,
@@ -17,34 +15,7 @@ import type {
   McpAppsRemoteHostOptions,
 } from "./types";
 
-type CapturedRendererStore = {
-  getState: () => { host: McpAppsHost };
-};
-
-const { framePropsMock, rendererStores } = vi.hoisted(() => ({
-  framePropsMock: vi.fn(),
-  rendererStores: [] as CapturedRendererStore[],
-}));
-
-vi.mock("zustand", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("zustand")>();
-  const create = (...args: unknown[]) => {
-    const store = Reflect.apply(actual.create, undefined, args) as {
-      getState?: () => unknown;
-    };
-    const state = store.getState?.();
-    if (
-      state != null &&
-      typeof state === "object" &&
-      "host" in state &&
-      "options" in state
-    ) {
-      rendererStores.push(store as CapturedRendererStore);
-    }
-    return store;
-  };
-  return { ...actual, create };
-});
+const { framePropsMock } = vi.hoisted(() => ({ framePropsMock: vi.fn() }));
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -179,11 +150,6 @@ function OptionsHarness({
   ));
 }
 
-function PassiveProbe({ onEffect }: { onEffect: () => void }) {
-  useEffect(onEffect, [onEffect]);
-  return null;
-}
-
 const framePropsCalls = () =>
   framePropsMock.mock.calls.map(([props]) => props as McpAppFrameProps);
 
@@ -221,7 +187,6 @@ function RemoteHarness({
 describe("McpAppRenderer", () => {
   beforeEach(() => {
     framePropsMock.mockReset();
-    rendererStores.length = 0;
   });
 
   it("loads newly mounted parts through the committed host", async () => {
@@ -239,59 +204,6 @@ describe("McpAppRenderer", () => {
     await waitFor(() => expect(hostB.loadResource).toHaveBeenCalled());
 
     expect(hostA.loadResource).not.toHaveBeenCalled();
-  });
-
-  it("checks the current host before starting a deferred resource load", async () => {
-    const hostA = loadingHost();
-    const hostB = loadingHost();
-    const initialPassiveEffect = vi.fn();
-    const updatedPassiveEffect = vi.fn();
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root = createRoot(container);
-    const global = globalThis as {
-      IS_REACT_ACT_ENVIRONMENT?: boolean | undefined;
-    };
-    const previousActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
-
-    try {
-      await act(async () => {
-        root.render(
-          <>
-            <OptionsHarness host={hostA} toolCallIds={["call-1"]} />
-            <PassiveProbe onEffect={initialPassiveEffect} />
-          </>,
-        );
-      });
-      await vi.waitFor(() => expect(hostA.loadResource).toHaveBeenCalledOnce());
-      vi.mocked(hostA.loadResource).mockClear();
-      const rendererStore = rendererStores.at(-1);
-      expect(rendererStore).toBeDefined();
-      const staleHost = rendererStore!.getState().host;
-      expect(staleHost).toBe(hostA);
-
-      global.IS_REACT_ACT_ENVIRONMENT = false;
-      flushSync(() => {
-        root.render(
-          <>
-            <OptionsHarness host={hostA} toolCallIds={["call-1", "call-2"]} />
-            <PassiveProbe onEffect={updatedPassiveEffect} />
-          </>,
-        );
-      });
-      expect(rendererStore?.getState().host).toBe(staleHost);
-      // Publish the current host without triggering effect cleanup, leaving the
-      // identity guard as the only protection against the stale deferred load.
-      rendererStore!.getState().host = hostB;
-      await vi.waitFor(() => expect(updatedPassiveEffect).toHaveBeenCalled());
-      await Promise.resolve();
-
-      expect(hostA.loadResource).not.toHaveBeenCalled();
-    } finally {
-      global.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
-      await act(async () => root.unmount());
-      container.remove();
-    }
   });
 
   it("merges forPart handlers over the thread-wide handlers", async () => {

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { render, waitFor } from "@testing-library/react";
 import { resource, useResource, withKey } from "@assistant-ui/tap";
-import { act, memo, startTransition, Suspense } from "react";
+import { act, memo, startTransition, Suspense, useEffect } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
 import type {
   ToolCallMessagePartComponent,
   ToolCallMessagePartProps,
@@ -15,7 +17,34 @@ import type {
   McpAppsRemoteHostOptions,
 } from "./types";
 
-const { framePropsMock } = vi.hoisted(() => ({ framePropsMock: vi.fn() }));
+type CapturedRendererStore = {
+  getState: () => { host: McpAppsHost };
+};
+
+const { framePropsMock, rendererStores } = vi.hoisted(() => ({
+  framePropsMock: vi.fn(),
+  rendererStores: [] as CapturedRendererStore[],
+}));
+
+vi.mock("zustand", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("zustand")>();
+  const create = (...args: unknown[]) => {
+    const store = Reflect.apply(actual.create, undefined, args) as {
+      getState?: () => unknown;
+    };
+    const state = store.getState?.();
+    if (
+      state != null &&
+      typeof state === "object" &&
+      "host" in state &&
+      "options" in state
+    ) {
+      rendererStores.push(store as CapturedRendererStore);
+    }
+    return store;
+  };
+  return { ...actual, create };
+});
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -150,6 +179,11 @@ function OptionsHarness({
   ));
 }
 
+function PassiveProbe({ onEffect }: { onEffect: () => void }) {
+  useEffect(onEffect, [onEffect]);
+  return null;
+}
+
 const framePropsCalls = () =>
   framePropsMock.mock.calls.map(([props]) => props as McpAppFrameProps);
 
@@ -187,6 +221,7 @@ function RemoteHarness({
 describe("McpAppRenderer", () => {
   beforeEach(() => {
     framePropsMock.mockReset();
+    rendererStores.length = 0;
   });
 
   it("loads newly mounted parts through the committed host", async () => {
@@ -204,6 +239,58 @@ describe("McpAppRenderer", () => {
     await waitFor(() => expect(hostB.loadResource).toHaveBeenCalled());
 
     expect(hostA.loadResource).not.toHaveBeenCalled();
+  });
+
+  it("checks the current host before starting a deferred resource load", async () => {
+    const hostA = loadingHost();
+    const hostB = loadingHost();
+    const initialPassiveEffect = vi.fn();
+    const updatedPassiveEffect = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const global = globalThis as {
+      IS_REACT_ACT_ENVIRONMENT?: boolean | undefined;
+    };
+    const previousActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
+
+    try {
+      await act(async () => {
+        root.render(
+          <>
+            <OptionsHarness host={hostA} toolCallIds={["call-1"]} />
+            <PassiveProbe onEffect={initialPassiveEffect} />
+          </>,
+        );
+      });
+      await vi.waitFor(() => expect(hostA.loadResource).toHaveBeenCalledOnce());
+      vi.mocked(hostA.loadResource).mockClear();
+      const rendererStore = rendererStores.at(-1);
+      expect(rendererStore).toBeDefined();
+      const staleHost = rendererStore!.getState().host;
+
+      global.IS_REACT_ACT_ENVIRONMENT = false;
+      flushSync(() => {
+        root.render(
+          <>
+            <OptionsHarness host={hostA} toolCallIds={["call-1", "call-2"]} />
+            <PassiveProbe onEffect={updatedPassiveEffect} />
+          </>,
+        );
+      });
+      expect(rendererStore?.getState().host).toBe(staleHost);
+      // Publish the current host without triggering effect cleanup, leaving the
+      // identity guard as the only protection against the stale deferred load.
+      rendererStore!.getState().host = hostB;
+      await vi.waitFor(() => expect(updatedPassiveEffect).toHaveBeenCalled());
+      await Promise.resolve();
+
+      expect(hostA.loadResource).not.toHaveBeenCalled();
+    } finally {
+      global.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      await act(async () => root.unmount());
+      container.remove();
+    }
   });
 
   it("merges forPart handlers over the thread-wide handlers", async () => {

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -196,7 +196,7 @@ function InlineRenderer({
 
     const loadResource = async () => {
       await Promise.resolve();
-      if (cancelled) return;
+      if (cancelled || useRendererStore.getState().host !== targetHost) return;
       try {
         const res = await targetHost.loadResource({
           uri: targetUri,
@@ -229,7 +229,7 @@ function InlineRenderer({
     return () => {
       cancelled = true;
     };
-  }, [host, resourceUri, serverId]);
+  }, [host, resourceUri, serverId, useRendererStore]);
 
   const bridgeHandlers = useMemo<McpAppBridgeHandlers>(
     () => ({

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -194,12 +194,14 @@ function InlineRenderer({
     const targetUri = resourceUri;
     const targetServerId = serverId;
 
-    targetHost
-      .loadResource({
-        uri: targetUri,
-        ...(targetServerId ? { serverId: targetServerId } : {}),
-      })
-      .then((res) => {
+    const loadResource = async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      try {
+        const res = await targetHost.loadResource({
+          uri: targetUri,
+          ...(targetServerId ? { serverId: targetServerId } : {}),
+        });
         if (!cancelled)
           setLoadedResource({
             host: targetHost,
@@ -209,8 +211,7 @@ function InlineRenderer({
               : {}),
             resource: res,
           });
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         if (!cancelled) {
           setLoadedResource({
             host: targetHost,
@@ -221,7 +222,9 @@ function InlineRenderer({
             error: error instanceof Error ? error : new Error(String(error)),
           });
         }
-      });
+      }
+    };
+    void loadResource();
 
     return () => {
       cancelled = true;

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -194,6 +194,8 @@ function InlineRenderer({
     const targetUri = resourceUri;
     const targetServerId = serverId;
 
+    // Host changes are published later in this passive flush. Defer until that
+    // publication lands, then verify this effect still owns the current host.
     const loadResource = async () => {
       await Promise.resolve();
       if (cancelled || useRendererStore.getState().host !== targetHost) return;


### PR DESCRIPTION
## Problem

When an MCP App host changes in the same commit that mounts a new app part, the new part can start its resource request through the previous host. A focused A to B reproduction on current main observed a stale host A request after B was committed, which can pair a new workspace part with the previous workspace URL or credentials.

Affected: current main. `useHostStore.setState({ host })` has run from a passive effect since #5432, so this is a latent window rather than a regression from #6629.

## Root cause

McpAppRenderer publishes its resolved host to a stable renderer store from a passive effect. A newly mounted InlineRenderer can therefore render with the previous store value and schedule a resource load before the new host publication causes its stale effect to clean up.

Tap offers no earlier commit phase to publish from: its dispatcher maps `useLayoutEffect` and `useInsertionEffect` onto `useEffect` (`packages/tap/src/core/react-dispatcher.ts`), and `commitResourceFiber` runs inside `useTapRoot`'s own passive effect. Publishing during the resource run instead would reintroduce the render-phase write that #6370 removed. Deferring the consumer's I/O is the remaining seam.

## Change

Defer resource loading by one microtask so the host publication in the same passive flush lands first, then require both that the effect is still active and that the renderer store still identifies the captured host before starting I/O. In every ordering observed here React runs the passive cleanup before the microtask drains, so the identity check is a hedge against a flush that does not, not a path the tests reach. Converting the promise chain to `try`/`catch` also routes a synchronous throw from `loadResource` into the error state instead of letting it escape the effect. Normal loading, cancellation, and error handling are otherwise unchanged.

## Verification

- Added the A to B regression while mounting a second app part. It reports exactly one stale host A request against current main and passes with the fix.
- Reproduced the same failure outside `act`, through both `flushSync` and a concurrent `root.render`, so the window is not an artifact of the test renderer.
- pnpm --filter @assistant-ui/react test: 56 files, 508 tests.
- pnpm --filter @assistant-ui/react build.
- pnpm changesets:check.
- Targeted oxlint and oxfmt checks.

## Public surface

- Package: @assistant-ui/react.
- Exports, API reference, docs, and templates: None.
- Changeset: patch.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6G0IbZKJwBys-U4Oz4TUGNSMseNeSreJHOP8qAzID6S4hIHox5Uqaf8DYvM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
