### PR TITLE
fix(react): refresh model context mentions and honor explicit tool categories

### DIFF
--- a/.changeset/fresh-mentions-update.md
+++ b/.changeset/fresh-mentions-update.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): keep model-context mentions current and honor explicit tool categories without requiring custom categories

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -290,9 +290,9 @@ const mention = unstable_useMentionAdapter({
 
 | Option | Type | Behavior |
 | --- | --- | --- |
-| `items` | `Unstable_Mention[]` | Flat list (ignored when `categories` is set) |
+| `items` | `Unstable_Mention[]` | Flat list (ignored when `categories` is set); supplying it keeps the adapter flat even when a tool `category` is configured |
 | `categories` | `{id, label, items}[]` | Drill-down groups |
-| `includeModelContextTools` | `boolean \| object` | Default: `true` iff neither `items` nor `categories` |
+| `includeModelContextTools` | `boolean \| object` | Default: `true` iff neither `items` nor `categories`; an object `category` selects drill-down on its own unless `items` is given |
 | `formatter` | `Unstable_DirectiveFormatter` | Override directive serialization (default: `unstable_defaultDirectiveFormatter`) |
 | `onInserted` | `(item) => void` | Fires after the directive is inserted into the composer |
 | `iconMap` | `Record<string, IconComponent>` | Maps `metadata.icon` / category `id` strings to React components |

--- a/apps/docs/content/elements/composer-mentions.mdx
+++ b/apps/docs/content/elements/composer-mentions.mdx
@@ -195,6 +195,8 @@ const mention = unstable_useMentionAdapter({
 });
 ```
 
+Naming a `category` puts the tools behind a drill-down entry instead of listing them flat. Pass `items` alongside it to keep the flat list.
+
 </RuntimeMode>
 
 ### Restyle the menu

--- a/apps/docs/content/elements/composer-mentions.mdx
+++ b/apps/docs/content/elements/composer-mentions.mdx
@@ -191,11 +191,11 @@ Leaving `items` and `categories` unset (or passing `includeModelContextTools: tr
 
 ```tsx
 const mention = unstable_useMentionAdapter({
-  includeModelContextTools: { category: { id: "tools", label: "Tools" } },
+  includeModelContextTools: true,
 });
 ```
 
-Naming a `category` puts the tools behind a drill-down entry instead of listing them flat. Pass `items` alongside it to keep the flat list.
+Passing `includeModelContextTools: { category }` instead puts the tools behind a drill-down entry rather than listing them flat, unless `items` is also given.
 
 </RuntimeMode>
 

--- a/apps/docs/content/elements/composer-mentions.mdx
+++ b/apps/docs/content/elements/composer-mentions.mdx
@@ -226,9 +226,9 @@ Both lanes render into `ComposerMenu`; the avatar circle, name, and role label a
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `items` | `Unstable_Mention[]` | Flat list: `{ id, type, label, description?, icon?, metadata? }`. |
-| `categories` | `Unstable_MentionCategory[]` | Grouped mentions for drill-down navigation; ignored if `items` is set. |
-| `includeModelContextTools` | `boolean \| { category?, formatLabel?, icon? }` | Include tools from `aui.thread.getModelContext()`. @default `true` when neither `items` nor `categories` is given |
+| `items` | `Unstable_Mention[]` | Flat list: `{ id, type, label, description?, icon?, metadata? }`; supplying it keeps the adapter flat even when a tool `category` is configured. |
+| `categories` | `Unstable_MentionCategory[]` | Grouped mentions for drill-down navigation; takes precedence over `items`. |
+| `includeModelContextTools` | `boolean \| { category?, formatLabel?, icon? }` | Include tools from `aui.thread.getModelContext()`; an object `category` selects drill-down on its own unless `items` is given. @default `true` when neither `items` nor `categories` is given |
 | `formatter` | `Unstable_DirectiveFormatter` | @default `unstable_defaultDirectiveFormatter` |
 | `onInserted` | `(item) => void` | Fires after the directive text lands in the composer. |
 

--- a/packages/react/src/unstable/useMentionAdapter.test.tsx
+++ b/packages/react/src/unstable/useMentionAdapter.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import {
+  createTapRoot,
+  flushTapSync,
+  resource,
+  useResource,
+} from "@assistant-ui/tap";
+import type { Unstable_TriggerAdapter } from "@assistant-ui/core";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TriggerNavigationResource } from "../primitives/composer/trigger/triggerNavigationResource";
+import { unstable_useMentionAdapter } from "./useMentionAdapter";
+
+const runtime = vi.hoisted(() => {
+  const state = {
+    tools: {} as Record<string, { description?: string }>,
+  };
+  const listeners = new Map<string, Set<() => void>>();
+  const events: string[] = [];
+  return {
+    state,
+    listeners,
+    events,
+    client: {
+      thread: {
+        getModelContext: () => ({ tools: state.tools }),
+      },
+      on: (event: string, listener: () => void) => {
+        events.push(event);
+        const eventListeners = listeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        listeners.set(event, eventListeners);
+        return () => eventListeners.delete(listener);
+      },
+    },
+    emit: (event: string) =>
+      listeners.get(event)?.forEach((listener) => listener()),
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => runtime.client,
+}));
+
+const TestNavigationResource = resource(function useTestNavigationResource(
+  initialAdapter: Unstable_TriggerAdapter,
+) {
+  const [adapter, setAdapter] = useState(initialAdapter);
+  const navigation = useResource(
+    TriggerNavigationResource({ adapter, query: "", open: true }),
+  );
+  return { navigation, setAdapter };
+});
+
+describe("unstable_useMentionAdapter", () => {
+  beforeEach(() => {
+    runtime.state.tools = {};
+    runtime.listeners.clear();
+    runtime.events.length = 0;
+  });
+
+  it("keeps categorized model-context tools current", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+    };
+
+    const { result } = renderHook(() =>
+      unstable_useMentionAdapter({
+        categories: [{ id: "people", label: "People", items: [] }],
+        includeModelContextTools: true,
+      }),
+    );
+    const initialAdapter = result.current.adapter;
+    const navigationRoot = createTapRoot(function NavigationRoot() {
+      return useResource(TestNavigationResource(initialAdapter));
+    });
+
+    expect(navigationRoot.getValue().navigation.categories).toEqual([
+      { id: "people", label: "People" },
+      { id: "tools", label: "Tools" },
+    ]);
+    expect(runtime.events).toContain("thread.modelContextUpdate");
+
+    act(() =>
+      flushTapSync(() =>
+        navigationRoot.getValue().navigation.selectCategory("tools"),
+      ),
+    );
+
+    expect(navigationRoot.getValue().navigation.items).toEqual([
+      {
+        id: "searchDocs",
+        type: "tool",
+        label: "searchDocs",
+        description: "Search documentation",
+      },
+    ]);
+
+    act(() => {
+      runtime.state.tools = {
+        createIssue: { description: "Create an issue" },
+      };
+      runtime.emit("thread.modelContextUpdate");
+    });
+
+    expect(result.current.adapter).not.toBe(initialAdapter);
+    flushTapSync(() =>
+      navigationRoot.getValue().setAdapter(result.current.adapter),
+    );
+    expect(navigationRoot.getValue().navigation.items).toEqual([
+      {
+        id: "createIssue",
+        type: "tool",
+        label: "createIssue",
+        description: "Create an issue",
+      },
+    ]);
+    act(() => {
+      runtime.state.tools = {};
+      runtime.emit("thread.modelContextUpdate");
+    });
+    flushTapSync(() =>
+      navigationRoot.getValue().setAdapter(result.current.adapter),
+    );
+
+    expect(navigationRoot.getValue().navigation.categories).toEqual([
+      { id: "people", label: "People" },
+    ]);
+    expect(navigationRoot.getValue().navigation.items).toEqual([]);
+    navigationRoot.unmount();
+  });
+
+  it("keeps flat model-context tools current while navigation is open", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+    };
+
+    const { result } = renderHook(() => unstable_useMentionAdapter());
+    const initialAdapter = result.current.adapter;
+    const navigationRoot = createTapRoot(function NavigationRoot() {
+      return useResource(TestNavigationResource(initialAdapter));
+    });
+
+    expect(runtime.events).toContain("thread.modelContextUpdate");
+
+    expect(navigationRoot.getValue().navigation.items).toEqual([
+      {
+        id: "searchDocs",
+        type: "tool",
+        label: "searchDocs",
+        description: "Search documentation",
+      },
+    ]);
+
+    act(() => {
+      runtime.state.tools = {
+        createIssue: { description: "Create an issue" },
+      };
+      runtime.emit("thread.modelContextUpdate");
+    });
+
+    expect(result.current.adapter).not.toBe(initialAdapter);
+    flushTapSync(() =>
+      navigationRoot.getValue().setAdapter(result.current.adapter),
+    );
+    expect(navigationRoot.getValue().navigation.items).toEqual([
+      {
+        id: "createIssue",
+        type: "tool",
+        label: "createIssue",
+        description: "Create an issue",
+      },
+    ]);
+    navigationRoot.unmount();
+  });
+
+  it("keeps adapter identity when tool mentions are unchanged", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+    };
+
+    const { result } = renderHook(() => unstable_useMentionAdapter());
+    const initialAdapter = result.current.adapter;
+
+    act(() => {
+      runtime.state.tools = {
+        searchDocs: { description: "Search documentation" },
+      };
+      runtime.emit("thread.modelContextUpdate");
+    });
+
+    expect(result.current.adapter).toBe(initialAdapter);
+  });
+
+  it("observes a description mutated in place on a stable tool object", () => {
+    const tool = { description: "Search documentation" };
+    runtime.state.tools = { searchDocs: tool };
+
+    const { result } = renderHook(() => unstable_useMentionAdapter());
+    const initialAdapter = result.current.adapter;
+
+    act(() => {
+      tool.description = "Search the docs site";
+      runtime.emit("thread.modelContextUpdate");
+    });
+
+    expect(result.current.adapter).not.toBe(initialAdapter);
+    expect(result.current.adapter.search?.("")).toEqual([
+      {
+        id: "searchDocs",
+        type: "tool",
+        label: "searchDocs",
+        description: "Search the docs site",
+      },
+    ]);
+  });
+
+  it("uses an explicit tool category without custom categories", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+    };
+
+    const { result } = renderHook(() =>
+      unstable_useMentionAdapter({
+        includeModelContextTools: {
+          category: { id: "actions", label: "Actions" },
+        },
+      }),
+    );
+
+    expect(result.current.adapter.categories()).toEqual([
+      { id: "actions", label: "Actions" },
+    ]);
+    expect(result.current.adapter.categoryItems("actions")).toEqual([
+      {
+        id: "searchDocs",
+        type: "tool",
+        label: "searchDocs",
+        description: "Search documentation",
+      },
+    ]);
+  });
+
+  it("keeps an async explicit item list flat when a tool category is configured", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+      createIssue: { description: "Create an issue" },
+    };
+
+    const { result, rerender } = renderHook(
+      ({
+        items,
+      }: {
+        items: readonly {
+          id: string;
+          type: string;
+          label: string;
+        }[];
+      }) =>
+        unstable_useMentionAdapter({
+          items,
+          includeModelContextTools: {
+            category: { id: "actions", label: "Actions" },
+          },
+        }),
+      { initialProps: { items: [] } },
+    );
+
+    expect(result.current.adapter.categories()).toEqual([]);
+
+    rerender({
+      items: [
+        {
+          id: "searchDocs",
+          type: "person",
+          label: "Documentation owner",
+        },
+      ],
+    });
+
+    expect(result.current.adapter.categories()).toEqual([]);
+    expect(result.current.adapter.search?.("")).toEqual([
+      {
+        id: "searchDocs",
+        type: "person",
+        label: "Documentation owner",
+      },
+      {
+        id: "createIssue",
+        type: "tool",
+        label: "createIssue",
+        description: "Create an issue",
+      },
+    ]);
+  });
+});

--- a/packages/react/src/unstable/useMentionAdapter.test.tsx
+++ b/packages/react/src/unstable/useMentionAdapter.test.tsx
@@ -27,7 +27,11 @@ const runtime = vi.hoisted(() => {
       thread: {
         getModelContext: () => ({ tools: state.tools }),
       },
-      on: (event: string, listener: () => void) => {
+      on: (
+        selector: string | { scope: string; event: string },
+        listener: () => void,
+      ) => {
+        const event = typeof selector === "string" ? selector : selector.event;
         events.push(event);
         const eventListeners = listeners.get(event) ?? new Set();
         eventListeners.add(listener);
@@ -107,8 +111,10 @@ describe("unstable_useMentionAdapter", () => {
     });
 
     expect(result.current.adapter).not.toBe(initialAdapter);
-    flushTapSync(() =>
-      navigationRoot.getValue().setAdapter(result.current.adapter),
+    act(() =>
+      flushTapSync(() =>
+        navigationRoot.getValue().setAdapter(result.current.adapter),
+      ),
     );
     expect(navigationRoot.getValue().navigation.items).toEqual([
       {
@@ -122,8 +128,10 @@ describe("unstable_useMentionAdapter", () => {
       runtime.state.tools = {};
       runtime.emit("thread.modelContextUpdate");
     });
-    flushTapSync(() =>
-      navigationRoot.getValue().setAdapter(result.current.adapter),
+    act(() =>
+      flushTapSync(() =>
+        navigationRoot.getValue().setAdapter(result.current.adapter),
+      ),
     );
 
     expect(navigationRoot.getValue().navigation.categories).toEqual([
@@ -163,8 +171,10 @@ describe("unstable_useMentionAdapter", () => {
     });
 
     expect(result.current.adapter).not.toBe(initialAdapter);
-    flushTapSync(() =>
-      navigationRoot.getValue().setAdapter(result.current.adapter),
+    act(() =>
+      flushTapSync(() =>
+        navigationRoot.getValue().setAdapter(result.current.adapter),
+      ),
     );
     expect(navigationRoot.getValue().navigation.items).toEqual([
       {
@@ -175,6 +185,34 @@ describe("unstable_useMentionAdapter", () => {
       },
     ]);
     navigationRoot.unmount();
+  });
+
+  it("refreshes tool mentions when the selected thread changes", () => {
+    runtime.state.tools = {
+      searchDocs: { description: "Search documentation" },
+    };
+
+    const { result } = renderHook(() => unstable_useMentionAdapter());
+    const initialAdapter = result.current.adapter;
+
+    expect(runtime.events).toContain("threads.selectionChanged");
+
+    act(() => {
+      runtime.state.tools = {
+        createIssue: { description: "Create an issue" },
+      };
+      runtime.emit("threads.selectionChanged");
+    });
+
+    expect(result.current.adapter).not.toBe(initialAdapter);
+    expect(result.current.adapter.search?.("")).toEqual([
+      {
+        id: "createIssue",
+        type: "tool",
+        label: "createIssue",
+        description: "Create an issue",
+      },
+    ]);
   });
 
   it("keeps adapter identity when tool mentions are unchanged", () => {

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -82,7 +82,7 @@ const EMPTY_TOOL_MENTIONS: Readonly<Record<string, string | undefined>> =
   Object.freeze({});
 
 // `getModelContext()` rebuilds its result on every call, so the fields the
-// adapter consumes are snapshotted on notify rather than read during render.
+// adapter consumes are snapshotted and compared rather than re-read per render.
 const readToolMentions = (aui: AssistantClient) => {
   const tools = aui.thread.getModelContext().tools;
   if (!tools) return EMPTY_TOOL_MENTIONS;

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -116,7 +116,19 @@ const useToolMentions = (aui: AssistantClient, enabled: boolean) => {
       );
     };
     read();
-    return aui.on("thread.modelContextUpdate", read);
+    const unsubscribeContext = aui.on("thread.modelContextUpdate", read);
+    // Rebinding the thread event subject to a new thread does not replay it,
+    // so a switch between threads carrying different providers is its own
+    // refresh trigger. Subscribed globally because a composer can render
+    // without a thread list scope.
+    const unsubscribeSelection = aui.on(
+      { scope: "*", event: "threads.selectionChanged" },
+      read,
+    );
+    return () => {
+      unsubscribeContext();
+      unsubscribeSelection();
+    };
   }, [aui, enabled]);
 
   return mentions;

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, type FC } from "react";
-import { useAui } from "@assistant-ui/store";
+import { useEffect, useMemo, useState, type FC } from "react";
+import { useAui, type AssistantClient } from "@assistant-ui/store";
 import type {
   Unstable_DirectiveFormatter,
   Unstable_TriggerAdapter,
@@ -32,7 +32,10 @@ export type Unstable_MentionCategory = {
 };
 
 export type Unstable_ModelContextToolsOptions = {
-  /** Wrap tools in a dedicated category (drill-down mode). */
+  /**
+   * Wrap tools in a dedicated category. Selects drill-down mode on its own
+   * when `categories` is unset and `items` is omitted.
+   */
   readonly category?: { readonly id: string; readonly label: string };
   /** Format tool name for display. */
   readonly formatLabel?: (toolName: string) => string;
@@ -41,7 +44,10 @@ export type Unstable_ModelContextToolsOptions = {
 };
 
 export type Unstable_UseMentionAdapterOptions = {
-  /** Flat mention list. Ignored when `categories` is set. */
+  /**
+   * Flat mention list. Ignored when `categories` is set, and keeps the
+   * adapter flat when a tool `category` is configured.
+   */
   readonly items?: readonly Unstable_Mention[];
   /** Categorized mentions for drill-down navigation. */
   readonly categories?: readonly Unstable_MentionCategory[];
@@ -50,7 +56,7 @@ export type Unstable_UseMentionAdapterOptions = {
    * - `false`: exclude.
    * - `true`: include (default when no `items`/`categories`; as a category
    *   if `categories` is set, flat otherwise).
-   * - object: explicit config.
+   * - object: explicit config; `category` also selects drill-down mode.
    *
    * Omitted → defaults to `true` iff neither `items` nor `categories`.
    */
@@ -70,6 +76,50 @@ export type Unstable_UseMentionAdapterOptions = {
 export type Unstable_MentionDirective = {
   readonly formatter: Unstable_DirectiveFormatter;
   readonly onInserted?: ((item: Unstable_TriggerItem) => void) | undefined;
+};
+
+const EMPTY_TOOL_MENTIONS: Readonly<Record<string, string | undefined>> =
+  Object.freeze({});
+
+// `getModelContext()` rebuilds its result on every call, so the fields the
+// adapter consumes are snapshotted on notify rather than read during render.
+const readToolMentions = (aui: AssistantClient) => {
+  const tools = aui.thread.getModelContext().tools;
+  if (!tools) return EMPTY_TOOL_MENTIONS;
+  const mentions: Record<string, string | undefined> = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    mentions[name] = tool.description;
+  }
+  return mentions;
+};
+
+const toolMentionsEqual = (
+  previous: Readonly<Record<string, string | undefined>>,
+  next: Readonly<Record<string, string | undefined>>,
+) => {
+  const names = Object.keys(previous);
+  if (names.length !== Object.keys(next).length) return false;
+  return names.every((name) => name in next && previous[name] === next[name]);
+};
+
+const useToolMentions = (aui: AssistantClient, enabled: boolean) => {
+  const [mentions, setMentions] = useState(() =>
+    enabled ? readToolMentions(aui) : EMPTY_TOOL_MENTIONS,
+  );
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const read = () => {
+      const next = readToolMentions(aui);
+      setMentions((previous) =>
+        toolMentionsEqual(previous, next) ? previous : next,
+      );
+    };
+    read();
+    return aui.on("thread.modelContextUpdate", read);
+  }, [aui, enabled]);
+
+  return mentions;
 };
 
 /**
@@ -104,50 +154,44 @@ export function unstable_useMentionAdapter(
   const wantsTools = includeTools !== false;
   const formatter = options?.formatter;
   const onInserted = options?.onInserted;
+  const isCategorized =
+    (categories !== undefined && categories.length > 0) ||
+    (toolsConfig?.category !== undefined && items === undefined);
+  const toolMentions = useToolMentions(aui, wantsTools);
 
   const adapter = useMemo<Unstable_TriggerAdapter>(() => {
-    const getModelContextTools = (): Unstable_TriggerItem[] => {
-      if (!wantsTools) return [];
-      const ctx = aui.thread.getModelContext();
-      const tools = ctx.tools;
-      if (!tools) return [];
-      const formatLabel = toolsConfig?.formatLabel;
-      const defaultIcon = toolsConfig?.icon;
-      return Object.entries(tools).map(([name, tool]) =>
-        toTriggerItem({
-          id: name,
-          type: "tool",
-          label: formatLabel ? formatLabel(name) : name,
-          description: tool.description ?? undefined,
-          icon: defaultIcon,
-        }),
-      );
-    };
+    const formatLabel = toolsConfig?.formatLabel;
+    const defaultIcon = toolsConfig?.icon;
+    const toolItems = wantsTools
+      ? Object.entries(toolMentions).map(([name, description]) =>
+          toTriggerItem({
+            id: name,
+            type: "tool",
+            label: formatLabel ? formatLabel(name) : name,
+            description,
+            icon: defaultIcon,
+          }),
+        )
+      : [];
 
     // Categorized: drill-down mode
-    if (categories && categories.length > 0) {
-      const groups = categories.map((cat) => ({
+    if (isCategorized) {
+      const groups = (categories ?? []).map((cat) => ({
         id: cat.id,
         label: cat.label,
         items: cat.items.map(toTriggerItem),
       }));
-
-      let toolCategory: {
-        id: string;
-        label: string;
-        items: Unstable_TriggerItem[];
-      } | null = null;
-      if (wantsTools) {
-        const toolItems = getModelContextTools();
-        if (toolItems.length > 0) {
-          toolCategory = {
-            id: toolsConfig?.category?.id ?? "tools",
-            label: toolsConfig?.category?.label ?? "Tools",
-            items: toolItems,
-          };
-        }
-      }
-      const allGroups = toolCategory ? [...groups, toolCategory] : groups;
+      const allGroups =
+        toolItems.length > 0
+          ? [
+              ...groups,
+              {
+                id: toolsConfig?.category?.id ?? "tools",
+                label: toolsConfig?.category?.label ?? "Tools",
+                items: toolItems,
+              },
+            ]
+          : groups;
 
       return {
         categories: () => allGroups.map(({ id, label }) => ({ id, label })),
@@ -163,25 +207,22 @@ export function unstable_useMentionAdapter(
 
     // Flat: items + (optionally) tools, all in one search pool
     const flatItems = (items ?? []).map(toTriggerItem);
-    const getFlatPool = (): Unstable_TriggerItem[] => {
-      if (!wantsTools) return flatItems;
-      const toolItems = getModelContextTools();
-      // Dedupe by id — explicit items win.
-      const seen = new Set(flatItems.map((i) => i.id));
-      return [...flatItems, ...toolItems.filter((t) => !seen.has(t.id))];
-    };
+    // Dedupe by id — explicit items win.
+    const seen = new Set(flatItems.map((i) => i.id));
+    const flatPool = [
+      ...flatItems,
+      ...toolItems.filter((t) => !seen.has(t.id)),
+    ];
 
     return {
       categories: (): readonly Unstable_TriggerCategory[] => [],
       categoryItems: () => [],
       search: (query) => {
         const lower = query.toLowerCase();
-        return getFlatPool().filter((item) =>
-          matchesTriggerItemQuery(item, lower),
-        );
+        return flatPool.filter((item) => matchesTriggerItemQuery(item, lower));
       },
     };
-  }, [aui, items, categories, wantsTools, toolsConfig]);
+  }, [items, categories, wantsTools, toolsConfig, isCategorized, toolMentions]);
 
   const directive = useMemo<Unstable_MentionDirective>(
     () => ({


### PR DESCRIPTION
## Problem

`unstable_useMentionAdapter` captured model-context tools when the hook first ran and never re-read them. registering or removing a tool left both flat and categorized mention results stale, including while the popover stayed open: changing the context from `searchDocs` to `createIssue` still listed `searchDocs`.

the documented `includeModelContextTools: { category }` form also stayed in flat mode unless a separate `categories` array was supplied, so `categories()` returned an empty list and the named category never appeared.

## Root cause

the adapter read `aui.thread.getModelContext()` inside `useMemo` with no subscription to `thread.modelContextUpdate`, so nothing re-rendered when the tool set changed. `thread.modelContextUpdate` alone is also not enough: `EventSubscriptionSubject._connect` rebinds `unstable_on` to the incoming thread core without replaying the event, so a switch between threads carrying different context providers is silent. categorized-mode detection keyed only on a non-empty `categories` array, so an explicit tool `category` was consulted only once some other category had already forced drill-down mode.

## Change

subscribe to `thread.modelContextUpdate` and hold the fields the adapter consumes (tool name and description) in state, so the adapter rebuilds when the tool set changes. `getModelContext()` reallocates on every call, so the snapshot is compared field-wise and the previous reference is kept when nothing observable changed, so a notification carrying no observable change does not rebuild the adapter and reset the popover's keyboard highlight. (a re-render of the component that owns the popover still rebuilds it, because `items`, `categories`, and an object `includeModelContextTools` are consumer-supplied identities; that is unchanged from before.) snapshotting the consumed fields rather than the tool objects also picks up a description mutated in place by a context provider.

also re-read on `threads.selectionChanged`, subscribed with `scope: "*"` because `aui.on` throws when a composer renders without a thread list scope. the read stays on `aui.thread` rather than moving to `aui.modelContext`: the latter is the app-level composite and would drop thread-level providers from the list.

treat an explicit tool `category` as drill-down mode when `items` is omitted. supplying `items` keeps the adapter flat, so an asynchronously populated list cannot flip modes mid-navigation.

with the snapshot in the memo's dependency list, the group and flat pools no longer have to be rebuilt on every adapter call, so they are computed once per adapter as before.

## Verification

- the stale-tool and missing-category regressions fail against the pre-fix source and pass with the change.
- new coverage: live flat and categorized updates, the exact `thread.modelContextUpdate` subscription, open-navigation refresh, an empty-to-populated explicit item list, adapter identity across an unchanged notification, a description mutated in place on a stable tool object, and a thread switch carrying a different tool set. the last two each fail against the version without their fix.
- `pnpm test` in `packages/react`: 58 files, 522 tests, no type errors.
- `pnpm build` in `packages/react`.
- oxlint and oxfmt on the touched files; `check-changeset-semver` and `check-workspace-ranges`.

## Public surface

`@assistant-ui/react` behavior only. no new exports or types. JSDoc on `items`, `includeModelContextTools`, and `Unstable_ModelContextToolsOptions.category` now describes the mode-selection rule, and `elements/composer-mentions` notes what naming a tool `category` does. patch changeset included.
