### PR TITLE
fix(core): keep one thread slot per remote id

### DIFF
--- a/.changeset/soft-slots-reconcile.md
+++ b/.changeset/soft-slots-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep one thread slot per remote id and clear every alias on delete

--- a/packages/core/src/react/client/RemoteThreadList.background.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.background.test.ts
@@ -360,8 +360,9 @@ describe("RemoteThreadList backgroundThreads", () => {
     listed = [{ status: "regular" as const, remoteId, title: "One" }];
     await aui.threads.reload();
     await vi.waitFor(() => {
-      expect(aui.threads.getState().threadIds).toContain(remoteId);
+      expect(aui.threads.getState().threadIds).toContain(localId);
     });
+    expect(aui.threads.getState().threadIds).not.toContain(remoteId);
 
     flushTapSync(() => aui.threads.switchToNewThread());
     await vi.waitFor(() => {

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -649,6 +649,55 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  const mountRacedInitialize = async (status: "regular" | "archived") => {
+    const initialize = deferred<{ remoteId: string; externalId: undefined }>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [] })),
+      initialize: vi.fn(() => initialize.promise),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    const localId = aui.threads.getState().mainThreadId;
+    const initialization = aui.threads.item("main").initialize();
+
+    adapter.list = vi.fn(async () => ({
+      threads: [{ status, remoteId: "remote-1", title: "Mine" }],
+    }));
+    await aui.threads.reload();
+
+    initialize.resolve({ remoteId: "remote-1", externalId: undefined });
+    await initialization;
+    return { handle, aui, localId };
+  };
+
+  it("collapses a slot the list minted while initialize was in flight", async () => {
+    const { handle, aui, localId } = await mountRacedInitialize("regular");
+
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([localId]);
+    });
+    expect(aui.threads.item({ id: "remote-1" }).getState().id).toBe(localId);
+
+    await aui.threads.item({ id: "remote-1" }).delete();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([]);
+    });
+    expect(() => aui.threads.item({ id: localId }).getState()).toThrow();
+    handle.destroy();
+  });
+
+  it("does not leave the collapsed slot in both lists when the race reported it archived", async () => {
+    const { handle, aui, localId } = await mountRacedInitialize("archived");
+
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([localId]);
+    });
+    expect(aui.threads.getState().archivedThreadIds).toEqual([]);
+    expect(aui.threads.item({ id: "remote-1" }).getState().id).toBe(localId);
+    handle.destroy();
+  });
+
   it("keeps item(main) isRunning after reload remaps the local id", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({ threads: [] })),

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -610,7 +610,7 @@ describe("RemoteThreadList", () => {
     await vi.waitFor(() => {
       expect(handle.getClient().threads.getState().threadIds).toEqual([
         "other",
-        `remote-${localId}`,
+        localId,
       ]);
     });
     expect(handle.getClient().threads.item("main").getState().remoteId).toBe(
@@ -619,6 +619,33 @@ describe("RemoteThreadList", () => {
     expect(handle.getClient().threads.item("main").getState().title).toBe(
       "Mine",
     );
+    handle.destroy();
+  });
+
+  it("keeps one slot per remote id across reload and clears it on delete", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({ threads: [] })),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    const localId = aui.threads.getState().mainThreadId;
+    await aui.threads.item("main").initialize();
+    const remoteId = `remote-${localId}`;
+    adapter.list = vi.fn(async () => ({
+      threads: [{ status: "regular" as const, remoteId, title: "Mine" }],
+    }));
+    await aui.threads.reload();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([localId]);
+    });
+
+    await aui.threads.item({ id: remoteId }).delete();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([]);
+    });
+    expect(() => aui.threads.item({ id: localId }).getState()).toThrow();
+    expect(() => aui.threads.item({ id: remoteId }).getState()).toThrow();
     handle.destroy();
   });
 

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -566,8 +566,8 @@ const useRemoteThreadList = (
           const fresh = classifyThreads(page.threads, {
             threadIds: [],
             archivedThreadIds: [],
-            threadIdMap: {},
-            threadData: {},
+            threadIdMap: { ...state.threadIdMap },
+            threadData: { ...state.threadData },
           });
           const merged = {
             ...state,
@@ -575,14 +575,8 @@ const useRemoteThreadList = (
             cursor: normalizeCursor(page.nextCursor),
             threadIds: fresh.threadIds,
             archivedThreadIds: fresh.archivedThreadIds,
-            threadIdMap: {
-              ...state.threadIdMap,
-              ...fresh.threadIdMap,
-            },
-            threadData: {
-              ...state.threadData,
-              ...fresh.threadData,
-            },
+            threadIdMap: fresh.threadIdMap,
+            threadData: fresh.threadData,
           };
           return preserveMidLoadTransitions(merged, state, statusAtRequest);
         },
@@ -909,21 +903,36 @@ const useRemoteThreadList = (
           const data = getThreadData(state, threadId);
           if (!data) return state;
           const mappingId = createThreadMappingId(threadId);
+          // A list() response that landed while this initialize was in flight
+          // could not know the remote id yet, so it may have minted its own
+          // slot for it; that slot collapses into this one.
+          const listedMappingId = state.threadIdMap[remoteId];
+          const orphan =
+            listedMappingId !== undefined && listedMappingId !== mappingId
+              ? state.threadData[listedMappingId]
+              : undefined;
+
+          const threadData = { ...state.threadData };
+          if (orphan !== undefined) delete threadData[listedMappingId!];
+          threadData[mappingId] = {
+            ...data,
+            initializeTask: Promise.resolve({ remoteId, externalId }),
+            remoteId,
+            externalId,
+          } as RemoteThreadData;
+
+          const rewire = (ids: readonly string[]) =>
+            orphan === undefined ? ids : ids.filter((id) => id !== orphan.id);
+
           return {
             ...state,
+            threadIds: rewire(state.threadIds),
+            archivedThreadIds: rewire(state.archivedThreadIds),
             threadIdMap: {
               ...state.threadIdMap,
               [remoteId]: mappingId,
             },
-            threadData: {
-              ...state.threadData,
-              [mappingId]: {
-                ...data,
-                initializeTask: Promise.resolve({ remoteId, externalId }),
-                remoteId,
-                externalId,
-              },
-            },
+            threadData,
           };
         },
       });

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -10,6 +10,7 @@ import { useSubscribable } from "../../store/runtime-clients/useSubscribable";
 import { OptimisticState } from "../../runtimes/remote-thread-list/optimistic-state";
 import { EMPTY_THREAD_CORE } from "../../runtimes/remote-thread-list/empty-thread-core";
 import type {
+  ClassifyAccumulator,
   RemoteThreadData,
   RemoteThreadState,
 } from "../../runtimes/remote-thread-list/remote-thread-state";
@@ -154,8 +155,8 @@ export class RemoteThreadListThreadListRuntimeCore
             const fresh = classifyThreads(l.threads, {
               threadIds: [],
               archivedThreadIds: [],
-              threadIdMap: {},
-              threadData: {},
+              threadIdMap: { ...state.threadIdMap },
+              threadData: { ...state.threadData },
             });
             const merged = {
               ...state,
@@ -163,8 +164,8 @@ export class RemoteThreadListThreadListRuntimeCore
               cursor: normalizeCursor(l.nextCursor),
               threadIds: fresh.threadIds,
               archivedThreadIds: fresh.archivedThreadIds,
-              threadIdMap: { ...state.threadIdMap, ...fresh.threadIdMap },
-              threadData: { ...state.threadData, ...fresh.threadData },
+              threadIdMap: fresh.threadIdMap,
+              threadData: fresh.threadData,
             };
             return preserveMidLoadTransitions(merged, state, statusAtRequest);
           },
@@ -344,24 +345,11 @@ export class RemoteThreadListThreadListRuntimeCore
     threads: readonly RemoteThreadMetadata[],
     cursor: string | undefined,
   ): RemoteThreadState {
-    const fresh = classifyThreads(threads, {
-      threadIds: [],
-      archivedThreadIds: [],
-      threadIdMap: {},
-      threadData: {},
-    });
-    const threadIdMap = { ...fresh.threadIdMap };
-    const threadData = { ...fresh.threadData };
-    const threadIds = [...fresh.threadIds];
-    const archivedThreadIds = [...fresh.archivedThreadIds];
-
+    const carried: RemoteThreadData[] = [];
     if (state.newThreadId) {
       const mappingId = state.threadIdMap[state.newThreadId];
       const draft = mappingId ? state.threadData[mappingId] : undefined;
-      if (draft?.status === "new") {
-        threadIdMap[state.newThreadId] = mappingId!;
-        threadData[mappingId!] = draft;
-      }
+      if (draft?.status === "new") carried.push(draft);
     }
 
     const stale = this._staleThreadIdsOnReplace;
@@ -369,25 +357,43 @@ export class RemoteThreadListThreadListRuntimeCore
       for (const item of Object.values(state.threadData)) {
         if (stale.has(item.id)) continue;
         if (item.status !== "new" && item.remoteId === undefined) continue;
-        const mappingId = createThreadMappingId(item.id);
-        if (threadData[mappingId]) continue;
-        threadIdMap[item.id] = mappingId;
-        if (item.remoteId !== undefined) {
-          threadIdMap[item.remoteId] = mappingId;
-        }
-        threadData[mappingId] = item;
-        if (item.remoteId === undefined) continue;
-        if (item.status === "regular" && !threadIds.includes(item.remoteId)) {
-          threadIds.push(item.remoteId);
-        } else if (
-          item.status === "archived" &&
-          !archivedThreadIds.includes(item.remoteId)
-        ) {
-          archivedThreadIds.push(item.remoteId);
-        }
+        carried.push(item);
       }
     }
     this._staleThreadIdsOnReplace = undefined;
+
+    const seed: ClassifyAccumulator = {
+      threadIds: [],
+      archivedThreadIds: [],
+      threadIdMap: {},
+      threadData: {},
+    };
+    for (const item of carried) {
+      const mappingId = createThreadMappingId(item.id);
+      if (seed.threadData[mappingId]) continue;
+      seed.threadIdMap[item.id] = mappingId;
+      if (item.remoteId !== undefined) {
+        seed.threadIdMap[item.remoteId] = mappingId;
+      }
+      seed.threadData[mappingId] = item;
+    }
+
+    const { threadIds, archivedThreadIds, threadIdMap, threadData } =
+      classifyThreads(threads, seed);
+
+    for (const item of carried) {
+      if (item.remoteId === undefined) continue;
+      const current = threadData[createThreadMappingId(item.id)];
+      if (current === undefined) continue;
+      if (current.status === "regular" && !threadIds.includes(current.id)) {
+        threadIds.push(current.id);
+      } else if (
+        current.status === "archived" &&
+        !archivedThreadIds.includes(current.id)
+      ) {
+        archivedThreadIds.push(current.id);
+      }
+    }
 
     let nextState: RemoteThreadState = {
       ...state,
@@ -642,9 +648,8 @@ export class RemoteThreadListThreadListRuntimeCore
       // A concurrent `list()` may already have placed this thread; keep that
       // position and only merge metadata. A genuinely absent thread stays
       // appended: it may live on an unloaded page, and a prepend would pin it
-      // above newer threads permanently since `classifyThreads` skips ids it
-      // has already seen. Filtering both arrays first still prevents
-      // duplication or a wrong-status entry from `list()`.
+      // above newer threads permanently. Filtering both arrays first still
+      // prevents duplication or a wrong-status entry from `list()`.
       const remoteId = remoteMetadata.remoteId;
       const wasInTarget =
         remoteMetadata.status === "regular"

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -824,11 +824,7 @@ export class RemoteThreadListThreadListRuntimeCore
         } as RemoteThreadData;
 
         const rewire = (ids: readonly string[]) =>
-          orphan === undefined
-            ? ids
-            : ids.includes(data.id)
-              ? ids.filter((id) => id !== orphan.id)
-              : ids.map((id) => (id === orphan.id ? data.id : id));
+          orphan === undefined ? ids : ids.filter((id) => id !== orphan.id);
 
         return {
           ...state,

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -805,21 +805,40 @@ export class RemoteThreadListThreadListRuntimeCore
         if (!data) return state;
 
         const mappingId = createThreadMappingId(threadId);
+        // A list() response that landed while this initialize was in flight
+        // could not know the remote id yet, so it may have minted its own slot
+        // for it; that slot collapses into this one.
+        const listedMappingId = state.threadIdMap[remoteId];
+        const orphan =
+          listedMappingId !== undefined && listedMappingId !== mappingId
+            ? state.threadData[listedMappingId]
+            : undefined;
+
+        const threadData = { ...state.threadData };
+        if (orphan !== undefined) delete threadData[listedMappingId!];
+        threadData[mappingId] = {
+          ...data,
+          initializeTask: Promise.resolve({ remoteId, externalId }),
+          remoteId,
+          externalId,
+        } as RemoteThreadData;
+
+        const rewire = (ids: readonly string[]) =>
+          orphan === undefined
+            ? ids
+            : ids.includes(data.id)
+              ? ids.filter((id) => id !== orphan.id)
+              : ids.map((id) => (id === orphan.id ? data.id : id));
+
         return {
           ...state,
+          threadIds: rewire(state.threadIds),
+          archivedThreadIds: rewire(state.archivedThreadIds),
           threadIdMap: {
             ...state.threadIdMap,
             [remoteId]: mappingId,
           },
-          threadData: {
-            ...state.threadData,
-            [mappingId]: {
-              ...data,
-              initializeTask: Promise.resolve({ remoteId, externalId }),
-              remoteId,
-              externalId,
-            },
-          },
+          threadData,
         };
       },
     });

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
@@ -1,9 +1,45 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyThreads,
   createEmptyRemoteThreadState,
   createThreadMappingId,
   seedNewThread,
+  updateStatusReducer,
 } from "./remote-thread-state";
+import type { RemoteThreadState } from "./remote-thread-state";
+
+const initializedDraft = () => {
+  const seeded = seedNewThread(createEmptyRemoteThreadState());
+  const regular = updateStatusReducer(seeded.state, seeded.id, "regular");
+  const mappingId = regular.threadIdMap[seeded.id]!;
+  return {
+    id: seeded.id,
+    mappingId,
+    state: {
+      ...regular,
+      threadIdMap: { ...regular.threadIdMap, "remote-1": mappingId },
+      threadData: {
+        ...regular.threadData,
+        [mappingId]: {
+          ...regular.threadData[mappingId]!,
+          remoteId: "remote-1",
+          externalId: "remote-1",
+        },
+      },
+    } as RemoteThreadState,
+  };
+};
+
+const expectOneSlotPerIdentity = (state: RemoteThreadState) => {
+  const remoteIds = Object.values(state.threadData)
+    .map((data) => data.remoteId)
+    .filter((remoteId) => remoteId !== undefined);
+  expect(new Set(remoteIds).size).toBe(remoteIds.length);
+
+  for (const id of [...state.threadIds, ...state.archivedThreadIds]) {
+    expect(state.threadData[state.threadIdMap[id]!]?.id).toBe(id);
+  }
+};
 
 describe("remote thread state", () => {
   it("creates an empty state", () => {
@@ -33,5 +69,68 @@ describe("remote thread state", () => {
       createThreadMappingId(second.id),
     );
     expect(Object.keys(second.state.threadData)).toEqual([first.id, second.id]);
+  });
+
+  it("refreshes the local slot when a listed thread already has a mapping", () => {
+    const draft = initializedDraft();
+
+    const merged = classifyThreads(
+      [
+        {
+          status: "regular",
+          remoteId: "remote-1",
+          externalId: "remote-1",
+          title: "from the server",
+        },
+      ],
+      {
+        threadIds: [],
+        archivedThreadIds: [],
+        threadIdMap: { ...draft.state.threadIdMap },
+        threadData: { ...draft.state.threadData },
+      },
+    );
+
+    expect(Object.keys(merged.threadData)).toEqual([draft.mappingId]);
+    expect(merged.threadIds).toEqual([draft.id]);
+    expect(merged.threadIdMap["remote-1"]).toBe(draft.mappingId);
+    expect(merged.threadData[draft.mappingId]?.id).toBe(draft.id);
+    expect(merged.threadData[draft.mappingId]?.title).toBe("from the server");
+    expect(merged.threadData[draft.mappingId]?.localOrigin).toBe(true);
+    expectOneSlotPerIdentity({ ...draft.state, ...merged });
+  });
+
+  it("lists a repeated remote id once", () => {
+    const listed = classifyThreads(
+      [
+        { status: "regular", remoteId: "a", externalId: "a", title: "first" },
+        { status: "regular", remoteId: "a", externalId: "a", title: "second" },
+      ],
+      {
+        threadIds: [],
+        archivedThreadIds: [],
+        threadIdMap: {},
+        threadData: {},
+      },
+    );
+
+    expect(listed.threadIds).toEqual(["a"]);
+    expect(listed.threadData[createThreadMappingId("a")]?.title).toBe("second");
+  });
+
+  it("deletes every alias of an identity, by either id", () => {
+    for (const target of ["remote-1", "local"] as const) {
+      const draft = initializedDraft();
+      const deleted = updateStatusReducer(
+        draft.state,
+        target === "local" ? draft.id : target,
+        "deleted",
+      );
+
+      expect(deleted.threadData).toEqual({});
+      expect(deleted.threadIdMap).toEqual({});
+      expect(deleted.threadIds).toEqual([]);
+      expect(deleted.archivedThreadIds).toEqual([]);
+    }
   });
 });

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
@@ -6,15 +6,23 @@ import {
   seedNewThread,
   updateStatusReducer,
 } from "./remote-thread-state";
-import type { RemoteThreadState } from "./remote-thread-state";
+import type {
+  RemoteThreadData,
+  RemoteThreadState,
+} from "./remote-thread-state";
 
 const initializedDraft = () => {
   const seeded = seedNewThread(createEmptyRemoteThreadState());
   const regular = updateStatusReducer(seeded.state, seeded.id, "regular");
   const mappingId = regular.threadIdMap[seeded.id]!;
+  const initializeTask = Promise.resolve({
+    remoteId: "remote-1",
+    externalId: "remote-1",
+  });
   return {
     id: seeded.id,
     mappingId,
+    initializeTask,
     state: {
       ...regular,
       threadIdMap: { ...regular.threadIdMap, "remote-1": mappingId },
@@ -24,7 +32,8 @@ const initializedDraft = () => {
           ...regular.threadData[mappingId]!,
           remoteId: "remote-1",
           externalId: "remote-1",
-        },
+          initializeTask,
+        } as RemoteThreadData,
       },
     } as RemoteThreadState,
   };
@@ -97,6 +106,10 @@ describe("remote thread state", () => {
     expect(merged.threadData[draft.mappingId]?.id).toBe(draft.id);
     expect(merged.threadData[draft.mappingId]?.title).toBe("from the server");
     expect(merged.threadData[draft.mappingId]?.localOrigin).toBe(true);
+    const refreshed = merged.threadData[draft.mappingId]!;
+    expect(
+      refreshed.status === "new" ? undefined : refreshed.initializeTask,
+    ).toBe(draft.initializeTask);
     expectOneSlotPerIdentity({ ...draft.state, ...merged });
   });
 

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -47,26 +47,28 @@ export const LOCAL_THREAD_ID_PREFIX = "__LOCALID_";
 export const normalizeCursor = (c: string | undefined): string | undefined =>
   c || undefined;
 
-type ClassifyAccumulator = {
+export type ClassifyAccumulator = {
   threadIds: string[];
   archivedThreadIds: string[];
   threadIdMap: Record<string, THREAD_MAPPING_ID>;
   threadData: Record<THREAD_MAPPING_ID, RemoteThreadData>;
 };
 
+// A slot's `id` is fixed when it is minted: the hook instance manager keys live
+// thread runtimes by it, so renaming a slot would detach the runtime the user is
+// chatting in. A listed thread whose `remoteId` already maps to a slot therefore
+// refreshes that slot instead of minting a second one, and
+// `threadIds`/`archivedThreadIds` carry slot ids, never remote ids.
 export const classifyThreads = (
   threads: readonly RemoteThreadMetadata[],
   acc: ClassifyAccumulator,
 ): ClassifyAccumulator => {
-  for (const thread of threads) {
-    if (acc.threadIdMap[thread.remoteId] !== undefined) continue;
+  const listed = new Set([...acc.threadIds, ...acc.archivedThreadIds]);
 
+  for (const thread of threads) {
     switch (thread.status) {
       case "regular":
-        acc.threadIds.push(thread.remoteId);
-        break;
       case "archived":
-        acc.archivedThreadIds.push(thread.remoteId);
         break;
       default: {
         const _exhaustiveCheck: never = thread.status;
@@ -74,20 +76,44 @@ export const classifyThreads = (
       }
     }
 
-    const mappingId = createThreadMappingId(thread.remoteId);
+    const existingMappingId = acc.threadIdMap[thread.remoteId];
+    const existing =
+      existingMappingId !== undefined
+        ? acc.threadData[existingMappingId]
+        : undefined;
+    const id = existing?.id ?? thread.remoteId;
+    const mappingId = existingMappingId ?? createThreadMappingId(id);
+    const existingTask =
+      existing !== undefined && existing.status !== "new"
+        ? existing.initializeTask
+        : undefined;
+
+    if (!listed.has(id)) {
+      listed.add(id);
+      if (thread.status === "regular") {
+        acc.threadIds.push(id);
+      } else {
+        acc.archivedThreadIds.push(id);
+      }
+    }
+
+    acc.threadIdMap[id] = mappingId;
     acc.threadIdMap[thread.remoteId] = mappingId;
     acc.threadData[mappingId] = {
-      id: thread.remoteId,
+      ...(existing?.localOrigin === true ? { localOrigin: true as const } : {}),
+      id,
       remoteId: thread.remoteId,
       externalId: thread.externalId,
       status: thread.status,
       title: thread.title,
       lastMessageAt: thread.lastMessageAt,
       custom: thread.custom,
-      initializeTask: Promise.resolve({
-        remoteId: thread.remoteId,
-        externalId: thread.externalId,
-      }),
+      initializeTask:
+        existingTask ??
+        Promise.resolve({
+          remoteId: thread.remoteId,
+          externalId: thread.externalId,
+        }),
     };
   }
   return acc;
@@ -238,7 +264,7 @@ export const updateStatusReducer = (
   const data = getThreadData(state, threadIdOrRemoteId);
   if (!data) return state;
 
-  const { id, remoteId, status: lastStatus } = data;
+  const { id, status: lastStatus } = data;
   if (lastStatus === newStatus) return state;
 
   const newState = { ...state };
@@ -273,16 +299,20 @@ export const updateStatusReducer = (
       newState.archivedThreadIds = [id, ...newState.archivedThreadIds];
       break;
 
-    case "deleted":
+    case "deleted": {
+      const mappingId = state.threadIdMap[threadIdOrRemoteId]!;
       newState.threadData = Object.fromEntries(
-        Object.entries(newState.threadData).filter(([key]) => key !== id),
+        Object.entries(newState.threadData).filter(
+          ([key]) => key !== mappingId,
+        ),
       );
       newState.threadIdMap = Object.fromEntries(
         Object.entries(newState.threadIdMap).filter(
-          ([key]) => key !== id && key !== remoteId,
+          ([, value]) => value !== mappingId,
         ),
       );
       break;
+    }
 
     default: {
       const _exhaustiveCheck: never = newStatus;

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -57,7 +57,8 @@ export type ClassifyAccumulator = {
 // A slot's `id` is fixed when it is minted: the hook instance manager keys live
 // thread runtimes by it, so renaming a slot would detach the runtime the user is
 // chatting in. A listed thread whose `remoteId` already maps to a slot therefore
-// refreshes that slot instead of minting a second one, and
+// refreshes that slot instead of minting a second one, and a slot minted by a
+// list() that raced ahead of the remote id collapses when `initialize()` settles.
 // `threadIds`/`archivedThreadIds` carry slot ids, never remote ids.
 export const classifyThreads = (
   threads: readonly RemoteThreadMetadata[],
@@ -93,6 +94,14 @@ export const classifyThreads = (
       if (thread.status === "regular") {
         acc.threadIds.push(id);
       } else {
+        acc.archivedThreadIds.push(id);
+      }
+    } else if (existing !== undefined && existing.status !== thread.status) {
+      if (thread.status === "regular") {
+        acc.archivedThreadIds = acc.archivedThreadIds.filter((t) => t !== id);
+        acc.threadIds.push(id);
+      } else {
+        acc.threadIds = acc.threadIds.filter((t) => t !== id);
         acc.archivedThreadIds.push(id);
       }
     }

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -71,6 +71,47 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.getItemById("remote-1")).toBeUndefined();
     expect(core.threadIds).toEqual([]);
   });
+
+  it("collapses a slot the list minted while initialize was in flight", async () => {
+    const listDeferred = deferred<ListResult>();
+    const initializeDeferred = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => listDeferred.promise),
+      initialize: vi.fn(() => initializeDeferred.promise),
+    });
+    const core = createCore(adapter);
+
+    const loadPromise = core.getLoadThreadsPromise();
+    await core.switchToNewThread();
+    const localId = core.newThreadId!;
+    const initializePromise = core.initialize(localId);
+
+    listDeferred.resolve({
+      threads: [
+        { status: "regular", remoteId: "remote-1", externalId: "remote-1" },
+      ],
+    });
+    await loadPromise;
+
+    initializeDeferred.resolve({
+      remoteId: "remote-1",
+      externalId: "remote-1",
+    });
+    await initializePromise;
+
+    expect(Object.keys(core.threadItems)).toEqual([localId]);
+    expect(core.threadIds).toEqual([localId]);
+    expect(core.getItemById("remote-1")?.id).toBe(localId);
+
+    await core.delete("remote-1");
+
+    expect(core.getItemById(localId)).toBeUndefined();
+    expect(core.getItemById("remote-1")).toBeUndefined();
+    expect(core.threadIds).toEqual([]);
+  });
 });
 
 describe("preserveMidLoadTransitions", () => {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -112,6 +112,41 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.getItemById("remote-1")).toBeUndefined();
     expect(core.threadIds).toEqual([]);
   });
+
+  it("does not leave the collapsed slot in both lists when the race reported it archived", async () => {
+    const listDeferred = deferred<ListResult>();
+    const initializeDeferred = deferred<{
+      remoteId: string;
+      externalId: string;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => listDeferred.promise),
+      initialize: vi.fn(() => initializeDeferred.promise),
+    });
+    const core = createCore(adapter);
+
+    const loadPromise = core.getLoadThreadsPromise();
+    await core.switchToNewThread();
+    const localId = core.newThreadId!;
+    const initializePromise = core.initialize(localId);
+
+    listDeferred.resolve({
+      threads: [
+        { status: "archived", remoteId: "remote-1", externalId: "remote-1" },
+      ],
+    });
+    await loadPromise;
+
+    initializeDeferred.resolve({
+      remoteId: "remote-1",
+      externalId: "remote-1",
+    });
+    await initializePromise;
+
+    expect(Object.keys(core.threadItems)).toEqual([localId]);
+    expect(core.threadIds).toEqual([localId]);
+    expect(core.archivedThreadIds).toEqual([]);
+  });
 });
 
 describe("preserveMidLoadTransitions", () => {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -36,6 +36,41 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.threadIds[0]).toBe(newId);
     expect(core.threadIds).toContain("t1");
   });
+
+  it("keeps one slot when the list reports the thread just initialized", async () => {
+    const listDeferred = deferred<ListResult>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => listDeferred.promise),
+      initialize: vi.fn(async () => ({
+        remoteId: "remote-1",
+        externalId: "remote-1",
+      })),
+    });
+    const core = createCore(adapter);
+
+    const loadPromise = core.getLoadThreadsPromise();
+    await core.switchToNewThread();
+    const localId = core.newThreadId!;
+    await core.initialize(localId);
+
+    listDeferred.resolve({
+      threads: [
+        { status: "regular", remoteId: "remote-1", externalId: "remote-1" },
+      ],
+    });
+    await loadPromise;
+
+    expect(Object.keys(core.threadItems)).toEqual([localId]);
+    expect(core.threadIds).toEqual([localId]);
+    expect(core.getItemById("remote-1")?.id).toBe(localId);
+    expect(core.mainThreadId).toBe(localId);
+
+    await core.delete("remote-1");
+
+    expect(core.getItemById(localId)).toBeUndefined();
+    expect(core.getItemById("remote-1")).toBeUndefined();
+    expect(core.threadIds).toEqual([]);
+  });
 });
 
 describe("preserveMidLoadTransitions", () => {

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
@@ -265,6 +265,35 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     expect(core.threadIds).toEqual(["a", "b"]);
   });
 
+  it("refreshes a thread repeated on a later page instead of dropping it", async () => {
+    const listFn = vi
+      .fn<ListFn>()
+      .mockResolvedValueOnce({
+        threads: [
+          { status: "regular", remoteId: "a", externalId: "a", title: "old" },
+        ],
+        nextCursor: "c1",
+      })
+      .mockResolvedValueOnce({
+        threads: [
+          {
+            status: "regular",
+            remoteId: "a",
+            externalId: "a",
+            title: "updated",
+          },
+          { status: "regular", remoteId: "b", externalId: "b", title: "New" },
+        ],
+      });
+    const core = createCore(makeAdapter({ list: listFn }));
+
+    await core.getLoadThreadsPromise();
+    await core.loadMore();
+
+    expect(core.threadIds).toEqual(["a", "b"]);
+    expect(core.getItemById("a")?.title).toBe("updated");
+  });
+
   it("__internal_setOptions clears cursor and dedup handles on adapter swap, then refetches via the new adapter", async () => {
     const firstAdapter = makeAdapter({
       list: vi.fn<ListFn>(async () => ({

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-loadMore.test.ts
@@ -294,6 +294,31 @@ describe("RemoteThreadListThreadListRuntimeCore.loadMore", () => {
     expect(core.getItemById("a")?.title).toBe("updated");
   });
 
+  it("moves a thread whose status flips between pages", async () => {
+    const listFn = vi
+      .fn<ListFn>()
+      .mockResolvedValueOnce({
+        threads: [
+          { status: "regular", remoteId: "a", externalId: "a", title: "A" },
+          { status: "regular", remoteId: "b", externalId: "b", title: "B" },
+        ],
+        nextCursor: "c1",
+      })
+      .mockResolvedValueOnce({
+        threads: [
+          { status: "archived", remoteId: "a", externalId: "a", title: "A" },
+        ],
+      });
+    const core = createCore(makeAdapter({ list: listFn }));
+
+    await core.getLoadThreadsPromise();
+    await core.loadMore();
+
+    expect(core.threadIds).toEqual(["b"]);
+    expect(core.archivedThreadIds).toEqual(["a"]);
+    expect(core.getItemById("a")?.status).toBe("archived");
+  });
+
   it("__internal_setOptions clears cursor and dedup handles on adapter swap, then refetches via the new adapter", async () => {
     const firstAdapter = makeAdapter({
       list: vi.fn<ListFn>(async () => ({

--- a/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
+++ b/packages/core/src/tests/remote-thread-list-adapter-switch.test.ts
@@ -399,6 +399,50 @@ describe("RemoteThreadList adapter changes", () => {
 
     expect(core.getItemById(draftId!)?.remoteId).toBe("created-on-b");
     expect(core.mainThreadId).toBe(draftId);
-    expect(core.threadIds).toContain("created-on-b");
+    expect(core.threadIds).toContain(draftId);
+    expect(core.getItemById("created-on-b")?.id).toBe(draftId);
+  });
+
+  it("keeps one slot when the replacement list already carries the initialized thread", async () => {
+    const adapterA = makeAdapter({
+      list: async () => ({ threads: [thread("thread-a")] }),
+    });
+    const listB = deferred<{ threads: ReturnType<typeof thread>[] }>();
+    const adapterB = makeAdapter({
+      list: vi.fn(() => listB.promise),
+      initialize: vi.fn(async () => ({
+        remoteId: "created-on-b",
+        externalId: "created-on-b",
+      })),
+    });
+    const core = createCore(adapterA);
+
+    await core.getLoadThreadsPromise();
+    const draftId = core.newThreadId;
+
+    core.__internal_setOptions({
+      adapter: adapterB,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.initialize(draftId!);
+
+    listB.resolve({
+      threads: [thread("created-on-b"), thread("thread-b")],
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(
+      Object.values(core.threadItems).filter(
+        (item) => item.remoteId === "created-on-b",
+      ),
+    ).toHaveLength(1);
+    expect(core.threadIds).toEqual([draftId, "thread-b"]);
+    expect(core.getItemById("created-on-b")?.id).toBe(draftId);
+
+    await core.delete("created-on-b");
+
+    expect(core.getItemById("created-on-b")).toBeUndefined();
+    expect(core.getItemById(draftId!)).toBeUndefined();
+    expect(core.threadIds).toEqual(["thread-b"]);
   });
 });


### PR DESCRIPTION
closes #6647

## Problem

a conversation created as a draft and then initialized ends up in two `threadData` slots for the same `remoteId` after the next `list()` load. one identity holds the runtime the user is chatting in, the other renders in the sidebar, and `delete()` clears only the one it resolves, leaving the other behind as a dangling reference.

repro (`@assistant-ui/core` 0.3.16, and current main): open a new thread in `useRemoteThreadListRuntime`, send a message so `initialize()` runs, let the next `list()` land, then delete the conversation. it stays in `threadData` under its local key while the list entry is gone.

## Root cause

three call sites disagreed on what a thread list entry holds, which broke the slot identity invariant.

`initialize()` adds `threadIdMap[remoteId]` but keeps the slot under its `__LOCALID_…` key, which is correct: `RemoteThreadListHookInstanceManager` keys live thread runtimes by `RemoteThreadData.id`, so renaming the slot would detach the runtime the user is chatting in.

the ordinary load path then handed `classifyThreads` an empty accumulator, so the `if (acc.threadIdMap[thread.remoteId] !== undefined) continue` guard could never fire and a second slot was minted under the remote key. `_replaceWithThreads` had the same hole from the other direction: its carry-over checked `threadData[createThreadMappingId(item.id)]`, which never matches a fresh slot keyed by `remoteId`.

`updateStatusReducer`'s `deleted` branch then filtered `threadData` by `id` rather than by the mapping id and enumerated `threadIdMap` keys one at a time, so it could not reach a second slot or an alias pointing at it.

## Change

the invariant is now stated once, above `classifyThreads`: a slot's `id` is fixed when it is minted, a listed thread whose `remoteId` already maps to a slot refreshes that slot instead of minting a second one, and `threadIds`/`archivedThreadIds` carry slot ids rather than remote ids.

`classifyThreads` resolves each incoming `remoteId` through `threadIdMap` before minting, which is the O(1) reverse index that already exists for exactly this question. on a hit it reuses the slot, keeps its `id`, `localOrigin`, and settled `initializeTask`, and refreshes the server metadata. a `listed` set built once per call keeps a repeated `remoteId` from entering a list twice.

the ordinary load path seeds the accumulator with the current `threadIdMap` and `threadData` and takes the result wholesale, replacing the `{ ...state.x, ...fresh.x }` overlay that produced the duplicate. `initialize()` closes the mirror ordering: a slot a concurrent `list()` minted under the remote id before that id was known collapses into the local slot, and the orphan's list entry is dropped. the tap client (`packages/core/src/react/client/RemoteThreadList.ts`) carried its own copy of both the merge and the initialize completion and gets the same treatment, so every `classifyThreads` caller now shares one rule. `_replaceWithThreads` collects the surviving slots first, seeds them the same way, and lets `classifyThreads` do the reconciliation, so adapter swaps and ordinary refreshes share one code path instead of two that drifted. `loadMore` needed no change and now refreshes a thread repeated on a later page rather than silently dropping it, which was the sharp edge noted in the issue.

deletion clears the slot by its mapping id and every `threadIdMap` entry pointing at it. list cleanup was already correct once list entries hold slot ids, so the `lastStatus` branch handles it and nothing new was added there.

## Verification

- the thirteen new and updated tests fail on the unfixed source and pass with it (verified by stashing only the two source files and rerunning): `refreshes the local slot when a listed thread already has a mapping`, `lists a repeated remote id once`, `keeps one slot when the list reports the thread just initialized`, `refreshes a thread repeated on a later page instead of dropping it`, `keeps a thread initialized while the replacement list is pending`, `keeps one slot when the replacement list already carries the initialized thread`, `collapses a slot the list minted while initialize was in flight`, `moves a thread whose status flips between pages`, `does not leave the collapsed slot in both lists when the race reported it archived`, `keeps one slot per remote id across reload and clears it on delete`, plus the client mirrors of the two race cases.
- `pnpm -C packages/core vitest run`: 154 files, 1593 tests green.
- downstream suites green (`react`, `ai-sdk`, `react-langgraph`, `react-langchain`, `react-google-adk`, `react-opencode`, `react-pi`, `assistant-cloud`): 18 tasks.
- `tsc --noEmit -p packages/core/tsconfig.json` produces a byte-identical error set to main (pre-existing workspace resolution errors only, no new ones).
- `pnpm lint`, `pnpm changesets:check`, `pnpm -C packages/core build` pass.
- `classifyThreads` stays linear: 2000 threads in 0.7ms, matching main's 0.6ms.

`remote-thread-list-adapter-switch.test.ts` keeps its original fixture and scenario; only the assertion moved to the slot id, plus one added case where the replacement list already carries the initialized thread. the reducer tests assert the invariant directly (one slot per `remoteId`, every list entry resolving to a slot with that `id`) so a future regression fails on the contract rather than on an incidental key.

## Public surface

`packages/core` only, across both the runtime core and the tap client. no published export changed: `remote-thread-state.ts` is internal and reachable from no barrel, so widening `ClassifyAccumulator` to an exported type stays inside the package. changeset `.changeset/soft-slots-reconcile.md`, patch.

one observable behavior change worth calling out: `threadIds` and `archivedThreadIds` now carry slot ids, so a thread created in the current session appears under its `__LOCALID_…` id until the next reload instead of switching to its remote id mid-session. `getItemById` resolves both, and main already mixed the two (`preserveMidLoadTransitions` pushed slot ids while `classifyThreads` pushed remote ids), so this makes the lists consistent rather than introducing a new shape. code that treats a list entry as a durable remote identifier should read `getItemById(id)?.remoteId`.

cross-page status flips (a thread listed regular on one page and archived on a later one) now relocate the id to the list matching the incoming status. previously a repeat kept its old list membership while its slot took the new status, which would have rendered an archived thread in the open list.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.P0P3GqAbd4qCFcsPjdH2TFoYpVTPe2MTEzbyOXFps6Ub8VhqXaE50nDTLUI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

one narrow gap is left open deliberately and filed as #6673: if the user switched to the raced slot before `initialize()` settled, collapsing it orphans the runtime the hook manager started under that id. resolving it means choosing which of two live runtimes survives, which belongs at the slot-state/`RemoteThreadListHookInstanceManager` seam rather than in this reducer.

