### PR TITLE
fix(core): isolate late initialize listener errors

### DIFF
--- a/.changeset/late-initialize-listeners.md
+++ b/.changeset/late-initialize-listeners.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate errors from initialize listeners replayed after thread startup

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -136,17 +136,15 @@ describe("BaseThreadRuntimeCore subscriptions", () => {
 
     const syncError = new Error("sync listener failed");
     const asyncError = new Error("async listener failed");
-    const laterListener = vi.fn();
     runtime.unstable_on("initialize", () => {
       throw syncError;
     });
     runtime.unstable_on("initialize", async () => {
       throw asyncError;
     });
-    runtime.unstable_on("initialize", laterListener);
 
     await vi.waitFor(() => {
-      expect(laterListener).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledTimes(2);
       expect(consoleError).toHaveBeenCalledWith(
         '[assistant-ui] Thread runtime "initialize" listener threw an error',
         syncError,

--- a/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.test.ts
@@ -126,6 +126,37 @@ describe("BaseThreadRuntimeCore subscriptions", () => {
     expect(() => runtime.reset()).toThrow(error);
     expect(laterSubscriber).toHaveBeenCalledOnce();
   });
+
+  it("isolates initialize listener errors during late replay", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const runtime = new TestRuntime(createVoiceAdapter());
+    runtime.reset();
+
+    const syncError = new Error("sync listener failed");
+    const asyncError = new Error("async listener failed");
+    const laterListener = vi.fn();
+    runtime.unstable_on("initialize", () => {
+      throw syncError;
+    });
+    runtime.unstable_on("initialize", async () => {
+      throw asyncError;
+    });
+    runtime.unstable_on("initialize", laterListener);
+
+    await vi.waitFor(() => {
+      expect(laterListener).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith(
+        '[assistant-ui] Thread runtime "initialize" listener threw an error',
+        syncError,
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        '[assistant-ui] Thread runtime "initialize" listener threw an error',
+        asyncError,
+      );
+    });
+  });
 });
 
 describe("BaseThreadRuntimeCore voice volume subscriptions", () => {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -533,7 +533,7 @@ export abstract class BaseThreadRuntimeCore
     if (event === "initialize" && this._isInitialized) {
       queueMicrotask(() => {
         if (subscribers.has(wrapped)) {
-          notifyEventListeners([wrapped], {}, 'Thread runtime "initialize"');
+          notifyEventListeners([wrapped], {}, `Thread runtime "${event}"`);
         }
       });
     }

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -532,7 +532,9 @@ export abstract class BaseThreadRuntimeCore
     // after the thread already initialized, mirroring a BehaviorSubject.
     if (event === "initialize" && this._isInitialized) {
       queueMicrotask(() => {
-        if (subscribers.has(wrapped)) wrapped({});
+        if (subscribers.has(wrapped)) {
+          notifyEventListeners([wrapped], {}, 'Thread runtime "initialize"');
+        }
       });
     }
 


### PR DESCRIPTION
## Problem

On current main (`@assistant-ui/core` 0.3.16), an `initialize` listener attached after thread initialization is replayed on a microtask. If that listener throws or returns a rejected promise, the failure escapes as an uncaught exception or unhandled rejection instead of being isolated like normal runtime events.

Minimal reproduction: initialize a thread with `reset()`, attach throwing synchronous and asynchronous `unstable_on("initialize")` listeners, and flush the replay microtasks. Before this change, Vitest reports both failures as unhandled and the runtime error reporter is never called.

## Root cause

The late replay called the listener directly. The normal event path uses `notifyEventListeners`, which catches synchronous failures, observes rejected thenables, and reports them without disrupting other listeners.

## Change

Route the deferred one-listener replay through `notifyEventListeners` while retaining the existing subscription-presence check, timing, and one-shot behavior. Add focused coverage for synchronous errors and rejected promises.

## Verification

- Confirmed the new regression fails before the source change with one uncaught exception and one unhandled rejection
- `pnpm --filter @assistant-ui/core exec vitest run src/runtime/base/base-thread-runtime-core.test.ts`
- `pnpm --filter @assistant-ui/core test` (156 files, 1,630 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

Affected package: `@assistant-ui/core`. No exports, API reference, documentation, or templates change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UjAMYJAmt8xvF3J8iVm0s5NFg7UPB7BDSGDU2_2_FUBi9KfoCMNbOUEeRZw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
