### PR TITLE
fix(react-opencode): reject malformed message events

### DIFF
--- a/.changeset/quiet-fans-listen.md
+++ b/.changeset/quiet-fans-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: reject malformed OpenCode message update events

--- a/packages/react-opencode/src/OpenCodeEventSource.test.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.test.ts
@@ -39,7 +39,7 @@ const createEventStream = (signal: AbortSignal, events: readonly unknown[]) =>
   })();
 
 describe("OpenCodeEventSource", () => {
-  it("rejects malformed message updates without dropping unknown events", async () => {
+  it("rejects unroutable message updates without dropping compatible events", async () => {
     const client = {
       event: {
         subscribe: vi.fn((_: unknown, options: { signal: AbortSignal }) =>
@@ -49,7 +49,7 @@ describe("OpenCodeEventSource", () => {
                 type: "message.updated",
                 properties: {
                   sessionID: "ses_1",
-                  info: { id: "malformed-message", sessionID: "ses_1" },
+                  info: { sessionID: "ses_1", role: "assistant" },
                 },
               },
               {
@@ -60,6 +60,17 @@ describe("OpenCodeEventSource", () => {
                     id: "wrong-session",
                     sessionID: "ses_2",
                     role: "assistant",
+                  },
+                },
+              },
+              {
+                type: "message.updated",
+                properties: {
+                  sessionID: "ses_1",
+                  info: {
+                    id: "future-role",
+                    sessionID: "ses_1",
+                    role: "system",
                   },
                 },
               },
@@ -83,7 +94,15 @@ describe("OpenCodeEventSource", () => {
           expect.objectContaining({ type: "future.event" }),
         );
       });
-      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "message.updated",
+          properties: expect.objectContaining({
+            info: expect.objectContaining({ role: "system" }),
+          }),
+        }),
+      );
     } finally {
       source.dispose();
     }

--- a/packages/react-opencode/src/OpenCodeEventSource.test.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.test.ts
@@ -32,7 +32,63 @@ const createAbortableStream = (signal: AbortSignal) =>
     });
   })();
 
+const createEventStream = (signal: AbortSignal, events: readonly unknown[]) =>
+  (async function* () {
+    yield* events;
+    yield* createAbortableStream(signal);
+  })();
+
 describe("OpenCodeEventSource", () => {
+  it("rejects malformed message updates without dropping unknown events", async () => {
+    const client = {
+      event: {
+        subscribe: vi.fn((_: unknown, options: { signal: AbortSignal }) =>
+          Promise.resolve({
+            stream: createEventStream(options.signal, [
+              {
+                type: "message.updated",
+                properties: {
+                  sessionID: "ses_1",
+                  info: { id: "malformed-message", sessionID: "ses_1" },
+                },
+              },
+              {
+                type: "message.updated",
+                properties: {
+                  sessionID: "ses_1",
+                  info: {
+                    id: "wrong-session",
+                    sessionID: "ses_2",
+                    role: "assistant",
+                  },
+                },
+              },
+              {
+                type: "future.event",
+                properties: { sessionID: "ses_1", value: 42 },
+              },
+            ]),
+          }),
+        ),
+      },
+    };
+    const source = new OpenCodeEventSource(client as never);
+    const listener = vi.fn();
+
+    try {
+      source.subscribe(listener);
+
+      await waitFor(() => {
+        expect(listener).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "future.event" }),
+        );
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      source.dispose();
+    }
+  });
+
   it("reconnects immediately when a listener returns during backoff", async () => {
     const client = {
       event: {

--- a/packages/react-opencode/src/OpenCodeEventSource.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.ts
@@ -16,8 +16,7 @@ const isValidMessageUpdated = (
   if (
     !info ||
     typeof info.id !== "string" ||
-    typeof info.sessionID !== "string" ||
-    (info.role !== "user" && info.role !== "assistant")
+    typeof info.sessionID !== "string"
   ) {
     return false;
   }

--- a/packages/react-opencode/src/OpenCodeEventSource.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.ts
@@ -9,6 +9,25 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
     : null;
 };
 
+const isValidMessageUpdated = (
+  properties: Record<string, unknown>,
+): boolean => {
+  const info = asRecord(properties.info);
+  if (
+    !info ||
+    typeof info.id !== "string" ||
+    typeof info.sessionID !== "string" ||
+    (info.role !== "user" && info.role !== "assistant")
+  ) {
+    return false;
+  }
+
+  return (
+    typeof properties.sessionID !== "string" ||
+    properties.sessionID === info.sessionID
+  );
+};
+
 const extractSessionId = (
   type: string,
   properties: Record<string, unknown>,
@@ -56,13 +75,18 @@ const normalizeEventPayload = (event: unknown): OpenCodeServerEvent | null => {
     return null;
   }
 
+  const properties = candidate.properties as Record<string, unknown>;
+  if (
+    candidate.type === "message.updated" &&
+    !isValidMessageUpdated(properties)
+  ) {
+    return null;
+  }
+
   const normalized = {
     type: candidate.type,
-    properties: candidate.properties as Record<string, unknown>,
-    sessionId: extractSessionId(
-      candidate.type,
-      candidate.properties as Record<string, unknown>,
-    ),
+    properties,
+    sessionId: extractSessionId(candidate.type, properties),
     raw: event,
   } satisfies OpenCodeServerEvent;
 

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -21,6 +21,7 @@ import {
   projectOpenCodePermissionApproval,
   projectResolvedOpenCodePermissionApproval,
 } from "./openCodePermissionApproval";
+import { isOpenCodeMessageRoleRenderable } from "./openCodeMessageRoles";
 import { getOpenCodeTaskSessionId } from "./openCodeTaskSession";
 
 type ProjectedContentPart = Exclude<
@@ -604,7 +605,9 @@ const projectServerMessage = (
   message: OpenCodeServerMessage,
   timing?: MessageTiming,
 ): OpenCodeProjectedThreadMessage | null => {
-  if (!message.info) return null;
+  if (!message.info || !isOpenCodeMessageRoleRenderable(message.info.role)) {
+    return null;
+  }
 
   const metadata = {
     custom: {

--- a/packages/react-opencode/src/openCodeMessageRoles.ts
+++ b/packages/react-opencode/src/openCodeMessageRoles.ts
@@ -1,0 +1,2 @@
+export const isOpenCodeMessageRoleRenderable = (role: unknown) =>
+  role === "user" || role === "assistant";

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -357,7 +357,7 @@ describe("reduceOpenCodeThreadState", () => {
     expect(withPart.messagesById.msg_assistant?.parts).toHaveLength(1);
   });
 
-  it("stores messages with unknown roles without exposing them", () => {
+  it("stores unknown-role messages and exposes later supported updates", () => {
     const initial = createOpenCodeThreadState("ses_1");
 
     const withMessage = reduceOpenCodeThreadState(initial, {
@@ -382,8 +382,63 @@ describe("reduceOpenCodeThreadState", () => {
       } as never,
     });
 
+    const withSupportedRole = reduceOpenCodeThreadState(withPart, {
+      type: "message.updated",
+      info: {
+        id: "msg_system",
+        role: "assistant",
+        sessionID: "ses_1",
+        time: { created: 1001 },
+      } as never,
+    });
+
     expect(withPart.messageOrder).toEqual([]);
-    expect(withPart.messagesById.msg_system?.parts).toHaveLength(1);
+    expect(withSupportedRole.messageOrder).toEqual(["msg_system"]);
+    expect(withSupportedRole.messagesById.msg_system?.parts).toHaveLength(1);
+  });
+
+  it("keeps unknown-role history out of visible message order", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+
+    const history = reduceOpenCodeThreadState(initial, {
+      type: "history.loaded",
+      session: null,
+      messages: [
+        {
+          info: {
+            id: "msg_assistant_1",
+            role: "assistant",
+            sessionID: "ses_1",
+            time: { created: 1000 },
+          },
+          parts: [],
+        },
+        {
+          info: {
+            id: "msg_system",
+            role: "system",
+            sessionID: "ses_1",
+            time: { created: 1001 },
+          },
+          parts: [],
+        },
+        {
+          info: {
+            id: "msg_assistant_2",
+            role: "assistant",
+            sessionID: "ses_1",
+            time: { created: 1002 },
+          },
+          parts: [],
+        },
+      ] as unknown as MessageWithParts[],
+    });
+
+    expect(history.messageOrder).toEqual([
+      "msg_assistant_1",
+      "msg_assistant_2",
+    ]);
+    expect(history.messagesById.msg_system).toBeDefined();
   });
 
   it("reconciles a pending user message with a streamed message update", () => {

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -357,6 +357,35 @@ describe("reduceOpenCodeThreadState", () => {
     expect(withPart.messagesById.msg_assistant?.parts).toHaveLength(1);
   });
 
+  it("stores messages with unknown roles without exposing them", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+
+    const withMessage = reduceOpenCodeThreadState(initial, {
+      type: "message.updated",
+      info: {
+        id: "msg_system",
+        role: "system",
+        sessionID: "ses_1",
+        time: { created: 1001 },
+      } as never,
+    });
+
+    const withPart = reduceOpenCodeThreadState(withMessage, {
+      type: "part.updated",
+      messageId: "msg_system",
+      part: {
+        id: "prt_1",
+        type: "text",
+        text: "Hidden context",
+        sessionID: "ses_1",
+        messageID: "msg_system",
+      } as never,
+    });
+
+    expect(withPart.messageOrder).toEqual([]);
+    expect(withPart.messagesById.msg_system?.parts).toHaveLength(1);
+  });
+
   it("reconciles a pending user message with a streamed message update", () => {
     const initial = createOpenCodeThreadState("ses_1");
     const pending: PendingUserMessage = {

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -45,6 +45,9 @@ const sortMessageIds = (
   });
 };
 
+const isVisibleMessageRole = (role: unknown) =>
+  role === "user" || role === "assistant";
+
 const upsertMessage = (
   state: OpenCodeThreadState,
   messageId: string,
@@ -60,7 +63,7 @@ const upsertMessage = (
     [messageId]: nextMessage,
   };
   const messageOrder =
-    current || !includeInOrder
+    !includeInOrder || state.messageOrder.includes(messageId)
       ? state.messageOrder
       : sortMessageIds(messagesById, [...state.messageOrder, messageId]);
 
@@ -164,6 +167,7 @@ const historyLoaded = (
   };
 
   const nextMessagesById: Record<string, OpenCodeServerMessage> = {};
+  const nextMessageOrder: string[] = [];
   for (const message of messages) {
     const pendingMatch =
       message.info.role === "user"
@@ -179,6 +183,9 @@ const historyLoaded = (
           ? pendingMatch.parts
           : undefined,
     };
+    if (isVisibleMessageRole(message.info.role)) {
+      nextMessageOrder.push(message.info.id);
+    }
 
     if (pendingMatch) {
       nextState = removePending(nextState, pendingMatch.clientId);
@@ -188,10 +195,7 @@ const historyLoaded = (
   nextState = {
     ...nextState,
     messagesById: nextMessagesById,
-    messageOrder: sortMessageIds(
-      nextMessagesById,
-      Object.keys(nextMessagesById),
-    ),
+    messageOrder: sortMessageIds(nextMessagesById, nextMessageOrder),
   };
 
   return nextState;
@@ -406,7 +410,7 @@ export const reduceOpenCodeThreadState = (
               ? pendingMatch.parts
               : undefined),
         }),
-        event.info.role === "user" || event.info.role === "assistant",
+        isVisibleMessageRole(event.info.role),
       );
 
       if (pendingMatch) {

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -51,6 +51,7 @@ const upsertMessage = (
   updater: (
     current: OpenCodeServerMessage | undefined,
   ) => OpenCodeServerMessage,
+  includeInOrder: boolean,
 ): OpenCodeThreadState => {
   const current = state.messagesById[messageId];
   const nextMessage = updater(current);
@@ -58,9 +59,10 @@ const upsertMessage = (
     ...state.messagesById,
     [messageId]: nextMessage,
   };
-  const messageOrder = current
-    ? state.messageOrder
-    : sortMessageIds(messagesById, [...state.messageOrder, messageId]);
+  const messageOrder =
+    current || !includeInOrder
+      ? state.messageOrder
+      : sortMessageIds(messagesById, [...state.messageOrder, messageId]);
 
   return {
     ...state,
@@ -391,16 +393,21 @@ export const reduceOpenCodeThreadState = (
           ? findPendingMatchByMessageInfo(state, event.info)
           : undefined;
 
-      let nextState = upsertMessage(state, event.info.id, (current) => ({
-        id: event.info.id,
-        info: event.info,
-        parts: current?.parts ?? [],
-        shadowParts:
-          current?.shadowParts ??
-          (pendingMatch && (current?.parts?.length ?? 0) === 0
-            ? pendingMatch.parts
-            : undefined),
-      }));
+      let nextState = upsertMessage(
+        state,
+        event.info.id,
+        (current) => ({
+          id: event.info.id,
+          info: event.info,
+          parts: current?.parts ?? [],
+          shadowParts:
+            current?.shadowParts ??
+            (pendingMatch && (current?.parts?.length ?? 0) === 0
+              ? pendingMatch.parts
+              : undefined),
+        }),
+        event.info.role === "user" || event.info.role === "assistant",
+      );
 
       if (pendingMatch) {
         nextState = removePending(nextState, pendingMatch.clientId);

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -8,6 +8,7 @@ import type {
   PendingUserMessage,
   ThreadUserMessagePart,
 } from "./types";
+import { isOpenCodeMessageRoleRenderable } from "./openCodeMessageRoles";
 import { serializeOpenCodeParts } from "./serializeUserParts";
 
 const PENDING_MATCH_WINDOW_MS = 2 * 60 * 1000;
@@ -44,9 +45,6 @@ const sortMessageIds = (
     return leftId.localeCompare(rightId);
   });
 };
-
-const isVisibleMessageRole = (role: unknown) =>
-  role === "user" || role === "assistant";
 
 const upsertMessage = (
   state: OpenCodeThreadState,
@@ -183,7 +181,7 @@ const historyLoaded = (
           ? pendingMatch.parts
           : undefined,
     };
-    if (isVisibleMessageRole(message.info.role)) {
+    if (isOpenCodeMessageRoleRenderable(message.info.role)) {
       nextMessageOrder.push(message.info.id);
     }
 
@@ -410,7 +408,7 @@ export const reduceOpenCodeThreadState = (
               ? pendingMatch.parts
               : undefined),
         }),
-        isVisibleMessageRole(event.info.role),
+        isOpenCodeMessageRoleRenderable(event.info.role),
       );
 
       if (pendingMatch) {


### PR DESCRIPTION
## Problem

`@assistant-ui/react-opencode` 0.2.21 accepts malformed `message.updated` stream events. A payload with an ID but no supported visible role enters `messageOrder` while projection drops it, leaving invisible state. A payload whose embedded message belongs to a different session can also be routed using the outer session ID.

Minimal reproduction: stream `{ type: "message.updated", properties: { sessionID: "ses_1", info: { id: "bad", sessionID: "ses_1" } } }`. The event currently enters visible ordering even though it cannot be projected.

## Root cause

The stream boundary checked only that `type` was a string and `properties` was an object. The controller then cast `properties.info` to the SDK message type after checking only for an `id` property, and both streamed updates and history loads ordered every message regardless of whether its role was renderable.

## Change

Validate the string message and session IDs needed for routing, and reject outer/embedded session mismatches. Keep unknown future roles transport-compatible and store their parts for state consistency, but exclude them from visible message ordering. A later supported-role update for the same message can make it visible without losing already streamed parts.

## Verification

- Regression test confirms unroutable and cross-session message updates are dropped while unknown roles and event types remain compatible.
- Reducer tests confirm unknown-role messages retain streamed parts, become visible after a supported-role update, and stay out of history ordering.
- `pnpm --filter @assistant-ui/react-opencode test` (135 passed)
- `pnpm --filter @assistant-ui/react-opencode build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-opencode` behavior only. No exports or documentation changed. Includes a patch changeset.