### PR TITLE
fix(docs): lift the file-count cap on the repo sandboxes

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -223,7 +223,7 @@ function createRepoTools() {
       bashToolkitPromise = createBashTool({
         files: SOURCE_SNAPSHOT,
         destination: "/repo",
-        maxFiles: 5000,
+        maxFiles: 0,
         maxOutputLength: 15000,
       });
     }

--- a/apps/docs/app/api/xulux/chat/tools/learn-source-map-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/learn-source-map-tools.ts
@@ -31,7 +31,7 @@ export function createLearnSourceMapTools({
       repoToolkitPromise ??= createBashTool({
         files: getRepoSourceSnapshot(),
         destination: "/repo",
-        maxFiles: 5000,
+        maxFiles: 0,
         maxOutputLength: 15000,
         promptOptions: { toolPrompt: "" },
       });

--- a/apps/docs/app/api/xulux/chat/tools/source-map-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/source-map-tools.ts
@@ -49,7 +49,7 @@ export function createSourceMapTools() {
       bashToolkitPromise = createBashTool({
         files: SOURCE_SNAPSHOT,
         destination: "/repo",
-        maxFiles: 5000,
+        maxFiles: 0,
         maxOutputLength: 15000,
         promptOptions: { toolPrompt: "" },
       });


### PR DESCRIPTION
## problem

the docs assistant lost the ability to read the repo. over the 24 hours before this fix, 224 of 249 `bash` tool calls failed, `inspectSourceMap` failed 8 of 8, and `readSourceMapFile` and `readFile` failed too, across 71 conversations. every failure carried the same message:

```
Too many files to load: 5034 files exceeds the limit of 5000. Either increase maxFiles,
use a more restrictive include pattern in uploadDirectory, or provide your own sandbox
with files already written.
```

the runs themselves survive (the `chat` and `invoke_agent` spans are not erroring), so this never surfaced as a broken conversation. the assistant just answers repo questions without being able to open a single file.

## root cause

the three repo sandboxes passed `maxFiles: 5000` to `createBashTool`. that number was a literal chosen when the monorepo was smaller.

`generated/source-snapshot.json` is built at build time by `apps/docs/scripts/generate-source-snapshot.mts` from `git ls-files` minus lockfiles and binaries. that set crossed 5000 on 2026-09-01 and is now 5034, growing roughly 45 files a day:

| commit date | files |
| --- | --- |
| 2026-08-29 | 4855 |
| 2026-08-31 | 4961 |
| 2026-09-01 | 4998 |
| 2026-09-02 | 5034 |

so the failure is deterministic, not intermittent, and it gets worse with every merge. the escalating counts in production (5003, 5007, 5012, ... 5034) are one per deploy.

two things make it worse than a single failed call. the throw happens inside `createBashTool`, not inside the tool call, so nothing about the failure is specific to what the model asked for. and `bashToolkitPromise` memoizes the rejected promise, so once a warm instance fails to construct the toolkit, every later call in that instance rethrows without retrying.

## change

`maxFiles: 0`, which is bash-tool's documented "disable the limit" value (`Set to 0 to disable the limit`, `BashToolOptions.maxFiles`).

removing the cap rather than raising it, for three reasons. the input set is not user controlled: the generator already decides it from tracked files minus an explicit exclude list, so a second count ceiling on top of that curated set constrains nothing anyone can influence. the check does not protect memory either: bash-tool runs it in `createBashTool` *after* the `streamFiles` loop has read every file into `filesWithDestination`, so by the time it throws the memory is already spent. and any new literal is a stopgap that re-breaks on the current growth rate.

the course scope in `learn-source-map-tools.ts` keeps its own `maxFiles: 500`. that one bounds `resolveStageFiles` output, a small per-stage file set, and it has never fired.

if we do want a guard, the honest one is a size budget in the generator: the snapshot is 29 MB and gets `readFileSync` into every serverless instance at module scope. that is a real constraint, file count is not, and a build-time budget fails visibly in CI instead of silently killing a tool in production. worth its own PR.

## verification

reproduced against the real `bash-tool@1.3.19` with the snapshot this branch produces, built by replicating the generator's `git ls-files` plus exclude list:

```
snapshot: 5034 files, 29.0 MB
maxFiles: 5000 -> THREW: Too many files to load: 5034 files exceeds the limit of 5000
maxFiles: 0    -> constructed in 111ms, rss 416 MB
bash ls  -> "agent-launcher\nai-sdk\nassistant-stream\ncli\ncloud"
bash grep-> "1"
readFile -> OK (sees maxFiles: 0)
```

the file count and the error text match production exactly, the repro fails on the old value, and after the change `bash` and `readFile` both execute against `/repo`.

`oxlint` clean on the three changed files. no test added: the failing condition is the size of the real repo at build time, which a colocated unit test cannot hold, and the guard that would actually catch a regression here is the generator budget described above.

## public surface

none. `@assistant-ui/docs` is `private: true`, so no changeset. no exports, api-reference output, or templates touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nZxJxD8zx8D0DzXHALO0MFTNmkx_KuLl-f2ZBGfd9JF_4N5FLJrZ7BS_njk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->