### PR TITLE
docs: name ThreadPrimitive.Suggestion by what it does, not legacy

### DIFF
--- a/apps/docs/content/docs/primitives/suggestion.mdx
+++ b/apps/docs/content/docs/primitives/suggestion.mdx
@@ -139,21 +139,26 @@ When no static configuration is provided, the `suggestions` scope derives from `
 
 See [Suggested Prompts](/docs/guides/suggestions) for end to end examples.
 
-### ThreadPrimitive.Suggestion (Legacy)
+### ThreadPrimitive.Suggestion
 
-`ThreadPrimitive.Suggestion` is a self-contained button that takes a `prompt` prop directly. The newer pattern (`ThreadPrimitive.Suggestions` + `SuggestionPrimitive` parts) is preferred for structured suggestions with title and description:
+`ThreadPrimitive.Suggestion` is a self-contained button that takes its `prompt` as a prop instead of reading the `suggestions` scope. Both paths run the same trigger behavior, including the queueing and disabled handling described above, so the choice is about where the prompt comes from:
+
+- Rendering the `suggestions` scope: use `ThreadPrimitive.Suggestions` with the `SuggestionPrimitive` parts, which supply the title and description for you.
+- Rendering prompts from anywhere else: use `ThreadPrimitive.Suggestion` and pass the prompt directly.
 
 ```tsx
-// Legacy: still works, but limited
-<ThreadPrimitive.Suggestion prompt="Write a blog post" />
-
-// Preferred: structured with title/description
+// Prompts from the suggestions scope
 <ThreadPrimitive.Suggestions>
   {() => <MySuggestionItem />}
 </ThreadPrimitive.Suggestions>
+
+// A prompt the caller already holds
+<ThreadPrimitive.Suggestion prompt="Write a blog post" />
 ```
 
-`ThreadPrimitive.Suggestion` also supports deprecated `autoSend` and `method` props for backwards compatibility. Prefer `send` and `clearComposer`.
+The second case is not a fallback. A component that renders `thread.suggestions` cannot read them through the `suggestions` scope once the app also configures static suggestions, because that configuration takes precedence over the derived values. The shadcn `ThreadFollowupSuggestions` component reads `thread.suggestions` and renders each entry with `ThreadPrimitive.Suggestion` for that reason.
+
+The `autoSend` and `method` props are deprecated; prefer `send` and `clearComposer`.
 
 ## Parts
 


### PR DESCRIPTION
refs #6667

## Problem

`primitives/suggestion.mdx` headed `ThreadPrimitive.Suggestion` with "(Legacy)" and called `ThreadPrimitive.Suggestions` plus the `SuggestionPrimitive` parts the preferred pattern "for structured suggestions with title and description". thirty lines above, the same page tells anyone rendering runtime suggestions to use the shadcn `ThreadFollowupSuggestions` component, which renders each chip with the primitive the page just labelled legacy.

it is not legacy, and #6667 was filed to port `follow-up-suggestions.aui.tsx` off it on the strength of that label. the port would be a regression. `ThreadPrimitive.Suggestions` reads the `suggestions` scope, and all three runtime clients (`runtime-adapter.ts:28`, `InMemoryThreadList.ts:287`, `external-thread.ts:1204`) only derive that scope from `thread.suggestions` when the host supplied no `Suggestions(...)` of its own. 27 files under examples, templates, and apps do supply one, so in nearly every app we ship the follow-up row would render the welcome prompts. it would also disagree with its own gate, which reads `s.thread.suggestions.length > 0`: the row would appear when the runtime produced follow-ups and show the static list instead.

## Change

name the primitive by what it does. it takes its `prompt` as a prop instead of reading the `suggestions` scope, and the choice between the two is about where the prompt comes from, not about which one is newer. both go through the same `useSuggestionTrigger`, so the queueing and disabled behavior is identical either way.

the section now states the precedence consequence directly: a component rendering `thread.suggestions` cannot reach them through the scope once static suggestions are configured, which is why `ThreadFollowupSuggestions` passes prompts in. only `autoSend` and `method` stay described as deprecated, which is what actually is.

the heading loses its "(Legacy)" suffix, so its anchor changes from `#threadprimitivesuggestion-legacy` to `#threadprimitivesuggestion`. nothing in the repo links to either.

`guides/suggestions.mdx` needs no change: its "Switching from `ThreadPrimitive.Suggestion`" section is about moving hardcoded prompts to centralized config, a different question, and it already says the inline form is supported.

## Verification

- `pnpm -C apps/docs test` -> 58 files, 473/473 green.
- `grep -rn "threadprimitivesuggestion-legacy"` across `apps` and `packages` -> no hits, so no link breaks on the anchor change.
- oxfmt ignores `**/*.mdx`, so no formatting pass applies to this file.

## Public surface

docs only, no code change. `@assistant-ui/docs` is private, so no changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rNolgoRe1pYRoOcHoeToB3EExTuw7kQL5ihy-ejlzz7lYJPdDm7z_gFeG0o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->