### PR TITLE
chore(ui): stop teaching the deprecated Suggestion props

### DIFF
--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -277,8 +277,7 @@ function FollowUps() {
           <ThreadPrimitive.Suggestion
             key={i}
             prompt={s.prompt}
-            method="replace"
-            autoSend
+            send
           >
             {s.title ?? s.prompt}
             {s.label && (

--- a/apps/docs/content/docs/guides/suggestions.mdx
+++ b/apps/docs/content/docs/guides/suggestions.mdx
@@ -274,11 +274,7 @@ function FollowUps() {
     <AuiIf condition={(s) => !s.thread.isEmpty && !s.thread.isRunning}>
       <div className="flex gap-2">
         {suggestions.map((s, i) => (
-          <ThreadPrimitive.Suggestion
-            key={i}
-            prompt={s.prompt}
-            send
-          >
+          <ThreadPrimitive.Suggestion key={i} prompt={s.prompt} send>
             {s.title ?? s.prompt}
             {s.label && (
               <span className="text-muted-foreground ms-1">{s.label}</span>

--- a/apps/docs/content/elements/follow-up-suggestions.mdx
+++ b/apps/docs/content/elements/follow-up-suggestions.mdx
@@ -100,7 +100,7 @@ The first chip reads "Weather" with "in SF" trailing it, but sends the full weat
 
 ### How a suggestion sends
 
-Each chip uses `ThreadPrimitive.Suggestion` with `method="replace"` and `autoSend`, so clicking one replaces whatever's in the composer with the suggestion's prompt and sends it immediately, with no confirmation step.
+Each chip uses `ThreadPrimitive.Suggestion` with `send`, so clicking one sends the suggestion's prompt immediately and clears the composer, with no confirmation step.
 
 </RuntimeMode>
 
@@ -122,7 +122,7 @@ Each chip uses `ThreadPrimitive.Suggestion` with `method="replace"` and `autoSen
 
 | Part | Notes |
 |------|-------|
-| `ThreadPrimitive.Suggestion` | One chip. Takes `prompt`, `method`, and `autoSend`. |
+| `ThreadPrimitive.Suggestion` | One chip. Takes `prompt` and `send`. |
 
 </RuntimeMode>
 

--- a/packages/ui/src/components/react/assistant-ui/elements/follow-up-suggestions.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/follow-up-suggestions.aui.test.tsx
@@ -28,20 +28,17 @@ vi.mock("@assistant-ui/react", async (importOriginal) => ({
   ThreadPrimitive: {
     Suggestion: ({
       prompt,
-      method,
-      autoSend,
+      send,
       children,
     }: {
       prompt: string;
-      method: string;
-      autoSend: boolean;
+      send: boolean;
       children: ReactNode;
     }) => (
       <button
         data-testid="suggestion"
         data-prompt={prompt}
-        data-method={method}
-        data-autosend={String(autoSend)}
+        data-send={String(send)}
       >
         {children}
       </button>
@@ -80,8 +77,7 @@ describe("ThreadFollowupSuggestions", () => {
     expect(rich?.getAttribute("data-prompt")).toBe(
       "What is the weather in San Francisco today?",
     );
-    expect(rich?.getAttribute("data-method")).toBe("replace");
-    expect(rich?.getAttribute("data-autosend")).toBe("true");
+    expect(rich?.getAttribute("data-send")).toBe("true");
     expect(
       rich?.querySelector(".aui-thread-followup-suggestion-label")?.textContent,
     ).toBe("in SF");

--- a/packages/ui/src/components/react/assistant-ui/elements/follow-up-suggestions.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/follow-up-suggestions.aui.tsx
@@ -54,8 +54,7 @@ const FollowupSuggestionsRow: FC = () => {
             key={idx}
             className="aui-thread-followup-suggestion bg-background hover:bg-muted/80 rounded-full border px-3 py-1 text-sm whitespace-nowrap transition-colors ease-in"
             prompt={suggestion.prompt}
-            method="replace"
-            autoSend
+            send
           >
             {suggestion.title ?? suggestion.prompt}
             {suggestion.label && (


### PR DESCRIPTION
## Problem

The shadcn kit's `ThreadFollowupSuggestions` component still passes the deprecated `method="replace"`/`autoSend` props to `ThreadPrimitive.Suggestion`, and the suggestions guide teaches the same deprecated form. Since the kit is the canonical source copied into user projects via the registry, every new install propagates the deprecated API.

## Change

Replace `method="replace" autoSend` with the current `send` prop. Behavior is identical: `send` resolves the same as `autoSend` did (`send ?? autoSend ?? false` in `useThreadSuggestion`), `method` was already ignored by the hook, and `clearComposer` defaults to `true`. The colocated test's mock and assertions now reflect the new props, and the two docs pages that teach/describe this pattern (`guides/suggestions.mdx`, `elements/follow-up-suggestions.mdx`) are updated to match — including fixing the prose that claimed the prompt is placed into the composer before sending (it is sent directly and the composer is cleared).

The deprecation documentation in `primitives/suggestion.mdx` and `primitives/index.mdx` is intentionally left in place.

## Verification

- `pnpm turbo run test --filter=@assistant-ui/ui`: 15 files, 408 passed, 15 skipped
- `tsc --noEmit` in `packages/ui`: 7 pre-existing errors on clean main (unrelated files: `image.test.tsx`, `thread-list.aui.test.tsx`, vue tests), same 7 with this change — nothing new
- `pnpm lint` clean

## Public surface

None. `@assistant-ui/ui` and the docs app are private, so no changeset. No template copies of this component exist (`sync-templates` unaffected).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TxtmZSeKRdWvav_zEZtHaXgxk_099n_25NkLZI1SVN6kKd73IRq-gRDN5Ao?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->