### PR TITLE
fix: skip the deferred render pass when defer is off

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: stop charging every streamed token a second render pass when `defer` is off

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -89,6 +89,9 @@ export type MarkdownTextPrimitiveProps = Omit<
    * re-parsing the growing message on every streamed token. Intermediate
    * streaming states may be skipped under load; the final text always renders.
    *
+   * Must stay constant for the lifetime of the component: the deferred path is
+   * a separate component, so toggling this remounts the rendered markdown.
+   *
    * @default false
    */
   defer?: boolean | undefined;

--- a/packages/react-markdown/src/primitives/MarkdownText.tsx
+++ b/packages/react-markdown/src/primitives/MarkdownText.tsx
@@ -37,6 +37,23 @@ import classNames from "classnames";
 
 const { useSmooth, useSmoothStatus, withSmoothContextProvider } = INTERNAL;
 
+type MarkdownRendererProps = Omit<Options, "children"> & { text: string };
+
+const MarkdownRenderer: FC<MarkdownRendererProps> = ({ text, ...options }) => (
+  <ReactMarkdown {...options}>{text}</ReactMarkdown>
+);
+
+// `useDeferredValue` schedules a second render pass whenever its input changes,
+// so the deferred path lives in its own component and `defer={false}` never
+// mounts it.
+const DeferredMarkdownRenderer: FC<MarkdownRendererProps> = ({
+  text,
+  ...options
+}) => {
+  const deferredText = useDeferredValue(text);
+  return <ReactMarkdown {...options}>{deferredText}</ReactMarkdown>;
+};
+
 type MarkdownTextPrimitiveElement = ComponentRef<typeof Primitive.div>;
 type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
 
@@ -102,9 +119,6 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
 
   const { text } = useSmooth(processedMessagePart, smooth);
 
-  const deferredText = useDeferredValue(text);
-  const resolvedText = defer ? deferredText : text;
-
   const {
     pre = DefaultPre,
     code = DefaultCode,
@@ -141,11 +155,9 @@ const MarkdownTextInner: FC<MarkdownTextPrimitiveProps> = ({
     };
   }, [CodeComponent, PreComponentWithFallback, userComponents]);
 
-  return (
-    <ReactMarkdown components={components} {...rest}>
-      {resolvedText}
-    </ReactMarkdown>
-  );
+  const Renderer = defer ? DeferredMarkdownRenderer : MarkdownRenderer;
+
+  return <Renderer text={text} components={components} {...rest} />;
 };
 
 const MarkdownTextPrimitiveImpl: ForwardRefExoticComponent<MarkdownTextPrimitiveProps> &

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -14,6 +14,7 @@ import {
 } from "streamdown";
 import {
   type ComponentRef,
+  type FC,
   forwardRef,
   useDeferredValue,
   useMemo,
@@ -28,6 +29,25 @@ import type {
 } from "../types";
 
 type StreamdownTextPrimitiveElement = ComponentRef<"div">;
+
+type StreamdownBodyProps = Omit<StreamdownProps, "children"> & {
+  text: string;
+};
+
+const StreamdownBody: FC<StreamdownBodyProps> = ({ text, ...props }) => (
+  <Streamdown {...props}>{text}</Streamdown>
+);
+
+// `useDeferredValue` schedules a second render pass whenever its input changes,
+// so the deferred path lives in its own component and `defer={false}` never
+// mounts it.
+const DeferredStreamdownBody: FC<StreamdownBodyProps> = ({
+  text,
+  ...props
+}) => {
+  const deferredText = useDeferredValue(text);
+  return <Streamdown {...props}>{deferredText}</Streamdown>;
+};
 
 // Streamdown extends the default sanitize schema without exporting it, so it is
 // read back off its own plugin set; a copy would fall behind on a bump. An
@@ -172,19 +192,13 @@ export const StreamdownTextPrimitive = forwardRef<
 
     const { text, status } = useSmooth(processedPart, smooth);
 
-    const deferredText = useDeferredValue(text);
-    const processedText = defer ? deferredText : text;
-
     const shouldTailRemend =
       mode === "streaming" &&
       parseIncompleteMarkdown !== false &&
       !parseMarkdownIntoBlocksFn;
     const repairedText = useMemo(
-      () =>
-        shouldTailRemend
-          ? tailBoundedRemend(processedText, remend)
-          : processedText,
-      [shouldTailRemend, processedText, remend],
+      () => (shouldTailRemend ? tailBoundedRemend(text, remend) : text),
+      [shouldTailRemend, text, remend],
     );
     const resolvedParseIncomplete = shouldTailRemend
       ? false
@@ -249,6 +263,8 @@ export const StreamdownTextPrimitive = forwardRef<
       ...(parseMarkdownIntoBlocksFn && { parseMarkdownIntoBlocksFn }),
     };
 
+    const Body = defer ? DeferredStreamdownBody : StreamdownBody;
+
     return (
       <div
         ref={ref}
@@ -256,15 +272,14 @@ export const StreamdownTextPrimitive = forwardRef<
         {...containerProps}
         className={containerClass}
       >
-        <Streamdown
+        <Body
+          text={repairedText}
           mode={mode}
           isAnimating={status.type === "running"}
           components={mergedComponents}
           {...optionalProps}
           {...streamdownProps}
-        >
-          {repairedText}
-        </Streamdown>
+        />
       </div>
     );
   },

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -24,6 +24,7 @@ import { DEFAULT_SHIKI_THEME, mergePlugins } from "../defaults";
 import { tailBoundedRemend } from "../remend";
 import type {
   AllowedTags,
+  RemendConfig,
   SecurityConfig,
   StreamdownTextPrimitiveProps,
 } from "../types";
@@ -32,21 +33,47 @@ type StreamdownTextPrimitiveElement = ComponentRef<"div">;
 
 type StreamdownBodyProps = Omit<StreamdownProps, "children"> & {
   text: string;
+  shouldTailRemend: boolean;
+  remendConfig: RemendConfig | undefined;
 };
 
-const StreamdownBody: FC<StreamdownBodyProps> = ({ text, ...props }) => (
-  <Streamdown {...props}>{text}</Streamdown>
-);
+const useRepairedText = (
+  text: string,
+  shouldTailRemend: boolean,
+  remendConfig: RemendConfig | undefined,
+) =>
+  useMemo(
+    () => (shouldTailRemend ? tailBoundedRemend(text, remendConfig) : text),
+    [shouldTailRemend, text, remendConfig],
+  );
+
+const StreamdownBody: FC<StreamdownBodyProps> = ({
+  text,
+  shouldTailRemend,
+  remendConfig,
+  ...props
+}) => {
+  const repairedText = useRepairedText(text, shouldTailRemend, remendConfig);
+  return <Streamdown {...props}>{repairedText}</Streamdown>;
+};
 
 // `useDeferredValue` schedules a second render pass whenever its input changes,
 // so the deferred path lives in its own component and `defer={false}` never
-// mounts it.
+// mounts it. The repair stays below the deferral so it runs in the deferred
+// pass rather than on the urgent one.
 const DeferredStreamdownBody: FC<StreamdownBodyProps> = ({
   text,
+  shouldTailRemend,
+  remendConfig,
   ...props
 }) => {
   const deferredText = useDeferredValue(text);
-  return <Streamdown {...props}>{deferredText}</Streamdown>;
+  const repairedText = useRepairedText(
+    deferredText,
+    shouldTailRemend,
+    remendConfig,
+  );
+  return <Streamdown {...props}>{repairedText}</Streamdown>;
 };
 
 // Streamdown extends the default sanitize schema without exporting it, so it is
@@ -196,10 +223,6 @@ export const StreamdownTextPrimitive = forwardRef<
       mode === "streaming" &&
       parseIncompleteMarkdown !== false &&
       !parseMarkdownIntoBlocksFn;
-    const repairedText = useMemo(
-      () => (shouldTailRemend ? tailBoundedRemend(text, remend) : text),
-      [shouldTailRemend, text, remend],
-    );
     const resolvedParseIncomplete = shouldTailRemend
       ? false
       : parseIncompleteMarkdown;
@@ -273,7 +296,9 @@ export const StreamdownTextPrimitive = forwardRef<
         className={containerClass}
       >
         <Body
-          text={repairedText}
+          text={text}
+          shouldTailRemend={shouldTailRemend}
+          remendConfig={remend}
           mode={mode}
           isAnimating={status.type === "running"}
           components={mergedComponents}

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -248,6 +248,9 @@ export type StreamdownTextPrimitiveProps = Omit<
    * re-parsing the growing message on every streamed token. Intermediate
    * streaming states may be skipped under load; the final text always renders.
    *
+   * Must stay constant for the lifetime of the component: the deferred path is
+   * a separate component, so toggling this remounts the rendered markdown.
+   *
    * @default false
    */
   defer?: boolean | undefined;

--- a/packages/x-performance/README.md
+++ b/packages/x-performance/README.md
@@ -64,7 +64,7 @@ Benchmarks import only public package entry points so the react-compiler output 
 
 - A token appended to the streaming message re-renders only that message's text part. It commits twice (host state, then the adapter push through the store) on the external-store and AI SDK runtimes and once on the local runtime, in a 2-message and a 200-message thread alike; `convertMessage` runs once per token.
 - Mounting a 200-message thread renders and converts each message once in a single commit.
-- A markdown message re-parses its whole text twice per token, once for the part update and once for the smooth status store write, while only the paragraph that changed re-renders.
+- A markdown message re-parses its whole text once per token, or twice with `defer` on (the previous text at normal priority, the new text in the deferred pass), while only the paragraph that changed re-renders.
 - Smooth streaming commits once per animation frame while draining a chunk; `minCommitMs` batches those commits; smoothing off commits once per chunk.
 - One store slice write notifies once and re-renders only that slice's subscriber; part memoization keys on shallow field identity, not on the outer part object.
 - Unmounting releases the runtime, the converted messages, and the external messages.

--- a/packages/x-performance/contracts/markdown-streaming.test.tsx
+++ b/packages/x-performance/contracts/markdown-streaming.test.tsx
@@ -33,20 +33,21 @@ const Paragraph = ({ children }: { children?: ReactNode }) => {
 
 const components = memoizeMarkdownComponents({ p: Paragraph });
 
-const Text = () => (
-  <MarkdownTextPrimitive
-    smooth={false}
-    components={components}
-    remarkPlugins={[countParses]}
-  />
-);
-
-const Message = () => {
-  counter.useRender("message");
-  return <MessagePrimitive.Parts components={{ Text }} />;
+const makeComponents = (defer: boolean) => {
+  const Text = () => (
+    <MarkdownTextPrimitive
+      smooth={false}
+      defer={defer}
+      components={components}
+      remarkPlugins={[countParses]}
+    />
+  );
+  const Message = () => {
+    counter.useRender("message");
+    return <MessagePrimitive.Parts components={{ Text }} />;
+  };
+  return { Message };
 };
-
-const COMPONENTS = { Message };
 
 const convertMessage = (m: Msg): ThreadMessageLike => ({
   id: m.id,
@@ -61,7 +62,8 @@ const document = Array.from(
     `Paragraph ${i} of the streamed answer, with **emphasis** and \`code\`.`,
 ).join("\n\n");
 
-const mount = () => {
+const mount = (defer = false) => {
+  const COMPONENTS = makeComponents(defer);
   let setMessages!: (updater: (prev: Msg[]) => Msg[]) => void;
   const App = () => {
     const [messages, set] = useState<Msg[]>([
@@ -97,16 +99,38 @@ const mount = () => {
 describe("markdown streaming", () => {
   // react-markdown re-parses the whole accumulated text on every render and
   // memoizes per hast node, so the paragraph a token lands in renders once and
-  // the paragraphs before it not at all. The parse runs twice per token: once
-  // for the part update and once more when useSmooth's effect writes the
-  // smooth status store that MarkdownTextPrimitive's context provider owns,
-  // even with smoothing off. Collapsing that to one parse is an optimization;
-  // a third parse is a regression. The user message renders through the same
+  // the paragraphs before it not at all. With `defer` off the part update is
+  // the only render of the primitive, so the parse runs once per token; a
+  // second parse is a regression. The user message renders through the same
   // Text slot, hence the extra paragraph and the two parses at mount.
-  it("re-parses the whole message twice per token but re-renders only the changed paragraph", () => {
+  it("re-parses the whole message once per token and re-renders only the changed paragraph", () => {
     counter.reset();
     parses = 0;
     const app = mount();
+    const MOUNT_PARAGRAPHS = PARAGRAPHS + 1;
+    expect(counter.renders("p")).toBe(MOUNT_PARAGRAPHS);
+    expect(parses).toBe(2);
+    const mountedCommits = counter.commits("thread");
+
+    const TOKENS = 10;
+    for (let i = 0; i < TOKENS; i++) app.append();
+
+    expect(counter.renders("p")).toBe(MOUNT_PARAGRAPHS + TOKENS);
+    expect(counter.renders("message")).toBe(2);
+    expect(parses).toBe(2 + TOKENS);
+    expect(counter.commits("thread") - mountedCommits).toBe(2 * TOKENS);
+    app.unmount();
+  });
+
+  // `defer` buys interruptibility with a second parse: React renders the
+  // previous text at normal priority and the new text in the deferred pass,
+  // and react-markdown has no incremental mode that would make the first pass
+  // free. Collapsing that to one parse is an optimization; a third is a
+  // regression.
+  it("re-parses once for the previous text and once for the new one when deferred", () => {
+    counter.reset();
+    parses = 0;
+    const app = mount(true);
     const MOUNT_PARAGRAPHS = PARAGRAPHS + 1;
     expect(counter.renders("p")).toBe(MOUNT_PARAGRAPHS);
     expect(parses).toBe(2);


### PR DESCRIPTION
closes #6726

## Problem

every streamed token made `MarkdownTextPrimitive` run the remark pipeline twice over the whole accumulated message, pinned in `packages/x-performance/contracts/markdown-streaming.test.tsx` as `2 + 2 * TOKENS` parses. `StreamdownTextPrimitive` had the same defect, costing a duplicate primitive render per token instead of a duplicate parse (streamdown memoizes blocks by content, so the wasted pass reaches its renderer but not its parser).

#6726 attributed the second parse to `useSmooth`'s effect writing the smooth status store that `withSmoothContextProvider` owns. that diagnosis is wrong. guarding the status write with `shallowEqual` and changing nothing else leaves the contract at `2 + 2 * TOKENS`:

```
guard only, no other change:  parsesPerToken 2, innerRendersPerToken 2
```

## Root cause

`defer` is opt-in and defaults to `false` (#4348), but both primitives called `useDeferredValue(text)` unconditionally:

```tsx
const deferredText = useDeferredValue(text);
const resolvedText = defer ? deferredText : text;
```

React schedules a second render pass whenever a `useDeferredValue` input changes, whether or not the caller reads the result. with `defer` off both passes resolve to the same string, so react-markdown re-parses text it just parsed and streamdown re-renders a tree it just rendered. removing the unconditional call, with no memo anywhere, drops the contract to one parse and one render per token:

```
useDeferredValue removed:     parsesPerToken 1, innerRendersPerToken 1
```

## Change

a hook cannot be called conditionally, so the deferred read moves into its own component and `defer={false}` never mounts it. `MarkdownTextInner` picks between `MarkdownRenderer` and `DeferredMarkdownRenderer`; `StreamdownTextPrimitive` picks between `StreamdownBody` and `DeferredStreamdownBody`.

in streamdown the `tailBoundedRemend` memo travels down with the text and stays below the deferral, so the repair still runs inside the deferred pass rather than moving onto the urgent one. `findRemendWindowStart` scans the whole message per token by its own docstring, and that is exactly the work `defer` exists to move off the urgent path. keeping it below the deferral also avoids a one-frame double repair when `mode` flips `streaming` to `static`.

switching the component type means a runtime `defer` toggle remounts the rendered markdown, so both `defer` props now document that the flag has to stay constant. nothing in-repo toggles it, and a conditional hook is not an option, so the constraint is stated rather than engineered around.

memoizing the parser boundary was the other candidate and is not what landed. `memo(ReactMarkdown)` makes the redundant pass cheap instead of removing it, it leaves the extra commit in place, and it only hits when every prop is referentially stable: with the inline `remarkPlugins={[remarkGfm]}` the shadcn kit and the docs both use, the memo misses on the urgent render and buys nothing on the deferred path. measured with an inline array it leaves `defer` at 2 parses per token; with a module-scope array it drops to 1.

the markdown contract now pins both paths rather than only the default one, so the parse still spent on the deferred path is visible instead of hidden behind a single number. that residual is #6730.

## Verification

counters per token, 20-paragraph document, measured on `0fb53906f` and on this branch:

| | before | after |
|---|---|---|
| react-markdown, `defer` off, parses | 2 | 1 |
| react-markdown, `defer` off, inner renders | 2 | 1 |
| react-markdown, `defer` off, thread commits | 3 | 2 |
| react-markdown, `defer` on, parses | 2 | 2 |
| react-markdown, `defer` on, inner renders | 2 | 1 |
| react-streamdown, primitive renders | 3 | 2 |
| react-streamdown, repair calls (and their priority) | 1, deferred | 1, deferred |

- `pnpm --filter @assistant-ui/x-performance exec vitest run contracts/markdown-streaming.test.tsx` -> 2/2 green here; on `0fb53906f` the same file fails `expected 22 to be 12`, which is the reproduction.
- `pnpm --filter @assistant-ui/x-performance test` -> 18 files, 77/77 green (no other contract moved).
- `pnpm --filter @assistant-ui/react-markdown test` -> 55/55 green. `pnpm --filter @assistant-ui/react-streamdown test` -> 142/142 green.
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` clean on the changed trees; both packages build; `pnpm --filter @assistant-ui/react-streamdown exec tsc --noEmit` clean.
- `pnpm size:check` passes: `@assistant-ui/react-markdown .` +15 B, `@assistant-ui/react-streamdown .` +66 B, both inside the max(2%, 256 B) budget.
- `pnpm changesets:check` passes.
- `pnpm --filter @assistant-ui/react-markdown exec tsc --noEmit` reports one error in `MarkdownText.test.tsx:48` that is already present on `0fb53906f`, untouched here.

#6726 also predicted the bench rows would roughly halve. they do not move: 0.3008 / 0.8396 / 3.9552 ms before against 0.3023 / 0.8279 / 3.8914 ms after, at 1 / 10 / 50 paragraphs, all inside the run's own noise. `bench/markdown-streaming.bench.tsx` drives each sample through `flushSync`, which flushes the urgent render only, so the transition-priority pass this PR removes was never inside the measured window. that measurement gap is #6731.

the streamdown half ships unpinned, deliberately. the counter it moves is the primitive's own render count, and that is not observable through the public entry: streamdown memoizes blocks by content, so measured before and after, both `rehypePlugins` invocations and changed-block child renders stay at 1 per token in either `defer` mode while the primitive goes 3 renders to 2. pinning it means adding `packages/react-streamdown` to the measured set (the four wirings in the x-performance README), which is #6734.

who feels this: consumers of the raw primitive with `defer` off get the parse. `packages/ui/src/components/react/assistant-ui/elements/markdown-text.tsx` sets `defer`, so the copied kit component keeps its 2 parses per token and gains one fewer `MarkdownTextInner` render instead. #6730 is the residual there.

## Public surface

`@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`, both patch, one changeset. no exports added, removed or moved; the new components are module-private. the two `defer` JSDoc blocks gain the constant-for-lifetime constraint. no api-reference output changes. `packages/x-performance/README.md` gains the deferred case in its markdown contract line.