### PR TITLE
fix(react-generative-ui): bound a node whose has trap hides children

### DIFF
--- a/.changeset/6687-boundspec-has-trap.md
+++ b/.changeset/6687-boundspec-has-trap.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: bound a node whose `has` trap hides `children` from the pre-pass
+
+`boundSpec` gated its record branch on `"children" in value`, a `[[HasProperty]]`, while every consumer reads `children` with `[[Get]]`. A record whose `has` trap answered `false` for `"children"` was returned untouched, and `normalizeSpec` then pulled the array through the `get` trap and walked its full reported length, skipping the children cap, the node budget, and the depth ceiling. Every object is now returned as a plain copy whose `children` comes from the same read the bound used.

--- a/packages/react-generative-ui/src/convert/boundSpec.test.ts
+++ b/packages/react-generative-ui/src/convert/boundSpec.test.ts
@@ -20,10 +20,12 @@ const nest = (levels: number): unknown =>
     : { type: "Box", children: [nest(levels - 1)] };
 
 describe("boundSpec", () => {
-  it("returns a value without children as-is", () => {
+  it("copies an object without children and passes primitives through", () => {
     const leaf = { type: "Text", props: { value: "hi" } };
+    const { reasons, result } = walk(leaf);
 
-    expect(walk(leaf)).toEqual({ reasons: [], result: leaf });
+    expect({ reasons, result }).toEqual({ reasons: [], result: leaf });
+    expect(result).not.toBe(leaf);
     expect(walk("text").result).toBe("text");
     expect(walk(null).result).toBe(null);
   });
@@ -84,6 +86,49 @@ describe("boundSpec", () => {
 
     expect(reasons).toEqual([]);
     expect(result).toEqual([{ type: "Text" }, { type: "Text" }]);
+  });
+
+  it("bounds a record that hides its children behind a has trap", () => {
+    const hostileChildren = new Proxy([{ type: "Text" }], {
+      get: (target, prop, receiver) =>
+        prop === "length"
+          ? Number.MAX_SAFE_INTEGER
+          : Reflect.get(target, prop, receiver),
+    });
+    const hostile = new Proxy(
+      { type: "Box", children: hostileChildren } as Record<string, unknown>,
+      {
+        has: (target, prop) => prop !== "children" && Reflect.has(target, prop),
+      },
+    );
+
+    const { reasons, result } = walk(hostile);
+
+    expect(reasons).toEqual(["children"]);
+    expect((result as { children: unknown[] }).children).toHaveLength(
+      CHILDREN_CAP,
+    );
+  });
+
+  it("bounds a record that answers a later read of children differently", () => {
+    let reads = 0;
+    const hostile = new Proxy(
+      { type: "Box", children: undefined } as Record<string, unknown>,
+      {
+        get: (target, prop, receiver) => {
+          if (prop !== "children") return Reflect.get(target, prop, receiver);
+          reads += 1;
+          return reads === 1
+            ? undefined
+            : Array(CHILDREN_CAP * 2).fill({ type: "Text" });
+        },
+      },
+    );
+
+    const { reasons, result } = walk(hostile);
+
+    expect(reasons).toEqual([]);
+    expect((result as { children: unknown }).children).toBeUndefined();
   });
 
   it("accepts nesting exactly at the element-depth ceiling", () => {

--- a/packages/react-generative-ui/src/convert/boundSpec.ts
+++ b/packages/react-generative-ui/src/convert/boundSpec.ts
@@ -81,26 +81,22 @@ function boundNode(
     ancestors.delete(value);
     return result;
   }
-  if (
-    value !== null &&
-    typeof value === "object" &&
-    "children" in (value as Record<string, unknown>)
-  ) {
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    // Every object is copied and every copy takes its `children` from this one
+    // read. A record that answers `[[HasProperty]]` and `[[Get]]`, or two
+    // `[[Get]]`s, differently would otherwise hand the bound one value and
+    // `normalizeSpec` another, skipping the bound entirely for that subtree.
+    const children = record["children"];
+    if (children === undefined) return { ...record, children: undefined };
     if (ancestors.has(value)) {
       onClamp("cycle");
       return null;
     }
     ancestors.add(value);
-    const record = value as Record<string, unknown>;
     const result = {
       ...record,
-      children: boundNode(
-        record["children"],
-        depth + 1,
-        onClamp,
-        state,
-        ancestors,
-      ),
+      children: boundNode(children, depth + 1, onClamp, state, ancestors),
     };
     ancestors.delete(value);
     return result;
@@ -116,7 +112,9 @@ function boundNode(
  * (root, or `children` at any depth) is capped to {@link CHILDREN_CAP}
  * entries by index, which bounds a proxy however it fabricates `length` or
  * replaces its array methods; recursion itself is capped at
- * {@link MAX_TRAVERSAL_DEPTH}. `onClamp` fires once per level that was
+ * {@link MAX_TRAVERSAL_DEPTH}. Every object is returned as a plain copy whose
+ * `children` came from the same read the bound used, so a record cannot answer
+ * the walk one way and `normalizeSpec` another. `onClamp` fires once per level that was
  * truncated, receiving the reason for that truncation: `"children"`,
  * `"depth"`, `"budget"`, or `"cycle"`. The walk also spends a total budget of
  * {@link NODE_BUDGET} nodes, so shared references cannot multiply work

--- a/packages/react-generative-ui/src/convert/boundSpec.ts
+++ b/packages/react-generative-ui/src/convert/boundSpec.ts
@@ -83,11 +83,9 @@ function boundNode(
   }
   if (value !== null && typeof value === "object") {
     const record = value as Record<string, unknown>;
-    // Every object is copied and every copy takes its `children` from this one
-    // read. A record that answers `[[HasProperty]]` and `[[Get]]`, or two
-    // `[[Get]]`s, differently would otherwise hand the bound one value and
-    // `normalizeSpec` another, skipping the bound entirely for that subtree.
     const children = record["children"];
+    // The spread performs a `children` read of its own, so the copy states the
+    // bounded value even when there is none.
     if (children === undefined) return { ...record, children: undefined };
     if (ancestors.has(value)) {
       onClamp("cycle");
@@ -113,8 +111,10 @@ function boundNode(
  * entries by index, which bounds a proxy however it fabricates `length` or
  * replaces its array methods; recursion itself is capped at
  * {@link MAX_TRAVERSAL_DEPTH}. Every object is returned as a plain copy whose
- * `children` came from the same read the bound used, so a record cannot answer
- * the walk one way and `normalizeSpec` another. `onClamp` fires once per level that was
+ * `children` came from a single read, because a record that answers
+ * `[[HasProperty]]` and `[[Get]]`, or two `[[Get]]`s, differently would
+ * otherwise hand the bound one value and `normalizeSpec` another, skipping
+ * every bound here for that subtree. `onClamp` fires once per level that was
  * truncated, receiving the reason for that truncation: `"children"`,
  * `"depth"`, `"budget"`, or `"cycle"`. The walk also spends a total budget of
  * {@link NODE_BUDGET} nodes, so shared references cannot multiply work


### PR DESCRIPTION
Closes #6687

## Problem

`boundSpec` is the pre-pass that bounds a raw generative-ui spec before `normalizeSpec` walks it, because `normalizeSpec` iterates a hostile array's full reported `length` before any per-field cap downstream applies. A record could opt out of that pre-pass entirely.

Minimal reproduction, against `f2f9920` in `packages/react-generative-ui`:

```ts
const hostileArray = (len: number) =>
  new Proxy([] as unknown[], {
    get(target, key, recv) {
      if (key === "length") return len;
      if (typeof key === "string" && /^\d+$/.test(key)) return "x";
      return Reflect.get(target, key, recv);
    },
    has(target, key) {
      if (typeof key === "string" && /^\d+$/.test(key)) return true;
      return Reflect.has(target, key);
    },
  });

const record = (hideChildren: boolean) =>
  new Proxy({ $type: "Box", children: hostileArray(2_000_000) } as Record<string, unknown>, {
    has(target, key) {
      if (hideChildren && key === "children") return false;
      return Reflect.has(target, key);
    },
  });

toSlackBlocks(record(false)); //   1ms, clamped to 200
toSlackBlocks(record(true));  // 356ms, walked in full
```

The cost is linear in the fabricated `length`, so `length: 1e9` blocks the event loop for minutes on a single call. All three outbound converters were affected, since each calls `boundSpec` on its raw input: `toSlackBlocks.ts:1348`, `toAdaptiveCard.ts:799`, `toTeamsAttachments.ts:89`.

## Root cause

`boundSpec.ts:84-88` gated its record branch on `[[HasProperty]]`:

```ts
"children" in (value as Record<string, unknown>)
```

Every consumer reads `children` with `[[Get]]` instead. `ir.ts:214` destructures it out of the node, and `boundNode` itself re-read `record["children"]` at `:98`. On a proxy those are separable operations, so a record whose `has` trap answered `false` for `"children"` failed the gate, fell through to the bare `return value` at `:108`, and reached `normalizeSpec` with its identity intact. `normalizeUINode` then pulled the array back through the `get` trap and `ir.ts:203-206` walked it with `node.map(...)`, skipping `CHILDREN_CAP`, `NODE_BUDGET`, and the depth ceiling alike.

The gate deciding whether to protect a node was the one operation an attacker could answer separately from the read that later consumed it.

## Change

`boundNode` reads `children` once, and every copy takes its `children` from that read, so the gate and the consumer are now the same operation.

Every object is also returned as a plain copy. That is what closes the class rather than the instance: while any object can leave the pre-pass carrying its own identity, a later read can differ from the one that was bounded, so swapping `in` for a `!== undefined` test on a separate read would only move the bypass rather than remove it.

The childless path writes `children: undefined` explicitly because `{ ...record }` performs a `[[Get]]` of `children` of its own; without that overwrite the spread becomes the new bypass. It returns early instead of recursing into `boundNode(undefined)`, so a leaf still spends exactly one `NODE_BUDGET` unit and the budget arithmetic is unchanged.

`:87` was the only `[[HasProperty]]` gate anywhere in the chain, checked across `ir.ts`, `isElement.ts`, and both converters.

## Verification

- `packages/react-generative-ui`: `vitest run`, 29 files / 622 tests passing. Three colocated cases in `boundSpec.test.ts` cover this: a record hiding its children behind a `has` trap, a record answering a later read of `children` differently, and the copy contract for an object without children. Reverting `boundSpec.ts` alone fails exactly those three and no others.
- The reproduction above, re-run against the fix on all three entry points: `toSlackBlocks` 1ms, `toAdaptiveCard` 0ms, `toTeamsAttachments` 0ms, each reporting `children were clamped to 200 entries.` where the unfixed tree reported no clamp at all.
- `aui-build` clean, `oxlint` clean on the package, `oxfmt --check` clean, `pnpm changesets:check` passing.
- `tsc --noEmit` reports nothing in the touched files; the files it does flag fail identically on an unmodified tree.

## Public surface

None. `boundSpec`'s exported signature and its bounds are unchanged, and no export is added or removed. Changeset: patch for `@assistant-ui/react-generative-ui`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SQOwWqQMLpbMrzssz-EQzjB3-AC16BdlXFVRqal3vq_Js5ivCZgbm8hgPeY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->