### PR TITLE
fix(react-mcp): fence oauth writes across storages that share a scopeId

### DIFF
--- a/.changeset/tricky-poems-clap.md
+++ b/.changeset/tricky-poems-clap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix(react-mcp): key the oauth write fence on scopeId so a same-scope storage swap cannot resurrect cleared tokens

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -39,6 +39,23 @@ const createStorage = (initial: MCPPersistedAuthState | null = null) => {
   return { storage, getState: () => state };
 };
 
+const createSharedStorages = (scopeId: string) => {
+  let state: MCPPersistedAuthState | null = null;
+  const create = (): MCPStorage => ({
+    scopeId,
+    loadCustomServers: async () => [],
+    saveCustomServers: async () => {},
+    loadAuthState: async () => state,
+    saveAuthState: async (_serverId, next) => {
+      state = next;
+    },
+    clearAuthState: async () => {
+      state = null;
+    },
+  });
+  return { create, getState: () => state };
+};
+
 const createProvider = (storage: MCPStorage) =>
   createOAuthProvider({
     serverId: "docs",
@@ -337,6 +354,63 @@ describe("createOAuthProvider persistence across provider instances", () => {
     storage.saveAuthState = saveAuthState;
     await provider.saveCodeVerifier("late-verifier");
     expect(getState()).toBeNull();
+  });
+
+  it("fences a queued write when clearing through a same-scope storage", async () => {
+    const { create, getState } = createSharedStorages("same-scope-clear");
+    const storage = create();
+    const replacement = create();
+    const pendingWrites: Array<() => void> = [];
+    const saveAuthState = storage.saveAuthState;
+    storage.saveAuthState = async (serverId, next) => {
+      await new Promise<void>((resolve) => pendingWrites.push(resolve));
+      await saveAuthState(serverId, next);
+    };
+    const clearAuthState = vi.spyOn(replacement, "clearAuthState");
+    const provider = createProvider(storage);
+    await provider.tokens();
+
+    const save = provider.saveTokens({
+      access_token: "access-token",
+      token_type: "bearer",
+    });
+    await vi.waitFor(() => expect(pendingWrites).toHaveLength(1));
+
+    const clear = clearOAuthProviderAuthState(replacement, "docs");
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(clearAuthState).not.toHaveBeenCalled();
+
+    pendingWrites.shift()!();
+    await expect(save).resolves.toBeUndefined();
+    await clear;
+    expect(clearAuthState).toHaveBeenCalledTimes(1);
+    expect(getState()).toBeNull();
+
+    storage.saveAuthState = saveAuthState;
+    await provider.saveCodeVerifier("late-verifier");
+    expect(getState()).toBeNull();
+  });
+
+  it("keeps differently-scoped storages on separate persistence", async () => {
+    const first = createSharedStorages("scope-a");
+    const second = createSharedStorages("scope-b");
+    const firstProvider = createProvider(first.create());
+    const secondProvider = createProvider(second.create());
+
+    await firstProvider.saveTokens({
+      access_token: "first-token",
+      token_type: "bearer",
+    });
+    await secondProvider.saveTokens({
+      access_token: "second-token",
+      token_type: "bearer",
+    });
+    await clearOAuthProviderAuthState(second.create(), "docs");
+
+    expect(first.getState()).toEqual({
+      tokens: { access_token: "first-token", token_type: "bearer" },
+    });
+    expect(second.getState()).toBeNull();
   });
 
   it("re-derives static client information for a replacement provider", async () => {

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -406,9 +406,11 @@ describe("createOAuthProvider persistence across provider instances", () => {
       token_type: "bearer",
     });
     await clearOAuthProviderAuthState(second.create(), "docs");
+    await firstProvider.saveCodeVerifier("first-verifier");
 
     expect(first.getState()).toEqual({
       tokens: { access_token: "first-token", token_type: "bearer" },
+      codeVerifier: "first-verifier",
     });
     expect(second.getState()).toBeNull();
   });

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -72,12 +72,39 @@ type OAuthProviderPersistence = {
   invalidated: boolean;
 };
 
+// scopeId, not object identity, is what addresses the same persisted data, so
+// storages sharing one share an anchor and an unscoped storage is its own
+// identity. Every storage declaring a scope holds that scope's anchor, so the
+// coordination state below is collected once the last of them is gone.
+const anchorByStorage = new WeakMap<MCPStorage, object>();
+const anchorByScope = new Map<string, WeakRef<object>>();
+const anchorRegistry = new FinalizationRegistry<string>((scopeId) => {
+  if (!anchorByScope.get(scopeId)?.deref()) anchorByScope.delete(scopeId);
+});
+
+const getStorageIdentity = (storage: MCPStorage): object => {
+  const existing = anchorByStorage.get(storage);
+  if (existing) return existing;
+
+  const { scopeId } = storage;
+  if (scopeId === undefined) return storage;
+
+  let anchor = anchorByScope.get(scopeId)?.deref();
+  if (!anchor) {
+    anchor = {};
+    anchorByScope.set(scopeId, new WeakRef(anchor));
+    anchorRegistry.register(anchor, scopeId);
+  }
+  anchorByStorage.set(storage, anchor);
+  return anchor;
+};
+
 // McpServerResource builds a fresh provider for every transport, so the cache,
 // the in-flight load, and the write queue have to outlive any one provider.
 // saveAuthState replaces the whole record, so two providers writing their own
 // snapshots concurrently would drop whichever field the loser had added.
-const persistenceByStorage = new WeakMap<
-  MCPStorage,
+const persistenceByIdentity = new WeakMap<
+  object,
   Map<string, OAuthProviderPersistence>
 >();
 
@@ -85,10 +112,11 @@ const getPersistence = (
   storage: MCPStorage,
   serverId: string,
 ): OAuthProviderPersistence => {
-  let byServerId = persistenceByStorage.get(storage);
+  const identity = getStorageIdentity(storage);
+  let byServerId = persistenceByIdentity.get(identity);
   if (!byServerId) {
     byServerId = new Map();
-    persistenceByStorage.set(storage, byServerId);
+    persistenceByIdentity.set(identity, byServerId);
   }
 
   let persistence = byServerId.get(serverId);
@@ -113,7 +141,8 @@ export const clearOAuthProviderAuthState = async (
   storage: MCPStorage,
   serverId: string,
 ): Promise<void> => {
-  const byServerId = persistenceByStorage.get(storage);
+  const identity = getStorageIdentity(storage);
+  const byServerId = persistenceByIdentity.get(identity);
   const persistence = byServerId?.get(serverId);
   if (!byServerId || !persistence) {
     await storage.clearAuthState(serverId);
@@ -124,7 +153,7 @@ export const clearOAuthProviderAuthState = async (
   // on a fresh generation instead of inheriting the fenced one.
   persistence.invalidated = true;
   byServerId.delete(serverId);
-  if (byServerId.size === 0) persistenceByStorage.delete(storage);
+  if (byServerId.size === 0) persistenceByIdentity.delete(identity);
 
   await Promise.allSettled([persistence.cachePromise, persistence.queue]);
   await storage.clearAuthState(serverId);

--- a/packages/react-mcp/src/resources/storage/types.ts
+++ b/packages/react-mcp/src/resources/storage/types.ts
@@ -9,10 +9,10 @@ export type MCPStorage = {
    * connections and the OAuth write fence key on it, so swapping to a
    * differently-scoped storage reconnects instead of leaving a live OAuth flow
    * on the replaced store, and clearing through a same-scoped replacement still
-   * waits for writes queued against the storage it replaced. When absent, both
-   * fall back to object identity and storage swaps never key a reconnect, so a
-   * storage rebuilt on every render has to declare one; without it a clear runs
-   * unfenced against the writes queued by the object it replaced.
+   * waits for writes queued against the storage it replaced. When absent, the
+   * fence falls back to object identity while connections never re-key at all,
+   * so a storage rebuilt on every render has to declare a scopeId; without one
+   * a clear runs unfenced against the writes queued by the object it replaced.
    */
   scopeId?: string;
   loadCustomServers: () => Promise<MCPCustomServerRecord[]>;

--- a/packages/react-mcp/src/resources/storage/types.ts
+++ b/packages/react-mcp/src/resources/storage/types.ts
@@ -6,9 +6,11 @@ export type MCPStorage = {
   /**
    * Stable identity of the backing store. Two storages with the same scopeId
    * must read and write the same persisted data. When present, server
-   * connections key on it, so swapping to a differently-scoped storage
-   * reconnects instead of leaving a live OAuth flow on the replaced store;
-   * when absent, storage swaps never key a reconnect.
+   * connections and the OAuth write fence key on it, so swapping to a
+   * differently-scoped storage reconnects instead of leaving a live OAuth flow
+   * on the replaced store, and clearing through a same-scoped replacement still
+   * waits for writes queued against the storage it replaced. When absent, both
+   * fall back to object identity and storage swaps never key a reconnect.
    */
   scopeId?: string;
   loadCustomServers: () => Promise<MCPCustomServerRecord[]>;

--- a/packages/react-mcp/src/resources/storage/types.ts
+++ b/packages/react-mcp/src/resources/storage/types.ts
@@ -10,7 +10,9 @@ export type MCPStorage = {
    * differently-scoped storage reconnects instead of leaving a live OAuth flow
    * on the replaced store, and clearing through a same-scoped replacement still
    * waits for writes queued against the storage it replaced. When absent, both
-   * fall back to object identity and storage swaps never key a reconnect.
+   * fall back to object identity and storage swaps never key a reconnect, so a
+   * storage rebuilt on every render has to declare one; without it a clear runs
+   * unfenced against the writes queued by the object it replaced.
    */
   scopeId?: string;
   loadCustomServers: () => Promise<MCPCustomServerRecord[]>;


### PR DESCRIPTION
Closes #6679

## Problem

`clearOAuthProviderAuthState` exists to hold a clear until the in-flight load and every queued write for that server have settled, so a discarded provider cannot recreate the record it was mid-save on. It misses that fence whenever the clear arrives through a different storage object than the one the live provider was built with, which is exactly what happens once two storages share a `scopeId`. Removing an OAuth server then resolves while a write is still in flight, and the losing write puts the access token back into the store the user just cleared.

Minimal reproduction, against `d746b30` in `packages/react-mcp`: two `MCPStorage` objects declaring one `scopeId` over one backing record, an OAuth provider built on the first with `saveAuthState` blocked mid-`saveTokens`, then `clearOAuthProviderAuthState` through the second.

```
clear resolves without awaiting the queued write
final state   { tokens: { access_token: "access-token", token_type: "bearer" } }   (null is correct)
```

Distinct objects under one scope is the ordinary shape, not an exotic one. Two `McpManagerResource` mounts both defaulting to `McpLocalStorage()` already produce two objects under the constant scope `local-storage:aui-mcp`, and `McpCustomStorage` returns its argument untouched, so the inline form the docs show (`user-managed-mcp.mdx:316`) constructs a fresh object on every render under one declared scope.

## Root cause

#6625 made `scopeId` the identity of shared persisted data: `getConnectionDependencies` keys a server's connection on `props.storage.scopeId` (`McpServerResource.ts:58,69`), so a same-scope storage swap deliberately does not reconnect. The live transport therefore keeps the provider built on the previous object, and that provider's `persist()` closure keeps writing through it.

The write fence never moved to that identity. Its registry was a `WeakMap` keyed on the storage object (`createOAuthProvider.ts:79-82`), while both clear paths pass whatever storage the resource currently renders with (`McpServerResource.ts:650`, `McpManagerResource.ts:307`). The lookup for the replacement missed the entry created for the original and fell through to the unfenced `storage.clearAuthState(serverId)`, and the entry's `invalidated` flag was never set either, so a task still sitting in the original's queue ran afterwards and re-saved the record.

Keying the fence on a narrower identity than the connection was the whole defect: the storage contract already states that two storages with the same `scopeId` read and write the same persisted data, which is the premise the connection keying rests on.

## Change

`getStorageIdentity` resolves a storage to the object that identifies its backing data: a per-scope anchor when `scopeId` is present, the storage itself when it is absent. The persistence registry keys on that instead, so `getPersistence` and `clearOAuthProviderAuthState` reach the same entry whichever same-scope object they are handed. The nested map, the detach-before-await on clear, and the empty-map cleanup are unchanged.

This follows `getClientId` (`packages/store/src/utils/client-accessor.ts:105-114`), which solves the same problem for clients: resolve an opaque object identity, fall back to the object itself, and keep the registry a `WeakMap` so lifetime stays GC driven. The anchor is held by every storage declaring its scope through a `WeakMap` value, which gives one statable invariant: per-scope coordination state lives until the last storage declaring that scope is gone, and the unscoped path keeps today's behavior exactly. The `WeakRef` plus `FinalizationRegistry` that prunes the scope index mirrors `packages/react-ink/src/adapters/FileStorage.ts:68-73`, the existing precedent in this repo for a string-keyed module registry.

A strong scope map was the alternative and is rejected: `McpMemoryStorage` mints `memory:${generateId()}` per instance, so entries holding access tokens would outlive stores that can never issue a clear, and it would be the only module-level registry in the repo that strongly retains per-instance state.

## Verification

`pnpm --filter @assistant-ui/react-mcp test` passes 171/171, including two new contract tests in `createOAuthProvider.test.ts`:

- `fences a queued write when clearing through a same-scope storage` fails without this change (the clear calls `clearAuthState` immediately, and the queued write restores the record) and passes with it. It also asserts the fenced provider cannot write after the clear.
- `keeps differently-scoped storages on separate persistence` guards the other direction, so the shared anchor cannot merge scopes that address different data.

The existing fence tests all use storages that declare no `scopeId`, so they pin the object-identity fallback unchanged.

`pnpm api-surface:check --filter @assistant-ui/react-mcp` reports no drift, and `oxlint` plus `oxfmt --check` are clean on the touched files. `tsc --noEmit` and `changeset-semver:check` fail identically before and after this change (`McpServerResource.ts`, `prepareElicitationContent.ts`, and a pre-existing `@assistant-ui/mcp-docs-server@minor` changeset on main); neither is touched here.

## Public surface

`@assistant-ui/react-mcp`, patch changeset. No exported signature changes. The `MCPStorage.scopeId` JSDoc widens to state that the OAuth write fence keys on it too, since that is now part of the contract a custom storage relies on. No api-reference output changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Q1nsR6MCYMqIfYvQ7UJ9hBmqrKn5kGmp3fZiWCHMQZmJ47s6bAPB9nqjd9w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->