### PR TITLE
chore: name the lib lane in sync-templates output and provenance doc

### DIFF
--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -34,8 +34,9 @@ NUXT_DIR="$TEMPLATES_ROOT/nuxt/app/components/assistant-ui"
 # is already the Base UI source, so minimal's assistant-ui element copies sync
 # from it directly, and `components/ui` copies sync from the vendored
 # `ui/base` stand-ins. Base sources already use the scaffold import shape.
-# Minimal's `hooks` copies sync from packages/ui/src/hooks. The Nuxt template's
-# vue kit copies sync verbatim from packages/ui/src/components/vue/assistant-ui.
+# Minimal's `hooks` copies sync from packages/ui/src/hooks, and its `lib`
+# copies from packages/ui/src/lib. The Nuxt template's vue kit copies sync
+# verbatim from packages/ui/src/components/vue/assistant-ui.
 OVERRIDES=(
     # minimal intentionally ships a slim thread.aui.tsx without GroupedParts /
     # reasoning / tool-group, since it doesn't bundle those companion files.
@@ -336,7 +337,7 @@ while IFS= read -r -d '' ex_file; do
 done < <(find "$EXAMPLES_ROOT" -path "*/components/assistant-ui/elements/*" -maxdepth 5 -type f \( -name "*.tsx" -o -name "*.ts" \) -not -path "*/node_modules/*" -print0)
 
 if [[ ${#drift[@]} -eq 0 && ${#vue_drift[@]} -eq 0 && ${#vue_missing[@]} -eq 0 && ${#ui_drift[@]} -eq 0 && ${#hooks_drift[@]} -eq 0 && ${#lib_drift[@]} -eq 0 && ${#redundant[@]} -eq 0 ]]; then
-    echo "✓ all template components and hooks are in sync with packages/ui"
+    echo "✓ all template components, hooks, and lib files are in sync with packages/ui"
     echo "✓ no redundant packages/ui copies in examples"
     exit 0
 fi


### PR DESCRIPTION
Follow-up to #6704, which merged before its review round landed. Addresses both reviewer notes:

- The per-lane provenance comment block now names where minimal's `lib` copies sync from (claude's nit).
- The success line now says "components, hooks, and lib files", matching what the check actually validates (cubic's P3).

Verified: `bash scripts/sync-templates.sh` exits green with the updated output.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JntsvwO8D7jN-D6fx7WVl3_RlmkuZ2JVTIK2SPoMG2-jnjHLM1ZzcRzSHZ4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->