### PR TITLE
fix(core): cancel frame tools after provider removal

### DIFF
--- a/.changeset/calm-frames-cancel.md
+++ b/.changeset/calm-frames-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: cancel AssistantFrame tool calls when their provider is removed

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -362,6 +362,44 @@ describe("AssistantFrameProvider", () => {
     expect(toolSignal?.aborted).toBe(true);
   });
 
+  it("cancels only calls owned by the removed provider", async () => {
+    const shadowedExecute = vi.fn(async () => "shadowed");
+    const removeShadowed = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute: shadowedExecute } },
+      }),
+    });
+
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    const removeOwner = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({
+        tools: { sensitiveTool: { execute } },
+      }),
+    });
+
+    dispatchToolCall(window.location.origin);
+    await vi.waitFor(() => expect(toolSignal).toBeDefined());
+    expect(shadowedExecute).not.toHaveBeenCalled();
+
+    removeShadowed();
+    expect(toolSignal?.aborted).toBe(false);
+
+    removeOwner();
+    expect(toolSignal?.aborted).toBe(true);
+  });
+
   it("upgrades a wildcard origin policy when a strict provider registers", async () => {
     AssistantFrameProvider.addModelContextProvider(
       { getModelContext: () => ({}) },

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -284,6 +284,84 @@ describe("AssistantFrameProvider", () => {
     expect(toolResults).toHaveLength(1);
   });
 
+  it("aborts in-flight tool calls when their provider is removed", async () => {
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    const removeProvider = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
+    });
+
+    dispatchToolCall(window.location.origin);
+    await vi.waitFor(() => expect(toolSignal).toBeDefined());
+
+    removeProvider();
+
+    expect(toolSignal?.aborted).toBe(true);
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: {
+          type: "tool-result",
+          id: "tool-call-1",
+          error: "AssistantFrame tool provider has been removed",
+        },
+      },
+      { targetOrigin: window.location.origin },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const toolResults = vi
+      .mocked(parentWindow.postMessage)
+      .mock.calls.filter(
+        ([data]) =>
+          (data as { message?: { type?: string } }).message?.type ===
+          "tool-result",
+      );
+    expect(toolResults).toHaveLength(1);
+  });
+
+  it("keeps tool calls active while the same provider remains registered", async () => {
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    const provider = {
+      getModelContext: () => ({ tools: { sensitiveTool: { execute } } }),
+    };
+    const removeFirst =
+      AssistantFrameProvider.addModelContextProvider(provider);
+    const removeSecond =
+      AssistantFrameProvider.addModelContextProvider(provider);
+
+    dispatchToolCall(window.location.origin);
+    await vi.waitFor(() => expect(toolSignal).toBeDefined());
+
+    removeFirst();
+    expect(toolSignal?.aborted).toBe(false);
+
+    removeSecond();
+    expect(toolSignal?.aborted).toBe(true);
+  });
+
   it("upgrades a wildcard origin policy when a strict provider registers", async () => {
     AssistantFrameProvider.addModelContextProvider(
       { getModelContext: () => ({}) },

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -559,6 +559,48 @@ describe("AssistantFrameProvider", () => {
     ).not.toThrow();
   });
 
+  it("cancels reentrant tool calls when registration rolls back", async () => {
+    let toolSignal: AbortSignal | undefined;
+    const execute = vi.fn(
+      async (_args: unknown, context: { abortSignal: AbortSignal }) => {
+        toolSignal = context.abortSignal;
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+
+    expect(() =>
+      AssistantFrameProvider.addModelContextProvider({
+        getModelContext: () => ({
+          tools: { sensitiveTool: { execute } },
+        }),
+        subscribe: () => {
+          dispatchToolCall(window.location.origin);
+          throw new Error("subscribe failed");
+        },
+      }),
+    ).toThrow("subscribe failed");
+
+    expect(toolSignal?.aborted).toBe(true);
+    expect(parentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message: {
+          type: "tool-result",
+          id: "tool-call-1",
+          error: "AssistantFrame tool provider has been removed",
+        },
+      },
+      { targetOrigin: window.location.origin },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   it("keeps an existing registration when the same provider fails to register again", async () => {
     const execute = vi.fn(async () => "result");
     const firstUnsubscribe = vi.fn();

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -13,6 +13,7 @@ describe("AssistantFrameProvider", () => {
     origin: string,
     source: Window = parentWindow,
     id = "tool-call-1",
+    toolName = "sensitiveTool",
   ) => {
     messageHandler?.(
       new MessageEvent("message", {
@@ -21,7 +22,7 @@ describe("AssistantFrameProvider", () => {
           message: {
             type: "tool-call",
             id,
-            toolName: "sensitiveTool",
+            toolName,
             args: {},
           },
         },
@@ -398,6 +399,63 @@ describe("AssistantFrameProvider", () => {
 
     removeOwner();
     expect(toolSignal?.aborted).toBe(true);
+  });
+
+  it("keeps other providers' tool calls active when one is removed", async () => {
+    const signals = new Map<string, AbortSignal>();
+    const execute = vi.fn(
+      async (
+        _args: unknown,
+        context: { toolCallId: string; abortSignal: AbortSignal },
+      ) => {
+        signals.set(context.toolCallId, context.abortSignal);
+        await new Promise<never>((_resolve, reject) => {
+          context.abortSignal.addEventListener(
+            "abort",
+            () => reject(context.abortSignal.reason),
+            { once: true },
+          );
+        });
+      },
+    );
+    const removeFirst = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { firstTool: { execute } } }),
+    });
+    const removeSecond = AssistantFrameProvider.addModelContextProvider({
+      getModelContext: () => ({ tools: { secondTool: { execute } } }),
+    });
+
+    dispatchToolCall(
+      window.location.origin,
+      parentWindow,
+      "first-call",
+      "firstTool",
+    );
+    dispatchToolCall(
+      window.location.origin,
+      parentWindow,
+      "second-call",
+      "secondTool",
+    );
+    await vi.waitFor(() => expect(signals.size).toBe(2));
+
+    removeFirst();
+
+    expect(signals.get("first-call")?.aborted).toBe(true);
+    expect(signals.get("second-call")?.aborted).toBe(false);
+    const toolResults = vi
+      .mocked(parentWindow.postMessage)
+      .mock.calls.filter(
+        ([data]) =>
+          (data as { message?: { type?: string } }).message?.type ===
+          "tool-result",
+      );
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0]?.[0]).toMatchObject({
+      message: { id: "first-call" },
+    });
+
+    removeSecond();
   });
 
   it("upgrades a wildcard origin policy when a strict provider registers", async () => {

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -314,8 +314,18 @@ export class AssistantFrameProvider {
 
       instance.broadcastUpdate();
     } catch (error) {
-      const { unsubscribe } = instance.removeProvider(id, origin);
+      const { unsubscribe, removedProvider } = instance.removeProvider(
+        id,
+        origin,
+      );
       // Rollback failures must not replace the registration error.
+      try {
+        if (removedProvider) {
+          instance.cancelToolCallsForProvider(removedProvider);
+        }
+      } catch (cancelError) {
+        console.error(cancelError);
+      }
       try {
         unsubscribe?.();
       } catch (unsubscribeError) {

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -38,7 +38,11 @@ export class AssistantFrameProvider {
   private _providerUnsubscribes = new Map<symbol, Unsubscribe | undefined>();
   private _activeToolCalls = new Map<
     string,
-    { abortController: AbortController; event: MessageEvent }
+    {
+      abortController: AbortController;
+      event: MessageEvent;
+      provider: ModelContextProvider | undefined;
+    }
   >();
   private _targetOrigin: string;
   private _strictRegistrations = 0;
@@ -115,10 +119,15 @@ export class AssistantFrameProvider {
     message: Extract<FrameMessage, { type: "tool-call" }>,
     event: MessageEvent,
   ) {
-    const tool = this.getModelContext().tools?.[message.toolName];
+    const resolvedTool = this.getTool(message.toolName);
+    const tool = resolvedTool?.tool;
     const abortController = new AbortController();
     this._activeToolCalls.get(message.id)?.abortController.abort();
-    const activeCall = { abortController, event };
+    const activeCall = {
+      abortController,
+      event,
+      provider: resolvedTool?.provider,
+    };
     this._activeToolCalls.set(message.id, activeCall);
 
     let result: any;
@@ -161,6 +170,20 @@ export class AssistantFrameProvider {
     activeCall.abortController.abort();
   }
 
+  private cancelToolCallsForProvider(provider: ModelContextProvider) {
+    this._activeToolCalls.forEach((activeCall, id) => {
+      if (activeCall.provider !== provider) return;
+
+      this._activeToolCalls.delete(id);
+      activeCall.abortController.abort();
+      this.sendMessage(activeCall.event, {
+        type: "tool-result",
+        id,
+        error: "AssistantFrame tool provider has been removed",
+      });
+    });
+  }
+
   private sendMessage(event: MessageEvent, message: FrameMessage) {
     event.source?.postMessage(
       { channel: FRAME_MESSAGE_CHANNEL, message },
@@ -168,9 +191,26 @@ export class AssistantFrameProvider {
     );
   }
 
+  private getProviders() {
+    return Array.from(new Set(this._providers.values()));
+  }
+
+  private getTool(toolName: string) {
+    let resolved:
+      | { provider: ModelContextProvider; tool: Tool<any, any> }
+      | undefined;
+
+    for (const provider of this.getProviders()) {
+      const tool = provider.getModelContext().tools?.[toolName];
+      if (tool) resolved = { provider, tool };
+    }
+
+    return resolved;
+  }
+
   private getModelContext(): ModelContext {
-    const contexts = Array.from(new Set(this._providers.values())).map((p) =>
-      p.getModelContext(),
+    const contexts = this.getProviders().map((provider) =>
+      provider.getModelContext(),
     );
 
     return contexts.reduce(
@@ -200,7 +240,14 @@ export class AssistantFrameProvider {
     }
   }
 
-  private removeProvider(id: symbol, origin: string): Unsubscribe | undefined {
+  private removeProvider(
+    id: symbol,
+    origin: string,
+  ): {
+    unsubscribe: Unsubscribe | undefined;
+    removedProvider: ModelContextProvider | undefined;
+  } {
+    const provider = this._providers.get(id);
     this._providers.delete(id);
     const unsubscribe = this._providerUnsubscribes.get(id);
     this._providerUnsubscribes.delete(id);
@@ -219,7 +266,11 @@ export class AssistantFrameProvider {
           this._wildcardRegistrations > 0 ? "*" : getDefaultTargetOrigin();
       }
     }
-    return unsubscribe;
+    const removedProvider =
+      provider && !this.getProviders().includes(provider)
+        ? provider
+        : undefined;
+    return { unsubscribe, removedProvider };
   }
 
   static addModelContextProvider(
@@ -246,8 +297,18 @@ export class AssistantFrameProvider {
 
       instance.broadcastUpdate();
     } catch (error) {
-      const unsubscribe = instance.removeProvider(id, origin);
+      const { unsubscribe, removedProvider } = instance.removeProvider(
+        id,
+        origin,
+      );
       // Rollback failures must not replace the registration error.
+      try {
+        if (removedProvider) {
+          instance.cancelToolCallsForProvider(removedProvider);
+        }
+      } catch (cancelError) {
+        console.error(cancelError);
+      }
       try {
         unsubscribe?.();
       } catch (unsubscribeError) {
@@ -265,22 +326,32 @@ export class AssistantFrameProvider {
     return () => {
       if (released) return;
       released = true;
-      const unsubscribe = instance.removeProvider(id, origin);
-      let unsubscribeFailed = false;
-      let unsubscribeError: unknown;
-      try {
-        unsubscribe?.();
-      } catch (error) {
-        unsubscribeFailed = true;
-        unsubscribeError = error;
+      const { unsubscribe, removedProvider } = instance.removeProvider(
+        id,
+        origin,
+      );
+      let cleanupFailed = false;
+      let cleanupError: unknown;
+      const runCleanup = (cleanup: () => void) => {
+        try {
+          cleanup();
+        } catch (error) {
+          if (cleanupFailed) {
+            console.error(error);
+          } else {
+            cleanupFailed = true;
+            cleanupError = error;
+          }
+        }
+      };
+
+      if (removedProvider) {
+        runCleanup(() => instance.cancelToolCallsForProvider(removedProvider));
       }
-      try {
-        instance.broadcastUpdate();
-      } catch (error) {
-        if (!unsubscribeFailed) throw error;
-        console.error(error);
-      }
-      if (unsubscribeFailed) throw unsubscribeError;
+      if (unsubscribe) runCleanup(unsubscribe);
+      runCleanup(() => instance.broadcastUpdate());
+
+      if (cleanupFailed) throw cleanupError;
     };
   }
 

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -171,17 +171,34 @@ export class AssistantFrameProvider {
   }
 
   private cancelToolCallsForProvider(provider: ModelContextProvider) {
-    this._activeToolCalls.forEach((activeCall, id) => {
-      if (activeCall.provider !== provider) return;
-
+    const matchingCalls = Array.from(this._activeToolCalls).filter(
+      ([, activeCall]) => activeCall.provider === provider,
+    );
+    for (const [id, activeCall] of matchingCalls) {
       this._activeToolCalls.delete(id);
       activeCall.abortController.abort();
-      this.sendMessage(activeCall.event, {
-        type: "tool-result",
-        id,
-        error: "AssistantFrame tool provider has been removed",
-      });
-    });
+    }
+
+    let sendFailed = false;
+    let sendError: unknown;
+    for (const [id, activeCall] of matchingCalls) {
+      try {
+        this.sendMessage(activeCall.event, {
+          type: "tool-result",
+          id,
+          error: "AssistantFrame tool provider has been removed",
+        });
+      } catch (error) {
+        if (sendFailed) {
+          console.error(error);
+        } else {
+          sendFailed = true;
+          sendError = error;
+        }
+      }
+    }
+
+    if (sendFailed) throw sendError;
   }
 
   private sendMessage(event: MessageEvent, message: FrameMessage) {
@@ -297,18 +314,8 @@ export class AssistantFrameProvider {
 
       instance.broadcastUpdate();
     } catch (error) {
-      const { unsubscribe, removedProvider } = instance.removeProvider(
-        id,
-        origin,
-      );
+      const { unsubscribe } = instance.removeProvider(id, origin);
       // Rollback failures must not replace the registration error.
-      try {
-        if (removedProvider) {
-          instance.cancelToolCallsForProvider(removedProvider);
-        }
-      } catch (cancelError) {
-        console.error(cancelError);
-      }
       try {
         unsubscribe?.();
       } catch (unsubscribeError) {


### PR DESCRIPTION
## Problem

Removing an AssistantFrame model-context provider leaves its in-flight tool executions running. A provider can disappear during unmount or an account/workspace switch, but its old requests and side effects continue.

The minimal reproduction starts a pending frame tool, releases its provider, and observes that the tool signal remains un-aborted on current main.

## Root cause

Active frame calls tracked only their abort controller and message event. Provider removal had no way to identify which calls belonged to the removed provider.

## Change

Resolve each tool together with the provider that supplied the winning model-context definition and retain that ownership for the active call. Releasing the final registration for that provider now aborts only its calls and immediately sends the host a structured error result.

Repeated registrations of the same provider keep their calls alive until the final registration is released, preserving the existing provider deduplication behavior.

## Verification

- Confirmed the regression test fails on current main and passes with this change
- `vitest run src/model-context/frame/provider.test.ts`: 25 tests passed
- Full `@assistant-ui/core` suite: 155 files and 1,610 tests passed
- `aui-build` for `@assistant-ui/core`
- Targeted oxlint and oxfmt checks
- `node scripts/check-changesets.mjs`

## Public surface

`@assistant-ui/core` behavior only. No exports, API-reference pages, templates, or public types change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.G4GnJFvgGqx15dm-WLgPtpIU8PWlAsRlmS9gJAXkLvRrUbOQXrAngEdlM6U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->