### PR TITLE
fix(react-pi): re-render usePiThreadState only when the selected slice changes

### DIFF
--- a/.changeset/pi-selector-render-bailout.md
+++ b/.changeset/pi-selector-render-bailout.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix(react-pi): re-render `usePiThreadState` only when the selected slice changes

--- a/packages/react-pi/src/runtime/hooks.ts
+++ b/packages/react-pi/src/runtime/hooks.ts
@@ -19,7 +19,14 @@ export const usePiRuntimeExtras = (): PiRuntimeExtras =>
 export const usePiSession = (): PiThreadMetadata | null =>
   piExtras.use((e) => e.metadata, null);
 
-/** The live Pi thread state, optionally projected through a selector. */
+/**
+ * The live Pi thread state, optionally projected through a selector.
+ *
+ * The selected value is compared with `Object.is`, so the component re-renders
+ * only when that value changes. A selector returning a new object or array
+ * literal re-renders on every controller notification; select primitives or
+ * return a memoized reference.
+ */
 export function usePiThreadState(): PiThreadState;
 export function usePiThreadState<T>(selector: (state: PiThreadState) => T): T;
 export function usePiThreadState<T>(selector?: (state: PiThreadState) => T) {

--- a/packages/react-pi/src/runtime/usePiRuntime.test.tsx
+++ b/packages/react-pi/src/runtime/usePiRuntime.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
+import { act, createElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppendMessage, ExternalStoreAdapter } from "@assistant-ui/react";
@@ -83,7 +83,8 @@ vi.mock("./ThreadController", async (importOriginal) => {
 });
 
 import { ExportedMessageRepository } from "@assistant-ui/react";
-import { createPiThreadState } from "./threadState";
+import { createPiThreadState, type PiThreadState } from "./threadState";
+import type { PiThreadControllerLike } from "./ThreadController";
 import {
   NOOP_CONTROLLER,
   usePiControllerStateSelector,
@@ -282,7 +283,75 @@ describe("usePiRuntime controller subscriptions", () => {
   });
 });
 
+const publishableController = () => {
+  let state = createPiThreadState("t1");
+  const listeners = new Set<() => void>();
+  return {
+    controller: {
+      ...NOOP_CONTROLLER,
+      getState: () => state,
+      getStateSnapshot: () => state,
+      subscribe: (listener: () => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    } as PiThreadControllerLike,
+    publish: (patch: Partial<PiThreadState> = {}) => {
+      state = { ...state, ...patch };
+      for (const listener of [...listeners]) listener();
+    },
+  };
+};
+
 describe("usePiControllerStateSelector", () => {
+  it("re-renders only when the selected slice changes", async () => {
+    const { controller, publish } = publishableController();
+    const container = document.createElement("div");
+    let renders = 0;
+    const App = () => {
+      const status = usePiControllerStateSelector(
+        controller,
+        (state) => state.runStatus,
+      );
+      renders++;
+      return createElement("div", null, status);
+    };
+
+    root = createRoot(container);
+    await act(async () => root!.render(createElement(App)));
+    expect(renders).toBe(1);
+
+    await act(async () => publish());
+    await act(async () => publish());
+    expect(renders).toBe(1);
+
+    await act(async () => publish({ runStatus: "running" }));
+    expect(renders).toBe(2);
+    expect(container.textContent).toBe("running");
+  });
+
+  it("re-runs a selector whose closure changed without a publish", async () => {
+    const { controller } = publishableController();
+    const container = document.createElement("div");
+    let setLabel: ((label: string) => void) | undefined;
+    const App = () => {
+      const [label, set] = useState("a");
+      setLabel = set;
+      const text = usePiControllerStateSelector(
+        controller,
+        (state) => `${state.runStatus}:${label}`,
+      );
+      return createElement("div", null, text);
+    };
+
+    root = createRoot(container);
+    await act(async () => root!.render(createElement(App)));
+    expect(container.textContent).toBe("idle:a");
+
+    await act(async () => setLabel!("b"));
+    expect(container.textContent).toBe("idle:b");
+  });
+
   it("supports selectors that allocate objects and arrays", async () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/react-pi/src/runtime/usePiRuntime.ts
+++ b/packages/react-pi/src/runtime/usePiRuntime.ts
@@ -183,8 +183,29 @@ export const usePiControllerStateSelector = <T>(
   controller: PiThreadControllerLike,
   selector: (state: PiThreadState) => T,
 ): T => {
-  const state = usePiControllerState(controller);
-  return useMemo(() => selector(state), [selector, state]);
+  // `useSyncExternalStore` compares snapshots with `Object.is`, so selecting
+  // inside `getSnapshot` is what lets the store observe the selected slice
+  // rather than the whole state. Memoizing on the source state keeps repeated
+  // reads of one state object referentially stable; re-keying the memo on the
+  // selector re-runs a changed closure instead of replaying its last result.
+  const getSelection = useMemo(() => {
+    let memo: { state: PiThreadState; selection: T } | undefined;
+    return () => {
+      const state = stateSnapshotOf(controller);
+      if (!memo || memo.state !== state)
+        memo = { state, selection: selector(state) };
+      return memo.selection;
+    };
+  }, [controller, selector]);
+
+  return useSyncExternalStore(
+    useCallback(
+      (listener: () => void) => controller.subscribe(listener),
+      [controller],
+    ),
+    getSelection,
+    getSelection,
+  );
 };
 
 const isPiStateRunning = (state: PiThreadState): boolean =>


### PR DESCRIPTION
Closes #6429

## Problem

`usePiThreadState` re-rendered its consumer on every controller notification rather than when the selected slice changed.

Minimal reproduction, against `05e3e6d` in `packages/react-pi`: a controller that publishes a new `PiThreadState` object whose `runStatus` never moves, read through `usePiThreadState((state) => state.runStatus)`.

```
mount + 2 no-op publishes    3 renders    (1 is correct)
```

The two in-repo consumers are exactly that shape: `examples/with-pi/app/page.tsx:83` selects `state.readiness`, and `examples/with-pi/components/assistant-ui/elements/thread.tsx:429` selects `s.contextUsage`. Both read fields the reducer carries forward by reference across unrelated publishes (`threadState.ts:133,135`), so every one of those extra renders was wasted work.

## Root cause

#6422 fixed #6419 (React's "The result of getSnapshot should be cached to avoid an infinite loop", raised by a selector that allocates) by moving the selector out of `getSnapshot`:

```ts
const state = usePiControllerState(controller);
return useMemo(() => selector(state), [selector, state]);
```

That leaves the store observing the whole `PiThreadState`. In `react-dom@19.2.8`, `checkIfSnapshotChanged` (`cjs/react-dom-client.development.js:8250`) compares `inst.value` against the latest committed `getSnapshot()` under `Object.is` and calls `forceStoreRerender` only when they differ, so the render bailout is on whatever the snapshot returns. Returning the whole state means each publish allocates a fresh state object, each publish re-renders, and the selector then runs during render only to discard an unchanged result.

#6422 considered restoring the bailout with a comparison cache and rejected it, on the grounds that a cache keyed on the source state serves a stale value when an inline selector's closure changes without a publish. That measurement is correct for a cache keyed on state alone, but it does not generalize: React's own `useSyncExternalStoreWithSelector` (`use-sync-external-store@1.6.0`) is a cache keyed on the source state,

```js
if (objectIs(memoizedSnapshot, nextSnapshot)) return currentSelection;
```

and it is not stale because the enclosing `useMemo` is keyed on the selector as well as the snapshot getters, so a changed closure rebuilds the cache and recomputes. The rejected design was one memo dependency short of React's own.

## Change

`usePiControllerStateSelector` selects inside `getSnapshot` again, with the memo shaped the way `useSyncExternalStoreWithSelector` shapes it: keyed on the source state so repeated reads of one state object stay referentially stable, and re-keyed on the selector so a changed closure re-runs instead of replaying its last result. The `isEqual` parameter is deliberately not carried over; it matters only for selectors that allocate, and adding it would change a published signature and pull in a dependency this tree does not have.

This restores the mechanism `@assistant-ui/store` already uses. `useAuiState` (`packages/store/src/useAuiState.ts:45`) selects inside `getSnapshot` and documents the same contract, with `useShallowSelector` as the opt-in for selectors that allocate. `usePiThreadState` now carries that contract in its JSDoc too.

Both prior defects stay fixed at once. The published signature and the controller snapshot contract are unchanged, and no dependency is added.

## Verification

`pnpm --filter @assistant-ui/react-pi test` passes 240/240, including two new contract tests in `usePiRuntime.test.tsx`:

- `re-renders only when the selected slice changes` fails without this change (`expected 3 to be 1`) and passes with it, and still asserts a real slice change does re-render.
- `re-runs a selector whose closure changed without a publish` guards the staleness #6422 was right to refuse; it passes both before and after, so the repair does not buy renders with a stale read.

The existing `supports selectors that allocate objects and arrays` case continues to pass, so #6419 does not reopen: within one state object the memo hands back the same reference, which is what silences React's cached-snapshot warning.

Also green: `pnpm lint`, `pnpm api-surface:check`.

## Public surface

`@assistant-ui/react-pi` only. No exports added, removed, or re-signed; `usePiThreadState` gains JSDoc describing its re-render contract. No api-reference page references this hook, so the generated tree does not move. Changeset: `.changeset/pi-selector-render-bailout.md` (patch).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.77o5rcRBn_F68AuJii92WjVp0MIgaLBBU9IJBVVRu9C5eTgT2VH8g28q5fI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->