### PR TITLE
fix(react-google-adk): never execute a frontend tool on a call ADK resolves itself

### DIFF
--- a/.changeset/adk-provider-owned-tool-calls.md
+++ b/.changeset/adk-provider-owned-tool-calls.md
@@ -3,4 +3,4 @@
 "@assistant-ui/react-google-adk": patch
 ---
 
-fix: never execute a frontend tool on a tool call ADK resolves itself
+fix: never execute a frontend tool on a tool call ADK resolves itself; a client-executed tool must be registered as a `LongRunningFunctionTool` on the agent

--- a/.changeset/adk-provider-owned-tool-calls.md
+++ b/.changeset/adk-provider-owned-tool-calls.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: never execute a frontend tool on a tool call ADK resolves itself

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -822,6 +822,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1771,6 +1771,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 
@@ -5497,7 +5498,7 @@ type ToolExecutionStatus = {
 
 declare class ToolInvocationTracker {
   #private;
-  constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTracker.Callbacks);
+  constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTracker.Callbacks, isClientToolCall?: (toolCall: ToolCallMessagePart) => boolean);
   setState(snapshot: ToolInvocationTracker.Snapshot): void;
   reset(): void;
   abort(): Promise<void>;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -407,6 +407,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -683,6 +683,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -454,6 +454,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -822,6 +822,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1107,6 +1107,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -736,6 +736,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -755,6 +755,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -478,6 +478,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -480,6 +480,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2166,6 +2166,7 @@ type ExternalStoreAdapterBase<T> = {
     copy?: boolean | undefined;
   } | undefined;
   unstable_enableToolInvocations?: boolean | undefined;
+  unstable_isClientToolCall?: ((toolCall: ToolCallMessagePart) => boolean) | undefined;
   setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 

--- a/apps/docs/content/docs/runtimes/google-adk/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/google-adk/hooks.mdx
@@ -645,6 +645,8 @@ function PendingToolsIndicator() {
 
 This hook reports every tool call ADK marked via `long_running_tool_ids`, including HITL interrupts. To respond to a specific HITL type, see [tool confirmations](#tool-confirmations), [auth requests](#auth-requests), or [input requests](#input-requests).
 
+That same set decides which tool calls the client owns. A registered frontend tool's `execute` runs only for a call ADK marked long-running, because ADK resolves every other call itself and yields the call to the client before its own response. Register a tool the client executes as a `LongRunningFunctionTool` on the agent.
+
 ## Per-message metadata
 
 Access grounding, citation, and token usage metadata per message:

--- a/packages/core/src/runtimes/external-store/external-store-adapter.ts
+++ b/packages/core/src/runtimes/external-store/external-store-adapter.ts
@@ -1,4 +1,8 @@
-import type { AppendMessage, ThreadMessage } from "../../types/message";
+import type {
+  AppendMessage,
+  ThreadMessage,
+  ToolCallMessagePart,
+} from "../../types/message";
 import type { ThreadMessageLike } from "../../runtime/utils/thread-message-like";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type {
@@ -219,6 +223,23 @@ type ExternalStoreAdapterBase<T> = {
    * `modelContent` populated when present.
    */
   unstable_enableToolInvocations?: boolean | undefined;
+  /**
+   * Decides whether a tool call's result is produced on the client. Only
+   * consulted when `unstable_enableToolInvocations` is `true`; when omitted,
+   * every call whose name matches a registered tool is treated as
+   * client-owned.
+   *
+   * A provider that runs tools itself answers its own calls, and its result
+   * arrives one or more snapshots after the call's arguments complete. In
+   * that window the call is complete and result-less, so a registered tool
+   * of the same name would otherwise execute locally and produce a result
+   * the provider never asked for. An adapter that can tell the two apart
+   * supplies this predicate; it is read once per tool call, when the call is
+   * first observed live.
+   */
+  unstable_isClientToolCall?:
+    | ((toolCall: ToolCallMessagePart) => boolean)
+    | undefined;
   /**
    * Receives the current per-tool-call execution status map whenever it
    * changes. Only invoked when `unstable_enableToolInvocations` is `true`

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -555,6 +555,7 @@ export class ExternalStoreThreadRuntimeCore
             }
           },
         },
+        (toolCall) => this._store.unstable_isClientToolCall?.(toolCall) ?? true,
       );
     }
 

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -103,6 +103,11 @@ the call is first observed live, and never re-read: ownership is fixed
 when the provider emits the call, so a later snapshot cannot revoke it
 and drop the result of an execute already in flight.
 
+Outside production, a provider-owned call whose name resolves to a tool
+with an `execute` logs a `console.warn`. The two together are a
+misconfiguration: the provider answers the call, so the registered
+`execute` would never run and the skip is otherwise silent.
+
 Without it, a provider that runs tools itself races the tracker. Its
 result arrives one or more snapshots after the call's arguments
 complete, and in that window the call is complete and result-less, so a

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -92,9 +92,12 @@ in-flight `execute` resolves, the execute runs to completion (its side
 effects happen) but its result chunk is dropped: `onResult` never fires,
 and the `executing` status, plus any `human()` interrupt the execution
 parked, stays up until the promise settles. Only a gate that lands after
-the result chunk has already been emitted is fully too late; an adapter
-whose provider gates a call it has already streamed declares ownership
-up front instead (A.9).
+the result chunk has already been emitted is fully too late. An adapter
+whose provider both gates and answers such a call closes that window by
+declaring ownership up front (A.9). A call the client owns and the
+provider gates anyway stays exposed: the client is meant to execute it,
+so nothing but the gate's arrival says otherwise, and the gate is late
+by construction.
 
 ### A.9. Adapter reports the tool call as provider-owned
 The entry is marked `skipExecute` at creation, exactly like a call
@@ -115,6 +118,11 @@ registered tool of the same name executes locally: the frontend side
 effect fires, and the local result is either overwritten by the
 provider's (a plain call) or kept beside a gate the provider raises
 afterwards (#6285).
+
+The predicate decides who answers a call, not whether a call is gated,
+so it closes that window only for calls the provider answers. A gate on
+a call the client owns still arrives after the args complete, and A.8
+governs it (#6677).
 
 ## B. Tool call disappears from snapshot
 

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -104,7 +104,9 @@ The entry is marked `skipExecute` at creation, exactly like a call
 observed with a `result`. `unstable_isClientToolCall` is read once, when
 the call is first observed live, and never re-read: ownership is fixed
 when the provider emits the call, so a later snapshot cannot revoke it
-and drop the result of an execute already in flight.
+and drop the result of an execute already in flight. `streamCall` still
+fires once, as under A.8; only the wrapped `execute` and its result
+chunk are withheld.
 
 Outside production, a provider-owned call whose name resolves to a tool
 with an `execute` logs a `console.warn`. The two together are a

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -92,8 +92,24 @@ in-flight `execute` resolves, the execute runs to completion (its side
 effects happen) but its result chunk is dropped: `onResult` never fires,
 and the `executing` status, plus any `human()` interrupt the execution
 parked, stays up until the promise settles. Only a gate that lands after
-the result chunk has already been emitted is fully too late; the adapter
-must project the gate before that (#6285).
+the result chunk has already been emitted is fully too late; an adapter
+whose provider gates a call it has already streamed declares ownership
+up front instead (A.9).
+
+### A.9. Adapter reports the tool call as provider-owned
+The entry is marked `skipExecute` at creation, exactly like a call
+observed with a `result`. `unstable_isClientToolCall` is read once, when
+the call is first observed live, and never re-read: ownership is fixed
+when the provider emits the call, so a later snapshot cannot revoke it
+and drop the result of an execute already in flight.
+
+Without it, a provider that runs tools itself races the tracker. Its
+result arrives one or more snapshots after the call's arguments
+complete, and in that window the call is complete and result-less, so a
+registered tool of the same name executes locally: the frontend side
+effect fires, and the local result is either overwritten by the
+provider's (a plain call) or kept beside a gate the provider raises
+afterwards (#6285).
 
 ## B. Tool call disappears from snapshot
 

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -510,6 +510,134 @@ describe("ToolInvocationTracker", () => {
     expect(onResult).not.toHaveBeenCalled();
   });
 
+  it("never executes a tool call the adapter reports as provider-owned", async () => {
+    const execute = vi.fn(async () => ({ deleted: true }));
+    const getTools = () => ({
+      deleteFile: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    const tracker = new ToolInvocationTracker(
+      getTools,
+      { onResult, onStatusesChange: () => {} },
+      () => false,
+    );
+    tracker.setState(createState([]));
+
+    tracker.setState(
+      createState(
+        [
+          createAssistantMessage(
+            '{"path":"/tmp/a"}',
+            { path: "/tmp/a" },
+            { toolName: "deleteFile" },
+          ),
+        ],
+        true,
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+
+    tracker.setState(
+      createState(
+        [
+          createAssistantMessage(
+            '{"path":"/tmp/a"}',
+            { path: "/tmp/a" },
+            { toolName: "deleteFile", result: { server: "deleted" } },
+          ),
+        ],
+        false,
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it("executes a tool call the adapter reports as client-owned", async () => {
+    const execute = vi.fn(async () => ({ deleted: true }));
+    const getTools = () => ({
+      deleteFile: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    const tracker = new ToolInvocationTracker(
+      getTools,
+      { onResult, onStatusesChange: () => {} },
+      (toolCall) => toolCall.toolCallId === "tool-1",
+    );
+    tracker.setState(createState([]));
+
+    tracker.setState(
+      createState(
+        [
+          createAssistantMessage(
+            '{"path":"/tmp/a"}',
+            { path: "/tmp/a" },
+            { toolName: "deleteFile" },
+          ),
+        ],
+        true,
+      ),
+    );
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onResult).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the result of a call the adapter stops reporting as client-owned mid-execution", async () => {
+    let resolveExecute!: (value: { deleted: boolean }) => void;
+    const execute = vi.fn(
+      () =>
+        new Promise<{ deleted: boolean }>((r) => {
+          resolveExecute = r;
+        }),
+    );
+    const getTools = () => ({
+      deleteFile: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    let clientOwned = true;
+    const tracker = new ToolInvocationTracker(
+      getTools,
+      { onResult, onStatusesChange: () => {} },
+      () => clientOwned,
+    );
+    tracker.setState(createState([]));
+
+    const live = () =>
+      createState(
+        [
+          createAssistantMessage(
+            '{"path":"/tmp/a"}',
+            { path: "/tmp/a" },
+            { toolName: "deleteFile" },
+          ),
+        ],
+        true,
+      );
+
+    tracker.setState(live());
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+    clientOwned = false;
+    tracker.setState(live());
+    resolveExecute({ deleted: true });
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledTimes(1));
+  });
+
   it("does not re-execute asynchronously loaded resolved tool calls after reset", async () => {
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const getTools = () => ({

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -519,6 +519,7 @@ describe("ToolInvocationTracker", () => {
       } satisfies Tool,
     });
     const onResult = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const tracker = new ToolInvocationTracker(
       getTools,
       { onResult, onStatusesChange: () => {} },
@@ -542,6 +543,8 @@ describe("ToolInvocationTracker", () => {
 
     expect(execute).not.toHaveBeenCalled();
     expect(onResult).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
 
     tracker.setState(
       createState(

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -520,48 +520,52 @@ describe("ToolInvocationTracker", () => {
     });
     const onResult = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const tracker = new ToolInvocationTracker(
-      getTools,
-      { onResult, onStatusesChange: () => {} },
-      () => false,
-    );
-    tracker.setState(createState([]));
 
-    tracker.setState(
-      createState(
-        [
-          createAssistantMessage(
-            '{"path":"/tmp/a"}',
-            { path: "/tmp/a" },
-            { toolName: "deleteFile" },
-          ),
-        ],
-        true,
-      ),
-    );
-    await new Promise((r) => setTimeout(r, 0));
+    try {
+      const tracker = new ToolInvocationTracker(
+        getTools,
+        { onResult, onStatusesChange: () => {} },
+        () => false,
+      );
+      tracker.setState(createState([]));
 
-    expect(execute).not.toHaveBeenCalled();
-    expect(onResult).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
+      tracker.setState(
+        createState(
+          [
+            createAssistantMessage(
+              '{"path":"/tmp/a"}',
+              { path: "/tmp/a" },
+              { toolName: "deleteFile" },
+            ),
+          ],
+          true,
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 0));
 
-    tracker.setState(
-      createState(
-        [
-          createAssistantMessage(
-            '{"path":"/tmp/a"}',
-            { path: "/tmp/a" },
-            { toolName: "deleteFile", result: { server: "deleted" } },
-          ),
-        ],
-        false,
-      ),
-    );
-    await new Promise((r) => setTimeout(r, 0));
+      expect(execute).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
 
-    expect(execute).not.toHaveBeenCalled();
-    expect(onResult).not.toHaveBeenCalled();
+      tracker.setState(
+        createState(
+          [
+            createAssistantMessage(
+              '{"path":"/tmp/a"}',
+              { path: "/tmp/a" },
+              { toolName: "deleteFile", result: { server: "deleted" } },
+            ),
+          ],
+          false,
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("executes a tool call the adapter reports as client-owned", async () => {

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -591,7 +591,7 @@ export class ToolInvocationTracker {
     if (process.env.NODE_ENV === "production") return;
     if (this._getTools()?.[toolName]?.execute === undefined) return;
     console.warn(
-      "[ToolInvocationTracker] adapter reports this tool call as provider-owned; the registered execute is skipped (see EDGE_CASES.md A.9)",
+      "[ToolInvocationTracker] the runtime reports this tool call as provider-owned, so the registered execute is skipped; the provider has to hand the call to the client for it to run (see EDGE_CASES.md A.9)",
       { toolCallId, toolName },
     );
   }

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -587,6 +587,15 @@ export class ToolInvocationTracker {
     return tool?.execute !== undefined || tool?.streamCall !== undefined;
   }
 
+  private _warnProviderOwnedSkip(toolName: string, toolCallId: string): void {
+    if (process.env.NODE_ENV === "production") return;
+    if (this._getTools()?.[toolName]?.execute === undefined) return;
+    console.warn(
+      "[ToolInvocationTracker] adapter reports this tool call as provider-owned; the registered execute is skipped (see EDGE_CASES.md A.9)",
+      { toolCallId, toolName },
+    );
+  }
+
   private _shouldCloseArgsStream({
     toolName,
     argsText,
@@ -793,10 +802,14 @@ export class ToolInvocationTracker {
         }
 
         if (!entry) {
+          const providerOwned =
+            content.result === undefined && !this._isClientToolCall(content);
+          if (providerOwned)
+            this._warnProviderOwnedSkip(content.toolName, content.toolCallId);
           entry = this._startActiveEntry(
             content.toolCallId,
             content.toolName,
-            content.result !== undefined || !this._isClientToolCall(content),
+            content.result !== undefined || providerOwned,
           );
         }
 

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -14,7 +14,7 @@ import {
   type ReadonlyJSONValue,
 } from "assistant-stream/utils";
 import { isJSONValueEqual } from "../../utils/json/is-json-equal";
-import type { ThreadMessage } from "../../types/message";
+import type { ThreadMessage, ToolCallMessagePart } from "../../types/message";
 
 const TOOL_EXECUTION_ID = Symbol.for("assistant-stream.tool-execution-id");
 
@@ -116,6 +116,9 @@ const getToolExecutionId = (value: object): symbol | undefined =>
 export class ToolInvocationTracker {
   private readonly _getTools: () => Record<string, Tool> | undefined;
   private readonly _callbacks: ToolInvocationTracker.Callbacks;
+  private readonly _isClientToolCall: (
+    toolCall: ToolCallMessagePart,
+  ) => boolean;
 
   private readonly _entries = new Map<string, ToolCallEntry>();
   private readonly _humanInput = new Map<
@@ -154,9 +157,11 @@ export class ToolInvocationTracker {
   constructor(
     getTools: () => Record<string, Tool> | undefined,
     callbacks: ToolInvocationTracker.Callbacks,
+    isClientToolCall?: (toolCall: ToolCallMessagePart) => boolean,
   ) {
     this._getTools = getTools;
     this._callbacks = callbacks;
+    this._isClientToolCall = isClientToolCall ?? (() => true);
 
     this._initPipeline();
   }
@@ -791,7 +796,7 @@ export class ToolInvocationTracker {
           entry = this._startActiveEntry(
             content.toolCallId,
             content.toolName,
-            content.result !== undefined,
+            content.result !== undefined || !this._isClientToolCall(content),
           );
         }
 

--- a/packages/react-google-adk/src/useAdkRuntime.toolOwnership.test.tsx
+++ b/packages/react-google-adk/src/useAdkRuntime.toolOwnership.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import { type FC } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AssistantRuntimeProvider,
+  useAssistantTool,
+} from "@assistant-ui/core/react";
+import type {
+  AssistantRuntime,
+  RemoteThreadListAdapter,
+  ToolCallMessagePart,
+} from "@assistant-ui/core";
+import { useAdkRuntime } from "./useAdkRuntime";
+import type { AdkEvent } from "./types";
+
+const makeThreadListAdapter = (): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({
+    threads: [
+      {
+        status: "regular" as const,
+        remoteId: "adk-1",
+        externalId: "adk-1",
+        title: "Existing ADK session",
+      },
+    ],
+  })),
+  initialize: vi.fn(async () => ({ remoteId: "adk-1", externalId: "adk-1" })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(async () => new ReadableStream() as never),
+  fetch: vi.fn(async () => ({
+    status: "regular" as const,
+    remoteId: "adk-1",
+    externalId: "adk-1",
+    title: "Existing ADK session",
+  })),
+});
+
+const toolCalls = (runtime: AssistantRuntime): ToolCallMessagePart[] =>
+  runtime.thread
+    .getState()
+    .messages.flatMap((message) => message.content as readonly unknown[])
+    .filter(
+      (part): part is ToolCallMessagePart =>
+        (part as ToolCallMessagePart).type === "tool-call",
+    );
+
+const GATED_CALL = {
+  id: "adk-original-1",
+  name: "delete_file",
+  args: { path: "/tmp/a" },
+};
+
+const callEvent = (longRunningToolIds?: string[]): AdkEvent => ({
+  id: "ev-1",
+  invocationId: "inv-1",
+  author: "agent",
+  content: { role: "model", parts: [{ functionCall: GATED_CALL }] },
+  ...(longRunningToolIds && { longRunningToolIds }),
+});
+
+const confirmationEvent = (): AdkEvent => ({
+  id: "ev-2",
+  invocationId: "inv-1",
+  author: "agent",
+  content: {
+    role: "model",
+    parts: [
+      {
+        functionCall: {
+          id: "adk-confirmation-1",
+          name: "adk_request_confirmation",
+          args: {
+            originalFunctionCall: GATED_CALL,
+            toolConfirmation: { hint: "Delete /tmp/a?" },
+          },
+        },
+      },
+    ],
+  },
+  longRunningToolIds: ["adk-confirmation-1"],
+});
+
+const serverResultEvent = (): AdkEvent => ({
+  id: "ev-2",
+  invocationId: "inv-1",
+  author: "agent",
+  content: {
+    role: "user",
+    parts: [
+      {
+        functionResponse: {
+          id: "adk-original-1",
+          name: "delete_file",
+          response: { server: "deleted" },
+        },
+      },
+    ],
+  },
+});
+
+/**
+ * Streams `first`, hands control back so the window between the two events is
+ * observable, then streams `second` once the returned `release` is called.
+ */
+const renderStreamingAdk = async (first: AdkEvent, second: AdkEvent) => {
+  let release!: () => void;
+  const held = new Promise<void>((r) => (release = r));
+  let firstDelivered!: () => void;
+  const firstDeliveredP = new Promise<void>((r) => (firstDelivered = r));
+
+  const stream = vi.fn(async function* (): AsyncGenerator<AdkEvent> {
+    yield first;
+    firstDelivered();
+    await held;
+    yield second;
+  });
+
+  const execute = vi.fn(async () => ({ deleted: true }));
+  const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+  const DeleteFileTool = () => {
+    useAssistantTool({
+      toolName: "delete_file",
+      description: "delete a file",
+      parameters: {
+        type: "object" as const,
+        properties: { path: { type: "string" } },
+      },
+      execute,
+    });
+    return null;
+  };
+
+  const Inner: FC = () => {
+    const runtime = useAdkRuntime({
+      stream: stream as never,
+      sessionAdapter: makeThreadListAdapter(),
+    });
+    capture.runtime = runtime;
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <DeleteFileTool />
+      </AssistantRuntimeProvider>
+    );
+  };
+
+  await act(async () => {
+    render(<Inner />);
+  });
+  await waitFor(() => expect(capture.runtime).not.toBeNull());
+  await act(async () => {
+    await capture.runtime!.threads.switchToThread("adk-1");
+  });
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  await act(async () => {
+    void capture.runtime!.thread.append({
+      role: "user",
+      content: [{ type: "text", text: "delete it" }],
+    });
+    await firstDeliveredP;
+  });
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  const settle = async () => {
+    await act(async () => {
+      release();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  };
+
+  return { capture, execute, settle };
+};
+
+describe("useAdkRuntime tool ownership", () => {
+  it("does not run a frontend execute on a call ADK is about to gate", async () => {
+    const { capture, execute, settle } = await renderStreamingAdk(
+      callEvent(),
+      confirmationEvent(),
+    );
+
+    const inWindow = toolCalls(capture.runtime!)[0]!;
+    expect(inWindow.argsText).toBe('{"path":"/tmp/a"}');
+    expect(inWindow.approval).toBeUndefined();
+    expect(inWindow.result).toBeUndefined();
+    expect(execute).not.toHaveBeenCalled();
+
+    await settle();
+
+    const gated = toolCalls(capture.runtime!).find(
+      (part) => part.toolCallId === "adk-original-1",
+    )!;
+    expect(gated.approval).toEqual({ id: "adk-confirmation-1" });
+    expect(gated.result).toBeUndefined();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("does not run a frontend execute on a call ADK resolves itself", async () => {
+    const { capture, execute, settle } = await renderStreamingAdk(
+      callEvent(),
+      serverResultEvent(),
+    );
+
+    expect(toolCalls(capture.runtime!)[0]!.result).toBeUndefined();
+    expect(execute).not.toHaveBeenCalled();
+
+    await settle();
+
+    expect(toolCalls(capture.runtime!)[0]!.result).toBe('{"server":"deleted"}');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("runs a frontend execute on a call ADK marks long-running", async () => {
+    const { capture, execute } = await renderStreamingAdk(
+      callEvent(["adk-original-1"]),
+      serverResultEvent(),
+    );
+
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(toolCalls(capture.runtime!)[0]!.result).toBeDefined(),
+    );
+  });
+});

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -8,6 +8,7 @@ import {
   type RealtimeVoiceAdapter,
   type SpeechSynthesisAdapter,
   type AppendMessage,
+  type ToolCallMessagePart,
   type ToolExecutionStatus,
   generateId,
 } from "@assistant-ui/core";
@@ -172,6 +173,17 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
   const toolApprovalsRef = useRef(toolApprovals);
   toolApprovalsRef.current = toolApprovals;
 
+  const longRunningToolIdsRef = useRef(longRunningToolIds);
+  longRunningToolIdsRef.current = longRunningToolIds;
+  // ADK resolves every call it did not mark long-running itself, and yields
+  // that call to the client one or more events before its own response, so
+  // only a long-running call is the client's to execute.
+  const isClientToolCall = useCallback(
+    (toolCall: ToolCallMessagePart) =>
+      longRunningToolIdsRef.current.includes(toolCall.toolCallId),
+    [],
+  );
+
   const messageConverter = useMemo(
     () =>
       toolApprovalsKey === ""
@@ -300,6 +312,7 @@ const useAdkRuntimeImpl = (options: UseAdkRuntimeOptions) => {
     isLoading: isLoadingThread,
     messages: threadMessages,
     unstable_enableToolInvocations: true,
+    unstable_isClientToolCall: isClientToolCall,
     setToolStatuses,
     adapters: { attachments, dictation, feedback, speech, voice },
     extras: adkExtras.provide({


### PR DESCRIPTION
## Problem

`useAdkRuntime` runs a registered frontend tool on tool calls ADK resolves itself.

ADK yields the model's own event, carrying the original `functionCall`, before it runs the tool and before it emits either the tool's `functionResponse` or the synthetic `adk_request_confirmation` call. `useAdkMessages` commits state per streamed event, so between those two events the transcript holds a tool call with complete args, no result, and no approval. `ToolInvocationTracker` closes the args stream for any call whose name matches a registered tool as soon as `argsText` parses, so the frontend `execute` fires there.

two shapes, both reproduced against `@google/adk@2.0.0` event ordering:

- a confirmation-gated call. the frontend tool runs and writes a local result, then the gate lands on a call that already ran, so the user is asked to approve something the client already did.
- an ordinary server-executed call whose name collides with a registered frontend tool. the frontend tool runs, and the server's own result then overwrites the local one, so the UI looks correct while the frontend side effect has already fired.

this is the Google ADK half of #6285. the AG-UI half is tracked separately in #6677: AG-UI has no per-call ownership signal, so it needs a latency versus safety decision rather than this fix.

## Root cause

the tracker has no notion of who produces a tool call's result. it treats "a tool of this name is registered" as "the client owns this call", which is wrong for any provider that runs tools server-side. #6282 taught it to skip a call carrying an `approval`, but the gate arrives too late for that to help: the local result is already written by the time it lands.

ADK does carry the ownership signal. `long_running_tool_ids` names exactly the calls whose result the client (or an external system) owes; everything else ADK answers itself. `getPendingCancellations` already reads that same set, so the rule is not new to this adapter, only newly applied here.

## Change

core gains an optional `unstable_isClientToolCall` on the external-store adapter, consulted only when `unstable_enableToolInvocations` is on. `ToolInvocationTracker` reads it once per tool call, when the call is first observed live, and marks a provider-owned call `skipExecute` exactly as it already marks a call observed with a `result`.

ownership is read once rather than per snapshot on purpose: it is fixed when the provider emits the call, so a later snapshot cannot revoke it and drop the result of an `execute` already in flight. that is the one place where it differs from the `approval` check, which genuinely lands later.

`useAdkRuntime` supplies the predicate from `long_running_tool_ids`.

outside production, a provider-owned call whose name resolves to a tool with an `execute` logs a warning: that combination is a misconfiguration, and the skip would otherwise be silent for an app developer whose tool stopped firing.

ownership decides who answers a call, not whether a call is gated, so this closes the window only for calls ADK answers. `isLongRunning` and `requireConfirmation` are independent options on ADK's `FunctionTool`, so a `LongRunningFunctionTool` that also requires confirmation is genuinely the client's to execute and its gate still arrives late. EDGE_CASES.md A.8 records that, and #6677 tracks the decision, which is the same latency versus safety call the AG-UI half needs.

no latency cost: a client-owned call behaves exactly as before, and `streamCall` still fires for a provider-owned call so rendering is unchanged. only the wrapped `execute` and its result chunk are withheld, the same mechanism #6282 used. every other adapter that opts into the tracker (ai-sdk, ag-ui, langgraph, langchain, eve) passes no predicate and is untouched.

buffering complete result-less calls at the adapter boundary was considered and rejected: it delays every non-gated frontend tool, holds back the tool call part's streaming render, and would be duplicated per adapter.

## Verification

`pnpm -C packages/react-google-adk test`, `pnpm -C packages/core test`, plus the react-ag-ui, react-langgraph, react-langchain and ai-sdk suites: all green (core 1596, react-google-adk 326, react-ag-ui 535).

new `packages/react-google-adk/src/useAdkRuntime.toolOwnership.test.tsx` drives the real `useAdkRuntime`, `AdkEventAccumulator` and external-store runtime, delivering the two ADK events in separate `act` phases so the window is observable:

- a call ADK is about to gate: no result and no `execute` in the window, and after the confirmation lands the call carries the approval with no local result.
- a call ADK resolves itself: no `execute`, and the server result lands normally.
- a call ADK marks long-running: `execute` runs and its result is written, so the fix does not over-block.

the first two fail with `unstable_isClientToolCall` removed from the runtime and pass with it; the third passes either way.

core adds three tracker tests: provider-owned never executes and warns once, client-owned executes, and a call whose ownership flips mid-execution still delivers its result.

`pnpm lint` clean. `pnpm api-surface:check` passes against the regenerated snapshot.

## Public surface

- `@assistant-ui/core`: new optional `ExternalStoreAdapterBase.unstable_isClientToolCall`; new optional third constructor parameter on the internal `ToolInvocationTracker`. additive only.
- `@assistant-ui/react-google-adk`: no exported surface change.
- `EDGE_CASES.md` gains case A.9, and A.8 is rewritten to say which half of #6285 it still governs.
- `runtimes/google-adk/hooks.mdx` documents the ownership rule under long-running tools.
- api-surface snapshots regenerated (12 files, additive).
- changesets: patch for `@assistant-ui/core` and `@assistant-ui/react-google-adk`.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yznfA6Bpb0FIGpEevMFbCYzPnT4kLE_Y5e4b3UDECrJDQ4HNQe-y8L4am2M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->