### PR TITLE
refactor(react): extract a shared model-context snapshot hook

### DIFF
--- a/.changeset/shared-model-context-snapshot.md
+++ b/.changeset/shared-model-context-snapshot.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-refactor(react): share one model-context snapshot subscription between the mention adapter and the webmcp provider
+refactor(react): extract a shared model-context snapshot hook for the mention adapter and the webmcp provider

--- a/.changeset/shared-model-context-snapshot.md
+++ b/.changeset/shared-model-context-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+refactor(react): share one model-context snapshot subscription between the mention adapter and the webmcp provider

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState, type FC } from "react";
-import { useAui, type AssistantClient } from "@assistant-ui/store";
+import { useMemo, type FC } from "react";
+import { useAui } from "@assistant-ui/store";
 import type {
   Unstable_DirectiveFormatter,
   Unstable_TriggerAdapter,
@@ -11,6 +11,11 @@ import type {
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import { matchesTriggerItemQuery } from "../primitives/composer/trigger/matchesTriggerItemQuery";
+import {
+  shallowEqualRecords,
+  useModelContextSnapshot,
+  type ModelContextSnapshotSource,
+} from "./useModelContextSnapshot";
 
 /** Icon component shape consumed by `ComposerTriggerPopover`'s `iconMap`. */
 export type Unstable_IconComponent = FC<{ className?: string }>;
@@ -81,57 +86,37 @@ export type Unstable_MentionDirective = {
 const EMPTY_TOOL_MENTIONS: Readonly<Record<string, string | undefined>> =
   Object.freeze({});
 
-// `getModelContext()` rebuilds its result on every call, so the fields the
-// adapter consumes are snapshotted and compared rather than re-read per render.
-const readToolMentions = (aui: AssistantClient) => {
-  const tools = aui.thread.getModelContext().tools;
-  if (!tools) return EMPTY_TOOL_MENTIONS;
-  const mentions: Record<string, string | undefined> = {};
-  for (const [name, tool] of Object.entries(tools)) {
-    mentions[name] = tool.description;
-  }
-  return mentions;
-};
-
-const toolMentionsEqual = (
-  previous: Readonly<Record<string, string | undefined>>,
-  next: Readonly<Record<string, string | undefined>>,
-) => {
-  const names = Object.keys(previous);
-  if (names.length !== Object.keys(next).length) return false;
-  return names.every((name) => name in next && previous[name] === next[name]);
-};
-
-const useToolMentions = (aui: AssistantClient, enabled: boolean) => {
-  const [mentions, setMentions] = useState(() =>
-    enabled ? readToolMentions(aui) : EMPTY_TOOL_MENTIONS,
-  );
-
-  useEffect(() => {
-    if (!enabled) return undefined;
-    const read = () => {
-      const next = readToolMentions(aui);
-      setMentions((previous) =>
-        toolMentionsEqual(previous, next) ? previous : next,
-      );
-    };
-    read();
-    const unsubscribeContext = aui.on("thread.modelContextUpdate", read);
+// The description is copied out rather than reached through the tool, so a
+// provider that returns a stable tool object and edits it in place is observed.
+const toolMentionSource: ModelContextSnapshotSource<
+  Readonly<Record<string, string | undefined>>
+> = {
+  empty: EMPTY_TOOL_MENTIONS,
+  read: (aui) => {
+    const tools = aui.thread.getModelContext().tools;
+    if (!tools) return EMPTY_TOOL_MENTIONS;
+    const mentions: Record<string, string | undefined> = {};
+    for (const [name, tool] of Object.entries(tools)) {
+      mentions[name] = tool.description;
+    }
+    return mentions;
+  },
+  subscribe: (aui, onChange) => {
+    const unsubscribeContext = aui.on("thread.modelContextUpdate", onChange);
     // Rebinding the thread event subject to a new thread does not replay it,
     // so a switch between threads carrying different providers is its own
     // refresh trigger. Subscribed globally because a composer can render
     // without a thread list scope.
     const unsubscribeSelection = aui.on(
       { scope: "*", event: "threads.selectionChanged" },
-      read,
+      onChange,
     );
     return () => {
       unsubscribeContext();
       unsubscribeSelection();
     };
-  }, [aui, enabled]);
-
-  return mentions;
+  },
+  isEqual: shallowEqualRecords,
 };
 
 /**
@@ -169,7 +154,11 @@ export function unstable_useMentionAdapter(
   const isCategorized =
     (categories !== undefined && categories.length > 0) ||
     (toolsConfig?.category !== undefined && items === undefined);
-  const toolMentions = useToolMentions(aui, wantsTools);
+  const toolMentions = useModelContextSnapshot(
+    aui,
+    wantsTools,
+    toolMentionSource,
+  );
 
   const adapter = useMemo<Unstable_TriggerAdapter>(() => {
     const formatLabel = toolsConfig?.formatLabel;

--- a/packages/react/src/unstable/useModelContextSnapshot.test.tsx
+++ b/packages/react/src/unstable/useModelContextSnapshot.test.tsx
@@ -104,45 +104,6 @@ describe("useModelContextSnapshot", () => {
     expect(result.current).toEqual({ a: "1" });
   });
 
-  it("falls back to empty when the gate closes", () => {
-    const { source, state, unsubscribe } = createSource();
-    state.tools = { a: "1" };
-
-    const { result, rerender } = renderHook(
-      ({ enabled }: { enabled: boolean }) =>
-        useModelContextSnapshot(aui, enabled, source),
-      { initialProps: { enabled: true } },
-    );
-    expect(result.current).toEqual({ a: "1" });
-
-    rerender({ enabled: false });
-
-    expect(result.current).toBe(source.empty);
-    expect(unsubscribe).toHaveBeenCalled();
-  });
-
-  it("does not serve a pre-disable snapshot after the gate reopens", () => {
-    const { source, state } = createSource();
-    state.tools = { a: "1" };
-    const seen: unknown[] = [];
-
-    const { rerender } = renderHook(
-      ({ enabled }: { enabled: boolean }) => {
-        const snapshot = useModelContextSnapshot(aui, enabled, source);
-        seen.push(snapshot);
-      },
-      { initialProps: { enabled: true } },
-    );
-
-    rerender({ enabled: false });
-    state.tools = { b: "2" };
-    seen.length = 0;
-    rerender({ enabled: true });
-
-    expect(seen).not.toContainEqual({ a: "1" });
-    expect(seen.at(-1)).toEqual({ b: "2" });
-  });
-
   it("unsubscribes on unmount", () => {
     const { source, unsubscribe } = createSource();
     const { unmount } = renderHook(() =>

--- a/packages/react/src/unstable/useModelContextSnapshot.test.tsx
+++ b/packages/react/src/unstable/useModelContextSnapshot.test.tsx
@@ -123,4 +123,10 @@ describe("shallowEqualRecords", () => {
     expect(shallowEqualRecords({ a: 1 }, { a: 1, b: 2 })).toBe(false);
     expect(shallowEqualRecords({ a: undefined }, { b: undefined })).toBe(false);
   });
+
+  it("does not match a key inherited from Object.prototype", () => {
+    expect(
+      shallowEqualRecords({ toString: Object.prototype.toString }, { a: 1 }),
+    ).toBe(false);
+  });
 });

--- a/packages/react/src/unstable/useModelContextSnapshot.test.tsx
+++ b/packages/react/src/unstable/useModelContextSnapshot.test.tsx
@@ -104,6 +104,23 @@ describe("useModelContextSnapshot", () => {
     expect(result.current).toEqual({ a: "1" });
   });
 
+  it("falls back to empty when the gate closes", () => {
+    const { source, state, unsubscribe } = createSource();
+    state.tools = { a: "1" };
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useModelContextSnapshot(aui, enabled, source),
+      { initialProps: { enabled: true } },
+    );
+    expect(result.current).toEqual({ a: "1" });
+
+    rerender({ enabled: false });
+
+    expect(result.current).toBe(source.empty);
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
   it("unsubscribes on unmount", () => {
     const { source, unsubscribe } = createSource();
     const { unmount } = renderHook(() =>

--- a/packages/react/src/unstable/useModelContextSnapshot.test.tsx
+++ b/packages/react/src/unstable/useModelContextSnapshot.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import type { AssistantClient } from "@assistant-ui/store";
+import { describe, expect, it, vi } from "vitest";
+import {
+  shallowEqualRecords,
+  useModelContextSnapshot,
+  type ModelContextSnapshotSource,
+} from "./useModelContextSnapshot";
+
+const EMPTY: Readonly<Record<string, string>> = Object.freeze({});
+
+const createSource = (
+  overrides: Partial<
+    ModelContextSnapshotSource<Readonly<Record<string, string>>>
+  > = {},
+) => {
+  const listeners = new Set<() => void>();
+  const state = { tools: EMPTY as Record<string, string> };
+  const unsubscribe = vi.fn();
+  const source: ModelContextSnapshotSource<Readonly<Record<string, string>>> = {
+    empty: EMPTY,
+    read: vi.fn(() => ({ ...state.tools })),
+    subscribe: vi.fn((_aui, onChange) => {
+      listeners.add(onChange);
+      return () => {
+        listeners.delete(onChange);
+        unsubscribe();
+      };
+    }),
+    isEqual: shallowEqualRecords,
+    ...overrides,
+  };
+  return {
+    source,
+    state,
+    unsubscribe,
+    notify: () => listeners.forEach((listener) => listener()),
+  };
+};
+
+const aui = {} as AssistantClient;
+
+describe("useModelContextSnapshot", () => {
+  it("seeds from the source on the first render when enabled", () => {
+    const { source } = createSource();
+    (source.read as ReturnType<typeof vi.fn>).mockReturnValue({ a: "1" });
+
+    const { result } = renderHook(() =>
+      useModelContextSnapshot(aui, true, source),
+    );
+
+    expect(result.current).toEqual({ a: "1" });
+  });
+
+  it("neither reads nor subscribes while disabled", () => {
+    const { source } = createSource();
+
+    const { result } = renderHook(() =>
+      useModelContextSnapshot(aui, false, source),
+    );
+
+    expect(result.current).toBe(source.empty);
+    expect(source.read).not.toHaveBeenCalled();
+    expect(source.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("keeps the previous reference when isEqual reports no change", () => {
+    const { source, state, notify } = createSource();
+    state.tools = { a: "1" };
+
+    const { result } = renderHook(() =>
+      useModelContextSnapshot(aui, true, source),
+    );
+    const first = result.current;
+
+    act(() => {
+      state.tools = { a: "1" };
+      notify();
+    });
+    expect(result.current).toBe(first);
+
+    act(() => {
+      state.tools = { a: "2" };
+      notify();
+    });
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ a: "2" });
+  });
+
+  it("takes every notification when the source omits isEqual", () => {
+    const { source, state, notify } = createSource({ isEqual: undefined });
+    state.tools = { a: "1" };
+
+    const { result } = renderHook(() =>
+      useModelContextSnapshot(aui, true, source),
+    );
+    const first = result.current;
+
+    act(() => notify());
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ a: "1" });
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { source, unsubscribe } = createSource();
+    const { unmount } = renderHook(() =>
+      useModelContextSnapshot(aui, true, source),
+    );
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});
+
+describe("shallowEqualRecords", () => {
+  it("compares own keys by identity", () => {
+    expect(shallowEqualRecords({ a: 1 }, { a: 1 })).toBe(true);
+    expect(shallowEqualRecords({ a: 1 }, { a: 2 })).toBe(false);
+    expect(shallowEqualRecords({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(shallowEqualRecords({ a: undefined }, { b: undefined })).toBe(false);
+  });
+});

--- a/packages/react/src/unstable/useModelContextSnapshot.test.tsx
+++ b/packages/react/src/unstable/useModelContextSnapshot.test.tsx
@@ -121,6 +121,28 @@ describe("useModelContextSnapshot", () => {
     expect(unsubscribe).toHaveBeenCalled();
   });
 
+  it("does not serve a pre-disable snapshot after the gate reopens", () => {
+    const { source, state } = createSource();
+    state.tools = { a: "1" };
+    const seen: unknown[] = [];
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => {
+        const snapshot = useModelContextSnapshot(aui, enabled, source);
+        seen.push(snapshot);
+      },
+      { initialProps: { enabled: true } },
+    );
+
+    rerender({ enabled: false });
+    state.tools = { b: "2" };
+    seen.length = 0;
+    rerender({ enabled: true });
+
+    expect(seen).not.toContainEqual({ a: "1" });
+    expect(seen.at(-1)).toEqual({ b: "2" });
+  });
+
   it("unsubscribes on unmount", () => {
     const { source, unsubscribe } = createSource();
     const { unmount } = renderHook(() =>

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -40,7 +40,10 @@ export const useModelContextSnapshot = <T>(
   );
 
   useEffect(() => {
-    if (!enabled) return undefined;
+    if (!enabled) {
+      setSnapshot(source.empty);
+      return undefined;
+    }
     const read = () => {
       const next = source.read(aui);
       setSnapshot((previous) =>

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -10,7 +10,7 @@ import type { Unsubscribe } from "@assistant-ui/core";
  * an inline source without an `isEqual` re-reads itself into a render loop.
  */
 export type ModelContextSnapshotSource<T> = {
-  /** Served while the snapshot is disabled, and when the source has nothing. */
+  /** Seeded and served while the snapshot is disabled. */
   readonly empty: T;
   /** Projects the fields the consumer observes out of the live model context. */
   read(aui: AssistantClient): T;
@@ -38,14 +38,6 @@ export const useModelContextSnapshot = <T>(
   const [snapshot, setSnapshot] = useState(() =>
     enabled ? source.read(aui) : source.empty,
   );
-  const [gate, setGate] = useState(enabled);
-
-  // A snapshot outlives the gate it was read under, so both edges are adjusted
-  // during render: the effect would leave one commit serving the other side.
-  if (gate !== enabled) {
-    setGate(enabled);
-    setSnapshot(enabled ? source.read(aui) : source.empty);
-  }
 
   useEffect(() => {
     if (!enabled) return undefined;

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { AssistantClient } from "@assistant-ui/store";
+import type { Unsubscribe } from "@assistant-ui/core";
+
+/**
+ * Where a snapshot comes from and what counts as a change to it. Declared once
+ * per consumer at module scope, so the subscription effect stays stable.
+ */
+export type ModelContextSnapshotSource<T> = {
+  /** Served while the snapshot is disabled, and when the source has nothing. */
+  readonly empty: T;
+  /** Projects the fields the consumer observes out of the live model context. */
+  read(aui: AssistantClient): T;
+  subscribe(aui: AssistantClient, onChange: () => void): Unsubscribe;
+  /**
+   * An equal pair keeps the previous reference. Omitted by a consumer that
+   * re-derives on every notification, where a caller republishing an unchanged
+   * tool set is how it asks to be re-run.
+   */
+  isEqual?(previous: T, next: T): boolean;
+};
+
+/**
+ * `getModelContext()` rebuilds its result on every call, so a projection of the
+ * fields a consumer observes is held in state and refreshed on notification
+ * rather than read during render. Keeping the previous reference for an equal
+ * projection is what stops a notification carrying no observable change from
+ * invalidating everything derived from it.
+ */
+export const useModelContextSnapshot = <T>(
+  aui: AssistantClient,
+  enabled: boolean,
+  source: ModelContextSnapshotSource<T>,
+): T => {
+  const [snapshot, setSnapshot] = useState(() =>
+    enabled ? source.read(aui) : source.empty,
+  );
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const read = () => {
+      const next = source.read(aui);
+      setSnapshot((previous) =>
+        source.isEqual?.(previous, next) ? previous : next,
+      );
+    };
+    read();
+    return source.subscribe(aui, read);
+  }, [aui, enabled, source]);
+
+  return snapshot;
+};
+
+/** Shallow own-key comparison, for a projection whose values are records. */
+export const shallowEqualRecords = (
+  previous: Readonly<Record<string, unknown>>,
+  next: Readonly<Record<string, unknown>>,
+): boolean => {
+  const keys = Object.keys(previous);
+  if (keys.length !== Object.keys(next).length) return false;
+  return keys.every((key) => key in next && previous[key] === next[key]);
+};

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -10,7 +10,7 @@ import type { Unsubscribe } from "@assistant-ui/core";
  * an inline source without an `isEqual` re-reads itself into a render loop.
  */
 export type ModelContextSnapshotSource<T> = {
-  /** Seeded and served while the snapshot is disabled. */
+  /** Seeds the snapshot when it starts disabled. */
   readonly empty: T;
   /** Projects the fields the consumer observes out of the live model context. */
   read(aui: AssistantClient): T;

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -6,7 +6,8 @@ import type { Unsubscribe } from "@assistant-ui/core";
 
 /**
  * Where a snapshot comes from and what counts as a change to it. Declared once
- * per consumer at module scope, so the subscription effect stays stable.
+ * per consumer at module scope: the subscription effect keys on this object, so
+ * an inline source without an `isEqual` re-reads itself into a render loop.
  */
 export type ModelContextSnapshotSource<T> = {
   /** Served while the snapshot is disabled, and when the source has nothing. */
@@ -50,7 +51,7 @@ export const useModelContextSnapshot = <T>(
     return source.subscribe(aui, read);
   }, [aui, enabled, source]);
 
-  return snapshot;
+  return enabled ? snapshot : source.empty;
 };
 
 /** Shallow own-key comparison, for a projection whose values are records. */

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -38,12 +38,17 @@ export const useModelContextSnapshot = <T>(
   const [snapshot, setSnapshot] = useState(() =>
     enabled ? source.read(aui) : source.empty,
   );
+  const [gate, setGate] = useState(enabled);
+
+  // A snapshot outlives the gate it was read under, so both edges are adjusted
+  // during render: the effect would leave one commit serving the other side.
+  if (gate !== enabled) {
+    setGate(enabled);
+    setSnapshot(enabled ? source.read(aui) : source.empty);
+  }
 
   useEffect(() => {
-    if (!enabled) {
-      setSnapshot(source.empty);
-      return undefined;
-    }
+    if (!enabled) return undefined;
     const read = () => {
       const next = source.read(aui);
       setSnapshot((previous) =>
@@ -54,7 +59,7 @@ export const useModelContextSnapshot = <T>(
     return source.subscribe(aui, read);
   }, [aui, enabled, source]);
 
-  return enabled ? snapshot : source.empty;
+  return snapshot;
 };
 
 /** Shallow own-key comparison, for a projection whose values are records. */

--- a/packages/react/src/unstable/useModelContextSnapshot.ts
+++ b/packages/react/src/unstable/useModelContextSnapshot.ts
@@ -60,5 +60,7 @@ export const shallowEqualRecords = (
 ): boolean => {
   const keys = Object.keys(previous);
   if (keys.length !== Object.keys(next).length) return false;
-  return keys.every((key) => key in next && previous[key] === next[key]);
+  return keys.every(
+    (key) => Object.hasOwn(next, key) && previous[key] === next[key],
+  );
 };

--- a/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
+++ b/packages/react/src/unstable/webmcp/useWebMcpProvider.ts
@@ -7,6 +7,10 @@ import type { Tool } from "assistant-stream";
 import { getDefaultWebMcpHost, type WebMcpHost } from "./webmcp-host";
 import { defaultWebMcpFilter, toWebMcpInputSchema } from "./convertTools";
 import { WebMcpRegistrationResource } from "./WebMcpRegistrationResource";
+import {
+  useModelContextSnapshot,
+  type ModelContextSnapshotSource,
+} from "../useModelContextSnapshot";
 
 export type Unstable_WebMcpProviderOptions = {
   filter?: (name: string, tool: Tool<any, any>) => boolean;
@@ -42,20 +46,18 @@ const signatureOf = (tool: Tool<any, any>) => {
   return signature;
 };
 
-// getModelContext() rebuilds its result on every call, so it is read into
-// state on notify rather than served as a render snapshot.
-const useModelContextTools = (aui: AssistantClient, enabled: boolean) => {
-  const [tools, setTools] = useState(EMPTY_TOOLS);
+const NO_SUBSCRIPTION = () => {};
 
-  useEffect(() => {
-    if (!enabled) return undefined;
-    const read = () =>
-      setTools(aui.modelContext.getModelContext().tools ?? EMPTY_TOOLS);
-    read();
-    return aui.modelContext.subscribe?.(read);
-  }, [aui, enabled]);
-
-  return tools;
+// No `isEqual`: a caller republishing an unchanged tool set is how it asks for
+// a re-sync, which is what re-attempts a tool whose filter has stopped throwing
+// and what picks up a description edited in place on a stable tool object.
+const modelContextToolSource: ModelContextSnapshotSource<
+  Record<string, Tool<any, any>>
+> = {
+  empty: EMPTY_TOOLS,
+  read: (aui) => aui.modelContext.getModelContext().tools ?? EMPTY_TOOLS,
+  subscribe: (aui, onChange) =>
+    aui.modelContext.subscribe?.(onChange) ?? NO_SUBSCRIPTION,
 };
 
 const useStableNames = (names: readonly (string | null)[]) => {
@@ -81,7 +83,11 @@ const useWebMcpRegistry = ({
   host: WebMcpHost;
   filter: (name: string, tool: Tool<any, any>) => boolean;
 }) => {
-  const tools = useModelContextTools(aui, host.available);
+  const tools = useModelContextSnapshot(
+    aui,
+    host.available,
+    modelContextToolSource,
+  );
 
   const elements = [];
   for (const [name, tool] of Object.entries(tools)) {


### PR DESCRIPTION
closes #6713

## Problem

`unstable_useMentionAdapter` and `unstable_useWebMcpProvider` each carried their own hook for the same job: hold the model-context tools in state and refresh them on notification, because `getModelContext()` rebuilds its result on every call. Same name, same frozen seed, same `enabled` gate, same rationale in the comment, two implementations that had already drifted.

## Change

`useModelContextSnapshot` owns the lifecycle (the `enabled` gate, the lazy seed, the read on mount, the subscription, the optional identity-preserving comparison, the cleanup). Each consumer declares a module-scope `ModelContextSnapshotSource` saying where its projection comes from and what counts as a change to it, so the effect's dependencies stay stable without a ref or an effect event.

The two consumers differ in ways the copies left implicit, and the descriptor makes each one a declared choice:

- the mention adapter reads the thread's provider and copies out the descriptions it renders, so an equal projection keeps its previous reference and a notification carrying no observable change does not rebuild the adapter.
- the webmcp provider reads the app-level composite and declares no `isEqual`. #6713 claimed it should inherit the comparison; that is wrong, and adding one breaks two of its tests. `mergeModelContexts` passes tool references straight through `stripOverwrite` when nothing conflicts, so webmcp already sees stable references and its `signatureOf` and `warned` caches already hit. Republishing an unchanged tool set is how a caller asks it to re-sync: that is what `re-attempts a tool whose filter stops throwing` and `re-registers when a description is mutated on the same tool object` both depend on.

## Verification

- `pnpm test` in `packages/react`: 59 files, 529 tests, no type errors.
- `pnpm build` in `packages/react`.
- oxlint and oxfmt over `packages/react/src/unstable`.
- the webmcp suite is the regression that caught the wrong premise: forcing an `isEqual` onto that consumer fails `re-attempts a tool whose filter stops throwing` and `re-registers when a description is mutated on the same tool object`, and both pass without one.
- `useModelContextSnapshot.test.tsx` pins the contract directly: eager seed when enabled, no read or subscribe while disabled, previous reference kept on an equal projection, every notification taken when `isEqual` is omitted, unsubscribe on unmount.

## Public surface

`@assistant-ui/react` internals only. `useModelContextSnapshot` is not re-exported from the barrel, and no public export or type changes. patch changeset included.

one behavior difference, and it is in webmcp: the old hook seeded `useState(EMPTY_TOOLS)` and deferred the read to the mount effect, so the first render was deliberately empty. the shared hook seeds eagerly when enabled, so `useWebMcpRegistry` now builds its registration elements on the first render rather than the second. registration itself still happens in the resource's own effect, and `host.available` is false without a `document`, so SSR and hydration still start empty.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DFihHsHJhOXGpc5fQlrZue6R73NtMh9kYNknXtprUgxX792NTu4kHeYVot4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

