### PR TITLE
fix(react-ag-ui): reject malformed message snapshots

### DIFF
--- a/.changeset/calm-snapshots-wait.md
+++ b/.changeset/calm-snapshots-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: reject malformed message snapshot events

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -300,7 +300,13 @@ export const parseAgUiEvent = (
         delta: Array.isArray(payload.delta) ? (payload.delta as any[]) : [],
       };
     case "MESSAGES_SNAPSHOT":
-      if (!Array.isArray(payload.messages)) return null;
+      if (!Array.isArray(payload.messages)) {
+        options?.logger?.debug?.(
+          "[agui] MESSAGES_SNAPSHOT missing messages array",
+          payload,
+        );
+        return null;
+      }
       return {
         type: "MESSAGES_SNAPSHOT",
         messages: payload.messages as any[],

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -300,11 +300,10 @@ export const parseAgUiEvent = (
         delta: Array.isArray(payload.delta) ? (payload.delta as any[]) : [],
       };
     case "MESSAGES_SNAPSHOT":
+      if (!Array.isArray(payload.messages)) return null;
       return {
         type: "MESSAGES_SNAPSHOT",
-        messages: Array.isArray(payload.messages)
-          ? (payload.messages as any[])
-          : [],
+        messages: payload.messages as any[],
       };
     case "ACTIVITY_SNAPSHOT": {
       const activityType = getString("activityType");

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -79,8 +79,9 @@ describe("parseAgUiEvent", () => {
       ),
     ).toBeNull();
     expect(debug).toHaveBeenCalledTimes(1);
-    expect(debug.mock.calls[0][0]).toMatch(
-      /MESSAGES_SNAPSHOT missing messages/,
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringMatching(/MESSAGES_SNAPSHOT missing messages/),
+      { type: "MESSAGES_SNAPSHOT", messages: {} },
     );
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT" })).toBeNull();
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: [] })).toEqual(

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -70,6 +70,16 @@ describe("parseAgUiEvent", () => {
     expect(event).toBeNull();
   });
 
+  it("rejects malformed message snapshots without rejecting empty snapshots", () => {
+    expect(
+      parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: {} }),
+    ).toBeNull();
+    expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT" })).toBeNull();
+    expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: [] })).toEqual(
+      { type: "MESSAGES_SNAPSHOT", messages: [] },
+    );
+  });
+
   it("parses reasoning content with optional message id", () => {
     const event = parseAgUiEvent({
       type: "REASONING_MESSAGE_CONTENT",

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -78,9 +78,9 @@ describe("parseAgUiEvent", () => {
         { logger: { debug } as any },
       ),
     ).toBeNull();
-    expect(debug).toHaveBeenCalledWith(
-      "[agui] MESSAGES_SNAPSHOT missing messages array",
-      { type: "MESSAGES_SNAPSHOT", messages: {} },
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls[0][0]).toMatch(
+      /MESSAGES_SNAPSHOT missing messages/,
     );
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT" })).toBeNull();
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: [] })).toEqual(

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -71,9 +71,17 @@ describe("parseAgUiEvent", () => {
   });
 
   it("rejects malformed message snapshots without rejecting empty snapshots", () => {
+    const debug = vi.fn();
     expect(
-      parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: {} }),
+      parseAgUiEvent(
+        { type: "MESSAGES_SNAPSHOT", messages: {} },
+        { logger: { debug } as any },
+      ),
     ).toBeNull();
+    expect(debug).toHaveBeenCalledWith(
+      "[agui] MESSAGES_SNAPSHOT missing messages array",
+      { type: "MESSAGES_SNAPSHOT", messages: {} },
+    );
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT" })).toBeNull();
     expect(parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: [] })).toEqual(
       { type: "MESSAGES_SNAPSHOT", messages: [] },

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -236,6 +236,17 @@ describe("createAgUiSubscriber", () => {
     });
   });
 
+  it("does not dispatch malformed message snapshots", () => {
+    const dispatch = vi.fn();
+    const subscriber = createAgUiSubscriber({ dispatch, runId: "run" });
+
+    subscriber.onMessagesSnapshotEvent?.({
+      event: { type: "MESSAGES_SNAPSHOT", messages: {} } as never,
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
   it("dispatches reasoning handlers without duplication", () => {
     const events: AgUiEvent[] = [];
     const subscriber = createAgUiSubscriber({

--- a/packages/react-ag-ui/test/subscriber.spec.ts
+++ b/packages/react-ag-ui/test/subscriber.spec.ts
@@ -241,7 +241,7 @@ describe("createAgUiSubscriber", () => {
     const subscriber = createAgUiSubscriber({ dispatch, runId: "run" });
 
     subscriber.onMessagesSnapshotEvent?.({
-      event: { type: "MESSAGES_SNAPSHOT", messages: {} } as never,
+      event: { type: "MESSAGES_SNAPSHOT", messages: {} },
     });
 
     expect(dispatch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

`@assistant-ui/react-ag-ui` 0.0.57 normalizes a malformed `MESSAGES_SNAPSHOT` event whose `messages` field is missing or not an array into a valid empty snapshot. The runtime then imports that snapshot and can clear the current conversation.

Reproduction against parent commit `48e12ab06`: add the following assertion to `packages/react-ag-ui/test/event-parser.spec.ts` and run `pnpm --filter @assistant-ui/react-ag-ui exec vitest run test/event-parser.spec.ts`.

```ts
expect(
  parseAgUiEvent({ type: "MESSAGES_SNAPSHOT", messages: {} }),
).toBeNull();
```

Before this fix, the assertion fails because the parser returns `{ type: "MESSAGES_SNAPSHOT", messages: [] }`. That event is dispatched as a replacement snapshot, clearing the visible conversation.

## Root cause

The event parser used an empty array as a fallback for every non-array `messages` value, making malformed transport data indistinguishable from a legitimate empty snapshot.

## Change

Reject malformed message snapshots at the protocol boundary. Preserve `messages: []` as a valid snapshot so servers can still intentionally clear history.

## Verification

- Parser regression covers object-valued and missing `messages`, plus a valid empty array.
- Subscriber regression confirms malformed snapshots are not dispatched.
- `pnpm --filter @assistant-ui/react-ag-ui exec vitest run test/event-parser.spec.ts test/subscriber.spec.ts` (48 passed)
- `pnpm --filter @assistant-ui/react-ag-ui test` (512 passed)
- `pnpm --filter @assistant-ui/react-ag-ui... build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/react-ag-ui` parsing behavior only. No exports or documentation changed. Includes a patch changeset.