### PR TITLE
feat(examples): add with-webmcp example for unstable_useWebMcpProvider

### DIFF
--- a/apps/docs/content/docs/tools/webmcp.mdx
+++ b/apps/docs/content/docs/tools/webmcp.mdx
@@ -30,11 +30,11 @@ const WebMcpTools = () => {
 };
 ```
 
-A complete setup — a task-list page whose toolkit is published to the browser, with a destructive tool held back — runs in [`examples/with-webmcp`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-webmcp).
-
 `status` is `"unsupported"` when the page has no `modelContext` — every browser without WebMCP today — and `"active"` once the provider is running. The check runs when the hook mounts and is not repeated: WebMCP defines no availability event, and the provider does not poll, so an extension that injects `modelContext` into an already-rendered page is only picked up on the next mount. `registeredToolNames` is the sorted list of names the provider is publishing; a name that the host refuses (because the page already registered it, or because the page's tools permission is off) drops out of the list once the refusal arrives. A name appears for the commit in which its registration is set up, so treat the list as what the provider intends to have live rather than a synchronous read of the host.
 
 With no `filter`, the provider publishes every enabled frontend tool that has an `execute`; backend tools, disabled tools, and tools with no client-side implementation are skipped. A tool authored without a `type` counts as frontend when it has an `execute`, since that is what separates the deprecated type-less form from a backend or human tool. A `filter` you pass **replaces** that default rather than narrowing it — see below.
+
+A complete setup — a task-list page whose toolkit is published to the browser, with a destructive tool held back — runs in [`examples/with-webmcp`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-webmcp).
 
 ## Choosing which tools to publish
 

--- a/apps/docs/content/docs/tools/webmcp.mdx
+++ b/apps/docs/content/docs/tools/webmcp.mdx
@@ -30,6 +30,8 @@ const WebMcpTools = () => {
 };
 ```
 
+A complete setup — a task-list page whose toolkit is published to the browser, with a destructive tool held back — runs in [`examples/with-webmcp`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-webmcp).
+
 `status` is `"unsupported"` when the page has no `modelContext` — every browser without WebMCP today — and `"active"` once the provider is running. The check runs when the hook mounts and is not repeated: WebMCP defines no availability event, and the provider does not poll, so an extension that injects `modelContext` into an already-rendered page is only picked up on the next mount. `registeredToolNames` is the sorted list of names the provider is publishing; a name that the host refuses (because the page already registered it, or because the page's tools permission is off) drops out of the list once the refusal arrives. A name appears for the commit in which its registration is set up, so treat the list as what the provider intends to have live rather than a synchronous read of the host.
 
 With no `filter`, the provider publishes every enabled frontend tool that has an `execute`; backend tools, disabled tools, and tools with no client-side implementation are skipped. A tool authored without a `type` counts as frontend when it has an `execute`, since that is what separates the deprecated type-less form from a backend or human tool. A `filter` you pass **replaces** that default rather than narrowing it — see below.

--- a/examples/with-webmcp/.env.example
+++ b/examples/with-webmcp/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/examples/with-webmcp/README.md
+++ b/examples/with-webmcp/README.md
@@ -1,0 +1,47 @@
+# with-webmcp
+
+Exposes an app's frontend tools to a WebMCP-capable browser with
+`unstable_useWebMcpProvider`, while the same tools stay callable from the
+assistant-ui chat thread.
+
+The page holds a small task list and a `"use generative"` toolkit with three
+frontend tools:
+
+- `add_task` — mutates the page's task list.
+- `list_tasks` — reads the page's task list.
+- `clear_completed_tasks` — destructive, gated on user approval via `human()`.
+
+`unstable_useWebMcpProvider` publishes the first two to the browser's
+`document.modelContext`, so the user's browser agent can call them directly.
+`clear_completed_tasks` is kept chat-only by composing
+`unstable_defaultWebMcpFilter` with a name check: a WebMCP caller has no
+assistant-ui composer to answer the approval prompt with, and destructive
+tools should not be published anyway.
+
+## Run
+
+Create `.env.local`:
+
+```sh
+OPENAI_API_KEY=your-api-key-here
+```
+
+Then:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+The chat works in any browser. The status line under the task list shows
+"WebMCP not detected" unless the browser (or an extension) provides
+`document.modelContext`; with WebMCP available it lists the published tool
+names, and a browser agent can add or list tasks without going through the
+chat thread.
+
+## Related Documentation
+
+- [WebMCP provider](https://www.assistant-ui.com/docs/tools/webmcp)
+- [Defining Tools](https://www.assistant-ui.com/docs/tools/defining-tools)

--- a/examples/with-webmcp/README.md
+++ b/examples/with-webmcp/README.md
@@ -8,7 +8,7 @@ The page holds a small task list and a `"use generative"` toolkit with three fro
 - `list_tasks` — reads the page's task list.
 - `clear_completed_tasks` — destructive, gated on user approval via `human()`.
 
-`unstable_useWebMcpProvider` publishes the first two to the browser's `document.modelContext`, so the user's browser agent can call them directly. `clear_completed_tasks` is kept chat-only by composing `unstable_defaultWebMcpFilter` with a name check: a published tool is callable by anyone driving the browser, with the assistant's approval step out of the loop, and this one deletes data. Its `human()` prompt is chat-only as well, though that needs no filter of its own; a WebMCP call rejects it with "human input not supported in WebMCP context" rather than hanging.
+`unstable_useWebMcpProvider` publishes the first two to the browser's `document.modelContext`, so the user's browser agent can call them directly. `clear_completed_tasks` is kept chat-only by composing `unstable_defaultWebMcpFilter` with an allowlist: a published tool is callable by anyone driving the browser, with the assistant's approval step out of the loop, and this one deletes data. The allowlist is what makes chat-only the default, so the next tool added to the toolkit is not published until someone names it here. Its `human()` prompt is chat-only as well, though that needs no filter of its own; a WebMCP call rejects it with "human input not supported in WebMCP context" rather than hanging.
 
 ## Run
 

--- a/examples/with-webmcp/README.md
+++ b/examples/with-webmcp/README.md
@@ -1,22 +1,14 @@
 # with-webmcp
 
-Exposes an app's frontend tools to a WebMCP-capable browser with
-`unstable_useWebMcpProvider`, while the same tools stay callable from the
-assistant-ui chat thread.
+Exposes an app's frontend tools to a WebMCP-capable browser with `unstable_useWebMcpProvider`, while the same tools stay callable from the assistant-ui chat thread.
 
-The page holds a small task list and a `"use generative"` toolkit with three
-frontend tools:
+The page holds a small task list and a `"use generative"` toolkit with three frontend tools:
 
 - `add_task` — mutates the page's task list.
 - `list_tasks` — reads the page's task list.
 - `clear_completed_tasks` — destructive, gated on user approval via `human()`.
 
-`unstable_useWebMcpProvider` publishes the first two to the browser's
-`document.modelContext`, so the user's browser agent can call them directly.
-`clear_completed_tasks` is kept chat-only by composing
-`unstable_defaultWebMcpFilter` with a name check: a WebMCP caller has no
-assistant-ui composer to answer the approval prompt with, and destructive
-tools should not be published anyway.
+`unstable_useWebMcpProvider` publishes the first two to the browser's `document.modelContext`, so the user's browser agent can call them directly. `clear_completed_tasks` is kept chat-only by composing `unstable_defaultWebMcpFilter` with a name check: a published tool is callable by anyone driving the browser, with the assistant's approval step out of the loop, and this one deletes data. Its `human()` prompt is chat-only as well, though that needs no filter of its own; a WebMCP call rejects it with "human input not supported in WebMCP context" rather than hanging.
 
 ## Run
 
@@ -35,11 +27,7 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
-The chat works in any browser. The status line under the task list shows
-"WebMCP not detected" unless the browser (or an extension) provides
-`document.modelContext`; with WebMCP available it lists the published tool
-names, and a browser agent can add or list tasks without going through the
-chat thread.
+The chat works in any browser. The status line under the task list shows "WebMCP not detected" unless the browser (or an extension) provides `document.modelContext`; with WebMCP available it lists the published tool names, and a browser agent can add or list tasks without going through the chat thread.
 
 ## Related Documentation
 

--- a/examples/with-webmcp/app/api/chat/route.ts
+++ b/examples/with-webmcp/app/api/chat/route.ts
@@ -1,0 +1,34 @@
+import { openai } from "@ai-sdk/openai";
+import {
+  AISDKToolkit,
+  type AISDKToolkitToolsOptions,
+} from "@assistant-ui/ai-sdk";
+import { streamText, convertToModelMessages, stepCountIs } from "ai";
+import type { UIMessage } from "ai";
+import toolkit from "../../toolkit";
+
+export const maxDuration = 30;
+
+const aiToolkit = new AISDKToolkit({ toolkit });
+
+export async function POST(req: Request) {
+  const {
+    messages,
+    system,
+    tools,
+  }: {
+    messages: UIMessage[];
+    system?: string;
+    tools?: NonNullable<AISDKToolkitToolsOptions["frontend"]>;
+  } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.6-luna"),
+    messages: await convertToModelMessages(messages),
+    stopWhen: stepCountIs(10),
+    ...(system ? { system } : {}),
+    tools: await aiToolkit.tools({ ...(tools && { frontend: tools }) }),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/examples/with-webmcp/app/globals.css
+++ b/examples/with-webmcp/app/globals.css
@@ -1,0 +1,122 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@source "../../../packages/ui/src";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/examples/with-webmcp/app/layout.tsx
+++ b/examples/with-webmcp/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "WebMCP Example",
+  description:
+    "Example exposing assistant-ui frontend tools to a WebMCP-capable browser",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className="h-dvh">{children}</body>
+    </html>
+  );
+}

--- a/examples/with-webmcp/app/page.tsx
+++ b/examples/with-webmcp/app/page.tsx
@@ -16,8 +16,8 @@ import { TaskPanel } from "./task-panel";
 
 const WebMcpStatus = () => {
   const { status, registeredToolNames } = unstable_useWebMcpProvider({
-    // clear_completed_tasks stays chat-only: it is destructive and asks for
-    // approval through human(), which a WebMCP caller cannot answer.
+    // clear_completed_tasks deletes data, and a published tool is callable by
+    // anyone driving the browser with the approval step out of the loop.
     filter: (name, tool) =>
       unstable_defaultWebMcpFilter(name, tool) &&
       name !== "clear_completed_tasks",

--- a/examples/with-webmcp/app/page.tsx
+++ b/examples/with-webmcp/app/page.tsx
@@ -14,13 +14,14 @@ import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import toolkit from "./toolkit";
 import { TaskPanel } from "./task-panel";
 
+// clear_completed_tasks is left out because it deletes data, and a published
+// tool runs with the approval step out of the loop.
+const WEBMCP_TOOLS = new Set(["add_task", "list_tasks"]);
+
 const WebMcpStatus = () => {
   const { status, registeredToolNames } = unstable_useWebMcpProvider({
-    // clear_completed_tasks deletes data, and a published tool is callable by
-    // anyone driving the browser with the approval step out of the loop.
     filter: (name, tool) =>
-      unstable_defaultWebMcpFilter(name, tool) &&
-      name !== "clear_completed_tasks",
+      unstable_defaultWebMcpFilter(name, tool) && WEBMCP_TOOLS.has(name),
   });
 
   return (

--- a/examples/with-webmcp/app/page.tsx
+++ b/examples/with-webmcp/app/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Thread } from "@/components/assistant-ui/elements/thread.aui";
+import {
+  AssistantRuntimeProvider,
+  AuiConfig,
+  Suggestions,
+  Tools,
+  unstable_defaultWebMcpFilter,
+  unstable_useWebMcpProvider,
+} from "@assistant-ui/react";
+import { useChatRuntime } from "@assistant-ui/ai-sdk";
+import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import toolkit from "./toolkit";
+import { TaskPanel } from "./task-panel";
+
+const WebMcpStatus = () => {
+  const { status, registeredToolNames } = unstable_useWebMcpProvider({
+    // clear_completed_tasks stays chat-only: it is destructive and asks for
+    // approval through human(), which a WebMCP caller cannot answer.
+    filter: (name, tool) =>
+      unstable_defaultWebMcpFilter(name, tool) &&
+      name !== "clear_completed_tasks",
+  });
+
+  return (
+    <p className="text-muted-foreground text-xs">
+      {status === "unsupported"
+        ? "WebMCP not detected in this browser — the tools stay chat-only."
+        : registeredToolNames.length === 0
+          ? "WebMCP detected — no tools published yet."
+          : `Exposed to your browser agent: ${registeredToolNames.join(", ")}`}
+    </p>
+  );
+};
+
+export default function Home() {
+  const runtime = useChatRuntime({
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  });
+
+  const config = AuiConfig({
+    tools: Tools({ toolkit }),
+    suggestions: Suggestions([
+      {
+        title: "Add a task",
+        label: "to the list",
+        prompt: "Add a task: water the plants",
+      },
+      {
+        title: "What's on my list?",
+        label: "read the tasks",
+        prompt: "What tasks are on my list?",
+      },
+      {
+        title: "Clear completed",
+        label: "with approval",
+        prompt: "Clear my completed tasks.",
+      },
+    ]),
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime} config={config}>
+      <div className="grid h-dvh grid-rows-[auto_minmax(0,1fr)] md:grid-cols-[280px_minmax(0,1fr)] md:grid-rows-1">
+        <aside className="border-border flex flex-col gap-4 border-b p-4 md:border-r md:border-b-0">
+          <TaskPanel />
+          <WebMcpStatus />
+        </aside>
+        <main className="h-full min-w-0">
+          <Thread />
+        </main>
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}

--- a/examples/with-webmcp/app/task-panel.tsx
+++ b/examples/with-webmcp/app/task-panel.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { taskStore } from "./task-store";
+
+export const TaskPanel = () => {
+  const tasks = useSyncExternalStore(
+    taskStore.subscribe,
+    taskStore.getSnapshot,
+    taskStore.getSnapshot,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="font-semibold">Tasks</h2>
+      {tasks.length === 0 && (
+        <p className="text-muted-foreground text-sm">No tasks yet.</p>
+      )}
+      <ul className="flex flex-col gap-1">
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={task.done}
+                onChange={(e) => taskStore.setDone(task.id, e.target.checked)}
+              />
+              <span
+                className={
+                  task.done ? "text-muted-foreground line-through" : ""
+                }
+              >
+                {task.title}
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/examples/with-webmcp/app/task-store.ts
+++ b/examples/with-webmcp/app/task-store.ts
@@ -1,0 +1,42 @@
+type Task = {
+  id: number;
+  title: string;
+  done: boolean;
+};
+
+let nextId = 4;
+let tasks: readonly Task[] = [
+  { id: 1, title: "Ship the release notes", done: false },
+  { id: 2, title: "Review the onboarding PR", done: true },
+  { id: 3, title: "Book the offsite venue", done: false },
+];
+
+const listeners = new Set<() => void>();
+
+const notify = () => {
+  for (const listener of listeners) listener();
+};
+
+export const taskStore = {
+  subscribe: (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot: () => tasks,
+  add: (title: string): Task => {
+    const task = { id: nextId++, title, done: false };
+    tasks = [...tasks, task];
+    notify();
+    return task;
+  },
+  setDone: (id: number, done: boolean): void => {
+    tasks = tasks.map((t) => (t.id === id ? { ...t, done } : t));
+    notify();
+  },
+  clearCompleted: (): number => {
+    const removed = tasks.filter((t) => t.done).length;
+    tasks = tasks.filter((t) => !t.done);
+    notify();
+    return removed;
+  },
+};

--- a/examples/with-webmcp/app/toolkit.tsx
+++ b/examples/with-webmcp/app/toolkit.tsx
@@ -32,6 +32,9 @@ export default defineToolkit({
     },
   },
   clear_completed_tasks: {
+    // A frontend tool renders inside the collapsed tool group, which would put
+    // the approval prompt behind a disclosure the user has no reason to open.
+    display: "standalone",
     description:
       "Remove every completed task from the user's task list. Requires the user's approval.",
     parameters: z.object({}),

--- a/examples/with-webmcp/app/toolkit.tsx
+++ b/examples/with-webmcp/app/toolkit.tsx
@@ -1,0 +1,82 @@
+"use generative";
+
+import { defineToolkit } from "@assistant-ui/react";
+import { z } from "zod";
+import { taskStore } from "./task-store";
+
+export default defineToolkit({
+  add_task: {
+    description: "Add a task to the user's task list.",
+    parameters: z.object({
+      title: z.string().describe("The task title"),
+    }),
+    execute: async ({ title }) => {
+      "use client";
+      return taskStore.add(title);
+    },
+    renderText: {
+      running: "Adding task…",
+      complete: ({ result }) => `Added task "${result.title}"`,
+    },
+  },
+  list_tasks: {
+    description: "List the tasks on the user's task list.",
+    parameters: z.object({}),
+    execute: async () => {
+      "use client";
+      return taskStore.getSnapshot();
+    },
+    renderText: {
+      running: "Reading tasks…",
+      complete: ({ result }) => `Found ${result.length} tasks`,
+    },
+  },
+  clear_completed_tasks: {
+    description:
+      "Remove every completed task from the user's task list. Requires the user's approval.",
+    parameters: z.object({}),
+    execute: async (_args, { human }) => {
+      "use client";
+      const approved = (await human({})) === true;
+      if (!approved) return { cleared: 0, message: "The user declined." };
+      return { cleared: taskStore.clearCompleted() };
+    },
+    render: ({ result, interrupt, resume }) => {
+      if (result) {
+        return (
+          <p className="text-muted-foreground text-sm">
+            {result.cleared > 0
+              ? `Cleared ${result.cleared} completed task(s).`
+              : (result.message ?? "No completed tasks to clear.")}
+          </p>
+        );
+      }
+      if (interrupt) {
+        return (
+          <div className="border-border bg-muted/50 flex items-center gap-3 rounded-lg border p-3 text-sm">
+            <span>Clear all completed tasks?</span>
+            <button
+              type="button"
+              onClick={() => resume(true)}
+              className="bg-primary text-primary-foreground rounded-md px-3 py-1"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => resume(false)}
+              className="border-border rounded-md border px-3 py-1"
+            >
+              Decline
+            </button>
+          </div>
+        );
+      }
+      return (
+        <p className="text-muted-foreground text-sm">
+          Clearing completed tasks…
+        </p>
+      );
+    },
+  },
+});

--- a/examples/with-webmcp/components.json
+++ b/examples/with-webmcp/components.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide",
+  "registries": {
+    "@assistant-ui": "https://r.assistant-ui.com/{name}.json"
+  }
+}

--- a/examples/with-webmcp/next.config.js
+++ b/examples/with-webmcp/next.config.js
@@ -1,0 +1,7 @@
+import { withAui } from "@assistant-ui/next";
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@assistant-ui/react", "@assistant-ui/ai-sdk"],
+};
+
+export default withAui(nextConfig);

--- a/examples/with-webmcp/package.json
+++ b/examples/with-webmcp/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "with-webmcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^4.0.50",
+    "@assistant-ui/ai-sdk": "workspace:*",
+    "@assistant-ui/react": "workspace:*",
+    "@assistant-ui/react-markdown": "workspace:*",
+    "@assistant-ui/ui": "workspace:*",
+    "ai": "^7.0.83",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.34.0",
+    "next": "^16.3.3",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@assistant-ui/next": "workspace:*",
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@tailwindcss/postcss": "^4.3.3",
+    "@types/node": "^26.4.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.5",
+    "postcss": "^8.5.26",
+    "tailwindcss": "^4.3.3",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/examples/with-webmcp/postcss.config.mjs
+++ b/examples/with-webmcp/postcss.config.mjs
@@ -1,0 +1,6 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+export default config;

--- a/examples/with-webmcp/tsconfig.json
+++ b/examples/with-webmcp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/next",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"],
+      "@/components/assistant-ui/*": [
+        "../../packages/ui/src/components/react/assistant-ui/*"
+      ],
+      "@/hooks/*": ["../../packages/ui/src/hooks/*"],
+      "@/components/ui/*": [
+        "../../packages/ui/src/components/react/ui/base/*",
+        "../../packages/ui/src/components/react/ui/radix/*"
+      ],
+      "@/components/ui/radix/*": [
+        "../../packages/ui/src/components/react/ui/radix/*"
+      ],
+      "@/lib/utils": ["../../packages/ui/src/lib/utils"],
+      "@assistant-ui/ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3690,6 +3690,82 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0)
 
+  examples/with-webmcp:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.50
+        version: 4.0.50(zod@4.4.3)
+      '@assistant-ui/ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/ai-sdk
+      '@assistant-ui/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@assistant-ui/react-markdown':
+        specifier: workspace:*
+        version: link:../../packages/react-markdown
+      '@assistant-ui/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      ai:
+        specifier: ^7.0.83
+        version: 7.0.83(zod@4.4.3)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.34.0
+        version: 1.34.0(react@19.2.8)
+      next:
+        specifier: ^16.3.3
+        version: 16.3.3(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@assistant-ui/next':
+        specifier: workspace:*
+        version: link:../../packages/next
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../../packages/x-buildutils
+      '@tailwindcss/postcss':
+        specifier: ^4.3.3
+        version: 4.3.3
+      '@types/node':
+        specifier: ^26.4.0
+        version: 26.4.0
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.5
+        version: 19.2.5(@types/react@19.2.18)
+      postcss:
+        specifier: ^8.5.26
+        version: 8.5.26
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+
   packages/agent-launcher:
     dependencies:
       cross-spawn:


### PR DESCRIPTION
## Problem

`unstable_useWebMcpProvider` shipped (#6540, #6614) with a docs page but no runnable example. There is nothing in `examples/` a user can start to see a WebMCP-published toolkit working against a real chat runtime, or to see why a tool would be held back from the browser agent.

## Change

Adds `examples/with-webmcp`, the smallest example that shows the provider's differentiator: the same `"use generative"` toolkit serves the chat thread and the browser's `document.modelContext`.

- A page-local task list with three frontend tools: `add_task` (mutation), `list_tasks` (query), and `clear_completed_tasks` (destructive, gated on user approval via `human()`).
- `unstable_useWebMcpProvider` publishes the first two; `clear_completed_tasks` is held back by composing `unstable_defaultWebMcpFilter` with an allowlist, so chat-only is the default and the next tool added to the toolkit is not published until someone names it — the composition pattern the docs prescribe, and the reason is in the code: a published tool is callable by anyone driving the browser with the approval step out of the loop, and this one deletes data. Its `human()` prompt is chat-only too, but that needs no filter of its own; the provider already rejects `human()` in a WebMCP context with a clear error instead of hanging.
- A status line surfaces `status` / `registeredToolNames`, including the no-host and empty-active states.
- Stack and structure copy `with-ai-sdk-v7` / `with-generative-ui` exactly (Next.js + `withAui`, `AISDKToolkit` route, tsconfig aliases into `packages/ui` — no synced component copies, no new dependencies).

Also adds a one-line link to the example from `docs/tools/webmcp.mdx`, following the `with-generative-ui` docs convention.

Not registered in the CLI example registry, matching `with-mcp` and `with-generative-ui`; happy to add it in a follow-up if you want it there.

## Verification

- `pnpm exec turbo build --filter=with-webmcp` green (Next build includes typecheck).
- `oxlint` / `oxfmt --check` clean on the new files.
- Served the production build and confirmed the page renders the task list and the WebMCP status line.
- No changeset: only a private example, docs content, and the lockfile importer entry change.

## Public surface

None — no published package changes. New files are the private `with-webmcp` example (+566 lines, of which 122 are the standard copied `globals.css`), a 2-line docs addition, and the pnpm-lock importer entry (+76).

---

Disclosure: this example was user-directed work from a maintainer-adjacent workflow rather than issue-first. If you'd prefer the issue-first route (as #6540 took), I'm glad to convert this to an issue and wait for direction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.J7Xxeqt2_1z4SamDJgWODKHtlQx9etu4q_bEo5fZa385MdQrWTNYNdGZCoA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
