### PR TITLE
fix(react-ink): preserve CRLF text boundaries

### DIFF
--- a/.changeset/tidy-years-juggle.md
+++ b/.changeset/tidy-years-juggle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: keep CRLF line endings intact during text input editing

--- a/packages/react-ink/src/primitives/textInput/TextInput.tsx
+++ b/packages/react-ink/src/primitives/textInput/TextInput.tsx
@@ -215,7 +215,7 @@ export const TextInput = ({
   const isShowingPlaceholder = !hasText && placeholder.length > 0;
   const before = hasText ? text.slice(0, cursorOffset) : "";
   const charAtCursor = hasText ? getGraphemeAt(text, cursorOffset) : "";
-  const isOnNewline = charAtCursor === "\n";
+  const isOnNewline = charAtCursor === "\n" || charAtCursor === "\r\n";
   // render a space when on a newline so the inverse cursor cell stays visible
   const atCursor = charAtCursor === "" || isOnNewline ? " " : charAtCursor;
   const after = hasText

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -82,7 +82,7 @@ const getLineStart = (text: string, cursorOffset: number) => {
 const getLineEnd = (text: string, cursorOffset: number) => {
   const lineBreakIndex = text.indexOf("\n", cursorOffset);
   if (lineBreakIndex === -1) return text.length;
-  return lineBreakIndex > 0 && text[lineBreakIndex - 1] === "\r"
+  return lineBreakIndex > cursorOffset && text[lineBreakIndex - 1] === "\r"
     ? lineBreakIndex - 1
     : lineBreakIndex;
 };

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -81,7 +81,15 @@ const getLineStart = (text: string, cursorOffset: number) => {
 
 const getLineEnd = (text: string, cursorOffset: number) => {
   const lineBreakIndex = text.indexOf("\n", cursorOffset);
-  return lineBreakIndex === -1 ? text.length : lineBreakIndex;
+  if (lineBreakIndex === -1) return text.length;
+  return lineBreakIndex > 0 && text[lineBreakIndex - 1] === "\r"
+    ? lineBreakIndex - 1
+    : lineBreakIndex;
+};
+
+const getLineBreakEnd = (text: string, lineEnd: number) => {
+  if (text.startsWith("\r\n", lineEnd)) return lineEnd + 2;
+  return lineEnd < text.length ? lineEnd + 1 : lineEnd;
 };
 
 const getLineRange = (text: string, cursorOffset: number) => {
@@ -123,7 +131,9 @@ const moveVertical = (
   }
 
   const adjacentCursorBase =
-    direction === -1 ? adjacentBreakIndex : adjacentBreakIndex + 1;
+    direction === -1
+      ? adjacentBreakIndex
+      : getLineBreakEnd(text, adjacentBreakIndex);
   const adjacentRange = getLineRange(text, adjacentCursorBase);
   const nextCursorOffset = clamp(
     adjacentRange.start + currentColumn,
@@ -293,7 +303,7 @@ export const textBufferReducer = (
         action.multiLine &&
         lineEnd === state.cursorOffset &&
         lineEnd < state.text.length
-          ? lineEnd + 1
+          ? getLineBreakEnd(state.text, lineEnd)
           : lineEnd;
       if (rangeEnd === state.cursorOffset) return state;
 

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -92,6 +92,9 @@ const getLineBreakEnd = (text: string, lineEnd: number) => {
   return lineEnd < text.length ? lineEnd + 1 : lineEnd;
 };
 
+const getLineBreakStart = (text: string, lineBreakIndex: number) =>
+  text[lineBreakIndex - 1] === "\r" ? lineBreakIndex - 1 : lineBreakIndex;
+
 const getLineRange = (text: string, cursorOffset: number) => {
   const start = getLineStart(text, cursorOffset);
   const end = getLineEnd(text, cursorOffset);
@@ -132,7 +135,7 @@ const moveVertical = (
 
   const adjacentCursorBase =
     direction === -1
-      ? adjacentBreakIndex
+      ? getLineBreakStart(text, adjacentBreakIndex)
       : getLineBreakEnd(text, adjacentBreakIndex);
   const adjacentRange = getLineRange(text, adjacentCursorBase);
   const nextCursorOffset = clamp(

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -169,6 +169,18 @@ const clearPreferredColumn = (
   preferredColumn: undefined,
 });
 
+const clearPreferredColumnAtGraphemeBoundary = (
+  state: TextBufferState,
+  cursorOffset: number,
+  direction: "backward" | "forward",
+) =>
+  clearPreferredColumn(
+    state,
+    direction === "backward"
+      ? snapToGraphemeBoundary(state.text, cursorOffset)
+      : snapToNextGraphemeBoundary(state.text, cursorOffset),
+  );
+
 export const textBufferReducer = (
   state: TextBufferState,
   action: TextBufferAction,
@@ -181,13 +193,10 @@ export const textBufferReducer = (
         state.text.slice(0, state.cursorOffset) +
         action.text +
         state.text.slice(state.cursorOffset);
-      const nextCursorOffset = snapToNextGraphemeBoundary(
-        nextText,
-        state.cursorOffset + action.text.length,
-      );
-      return clearPreferredColumn(
+      return clearPreferredColumnAtGraphemeBoundary(
         { ...state, text: nextText },
-        nextCursorOffset,
+        state.cursorOffset + action.text.length,
+        "forward",
       );
     }
 
@@ -198,7 +207,11 @@ export const textBufferReducer = (
       const nextText =
         state.text.slice(0, previousOffset) +
         state.text.slice(state.cursorOffset);
-      return clearPreferredColumn({ ...state, text: nextText }, previousOffset);
+      return clearPreferredColumnAtGraphemeBoundary(
+        { ...state, text: nextText },
+        previousOffset,
+        "backward",
+      );
     }
 
     case "delete-forward": {
@@ -207,9 +220,10 @@ export const textBufferReducer = (
       const nextOffset = stepGraphemeRight(state.text, state.cursorOffset);
       const nextText =
         state.text.slice(0, state.cursorOffset) + state.text.slice(nextOffset);
-      return clearPreferredColumn(
+      return clearPreferredColumnAtGraphemeBoundary(
         { ...state, text: nextText },
         state.cursorOffset,
+        "forward",
       );
     }
 
@@ -281,9 +295,10 @@ export const textBufferReducer = (
       const nextText =
         state.text.slice(0, nextCursorOffset) +
         state.text.slice(state.cursorOffset);
-      return clearPreferredColumn(
+      return clearPreferredColumnAtGraphemeBoundary(
         { ...state, text: nextText },
         nextCursorOffset,
+        "backward",
       );
     }
 
@@ -293,9 +308,10 @@ export const textBufferReducer = (
 
       const nextText =
         state.text.slice(0, state.cursorOffset) + state.text.slice(nextOffset);
-      return clearPreferredColumn(
+      return clearPreferredColumnAtGraphemeBoundary(
         { ...state, text: nextText },
         state.cursorOffset,
+        "forward",
       );
     }
 
@@ -325,9 +341,10 @@ export const textBufferReducer = (
 
       const nextText =
         state.text.slice(0, state.cursorOffset) + state.text.slice(rangeEnd);
-      return clearPreferredColumn(
+      return clearPreferredColumnAtGraphemeBoundary(
         { ...state, text: nextText },
         state.cursorOffset,
+        "forward",
       );
     }
 

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -55,6 +55,16 @@ const snapToGraphemeBoundary = (text: string, offset: number) => {
   return previous;
 };
 
+const snapToNextGraphemeBoundary = (text: string, offset: number) => {
+  if (offset <= 0) return 0;
+  if (offset >= text.length) return text.length;
+  for (const { index, segment } of graphemeSegmenter.segment(text)) {
+    const end = index + segment.length;
+    if (offset <= end) return end;
+  }
+  return text.length;
+};
+
 const stepGraphemeRight = (text: string, offset: number) => {
   if (offset >= text.length) return text.length;
   for (const { index, segment } of graphemeSegmenter.segment(text)) {
@@ -171,7 +181,10 @@ export const textBufferReducer = (
         state.text.slice(0, state.cursorOffset) +
         action.text +
         state.text.slice(state.cursorOffset);
-      const nextCursorOffset = state.cursorOffset + action.text.length;
+      const nextCursorOffset = snapToNextGraphemeBoundary(
+        nextText,
+        state.cursorOffset + action.text.length,
+      );
       return clearPreferredColumn(
         { ...state, text: nextText },
         nextCursorOffset,

--- a/packages/react-ink/src/tests/TextInput.test.tsx
+++ b/packages/react-ink/src/tests/TextInput.test.tsx
@@ -177,6 +177,19 @@ describe("TextInput", () => {
     expect(onChange).toHaveBeenLastCalledWith("foo\nbar");
   });
 
+  it("keeps CRLF intact when editing at the end of a line", async () => {
+    const onChange = vi.fn();
+    render(<Controlled initial={"a\r\nb"} multiLine onChange={onChange} />);
+    await flush();
+
+    inputHandler?.("", { home: true });
+    inputHandler?.("", { upArrow: true });
+    inputHandler?.("", { end: true });
+    inputHandler?.("x", {});
+
+    expect(onChange).toHaveBeenLastCalledWith("ax\r\nb");
+  });
+
   it("shows the placeholder only while empty", async () => {
     const onChange = vi.fn();
     const { rerender, lastFrame } = render(

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -170,6 +170,83 @@ describe("textBufferReducer", () => {
     expect(killed.cursorOffset).toBe(3);
   });
 
+  it.each([
+    {
+      name: "deleting backward",
+      text: "a\rx\nb",
+      cursorOffset: 3,
+      action: { type: "delete-backward" },
+      expectedText: "a\r\nb",
+      expectedCursorOffset: 1,
+      expectedInsertedText: "ax\r\nb",
+    },
+    {
+      name: "deleting forward",
+      text: "a\rx\nb",
+      cursorOffset: 2,
+      action: { type: "delete-forward" },
+      expectedText: "a\r\nb",
+      expectedCursorOffset: 3,
+      expectedInsertedText: "a\r\nxb",
+    },
+    {
+      name: "killing a word backward",
+      text: "a\rword\nb",
+      cursorOffset: 6,
+      action: { type: "kill-word-backward" },
+      expectedText: "a\r\nb",
+      expectedCursorOffset: 1,
+      expectedInsertedText: "ax\r\nb",
+    },
+    {
+      name: "killing a word forward",
+      text: "a\rword\nb",
+      cursorOffset: 2,
+      action: { type: "kill-word-forward" },
+      expectedText: "a\r\nb",
+      expectedCursorOffset: 3,
+      expectedInsertedText: "a\r\nxb",
+    },
+    {
+      name: "killing to the line end",
+      text: "a\rb\nc",
+      cursorOffset: 2,
+      action: { type: "kill-end", multiLine: true },
+      expectedText: "a\r\nc",
+      expectedCursorOffset: 3,
+      expectedInsertedText: "a\r\nxc",
+    },
+  ] satisfies Array<{
+    name: string;
+    text: string;
+    cursorOffset: number;
+    action: TextBufferAction;
+    expectedText: string;
+    expectedCursorOffset: number;
+    expectedInsertedText: string;
+  }>)(
+    "keeps the cursor outside a CRLF formed by $name",
+    ({
+      text,
+      cursorOffset,
+      action,
+      expectedText,
+      expectedCursorOffset,
+      expectedInsertedText,
+    }) => {
+      const state = reduce(
+        createTextBufferState(text),
+        { type: "set-cursor", cursorOffset },
+        action,
+      );
+      const inserted = reduce(state, { type: "insert", text: "x" });
+
+      expect(state.text).toBe(expectedText);
+      expect(state.cursorOffset).toBe(expectedCursorOffset);
+      expect(inserted.text).toBe(expectedInsertedText);
+    },
+  );
+
   it("kills to line boundaries in multi-line mode", () => {
     const killStart = reduce(
       createTextBufferState("one\ntwo\nthree"),

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -145,6 +145,18 @@ describe("textBufferReducer", () => {
     expect(state.cursorOffset).toBe(3);
   });
 
+  it("does not move backward when killing between CRLF characters", () => {
+    const state = reduce(
+      createTextBufferState("a\nb"),
+      { type: "set-cursor", cursorOffset: 1 },
+      { type: "insert", text: "\r" },
+      { type: "kill-end", multiLine: true },
+    );
+
+    expect(state.text).toBe("a\rb");
+    expect(state.cursorOffset).toBe(2);
+  });
+
   it("kills to line boundaries in multi-line mode", () => {
     const killStart = reduce(
       createTextBufferState("one\ntwo\nthree"),

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -92,6 +92,17 @@ describe("textBufferReducer", () => {
     expect(movedUp.cursorOffset).toBe(1);
   });
 
+  it("clamps upward movement before a CRLF line ending", () => {
+    const moved = reduce(
+      createTextBufferState("abcde\r\nfghijk"),
+      { type: "move-up" },
+      { type: "insert", text: "x" },
+    );
+
+    expect(moved.text).toBe("abcdex\r\nfghijk");
+    expect(moved.cursorOffset).toBe(6);
+  });
+
   it("preserves preferred column when moving vertically", () => {
     const movedUp = reduce(
       createTextBufferState("abcde\nxy\n123456"),

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -156,16 +156,18 @@ describe("textBufferReducer", () => {
     expect(state.cursorOffset).toBe(3);
   });
 
-  it("does not move backward when killing between CRLF characters", () => {
+  it("keeps the cursor outside CRLF when insertion creates the boundary", () => {
     const state = reduce(
       createTextBufferState("a\nb"),
       { type: "set-cursor", cursorOffset: 1 },
       { type: "insert", text: "\r" },
-      { type: "kill-end", multiLine: true },
     );
+    const killed = reduce(state, { type: "kill-end", multiLine: true });
 
-    expect(state.text).toBe("a\rb");
-    expect(state.cursorOffset).toBe(2);
+    expect(state.text).toBe("a\r\nb");
+    expect(state.cursorOffset).toBe(3);
+    expect(killed.text).toBe("a\r\n");
+    expect(killed.cursorOffset).toBe(3);
   });
 
   it("kills to line boundaries in multi-line mode", () => {

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -68,6 +68,30 @@ describe("textBufferReducer", () => {
     expect(end.cursorOffset).toBe(7);
   });
 
+  it("keeps CRLF intact when inserting at the end of a line", () => {
+    const state = reduce(
+      createTextBufferState("a\r\nb"),
+      { type: "set-cursor", cursorOffset: 0 },
+      { type: "move-end", multiLine: true },
+      { type: "insert", text: "x" },
+    );
+
+    expect(state.text).toBe("ax\r\nb");
+    expect(state.cursorOffset).toBe(2);
+  });
+
+  it("moves vertically across CRLF line endings", () => {
+    const movedDown = reduce(
+      createTextBufferState("ab\r\ncd"),
+      { type: "set-cursor", cursorOffset: 1 },
+      { type: "move-down" },
+    );
+    const movedUp = reduce(movedDown, { type: "move-up" });
+
+    expect(movedDown.cursorOffset).toBe(5);
+    expect(movedUp.cursorOffset).toBe(1);
+  });
+
   it("preserves preferred column when moving vertically", () => {
     const movedUp = reduce(
       createTextBufferState("abcde\nxy\n123456"),
@@ -107,6 +131,17 @@ describe("textBufferReducer", () => {
     );
 
     expect(state.text).toBe("onetwo\nthree");
+    expect(state.cursorOffset).toBe(3);
+  });
+
+  it("removes the entire CRLF when killing forward at end-of-line", () => {
+    const state = reduce(
+      createTextBufferState("one\r\ntwo"),
+      { type: "set-cursor", cursorOffset: 3 },
+      { type: "kill-end", multiLine: true },
+    );
+
+    expect(state.text).toBe("onetwo");
     expect(state.cursorOffset).toBe(3);
   });
 


### PR DESCRIPTION
## Problem

React Ink could place the cursor between the two code units of a CRLF line ending. End, vertical movement, insertion, Ctrl+K, and splice-based deletions could then split the delimiter, turning a controlled or pasted CRLF value into stray carriage-return or line-feed characters.

Affected: current main.

## Root cause

The text buffer treated only the line-feed byte as the line boundary. It also computed mutation cursors against the old text, so deleting content between a lone carriage return and a later line feed could form a new CRLF with the cursor left inside it.

## Change

Model both the start and end of CRLF for line navigation and deletion, and render CRLF as one cursor grapheme. After insertion or a splice that can join text, snap the resulting cursor against the new text in the operation's natural direction: backward for backward deletion and forward for insertion, forward deletion, and forward kills. If inserting a carriage return immediately before an existing line feed forms CRLF, the cursor advances past that logical newline instead of remaining inside it.

## Verification

- Added reducer coverage for End plus insert, unequal-width vertical movement, Ctrl+K, insertion-created CRLF, and all five splice-join paths.
- Added a real TextInput interaction that navigates to a CRLF boundary and inserts without splitting it.
- pnpm --filter @assistant-ui/react-ink test: 26 files, 267 tests.
- pnpm --filter @assistant-ui/react-ink build.
- pnpm changesets:check.
- Targeted oxlint and oxfmt checks.

## Public surface

- Package: @assistant-ui/react-ink.
- Exports, API reference, docs, and templates: None.
- Changeset: patch.