### PR TITLE
fix(eve): cancel active turns on runtime teardown

### DIFF
--- a/.changeset/warm-eve-teardown.md
+++ b/.changeset/warm-eve-teardown.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: cancel active Eve turns when the runtime unmounts

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1820,6 +1820,59 @@ describe("useEveAgentRuntime cancel binding", () => {
   });
 });
 
+describe("useEveAgentRuntime teardown", () => {
+  it("cancels an active Eve turn when the runtime unmounts", () => {
+    const cancel = vi.fn().mockResolvedValue({ status: "cancelled" });
+    const agent = createAgent({ status: "streaming", cancel });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { unmount } = renderHook(() => useEveAgentRuntime());
+
+    unmount();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops an active turn through the legacy Eve binding on unmount", () => {
+    const agent = createAgent({ status: "streaming" });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { unmount } = renderHook(() => useEveAgentRuntime());
+
+    unmount();
+
+    expect(agent.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel an idle Eve agent when the runtime unmounts", () => {
+    const cancel = vi.fn().mockResolvedValue({ status: "cancelled" });
+    const agent = createAgent({ status: "ready", cancel });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { unmount } = renderHook(() => useEveAgentRuntime());
+
+    unmount();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("reports teardown cancellation failures without rejecting globally", async () => {
+    const error = new Error("cancel failed");
+    const cancel = vi.fn().mockRejectedValue(error);
+    const agent = createAgent({ status: "streaming", cancel });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { unmount } = renderHook(() => useEveAgentRuntime());
+
+    expect(() => unmount()).not.toThrow();
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui/eve] failed to cancel active turn on teardown",
+        error,
+      );
+    });
+  });
+});
+
 describe("useEveAgentRuntime thread refetch", () => {
   const session = { sessionId: "s1" };
 

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -57,6 +57,22 @@ const sendAbandonedError = new Error(
 const isDroppedSend = (error: unknown) =>
   error === sendCancelledError || error === sendAbandonedError;
 
+type EveAgentControls =
+  | { readonly cancel: () => Promise<unknown> }
+  | { readonly stop: () => void };
+
+const cancelEveTurn = async (agent: unknown) => {
+  const controls = agent as EveAgentControls;
+  if ("cancel" in controls) {
+    await controls.cancel();
+  } else {
+    controls.stop();
+  }
+};
+
+const isEveTurnActive = (status: UseEveAgentStatus) =>
+  status === "submitted" || status === "streaming";
+
 type EveLifecycleCallbackName =
   | "onError"
   | "onEvent"
@@ -207,8 +223,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const hasExecutingTools = Object.values(toolStatuses).some(
     (status) => status?.type === "executing",
   );
-  const providerIsRunning =
-    agent.status === "submitted" || agent.status === "streaming";
+  const providerIsRunning = isEveTurnActive(agent.status);
   const isRunning = providerIsRunning || hasExecutingTools;
 
   const convertedMessages = useMemo(() => {
@@ -283,6 +298,15 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     return () => {
       isMountedRef.current = false;
       sendEpochRef.current += 1;
+      const liveAgent = agentRef.current;
+      if (isEveTurnActive(liveAgent.status)) {
+        void cancelEveTurn(liveAgent).catch((error) => {
+          console.error(
+            "[assistant-ui/eve] failed to cancel active turn on teardown",
+            error,
+          );
+        });
+      }
     };
   }, []);
 
@@ -441,14 +465,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       // Eve 0.38 replaced the binding's local-abort `stop()` with the durable
       // `cancel()`, so the adapter detects which side of that break the host's
       // eve provides instead of pinning the peer range to one of them.
-      const controls = agent as
-        | { readonly cancel: () => Promise<unknown> }
-        | { readonly stop: () => void };
-      if ("cancel" in controls) {
-        await controls.cancel();
-      } else {
-        controls.stop();
-      }
+      await cancelEveTurn(agent);
     },
     // Hosts below eve 0.44.1 expose no `resume`; leaving the capability absent
     // keeps `threads.reloadMainThread()` on core's no-capability no-op.


### PR DESCRIPTION
## Problem

Unmounting `useEveAgentRuntime()` while Eve is submitted or streaming leaves the active turn running. The runtime disappears, but the provider can continue model generation, network activity, and callbacks.

A focused regression reproduced `cancel()` being called zero times after unmount.

## Root cause

The existing teardown invalidated queued assistant-ui sends but never asked the committed Eve agent to cancel its active provider turn.

## Change

Reuse one cancellation helper for explicit cancellation and teardown. Teardown reads the latest committed Eve agent, cancels only submitted or streaming turns, preserves the pre-0.38 `stop()` fallback, and reports rejected teardown cancellation without creating an unhandled rejection.

## Verification

- Confirmed the active-turn teardown test fails before the implementation with zero cancellation calls.
- Covered modern `cancel()`, legacy `stop()`, idle agents, and rejected teardown cancellation.
- `pnpm -C packages/eve test` (4 files, 154 tests)
- `pnpm -C packages/eve build`
- Focused oxfmt and oxlint checks
- `pnpm changesets:check`

## Public surface

`@assistant-ui/eve` behavior only. No exports, API reference, docs, or templates change. Includes a patch changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.oolB0XhCv2KWires_U5af6zl3YIoLUW_JSmLhmd22K8-oz2uMHNG2mlM3Y8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->