### PR TITLE
refactor(react-generative-ui): drop the third copy of the cap helper

### DIFF
--- a/.changeset/6437-teams-carousel-copybounded.md
+++ b/.changeset/6437-teams-carousel-copybounded.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+refactor: cap the Teams carousel through the shared bounded copy

--- a/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
+++ b/packages/react-generative-ui/src/teams/toTeamsAttachments.ts
@@ -1,4 +1,5 @@
 import { boundSpec, clampReasonDetail } from "../convert/boundSpec";
+import { copyBounded } from "../convert/copyBounded";
 import { isElement } from "../convert/isElement";
 import {
   normalizeSpec,
@@ -30,14 +31,6 @@ const normalizedList = (
   if (!Array.isArray(node)) return [node];
   return node.flatMap((child) => normalizedList(child));
 };
-
-const clampArray = <T>(
-  value: readonly T[],
-  cap: number,
-): { readonly items: T[]; readonly truncated: boolean } => ({
-  items: value.slice(0, cap),
-  truncated: value.length > cap,
-});
 
 /**
  * Recognizes a root that is a single `Carousel` element, returning its `Card`
@@ -96,7 +89,7 @@ export function toTeamsAttachments(
     const { root } = normalizeSpec(bounded as never);
     const carouselCards = rootCarouselCards(root, context);
     if (carouselCards !== undefined) {
-      const { items, truncated } = clampArray(
+      const { items, truncated } = copyBounded(
         carouselCards,
         CAROUSEL_ATTACHMENT_CAP,
       );


### PR DESCRIPTION
Closes #6437

## Problem

#6437 recorded two follow-ups left over from #6436. This addresses the second.

`toTeamsAttachments.ts:34-40` carried a third copy of the cap helper the other cap sites share, and it was the one copy that clamped with `slice`:

```ts
const clampArray = <T>(value: readonly T[], cap: number) => ({
  items: value.slice(0, cap),
  truncated: value.length > cap,
});
```

`toAdaptiveCard.ts:134-140` and `fromSlackBlocks.ts:42-48` hold the same helper and both delegate to `copyBounded`, which copies by index. `slice` dispatches on its input: a replaced `slice` is called directly, and the intrinsic one reaches a `constructor` whose `@@species` can return an arbitrary object, which then supplies the `map` the caller runs next.

It is not a live vector. The only caller is `:99`, which passes `carouselCards` from `rootCarouselCards`, and that array is built locally at `:56-72` with `push`, so its `constructor` is the intrinsic `Array` and there is nothing to redirect. The defect is that one of three copies of a single helper behaves differently, and the difference only surfaces once a later change feeds it a prop.

## Change

The local helper is deleted rather than made to delegate. Its signature (`<T>(value: readonly T[], cap: number) => { items: T[]; truncated: boolean }`) is already `copyBounded`'s, so a wrapper would do nothing; `:99` calls `copyBounded` directly.

The other two are not duplicates and stay. Both are `(value: unknown, cap: number)` with an `Array.isArray` guard, so they earn their place by narrowing `unknown` before `copyBounded` sees it. This site's input is already typed as an array.

The other follow-up recorded in #6437, `boundSpec` spreading prop arrays rather than copying them, is deliberately left alone. Copying every prop array in the pre-pass is a hot path cost on every outbound conversion, and the class it would close is already closed at every reachable site: each prop-array cap routes through `copyBounded` (`toSlackBlocks.ts:248`, `:326`, `:940`, `:944`, `:982`; `toAdaptiveCard.ts:182`, `:291`, `:295`, `:343`), and each carries a contract test asserting no `@@species` dispatch. The trade-off #6434 made still holds. #6437 exists to record it, so this closes it as recorded.

## Verification

- `pnpm -C packages/react-generative-ui exec vitest run` -> 29 files, 622 tests green.
- `tsc --noEmit` -> 19 errors, identical file for file to the same run on `05e3e6d`, all in test files this diff does not touch.
- `pnpm lint` and `pnpm changesets:check` -> clean.

No test is added. The vector is unreachable through the public entry point, since `rootCarouselCards` always returns a locally built array, so a hostile `@@species` input cannot be constructed for this site.

## Public surface

`@assistant-ui/react-generative-ui`, patch changeset. `clampArray` was module-local, so no exported symbol changes, and behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6LUU-89rm5fKOtYKmJrKgzhk9c6hcg5LHGT_meOVbWIJNY5xaBjoynDFqYQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->