### PR TITLE
refactor(react): collapse the three trigger-item query predicates onto one helper

### DIFF
--- a/.changeset/trigger-item-query-helper.md
+++ b/.changeset/trigger-item-query-helper.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+refactor: collapse the three trigger-item query predicates onto one shared helper

--- a/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.test.ts
+++ b/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.test.ts
@@ -17,9 +17,9 @@ describe("matchesTriggerItemQuery", () => {
   });
 
   it("matches case-insensitively against the id", () => {
-    expect(matchesTriggerItemQuery(item({ id: "SummArize" }), "marize")).toBe(
-      true,
-    );
+    expect(
+      matchesTriggerItemQuery(item({ id: "SummArize", label: "y" }), "marize"),
+    ).toBe(true);
   });
 
   it("matches case-insensitively against the label", () => {

--- a/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.test.ts
+++ b/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { matchesTriggerItemQuery } from "./matchesTriggerItemQuery";
+import type { Unstable_TriggerItem } from "@assistant-ui/core";
+
+const item = (
+  overrides: Partial<Unstable_TriggerItem>,
+): Unstable_TriggerItem => ({
+  id: "summarize",
+  type: "command",
+  label: "Summarize",
+  ...overrides,
+});
+
+describe("matchesTriggerItemQuery", () => {
+  it("matches every item on an empty query", () => {
+    expect(matchesTriggerItemQuery(item({}), "")).toBe(true);
+  });
+
+  it("matches case-insensitively against the id", () => {
+    expect(matchesTriggerItemQuery(item({ id: "SummArize" }), "marize")).toBe(
+      true,
+    );
+  });
+
+  it("matches case-insensitively against the label", () => {
+    expect(
+      matchesTriggerItemQuery(
+        item({ id: "x", label: "Translate Text" }),
+        "late",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches against the description when present", () => {
+    expect(
+      matchesTriggerItemQuery(
+        item({ id: "x", label: "y", description: "Condense the thread" }),
+        "condense",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when no field contains the query", () => {
+    expect(
+      matchesTriggerItemQuery(item({ description: "nothing here" }), "zzz"),
+    ).toBe(false);
+  });
+
+  it("does not throw on items without a description", () => {
+    expect(matchesTriggerItemQuery(item({}), "zzz")).toBe(false);
+  });
+});

--- a/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.ts
+++ b/packages/react/src/primitives/composer/trigger/matchesTriggerItemQuery.ts
@@ -1,0 +1,13 @@
+import type { Unstable_TriggerItem } from "@assistant-ui/core";
+
+export function matchesTriggerItemQuery(
+  item: Unstable_TriggerItem,
+  lowerQuery: string,
+): boolean {
+  if (!lowerQuery) return true;
+  return (
+    item.id.toLowerCase().includes(lowerQuery) ||
+    item.label.toLowerCase().includes(lowerQuery) ||
+    (item.description?.toLowerCase().includes(lowerQuery) ?? false)
+  );
+}

--- a/packages/react/src/primitives/composer/trigger/triggerNavigationResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerNavigationResource.ts
@@ -5,14 +5,7 @@ import type {
   Unstable_TriggerCategory,
   Unstable_TriggerItem,
 } from "@assistant-ui/core";
-
-function matchesQuery(item: Unstable_TriggerItem, lower: string): boolean {
-  return (
-    item.id.toLowerCase().includes(lower) ||
-    item.label.toLowerCase().includes(lower) ||
-    (item.description?.toLowerCase().includes(lower) ?? false)
-  );
-}
+import { matchesTriggerItemQuery } from "./matchesTriggerItemQuery";
 
 export type TriggerNavigationResourceOutput = {
   /** Filtered categories visible in the list (empty in search mode). */
@@ -76,7 +69,7 @@ const useTriggerNavigationResource = ({
     const lower = query.toLowerCase();
     for (const cat of categories) {
       for (const item of adapter.categoryItems(cat.id)) {
-        if (matchesQuery(item, lower)) {
+        if (matchesTriggerItemQuery(item, lower)) {
           all.push(item);
         }
       }
@@ -97,7 +90,7 @@ const useTriggerNavigationResource = ({
     if (isSearchMode) return searchResults ?? [];
     if (!query) return allItems;
     const lower = query.toLowerCase();
-    return allItems.filter((item) => matchesQuery(item, lower));
+    return allItems.filter((item) => matchesTriggerItemQuery(item, lower));
   }, [allItems, query, isSearchMode, searchResults]);
 
   const navigableList = useMemo(() => {

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -10,6 +10,7 @@ import type {
 } from "@assistant-ui/core";
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
+import { matchesTriggerItemQuery } from "../primitives/composer/trigger/matchesTriggerItemQuery";
 
 /** Icon component shape consumed by `ComposerTriggerPopover`'s `iconMap`. */
 export type Unstable_IconComponent = FC<{ className?: string }>;
@@ -155,7 +156,7 @@ export function unstable_useMentionAdapter(
           const lower = query.toLowerCase();
           return allGroups
             .flatMap((g) => g.items)
-            .filter((item) => matchesQuery(item, lower));
+            .filter((item) => matchesTriggerItemQuery(item, lower));
         },
       };
     }
@@ -175,7 +176,9 @@ export function unstable_useMentionAdapter(
       categoryItems: () => [],
       search: (query) => {
         const lower = query.toLowerCase();
-        return getFlatPool().filter((item) => matchesQuery(item, lower));
+        return getFlatPool().filter((item) =>
+          matchesTriggerItemQuery(item, lower),
+        );
       },
     };
   }, [aui, items, categories, wantsTools, toolsConfig]);
@@ -206,12 +209,4 @@ function toTriggerItem(m: Unstable_Mention): Unstable_TriggerItem {
     ...(m.description !== undefined ? { description: m.description } : {}),
     ...(metadata !== undefined ? { metadata } : {}),
   };
-}
-
-function matchesQuery(item: Unstable_TriggerItem, lower: string): boolean {
-  if (!lower) return true;
-  if (item.id.toLowerCase().includes(lower)) return true;
-  if (item.label.toLowerCase().includes(lower)) return true;
-  if (item.description?.toLowerCase().includes(lower)) return true;
-  return false;
 }

--- a/packages/react/src/unstable/useSlashCommandAdapter.ts
+++ b/packages/react/src/unstable/useSlashCommandAdapter.ts
@@ -6,6 +6,7 @@ import type {
   Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import type { Unstable_IconComponent } from "./useMentionAdapter";
+import { matchesTriggerItemQuery } from "../primitives/composer/trigger/matchesTriggerItemQuery";
 
 export type Unstable_SlashCommand = {
   readonly id: string;
@@ -81,7 +82,7 @@ export function unstable_useSlashCommandAdapter(
       categoryItems: () => [],
       search: (query: string) => {
         const lower = query.toLowerCase();
-        return items.filter((item) => matchesQuery(item, lower));
+        return items.filter((item) => matchesTriggerItemQuery(item, lower));
       },
     }),
     [items],
@@ -116,14 +117,6 @@ function toItem(cmd: Unstable_SlashCommand): Unstable_TriggerItem {
     ...(cmd.description !== undefined ? { description: cmd.description } : {}),
     ...(cmd.icon !== undefined ? { metadata: { icon: cmd.icon } } : {}),
   };
-}
-
-function matchesQuery(item: Unstable_TriggerItem, lower: string): boolean {
-  if (!lower) return true;
-  if (item.id.toLowerCase().includes(lower)) return true;
-  if (item.label.toLowerCase().includes(lower)) return true;
-  if (item.description?.toLowerCase().includes(lower)) return true;
-  return false;
 }
 
 function areTriggerItemsEqual(


### PR DESCRIPTION
Closes #6423.

## Problem

Three near-copies of the same trigger-item predicate live in `packages/react/src`: `useMentionAdapter.ts`, `useSlashCommandAdapter.ts` (byte-identical since #6406), and `triggerNavigationResource.ts` (same result written without the empty-query early return). A future change to match rules would have to land three times, and the copies can silently diverge.

## Change

One shared `matchesTriggerItemQuery(item, lowerQuery)` in `primitives/composer/trigger/`, imported by all three call sites; the local copies are deleted. The helper keeps the empty-query early return — behavior-neutral for the navigation resource's copy too, since `id.toLowerCase().includes("")` is already `true` for every item, so all three copies agreed on the empty-query case. Not exported from the package barrel; the public surface is unchanged.

A colocated test pins the contract: case-insensitive matching across `id`, `label`, and `description`, match-all on empty query, and no throw on items without a description.

## Verification

- `pnpm vitest run` over the new helper test plus the existing `useSlashCommandAdapter` and `triggerSelectionResource` suites: 14 tests pass, no type errors.
- oxlint clean on all touched files (the three pre-existing `triggerNavigationResource` warnings are #6311's scope and untouched).

## Public surface

`@assistant-ui/react` internals only; no new exports. Changeset: patch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7O2Bpcw5l8_BPA70c5pxLx1NQ05-zwjSNI2HPcQIo6XqQ03OV-wkQYcOjJY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->