### PR TITLE
fix(cloud): read cached and reasoning tokens from AI SDK v7 details

### DIFF
--- a/.changeset/v7-token-details.md
+++ b/.changeset/v7-token-details.md
@@ -1,0 +1,6 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/core": patch
+---
+
+fix: report cached and reasoning tokens from the AI SDK v7 token details

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -488,6 +488,12 @@ type RunTelemetryUsage = {
 type RunTelemetryUsageInit = RunTelemetryUsage & {
   promptTokens?: number;
   completionTokens?: number;
+  inputTokenDetails?: {
+    cacheReadTokens?: number;
+  };
+  outputTokenDetails?: {
+    reasoningTokens?: number;
+  };
 };
 
 type SamplingCallData = {

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
@@ -169,6 +169,24 @@ describe("extractRunTelemetry", () => {
     expect(result.cachedInputTokens).toBe(2);
   });
 
+  it("extracts reasoning and cached input tokens from AI SDK v7 details", () => {
+    const result = extractRunTelemetry([
+      assistantMsg("m-1", [{ type: "text", text: "ok" }], {
+        usage: {
+          inputTokens: 12,
+          outputTokens: 7,
+          inputTokenDetails: { cacheReadTokens: 2 },
+          outputTokenDetails: { reasoningTokens: 3 },
+        },
+      }),
+    ])!;
+
+    expect(result.inputTokens).toBe(12);
+    expect(result.outputTokens).toBe(7);
+    expect(result.reasoningTokens).toBe(3);
+    expect(result.cachedInputTokens).toBe(2);
+  });
+
   it("attaches sampling calls from metadata to matching tool calls", () => {
     const result = extractRunTelemetry([
       assistantMsg(

--- a/packages/cloud/src/runTelemetry.test.ts
+++ b/packages/cloud/src/runTelemetry.test.ts
@@ -124,7 +124,48 @@ describe("normalizeRunTelemetryUsage", () => {
     ).toEqual({ inputTokens: 0, cachedInputTokens: 5 });
   });
 
+  it("reads the AI SDK v7 token detail objects", () => {
+    expect(
+      normalizeRunTelemetryUsage({
+        inputTokens: 12,
+        outputTokens: 7,
+        inputTokenDetails: { cacheReadTokens: 5 },
+        outputTokenDetails: { reasoningTokens: 3 },
+      }),
+    ).toEqual({
+      inputTokens: 12,
+      outputTokens: 7,
+      reasoningTokens: 3,
+      cachedInputTokens: 5,
+    });
+  });
+
+  it("prefers the top-level detail counts over the nested ones", () => {
+    expect(
+      normalizeRunTelemetryUsage({
+        reasoningTokens: 3,
+        cachedInputTokens: 5,
+        inputTokenDetails: { cacheReadTokens: 90 },
+        outputTokenDetails: { reasoningTokens: 90 },
+      }),
+    ).toEqual({ reasoningTokens: 3, cachedInputTokens: 5 });
+  });
+
+  it("returns a usage object when only the nested counts are present", () => {
+    expect(
+      normalizeRunTelemetryUsage({
+        inputTokenDetails: { cacheReadTokens: 5 },
+      }),
+    ).toEqual({ cachedInputTokens: 5 });
+  });
+
   it("returns undefined when no count is present", () => {
     expect(normalizeRunTelemetryUsage({})).toBeUndefined();
+    expect(
+      normalizeRunTelemetryUsage({
+        inputTokenDetails: {},
+        outputTokenDetails: {},
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/cloud/src/runTelemetry.ts
+++ b/packages/cloud/src/runTelemetry.ts
@@ -105,11 +105,14 @@ export type RunTelemetryUsage = {
 export type RunTelemetryUsageInit = RunTelemetryUsage & {
   promptTokens?: number;
   completionTokens?: number;
+  inputTokenDetails?: { cacheReadTokens?: number };
+  outputTokenDetails?: { reasoningTokens?: number };
 };
 
 /**
- * Resolves the token counts a provider reports under either the current or the
- * legacy prompt/completion names. Returns undefined when no count is present,
+ * Resolves the token counts a provider reports under any of the names the AI
+ * SDK has used: the current top-level ones, the legacy prompt/completion pair,
+ * and the v7 token detail objects. Returns undefined when no count is present,
  * so callers can tell an empty usage object from a zeroed one.
  */
 export function normalizeRunTelemetryUsage(
@@ -117,12 +120,17 @@ export function normalizeRunTelemetryUsage(
 ): RunTelemetryUsage | undefined {
   const inputTokens = usage.inputTokens ?? usage.promptTokens;
   const outputTokens = usage.outputTokens ?? usage.completionTokens;
+  // AI SDK v7 moved these under token detail objects; v6 kept them top-level.
+  const reasoningTokens =
+    usage.reasoningTokens ?? usage.outputTokenDetails?.reasoningTokens;
+  const cachedInputTokens =
+    usage.cachedInputTokens ?? usage.inputTokenDetails?.cacheReadTokens;
 
   if (
     inputTokens == null &&
     outputTokens == null &&
-    usage.reasoningTokens == null &&
-    usage.cachedInputTokens == null
+    reasoningTokens == null &&
+    cachedInputTokens == null
   ) {
     return undefined;
   }
@@ -130,11 +138,7 @@ export function normalizeRunTelemetryUsage(
   return {
     ...(inputTokens != null ? { inputTokens } : undefined),
     ...(outputTokens != null ? { outputTokens } : undefined),
-    ...(usage.reasoningTokens != null
-      ? { reasoningTokens: usage.reasoningTokens }
-      : undefined),
-    ...(usage.cachedInputTokens != null
-      ? { cachedInputTokens: usage.cachedInputTokens }
-      : undefined),
+    ...(reasoningTokens != null ? { reasoningTokens } : undefined),
+    ...(cachedInputTokens != null ? { cachedInputTokens } : undefined),
   };
 }

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
@@ -61,5 +61,19 @@ describe("extractAuiV0", () => {
     expect(result?.outputTokens).toBe(6);
     expect(result?.cachedInputTokens).toBe(9);
     expect(result?.reasoningTokens).toBe(2);
+    expect(result?.steps).toEqual([
+      {
+        input_tokens: 10,
+        output_tokens: 4,
+        reasoning_tokens: 1,
+        cached_input_tokens: 6,
+      },
+      {
+        input_tokens: 5,
+        output_tokens: 2,
+        reasoning_tokens: 1,
+        cached_input_tokens: 3,
+      },
+    ]);
   });
 });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
@@ -31,4 +31,35 @@ describe("extractAuiV0", () => {
     expect(result?.inputTokens).toBe(1);
     expect(result?.outputTokens).toBe(2);
   });
+
+  it("sums step usage reported under the AI SDK v7 token details", () => {
+    const result = extractAuiV0({
+      ...auiV0Message({ type: "complete" }),
+      metadata: {
+        steps: [
+          {
+            usage: {
+              inputTokens: 10,
+              outputTokens: 4,
+              inputTokenDetails: { cacheReadTokens: 6 },
+              outputTokenDetails: { reasoningTokens: 1 },
+            },
+          },
+          {
+            usage: {
+              inputTokens: 5,
+              outputTokens: 2,
+              inputTokenDetails: { cacheReadTokens: 3 },
+              outputTokenDetails: { reasoningTokens: 1 },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result?.inputTokens).toBe(15);
+    expect(result?.outputTokens).toBe(6);
+    expect(result?.cachedInputTokens).toBe(9);
+    expect(result?.reasoningTokens).toBe(2);
+  });
 });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -446,20 +446,25 @@ export function extractAuiV0<T>(content: T): TelemetryData | null {
 
   const telemetrySteps: TelemetryStepData[] | undefined =
     steps && steps.length > 1
-      ? steps.map((s) => ({
-          ...(s.usage?.inputTokens != null
-            ? { input_tokens: s.usage.inputTokens }
-            : undefined),
-          ...(s.usage?.outputTokens != null
-            ? { output_tokens: s.usage.outputTokens }
-            : undefined),
-          ...(s.usage?.reasoningTokens != null
-            ? { reasoning_tokens: s.usage.reasoningTokens }
-            : undefined),
-          ...(s.usage?.cachedInputTokens != null
-            ? { cached_input_tokens: s.usage.cachedInputTokens }
-            : undefined),
-        }))
+      ? steps.map((s) => {
+          const usage = s.usage
+            ? normalizeRunTelemetryUsage(s.usage)
+            : undefined;
+          return {
+            ...(usage?.inputTokens != null
+              ? { input_tokens: usage.inputTokens }
+              : undefined),
+            ...(usage?.outputTokens != null
+              ? { output_tokens: usage.outputTokens }
+              : undefined),
+            ...(usage?.reasoningTokens != null
+              ? { reasoning_tokens: usage.reasoningTokens }
+              : undefined),
+            ...(usage?.cachedInputTokens != null
+              ? { cached_input_tokens: usage.cachedInputTokens }
+              : undefined),
+          };
+        })
       : undefined;
 
   return {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -364,14 +364,7 @@ export function extractAuiV0<T>(content: T): TelemetryData | null {
     }[];
     metadata?: {
       modelId?: string;
-      steps?: readonly {
-        usage?: {
-          inputTokens?: number;
-          outputTokens?: number;
-          reasoningTokens?: number;
-          cachedInputTokens?: number;
-        };
-      }[];
+      steps?: readonly { usage?: RunTelemetryUsageInit }[];
       custom?: Record<string, unknown> & { modelId?: string };
     };
   };
@@ -414,20 +407,23 @@ export function extractAuiV0<T>(content: T): TelemetryData | null {
     let hasReasoning = false;
     let hasCachedInput = false;
     for (const step of steps) {
-      if (step.usage?.inputTokens != null) {
-        totalInput += step.usage.inputTokens;
+      if (!step.usage) continue;
+      const usage = normalizeRunTelemetryUsage(step.usage);
+      if (!usage) continue;
+      if (usage.inputTokens != null) {
+        totalInput += usage.inputTokens;
         hasInput = true;
       }
-      if (step.usage?.outputTokens != null) {
-        totalOutput += step.usage.outputTokens;
+      if (usage.outputTokens != null) {
+        totalOutput += usage.outputTokens;
         hasOutput = true;
       }
-      if (step.usage?.reasoningTokens != null) {
-        totalReasoning += step.usage.reasoningTokens;
+      if (usage.reasoningTokens != null) {
+        totalReasoning += usage.reasoningTokens;
         hasReasoning = true;
       }
-      if (step.usage?.cachedInputTokens != null) {
-        totalCachedInput += step.usage.cachedInputTokens;
+      if (usage.cachedInputTokens != null) {
+        totalCachedInput += usage.cachedInputTokens;
         hasCachedInput = true;
       }
     }


### PR DESCRIPTION
## Problem

on AI SDK v7, cloud run telemetry silently loses the cached input and reasoning token counts. a run reports `inputTokens` and `outputTokens` but never `cachedInputTokens` or `reasoningTokens`, so the cache hit rate and reasoning spend read as zero for every v7 host.

## Root cause

`normalizeRunTelemetryUsage` reads `usage.reasoningTokens` and `usage.cachedInputTokens` off the top level. v6 put them there; v7 moved them into detail objects and dropped the top-level names entirely (`ai@7.0.77`, `LanguageModelUsage`):

```ts
inputTokenDetails: { noCacheTokens, cacheReadTokens, cacheWriteTokens }
outputTokenDetails: { textTokens, reasoningTokens }
```

so on v7 both reads are `undefined` and the counts never reach the run record. `@assistant-ui/cloud-ai-sdk` inherits the same gap because it normalizes through the same helper.

`extractAuiV0` in core had a second copy of the problem: both its per-step totals and the per-step `steps` breakdown it reports alongside them read their own inline v6-shaped literal instead of going through the helper at all, so a v7 step contributed nothing to the cached or reasoning numbers on either surface.

## Change

`normalizeRunTelemetryUsage` now resolves each count across every name the SDK has used, preferring the top-level value and falling back to the nested one:

- `reasoningTokens ?? outputTokenDetails.reasoningTokens`
- `cachedInputTokens ?? inputTokenDetails.cacheReadTokens`

`RunTelemetryUsageInit` gains the two detail objects, so the input type describes v6 and v7 in one shape rather than a per-major branch. the undefined-when-empty contract is unchanged: a usage object carrying only empty detail objects still returns undefined, so callers can still tell an absent usage from a zeroed one.

`extractAuiV0` drops its inline step-usage literal for `RunTelemetryUsageInit` and reads through the normalizer in both places it touches usage, the totals and the `steps` breakdown, so the aggregate and the per-step rows cannot disagree about the same run. `extractAiSdkV6Usage` already normalized, and is unchanged.

this is the union-satellite posture from AGENTS.md working as intended: `@assistant-ui/cloud-ai-sdk` advertises `ai: ^6.0.0 || ^7.0.0`, so both legs have to keep working, and the fix lives in the shared normalizer rather than a v7-only path.

## Verification

- `packages/cloud` `vitest run src/runTelemetry.test.ts`: 15/15 green, covering the v7 detail objects, the top-level-wins precedence, nested-only counts, and empty detail objects still returning undefined.
- `packages/cloud-ai-sdk` `vitest run src/core/extractRunTelemetry.test.ts`: 13/13 green, including a v7 assistant message whose usage carries only the detail objects.
- `packages/core` `vitest run src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts`: 10/10 green. the added case feeds a two-step v7 payload and asserts both the totals (9 cached, 2 reasoning) and the exact `steps` rows, so it fails on the unnormalized per-step read as well as the unnormalized totals.
- a repo-wide sweep for `cachedInputTokens`, `reasoningTokens`, `cacheReadTokens`, `inputTokenDetails`, and `outputTokenDetails` confirms no remaining reader of the v6-only names on a v7-reachable path.
- the field names are read off the pinned `ai@7.0.77` `LanguageModelUsage` declaration, not from memory.

## Public surface

`assistant-cloud` and `@assistant-ui/core`, both patch (changeset added). `RunTelemetryUsageInit` gains two optional properties; nothing is removed or renamed.