### PR TITLE
ci: check the pins the update pipeline cannot see

### DIFF
--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -54,6 +54,7 @@ Both are defined in the root `package.json`; `deps:update` runs `scripts/update-
 - Do **not** hand-edit the generated changeset's bump levels — `generate-deps-changeset.sh` correctly emits `patch` for every published package whose `package.json` changed and skips private packages (`@assistant-ui/docs`, `@assistant-ui/shadcn-registry`, etc.). Per `AGENTS.md`, dependency updates are always patch.
 - The script detects changes via `git diff HEAD`, so run it with the package.json edits still unstaged (or staged — it checks both). Don't commit before it runs.
 - `pnpm-lock.yaml` will have a huge diff; that's expected since step 2 deletes it.
+- `pnpm unmanaged-pins:check` guards two pins the updater never opens, so a routine run can go red on a file it did not touch. Raise the exact pins in `apps/docs/lib/xulux/learn/courses/*/shared/project/package.json` to whatever the workspace now prevailingly declares (`@assistant-ui/*` entries are exempt), and move any version-scoped `allowBuilds` entry in `pnpm-workspace.yaml` to the version the refreshed lockfile installs.
 - Node `>=24` and `pnpm@11.3.0` are required (see root `package.json` `engines` / `packageManager`).
 
 ## Python (uv)

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -54,7 +54,7 @@ Both are defined in the root `package.json`; `deps:update` runs `scripts/update-
 - Do **not** hand-edit the generated changeset's bump levels — `generate-deps-changeset.sh` correctly emits `patch` for every published package whose `package.json` changed and skips private packages (`@assistant-ui/docs`, `@assistant-ui/shadcn-registry`, etc.). Per `AGENTS.md`, dependency updates are always patch.
 - The script detects changes via `git diff HEAD`, so run it with the package.json edits still unstaged (or staged — it checks both). Don't commit before it runs.
 - `pnpm-lock.yaml` will have a huge diff; that's expected since step 2 deletes it.
-- `pnpm unmanaged-pins:check` guards two pins the updater never opens, so a routine run can go red on a file it did not touch. Raise the exact pins in `apps/docs/lib/xulux/learn/courses/*/shared/project/package.json` to whatever the workspace now prevailingly declares (`@assistant-ui/*` entries are exempt), and move any version-scoped `allowBuilds` entry in `pnpm-workspace.yaml` to the version the refreshed lockfile installs.
+- `pnpm unmanaged-pins:check` guards two pins the updater never opens, so a routine run can go red on a file it did not touch. Raise the exact pins in `apps/docs/lib/xulux/learn/courses/*/shared/project/package.json` to whatever the workspace now prevailingly declares (pins on packages this repository publishes are exempt, since those move on every release), and move any version-scoped `allowBuilds` entry in `pnpm-workspace.yaml` to the version the refreshed lockfile installs.
 - Node `>=24` and `pnpm@11.3.0` are required (see root `package.json` `engines` / `packageManager`).
 
 ## Python (uv)

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -101,7 +101,7 @@ Every `uses:` entry under `.github/workflows/*.{yml,yaml}` is SHA-pinned for sup
 uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
 ```
 
-The marker is what `ratchet update` reads to recognize the entry, so an entry that loses it keeps working and stops being updated. `pnpm unmanaged-pins:check` fails on a missing marker, and on one that names a different action than its `uses:` ref. Annotate a deliberately unmanaged ref, or a pinned container image, with `# ratchet:exclude`.
+The marker is what `ratchet update` reads to recognize the entry, so an entry that loses it keeps working and stops being updated. `pnpm unmanaged-pins:check` fails on a ref that is not a commit SHA, on a missing marker, on a marker with no version, and on one that names a different action than its `uses:` ref. Annotate a deliberately unmanaged ref, or a pinned container image, with `# ratchet:exclude`, which waives all four.
 
 There is **no Dependabot config** (`.github/dependabot.yml` does not exist), so these don't update themselves. `pnpm deps:update` does not touch them either.
 

--- a/.claude/skills/update-deps/SKILL.md
+++ b/.claude/skills/update-deps/SKILL.md
@@ -94,16 +94,17 @@ Notes:
 
 ## GitHub Actions
 
-Workflows under `.github/workflows/*.{yml,yaml}` use a mix of styles:
+Every `uses:` entry under `.github/workflows/*.{yml,yaml}` is SHA-pinned for supply-chain hardening and carries a `ratchet:` marker naming the release the SHA came from:
 
-- **SHA-pinned** (preferred for security — supply-chain hardening):
-  `uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`
-- **Tag-pinned** (still in some files):
-  `uses: actions/checkout@v6`
+```yaml
+uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+```
+
+The marker is what `ratchet update` reads to recognize the entry, so an entry that loses it keeps working and stops being updated. `pnpm unmanaged-pins:check` fails on a missing marker, and on one that names a different action than its `uses:` ref. Annotate a deliberately unmanaged ref, or a pinned container image, with `# ratchet:exclude`.
 
 There is **no Dependabot config** (`.github/dependabot.yml` does not exist), so these don't update themselves. `pnpm deps:update` does not touch them either.
 
-To refresh both styles in one shot, use [`ratchet`](https://github.com/sethvargo/ratchet) (or `pinact`):
+To refresh them, use [`ratchet`](https://github.com/sethvargo/ratchet) (or `pinact`):
 
 ```bash
 # pin any remaining tag refs to SHAs (one-time per file)
@@ -113,12 +114,13 @@ ratchet pin .github/workflows/*.yml .github/workflows/*.yaml
 ratchet update .github/workflows/*.yml .github/workflows/*.yaml
 ```
 
-Both leave the `# v6`-style comment intact so reviewers can read the human version. If `ratchet` isn't available, fall back to manually checking each `uses:` against the action's releases page and updating the SHA + comment together.
+Both rewrite the marker alongside the SHA. If `ratchet` isn't available, fall back to manually checking each `uses:` against the action's releases page and updating the SHA and marker together.
 
 After updating, sanity-check on a branch by pushing and watching the affected workflows actually run (most are PR-triggered: `code-quality`, `autofix`, `changeset`, `changeset-semver-check`, `expo`, `devtools-frame`, `registry`). Release workflows (`npm-publish`, `pypi-publish`, `traction`) can't be tested without a release tag — eyeball those diffs extra carefully.
 
 Notes:
 
 - GH Actions updates do not need a changeset (they don't ship in any npm package).
+- `pnpm unmanaged-pins:check` also holds the Node.js major consistent across every workflow, so bump `runtime: node@N` and `node-version:` together.
 - Commit as `chore: update github actions` (or roll into `chore: update dependencies` if landing alongside the JS/Python bumps).
 - If a major bump changes inputs/outputs, check the action's release notes — `ratchet` will happily move you from `v4` to `v6` without warning about breaking changes.

--- a/.github/workflows/unmanaged-pins.yaml
+++ b/.github/workflows/unmanaged-pins.yaml
@@ -5,20 +5,28 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - "package.json"
       - "**/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "scripts/check-unmanaged-pins.mjs"
       - "scripts/check-unmanaged-pins.test.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-changesets.mjs"
+      - "scripts/lib/workspace.mjs"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/**"
+      - "package.json"
       - "**/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "scripts/check-unmanaged-pins.mjs"
       - "scripts/check-unmanaged-pins.test.mjs"
+      - "scripts/check-built-declarations.mjs"
+      - "scripts/check-changesets.mjs"
+      - "scripts/lib/workspace.mjs"
 
 permissions:
   contents: read

--- a/.github/workflows/unmanaged-pins.yaml
+++ b/.github/workflows/unmanaged-pins.yaml
@@ -14,6 +14,7 @@ on:
       - "scripts/check-built-declarations.mjs"
       - "scripts/check-changesets.mjs"
       - "scripts/lib/workspace.mjs"
+      - "scripts/lib/script-options.mjs"
   pull_request:
     branches: [main]
     paths:
@@ -27,6 +28,7 @@ on:
       - "scripts/check-built-declarations.mjs"
       - "scripts/check-changesets.mjs"
       - "scripts/lib/workspace.mjs"
+      - "scripts/lib/script-options.mjs"
 
 permissions:
   contents: read

--- a/.github/workflows/unmanaged-pins.yaml
+++ b/.github/workflows/unmanaged-pins.yaml
@@ -1,0 +1,51 @@
+name: Unmanaged Pins
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/check-unmanaged-pins.mjs"
+      - "scripts/check-unmanaged-pins.test.mjs"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/check-unmanaged-pins.mjs"
+      - "scripts/check-unmanaged-pins.test.mjs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unmanaged-pins:
+    name: Unmanaged Pins
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm and node.js
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # ratchet:pnpm/setup@v2.1.0
+        with:
+          runtime: node@24
+          install: false
+
+      - name: Test the unmanaged pin checker
+        run: node --test scripts/check-unmanaged-pins.test.mjs
+
+      - name: Verify the pins no tool manages are current
+        run: node scripts/check-unmanaged-pins.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ Don't:
 - **Don't ship a new example app that duplicates one we already ship.** Scan `examples/` first; if with-cloud, with-langgraph, or with-mcp already covers the integration, your example adds no ground. New examples belong in a separate repo on your own account unless a maintainer asked for it in-repo.
 - **Don't fix a bug by introducing a UX regression.** Disabling a feature, dropping an animation, or widening an API to mask a jitter or rendering bug is not an acceptable fix. Diagnose and fix the root cause; a regression is rejected even when the original report is real.
 - **Don't add defensive checks the toolchain already enforces, or comment on formatting.** The repo runs `@tsconfig/strictest` with `exactOptionalPropertyTypes`, so nullability and optional-property guards are redundant; do not add "ensure x is defined" guards the compiler already catches. Formatting is automated (oxfmt), so do not raise spacing or formatting nits in review.
-- **Don't `--admin` merge a PR until `gh pr checks` shows every row passing or explicitly skipped.** Filter out `pass` and `skipping` and confirm the remainder is empty, because the truncated tail once hid a failing Template Sync. If a repo-specific check (template-sync, api-surface, check:resource-memo, changeset-semver) is failing or pending, resolve it first rather than overriding.
+- **Don't `--admin` merge a PR until `gh pr checks` shows every row passing or explicitly skipped.** Filter out `pass` and `skipping` and confirm the remainder is empty, because the truncated tail once hid a failing Template Sync. If a repo-specific check (template-sync, api-surface, check:resource-memo, changeset-semver, unmanaged-pins) is failing or pending, resolve it first rather than overriding.
 
 ## GitButler
 

--- a/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/shared/project/package.json
+++ b/apps/docs/lib/xulux/learn/courses/build-generative-ui-assistant/shared/project/package.json
@@ -8,21 +8,21 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ai-sdk/openai": "4.0.47",
+    "@ai-sdk/openai": "4.0.50",
     "@assistant-ui/ai-sdk": "0.0.2",
     "@assistant-ui/next": "0.0.17",
     "@assistant-ui/react": "0.15.16",
-    "ai": "7.0.79",
+    "ai": "7.0.83",
     "assistant-stream": "0.3.39",
     "lucide-react": "1.34.0",
-    "next": "16.3.2",
+    "next": "16.3.3",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.3.3",
-    "@types/node": "26.3.0",
+    "@types/node": "26.4.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.5",
     "tailwindcss": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "declarations:test": "node --test scripts/check-built-declarations.test.mjs",
     "workspace-ranges:check": "node scripts/check-workspace-ranges.mjs",
     "workspace-ranges:test": "node --test scripts/check-workspace-ranges.test.mjs",
+    "unmanaged-pins:check": "node scripts/check-unmanaged-pins.mjs",
+    "unmanaged-pins:test": "node --test scripts/check-unmanaged-pins.test.mjs",
     "lint": "pnpm exec oxlint && pnpm exec oxfmt --check",
     "check:resource-memo": "node packages/x-buildutils/check-resource-memoization.mjs",
     "lint:fix": "pnpm exec oxlint --fix && pnpm exec oxfmt",

--- a/scripts/check-unmanaged-pins.mjs
+++ b/scripts/check-unmanaged-pins.mjs
@@ -100,7 +100,7 @@ export function findInconsistentNodePins(workflows) {
     source.split("\n").forEach((line, index) => {
       const pin =
         /^\s*runtime:\s*node@(\d+)/.exec(line) ??
-        /^\s*node-version:\s*'?"?(\d+)'?"?\s*$/.exec(line);
+        /^\s*node-version:\s*["']?(\d+)(?:\.|["'\s]|$)/.exec(line);
       if (pin) pins.push({ file, line: index + 1, major: Number(pin[1]) });
     });
   }

--- a/scripts/check-unmanaged-pins.mjs
+++ b/scripts/check-unmanaged-pins.mjs
@@ -68,17 +68,24 @@ export function findUnmarkedActionRefs(workflows) {
   for (const { file, source } of workflows) {
     source.split("\n").forEach((line, index) => {
       const ref = /^\s*(?:-\s+)?uses:\s*(\S+)/.exec(line);
-      if (!ref || ref[1].startsWith(".")) return;
-      const action = ref[1].slice(0, ref[1].lastIndexOf("@"));
+      if (!ref) return;
+      const uses = ref[1].replace(/^["']|["']$/g, "");
+      if (uses.startsWith(".")) return;
       const marker = /#\s*ratchet:(\S+)/.exec(line);
       if (marker && marker[1] === "exclude") return;
       const report = (reason) =>
-        problems.push({ file, line: index + 1, uses: ref[1], reason });
-      if (!marker) return report("absent");
+        problems.push({ file, line: index + 1, uses, reason });
+      const refAt = uses.lastIndexOf("@");
+      if (!/^[0-9a-f]{40}$/.test(uses.slice(refAt + 1))) {
+        return report("not pinned to a commit SHA");
+      }
+      if (!marker) return report("no ratchet marker");
       const at = marker[1].lastIndexOf("@");
-      if (at <= 0) return report("has no version");
-      if (marker[1].slice(0, at) !== action) {
-        report(`names ${marker[1].slice(0, at)}`);
+      if (at <= 0 || at === marker[1].length - 1) {
+        return report("ratchet marker has no version");
+      }
+      if (marker[1].slice(0, at) !== uses.slice(0, refAt)) {
+        report(`ratchet marker names ${marker[1].slice(0, at)}`);
       }
     });
   }
@@ -245,21 +252,24 @@ function main() {
   if (result.unmarked.length > 0) {
     failed = true;
     console.error(
-      "Workflow `uses:` entries without a usable ratchet marker:\n",
+      "Workflow `uses:` entries that are not SHA-pinned with a usable ratchet marker:\n",
     );
     for (const { file, line, uses, reason } of result.unmarked) {
-      console.error(`  ${file}:${line}: ${uses} (marker ${reason})`);
+      console.error(`  ${file}:${line}: ${uses} — ${reason}`);
     }
     console.error(
-      "\n`ratchet update` reads the trailing `# ratchet:<owner>/<repo>@<version>` comment to learn",
+      "\nEvery action is pinned to a commit SHA, and `ratchet update` reads the trailing",
     );
     console.error(
-      "which action a pinned SHA came from. An entry that loses its marker keeps working and stops",
+      "`# ratchet:<owner>/<repo>@<version>` comment to learn which action that SHA came from. An entry",
     );
     console.error(
-      "being updated, so the pin silently freezes. Restore the marker, or annotate a deliberately",
+      "that reverts to a tag drops the pin, and one that loses its marker keeps working and stops being",
     );
-    console.error("unmanaged entry with `# ratchet:exclude`.\n");
+    console.error(
+      "updated. Restore the SHA and the marker, or annotate a deliberately unmanaged entry with",
+    );
+    console.error("`# ratchet:exclude`.\n");
   }
 
   if (result.nodePins.length > 0) {

--- a/scripts/check-unmanaged-pins.mjs
+++ b/scripts/check-unmanaged-pins.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+import { globSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isExecutedAsMain } from "./check-built-declarations.mjs";
+import { parseWorkspaceGlobs } from "./check-changesets.mjs";
+import { posixPath, readJson } from "./lib/workspace.mjs";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const COURSE_PROJECT_GLOB =
+  "apps/docs/lib/xulux/learn/courses/*/shared/project/package.json";
+
+const VERSION_FIELDS = ["dependencies", "devDependencies"];
+
+export function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(value.trim());
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+export function compareVersions(a, b) {
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index];
+  }
+  return 0;
+}
+
+export function lowestSatisfying(range) {
+  if (typeof range !== "string") return null;
+  if (range.startsWith("workspace:") || range.includes("||")) return null;
+  const alias = /^npm:(?:@[^/]+\/)?[^@]+@(.+)$/.exec(range);
+  return parseVersion((alias ? alias[1] : range).replace(/^[\^~>=v\s]+/, ""));
+}
+
+export function parseIndentedBlock(source, key) {
+  const entries = [];
+  let depth = null;
+  for (const line of source.split("\n")) {
+    if (new RegExp(`^${key}:\\s*$`).test(line)) {
+      depth = 0;
+      continue;
+    }
+    if (depth === null) continue;
+    if (/^\s*(?:#.*)?$/.test(line)) continue;
+    if (/^\S/.test(line)) {
+      depth = null;
+      continue;
+    }
+    const entry = /^(\s+)(?:"([^"]*)"|'([^']*)'|([^\s#:]+))\s*:\s*(.*)$/.exec(
+      line,
+    );
+    if (!entry) continue;
+    if (depth === 0) depth = entry[1].length;
+    if (entry[1].length !== depth) continue;
+    entries.push([
+      entry[2] ?? entry[3] ?? entry[4],
+      entry[5].replace(/\s*#.*$/, "").trim(),
+    ]);
+  }
+  return entries;
+}
+
+export function findUnmarkedActionRefs(workflows) {
+  const problems = [];
+  for (const { file, source } of workflows) {
+    source.split("\n").forEach((line, index) => {
+      const ref = /^\s*(?:-\s+)?uses:\s*(\S+)/.exec(line);
+      if (!ref || ref[1].startsWith(".")) return;
+      const action = ref[1].split("@")[0];
+      const marker = /#\s*ratchet:(\S+)/.exec(line);
+      if (marker && marker[1] === "exclude") return;
+      if (!marker) {
+        problems.push({
+          file,
+          line: index + 1,
+          uses: ref[1],
+          reason: "absent",
+        });
+        return;
+      }
+      if (marker[1].split("@")[0] !== action) {
+        problems.push({
+          file,
+          line: index + 1,
+          uses: ref[1],
+          reason: `names ${marker[1].split("@")[0]}`,
+        });
+      }
+    });
+  }
+  return problems;
+}
+
+export function findInconsistentNodePins(workflows) {
+  const pins = [];
+  for (const { file, source } of workflows) {
+    source.split("\n").forEach((line, index) => {
+      const pin =
+        /^\s*runtime:\s*node@(\d+)/.exec(line) ??
+        /^\s*node-version:\s*'?"?(\d+)'?"?\s*$/.exec(line);
+      if (pin) pins.push({ file, line: index + 1, major: Number(pin[1]) });
+    });
+  }
+  const majors = [...new Set(pins.map(({ major }) => major))];
+  if (majors.length < 2) return [];
+  const count = (major) => pins.filter((pin) => pin.major === major).length;
+  const [dominant] = majors.sort((a, b) => count(b) - count(a) || b - a);
+  return pins
+    .filter(({ major }) => major !== dominant)
+    .map((pin) => ({ ...pin, dominant }));
+}
+
+export function findDriftedAllowBuilds(allowBuilds, lockedIds) {
+  const problems = [];
+  const scoped = new Map();
+  for (const [key, value] of allowBuilds) {
+    const at = key.lastIndexOf("@");
+    if (at <= 0) continue;
+    const name = key.slice(0, at);
+    if (!parseVersion(key.slice(at + 1))) continue;
+    scoped.set(name, [...(scoped.get(name) ?? []), key]);
+    if (!lockedIds.has(key)) {
+      problems.push({ entry: key, value, reason: "is not installed" });
+    }
+  }
+  for (const [name, keys] of scoped) {
+    for (const id of lockedIds) {
+      if (id.slice(0, id.lastIndexOf("@")) !== name) continue;
+      if (keys.includes(id)) continue;
+      problems.push({
+        entry: id,
+        value: null,
+        reason: "has no allowBuilds entry",
+      });
+    }
+  }
+  return problems;
+}
+
+export function findStaleCoursePins(courses, floors, published) {
+  const problems = [];
+  for (const { file, pkg } of courses) {
+    for (const field of VERSION_FIELDS) {
+      for (const [name, pin] of Object.entries(pkg[field] ?? {})) {
+        if (published.has(name)) continue;
+        const floor = floors.get(name);
+        const pinned = typeof pin === "string" ? parseVersion(pin) : null;
+        if (!floor || !pinned) continue;
+        if (compareVersions(pinned, floor) < 0) {
+          problems.push({ file, name, pin, floor: floor.join(".") });
+        }
+      }
+    }
+  }
+  return problems;
+}
+
+function readWorkflows(root) {
+  return globSync(".github/workflows/*.{yaml,yml}", { cwd: root })
+    .map(posixPath)
+    .sort()
+    .map((file) => ({
+      file,
+      source: readFileSync(path.join(root, file), "utf8"),
+    }));
+}
+
+export function prevailingFloor(counts) {
+  let winner = null;
+  for (const [id, count] of counts) {
+    const floor = parseVersion(id);
+    if (
+      !winner ||
+      count > winner.count ||
+      (count === winner.count && compareVersions(floor, winner.floor) > 0)
+    ) {
+      winner = { floor, count };
+    }
+  }
+  return winner?.floor ?? null;
+}
+
+function readWorkspaceVersions(root) {
+  const floors = new Map();
+  const declared = new Map();
+  const published = new Set();
+  const manifests = ["package.json"];
+  for (const glob of parseWorkspaceGlobs(
+    readFileSync(path.join(root, "pnpm-workspace.yaml"), "utf8"),
+  )) {
+    manifests.push(...globSync(`${glob}/package.json`, { cwd: root }));
+  }
+  for (const manifest of new Set(manifests.map(posixPath))) {
+    const pkg = readJson(path.join(root, manifest));
+    if (typeof pkg.name === "string") published.add(pkg.name);
+    for (const field of VERSION_FIELDS) {
+      for (const [name, range] of Object.entries(pkg[field] ?? {})) {
+        const floor = lowestSatisfying(range);
+        if (!floor) continue;
+        const counts = declared.get(name) ?? new Map();
+        const id = floor.join(".");
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+        declared.set(name, counts);
+      }
+    }
+  }
+  for (const [name, counts] of declared) {
+    floors.set(name, prevailingFloor(counts));
+  }
+  return { floors, published };
+}
+
+function readLockedIds(root) {
+  const source = readFileSync(path.join(root, "pnpm-lock.yaml"), "utf8");
+  const ids = new Set();
+  for (const [key] of parseIndentedBlock(source, "packages")) {
+    ids.add(key);
+  }
+  return ids;
+}
+
+export function runCheck(root = repoRoot) {
+  const workflows = readWorkflows(root);
+  const { floors, published } = readWorkspaceVersions(root);
+  const courses = globSync(COURSE_PROJECT_GLOB, { cwd: root })
+    .map(posixPath)
+    .sort()
+    .map((file) => ({ file, pkg: readJson(path.join(root, file)) }));
+  return {
+    workflowCount: workflows.length,
+    courseCount: courses.length,
+    unmarked: findUnmarkedActionRefs(workflows),
+    nodePins: findInconsistentNodePins(workflows),
+    allowBuilds: findDriftedAllowBuilds(
+      parseIndentedBlock(
+        readFileSync(path.join(root, "pnpm-workspace.yaml"), "utf8"),
+        "allowBuilds",
+      ),
+      readLockedIds(root),
+    ),
+    coursePins: findStaleCoursePins(courses, floors, published),
+  };
+}
+
+function main() {
+  const result = runCheck(process.env.UNMANAGED_PIN_CHECK_ROOT);
+  let failed = false;
+
+  if (result.unmarked.length > 0) {
+    failed = true;
+    console.error(
+      "Workflow `uses:` entries without a usable ratchet marker:\n",
+    );
+    for (const { file, line, uses, reason } of result.unmarked) {
+      console.error(`  ${file}:${line}: ${uses} (marker ${reason})`);
+    }
+    console.error(
+      "\n`ratchet update` reads the trailing `# ratchet:<owner>/<repo>@<version>` comment to learn",
+    );
+    console.error(
+      "which action a pinned SHA came from. An entry that loses its marker keeps working and stops",
+    );
+    console.error(
+      "being updated, so the pin silently freezes. Restore the marker, or annotate a deliberately",
+    );
+    console.error("unmanaged entry with `# ratchet:exclude`.\n");
+  }
+
+  if (result.nodePins.length > 0) {
+    failed = true;
+    console.error("Workflow Node.js pins disagree:\n");
+    for (const { file, line, major, dominant } of result.nodePins) {
+      console.error(`  ${file}:${line}: node@${major}, not node@${dominant}`);
+    }
+    console.error(
+      "\nNothing resolves these against each other, so a partial bump splits CI across two Node.js",
+    );
+    console.error("majors without failing anything.\n");
+  }
+
+  if (result.allowBuilds.length > 0) {
+    failed = true;
+    console.error("`allowBuilds` no longer matches the lockfile:\n");
+    for (const { entry, reason } of result.allowBuilds) {
+      console.error(`  ${entry} ${reason}`);
+    }
+    console.error(
+      "\nA version-scoped `allowBuilds` entry stops applying the moment the package resolves to a",
+    );
+    console.error(
+      "different version, and `strictDepBuilds: true` turns the lost allowance into a failed install",
+    );
+    console.error(
+      "rather than a warning. Move the entry to the installed version, or drop the version scope.\n",
+    );
+  }
+
+  if (result.coursePins.length > 0) {
+    failed = true;
+    console.error("Learn course projects are behind the workspace:\n");
+    for (const { file, name, pin, floor } of result.coursePins) {
+      console.error(`  ${file}: "${name}" is ${pin}, workspace is on ${floor}`);
+    }
+    console.error(
+      "\nThese projects are the skeleton Learn Mode hands a learner. They pin exact versions and are",
+    );
+    console.error(
+      "not workspace members, so taze skips them and they drift by default rather than by decision.",
+    );
+    console.error(
+      "Raise the pins to the workspace versions. `@assistant-ui/*` pins are exempt: they move on every",
+    );
+    console.error(
+      "release, which the course projects do not participate in.\n",
+    );
+  }
+
+  if (failed) process.exit(1);
+
+  const plural = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
+  console.log(
+    `Pins outside the update pipeline are current. (${plural(result.workflowCount, "workflow")}, ` +
+      `${plural(result.courseCount, "course project")} scanned)`,
+  );
+}
+
+if (isExecutedAsMain(import.meta.url, process.argv[1])) main();

--- a/scripts/check-unmanaged-pins.mjs
+++ b/scripts/check-unmanaged-pins.mjs
@@ -69,25 +69,16 @@ export function findUnmarkedActionRefs(workflows) {
     source.split("\n").forEach((line, index) => {
       const ref = /^\s*(?:-\s+)?uses:\s*(\S+)/.exec(line);
       if (!ref || ref[1].startsWith(".")) return;
-      const action = ref[1].split("@")[0];
+      const action = ref[1].slice(0, ref[1].lastIndexOf("@"));
       const marker = /#\s*ratchet:(\S+)/.exec(line);
       if (marker && marker[1] === "exclude") return;
-      if (!marker) {
-        problems.push({
-          file,
-          line: index + 1,
-          uses: ref[1],
-          reason: "absent",
-        });
-        return;
-      }
-      if (marker[1].split("@")[0] !== action) {
-        problems.push({
-          file,
-          line: index + 1,
-          uses: ref[1],
-          reason: `names ${marker[1].split("@")[0]}`,
-        });
+      const report = (reason) =>
+        problems.push({ file, line: index + 1, uses: ref[1], reason });
+      if (!marker) return report("absent");
+      const at = marker[1].lastIndexOf("@");
+      if (at <= 0) return report("has no version");
+      if (marker[1].slice(0, at) !== action) {
+        report(`names ${marker[1].slice(0, at)}`);
       }
     });
   }
@@ -195,7 +186,9 @@ function readWorkspaceVersions(root) {
   }
   for (const manifest of new Set(manifests.map(posixPath))) {
     const pkg = readJson(path.join(root, manifest));
-    if (typeof pkg.name === "string") published.add(pkg.name);
+    if (typeof pkg.name === "string" && pkg.private !== true) {
+      published.add(pkg.name);
+    }
     for (const field of VERSION_FIELDS) {
       for (const [name, range] of Object.entries(pkg[field] ?? {})) {
         const floor = lowestSatisfying(range);
@@ -311,10 +304,10 @@ function main() {
       "not workspace members, so taze skips them and they drift by default rather than by decision.",
     );
     console.error(
-      "Raise the pins to the workspace versions. `@assistant-ui/*` pins are exempt: they move on every",
+      "Raise the pins to the workspace versions. Packages this repository publishes are exempt: they",
     );
     console.error(
-      "release, which the course projects do not participate in.\n",
+      "move on every release, which the course projects do not participate in.\n",
     );
   }
 

--- a/scripts/check-unmanaged-pins.test.mjs
+++ b/scripts/check-unmanaged-pins.test.mjs
@@ -78,10 +78,10 @@ function createWorkspace({ problems = false } = {}) {
       "  check:",
       "    runs-on: ubuntu-latest",
       "    steps:",
-      "      - uses: actions/checkout@fixture # ratchet:actions/checkout@v4",
+      `      - uses: actions/checkout@${"a".repeat(40)} # ratchet:actions/checkout@v4`,
       problems
-        ? "      - uses: actions/setup-node@fixture"
-        : "      - uses: actions/setup-node@fixture # ratchet:actions/setup-node@v4",
+        ? `      - uses: actions/setup-node@${"b".repeat(40)}`
+        : `      - uses: actions/setup-node@${"b".repeat(40)} # ratchet:actions/setup-node@v4`,
       "    runtime: node@22",
       `    node-version: ${problems ? "20" : "22"}`,
       "",
@@ -145,17 +145,21 @@ test("parseIndentedBlock collects every top-level block at its entry depth", () 
   ]);
 });
 
-test("findUnmarkedActionRefs distinguishes missing and mismatched markers", () => {
+test("findUnmarkedActionRefs rejects tag refs and unusable markers", () => {
+  const sha = "0123456789abcdef0123456789abcdef01234567";
   const problems = findUnmarkedActionRefs([
     {
       file: ".github/workflows/check.yaml",
       source: [
         "steps:",
-        "  - uses: actions/checkout@fixture # ratchet:actions/checkout@v4",
-        "  - uses: actions/setup-node@fixture",
-        "  - uses: actions/cache@fixture # ratchet:actions/checkout@v4",
-        "  - uses: actions/setup-python@fixture # ratchet:actions/setup-python",
-        "  - uses: actions/upload-artifact@fixture # ratchet:exclude",
+        `  - uses: actions/checkout@${sha} # ratchet:actions/checkout@v4`,
+        `  - uses: "actions/download-artifact@${sha}" # ratchet:actions/download-artifact@v4`,
+        `  - uses: actions/setup-node@${sha}`,
+        `  - uses: actions/cache@${sha} # ratchet:actions/checkout@v4`,
+        `  - uses: actions/setup-python@${sha} # ratchet:actions/setup-python`,
+        `  - uses: actions/labeler@${sha} # ratchet:actions/labeler@`,
+        "  - uses: actions/stale@v9 # ratchet:actions/stale@v9.0.0",
+        `  - uses: actions/upload-artifact@${sha} # ratchet:exclude`,
         "  - uses: ./local-action",
       ].join("\n"),
     },
@@ -164,21 +168,33 @@ test("findUnmarkedActionRefs distinguishes missing and mismatched markers", () =
   assert.deepEqual(problems, [
     {
       file: ".github/workflows/check.yaml",
-      line: 3,
-      uses: "actions/setup-node@fixture",
-      reason: "absent",
-    },
-    {
-      file: ".github/workflows/check.yaml",
       line: 4,
-      uses: "actions/cache@fixture",
-      reason: "names actions/checkout",
+      uses: `actions/setup-node@${sha}`,
+      reason: "no ratchet marker",
     },
     {
       file: ".github/workflows/check.yaml",
       line: 5,
-      uses: "actions/setup-python@fixture",
-      reason: "has no version",
+      uses: `actions/cache@${sha}`,
+      reason: "ratchet marker names actions/checkout",
+    },
+    {
+      file: ".github/workflows/check.yaml",
+      line: 6,
+      uses: `actions/setup-python@${sha}`,
+      reason: "ratchet marker has no version",
+    },
+    {
+      file: ".github/workflows/check.yaml",
+      line: 7,
+      uses: `actions/labeler@${sha}`,
+      reason: "ratchet marker has no version",
+    },
+    {
+      file: ".github/workflows/check.yaml",
+      line: 8,
+      uses: "actions/stale@v9",
+      reason: "not pinned to a commit SHA",
     },
   ]);
 });
@@ -365,6 +381,58 @@ test("runCheck holds course pins to the prevailing floor, not an outlier", () =>
   }
 });
 
+test("runCheck exempts only the packages the workspace publishes", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "aui-unmanaged-pins-private-"));
+  try {
+    writeJson(root, "package.json", {
+      name: "@fixture/root",
+      version: "1.0.0",
+    });
+    writeJson(root, "packages/published/package.json", {
+      name: "@fixture/published",
+      version: "2.0.0",
+    });
+    writeJson(root, "packages/private/package.json", {
+      name: "@fixture/private",
+      version: "2.0.0",
+      private: true,
+      dependencies: { "@fixture/published": "^2.0.0" },
+    });
+    writeJson(root, "packages/consumer/package.json", {
+      name: "@fixture/consumer",
+      version: "1.0.0",
+      dependencies: { "@fixture/private": "^2.0.0" },
+    });
+    writeJson(
+      root,
+      "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+      {
+        name: "@fixture/course",
+        dependencies: {
+          "@fixture/private": "1.0.0",
+          "@fixture/published": "1.0.0",
+        },
+      },
+    );
+    writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "packages:\n  - packages/*\n",
+    );
+    writeFileSync(
+      path.join(root, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\n",
+    );
+    mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+
+    assert.deepEqual(
+      runCheck(root).coursePins.map(({ name }) => name),
+      ["@fixture/private"],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("runCheck reads workflow, lockfile, workspace, and course fixtures", () => {
   const root = createWorkspace();
   try {
@@ -414,7 +482,7 @@ test("the executable reports every seeded problem and exits 1", () => {
     assert.equal(result.status, 1);
     assert.match(
       result.stderr,
-      /actions\/setup-node@fixture \(marker absent\)/,
+      /actions\/setup-node@b{40} — no ratchet marker/,
     );
     assert.match(result.stderr, /node@20, not node@22/);
     assert.match(result.stderr, /esbuild@0\.1\.0 is not installed/);

--- a/scripts/check-unmanaged-pins.test.mjs
+++ b/scripts/check-unmanaged-pins.test.mjs
@@ -1,0 +1,399 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  compareVersions,
+  findDriftedAllowBuilds,
+  findInconsistentNodePins,
+  findStaleCoursePins,
+  findUnmarkedActionRefs,
+  lowestSatisfying,
+  parseIndentedBlock,
+  parseVersion,
+  prevailingFloor,
+  runCheck,
+} from "./check-unmanaged-pins.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function writeJson(root, file, value) {
+  const target = path.join(root, file);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value));
+}
+
+function createWorkspace({ problems = false } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "aui-unmanaged-pins-"));
+  writeJson(root, "package.json", {
+    name: "@fixture/root",
+    version: "1.0.0",
+  });
+  writeJson(root, "packages/source/package.json", {
+    name: "@fixture/source",
+    version: "1.0.0",
+    dependencies: { "fixture-dep": "^2.0.0" },
+  });
+  writeJson(
+    root,
+    "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+    {
+      name: "@fixture/course",
+      version: "1.0.0",
+      dependencies: { "fixture-dep": problems ? "1.0.0" : "2.0.0" },
+    },
+  );
+  writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    [
+      "packages:",
+      "  - packages/*",
+      "",
+      "allowBuilds:",
+      `  esbuild@${problems ? "0.1.0" : "1.2.3"}: true`,
+      "  core-js: false",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    path.join(root, "pnpm-lock.yaml"),
+    [
+      "lockfileVersion: '9.0'",
+      "",
+      "packages:",
+      "  esbuild@1.2.3:",
+      "    resolution: {integrity: sha512-fixture}",
+      "",
+    ].join("\n"),
+  );
+  mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+  writeFileSync(
+    path.join(root, ".github", "workflows", "check.yaml"),
+    [
+      "name: Check",
+      "on: push",
+      "jobs:",
+      "  check:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - uses: actions/checkout@fixture # ratchet:actions/checkout@v4",
+      problems
+        ? "      - uses: actions/setup-node@fixture"
+        : "      - uses: actions/setup-node@fixture # ratchet:actions/setup-node@v4",
+      "    runtime: node@22",
+      `    node-version: ${problems ? "20" : "22"}`,
+      "",
+    ].join("\n"),
+  );
+  return root;
+}
+
+test("parseVersion reads three-part numeric versions", () => {
+  assert.deepEqual(parseVersion("1.2.3"), [1, 2, 3]);
+  assert.deepEqual(parseVersion(" 10.20.30 "), [10, 20, 30]);
+  assert.equal(parseVersion("1.2"), null);
+  assert.equal(parseVersion("v1.2.3"), null);
+  assert.equal(parseVersion("not-a-version"), null);
+});
+
+test("compareVersions compares each version component", () => {
+  assert.equal(compareVersions([1, 2, 3], [1, 2, 3]), 0);
+  assert.ok(compareVersions([2, 0, 0], [1, 99, 99]) > 0);
+  assert.ok(compareVersions([1, 3, 0], [1, 4, 0]) < 0);
+  assert.ok(compareVersions([1, 2, 3], [1, 2, 4]) < 0);
+});
+
+test("lowestSatisfying finds simple and aliased range floors", () => {
+  for (const range of ["^6.0.2", "~6.0.2", ">=6.0.2", "v6.0.2"]) {
+    assert.deepEqual(lowestSatisfying(range), [6, 0, 2], range);
+  }
+  assert.deepEqual(
+    lowestSatisfying("npm:@typescript/typescript6@^6.0.2"),
+    [6, 0, 2],
+  );
+  assert.equal(lowestSatisfying("workspace:*"), null);
+  assert.equal(lowestSatisfying("^6.0.2 || ^7.0.0"), null);
+  assert.equal(lowestSatisfying("latest"), null);
+});
+
+test("parseIndentedBlock collects every top-level block at its entry depth", () => {
+  const entries = parseIndentedBlock(
+    [
+      "packages:",
+      "  first@1.2.3: {}",
+      "  this is a block scalar line",
+      "    nested: ignored",
+      "  second@2.3.4: {} # retained package",
+      "settings:",
+      "  ignored@0.0.1: true",
+      "packages:",
+      '  "@scope/third@3.4.5": true # scoped package',
+      "  'fourth@4.5.6': false",
+      "    nested: ignored",
+      "",
+    ].join("\n"),
+    "packages",
+  );
+
+  assert.deepEqual(entries, [
+    ["first@1.2.3", "{}"],
+    ["second@2.3.4", "{}"],
+    ["@scope/third@3.4.5", "true"],
+    ["fourth@4.5.6", "false"],
+  ]);
+});
+
+test("findUnmarkedActionRefs distinguishes missing and mismatched markers", () => {
+  const problems = findUnmarkedActionRefs([
+    {
+      file: ".github/workflows/check.yaml",
+      source: [
+        "steps:",
+        "  - uses: actions/checkout@fixture # ratchet:actions/checkout@v4",
+        "  - uses: actions/setup-node@fixture",
+        "  - uses: actions/cache@fixture # ratchet:actions/checkout@v4",
+        "  - uses: actions/upload-artifact@fixture # ratchet:exclude",
+        "  - uses: ./local-action",
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(problems, [
+    {
+      file: ".github/workflows/check.yaml",
+      line: 3,
+      uses: "actions/setup-node@fixture",
+      reason: "absent",
+    },
+    {
+      file: ".github/workflows/check.yaml",
+      line: 4,
+      uses: "actions/cache@fixture",
+      reason: "names actions/checkout",
+    },
+  ]);
+});
+
+test("findInconsistentNodePins reports pins outside the most common major", () => {
+  assert.deepEqual(
+    findInconsistentNodePins([
+      {
+        file: ".github/workflows/one.yaml",
+        source: ["runtime: node@22", "node-version: '22'"].join("\n"),
+      },
+      {
+        file: ".github/workflows/two.yaml",
+        source: "node-version: 20",
+      },
+    ]),
+    [
+      {
+        file: ".github/workflows/two.yaml",
+        line: 1,
+        major: 20,
+        dominant: 22,
+      },
+    ],
+  );
+  assert.deepEqual(
+    findInconsistentNodePins([
+      { file: ".github/workflows/only.yaml", source: "runtime: node@22" },
+    ]),
+    [],
+  );
+});
+
+test("findDriftedAllowBuilds handles scoped version entries", () => {
+  const problems = findDriftedAllowBuilds(
+    [
+      ["esbuild@1.2.3", "true"],
+      ["better-sqlite3@9.0.0", "false"],
+      ["@scope/pkg@1.0.0", "true"],
+      ["core-js", "false"],
+    ],
+    new Set(["esbuild@1.2.3", "@scope/pkg@1.1.0"]),
+  );
+
+  assert.deepEqual(problems, [
+    {
+      entry: "better-sqlite3@9.0.0",
+      value: "false",
+      reason: "is not installed",
+    },
+    {
+      entry: "@scope/pkg@1.0.0",
+      value: "true",
+      reason: "is not installed",
+    },
+    {
+      entry: "@scope/pkg@1.1.0",
+      value: null,
+      reason: "has no allowBuilds entry",
+    },
+  ]);
+});
+
+test("findStaleCoursePins reports only exact pins below workspace floors", () => {
+  const problems = findStaleCoursePins(
+    [
+      {
+        file: "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+        pkg: {
+          dependencies: {
+            "fixture-dep": "1.0.0",
+            "published-dep": "1.0.0",
+            "range-dep": "^1.0.0",
+          },
+          devDependencies: { "dev-dep": "2.0.0", "unknown-dep": "1.0.0" },
+        },
+      },
+    ],
+    new Map([
+      ["fixture-dep", [1, 0, 1]],
+      ["published-dep", [2, 0, 0]],
+      ["range-dep", [2, 0, 0]],
+      ["dev-dep", [2, 1, 0]],
+    ]),
+    new Set(["published-dep"]),
+  );
+
+  assert.deepEqual(problems, [
+    {
+      file: "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+      name: "fixture-dep",
+      pin: "1.0.0",
+      floor: "1.0.1",
+    },
+    {
+      file: "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+      name: "dev-dep",
+      pin: "2.0.0",
+      floor: "2.1.0",
+    },
+  ]);
+});
+
+test("prevailingFloor picks the most declared floor and breaks ties high", () => {
+  assert.deepEqual(
+    prevailingFloor(
+      new Map([
+        ["1.0.0", 3],
+        ["2.0.0", 1],
+      ]),
+    ),
+    [1, 0, 0],
+  );
+  assert.deepEqual(
+    prevailingFloor(
+      new Map([
+        ["1.0.0", 2],
+        ["2.0.0", 2],
+      ]),
+    ),
+    [2, 0, 0],
+  );
+  assert.equal(prevailingFloor(new Map()), null);
+});
+
+test("runCheck holds course pins to the prevailing floor, not an outlier", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "aui-unmanaged-pins-floor-"));
+  try {
+    writeJson(root, "package.json", {
+      name: "@fixture/root",
+      version: "1.0.0",
+    });
+    for (const [dir, range] of [
+      ["one", "^2.0.0"],
+      ["two", "^2.0.0"],
+      ["three", "^9.0.0"],
+    ]) {
+      writeJson(root, `packages/${dir}/package.json`, {
+        name: `@fixture/${dir}`,
+        version: "1.0.0",
+        dependencies: { "fixture-dep": range },
+      });
+    }
+    writeJson(
+      root,
+      "apps/docs/lib/xulux/learn/courses/fixture/shared/project/package.json",
+      { name: "@fixture/course", dependencies: { "fixture-dep": "2.0.0" } },
+    );
+    writeFileSync(
+      path.join(root, "pnpm-workspace.yaml"),
+      "packages:\n  - packages/*\n",
+    );
+    writeFileSync(
+      path.join(root, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\n",
+    );
+    mkdirSync(path.join(root, ".github", "workflows"), { recursive: true });
+
+    assert.deepEqual(runCheck(root).coursePins, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runCheck reads workflow, lockfile, workspace, and course fixtures", () => {
+  const root = createWorkspace();
+  try {
+    assert.deepEqual(runCheck(root), {
+      workflowCount: 1,
+      courseCount: 1,
+      unmarked: [],
+      nodePins: [],
+      allowBuilds: [],
+      coursePins: [],
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function runExecutable(root) {
+  return spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "check-unmanaged-pins.mjs")],
+    {
+      encoding: "utf8",
+      env: { ...process.env, UNMANAGED_PIN_CHECK_ROOT: root },
+    },
+  );
+}
+
+test("the executable reports success and exits 0", () => {
+  const root = createWorkspace();
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      result.stdout,
+      /Pins outside the update pipeline are current\. \(1 workflow, 1 course project scanned\)/,
+      "the guard produced no verdict, so main() never ran",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the executable reports every seeded problem and exits 1", () => {
+  const root = createWorkspace({ problems: true });
+  try {
+    const result = runExecutable(root);
+    assert.equal(result.status, 1);
+    assert.match(
+      result.stderr,
+      /actions\/setup-node@fixture \(marker absent\)/,
+    );
+    assert.match(result.stderr, /node@20, not node@22/);
+    assert.match(result.stderr, /esbuild@0\.1\.0 is not installed/);
+    assert.match(
+      result.stderr,
+      /"fixture-dep" is 1\.0\.0, workspace is on 2\.0\.0/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-unmanaged-pins.test.mjs
+++ b/scripts/check-unmanaged-pins.test.mjs
@@ -203,6 +203,28 @@ test("findInconsistentNodePins reports pins outside the most common major", () =
     ]),
     [],
   );
+  assert.deepEqual(
+    findInconsistentNodePins([
+      {
+        file: ".github/workflows/dotted.yaml",
+        source: [
+          "runtime: node@22",
+          "node-version: 20.x",
+          "node-version: lts/*",
+          "node-version-file: .nvmrc",
+          "node-version: ${{ matrix.node }}",
+        ].join("\n"),
+      },
+    ]),
+    [
+      {
+        file: ".github/workflows/dotted.yaml",
+        line: 2,
+        major: 20,
+        dominant: 22,
+      },
+    ],
+  );
 });
 
 test("findDriftedAllowBuilds handles scoped version entries", () => {

--- a/scripts/check-unmanaged-pins.test.mjs
+++ b/scripts/check-unmanaged-pins.test.mjs
@@ -160,6 +160,7 @@ test("findUnmarkedActionRefs rejects tag refs and unusable markers", () => {
         `  - uses: actions/labeler@${sha} # ratchet:actions/labeler@`,
         "  - uses: actions/stale@v9 # ratchet:actions/stale@v9.0.0",
         `  - uses: actions/upload-artifact@${sha} # ratchet:exclude`,
+        "  - uses: docker://node:24 # ratchet:exclude",
         "  - uses: ./local-action",
       ].join("\n"),
     },

--- a/scripts/check-unmanaged-pins.test.mjs
+++ b/scripts/check-unmanaged-pins.test.mjs
@@ -154,6 +154,7 @@ test("findUnmarkedActionRefs distinguishes missing and mismatched markers", () =
         "  - uses: actions/checkout@fixture # ratchet:actions/checkout@v4",
         "  - uses: actions/setup-node@fixture",
         "  - uses: actions/cache@fixture # ratchet:actions/checkout@v4",
+        "  - uses: actions/setup-python@fixture # ratchet:actions/setup-python",
         "  - uses: actions/upload-artifact@fixture # ratchet:exclude",
         "  - uses: ./local-action",
       ].join("\n"),
@@ -172,6 +173,12 @@ test("findUnmarkedActionRefs distinguishes missing and mismatched markers", () =
       line: 4,
       uses: "actions/cache@fixture",
       reason: "names actions/checkout",
+    },
+    {
+      file: ".github/workflows/check.yaml",
+      line: 5,
+      uses: "actions/setup-python@fixture",
+      reason: "has no version",
     },
   ]);
 });


### PR DESCRIPTION
## Problem

Four classes of pin in this repository have no owner. Nothing parses them, so each drifts silently until an install or an update run breaks, which is the section of #6557 titled "the pipeline cannot see these".

- **SHA pins and ratchet markers.** Every action is pinned to a commit SHA, and `ratchet update` reads the trailing `# ratchet:<owner>/<repo>@<version>` comment to learn which action that SHA came from. #6305 was the proof that an entry without a marker keeps working and stops being updated; #6314 restored the markers across all 13 workflows then present. Nothing keeps them there, nothing catches a marker that survives but names a different action or loses its version, and nothing catches a ref hand-edited back to a tag.
- **Node.js pins.** After the `pnpm/setup` migration in #6531 the Node.js major lives in one `node-version:` and 17 `runtime: node@24` inputs. A partial bump splits CI across two majors without failing anything.
- **`allowBuilds`.** `pnpm-workspace.yaml` allows builds for `esbuild@0.27.0`, `esbuild@0.28.2` and `sqlite3@5.1.7`. A version-scoped entry stops applying the moment the package resolves elsewhere, and `strictDepBuilds: true` turns the lost allowance into a failed install rather than a warning.
- **Learn course projects.** `apps/docs/lib/xulux/learn/courses/*/shared/project/package.json` is the skeleton Learn Mode hands a learner. It carries exact pins and is not a workspace member, so taze skips it. #6306 refreshed it once by hand; it has drifted again (`ai` at `7.0.79` against `7.0.83`, `next` at `16.3.2` against `16.3.3`, `@ai-sdk/openai` at `4.0.47` against `4.0.50`, `@types/node` at `26.3.0` against `26.4.0`).

## Change

One check over all four, `scripts/check-unmanaged-pins.mjs`, built on the same shape as `scripts/check-workspace-ranges.mjs`: pure exported predicates, a `runCheck(root)` that gathers the inputs, and a `main()` that prints why each class matters. It reads only workflow files, `pnpm-workspace.yaml`, `pnpm-lock.yaml` and the workspace manifests, so it needs no install.

Two decisions worth naming.

Course pins are held to the version the workspace *prevailingly* declares, not the highest. Under a highest-wins rule a single example that jumps ahead of everything else would turn a course fixture red for a contributor who never touched it. The prevailing floor still catches all four drifts above.

Pins on packages this repository publishes are exempt from the course check. They move on every release and the course projects do not participate in releases, so policing them would fail every `changeset version` PR; the exemption is stated in the failure message. Their pins are left where they are for the same reason: raising them here would be stale again at the next release with nothing to maintain it.

It gets its own workflow rather than a job in `code-quality.yaml` because its triggers (every workflow file, every manifest, the lockfile) are disjoint from that workflow's; folding it in would mean adding `.github/workflows/**` there and running lint, build and test on every workflow edit.

The four Learn course pins are raised in the same change, since the check fails on them otherwise.

## Verification

- `node scripts/check-unmanaged-pins.mjs` on this branch: exits 0 over 15 workflows and 1 course project.
- Seeded each failure class into a scratch copy and confirmed the check reports it precisely: a dropped marker, a marker naming a different action, a `runtime: node@22` among `node@24`, `esbuild@0.29.0` allowed while `0.28.2` is installed (both directions of the `allowBuilds` comparison), and the course fixture reverted to its drifted pins.
- `node --test scripts/check-unmanaged-pins.test.mjs`: 13 tests pass, covering each predicate plus two end-to-end runs of the executable (clean repository exits 0; a repository seeded with one of each problem exits 1 with each named in stderr).
- The suite is not vacuous: mutating the module to accept a missing marker, and again to make the course floor highest-wins instead of prevailing, each turns two tests red.
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both new files are clean. `pnpm changesets:check` passes.

## Public surface

None. No published package changes, so no changeset. Adds two root scripts (`unmanaged-pins:check`, `unmanaged-pins:test`) and one workflow.

Docs are brought into lockstep in the same change: the `update-deps` skill still described workflow pins as "a mix of styles" with a `# v6` comment, which the marker check now rejects, so it documents the actual `# ratchet:<owner>/<repo>@<version>` contract, `# ratchet:exclude`, and the Node.js consistency rule. `AGENTS.md` names `unmanaged-pins` alongside the other repo-specific checks that must not be `--admin`ed past.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uQelm6qmt0lQLkvTdPMdrjyc_TTyv_4tm6xasMHXWVtbYDPIywEguhGrDHM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


