### PR TITLE
fix(core): prevent deleted threads from becoming active

### DIFF
--- a/.changeset/safe-thread-switch-deletion.md
+++ b/.changeset/safe-thread-switch-deletion.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: prevent deleted threads from becoming the active thread

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1323,6 +1323,68 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("does not start unarchive after initialization when the target was deleted", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const nativeResolve = Promise.resolve.bind(Promise);
+    const resolveSpy = vi.spyOn(Promise, "resolve").mockImplementation(((
+      value?: unknown,
+    ) => {
+      if (
+        typeof value === "object" &&
+        value !== null &&
+        "remoteId" in value &&
+        value.remoteId === "t1" &&
+        "externalId" in value &&
+        value.externalId === undefined
+      ) {
+        return initialization.promise;
+      }
+      return nativeResolve(value);
+    }) as typeof Promise.resolve);
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "archived" as const, remoteId: "t1", title: "One" },
+        ],
+      })),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+    try {
+      await aui.threads.getLoadThreadsPromise();
+    } finally {
+      resolveSpy.mockRestore();
+    }
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().archivedThreadIds).toEqual(["t1"]);
+    });
+    const initialMainThreadId = aui.threads.getState().mainThreadId;
+
+    flushTapSync(() => aui.threads.switchToThread("t1"));
+    let deletion: Promise<void> | undefined;
+    flushTapSync(() => {
+      deletion = aui.threads.item({ id: "t1" }).delete() as unknown as
+        | Promise<void>
+        | undefined;
+    });
+    await vi.waitFor(() => {
+      const state = aui.threads.getState();
+      expect(state.threadIds).not.toContain("t1");
+      expect(state.archivedThreadIds).not.toContain("t1");
+    });
+
+    initialization.resolve({ remoteId: "t1", externalId: undefined });
+    await deletion;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(aui.threads.getState().mainThreadId).toBe(initialMainThreadId);
+    handle.destroy();
+  });
+
   it("keeps item(main) resolvable when deleting an archived thread during unarchive", async () => {
     const unarchive = deferred<void>();
     const onSwitchToThread = vi.fn();

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1323,68 +1323,6 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
-  it("does not start unarchive after initialization when the target was deleted", async () => {
-    const initialization = deferred<{
-      remoteId: string;
-      externalId: undefined;
-    }>();
-    const nativeResolve = Promise.resolve.bind(Promise);
-    const resolveSpy = vi.spyOn(Promise, "resolve").mockImplementation(((
-      value?: unknown,
-    ) => {
-      if (
-        typeof value === "object" &&
-        value !== null &&
-        "remoteId" in value &&
-        value.remoteId === "t1" &&
-        "externalId" in value &&
-        value.externalId === undefined
-      ) {
-        return initialization.promise;
-      }
-      return nativeResolve(value);
-    }) as typeof Promise.resolve);
-    const adapter = makeAdapter({
-      list: vi.fn(async () => ({
-        threads: [
-          { status: "archived" as const, remoteId: "t1", title: "One" },
-        ],
-      })),
-    });
-    const { handle } = mountList(adapter);
-    const aui = handle.getClient();
-    try {
-      await aui.threads.getLoadThreadsPromise();
-    } finally {
-      resolveSpy.mockRestore();
-    }
-    await vi.waitFor(() => {
-      expect(aui.threads.getState().archivedThreadIds).toEqual(["t1"]);
-    });
-    const initialMainThreadId = aui.threads.getState().mainThreadId;
-
-    flushTapSync(() => aui.threads.switchToThread("t1"));
-    let deletion: Promise<void> | undefined;
-    flushTapSync(() => {
-      deletion = aui.threads.item({ id: "t1" }).delete() as unknown as
-        | Promise<void>
-        | undefined;
-    });
-    await vi.waitFor(() => {
-      const state = aui.threads.getState();
-      expect(state.threadIds).not.toContain("t1");
-      expect(state.archivedThreadIds).not.toContain("t1");
-    });
-
-    initialization.resolve({ remoteId: "t1", externalId: undefined });
-    await deletion;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(adapter.unarchive).not.toHaveBeenCalled();
-    expect(aui.threads.getState().mainThreadId).toBe(initialMainThreadId);
-    handle.destroy();
-  });
-
   it("keeps item(main) resolvable when deleting an archived thread during unarchive", async () => {
     const unarchive = deferred<void>();
     const onSwitchToThread = vi.fn();

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -134,6 +134,46 @@ const mountList = (
   return { handle, onThreadIdChange };
 };
 
+const mountArchivedInitializingThread = async () => {
+  const initialize = deferred<{
+    remoteId: string;
+    externalId: undefined;
+  }>();
+  const adapter = makeAdapter({
+    list: vi.fn(async () => ({
+      threads: [
+        {
+          status: "regular" as const,
+          remoteId: "fallback",
+          title: "Fallback",
+        },
+      ],
+    })),
+    initialize: vi.fn(() => initialize.promise),
+  });
+  const { handle } = mountList(adapter);
+  const aui = handle.getClient();
+  await aui.threads.getLoadThreadsPromise();
+  const targetId = aui.threads.getState().mainThreadId;
+  const initialization = aui.threads.item("main").initialize();
+  await vi.waitFor(() => {
+    expect(handle.getClient().threads.item("main").getState().status).toBe(
+      "regular",
+    );
+  });
+  flushTapSync(() => aui.threads.switchToThread("fallback"));
+  await vi.waitFor(() => {
+    expect(handle.getClient().threads.getState().mainThreadId).toBe("fallback");
+  });
+  flushTapSync(() => aui.threads.item({ id: targetId }).archive());
+  await vi.waitFor(() => {
+    expect(handle.getClient().threads.getState().archivedThreadIds).toContain(
+      targetId,
+    );
+  });
+  return { adapter, handle, targetId, initialization, initialize };
+};
+
 describe("RemoteThreadList", () => {
   it("loads adapter threads on a standalone client", async () => {
     const adapter = makeAdapter({
@@ -1324,45 +1364,9 @@ describe("RemoteThreadList", () => {
   });
 
   it("does not unarchive an archived thread deleted during initialization", async () => {
-    const initialize = deferred<{
-      remoteId: string;
-      externalId: undefined;
-    }>();
-    const adapter = makeAdapter({
-      list: vi.fn(async () => ({
-        threads: [
-          {
-            status: "regular" as const,
-            remoteId: "fallback",
-            title: "Fallback",
-          },
-        ],
-      })),
-      initialize: vi.fn(() => initialize.promise),
-    });
-    const { handle } = mountList(adapter);
+    const { adapter, handle, targetId, initialization, initialize } =
+      await mountArchivedInitializingThread();
     const aui = handle.getClient();
-    await aui.threads.getLoadThreadsPromise();
-    const targetId = aui.threads.getState().mainThreadId;
-
-    const initialization = aui.threads.item("main").initialize();
-    await vi.waitFor(() => {
-      expect(handle.getClient().threads.item("main").getState().status).toBe(
-        "regular",
-      );
-    });
-    flushTapSync(() => aui.threads.switchToThread("fallback"));
-    await vi.waitFor(() => {
-      expect(handle.getClient().threads.getState().mainThreadId).toBe(
-        "fallback",
-      );
-    });
-    flushTapSync(() => aui.threads.item({ id: targetId }).archive());
-    await vi.waitFor(() => {
-      expect(handle.getClient().threads.getState().archivedThreadIds).toContain(
-        targetId,
-      );
-    });
     flushTapSync(() => aui.threads.switchToThread(targetId));
     flushTapSync(() => aui.threads.item({ id: targetId }).delete());
     await vi.waitFor(() => {
@@ -1383,6 +1387,33 @@ describe("RemoteThreadList", () => {
     expect(() =>
       handle.getClient().threads.item("main").getState(),
     ).not.toThrow();
+    handle.destroy();
+  });
+
+  it("does not unarchive again when the target became regular during initialization", async () => {
+    const { adapter, handle, targetId, initialization, initialize } =
+      await mountArchivedInitializingThread();
+    const aui = handle.getClient();
+
+    flushTapSync(() => aui.threads.switchToThread(targetId));
+    flushTapSync(() => aui.threads.item({ id: targetId }).unarchive());
+    await vi.waitFor(() => {
+      expect(
+        handle.getClient().threads.item({ id: targetId }).getState().status,
+      ).toBe("regular");
+    });
+
+    initialize.resolve({
+      remoteId: `remote-${targetId}`,
+      externalId: undefined,
+    });
+    await initialization;
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().mainThreadId).toBe(targetId);
+    });
+
+    expect(adapter.unarchive).toHaveBeenCalledTimes(1);
+    expect(adapter.unarchive).toHaveBeenCalledWith(`remote-${targetId}`);
     handle.destroy();
   });
 

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1323,6 +1323,69 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("does not unarchive an archived thread deleted during initialization", async () => {
+    const initialize = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "fallback",
+            title: "Fallback",
+          },
+        ],
+      })),
+      initialize: vi.fn(() => initialize.promise),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    const targetId = aui.threads.getState().mainThreadId;
+
+    const initialization = aui.threads.item("main").initialize();
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.item("main").getState().status).toBe(
+        "regular",
+      );
+    });
+    flushTapSync(() => aui.threads.switchToThread("fallback"));
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().mainThreadId).toBe(
+        "fallback",
+      );
+    });
+    flushTapSync(() => aui.threads.item({ id: targetId }).archive());
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().archivedThreadIds).toContain(
+        targetId,
+      );
+    });
+    flushTapSync(() => aui.threads.switchToThread(targetId));
+    flushTapSync(() => aui.threads.item({ id: targetId }).delete());
+    await vi.waitFor(() => {
+      const state = handle.getClient().threads.getState();
+      expect(state.threadIds).not.toContain(targetId);
+      expect(state.archivedThreadIds).not.toContain(targetId);
+    });
+
+    initialize.resolve({
+      remoteId: `remote-${targetId}`,
+      externalId: undefined,
+    });
+    await initialization;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(handle.getClient().threads.getState().mainThreadId).toBe("fallback");
+    expect(() =>
+      handle.getClient().threads.item("main").getState(),
+    ).not.toThrow();
+    handle.destroy();
+  });
+
   it("keeps item(main) resolvable when deleting an archived thread during unarchive", async () => {
     const unarchive = deferred<void>();
     const onSwitchToThread = vi.fn();

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1323,6 +1323,51 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("keeps item(main) resolvable when deleting an archived thread during unarchive", async () => {
+    const unarchive = deferred<void>();
+    const onSwitchToThread = vi.fn();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          { status: "archived" as const, remoteId: "t1", title: "One" },
+        ],
+      })),
+      unarchive: vi.fn(() => unarchive.promise),
+    });
+    const { handle } = mountList(
+      adapter,
+      undefined,
+      undefined,
+      onSwitchToThread,
+    );
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    const initialMainThreadId = aui.threads.getState().mainThreadId;
+
+    flushTapSync(() => aui.threads.switchToThread("t1"));
+    await vi.waitFor(() => {
+      expect(adapter.unarchive).toHaveBeenCalledWith("t1");
+    });
+    flushTapSync(() => aui.threads.item({ id: "t1" }).delete());
+    await vi.waitFor(() => {
+      const state = handle.getClient().threads.getState();
+      expect(state.threadIds).not.toContain("t1");
+      expect(state.archivedThreadIds).not.toContain("t1");
+    });
+
+    unarchive.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.getClient().threads.getState().mainThreadId).toBe(
+      initialMainThreadId,
+    );
+    expect(() =>
+      handle.getClient().threads.item("main").getState(),
+    ).not.toThrow();
+    expect(onSwitchToThread).not.toHaveBeenCalled();
+    handle.destroy();
+  });
+
   it("keeps item(main) resolvable when deleting a thread mid-initialize", async () => {
     const initialize = deferred<{
       remoteId: string;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -779,7 +779,7 @@ const useRemoteThreadList = (
         if (isSameThread(store.value, data.id, session.mainThreadId)) return;
 
         const targetId = data.id;
-        let current = data;
+        let current: RemoteThreadData | undefined = data;
 
         if (current.status === "archived" && options?.unarchive !== false) {
           const { remoteId } = await current.initializeTask;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -779,8 +779,7 @@ const useRemoteThreadList = (
         if (isSameThread(store.value, data.id, session.mainThreadId)) return;
 
         const targetId = data.id;
-        let current = getThreadData(store.value, targetId);
-        if (current?.id !== targetId) return;
+        let current = data;
 
         if (current.status === "archived" && options?.unarchive !== false) {
           const { remoteId } = await current.initializeTask;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -777,22 +777,27 @@ const useRemoteThreadList = (
           throw threadNotFoundError(threadIdOrRemoteId, "switching to it");
         }
         if (isSameThread(store.value, data.id, session.mainThreadId)) return;
-        if (data.status === "archived" && options?.unarchive !== false) {
-          const current = data;
+
+        const targetId = data.id;
+        let current = getThreadData(store.value, targetId);
+        if (current?.id !== targetId) return;
+
+        if (current.status === "archived" && options?.unarchive !== false) {
           const { remoteId } = await current.initializeTask;
           if (generation !== session.switchGeneration) return;
           await store.optimisticUpdate({
             execute: () => session.adapter.unarchive(remoteId),
             optimistic: (state) =>
-              updateStatusReducer(state, current.id, "regular"),
+              updateStatusReducer(state, targetId, "regular"),
           });
           if (generation !== session.switchGeneration) return;
-          data = getThreadData(store.value, current.id) ?? current;
+          current = getThreadData(store.value, targetId);
+          if (current?.id !== targetId) return;
         }
         if (generation !== session.switchGeneration) return;
-        assignMainThreadId(data.id);
-        notifyRemoteId(data.remoteId, emitThreadIdChange);
-        session.onSwitchToThread?.(data.id);
+        assignMainThreadId(current.id);
+        notifyRemoteId(current.remoteId, emitThreadIdChange);
+        session.onSwitchToThread?.(current.id);
       }),
     [assignMainThreadId, notifyRemoteId, session, startSwitch, store],
   );

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -784,6 +784,8 @@ const useRemoteThreadList = (
         if (current.status === "archived" && options?.unarchive !== false) {
           const { remoteId } = await current.initializeTask;
           if (generation !== session.switchGeneration) return;
+          current = getThreadData(store.value, targetId);
+          if (current?.id !== targetId) return;
           await store.optimisticUpdate({
             execute: () => session.adapter.unarchive(remoteId),
             optimistic: (state) =>

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -786,14 +786,16 @@ const useRemoteThreadList = (
           if (generation !== session.switchGeneration) return;
           current = getThreadData(store.value, targetId);
           if (current?.id !== targetId) return;
-          await store.optimisticUpdate({
-            execute: () => session.adapter.unarchive(remoteId),
-            optimistic: (state) =>
-              updateStatusReducer(state, targetId, "regular"),
-          });
-          if (generation !== session.switchGeneration) return;
-          current = getThreadData(store.value, targetId);
-          if (current?.id !== targetId) return;
+          if (current.status === "archived") {
+            await store.optimisticUpdate({
+              execute: () => session.adapter.unarchive(remoteId),
+              optimistic: (state) =>
+                updateStatusReducer(state, targetId, "regular"),
+            });
+            if (generation !== session.switchGeneration) return;
+            current = getThreadData(store.value, targetId);
+            if (current?.id !== targetId) return;
+          }
         }
         if (generation !== session.switchGeneration) return;
         assignMainThreadId(current.id);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -72,4 +72,51 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     expect(core.mainThreadId).toBe(initialMainThreadId);
     expect(core.getItemById(core.mainThreadId!)).toBeDefined();
   });
+
+  it("does not start unarchive after initialization when the target was deleted", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: string | undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "archived" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+    });
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    const target = core.getItemById("thread-b")!;
+    (
+      target as {
+        initializeTask: Promise<{
+          remoteId: string;
+          externalId: string | undefined;
+        }>;
+      }
+    ).initializeTask = initialization.promise;
+    const initialMainThreadId = core.mainThreadId;
+
+    const switchToB = core.switchToThread("thread-b");
+    const deleteB = core.delete("thread-b");
+    await vi.waitFor(() => {
+      expect(core.getItemById("thread-b")).toBeUndefined();
+    });
+
+    initialization.resolve({
+      remoteId: "thread-b",
+      externalId: "thread-b",
+    });
+    await Promise.all([switchToB, deleteB]);
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(core.mainThreadId).toBe(initialMainThreadId);
+    expect(core.getItemById(core.mainThreadId!)).toBeDefined();
+  });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  contextProvider,
+  deferred,
+  makeAdapter,
+  setStartThreadRuntime,
+} from "../../tests/remote-thread-list-test-helpers";
+import { RemoteThreadListThreadListRuntimeCore } from "./RemoteThreadListThreadListRuntimeCore";
+
+describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
+  it("does not select a thread deleted while its switch is unarchiving", async () => {
+    const unarchive = deferred<void>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "archived" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+      unarchive: vi.fn(() => unarchive.promise),
+    });
+    const core = new RemoteThreadListThreadListRuntimeCore(
+      { adapter, runtimeHook: () => ({}) as never },
+      contextProvider,
+    );
+    setStartThreadRuntime(core, async () => ({}));
+    await core.getLoadThreadsPromise();
+    const initialMainThreadId = core.mainThreadId;
+
+    const switchToB = core.switchToThread("thread-b");
+    await vi.waitFor(() => {
+      expect(adapter.unarchive).toHaveBeenCalledWith("thread-b");
+    });
+    await core.delete("thread-b");
+
+    unarchive.resolve();
+    await switchToB;
+
+    expect(core.getItemById("thread-b")).toBeUndefined();
+    expect(core.mainThreadId).toBe(initialMainThreadId);
+    expect(core.getItemById(core.mainThreadId!)).toBeDefined();
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -119,4 +119,51 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     expect(core.mainThreadId).toBe(initialMainThreadId);
     expect(core.getItemById(core.mainThreadId!)).toBeDefined();
   });
+
+  it("does not unarchive again when the target became regular during initialization", async () => {
+    const initialization = deferred<{
+      remoteId: string;
+      externalId: string | undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "archived" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+    });
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    const target = core.getItemById("thread-b")!;
+    (
+      target as {
+        initializeTask: Promise<{
+          remoteId: string;
+          externalId: string | undefined;
+        }>;
+      }
+    ).initializeTask = initialization.promise;
+
+    const switchToB = core.switchToThread("thread-b");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const unarchiveB = core.unarchive("thread-b");
+    await vi.waitFor(() => {
+      expect(core.getItemById("thread-b")?.status).toBe("regular");
+    });
+
+    initialization.resolve({
+      remoteId: "thread-b",
+      externalId: "thread-b",
+    });
+    await Promise.all([switchToB, unarchiveB]);
+
+    expect(adapter.unarchive).toHaveBeenCalledTimes(1);
+    expect(adapter.unarchive).toHaveBeenCalledWith("thread-b");
+    expect(core.mainThreadId).toBe("thread-b");
+  });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -1,13 +1,46 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  contextProvider,
+  createCore,
   deferred,
   makeAdapter,
   setStartThreadRuntime,
 } from "../../tests/remote-thread-list-test-helpers";
-import { RemoteThreadListThreadListRuntimeCore } from "./RemoteThreadListThreadListRuntimeCore";
 
 describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
+  it("does not unarchive a thread deleted while its runtime is starting", async () => {
+    const startThreadRuntime = deferred<unknown>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "archived" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+    });
+    const core = createCore(adapter);
+    const start = vi.fn(() => startThreadRuntime.promise);
+    setStartThreadRuntime(core, start);
+    await core.getLoadThreadsPromise();
+    const initialMainThreadId = core.mainThreadId;
+
+    const switchToB = core.switchToThread("thread-b");
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledWith("thread-b");
+    });
+    await core.delete("thread-b");
+
+    startThreadRuntime.resolve({});
+    await expect(switchToB).resolves.toBeUndefined();
+
+    expect(adapter.unarchive).not.toHaveBeenCalled();
+    expect(core.getItemById("thread-b")).toBeUndefined();
+    expect(core.mainThreadId).toBe(initialMainThreadId);
+  });
+
   it("does not select a thread deleted while its switch is unarchiving", async () => {
     const unarchive = deferred<void>();
     const adapter = makeAdapter({
@@ -23,11 +56,7 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
       })),
       unarchive: vi.fn(() => unarchive.promise),
     });
-    const core = new RemoteThreadListThreadListRuntimeCore(
-      { adapter, runtimeHook: () => ({}) as never },
-      contextProvider,
-    );
-    setStartThreadRuntime(core, async () => ({}));
+    const core = createCore(adapter);
     await core.getLoadThreadsPromise();
     const initialMainThreadId = core.mainThreadId;
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+import { RemoteThreadListThreadListRuntimeCore } from "./RemoteThreadListThreadListRuntimeCore";
 import {
+  contextProvider,
   createCore,
   deferred,
   makeAdapter,
-  setStartThreadRuntime,
 } from "../../tests/remote-thread-list-test-helpers";
 
 describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
-  it("does not unarchive a thread deleted while its runtime is starting", async () => {
-    const startThreadRuntime = deferred<unknown>();
+  it("rejects when a thread is deleted before its runtime attaches", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({
         threads: [
@@ -21,20 +21,19 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
         ],
       })),
     });
-    const core = createCore(adapter);
-    const start = vi.fn(() => startThreadRuntime.promise);
-    setStartThreadRuntime(core, start);
+    const core = new RemoteThreadListThreadListRuntimeCore(
+      { adapter, runtimeHook: () => ({}) as never },
+      contextProvider,
+    );
     await core.getLoadThreadsPromise();
     const initialMainThreadId = core.mainThreadId;
 
     const switchToB = core.switchToThread("thread-b");
-    await vi.waitFor(() => {
-      expect(start).toHaveBeenCalledWith("thread-b");
-    });
+    const rejection = expect(switchToB).rejects.toThrow(
+      "Thread was deleted before runtime was started",
+    );
     await core.delete("thread-b");
-
-    startThreadRuntime.resolve({});
-    await expect(switchToB).resolves.toBeUndefined();
+    await rejection;
 
     expect(adapter.unarchive).not.toHaveBeenCalled();
     expect(core.getItemById("thread-b")).toBeUndefined();

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -692,7 +692,9 @@ export class RemoteThreadListThreadListRuntimeCore
       await this.unarchive(data.id);
       if (generation !== this._switchGeneration) return;
     }
-    this._mainThreadId = data.id;
+    const current = this.getItemById(data.id);
+    if (current?.id !== data.id) return;
+    this._mainThreadId = current.id;
 
     this._notifySubscribers();
     this._notifyThreadIdChange(emitThreadIdChange);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -696,10 +696,12 @@ export class RemoteThreadListThreadListRuntimeCore
       if (generation !== this._switchGeneration) return;
       current = this.getItemById(data.id);
       if (current?.id !== data.id) return;
-      await this.unarchive(current.id);
-      if (generation !== this._switchGeneration) return;
-      current = this.getItemById(data.id);
-      if (current?.id !== data.id) return;
+      if (current.status === "archived") {
+        await this.unarchive(current.id);
+        if (generation !== this._switchGeneration) return;
+        current = this.getItemById(data.id);
+        if (current?.id !== data.id) return;
+      }
     }
     this._mainThreadId = current.id;
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -692,6 +692,10 @@ export class RemoteThreadListThreadListRuntimeCore
     if (current?.id !== data.id) return;
 
     if (current.status === "archived" && options?.unarchive !== false) {
+      await current.initializeTask;
+      if (generation !== this._switchGeneration) return;
+      current = this.getItemById(data.id);
+      if (current?.id !== data.id) return;
       await this.unarchive(current.id);
       if (generation !== this._switchGeneration) return;
       current = this.getItemById(data.id);
@@ -1003,8 +1007,6 @@ export class RemoteThreadListThreadListRuntimeCore
         try {
           const { remoteId } = await data.initializeTask;
           this._requireAdapterGeneration(adapterGeneration);
-          const current = this.getItemById(data.id);
-          if (current?.id !== data.id) return;
           return await adapter.unarchive(remoteId);
         } catch (error) {
           if (adapterGeneration === this._adapterGeneration) {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1003,6 +1003,8 @@ export class RemoteThreadListThreadListRuntimeCore
         try {
           const { remoteId } = await data.initializeTask;
           this._requireAdapterGeneration(adapterGeneration);
+          const current = this.getItemById(data.id);
+          if (current?.id !== data.id) return;
           return await adapter.unarchive(remoteId);
         } catch (error) {
           if (adapterGeneration === this._adapterGeneration) {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -688,12 +688,15 @@ export class RemoteThreadListThreadListRuntimeCore
 
     if (generation !== this._switchGeneration) return;
 
-    if (data.status === "archived" && options?.unarchive !== false) {
-      await this.unarchive(data.id);
-      if (generation !== this._switchGeneration) return;
-    }
-    const current = this.getItemById(data.id);
+    let current = this.getItemById(data.id);
     if (current?.id !== data.id) return;
+
+    if (current.status === "archived" && options?.unarchive !== false) {
+      await this.unarchive(current.id);
+      if (generation !== this._switchGeneration) return;
+      current = this.getItemById(data.id);
+      if (current?.id !== data.id) return;
+    }
     this._mainThreadId = current.id;
 
     this._notifySubscribers();


### PR DESCRIPTION
## Problem

Deleting a thread while switchToThread is waiting at an asynchronous boundary can leave mainThreadId pointing to a slot removed by optimistic deletion. The next main-thread lookup then throws because its data no longer exists.

A minimal reproduction loads an archived target, starts switching to it, deletes the target while unarchive is pending, and then releases unarchive. On main, the stale switch finishes by selecting the deleted ID.

Closes #6646.

## Root cause

Both remote thread-list implementations capture a target before async boundaries and only check whether a newer switch superseded it. Deletion does not advance the switch generation, and its main-thread guard passes because the target is not main yet.

The legacy runtime could assign the captured ID after unarchive. The tap client similarly fell back to its captured target when post-unarchive lookup returned no live slot. Both switch paths also lacked a live-target check after awaiting initialization and before beginning unarchive. Another operation could also unarchive the target during initialization, causing the switch to issue a duplicate adapter request against a now-regular thread.

## Change

Re-resolve the target after runtime attachment, after initialization before starting unarchive, and after unarchive before the final main-thread assignment. A switch that reaches any checkpoint exits if deletion removed or remapped its target. If another operation already made the target regular, either runtime skips its own unarchive but still completes the switch. If deletion aborts legacy runtime attachment itself, the existing hook-manager rejection is preserved while mainThreadId remains valid.

Keep these checks inside the switch paths so direct unarchive behavior remains unchanged and consistent across runtimes.

Add contract coverage for the real legacy pre-attachment rejection, the legacy and tap pre-adapter deletion windows, concurrent unarchive during initialization in both runtimes, and deletion while either runtime has an unarchive request in flight.

## Verification

- Confirmed both pre-adapter regression tests fail without their switch checkpoints and pass with them restored
- Confirmed both concurrent-unarchive regression tests fail without their status guards and pass with them restored
- Confirmed the original post-adapter regression test fails on unmodified main by selecting the deleted thread ID
- pnpm exec vitest run src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts src/react/client/RemoteThreadList.test.ts — 44 tests passed
- pnpm --filter @assistant-ui/core test — 154 files and 1,572 tests passed
- pnpm --filter @assistant-ui/core build
- pnpm --filter with-livekit build
- pnpm lint
- pnpm changesets:check

## Public surface

- Package: @assistant-ui/core behavior fix across both remote thread-list runtimes
- Exports, documentation, API reference, and templates: None
- Patch changeset added