### PR TITLE
fix(core): report run events from background thread runtimes

### DIFF
--- a/.changeset/background-thread-run-events.md
+++ b/.changeset/background-thread-run-events.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: report run start and end for threads a remote thread list keeps alive in the background

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1722,6 +1722,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1789,6 +1790,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3734,6 +3734,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   }> | undefined;
   __internal_isThreadRunning(threadId: string): boolean;
   __internal_subscribeRunningChanged(callback: () => void): Unsubscribe$1;
+  __internal_subscribeRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   __internal_subscribeRuntimeReplaced(callback: () => void): Unsubscribe$1;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
@@ -3910,6 +3911,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
     unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
   }>;
   unstable_isThreadRunning(threadIdOrRemoteId: string): boolean;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getItemById(threadIdOrRemoteId: string): RemoteThreadData | undefined;
   switchToThread(threadIdOrRemoteId: string, options?: {
     unarchive?: boolean;
@@ -4718,6 +4720,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -4736,6 +4739,7 @@ type ThreadListRuntimeCore = {
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
   unstable_isThreadRunning?(threadId: string): boolean;
+  unstable_subscribeThreadRunEvents?(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -4769,6 +4773,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -4958,6 +4963,11 @@ declare namespace ThreadPrimitiveUnstable_MessageById {
 }
 
 declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
+};
 
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1143,6 +1143,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1210,6 +1211,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1470,6 +1470,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1537,6 +1538,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1256,6 +1256,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1334,6 +1335,11 @@ type ThreadMessageLike$1 = {
   toolCallId?: string;
   error?: string;
   attachments?: readonly AttachmentLike[];
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1722,6 +1722,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1789,6 +1790,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1466,6 +1466,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1533,6 +1534,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2036,6 +2036,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -2103,6 +2104,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3573,6 +3573,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -3591,6 +3592,7 @@ type ThreadListRuntimeCore = {
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
   unstable_isThreadRunning?(threadId: string): boolean;
+  unstable_subscribeThreadRunEvents?(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -3624,6 +3626,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -3772,6 +3775,11 @@ declare const ThreadRoot: (_param67: ThreadRootProps) => import("react").JSX.Ele
 
 type ThreadRootProps = ComponentProps<typeof Box> & {
   children: ReactNode;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1751,6 +1751,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1818,6 +1819,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1908,6 +1908,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1975,6 +1976,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3147,6 +3147,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -3165,6 +3166,7 @@ type ThreadListRuntimeCore = {
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
   unstable_isThreadRunning?(threadId: string): boolean;
+  unstable_subscribeThreadRunEvents?(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -3198,6 +3200,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -3333,6 +3336,11 @@ declare const ThreadRoot: (_param47: ThreadRootProps) => import("react").JSX.Ele
 
 type ThreadRootProps = ViewProps & {
   children: ReactNode;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1554,6 +1554,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -1621,6 +1622,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1966,6 +1966,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -2033,6 +2034,11 @@ type ThreadMessageLike = {
     readonly isOptimistic?: boolean | undefined;
     readonly custom?: Record<string, unknown> | undefined;
   } | undefined;
+};
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
 };
 
 type ThreadRuntime = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4591,6 +4591,7 @@ type ThreadListRuntime = {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -4609,6 +4610,7 @@ type ThreadListRuntimeCore = {
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
   unstable_isThreadRunning?(threadId: string): boolean;
+  unstable_subscribeThreadRunEvents?(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -4642,6 +4644,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
     unarchive?: boolean;
   }): Promise<void>;
   switchToNewThread(): Promise<void>;
+  unstable_subscribeThreadRunEvents(callback: (event: ThreadRunEvent) => void): Unsubscribe$1;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
   reloadMainThread(): Promise<void>;
@@ -4876,6 +4879,11 @@ declare const ThreadPrimitiveViewportFooter: import("react").ForwardRefExoticCom
 } & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
 
 declare const ThreadPrimitiveViewportProvider: FC<ThreadViewportProviderProps>;
+
+type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runEnd" | "runStart";
+};
 
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
@@ -8,12 +8,22 @@ const makeRuntime = (
   initial: Partial<Pick<ThreadRuntimeCore, "isRunning" | "messages">> = {},
 ) => {
   const subscribers = new Set<() => void>();
+  const eventListeners = new Map<string, Set<() => void>>();
   const runtime = {
     isRunning: initial.isRunning,
     messages: initial.messages ?? [],
     subscribe: (callback: () => void) => {
       subscribers.add(callback);
       return () => subscribers.delete(callback);
+    },
+    unstable_on: (event: string, callback: () => void) => {
+      let listeners = eventListeners.get(event);
+      if (!listeners) {
+        listeners = new Set();
+        eventListeners.set(event, listeners);
+      }
+      listeners.add(callback);
+      return () => listeners.delete(callback);
     },
   } as unknown as ThreadRuntimeCore & {
     isRunning: boolean | undefined;
@@ -23,6 +33,14 @@ const makeRuntime = (
   return {
     runtime,
     subscriberCount: () => subscribers.size,
+    eventListenerCount: () =>
+      [...eventListeners.values()].reduce(
+        (total, listeners) => total + listeners.size,
+        0,
+      ),
+    emit: (event: string) => {
+      for (const callback of eventListeners.get(event) ?? []) callback();
+    },
     setRunning: (isRunning: boolean | undefined) => {
       runtime.isRunning = isRunning;
       for (const callback of subscribers) callback();
@@ -152,6 +170,46 @@ describe("RemoteThreadListHookInstanceManager run tracking", () => {
     manager.stopThreadRuntime("thread-1");
 
     expect(thread.subscriberCount()).toBe(0);
+    expect(thread.eventListenerCount()).toBe(0);
     expect(manager.__internal_isThreadRunning("thread-1")).toBe(false);
+  });
+
+  it("forwards run events from every tracked thread with its thread id", () => {
+    const manager = makeManager();
+    const events: unknown[] = [];
+    manager.__internal_subscribeRunEvents((event) => events.push(event));
+
+    start(manager, "thread-1");
+    start(manager, "thread-2");
+    const first = makeRuntime();
+    const second = makeRuntime();
+    publish(manager, "thread-1", first.runtime);
+    publish(manager, "thread-2", second.runtime);
+
+    second.emit("runStart");
+    first.emit("runEnd");
+
+    expect(events).toEqual([
+      { threadId: "thread-2", type: "runStart" },
+      { threadId: "thread-1", type: "runEnd" },
+    ]);
+  });
+
+  it("stops forwarding run events from a runtime a restart replaced", () => {
+    const manager = makeManager();
+    const events: unknown[] = [];
+    manager.__internal_subscribeRunEvents((event) => events.push(event));
+
+    start(manager, "thread-1");
+    const before = makeRuntime();
+    publish(manager, "thread-1", before.runtime);
+    const after = makeRuntime();
+    publish(manager, "thread-1", after.runtime);
+
+    before.emit("runEnd");
+    after.emit("runEnd");
+
+    expect(before.eventListenerCount()).toBe(0);
+    expect(events).toEqual([{ threadId: "thread-1", type: "runEnd" }]);
   });
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -14,7 +14,10 @@ import { useResources, withKey } from "@assistant-ui/tap";
 import type { AssistantClient } from "@assistant-ui/store";
 import { ThreadListItemRuntimeProvider } from "../providers/ThreadListItemRuntimeProvider";
 import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
-import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import type {
+  ThreadListRuntimeCore,
+  ThreadRunEvent,
+} from "../../runtime/interfaces/thread-list-runtime-core";
 import type { Unsubscribe } from "../../types/unsubscribe";
 import {
   BaseSubscribable,
@@ -32,6 +35,8 @@ import {
   RemoteThreadResource,
   type RemoteThreadListHook,
 } from "./RemoteThreadResource";
+
+const RUN_EVENTS = ["runStart", "runEnd"] as const;
 
 type RemoteThreadListHookInstance = {
   runtime?: ThreadRuntimeCore | undefined;
@@ -151,6 +156,15 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     return () => this.runningSubscribers.delete(callback);
   }
 
+  private runEventSubscribers = new Set<(event: ThreadRunEvent) => void>();
+
+  public __internal_subscribeRunEvents(
+    callback: (event: ThreadRunEvent) => void,
+  ): Unsubscribe {
+    this.runEventSubscribers.add(callback);
+    return () => this.runEventSubscribers.delete(callback);
+  }
+
   private _publish = (
     threadId: string,
     runtime: ThreadRuntimeCore,
@@ -173,7 +187,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     instance.runtime = runtime;
     instance.publishedGeneration = generation;
     if (previousRuntime !== runtime) {
-      this._trackRunning(instance);
+      this._trackRunning(threadId, instance);
     }
     this._notifySubscribers();
     if (previousRuntime !== undefined && previousRuntime !== runtime) {
@@ -190,7 +204,10 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     return () => this.replacedSubscribers.delete(callback);
   }
 
-  private _trackRunning(instance: RemoteThreadListHookInstance) {
+  private _trackRunning(
+    threadId: string,
+    instance: RemoteThreadListHookInstance,
+  ) {
     instance.unsubscribeRunning?.();
 
     const runtime = instance.runtime;
@@ -201,9 +218,21 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     }
 
     this._setRunning(instance, getThreadRuntimeCoreIsRunning(runtime));
-    instance.unsubscribeRunning = runtime.subscribe(() => {
-      this._setRunning(instance, getThreadRuntimeCoreIsRunning(runtime));
-    });
+    const unsubscribers = [
+      runtime.subscribe(() => {
+        this._setRunning(instance, getThreadRuntimeCoreIsRunning(runtime));
+      }),
+      ...RUN_EVENTS.map((type) =>
+        runtime.unstable_on(type, () => {
+          for (const callback of this.runEventSubscribers) {
+            callback({ threadId, type });
+          }
+        }),
+      ),
+    ];
+    instance.unsubscribeRunning = () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
   }
 
   private _setRunning(

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1,4 +1,7 @@
-import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import type {
+  ThreadListRuntimeCore,
+  ThreadRunEvent,
+} from "../../runtime/interfaces/thread-list-runtime-core";
 import {
   BaseSubscribable,
   WritableSubscribable,
@@ -557,6 +560,12 @@ export class RemoteThreadListThreadListRuntimeCore
     const data = this.getItemById(threadIdOrRemoteId);
     if (!data) return false;
     return this._hookManager.__internal_isThreadRunning(data.id);
+  }
+
+  public unstable_subscribeThreadRunEvents(
+    callback: (event: ThreadRunEvent) => void,
+  ) {
+    return this._hookManager.__internal_subscribeRunEvents(callback);
   }
 
   public getItemById(threadIdOrRemoteId: string) {

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -7,7 +7,10 @@ import {
   SKIP_UPDATE,
   ShallowMemoizeSubject,
 } from "../../subscribable/subscribable";
-import type { ThreadListRuntimeCore } from "../interfaces/thread-list-runtime-core";
+import type {
+  ThreadListRuntimeCore,
+  ThreadRunEvent,
+} from "../interfaces/thread-list-runtime-core";
 import {
   type ThreadListItemRuntime,
   ThreadListItemRuntimeImpl,
@@ -21,6 +24,7 @@ import {
 } from "./thread-runtime";
 
 const RESOLVED_PROMISE = Promise.resolve();
+const NOOP_UNSUBSCRIBE = () => {};
 
 export type ThreadListState = {
   readonly mainThreadId: string;
@@ -56,6 +60,16 @@ export type ThreadListRuntime = {
     options?: { unarchive?: boolean },
   ): Promise<void>;
   switchToNewThread(): Promise<void>;
+
+  /**
+   * Observes run starts and ends on every thread this list keeps alive, so a
+   * run that outlives its thread's selection stays observable. Thread lists
+   * that mount only the main thread never emit; their main thread's runtime is
+   * observed directly.
+   */
+  unstable_subscribeThreadRunEvents(
+    callback: (event: ThreadRunEvent) => void,
+  ): Unsubscribe;
 
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
@@ -171,6 +185,8 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
   protected __internal_bindMethods() {
     this.switchToThread = this.switchToThread.bind(this);
     this.switchToNewThread = this.switchToNewThread.bind(this);
+    this.unstable_subscribeThreadRunEvents =
+      this.unstable_subscribeThreadRunEvents.bind(this);
     this.getLoadThreadsPromise = this.getLoadThreadsPromise.bind(this);
     this.reload = this.reload.bind(this);
     this.reloadMainThread = this.reloadMainThread.bind(this);
@@ -192,6 +208,15 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
 
   public switchToNewThread(): Promise<void> {
     return this._core.switchToNewThread();
+  }
+
+  public unstable_subscribeThreadRunEvents(
+    callback: (event: ThreadRunEvent) => void,
+  ): Unsubscribe {
+    return (
+      this._core.unstable_subscribeThreadRunEvents?.(callback) ??
+      NOOP_UNSUBSCRIBE
+    );
   }
 
   public getLoadThreadsPromise(): Promise<void> {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -16,6 +16,11 @@ export type ThreadListItemCoreState = {
   readonly runtime?: ThreadRuntimeCore | undefined;
 };
 
+export type ThreadRunEvent = {
+  readonly threadId: string;
+  readonly type: "runStart" | "runEnd";
+};
+
 export type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
   readonly isLoadingMore?: boolean;
@@ -40,6 +45,17 @@ export type ThreadListRuntimeCore = {
    * running, and the main thread's run state is read from its runtime directly.
    */
   unstable_isThreadRunning?(threadId: string): boolean;
+
+  /**
+   * Run lifecycle events from every thread this list keeps alive, including
+   * threads that are not the main one. Implemented by thread lists that keep
+   * runtimes alive for non-main threads. A thread list that mounts only the
+   * main thread leaves this undefined: its other threads have no runtime and so
+   * cannot run, and the main thread's runtime is observed directly.
+   */
+  unstable_subscribeThreadRunEvents?(
+    callback: (event: ThreadRunEvent) => void,
+  ): Unsubscribe;
 
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
 

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -1,7 +1,11 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useResource, withKey, resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
-import { useClientLookup, useClientResource } from "@assistant-ui/store/client";
+import {
+  useAssistantEmit,
+  useClientLookup,
+  useClientResource,
+} from "@assistant-ui/store/client";
 import { useThreadSelectionEvents } from "../clients/thread-selection-events";
 import type { ThreadListRuntime } from "../../runtime/api/thread-list-runtime";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
@@ -43,6 +47,16 @@ const useThreadListClient = ({
 }): ClientOutput<"threads"> => {
   const runtimeState = useSubscribable(runtime);
   useThreadSelectionEvents(runtimeState.mainThreadId);
+
+  const emit = useAssistantEmit();
+  useEffect(
+    () =>
+      runtime.unstable_subscribeThreadRunEvents(({ threadId, type }) => {
+        if (threadId === runtime.getState().mainThreadId) return;
+        emit(`thread.${type}`, { threadId });
+      }),
+    [runtime, emit],
+  );
 
   const main = useClientResource(
     ThreadClient({

--- a/packages/core/src/tests/thread-switch-events.test.tsx
+++ b/packages/core/src/tests/thread-switch-events.test.tsx
@@ -5,10 +5,14 @@ import { describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui, useAuiEvent } from "@assistant-ui/store";
 import { AssistantRuntimeProvider } from "../react/AssistantRuntimeProvider";
 import { useExternalStoreRuntime } from "../react/runtimes/useExternalStoreRuntime";
+import { useLocalRuntime } from "../react/runtimes/useLocalRuntime";
 import { useRemoteThreadListRuntime } from "../react/runtimes/useRemoteThreadListRuntime";
-import { makeAdapter } from "./remote-thread-list-test-helpers";
+import { deferred, makeAdapter } from "./remote-thread-list-test-helpers";
 import { RuntimeAdapter } from "../react/RuntimeAdapter";
-import { AssistantRuntimeImpl } from "../runtime/api/assistant-runtime";
+import {
+  AssistantRuntimeImpl,
+  type AssistantRuntime,
+} from "../runtime/api/assistant-runtime";
 import { ExternalStoreRuntimeCore } from "../runtimes/external-store/external-store-runtime-core";
 import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
 
@@ -230,5 +234,291 @@ describe("thread switch events", () => {
     };
     expect(payload.threadId).toBe("thread-a");
     expect(payload.previousThreadId).toMatch(/^__LOCALID_/);
+  });
+});
+
+const createExternalStoreRuntime = (
+  runningByThreadId: Map<string, boolean>,
+) => {
+  const threads = [
+    { id: "t1", title: "one" },
+    { id: "t2", title: "two" },
+  ];
+  let currentId = "t1";
+  const makeStoreAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages: EMPTY_MESSAGES,
+    isRunning: runningByThreadId.get(currentId) ?? false,
+    convertMessage: (m) => ({
+      id: m.id,
+      role: m.role,
+      content: [{ type: "text", text: m.text }],
+    }),
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: currentId,
+        threads: threads.map((t) => ({
+          status: "regular" as const,
+          id: t.id,
+          title: t.title,
+        })),
+        onSwitchToThread: (threadId: string) => {
+          currentId = threadId;
+          sync();
+        },
+        onSwitchToNewThread: () => {},
+      },
+    },
+  });
+  const core = new ExternalStoreRuntimeCore(makeStoreAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const sync = () => core.setAdapter(makeStoreAdapter());
+  return { runtime, sync };
+};
+
+const listAdapter = () =>
+  makeAdapter({
+    list: vi.fn(async () => ({
+      threads: [
+        { status: "regular" as const, remoteId: "thread-a", title: "A" },
+        { status: "regular" as const, remoteId: "thread-b", title: "B" },
+      ],
+    })),
+  });
+
+const renderRemoteList = (
+  adapter: ReturnType<typeof makeAdapter>,
+  run: () => Promise<{ content: [] }>,
+) => {
+  const globalRunStart = vi.fn();
+  const globalRunEnd = vi.fn();
+  const selectedRunStart = vi.fn();
+  const selectedRunEnd = vi.fn();
+  let runtime!: AssistantRuntime;
+
+  const Listener = () => {
+    useAuiEvent({ scope: "*", event: "thread.runStart" }, globalRunStart);
+    useAuiEvent({ scope: "*", event: "thread.runEnd" }, globalRunEnd);
+    useAuiEvent("thread.runStart", selectedRunStart);
+    useAuiEvent("thread.runEnd", selectedRunEnd);
+    return null;
+  };
+  const Harness = () => {
+    runtime = useRemoteThreadListRuntime({
+      adapter,
+      initialThreadId: "thread-a",
+      runtimeHook: function RuntimeHook() {
+        return useLocalRuntime({ run });
+      },
+    });
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Listener />
+      </AssistantRuntimeProvider>
+    );
+  };
+  render(<Harness />);
+
+  return {
+    getRuntime: () => runtime,
+    globalRunStart,
+    globalRunEnd,
+    selectedRunStart,
+    selectedRunEnd,
+  };
+};
+
+const switchTo = async (runtime: AssistantRuntime, remoteId: string) => {
+  await act(async () => {
+    await runtime.threads.switchToThread(remoteId);
+  });
+  await waitFor(() => {
+    expect(runtime.threads.mainItem.getState().remoteId).toBe(remoteId);
+  });
+};
+
+describe("background thread run events", () => {
+  it("delivers runEnd globally after the running thread is switched away", async () => {
+    const runA = deferred<{ content: [] }>();
+    const harness = renderRemoteList(listAdapter(), () => runA.promise);
+    const runtime = harness.getRuntime();
+
+    await waitFor(() => {
+      expect(runtime.threads.mainItem.getState().remoteId).toBe("thread-a");
+    });
+    const threadAId = runtime.threads.mainItem.getState().id;
+
+    await act(async () => {
+      runtime.thread.startRun({ parentId: null });
+    });
+    await waitFor(() => expect(runtime.thread.getState().isRunning).toBe(true));
+    await waitFor(() => {
+      expect(harness.globalRunStart).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadAId,
+      });
+      expect(harness.selectedRunStart).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadAId,
+      });
+    });
+
+    await switchTo(runtime, "thread-b");
+    await act(async () => {
+      runA.resolve({ content: [] });
+    });
+
+    await waitFor(() => {
+      expect(harness.globalRunEnd).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadAId,
+      });
+    });
+    expect(harness.selectedRunEnd).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate run events while the running thread is switched back and forth", async () => {
+    const runA = deferred<{ content: [] }>();
+    const harness = renderRemoteList(listAdapter(), () => runA.promise);
+    const runtime = harness.getRuntime();
+
+    await waitFor(() => {
+      expect(runtime.threads.mainItem.getState().remoteId).toBe("thread-a");
+    });
+    const threadAId = runtime.threads.mainItem.getState().id;
+
+    await act(async () => {
+      runtime.thread.startRun({ parentId: null });
+    });
+    await waitFor(() => expect(runtime.thread.getState().isRunning).toBe(true));
+
+    await switchTo(runtime, "thread-b");
+    await switchTo(runtime, "thread-a");
+    await switchTo(runtime, "thread-b");
+    await switchTo(runtime, "thread-a");
+    await switchTo(runtime, "thread-b");
+
+    await act(async () => {
+      runA.resolve({ content: [] });
+    });
+
+    await waitFor(() => {
+      expect(harness.globalRunEnd).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadAId,
+      });
+    });
+    expect(harness.globalRunStart).toHaveBeenCalledExactlyOnceWith({
+      threadId: threadAId,
+    });
+    expect(harness.selectedRunStart).toHaveBeenCalledExactlyOnceWith({
+      threadId: threadAId,
+    });
+    expect(harness.selectedRunEnd).not.toHaveBeenCalled();
+  });
+
+  it("reports the start and end of a run that is never selected", async () => {
+    const backgroundRun = deferred<{ content: [] }>();
+    const harness = renderRemoteList(
+      listAdapter(),
+      () => backgroundRun.promise,
+    );
+    const runtime = harness.getRuntime();
+
+    await waitFor(() => {
+      expect(runtime.threads.mainItem.getState().remoteId).toBe("thread-a");
+    });
+    await switchTo(runtime, "thread-b");
+    const threadBId = runtime.threads.mainItem.getState().id;
+    const threadB = runtime.threads.getById(threadBId);
+    await switchTo(runtime, "thread-a");
+
+    await act(async () => {
+      threadB.startRun({ parentId: null });
+    });
+    await waitFor(() => {
+      expect(harness.globalRunStart).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadBId,
+      });
+    });
+
+    await act(async () => {
+      backgroundRun.resolve({ content: [] });
+    });
+    await waitFor(() => {
+      expect(harness.globalRunEnd).toHaveBeenCalledExactlyOnceWith({
+        threadId: threadBId,
+      });
+    });
+    expect(harness.selectedRunStart).not.toHaveBeenCalled();
+    expect(harness.selectedRunEnd).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { operation: "delete", state: "deleted" },
+    { operation: "detach", state: "detached" },
+  ] as const)(
+    "stops reporting a background run once its thread is $state",
+    async ({ operation }) => {
+      const runA = deferred<{ content: [] }>();
+      const runSettled = vi.fn();
+      const harness = renderRemoteList(listAdapter(), async () => {
+        const result = await runA.promise;
+        runSettled();
+        return result;
+      });
+      const runtime = harness.getRuntime();
+
+      await waitFor(() => {
+        expect(runtime.threads.mainItem.getState().remoteId).toBe("thread-a");
+      });
+      const threadAId = runtime.threads.mainItem.getState().id;
+
+      await act(async () => {
+        runtime.thread.startRun({ parentId: null });
+      });
+      await waitFor(() =>
+        expect(runtime.thread.getState().isRunning).toBe(true),
+      );
+      await switchTo(runtime, "thread-b");
+
+      await act(async () => {
+        const item = runtime.threads.getItemById(threadAId);
+        if (operation === "delete") await item.delete();
+        else item.detach();
+      });
+      await act(async () => {
+        runA.resolve({ content: [] });
+      });
+
+      await waitFor(() => expect(runSettled).toHaveBeenCalledExactlyOnceWith());
+      expect(harness.globalRunEnd).not.toHaveBeenCalled();
+    },
+  );
+
+  it("emits nothing for a thread list that keeps only the main runtime", async () => {
+    const runningByThreadId = new Map<string, boolean>();
+    const { runtime, sync } = createExternalStoreRuntime(runningByThreadId);
+    const globalRunEnd = vi.fn();
+    const Listener = () => {
+      useAuiEvent({ scope: "*", event: "thread.runEnd" }, globalRunEnd);
+      return null;
+    };
+    const Harness = () => {
+      const aui = useAui({ threads: RuntimeAdapter(runtime) } as never);
+      return (
+        <AuiProvider value={aui}>
+          <Listener />
+        </AuiProvider>
+      );
+    };
+    render(<Harness />);
+    await act(async () => {});
+
+    runningByThreadId.set("t1", true);
+    await act(async () => sync());
+    await waitFor(() => expect(runtime.thread.getState().isRunning).toBe(true));
+
+    await act(async () => {
+      await runtime.threads.switchToThread("t2");
+    });
+    expect(runtime.threads.getState().mainThreadId).toBe("t2");
+    expect(globalRunEnd).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

`thread.runEnd` never reaches store listeners when a run outlives its thread's selection. Reproduces on current `main`: start a delayed run on thread A of a `useRemoteThreadListRuntime` list, subscribe with `useAuiEvent({ scope: "*", event: "thread.runEnd" }, cb)`, switch to thread B, then settle A. The retained runtime emits its internal `runEnd`, and the store listener receives nothing.

A run that starts on a thread that is not selected is invisible the same way, in both directions.

Fixes #6643.

## Root cause

The selected `ThreadClient` owns the runtime-to-store event bridge (`packages/core/src/store/runtime-clients/thread-runtime-client.ts`). It subscribes to `runtime.main`, whose `EventSubscriptionSubject` rebinds on every selection change, so switching threads unsubscribes the bridge from the thread that is still running. A remote thread list keeps that runtime alive, so the run finishes with no bridge attached.

## Change

`RemoteThreadListHookInstanceManager` already subscribes to every retained runtime to track `isRunning`. It now forwards `runStart` and `runEnd` from that same subscription, tagged with the thread id, through `__internal_subscribeRunEvents`. `RemoteThreadListThreadListRuntimeCore` exposes it as the optional core capability `unstable_subscribeThreadRunEvents`, alongside the existing `unstable_isThreadRunning`, and `ThreadListRuntimeImpl` surfaces it (returning a no-op unsubscribe for lists that do not implement it). `ThreadListClient` subscribes once and emits `thread.runStart` / `thread.runEnd` for any thread that is not the selected one, leaving the selected thread's events to `ThreadClient`.

Cleanup rides on the manager's existing `unsubscribeRunning`, so delete, detach, restart and runtime replacement all stop the forwarding without a second lifecycle to keep in sync. Thread lists that mount only the main thread (external store, local) leave the capability undefined: they retain no background runtime, so there is nothing to forward and no gate is needed.

The manager is the layer that already owns retained-runtime identity, so no captured core, generation stamp, pending map or synthesized event is needed to keep the reports honest. Every emitted event is one the runtime actually raised, at the moment it raised it, which matters because the devtools run timeline (`packages/react-devtools/src/views/runs/parse.ts`) pairs runs by these events.

Background events are emitted on the thread list's client stack, so they reach `scope: "*"` listeners. Default-scope listeners still follow the selected thread, unchanged.

This supersedes #6645 and #6644, which fix the same issue in the store client layer.

## Verification

- The three new failing-first regressions were confirmed against the unmodified checkout: switched-away delivery, repeated switching, and a never-selected run all fail without the change and pass with it.
- `pnpm --filter @assistant-ui/core test` (153 files, 1573 tests)
- `pnpm --filter @assistant-ui/react test` (56 files, 507 tests)
- `pnpm --filter @assistant-ui/store test` (24 files, 186 tests), `pnpm --filter @assistant-ui/tap test` (51 files, 580 tests), `pnpm --filter @assistant-ui/vue test` (18 files, 106 tests, 1 skipped)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`, `oxfmt --check` on the changed files, `pnpm changesets:check`
- `tsc --noEmit` reports no diagnostics on any changed file; the remaining errors are the pre-existing test-file ones on `main`.

## Public surface

`@assistant-ui/core`: adds the optional `ThreadListRuntimeCore.unstable_subscribeThreadRunEvents`, the `ThreadRunEvent` type, and `ThreadListRuntime.unstable_subscribeThreadRunEvents`. Additive only. No documentation, API-reference or template changes. Includes a patch changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Mn1d_bePlo2B1UG8gMJXEfgAJKWuq2QQ5DVrp6izd4uWZcD_UDXkKc-fZRA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->