### PR TITLE
fix(cli): restrict import reconciliation to module declarations

### DIFF
--- a/.changeset/fair-beans-smile.md
+++ b/.changeset/fair-beans-smile.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: restrict component import reconciliation to module declarations

--- a/packages/cli/src/lib/create-project.test.ts
+++ b/packages/cli/src/lib/create-project.test.ts
@@ -41,6 +41,27 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
+  it("rewrites module declarations without changing import-like source text", () => {
+    write(
+      "app/page.tsx",
+      'import { Thread } from "@/components/assistant-ui/thread";\n' +
+        'export { ThreadList } from "@/components/assistant-ui/thread-list";\n' +
+        "const example = 'from \"@/components/assistant-ui/thread\"';\n" +
+        '// from "@/components/assistant-ui/thread-list"\n',
+    );
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+    write("components/assistant-ui/elements/thread-list.aui.tsx", "export {};");
+
+    reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/page.tsx")).toBe(
+      'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n' +
+        'export { ThreadList } from "@/components/assistant-ui/elements/thread-list.aui";\n' +
+        "const example = 'from \"@/components/assistant-ui/thread\"';\n" +
+        '// from "@/components/assistant-ui/thread-list"\n',
+    );
+  });
+
   it("rewrites a legacy import to a bare elements file without the .aui segment", () => {
     write(
       "app/MyThread.tsx",

--- a/packages/cli/src/lib/create-project.test.ts
+++ b/packages/cli/src/lib/create-project.test.ts
@@ -24,7 +24,7 @@ describe("reconcileAssistantUIImportLayout", () => {
   const read = (file: string) =>
     fs.readFileSync(path.join(projectDir, file), "utf8");
 
-  it("rewrites a legacy import when only the elements layout exists", () => {
+  it("rewrites a legacy import when only the elements layout exists", async () => {
     write(
       "app/page.tsx",
       'import { Thread } from "@/components/assistant-ui/thread";\n' +
@@ -33,7 +33,7 @@ describe("reconcileAssistantUIImportLayout", () => {
     write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
     write("components/assistant-ui/elements/thread-list.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(
       'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n' +
@@ -41,7 +41,7 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
-  it("rewrites module declarations without changing import-like source text", () => {
+  it("rewrites module declarations without changing import-like source text", async () => {
     write(
       "app/page.tsx",
       'import { Thread } from "@/components/assistant-ui/thread";\n' +
@@ -52,7 +52,7 @@ describe("reconcileAssistantUIImportLayout", () => {
     write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
     write("components/assistant-ui/elements/thread-list.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(
       'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n' +
@@ -62,7 +62,7 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
-  it("rewrites a legacy import to a bare elements file without the .aui segment", () => {
+  it("rewrites a legacy import to a bare elements file without the .aui segment", async () => {
     write(
       "app/MyThread.tsx",
       'import { MarkdownText } from "@/components/assistant-ui/markdown-text";\n' +
@@ -74,7 +74,7 @@ describe("reconcileAssistantUIImportLayout", () => {
       "export {};",
     );
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/MyThread.tsx")).toBe(
       'import { MarkdownText } from "@/components/assistant-ui/elements/markdown-text";\n' +
@@ -82,7 +82,7 @@ describe("reconcileAssistantUIImportLayout", () => {
     );
   });
 
-  it("prefers the .aui variant when both variants share a basename", () => {
+  it("prefers the .aui variant when both variants share a basename", async () => {
     write(
       "app/page.tsx",
       'import { Reasoning } from "@/components/assistant-ui/reasoning";\n',
@@ -90,58 +90,86 @@ describe("reconcileAssistantUIImportLayout", () => {
     write("components/assistant-ui/elements/reasoning.tsx", "export {};");
     write("components/assistant-ui/elements/reasoning.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(
       'import { Reasoning } from "@/components/assistant-ui/elements/reasoning.aui";\n',
     );
   });
 
-  it("supports the src/ project layout", () => {
+  it("supports the src/ project layout", async () => {
     write(
       "src/routes/index.tsx",
       'import { Thread } from "@/components/assistant-ui/thread";\n',
     );
     write("src/components/assistant-ui/elements/thread.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("src/routes/index.tsx")).toBe(
       'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n',
     );
   });
 
-  it("leaves imports alone when the legacy file exists", () => {
+  it("leaves imports alone when the legacy file exists", async () => {
     const source =
       'import { Thread } from "@/components/assistant-ui/thread";\n';
     write("app/page.tsx", source);
     write("components/assistant-ui/thread.tsx", "export {};");
     write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(source);
   });
 
-  it("leaves imports alone when neither layout has the file", () => {
+  it("leaves imports alone when neither layout has the file", async () => {
     const source =
       'import { Custom } from "@/components/assistant-ui/custom-part";\n';
     write("app/page.tsx", source);
     write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(source);
   });
 
-  it("leaves elements imports untouched", () => {
+  it("leaves elements imports untouched", async () => {
     const source =
       'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n';
     write("app/page.tsx", source);
     write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
 
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
 
     expect(read("app/page.tsx")).toBe(source);
+  });
+
+  it("parses TypeScript files with generic arrow functions", async () => {
+    write(
+      "app/helpers.ts",
+      'import { Thread } from "@/components/assistant-ui/thread";\n' +
+        "export const identity = <T>(value: T) => value;\n",
+    );
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    await reconcileAssistantUIImportLayout(projectDir);
+
+    expect(read("app/helpers.ts")).toBe(
+      'import { Thread } from "@/components/assistant-ui/elements/thread.aui";\n' +
+        "export const identity = <T>(value: T) => value;\n",
+    );
+  });
+
+  it("leaves unparseable source files untouched", async () => {
+    const source =
+      'import { Thread } from "@/components/assistant-ui/thread";\nconst broken = ;\n';
+    write("app/broken.ts", source);
+    write("components/assistant-ui/elements/thread.aui.tsx", "export {};");
+
+    await expect(
+      reconcileAssistantUIImportLayout(projectDir),
+    ).resolves.toBeUndefined();
+    expect(read("app/broken.ts")).toBe(source);
   });
 });

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { downloadTemplate } from "giget";
+import jscodeshift from "jscodeshift";
 import {
   parse as parseJsonc,
   printParseErrorCode,
@@ -50,6 +51,8 @@ const LOCAL_PROJECT_ARTIFACT_DIRS: readonly string[] = [
 const LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES = LOCAL_PROJECT_ARTIFACT_DIRS.map(
   (dir) => `**/${dir}/**`,
 );
+
+const j = jscodeshift.withParser("tsx");
 
 export function resolvePackageManager(opts: {
   useNpm?: boolean;
@@ -474,17 +477,60 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
     cwd: projectDir,
     ignore: LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES,
   })) {
-    const next = content.replace(
-      /(from\s+["'])@\/components\/assistant-ui\/([^"'/]+)(["'])/g,
-      (match, prefix, specifier, suffix) => {
-        const name = stripImportExtension(specifier);
-        const installed = installedByName.get(name);
-        if (resolvesAtLegacyPath(name) || installed === undefined) {
-          return match;
-        }
-        return `${prefix}@/components/assistant-ui/${installed}${suffix}`;
-      },
-    );
+    if (!content.includes("@/components/assistant-ui/")) continue;
+
+    const replacements: Array<{ start: number; end: number; value: string }> =
+      [];
+    const collectReplacement = (source: {
+      value?: unknown;
+      start?: number | null;
+      end?: number | null;
+    }) => {
+      if (
+        typeof source.value !== "string" ||
+        source.start == null ||
+        source.end == null
+      ) {
+        return;
+      }
+
+      const prefix = "@/components/assistant-ui/";
+      if (!source.value.startsWith(prefix)) return;
+      const specifier = source.value.slice(prefix.length);
+      if (specifier.includes("/")) return;
+
+      const name = stripImportExtension(specifier);
+      const installed = installedByName.get(name);
+      if (resolvesAtLegacyPath(name) || installed === undefined) return;
+
+      const raw = content.slice(source.start, source.end);
+      const quote = raw[0];
+      if ((quote !== '"' && quote !== "'") || raw.at(-1) !== quote) return;
+      replacements.push({
+        start: source.start,
+        end: source.end,
+        value: `${quote}@/components/assistant-ui/${installed}${quote}`,
+      });
+    };
+
+    const root = j(content);
+    root
+      .find(j.ImportDeclaration)
+      .forEach(({ node }) => collectReplacement(node.source));
+    root
+      .find(j.ExportNamedDeclaration)
+      .forEach(({ node }) => node.source && collectReplacement(node.source));
+    root
+      .find(j.ExportAllDeclaration)
+      .forEach(({ node }) => collectReplacement(node.source));
+
+    let next = content;
+    for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+      next =
+        next.slice(0, replacement.start) +
+        replacement.value +
+        next.slice(replacement.end);
+    }
     if (next !== content) fs.writeFileSync(fullPath, next);
   }
 }

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { downloadTemplate } from "giget";
-import jscodeshift from "jscodeshift";
 import {
   parse as parseJsonc,
   printParseErrorCode,
@@ -51,8 +50,6 @@ const LOCAL_PROJECT_ARTIFACT_DIRS: readonly string[] = [
 const LOCAL_PROJECT_ARTIFACT_GLOB_IGNORES = LOCAL_PROJECT_ARTIFACT_DIRS.map(
   (dir) => `**/${dir}/**`,
 );
-
-const j = jscodeshift.withParser("tsx");
 
 export function resolvePackageManager(opts: {
   useNpm?: boolean;
@@ -236,7 +233,7 @@ export async function transformProject(
       pm,
     );
     if (failure) return { registryInstallFailure: failure };
-    reconcileAssistantUIImportLayout(projectDir);
+    await reconcileAssistantUIImportLayout(projectDir);
   }
   return {};
 }
@@ -435,7 +432,9 @@ function toAssistantUIItem(specifier: string): string | null {
  * specifier against the files the registry actually installed and rewrite it
  * only when the legacy path is absent and the elements layout has it.
  */
-export function reconcileAssistantUIImportLayout(projectDir: string): void {
+export async function reconcileAssistantUIImportLayout(
+  projectDir: string,
+): Promise<void> {
   const componentRoots = ["components", "src/components"]
     .map((dir) => path.join(projectDir, dir, "assistant-ui"))
     .filter((dir) => fs.existsSync(dir));
@@ -472,6 +471,12 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
     }
   }
   if (installedByName.size === 0) return;
+
+  const { default: jscodeshift } = await import("jscodeshift");
+  const parsers = {
+    ts: jscodeshift.withParser("ts"),
+    tsx: jscodeshift.withParser("tsx"),
+  };
 
   for (const { fullPath, content } of readProjectFiles("**/*.{ts,tsx}", {
     cwd: projectDir,
@@ -513,7 +518,13 @@ export function reconcileAssistantUIImportLayout(projectDir: string): void {
       });
     };
 
-    const root = j(content);
+    const j = fullPath.endsWith(".tsx") ? parsers.tsx : parsers.ts;
+    let root;
+    try {
+      root = j(content);
+    } catch {
+      continue;
+    }
     root
       .find(j.ImportDeclaration)
       .forEach(({ node }) => collectReplacement(node.source));


### PR DESCRIPTION
## Problem

The component import reconciliation added in #6627 matched import-like text anywhere in TypeScript source. On current main it rewrote ordinary string literals and comments containing from "@/components/assistant-ui/...", silently changing user-authored code that was not a module declaration.

## Root cause

The reconciler used a text regular expression without TypeScript syntax awareness, so comments and ordinary expressions were indistinguishable from static import and re-export source literals.

## Change

Load jscodeshift lazily only after a candidate installed layout is found. Parse .ts and .tsx files with their matching parsers, collect source ranges only from static import and re-export declarations, and apply replacements in descending order so unrelated bytes remain unchanged. Files that cannot be parsed are left untouched instead of aborting project creation after installation work has started.

## Verification

- Added coverage for imports, re-exports, comments, ordinary strings, valid TypeScript generic arrows, and malformed files.
- pnpm --filter assistant-ui test: 27 files, 315 tests.
- pnpm --filter assistant-ui build.
- pnpm changesets:check.
- Targeted oxlint and oxfmt checks.

## Public surface

- Package: assistant-ui CLI.
- Exports, API reference, docs, and templates: None.
- Changeset: patch.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BR-l6sTd3K4U4guApVVHINNZhfNKpX8lB-uCCWp_vxp9-pieAj4AozA0d0Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->