### PR TITLE
test(docs): fail CI when a previewed sample stops extracting

### DIFF
--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -182,7 +182,7 @@ describe("every real preview extracts", () => {
     // that preview unguarded.
     let occurrences = 0;
     let parsed = 0;
-    const pairs = new Set<string>();
+    const pairs = new Map<string, { file: string; name: string }>();
     for (const mdxFile of mdxFiles) {
       const mdx = readFileSync(mdxFile, "utf8");
       occurrences += mdx.match(/<PreviewCode[\s>]/g)?.length ?? 0;
@@ -190,7 +190,9 @@ describe("every real preview extracts", () => {
         /<PreviewCode\s[^>]*?file="([^"]+)"[^>]*?name="([^"]+)"/gs,
       )) {
         parsed += 1;
-        pairs.add(`${match[1]} ${match[2]}`);
+        const file = match[1]!;
+        const name = match[2]!;
+        pairs.set(JSON.stringify([file, name]), { file, name });
       }
     }
     expect(occurrences).toBeGreaterThan(0);
@@ -204,9 +206,10 @@ describe("every real preview extracts", () => {
         failures.push(`${sourceFile}#${name}: ${extracted}`);
         return;
       }
-      // A phantom string that swallows a brace truncates the snippet at an
-      // earlier boundary and still looks like code, so the text after the
-      // extracted region must start a new top-level construct.
+      // A phantom string that never closes already produces the marker above.
+      // This catches the other half: one that closes, having swallowed a lone
+      // opening delimiter, ends the region early at a boundary that still
+      // reads as code.
       const endIndex = source.indexOf(extracted) + extracted.length;
       const rest = source.slice(endIndex).replace(/^[\s;]*/, "");
       if (
@@ -221,8 +224,7 @@ describe("every real preview extracts", () => {
       }
     };
 
-    for (const pair of pairs) {
-      const [file, name] = pair.split(" ") as [string, string];
+    for (const { file, name } of pairs.values()) {
       const base = join(docsRoot, `${file}.tsx`);
       const radix = join(docsRoot, `${file}.radix.tsx`);
       if (existsSync(radix)) checkExtraction(radix, name);

--- a/apps/docs/components/pages/docs/preview-code-extract.test.ts
+++ b/apps/docs/components/pages/docs/preview-code-extract.test.ts
@@ -155,3 +155,82 @@ describe("extractFunctionCode", () => {
     );
   });
 });
+
+describe("every real preview extracts", () => {
+  // Extraction failure is silent at authoring time: the page renders the
+  // marker where the snippet should be, and nothing else notices. This sweep
+  // covers every previewed source rather than a fixture so that an input the
+  // scanner cannot read fails here instead of on the published page.
+  it("extracts every <PreviewCode> pair referenced from content", async () => {
+    const { readdirSync, readFileSync, existsSync } = await import("node:fs");
+    const { join, resolve } = await import("node:path");
+
+    const docsRoot = resolve(__dirname, "../../..");
+    const mdxFiles: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".mdx")) mdxFiles.push(full);
+      }
+    };
+    walk(join(docsRoot, "content"));
+
+    // Every <PreviewCode occurrence must yield a parsed pair, so a call site
+    // the pair regex cannot read (attribute reordering, an expression
+    // attribute containing ">") fails the sweep instead of silently leaving
+    // that preview unguarded.
+    let occurrences = 0;
+    let parsed = 0;
+    const pairs = new Set<string>();
+    for (const mdxFile of mdxFiles) {
+      const mdx = readFileSync(mdxFile, "utf8");
+      occurrences += mdx.match(/<PreviewCode[\s>]/g)?.length ?? 0;
+      for (const match of mdx.matchAll(
+        /<PreviewCode\s[^>]*?file="([^"]+)"[^>]*?name="([^"]+)"/gs,
+      )) {
+        parsed += 1;
+        pairs.add(`${match[1]} ${match[2]}`);
+      }
+    }
+    expect(occurrences).toBeGreaterThan(0);
+    expect(parsed).toBe(occurrences);
+
+    const failures: string[] = [];
+    const checkExtraction = (sourceFile: string, name: string) => {
+      const source = readFileSync(sourceFile, "utf8");
+      const extracted = extractFunctionCode(source, name);
+      if (extracted.startsWith("// Could not")) {
+        failures.push(`${sourceFile}#${name}: ${extracted}`);
+        return;
+      }
+      // A phantom string that swallows a brace truncates the snippet at an
+      // earlier boundary and still looks like code, so the text after the
+      // extracted region must start a new top-level construct.
+      const endIndex = source.indexOf(extracted) + extracted.length;
+      const rest = source.slice(endIndex).replace(/^[\s;]*/, "");
+      if (
+        rest !== "" &&
+        !/^(export\s|import\s|const\s|let\s|var\s|class\s|function\s|async\s|type\s|interface\s|["']use client["']|\/\/|\/\*)/.test(
+          rest,
+        )
+      ) {
+        failures.push(
+          `${sourceFile}#${name}: truncated extraction (resumes at ${JSON.stringify(rest.slice(0, 40))})`,
+        );
+      }
+    };
+
+    for (const pair of pairs) {
+      const [file, name] = pair.split(" ") as [string, string];
+      const base = join(docsRoot, `${file}.tsx`);
+      const radix = join(docsRoot, `${file}.radix.tsx`);
+      if (existsSync(radix)) checkExtraction(radix, name);
+      if (existsSync(base)) checkExtraction(base, name);
+      if (!existsSync(base) && !existsSync(radix)) {
+        failures.push(`${file}#${name}: source file missing`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
refs #6544

## Problem

preview-code extraction fails silently. when `extractFunctionCode` cannot read a sample, the page renders `// Could not parse function: X` where the snippet should be, and nothing in CI notices. #6532 and #6544 were both caught by hand, after the fact, and only because someone happened to look.

## Change

a sweep test that walks every `<PreviewCode>` reference in `content/**/*.mdx` and asserts each pair extracts. it covers all 61 current call sites (114 source files, counting `.radix` variants), and checks two things per pair: the result carries no `// Could not` marker, and the text after the extracted region begins a new top-level construct, so a phantom string that swallows a brace and truncates the snippet is caught too.

it also asserts that every raw `<PreviewCode` occurrence resolves to a parsed pair, so a call site the regex cannot read (reordered attributes, an expression attribute containing `>`) fails the sweep instead of dropping out of coverage unnoticed.

no scanner change. this is the guard on its own, and it passes against the extractor exactly as it stands today.

the sweep is Kinfe123's work from #6636, lifted out and shipped separately from the scanner heuristic that PR also carried.

## Verification

- `pnpm -C apps/docs exec vitest run --config vitest.config.ts components/pages/docs/preview-code-extract.test.ts components/pages/docs/preview-code.server.test.tsx` -> 18/18 green.
- proved the guard actually fires rather than passing vacuously: rewriting a previewed sample's JSX text to `Here's what people ask` fails the sweep with `accordion.radix.tsx#AccordionFAQSample: // Could not parse function: AccordionFAQSample`, and it goes green again on revert.
- oxlint and oxfmt clean on the changed file.

## Public surface

none. `@assistant-ui/docs` is private, so no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Y2KRL9pEjxLPwid2dwtEgGimSuOCmPSCbCmbg4CYbA9IjSJM25Cw7_WNJIQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->