### PR TITLE
fix(docs): gate and meter the Xulux template download proxy

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -45,6 +45,10 @@ AUI_ANONYMOUS_SESSIONS_PER_IP_PER_DAY=1000
 # in-process and stay unlimited.
 AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY=500
 AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY=5000
+# The template download proxy streams a sandbox archive per request, so it is
+# limited by IP and by a global daily ceiling on top of the browser session.
+AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY=200
+AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY=2000
 
 # Xulux coding agent — Blaxel cloud sandbox (app/api/xulux).
 # Required to provision sandboxes for scaffolding.

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -45,7 +45,7 @@ AUI_ANONYMOUS_SESSIONS_PER_IP_PER_DAY=1000
 # in-process and stay unlimited.
 AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY=500
 AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY=5000
-# The template download proxy streams a sandbox archive per request, so it is
+# The template download proxy buffers a whole sandbox archive per request, so it is
 # limited by IP and by a global daily ceiling on top of the browser session.
 AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY=200
 AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY=2000

--- a/apps/docs/app/api/xulux/download-proxy/route.test.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireSession: vi.fn(),
+  checkRateLimit: vi.fn(),
+  fetchSandboxResource: vi.fn(),
+  resolveSandboxDownloadUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/feature-flags")>()),
+  isAiPlaygroundEnabled: true,
+}));
+
+vi.mock("@/lib/anonymous-session", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/anonymous-session")>()),
+  requirePublicAssistantSession: mocks.requireSession,
+}));
+
+vi.mock("@/lib/rate-limit", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/rate-limit")>()),
+  checkXuluxDownloadProxyRateLimit: mocks.checkRateLimit,
+}));
+
+vi.mock("@/lib/xulux/fetch-sandbox", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/xulux/fetch-sandbox")>()),
+  fetchSandboxResource: mocks.fetchSandboxResource,
+}));
+
+vi.mock("@/lib/xulux/sandbox-download-url", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/xulux/sandbox-download-url")
+  >()),
+  resolveSandboxDownloadUrl: mocks.resolveSandboxDownloadUrl,
+}));
+
+import { GET } from "./route";
+
+const session = { id: "session_1234567890", expiresAt: Date.now() + 60_000 };
+const request = () =>
+  new Request(
+    "https://www.assistant-ui.com/api/xulux/download-proxy?templateId=demo",
+  );
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/xulux/download-proxy access boundary", () => {
+  it("rejects a request without a browser session before metering", async () => {
+    mocks.requireSession.mockReturnValue(
+      Response.json({ error: "website required" }, { status: 403 }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(403);
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.fetchSandboxResource).not.toHaveBeenCalled();
+  });
+
+  it("stops an exhausted quota before the sandbox is reached", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(
+      new Response("limited", { status: 429 }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(429);
+    expect(mocks.resolveSandboxDownloadUrl).not.toHaveBeenCalled();
+    expect(mocks.fetchSandboxResource).not.toHaveBeenCalled();
+  });
+
+  it("keeps a metered archive out of shared caches", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=3600");
+    expect(await response.arrayBuffer()).toEqual(
+      new Uint8Array([1, 2, 3]).buffer,
+    );
+  });
+});

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { requirePublicAssistantSession } from "@/lib/anonymous-session";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
+import { checkXuluxDownloadProxyRateLimit } from "@/lib/rate-limit";
 import { fetchSandboxResource } from "@/lib/xulux/fetch-sandbox";
 import { resolveSandboxDownloadUrl } from "@/lib/xulux/sandbox-download-url";
 import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
@@ -48,6 +50,12 @@ export async function GET(req: Request) {
   if (!isAiPlaygroundEnabled) {
     return NextResponse.json({ error: "Not found." }, { status: 404 });
   }
+
+  const session = requirePublicAssistantSession(req);
+  if (session instanceof Response) return session;
+
+  const rateLimitResponse = await checkXuluxDownloadProxyRateLimit(req);
+  if (rateLimitResponse) return rateLimitResponse;
 
   const { searchParams } = new URL(req.url);
   const templateId = searchParams.get("templateId");
@@ -134,7 +142,7 @@ export async function GET(req: Request) {
       headers: {
         "Content-Type":
           upstream.headers.get("content-type") ?? "application/octet-stream",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": "private, max-age=3600",
       },
     });
   } catch (err) {

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
@@ -43,6 +43,25 @@ describe("useVirtualArchive", () => {
     );
   });
 
+  it("downloads an in-process demo archive without a session", async () => {
+    const archive = { files: [] };
+    mocks.createVirtualArchive.mockReturnValue(archive);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }));
+
+    const { result } = renderHook(() =>
+      useVirtualArchive("/api/xulux/demo-download?slug=chatgpt", "chatgpt"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/xulux/demo-download?slug=chatgpt",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(mocks.anonymousSessionFetch).not.toHaveBeenCalled();
+  });
+
   it("surfaces a denied download as an error state", async () => {
     mocks.anonymousSessionFetch.mockResolvedValue(
       new Response("limited", { status: 429 }),

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  anonymousSessionFetch: vi.fn(),
+  createVirtualArchive: vi.fn(),
+}));
+
+vi.mock("@/lib/anonymous-session-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/anonymous-session-client")>()),
+  anonymousSessionFetch: mocks.anonymousSessionFetch,
+}));
+
+vi.mock("@/lib/xulux/virtual-archive", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/xulux/virtual-archive")>()),
+  createVirtualArchive: mocks.createVirtualArchive,
+}));
+
+import { useVirtualArchive } from "./useVirtualArchive";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useVirtualArchive", () => {
+  it("downloads a hosted archive through the proxy with the browser session", async () => {
+    const archive = { files: [] };
+    mocks.createVirtualArchive.mockReturnValue(archive);
+    mocks.anonymousSessionFetch.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+    );
+
+    const { result } = renderHook(() =>
+      useVirtualArchive("https://demo.bl.run/api/download?v=1", "demo", "v1"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(mocks.anonymousSessionFetch).toHaveBeenCalledWith(
+      "/api/xulux/download-proxy?templateId=demo&versionId=v1&downloadSearch=%3Fv%3D1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("surfaces a denied download as an error state", async () => {
+    mocks.anonymousSessionFetch.mockResolvedValue(
+      new Response("limited", { status: 429 }),
+    );
+
+    const { result } = renderHook(() =>
+      useVirtualArchive("https://demo.bl.run/api/download", "demo"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(mocks.createVirtualArchive).not.toHaveBeenCalled();
+  });
+});

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/lib/xulux/virtual-archive", async (importOriginal) => ({
 import { useVirtualArchive } from "./useVirtualArchive";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.ts
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.ts
@@ -17,8 +17,8 @@ function resolveDownloadFetchUrl(
   downloadUrl: string,
   templateId: string | undefined,
   versionId: string | undefined,
-): string {
-  if (downloadUrl.startsWith("/")) return downloadUrl;
+): { url: string; proxied: boolean } {
+  if (downloadUrl.startsWith("/")) return { url: downloadUrl, proxied: false };
 
   if (!templateId) {
     throw new Error("Template id is required to download hosted archives.");
@@ -28,7 +28,10 @@ function resolveDownloadFetchUrl(
   const params = new URLSearchParams({ templateId });
   if (versionId) params.set("versionId", versionId);
   if (parsed.search) params.set("downloadSearch", parsed.search);
-  return `/api/xulux/download-proxy?${params.toString()}`;
+  return {
+    url: `/api/xulux/download-proxy?${params.toString()}`,
+    proxied: true,
+  };
 }
 
 export function useVirtualArchive(
@@ -46,7 +49,11 @@ export function useVirtualArchive(
       let controller: AbortController | null = null;
 
       try {
-        const fetchUrl = resolveDownloadFetchUrl(url, templateId, versionId);
+        const { url: fetchUrl, proxied } = resolveDownloadFetchUrl(
+          url,
+          templateId,
+          versionId,
+        );
 
         if (
           cachedFetchUrlRef.current === fetchUrl &&
@@ -61,7 +68,7 @@ export function useVirtualArchive(
         abortRef.current = controller;
 
         setState({ status: "loading" });
-        const res = await anonymousSessionFetch(fetchUrl, {
+        const res = await (proxied ? anonymousSessionFetch : fetch)(fetchUrl, {
           signal: controller.signal,
         });
         if (!res.ok) throw new Error(`Download failed: ${res.status}`);

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.ts
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { anonymousSessionFetch } from "@/lib/anonymous-session-client";
 import {
   createVirtualArchive,
   type VirtualArchive,
@@ -60,7 +61,9 @@ export function useVirtualArchive(
         abortRef.current = controller;
 
         setState({ status: "loading" });
-        const res = await fetch(fetchUrl, { signal: controller.signal });
+        const res = await anonymousSessionFetch(fetchUrl, {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error(`Download failed: ${res.status}`);
         const buffer = await res.arrayBuffer();
         const archive = createVirtualArchive(new Uint8Array(buffer));

--- a/apps/docs/lib/rate-limit.test.ts
+++ b/apps/docs/lib/rate-limit.test.ts
@@ -48,6 +48,7 @@ import {
   checkAnonymousSessionIssuanceRateLimit,
   checkMcpTemplateToolRateLimit,
   checkPublicAssistantRateLimit,
+  checkXuluxDownloadProxyRateLimit,
 } from "./rate-limit";
 
 beforeEach(() => {
@@ -354,6 +355,109 @@ describe("MCP template tool rate limits", () => {
     expect(response?.status).toBe(503);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("mcp_template_rate_limit_unavailable"),
+    );
+  });
+});
+
+describe("Xulux download proxy rate limits", () => {
+  const request = () =>
+    new Request(
+      "https://www.assistant-ui.com/api/xulux/download-proxy?templateId=demo",
+      { headers: { "x-vercel-forwarded-for": "203.0.113.10" } },
+    );
+
+  it("keeps per-request egress bounded by an IP and a global ceiling", async () => {
+    await checkXuluxDownloadProxyRateLimit(request());
+
+    expect(mocks.configs.get("aui:xulux-download:ip:burst")).toEqual({
+      limit: 10,
+      window: "60s",
+    });
+    expect(mocks.configs.get("aui:xulux-download:ip:daily")).toEqual({
+      limit: 200,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:xulux-download:global:daily")).toEqual({
+      limit: 2_000,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:xulux-download:global:alert")).toEqual({
+      limit: 1,
+      window: "10m",
+    });
+  });
+
+  it("keys the per-client buckets by IP, the ceiling globally", async () => {
+    await expect(
+      checkXuluxDownloadProxyRateLimit(request()),
+    ).resolves.toBeNull();
+
+    expect(mocks.calls).toEqual([
+      { prefix: "aui:xulux-download:ip:burst", key: "203.0.113.10" },
+      { prefix: "aui:xulux-download:ip:daily", key: "203.0.113.10" },
+      { prefix: "aui:xulux-download:global:daily", key: "all" },
+    ]);
+  });
+
+  it.each([
+    ["aui:xulux-download:ip:burst", 1],
+    ["aui:xulux-download:ip:daily", 2],
+    ["aui:xulux-download:global:daily", 4],
+  ] as const)(
+    "stops after an exhausted %s limit",
+    async (prefix, expectedCalls) => {
+      mocks.results.set(prefix, false);
+
+      const response = await checkXuluxDownloadProxyRateLimit(request());
+
+      expect(response?.status).toBe(429);
+      expect(response?.headers.get("retry-after")).toBe("30");
+      expect(mocks.calls).toHaveLength(expectedCalls);
+    },
+  );
+
+  it("rate limits the global ceiling alert", async () => {
+    mocks.results.set("aui:xulux-download:global:daily", false);
+    mocks.results.set("aui:xulux-download:global:alert", false);
+
+    const response = await checkXuluxDownloadProxyRateLimit(request());
+
+    expect(response?.status).toBe(429);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once when the global ceiling is reached", async () => {
+    mocks.results.set("aui:xulux-download:global:daily", false);
+
+    await checkXuluxDownloadProxyRateLimit(request());
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("xulux_download_global_limit_exceeded"),
+    );
+  });
+
+  it("fails closed when no client IP is available", async () => {
+    const response = await checkXuluxDownloadProxyRateLimit(
+      new Request(
+        "https://www.assistant-ui.com/api/xulux/download-proxy?templateId=demo",
+      ),
+    );
+
+    expect(response?.status).toBe(503);
+    expect(mocks.calls).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("xulux_download_client_ip_missing"),
+    );
+  });
+
+  it("fails closed when the rate-limit store is unavailable", async () => {
+    mocks.errors.set("aui:xulux-download:ip:burst", new Error("Redis down"));
+
+    const response = await checkXuluxDownloadProxyRateLimit(request());
+
+    expect(response?.status).toBe(503);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("xulux_download_rate_limit_unavailable"),
     );
   });
 });

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -119,6 +119,38 @@ const getPublicAssistantRateLimits = async () => {
       prefix: "aui:mcp-template:global:alert",
       limiter: Ratelimit.fixedWindow(1, "10m"),
     }),
+    xuluxDownloadIpBurst: new Ratelimit({
+      redis,
+      prefix: "aui:xulux-download:ip:burst",
+      limiter: Ratelimit.fixedWindow(10, "60s"),
+    }),
+    xuluxDownloadIpDaily: new Ratelimit({
+      redis,
+      prefix: "aui:xulux-download:ip:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY,
+          200,
+        ),
+        "1d",
+      ),
+    }),
+    xuluxDownloadGlobalDaily: new Ratelimit({
+      redis,
+      prefix: "aui:xulux-download:global:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY,
+          2_000,
+        ),
+        "1d",
+      ),
+    }),
+    xuluxDownloadGlobalAlert: new Ratelimit({
+      redis,
+      prefix: "aui:xulux-download:global:alert",
+      limiter: Ratelimit.fixedWindow(1, "10m"),
+    }),
   };
 };
 
@@ -289,6 +321,52 @@ export async function checkMcpTemplateToolRateLimit(
       }
       return limitResponse(
         "Template tool usage limit exceeded",
+        globalDaily.reset,
+      );
+    }
+    return null;
+  });
+}
+
+export async function checkXuluxDownloadProxyRateLimit(
+  request: Request,
+): Promise<Response | null> {
+  return runRateLimitChecks(request, "xulux_download", async (limits) => {
+    const ip = getClientIp(request);
+    if (!ip) return missingClientIpResponse(request, "xulux_download");
+
+    const burst = await limits.xuluxDownloadIpBurst.limit(ip);
+    if (!burst.success) {
+      return limitResponse(
+        "Template download rate limit exceeded",
+        burst.reset,
+      );
+    }
+
+    const daily = await limits.xuluxDownloadIpDaily.limit(ip);
+    if (!daily.success) {
+      return limitResponse(
+        "Template download daily limit exceeded",
+        daily.reset,
+      );
+    }
+
+    const globalDaily = await limits.xuluxDownloadGlobalDaily.limit("all");
+    if (!globalDaily.success) {
+      const alert = await limits.xuluxDownloadGlobalAlert
+        .limit("all")
+        .catch(() => null);
+      if (alert?.success) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            message: "xulux_download_global_limit_exceeded",
+            requestId: request.headers.get("x-vercel-id"),
+          }),
+        );
+      }
+      return limitResponse(
+        "Template download usage limit exceeded",
         globalDaily.reset,
       );
     }


### PR DESCRIPTION
closes #6693

## Problem

`GET /api/xulux/download-proxy` is public, unauthenticated and unmetered. one anonymous request makes the docs deployment fetch a template archive from a Blaxel sandbox and buffer up to `MAX_ZIP_BYTES` (50 MB) into the invocation before responding. every other route in `apps/docs` that spends a resource goes through `lib/rate-limit.ts`; this one does not.

reproduction, against a deployment with the playground enabled:

```sh
for i in $(seq 1 50); do
  curl -s -o /dev/null -w '%{http_code} %{size_download}\n' \
    "https://www.assistant-ui.com/api/xulux/download-proxy?templateId=base-assistant-ui&downloadSearch=%3Fcachebust%3D$i"
done
```

every iteration is a fresh sandbox fetch returning a full archive. `resolveSandboxDownloadUrl` does allowlist the upstream against the hosted catalog, so this is not an open proxy; what is unbounded is egress plus memory.

the `Cache-Control: public, max-age=3600` on the response is not the mitigation it looks like. `downloadSearch` accepts any key matching `[a-zA-Z0-9._-]{1,64}` up to 2048 characters, so busting the shared cache costs one query parameter, which is what the loop above does.

#6689 gave this route a bounded `timeoutMs`, so a hung sandbox no longer pins the invocation. the metering gap is what remained.

## Root cause

the route was written as a CORS shim for the canvas rather than as a public endpoint, so it never picked up either gate. what kept the stricter one off the table was an assumption that the hosted MCP tools hand out proxy URLs, which would make a browser session gate break MCP clients.

they do not. `openTemplatePreview` returns `toAbsolute(baseUrl, ...)` for a configured preview, `entry.downloadUrl` for a fixed demo (a relative `/api/xulux/demo-download`), or `${baseUrl}/api/download`. none of those is the proxy. the proxy URL is built only in the browser, by `resolveDownloadFetchUrl` in `useVirtualArchive`, and only for an absolute sandbox URL. the browser is the sole caller, so the session gate is available here at no protocol cost.

## Change

**require the browser session.** `requirePublicAssistantSession` runs right after the feature flag and before the catalog is consulted, matching the order in `app/api/chat/route.ts` and `app/api/xulux/chat/handler.ts`. the session is a gate only: there is no session-keyed bucket, because an anonymous session is re-mintable at 1000 per IP per day, so a session bucket would add nothing the IP bucket does not already bound.

**meter by IP with a global ceiling.** `checkXuluxDownloadProxyRateLimit` mirrors `checkMcpTemplateToolRateLimit`, reusing the same Redis client, `getClientIp`, `limitResponse`, throttled alert and fail-closed path:

| prefix | limit | env |
|---|---|---|
| `aui:xulux-download:ip:burst` | 10 per 60s | |
| `aui:xulux-download:ip:daily` | 200 | `AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY` |
| `aui:xulux-download:global:daily` | 2000 | `AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY` |
| `aui:xulux-download:global:alert` | 1 per 10m | |

burst is 10 rather than the MCP lane's 15 because each request here is an archive rather than a JSON call, and `useVirtualArchive` caches per fetch URL, so re-opening the same template does not redraw from the bucket.

there is deliberately no byte budget. the resource worth bounding here is bytes, but a request already carries a hard 50 MB ceiling, so a request-count bucket is a byte bucket with a known multiplier. a second accounting mechanism (pre-fetch reservation, post-read reconciliation, atomic adjustment in the distributed store) would protect the same boundary at a much higher cost, against the existing primitive this route should just reuse.

**cache privately.** `Cache-Control` becomes `private`, so a shared cache cannot serve a gated archive to a caller that never passed the gate.

**carry the session on the client fetch.** `useVirtualArchive` moves to `anonymousSessionFetch` for the proxy URL only. `resolveDownloadFetchUrl` now reports whether it built a proxy URL or passed a relative one through, so an in-process download like `/api/xulux/demo-download`, which has no session requirement, keeps using bare `fetch` and does not gain a dependency on session issuance. same-origin the cookie already rides along whenever a session exists, but a canvas restored through `fromCanvasSnapshot` can outlive the 24 hour token, and `anonymousSessionFetch` re-mints once on a 401. it also covers the allowlisted cross-origin callers, which receive the token in the response body rather than as a cookie.

**out of scope.** the 50 MB buffer itself stays. `readLimitedBody` holds the whole archive only to hand it to `NextResponse`, and piping it through a counting `TransformStream` would remove the per-invocation memory peak, but that is a different mechanism from metering and lands better on its own. `/api/xulux/demo-download` and `/api/xulux/learn/download` are also public and unmetered; they build a zip in-process rather than spending sandbox egress, so they are a different cost class and are not touched here.

## Verification

```sh
pnpm --filter @assistant-ui/docs exec vitest run lib/rate-limit.test.ts app/api/xulux/download-proxy/route.test.ts components/xulux/canvas/useVirtualArchive.test.tsx
```

3 files, 38 tests green. oxlint plus oxfmt are clean on the changed files (the pre-existing `set-state-in-effect` warning in `useVirtualArchive.ts` is unchanged, only shifted). a standalone `tsc --noEmit` in `apps/docs` is not clean on any branch, since it reports 331 errors from the fumadocs and Next generated types that only exist after a build; none of them name a file this PR touches, and the app's own typecheck runs green in Build Changed Apps.

new coverage:

- `lib/rate-limit.test.ts`: bucket configuration and defaults, IP versus global keying, which bucket short-circuits the chain, alert throttling, exactly one log per global trip, fail closed with no client IP, fail closed when the store is unavailable.
- `app/api/xulux/download-proxy/route.test.ts`: a request without a browser session 403s before the limiter is consulted, an exhausted quota 429s before `resolveSandboxDownloadUrl` is reached, and a successful download carries `private, max-age=3600`. the first two fail against the pre-change route, which reaches the sandbox in both cases.
- `components/xulux/canvas/useVirtualArchive.test.tsx`: the archive download goes through `anonymousSessionFetch` at the expected proxy URL, an in-process `/api/xulux/demo-download` archive stays on bare `fetch` and never touches session issuance, and a denied download lands in the error state without building an archive.

## Public surface

- `apps/docs` only, which is `private: true`, so no changeset. naming a private package in one aborts `changeset version`.
- one new export internal to the docs app: `checkXuluxDownloadProxyRateLimit` in `apps/docs/lib/rate-limit.ts`.
- two new environment variables documented in `apps/docs/.env.example`: `AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY` and `AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY`. both have defaults, so no deploy change is required to land this.
- no docs pages, api-reference output, templates or published packages touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jq8nl8F71G29J2DFnPMYnKD26rb6Tv5uCSNJRgJ478u41FbMQLOJgLUpuIg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
