### PR TITLE
fix(docs): meter the hosted MCP endpoint's sandbox-calling tools

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -40,6 +40,11 @@ AUI_PUBLIC_ASSISTANT_REQUESTS_PER_SESSION_PER_DAY=500
 AUI_PUBLIC_ASSISTANT_REQUESTS_PER_IP_PER_DAY=2000
 AUI_PUBLIC_ASSISTANT_GLOBAL_REQUESTS_PER_DAY=20000
 AUI_ANONYMOUS_SESSIONS_PER_IP_PER_DAY=1000
+# The hosted MCP endpoint has no browser session to key on, so its two
+# sandbox-calling template tools are limited by IP alone. The docs tools are
+# in-process and stay unlimited.
+AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY=500
+AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY=5000
 
 # Xulux coding agent — Blaxel cloud sandbox (app/api/xulux).
 # Required to provision sandboxes for scaffolding.

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -3,6 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   fetchPreviewSession: vi.fn(),
   fetchTemplateContract: vi.fn(),
+  checkTemplateRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", async (importOriginal) => ({
+  ...(await importOriginal()),
+  checkMcpTemplateToolRateLimit: mocks.checkTemplateRateLimit,
 }));
 
 vi.mock("@/lib/xulux/sandbox-contract", async (importOriginal) => ({
@@ -297,6 +303,60 @@ describe("POST /api/mcp", () => {
       response.result as { messages: Array<{ content: { text: string } }> }
     ).messages;
     expect(messages[0]!.content.text).toContain("list_templates");
+  });
+
+  it("meters the two tools that call out to a sandbox", async () => {
+    mocks.fetchTemplateContract.mockResolvedValue(null);
+
+    await requestMcp("tools/call", {
+      name: "read_template",
+      arguments: { templateId: "base-assistant-ui" },
+    });
+    await requestMcp("tools/call", {
+      name: "preview_template",
+      arguments: { templateId: "base-assistant-ui" },
+    });
+
+    expect(mocks.checkTemplateRateLimit).toHaveBeenCalledTimes(2);
+    expect(mocks.checkTemplateRateLimit.mock.calls[0]?.[0]).toMatchObject({
+      url: `${ORIGIN}/api/mcp`,
+    });
+  });
+
+  it("leaves the in-process docs tools unmetered", async () => {
+    await requestMcp("tools/call", { name: "list_templates", arguments: {} });
+    await requestMcp("tools/call", {
+      name: "search_docs",
+      arguments: { query: "runtime" },
+    });
+    await requestMcp("tools/call", { name: "get_navigation", arguments: {} });
+
+    expect(mocks.checkTemplateRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a throttled template tool without reaching the sandbox", async () => {
+    mocks.checkTemplateRateLimit.mockResolvedValueOnce(
+      new Response("Template tool rate limit exceeded", {
+        status: 429,
+        headers: { "Retry-After": "30" },
+      }),
+    );
+
+    const response = await requestMcp("tools/call", {
+      name: "preview_template",
+      arguments: {
+        templateId: "base-assistant-ui",
+        config: { brandTheme: { preset: "assistantDark" } },
+      },
+    });
+    const result = getToolCallResult(response);
+    const text = result.content.find((block) => block.type === "text")?.text;
+
+    expect(result.isError).toBe(true);
+    expect(text).toBe(
+      "Template tool rate limit exceeded. Retry in 30s. The assistant-ui docs tools remain available.",
+    );
+    expect(mocks.fetchPreviewSession).not.toHaveBeenCalled();
   });
 
   it("rejects unsupported preview config roots before the sandbox", async () => {

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -359,6 +359,25 @@ describe("POST /api/mcp", () => {
     expect(mocks.fetchPreviewSession).not.toHaveBeenCalled();
   });
 
+  it("does not tell an MCP client the public assistant is down", async () => {
+    mocks.checkTemplateRateLimit.mockResolvedValueOnce(
+      new Response("Public assistant temporarily unavailable", { status: 503 }),
+    );
+
+    const response = await requestMcp("tools/call", {
+      name: "read_template",
+      arguments: { templateId: "base-assistant-ui" },
+    });
+    const result = getToolCallResult(response);
+    const text = result.content.find((block) => block.type === "text")?.text;
+
+    expect(result.isError).toBe(true);
+    expect(text).toBe(
+      "Template tools are temporarily unavailable. The assistant-ui docs tools remain available.",
+    );
+    expect(mocks.fetchTemplateContract).not.toHaveBeenCalled();
+  });
+
   it("rejects unsupported preview config roots before the sandbox", async () => {
     const response = await requestMcp("tools/call", {
       name: "preview_template",

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { getLLMText } from "@/lib/get-llm-text";
+import { checkMcpTemplateToolRateLimit } from "@/lib/rate-limit";
 import {
   SEARCH_DOCS_RESULT_LIMIT,
   docsToolDefinitions,
@@ -33,6 +34,7 @@ import {
 import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
 
 export const revalidate = false;
+export const maxDuration = 60;
 
 const templateToolDefinitions = [
   {
@@ -443,11 +445,24 @@ function registerResources(server: McpServer, requestUrl: string) {
   );
 }
 
-function buildMcpServer(requestUrl: string) {
+async function requireTemplateToolBudget(request: NextRequest) {
+  const denial = await checkMcpTemplateToolRateLimit(request);
+  if (!denial) return;
+
+  const retryAfter = denial.headers.get("Retry-After");
+  throw new Error(
+    `${await denial.text()}.` +
+      (retryAfter ? ` Retry in ${retryAfter}s.` : "") +
+      " The assistant-ui docs tools remain available.",
+  );
+}
+
+function buildMcpServer(request: NextRequest) {
   const server = new McpServer({
     name: "assistant-ui-docs",
     version: "1.0.0",
   });
+  const requestUrl = request.url;
   const requestOrigin = new URL(requestUrl).origin;
 
   server.registerTool(
@@ -502,9 +517,10 @@ function buildMcpServer(requestUrl: string) {
       inputSchema: readTemplateInputSchema,
     },
     (input) =>
-      toolResult(() =>
-        getTemplateDetails(buildXuluxMcpCatalog(requestOrigin), input),
-      ),
+      toolResult(async () => {
+        await requireTemplateToolBudget(request);
+        return getTemplateDetails(buildXuluxMcpCatalog(requestOrigin), input);
+      }),
   );
 
   server.registerTool(
@@ -514,9 +530,13 @@ function buildMcpServer(requestUrl: string) {
       inputSchema: previewTemplateInputSchema,
     },
     (input) =>
-      toolResult(() =>
-        createTemplatePreview(buildXuluxMcpCatalog(requestOrigin), input),
-      ),
+      toolResult(async () => {
+        await requireTemplateToolBudget(request);
+        return createTemplatePreview(
+          buildXuluxMcpCatalog(requestOrigin),
+          input,
+        );
+      }),
   );
 
   server.registerPrompt(
@@ -560,7 +580,7 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const server = buildMcpServer(request.url);
+  const server = buildMcpServer(request);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -34,7 +34,6 @@ import {
 import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
 
 export const revalidate = false;
-export const maxDuration = 60;
 
 const templateToolDefinitions = [
   {
@@ -448,6 +447,12 @@ function registerResources(server: McpServer, requestUrl: string) {
 async function requireTemplateToolBudget(request: NextRequest) {
   const denial = await checkMcpTemplateToolRateLimit(request);
   if (!denial) return;
+
+  if (denial.status !== 429) {
+    throw new Error(
+      "Template tools are temporarily unavailable. The assistant-ui docs tools remain available.",
+    );
+  }
 
   const retryAfter = denial.headers.get("Retry-After");
   throw new Error(

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -7,6 +7,7 @@ import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 export const runtime = "nodejs";
 
 const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB ceiling
+const ARCHIVE_TIMEOUT_MS = 60_000;
 
 async function readLimitedBody(
   body: ReadableStream<Uint8Array>,
@@ -75,6 +76,7 @@ export async function GET(req: Request) {
   try {
     const upstream = await fetchSandboxResource(upstreamUrl, {
       redirect: "manual",
+      timeoutMs: ARCHIVE_TIMEOUT_MS,
     });
 
     if (upstream.status >= 300 && upstream.status < 400) {

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -7,7 +7,9 @@ import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 export const runtime = "nodejs";
 
 const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB ceiling
-const ARCHIVE_TIMEOUT_MS = 60_000;
+// Covers the full body read, so it stops a stalled connection rather than
+// capping throughput; a 50 MB archive must not be truncated mid-download.
+const ARCHIVE_TIMEOUT_MS = 300_000;
 
 async function readLimitedBody(
   body: ReadableStream<Uint8Array>,

--- a/apps/docs/lib/rate-limit.test.ts
+++ b/apps/docs/lib/rate-limit.test.ts
@@ -46,6 +46,7 @@ vi.mock("@upstash/ratelimit", async (importOriginal) => ({
 
 import {
   checkAnonymousSessionIssuanceRateLimit,
+  checkMcpTemplateToolRateLimit,
   checkPublicAssistantRateLimit,
 } from "./rate-limit";
 
@@ -255,5 +256,98 @@ describe("public assistant rate limits", () => {
         key: "203.0.113.10",
       },
     ]);
+  });
+});
+
+describe("MCP template tool rate limits", () => {
+  const request = () =>
+    new Request("https://www.assistant-ui.com/api/mcp", {
+      method: "POST",
+      headers: { "x-vercel-forwarded-for": "203.0.113.10" },
+    });
+
+  it("leaves room for an IDE agent workflow under a daily ceiling", async () => {
+    await checkMcpTemplateToolRateLimit(request());
+
+    expect(mocks.configs.get("aui:mcp-template:ip:burst")).toEqual({
+      limit: 15,
+      window: "60s",
+    });
+    expect(mocks.configs.get("aui:mcp-template:ip:daily")).toEqual({
+      limit: 500,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:mcp-template:global:daily")).toEqual({
+      limit: 5_000,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:mcp-template:global:alert")).toEqual({
+      limit: 1,
+      window: "10m",
+    });
+  });
+
+  it("keys every bucket by IP because MCP clients carry no session", async () => {
+    await expect(checkMcpTemplateToolRateLimit(request())).resolves.toBeNull();
+
+    expect(mocks.calls).toEqual([
+      { prefix: "aui:mcp-template:ip:burst", key: "203.0.113.10" },
+      { prefix: "aui:mcp-template:ip:daily", key: "203.0.113.10" },
+      { prefix: "aui:mcp-template:global:daily", key: "all" },
+    ]);
+  });
+
+  it.each([
+    ["aui:mcp-template:ip:burst", 1],
+    ["aui:mcp-template:ip:daily", 2],
+    ["aui:mcp-template:global:daily", 4],
+  ] as const)(
+    "stops after an exhausted %s limit",
+    async (prefix, expectedCalls) => {
+      mocks.results.set(prefix, false);
+
+      const response = await checkMcpTemplateToolRateLimit(request());
+
+      expect(response?.status).toBe(429);
+      expect(response?.headers.get("retry-after")).toBe("30");
+      expect(mocks.calls).toHaveLength(expectedCalls);
+    },
+  );
+
+  it("rate limits the global ceiling alert", async () => {
+    mocks.results.set("aui:mcp-template:global:daily", false);
+    mocks.results.set("aui:mcp-template:global:alert", false);
+
+    const response = await checkMcpTemplateToolRateLimit(request());
+
+    expect(response?.status).toBe(429);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once when the global ceiling is reached", async () => {
+    mocks.results.set("aui:mcp-template:global:daily", false);
+
+    await checkMcpTemplateToolRateLimit(request());
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_template_global_limit_exceeded"),
+    );
+  });
+
+  it("fails closed when no client IP is available", async () => {
+    const response = await checkMcpTemplateToolRateLimit(
+      new Request("https://www.assistant-ui.com/api/mcp", { method: "POST" }),
+    );
+
+    expect(response?.status).toBe(503);
+    expect(mocks.calls).toHaveLength(0);
+  });
+
+  it("fails closed when the rate-limit store is unavailable", async () => {
+    mocks.errors.set("aui:mcp-template:ip:burst", new Error("Redis down"));
+
+    const response = await checkMcpTemplateToolRateLimit(request());
+
+    expect(response?.status).toBe(503);
   });
 });

--- a/apps/docs/lib/rate-limit.test.ts
+++ b/apps/docs/lib/rate-limit.test.ts
@@ -341,6 +341,9 @@ describe("MCP template tool rate limits", () => {
 
     expect(response?.status).toBe(503);
     expect(mocks.calls).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_template_client_ip_missing"),
+    );
   });
 
   it("fails closed when the rate-limit store is unavailable", async () => {
@@ -349,5 +352,8 @@ describe("MCP template tool rate limits", () => {
     const response = await checkMcpTemplateToolRateLimit(request());
 
     expect(response?.status).toBe(503);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_template_rate_limit_unavailable"),
+    );
   });
 });

--- a/apps/docs/lib/rate-limit.test.ts
+++ b/apps/docs/lib/rate-limit.test.ts
@@ -287,7 +287,7 @@ describe("MCP template tool rate limits", () => {
     });
   });
 
-  it("keys every bucket by IP because MCP clients carry no session", async () => {
+  it("keys the per-client buckets by IP, the ceiling globally", async () => {
     await expect(checkMcpTemplateToolRateLimit(request())).resolves.toBeNull();
 
     expect(mocks.calls).toEqual([

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -87,6 +87,38 @@ const getPublicAssistantRateLimits = async () => {
         "1d",
       ),
     }),
+    mcpTemplateIpBurst: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-template:ip:burst",
+      limiter: Ratelimit.fixedWindow(15, "60s"),
+    }),
+    mcpTemplateIpDaily: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-template:ip:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY,
+          500,
+        ),
+        "1d",
+      ),
+    }),
+    mcpTemplateGlobalDaily: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-template:global:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY,
+          5_000,
+        ),
+        "1d",
+      ),
+    }),
+    mcpTemplateGlobalAlert: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-template:global:alert",
+      limiter: Ratelimit.fixedWindow(1, "10m"),
+    }),
   };
 };
 
@@ -218,6 +250,46 @@ export async function checkAnonymousSessionIssuanceRateLimit(
     const daily = await limits.sessionIssuanceDaily.limit(ip);
     if (!daily.success) {
       return limitResponse("Anonymous session limit exceeded", daily.reset);
+    }
+    return null;
+  });
+}
+
+export async function checkMcpTemplateToolRateLimit(
+  request: Request,
+): Promise<Response | null> {
+  return runPublicAssistantRateLimit(request, async (limits) => {
+    const ip = getClientIp(request);
+    if (!ip) return missingClientIpResponse(request);
+
+    const burst = await limits.mcpTemplateIpBurst.limit(ip);
+    if (!burst.success) {
+      return limitResponse("Template tool rate limit exceeded", burst.reset);
+    }
+
+    const daily = await limits.mcpTemplateIpDaily.limit(ip);
+    if (!daily.success) {
+      return limitResponse("Template tool daily limit exceeded", daily.reset);
+    }
+
+    const globalDaily = await limits.mcpTemplateGlobalDaily.limit("all");
+    if (!globalDaily.success) {
+      const alert = await limits.mcpTemplateGlobalAlert
+        .limit("all")
+        .catch(() => null);
+      if (alert?.success) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            message: "mcp_template_global_limit_exceeded",
+            requestId: request.headers.get("x-vercel-id"),
+          }),
+        );
+      }
+      return limitResponse(
+        "Template tool usage limit exceeded",
+        globalDaily.reset,
+      );
     }
     return null;
   });

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -145,8 +145,9 @@ function getClientIp(request: Request): string | null {
   return null;
 }
 
-async function runPublicAssistantRateLimit(
+async function runRateLimitChecks(
   request: Request,
+  surface: string,
   check: (limits: PublicAssistantRateLimits) => Promise<Response | null>,
 ): Promise<Response | null> {
   try {
@@ -157,7 +158,7 @@ async function runPublicAssistantRateLimit(
     console.error(
       JSON.stringify({
         level: "error",
-        message: "public_assistant_rate_limit_unavailable",
+        message: `${surface}_rate_limit_unavailable`,
         requestId: request.headers.get("x-vercel-id"),
         error: error instanceof Error ? error.message : String(error),
       }),
@@ -168,11 +169,11 @@ async function runPublicAssistantRateLimit(
   }
 }
 
-function missingClientIpResponse(request: Request): Response {
+function missingClientIpResponse(request: Request, surface: string): Response {
   console.error(
     JSON.stringify({
       level: "error",
-      message: "public_assistant_client_ip_missing",
+      message: `${surface}_client_ip_missing`,
       requestId: request.headers.get("x-vercel-id"),
     }),
   );
@@ -193,9 +194,9 @@ export async function checkPublicAssistantRateLimit(
   request: Request,
   sessionId: string,
 ): Promise<Response | null> {
-  return runPublicAssistantRateLimit(request, async (limits) => {
+  return runRateLimitChecks(request, "public_assistant", async (limits) => {
     const ip = getClientIp(request);
-    if (!ip) return missingClientIpResponse(request);
+    if (!ip) return missingClientIpResponse(request, "public_assistant");
 
     const ipBurst = await limits.ipBurst.limit(ip);
     if (!ipBurst.success) {
@@ -239,9 +240,9 @@ export async function checkPublicAssistantRateLimit(
 export async function checkAnonymousSessionIssuanceRateLimit(
   request: Request,
 ): Promise<Response | null> {
-  return runPublicAssistantRateLimit(request, async (limits) => {
+  return runRateLimitChecks(request, "public_assistant", async (limits) => {
     const ip = getClientIp(request);
-    if (!ip) return missingClientIpResponse(request);
+    if (!ip) return missingClientIpResponse(request, "public_assistant");
 
     const burst = await limits.sessionIssuanceBurst.limit(ip);
     if (!burst.success) {
@@ -258,9 +259,9 @@ export async function checkAnonymousSessionIssuanceRateLimit(
 export async function checkMcpTemplateToolRateLimit(
   request: Request,
 ): Promise<Response | null> {
-  return runPublicAssistantRateLimit(request, async (limits) => {
+  return runRateLimitChecks(request, "mcp_template", async (limits) => {
     const ip = getClientIp(request);
-    if (!ip) return missingClientIpResponse(request);
+    if (!ip) return missingClientIpResponse(request, "mcp_template");
 
     const burst = await limits.mcpTemplateIpBurst.limit(ip);
     if (!burst.success) {

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   fetch: vi.fn<typeof fetch>(),
 }));
 
+const RETRY_DELAY_MS = 300;
+
 describe("fetchSandboxResource", () => {
   beforeEach(() => {
     mocks.fetch.mockReset();
@@ -142,19 +144,22 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("does not start an attempt when the deadline expires mid-backoff", async () => {
+  it("rejects at the budget rather than waiting out the backoff", async () => {
     mocks.fetch.mockRejectedValue(
       Object.assign(new Error("request failed"), {
         cause: { code: "ECONNRESET" },
       }),
     );
 
+    const startedAt = Date.now();
     await expect(
       fetchSandboxResource("https://sandbox.example.com/preview", {
-        timeoutMs: 150,
+        timeoutMs: 50,
       }),
     ).rejects.toThrow("request failed");
+
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
+    expect(Date.now() - startedAt).toBeLessThan(RETRY_DELAY_MS);
   });
 
   it("stops retrying once the caller has cancelled", async () => {

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -14,6 +14,7 @@ describe("fetchSandboxResource", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("adds sandbox headers and disables caching", async () => {
@@ -86,6 +87,51 @@ describe("fetchSandboxResource", () => {
 
     await expect(
       fetchSandboxResource("https://sandbox.example.com/preview"),
+    ).rejects.toBe(error);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds every attempt with an abort timeout", async () => {
+    vi.useFakeTimers();
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    mocks.fetch
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(new Response("ok"));
+
+    const pending = fetchSandboxResource("https://sandbox.example.com/preview");
+    await vi.advanceTimersByTimeAsync(300);
+    await pending;
+
+    expect(timeout.mock.calls).toEqual([[10_000], [10_000]]);
+    expect(mocks.fetch.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(mocks.fetch.mock.calls[1]?.[1]?.signal).not.toBe(
+      mocks.fetch.mock.calls[0]?.[1]?.signal,
+    );
+  });
+
+  it("honors a caller timeout without forwarding it to fetch", async () => {
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    mocks.fetch.mockResolvedValueOnce(new Response("ok"));
+
+    await fetchSandboxResource("https://sandbox.example.com/archive", {
+      timeoutMs: 60_000,
+    });
+
+    expect(timeout).toHaveBeenCalledWith(60_000);
+    expect(mocks.fetch.mock.calls[0]?.[1]).not.toHaveProperty("timeoutMs");
+  });
+
+  it("does not retry an attempt that hit the timeout", async () => {
+    const error = new DOMException(
+      "The operation was aborted due to timeout",
+      "TimeoutError",
+    );
+    mocks.fetch.mockRejectedValue(error);
+
+    await expect(
+      fetchSandboxResource("https://sandbox.example.com/session", {
+        method: "POST",
+      }),
     ).rejects.toBe(error);
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -157,6 +157,23 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("stops retrying once the caller has cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    mocks.fetch.mockRejectedValue(
+      Object.assign(new Error("request failed"), {
+        cause: { code: "ECONNRESET" },
+      }),
+    );
+
+    await expect(
+      fetchSandboxResource("https://sandbox.example.com/preview", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("request failed");
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts when the caller's own signal fires", async () => {
     const controller = new AbortController();
     mocks.fetch.mockImplementation(async (_url, init) => {

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -142,6 +142,21 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("does not start an attempt when the deadline expires mid-backoff", async () => {
+    mocks.fetch.mockRejectedValue(
+      Object.assign(new Error("request failed"), {
+        cause: { code: "ECONNRESET" },
+      }),
+    );
+
+    await expect(
+      fetchSandboxResource("https://sandbox.example.com/preview", {
+        timeoutMs: 150,
+      }),
+    ).rejects.toThrow("request failed");
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts when the caller's own signal fires", async () => {
     const controller = new AbortController();
     mocks.fetch.mockImplementation(async (_url, init) => {

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -91,7 +91,7 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("bounds every attempt with an abort timeout", async () => {
+  it("shares one deadline across every attempt", async () => {
     vi.useFakeTimers();
     const timeout = vi.spyOn(AbortSignal, "timeout");
     mocks.fetch
@@ -102,14 +102,14 @@ describe("fetchSandboxResource", () => {
     await vi.advanceTimersByTimeAsync(300);
     await pending;
 
-    expect(timeout.mock.calls).toEqual([[10_000], [10_000]]);
+    expect(timeout.mock.calls).toEqual([[30_000]]);
     expect(mocks.fetch.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
-    expect(mocks.fetch.mock.calls[1]?.[1]?.signal).not.toBe(
+    expect(mocks.fetch.mock.calls[1]?.[1]?.signal).toBe(
       mocks.fetch.mock.calls[0]?.[1]?.signal,
     );
   });
 
-  it("honors a caller timeout without forwarding it to fetch", async () => {
+  it("honors a caller budget without forwarding it to fetch", async () => {
     const timeout = vi.spyOn(AbortSignal, "timeout");
     mocks.fetch.mockResolvedValueOnce(new Response("ok"));
 
@@ -121,18 +121,47 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch.mock.calls[0]?.[1]).not.toHaveProperty("timeoutMs");
   });
 
-  it("does not retry an attempt that hit the timeout", async () => {
-    const error = new DOMException(
-      "The operation was aborted due to timeout",
-      "TimeoutError",
-    );
-    mocks.fetch.mockRejectedValue(error);
+  it("stops retrying once the budget is spent, whatever the error", async () => {
+    mocks.fetch.mockImplementation(async (_url, init) => {
+      await new Promise((_resolve, reject) => {
+        // A retryable classification must not buy a second attempt once the
+        // deadline is gone.
+        init?.signal?.addEventListener("abort", () =>
+          reject(new Error("fetch failed")),
+        );
+      });
+      throw new Error("unreachable");
+    });
 
     await expect(
       fetchSandboxResource("https://sandbox.example.com/session", {
         method: "POST",
+        timeoutMs: 20,
       }),
-    ).rejects.toBe(error);
+    ).rejects.toThrow("fetch failed");
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts when the caller's own signal fires", async () => {
+    const controller = new AbortController();
+    mocks.fetch.mockImplementation(async (_url, init) => {
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new Error("caller aborted")),
+        );
+      });
+      throw new Error("unreachable");
+    });
+
+    const pending = fetchSandboxResource(
+      "https://sandbox.example.com/preview",
+      {
+        signal: controller.signal,
+      },
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("caller aborted");
     expect(mocks.fetch).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -6,11 +6,11 @@ const SANDBOX_FETCH_HEADERS = {
 
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface SandboxFetchInit extends RequestInit {
-  // Bounds one attempt including the response body, so a streamed archive
-  // needs a wider value than a JSON call.
+  // Budget for the whole call, retries and response body included, so a
+  // streamed archive needs a wider value than a JSON call.
   timeoutMs?: number;
 }
 
@@ -41,7 +41,8 @@ export async function fetchSandboxResource(
   url: string | URL,
   init?: SandboxFetchInit,
 ): Promise<Response> {
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...requestInit } = init ?? {};
+  const deadline = AbortSignal.timeout(timeoutMs);
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
@@ -50,11 +51,15 @@ export async function fetchSandboxResource(
         ...requestInit,
         cache: "no-store",
         headers: mergeHeaders(requestInit.headers),
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: signal ? AbortSignal.any([signal, deadline]) : deadline,
       });
     } catch (error) {
       lastError = error;
-      if (!isRetryableFetchError(error) || attempt === MAX_ATTEMPTS) {
+      if (
+        deadline.aborted ||
+        !isRetryableFetchError(error) ||
+        attempt === MAX_ATTEMPTS
+      ) {
         throw error;
       }
       await sleep(RETRY_DELAY_MS * attempt);

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -43,6 +43,7 @@ export async function fetchSandboxResource(
 ): Promise<Response> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...requestInit } = init ?? {};
   const deadline = AbortSignal.timeout(timeoutMs);
+  const abort = signal ? AbortSignal.any([signal, deadline]) : deadline;
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
@@ -51,19 +52,19 @@ export async function fetchSandboxResource(
         ...requestInit,
         cache: "no-store",
         headers: mergeHeaders(requestInit.headers),
-        signal: signal ? AbortSignal.any([signal, deadline]) : deadline,
+        signal: abort,
       });
     } catch (error) {
       lastError = error;
       if (
-        deadline.aborted ||
+        abort.aborted ||
         !isRetryableFetchError(error) ||
         attempt === MAX_ATTEMPTS
       ) {
         throw error;
       }
       await sleep(RETRY_DELAY_MS * attempt);
-      if (deadline.aborted) throw error;
+      if (abort.aborted) throw error;
     }
   }
 

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -26,8 +26,16 @@ function isRetryableFetchError(error: unknown) {
   );
 }
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal: AbortSignal) {
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", settle);
+      resolve();
+    };
+    const timer = setTimeout(settle, ms);
+    signal.addEventListener("abort", settle, { once: true });
+  });
 }
 
 function mergeHeaders(headers?: HeadersInit): Headers {
@@ -63,7 +71,7 @@ export async function fetchSandboxResource(
       ) {
         throw error;
       }
-      await sleep(RETRY_DELAY_MS * attempt);
+      await sleep(RETRY_DELAY_MS * attempt, abort);
       if (abort.aborted) throw error;
     }
   }

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -63,6 +63,7 @@ export async function fetchSandboxResource(
         throw error;
       }
       await sleep(RETRY_DELAY_MS * attempt);
+      if (deadline.aborted) throw error;
     }
   }
 

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -6,6 +6,13 @@ const SANDBOX_FETCH_HEADERS = {
 
 const MAX_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 300;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface SandboxFetchInit extends RequestInit {
+  // Bounds one attempt including the response body, so a streamed archive
+  // needs a wider value than a JSON call.
+  timeoutMs?: number;
+}
 
 function isRetryableFetchError(error: unknown) {
   if (!(error instanceof Error)) return false;
@@ -32,16 +39,18 @@ function mergeHeaders(headers?: HeadersInit): Headers {
 
 export async function fetchSandboxResource(
   url: string | URL,
-  init?: RequestInit,
+  init?: SandboxFetchInit,
 ): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...requestInit } = init ?? {};
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     try {
       return await fetch(url, {
-        ...init,
+        ...requestInit,
         cache: "no-store",
-        headers: mergeHeaders(init?.headers),
+        headers: mergeHeaders(requestInit.headers),
+        signal: AbortSignal.timeout(timeoutMs),
       });
     } catch (error) {
       lastError = error;


### PR DESCRIPTION
closes #6496

## Problem

`/api/mcp` is public and unauthenticated, and two of its seven tools make server-side calls into the template sandboxes: `read_template` fetches the template contract and `preview_template` creates a preview session. neither reaches a meter: `/api/chat`, `/api/doc/chat`, `/api/xulux/chat`, `/api/playground-chat` and `/api/anonymous-session` all go through `lib/rate-limit.ts`, and `/api/mcp` does not.

it is not the only such route, though this PR only closes it. `GET /api/xulux/download-proxy` is also public, unauthenticated and unmetered, and buffers up to 50 MB per request, which is a larger amplifier than `preview_template`. that gap predates this change and is reachable from the client bundle independently of MCP, so it is filed separately as #6693 rather than folded in here.

the issue framed this as the same exposure the xulux chat route already had. it is not. that route reaches the same `fetchPreviewSession` behind three gates the MCP route has none of:

| | `/api/xulux/chat` | `/api/mcp` before this change |
|---|---|---|
| signed anonymous session | `requirePublicAssistantSession`, 403 without one (#6137) | none |
| rate limit | `checkPublicAssistantRateLimit` | none |
| path to the sandbox | an LLM turn budgeted by `usage-budget.ts` | direct from a JSON-RPC POST |

#6492 then began advertising the `/mcp` URL to every IDE, which raises the volume against that gap.

reproduction, against a deployment with the playground enabled:

```sh
curl -s https://www.assistant-ui.com/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  --data '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"preview_template","arguments":{"templateId":"base-assistant-ui","config":{"brandTheme":{"preset":"assistantDark"}}}}}'
```

each repetition creates another preview session on the sandbox, with nothing bounding the rate.

## Root cause

two separate mechanisms, both in the egress path:

1. no identity and no meter on the route. `buildMcpServer` only received `request.url`, so no tool handler could see the client at all.
2. `fetchSandboxResource` retries up to three times and passes no `AbortSignal`. one anonymous POST therefore amplifies to as many as three outbound preview-session creations, and an unresponsive sandbox holds the invocation open for as long as it likes.

not a cause, but worth recording since it bounds the severity: the sandbox base URLs are hardcoded in `templates-catalog.ts` and never caller-controlled, so this is abuse of our own sandboxes and not a general SSRF.

## Change

**give the whole sandbox call one deadline.** `SandboxFetchInit` gains `timeoutMs`, and a single `AbortSignal.timeout` covers every attempt rather than restarting per attempt. the retry loop ends as soon as that deadline fires, so the worst case is the budget itself instead of three times the budget. that also makes the no-further-retry property enforced rather than emergent: a late `ECONNRESET`, which `isRetryableFetchError` accepts, no longer buys a second attempt once the budget is spent. a caller's own `signal` is merged in via `AbortSignal.any` instead of being overwritten.

the default is 30s. this seam is shared with `/api/xulux/chat`, where `fetchTemplateContract` swallows failures into `catch { return null }` and degrades to `exampleConfig: null` with nothing logged, so a tight cap here could silently regress a cold sandbox on a route this change is not about. 30s bounds the pathological case without touching anything that works today. `download-proxy` passes a much wider budget, since the deadline covers the response body: there it stops a stalled connection rather than capping throughput, and must not truncate a 50 MB archive that is still making progress.

**meter the two tools that leave the process.** `checkMcpTemplateToolRateLimit` follows the existing shape in `lib/rate-limit.ts`, reusing the same Redis client, `getClientIp`, `limitResponse` and fail-closed path, and adds four buckets:

| prefix | limit | env |
|---|---|---|
| `aui:mcp-template:ip:burst` | 15 per 60s | |
| `aui:mcp-template:ip:daily` | 500 | `AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY` |
| `aui:mcp-template:global:daily` | 5000 | `AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY` |
| `aui:mcp-template:global:alert` | 1 per 10m | |

two deliberate departures from the public assistant precedent:

- **IP is the only key.** an MCP client cannot perform the `GET /api/anonymous-session` cookie handshake that `requirePublicAssistantSession` depends on, so there is no session identity to key on. this is forced by the protocol rather than chosen.
- **the meter sits at the tool, not at the route.** the two tools share one budget, deliberately: the resource being protected is the sandbox, so alternating between them must not buy twice the egress. the transport is stateless (`sessionIdGenerator: undefined`), so every JSON-RPC message is its own POST. reusing the existing 5 per 30s window on the route would trip during `initialize` plus `tools/list` in a normal IDE session, before any tool ran, and the docs tools are exactly what #6492 advertises. all five docs tools are in-process and stay unlimited; only `read_template` and `preview_template` draw on it. 15 per 60s leaves room for several concurrent workflows behind one NAT while stopping a scripted loop.

the meter sits at the tool entry, so it also charges the in-process resolutions those two tools can take (`preview_template` without config, `read_template` for a fixed demo or an unknown id). charging before resolution is the fail-safe direction and the burst window is wide enough that it does not bite; the accurate description is the two tools that may egress, not the two that always do.

the checker returns `Response | null` like every other checker in that file, and `requireTemplateToolBudget` converts it into a tool error through the existing `toolResult` path, since MCP has no `Retry-After` header to carry:

```
Template tool rate limit exceeded. Retry in 30s. The assistant-ui docs tools remain available.
```

that closing sentence is the agent's next action: a throttled template tool does not mean the docs endpoint is down. the fail-closed path (missing client IP, or Redis unreachable) gets its own message rather than passing through `missingClientIpResponse`'s "Public assistant temporarily unavailable", which names a surface the MCP client is not talking to.

## Verification

- `pnpm -C apps/docs exec vitest run --testTimeout=30000` — 58 files, 492 tests passing, including 27 new ones: one deadline shared across attempts, the retry loop stopping once the budget is spent (and once the caller cancels) even for an error classified retryable, no attempt started when the deadline expires mid-backoff, a caller signal still aborting the call, each bucket's configuration, key and short-circuit order, the throttled global alert, both fail-closed paths, and at the route level that the two egress tools are metered, the docs tools are not, a denial returns an `isError` result without reaching the sandbox, and the 503 path does not tell an MCP client the public assistant is down.
- `pnpm lint` — clean.
- `pnpm -C apps/docs exec tsc --noEmit` — no errors in the touched files. the 42 reported are pre-existing on `main` (unbuilt sibling packages and image module declarations).

on the reproduction above: without the change the request succeeds indefinitely; with it the 16th attempt inside a minute from one IP returns the throttled tool error and `fetchPreviewSession` is never called, which the route test asserts directly.

running the full suite in a fresh worktree needs `pnpm --filter "@assistant-ui/react..." --filter "@assistant-ui/ai-sdk..." build` first, otherwise seven unrelated files fail to resolve their workspace imports.

## Public surface

none. `apps/docs` is private, so no changeset. `checkMcpTemplateToolRateLimit` and `SandboxFetchInit` are internal to the app. two new optional environment variables, both documented in `apps/docs/.env.example` and both defaulted, so no deployment change is required to land this.

follow-ups this PR deliberately does not fold in:

- #6693 — `/api/xulux/download-proxy` is a second public unauthenticated egress path, unmetered, buffering up to 50 MB per request
- #6696 — no route in `apps/docs` has a verified execution ceiling, because the platform default is unrecorded; that is why this PR bounds the outbound call rather than setting a `maxDuration` it cannot justify
- #6101 is the umbrella for this class but scopes neither the MCP endpoint nor the download proxy; worth widening there
