### PR TITLE
fix(docs): surface WebMCP docs-tool errors instead of Chrome's generic UnknownError

### DIFF
--- a/apps/docs/lib/webmcp-tools.test.ts
+++ b/apps/docs/lib/webmcp-tools.test.ts
@@ -123,12 +123,12 @@ describe("registered tools", () => {
   it("getDoc calls read_page with the given path", async () => {
     const fetchImpl = fetchReturning({ result: okResult });
     await toolByName(fetchImpl, "getDoc").execute({
-      path: "/docs/architecture",
+      path: "/docs/installation",
     });
 
     expect(sentRequest(fetchImpl).body.params).toEqual({
       name: "read_page",
-      arguments: { path: "/docs/architecture" },
+      arguments: { path: "/docs/installation" },
     });
   });
 
@@ -283,7 +283,7 @@ describe("registered tools", () => {
       },
     }));
     const rejection = await toolByName(abortingBody, "getDoc")
-      .execute({ path: "/docs/architecture" })
+      .execute({ path: "/docs/installation" })
       .then(
         () => {
           throw new Error("expected rejection");

--- a/apps/docs/lib/webmcp-tools.test.ts
+++ b/apps/docs/lib/webmcp-tools.test.ts
@@ -11,6 +11,10 @@ const okResult = {
   content: [{ type: "text", text: "hello" }],
 };
 
+function errorResult(text: string) {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
 function fetchReturning(payload: unknown, ok = true, status = 200) {
   return vi.fn(async () => ({
     ok,
@@ -119,12 +123,12 @@ describe("registered tools", () => {
   it("getDoc calls read_page with the given path", async () => {
     const fetchImpl = fetchReturning({ result: okResult });
     await toolByName(fetchImpl, "getDoc").execute({
-      path: "/docs/getting-started",
+      path: "/docs/architecture",
     });
 
     expect(sentRequest(fetchImpl).body.params).toEqual({
       name: "read_page",
-      arguments: { path: "/docs/getting-started" },
+      arguments: { path: "/docs/architecture" },
     });
   });
 
@@ -196,44 +200,46 @@ describe("registered tools", () => {
     expect(init.signal).toBe(controller.signal);
   });
 
-  it("rejects on missing arguments without fetching", async () => {
+  it("returns isError results on missing arguments without fetching", async () => {
     const fetchImpl = fetchReturning({ result: okResult });
     await expect(
       toolByName(fetchImpl, "searchDocs").execute({}),
-    ).rejects.toThrow("query is required");
+    ).resolves.toEqual(errorResult("query is required"));
     await expect(
       toolByName(fetchImpl, "getDoc").execute({ path: "  " }),
-    ).rejects.toThrow("path is required");
+    ).resolves.toEqual(errorResult("path is required"));
     await expect(
       toolByName(fetchImpl, "getExample").execute({}),
-    ).rejects.toThrow("path is required");
+    ).resolves.toEqual(errorResult("path is required"));
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("rejects on fetch failures, HTTP errors, and JSON-RPC errors", async () => {
+  it("returns isError results on fetch failures, HTTP errors, and JSON-RPC errors", async () => {
     const rejecting = vi.fn(async () => {
       throw new Error("offline");
     });
     await expect(
       toolByName(rejecting as never, "searchDocs").execute({ query: "x" }),
-    ).rejects.toThrow("offline");
+    ).resolves.toEqual(errorResult("Docs request failed: offline"));
 
     await expect(
       toolByName(fetchReturning({}, false, 500), "searchDocs").execute({
         query: "x",
       }),
-    ).rejects.toThrow("500");
+    ).resolves.toEqual(errorResult("Docs request failed with status 500"));
 
     await expect(
       toolByName(
         fetchReturning({ error: { message: "nope" } }),
         "searchDocs",
       ).execute({ query: "x" }),
-    ).rejects.toThrow("nope");
+    ).resolves.toEqual(errorResult("nope"));
 
     await expect(
       toolByName(fetchReturning({}), "searchDocs").execute({ query: "x" }),
-    ).rejects.toThrow("unexpected response");
+    ).resolves.toEqual(
+      errorResult("Docs request returned an unexpected response"),
+    );
   });
 
   it("propagates AbortError rejections without wrapping them", async () => {
@@ -277,7 +283,7 @@ describe("registered tools", () => {
       },
     }));
     const rejection = await toolByName(abortingBody, "getDoc")
-      .execute({ path: "/docs/getting-started" })
+      .execute({ path: "/docs/architecture" })
       .then(
         () => {
           throw new Error("expected rejection");
@@ -288,7 +294,7 @@ describe("registered tools", () => {
     expect((rejection as DOMException).name).toBe("AbortError");
   });
 
-  it("rejects on route-level isError results, surfacing the error text", async () => {
+  it("passes route-level isError results through with their error text", async () => {
     const fetchImpl = fetchReturning({
       result: {
         content: [{ type: "text", text: "Page not found: nope" }],
@@ -297,10 +303,10 @@ describe("registered tools", () => {
     });
     await expect(
       toolByName(fetchImpl, "getDoc").execute({ path: "/docs/nope" }),
-    ).rejects.toThrow("Page not found: nope");
+    ).resolves.toEqual(errorResult("Page not found: nope"));
   });
 
-  it("rejects on malformed 200 responses", async () => {
+  it("returns isError results on malformed 200 responses", async () => {
     const invalidJson = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -310,7 +316,7 @@ describe("registered tools", () => {
     }));
     await expect(
       toolByName(invalidJson, "searchDocs").execute({ query: "x" }),
-    ).rejects.toThrow("invalid JSON");
+    ).resolves.toEqual(errorResult("Docs request returned invalid JSON"));
 
     for (const payload of [null, "ok", { result: { content: "text" } }]) {
       await expect(
@@ -318,7 +324,9 @@ describe("registered tools", () => {
           query: "x",
         }),
         JSON.stringify(payload),
-      ).rejects.toThrow("unexpected response");
+      ).resolves.toEqual(
+        errorResult("Docs request returned an unexpected response"),
+      );
     }
   });
 });

--- a/apps/docs/lib/webmcp-tools.ts
+++ b/apps/docs/lib/webmcp-tools.ts
@@ -123,11 +123,12 @@ async function callMcpRoute(
     : { content: payload.result.content };
 }
 
-// Chrome's native WebMCP masks page-side execute rejections behind a generic
-// "UnknownError: Tool was executed but the invocation failed", while isError
-// results pass through with their text intact — so failures resolve as isError
-// results. Abort rejections still propagate so a cancellation the caller
-// requested stays a rejection rather than a tool error.
+// Chrome's native WebMCP discards a rejected execute's value and reports
+// every rejection as a generic "Tool was executed but the invocation
+// failed", while it JSON-serializes a resolved object whole. A failure
+// therefore keeps its text only by resolving as an isError result. Abort
+// rejections still propagate so a cancellation the caller requested stays
+// a rejection rather than a tool error.
 const withErrorResults =
   (execute: WebMcpToolDescriptor["execute"]): WebMcpToolDescriptor["execute"] =>
   async (args, context) => {
@@ -199,14 +200,14 @@ function webMcpTools(fetchImpl: FetchLike): WebMcpToolDescriptor[] {
     {
       name: "getDoc",
       description:
-        "Read one assistant-ui docs or Tap docs page as markdown. Accepts a path such as /docs/architecture or tap/docs/store/state.",
+        "Read one assistant-ui docs or Tap docs page as markdown. Accepts a path such as /docs/installation or tap/docs/store/state.",
       inputSchema: {
         type: "object",
         properties: {
           path: {
             type: "string",
             description:
-              "Docs or Tap page path such as /docs/architecture or tap/docs/store/state, or a same-origin URL for one of those pages.",
+              "Docs or Tap page path such as /docs/installation or tap/docs/store/state, or a same-origin URL for one of those pages.",
           },
         },
         required: ["path"],

--- a/apps/docs/lib/webmcp-tools.ts
+++ b/apps/docs/lib/webmcp-tools.ts
@@ -10,11 +10,9 @@ import {
 
 type WebMcpToolResult = {
   content: { type: string; text?: string }[];
+  isError?: boolean;
 };
 
-// Per the spec, a fulfilled execute promise is a successful tool call and a
-// rejected one is a failure — there is no isError channel — so every failure
-// path in this module throws rather than resolving with an error payload.
 type WebMcpToolDescriptor = {
   name: string;
   description: string;
@@ -100,7 +98,7 @@ async function callMcpRoute(
   let payload;
   try {
     payload = (await response.json()) as {
-      result?: WebMcpToolResult & { isError?: boolean };
+      result?: WebMcpToolResult;
       error?: { message?: string };
     } | null;
   } catch (error) {
@@ -119,15 +117,35 @@ async function callMcpRoute(
     throw new Error("Docs request returned an unexpected response");
   }
   // The route reports tool-level failures (e.g. page not found) as MCP
-  // isError results on a 200; surface those as rejections too.
-  if (payload.result.isError) {
-    const text = payload.result.content.find(
-      (item) => typeof item.text === "string",
-    )?.text;
-    throw new Error(text ?? "Docs request failed");
-  }
-  return { content: payload.result.content };
+  // isError results on a 200; pass those through unchanged.
+  return payload.result.isError
+    ? { isError: true, content: payload.result.content }
+    : { content: payload.result.content };
 }
+
+// Chrome's native WebMCP masks page-side execute rejections behind a generic
+// "UnknownError: Tool was executed but the invocation failed", while isError
+// results pass through with their text intact — so failures resolve as isError
+// results. Abort rejections still propagate so a cancellation the caller
+// requested stays a rejection rather than a tool error.
+const withErrorResults =
+  (execute: WebMcpToolDescriptor["execute"]): WebMcpToolDescriptor["execute"] =>
+  async (args, context) => {
+    try {
+      return await execute(args, context);
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: error instanceof Error ? error.message : String(error),
+          },
+        ],
+      };
+    }
+  };
 
 function stringArg(args: Record<string, unknown>, key: string) {
   const value = args[key];
@@ -181,14 +199,14 @@ function webMcpTools(fetchImpl: FetchLike): WebMcpToolDescriptor[] {
     {
       name: "getDoc",
       description:
-        "Read one assistant-ui docs or Tap docs page as markdown. Accepts a path such as /docs/getting-started or tap/docs/store/state.",
+        "Read one assistant-ui docs or Tap docs page as markdown. Accepts a path such as /docs/architecture or tap/docs/store/state.",
       inputSchema: {
         type: "object",
         properties: {
           path: {
             type: "string",
             description:
-              "Docs or Tap page path such as /docs/getting-started or tap/docs/store/state, or a same-origin URL for one of those pages.",
+              "Docs or Tap page path such as /docs/architecture or tap/docs/store/state, or a same-origin URL for one of those pages.",
           },
         },
         required: ["path"],
@@ -244,7 +262,10 @@ export function registerWebMcpTools(
   const controller = new AbortController();
   for (const tool of webMcpTools(fetchImpl)) {
     Promise.resolve(
-      modelContext.registerTool(tool, { signal: controller.signal }),
+      modelContext.registerTool(
+        { ...tool, execute: withErrorResults(tool.execute) },
+        { signal: controller.signal },
+      ),
     ).catch((error) => {
       // Registration failures (permissions policy, duplicate names, spec
       // drift) must not break the page, but should be visible in development.


### PR DESCRIPTION
## Problem

Two issues in the docs-site WebMCP tools (`apps/docs/lib/webmcp-tools.ts`), both found while dogfooding the tools against Chrome's native WebMCP implementation (Chrome 151.0.7922.174 stable, launched with `--enable-blink-features=WebMCP`):

1. The intentional error messages never reach the agent. The tools throw on failure (missing argument, transport failure, page not found), but Chrome's native WebMCP masks page-side `execute` rejections behind a generic `UnknownError: Tool was executed but the invocation failed. For example, the script function threw an error` — the original message is lost. An agent calling `getDoc` on a missing page gets no usable signal about what went wrong, while a resolved result arrives with its text intact (verified: the route-level "Page not found" text survives only when the tool resolves rather than throws).
2. `getDoc`'s description and input schema cite `/docs/getting-started` as their example path, which 404s on the live site — the content directory `(getting-started)` is a Next.js route group, so its pages resolve at `/docs/architecture`, `/docs/installation`, etc. An agent that copies the example path gets a not-found error on its first call.

## Root cause

The tools were written to the spec draft's contract, where a rejected `execute` promise is the failure channel. Chrome's implementation drops the rejection value at the Blink boundary by construction, not as a bug: `ToolFunctionFinishedCallback::HandleFailure` in `third_party/blink/renderer/core/script_tools/model_context.cc` logs the real message to the console and forwards the rejection value only to the DevTools probe, then `ModelContext::OnToolExecuted` builds a `ScriptToolError(kToolInvocationFailed)` with no message, so `GetToolErrorMessage` falls back to the generic literal.

Resolved values take the other path: `React` JSON-serializes a resolved object whole and delivers it as a successful result. Blink has no `isError` concept, so under Chrome the flag rides along inside that serialized payload rather than marking the call as failed. That is still what keeps the message reachable, and hosts that implement the spec's `CallToolResult` shape (the WebMCP polyfill's `normalizeToolResponse`, and `@assistant-ui/react`'s own provider) honor the flag directly, so the result stays spec-shaped instead of Chrome-specific.

## Change

- Wrap each tool's `execute` at the registration boundary with `withErrorResults`, which catches non-abort failures and resolves them as `{ isError: true, content: [{ type: "text", text }] }` — the same pattern `@assistant-ui/react`'s WebMCP provider uses in `convertTools.ts`. `AbortError` rejections still propagate so a cancellation the caller requested stays a rejection rather than a tool error.
- Route-level `isError` results from `/api/mcp` now pass through unchanged (previously they were re-thrown with only the first text item, which the wrapper would have reconstructed anyway; the pass-through also preserves the full content array).
- Replace `/docs/getting-started` with `/docs/installation` in `getDoc`'s description and schema, and in the tests that mirrored it. That is the example `read_page`'s own schema in `lib/mcp-tool-definitions.ts` already uses, so an agent reading both descriptions sees one canonical path.

The wrapper is applied only at WebMCP registration; the module has no other consumers (`registerWebMcpTools` is called from `WebMcpTools` and tests only).

## Verification

- `apps/docs`: full vitest suite 58 files / 471 tests green, including updated `lib/webmcp-tools.test.ts` (failure paths now pinned as `isError` results; abort paths pinned as rejections, covering `DOMException`, non-Error `{name:"AbortError"}` values, and aborts surfacing from `response.json()` mid-stream) and the route transport integration tests in `app/api/mcp/route.test.ts`.
- `oxlint` and `oxfmt --check` clean on the changed files.
- Masking behavior observed directly against Chrome 151.0.7922.174 with `--enable-blink-features=WebMCP`: a throwing docs tool surfaces as a generic error with the message dropped, while a resolved result arrives with its text intact. Confirmed against `model_context.cc` at Chromium HEAD, which discards the rejection value rather than propagating it.
- `/docs/getting-started` returns 404 on the live site and `/docs/installation` returns 200; `content/docs/(getting-started)` is a Next.js route group, so it never appears in a URL.

## Public surface

None. `apps/docs` is private; no changeset needed. Diff: +61/−32 across the module (+40 impl) and its test file (+21 net).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fomGtU5hucXdIGgZiHm1IerksaKceVVsMmq3mQCoJCA6CXae1SWhnqsUnok?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
