### PR TITLE
feat(docs): budget the source snapshot by size at build time

### DIFF
--- a/.github/workflows/source-snapshot-budget.yaml
+++ b/.github/workflows/source-snapshot-budget.yaml
@@ -1,0 +1,36 @@
+name: Source Snapshot Budget
+
+# The snapshot is built from every tracked file, so this workflow carries no `paths:` filter.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source-snapshot-budget:
+    name: Source Snapshot Budget
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm and node.js
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # ratchet:pnpm/setup@v2.1.0
+        with:
+          runtime: node@24
+          install: false
+
+      - name: Verify the docs source snapshot fits its byte budget
+        run: node scripts/generate-source-snapshot.mts
+        working-directory: apps/docs

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -47,7 +47,8 @@ async function main() {
   const size = Buffer.byteLength(serialized, "utf-8");
 
   if (size > SNAPSHOT_BYTE_BUDGET) {
-    throw new Error(formatBudgetError(snapshot, size));
+    console.error(formatBudgetError(snapshot, size));
+    process.exit(1);
   }
 
   await fs.mkdir(OUTPUT_DIR, { recursive: true });

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -1,15 +1,16 @@
 import { execFileSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import {
+  SNAPSHOT_BYTE_BUDGET,
+  formatBudgetError,
+} from "./source-snapshot-budget.mts";
 
 const DOCS_ROOT = process.cwd();
 const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
 const OUTPUT_DIR = path.join(DOCS_ROOT, "generated");
 const OUTPUT_PATH = path.join(OUTPUT_DIR, "source-snapshot.json");
 const READ_CONCURRENCY = 32;
-// Measured single-flight: one materialized repo sandbox costs roughly 14x the snapshot's byte size in resident memory. Sandboxes are built per request, so concurrent repo-tool calls multiply that term.
-const SNAPSHOT_BYTE_BUDGET = 64_000_000;
-const BUDGET_REPORT_ENTRIES = 15;
 const SOURCE_SNAPSHOT_EXCLUDE = [
   /pnpm-lock\.yaml$/,
   /package-lock\.json$/,
@@ -48,7 +49,8 @@ async function main() {
 
   if (size > SNAPSHOT_BYTE_BUDGET) {
     console.error(formatBudgetError(snapshot, size));
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
@@ -101,36 +103,6 @@ function listTrackedFiles() {
   });
 
   return output.split("\0").filter(Boolean);
-}
-
-function formatBudgetError(snapshot: Record<string, string>, size: number) {
-  const largest = Object.entries(snapshot)
-    .map(([filePath, contents]) => ({
-      filePath,
-      bytes: Buffer.byteLength(contents, "utf-8"),
-    }))
-    .sort((a, b) => b.bytes - a.bytes)
-    .slice(0, BUDGET_REPORT_ENTRIES)
-    .map(
-      ({ filePath, bytes }) =>
-        `  ${formatBytes(bytes).padStart(9)}  ${filePath}`,
-    )
-    .join("\n");
-
-  return [
-    `Source snapshot is ${formatBytes(size)} across ${Object.keys(snapshot).length} files, over the ${formatBytes(SNAPSHOT_BYTE_BUDGET)} budget.`,
-    "",
-    "Prefer excluding files the docs assistant does not need to read, by adding a SOURCE_SNAPSHOT_EXCLUDE pattern in this script, over raising the budget.",
-    "",
-    "Largest entries:",
-    largest,
-  ].join("\n");
-}
-
-function formatBytes(bytes: number) {
-  return bytes >= 1_000_000
-    ? `${(bytes / 1_000_000).toFixed(1)} MB`
-    : `${Math.round(bytes / 1_000)} KB`;
 }
 
 await main();

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -7,10 +7,14 @@ const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
 const OUTPUT_DIR = path.join(DOCS_ROOT, "generated");
 const OUTPUT_PATH = path.join(OUTPUT_DIR, "source-snapshot.json");
 const READ_CONCURRENCY = 32;
+// Every serverless instance parses the snapshot at module scope and the repo sandbox materializes it again, costing roughly 14x its byte size in resident memory.
+const SNAPSHOT_BYTE_BUDGET = 64_000_000;
+const BUDGET_REPORT_ENTRIES = 15;
 const SOURCE_SNAPSHOT_EXCLUDE = [
   /pnpm-lock\.yaml$/,
   /package-lock\.json$/,
   /yarn\.lock$/,
+  /uv\.lock$/,
   /\.png$/,
   /\.jpg$/,
   /\.jpeg$/,
@@ -39,9 +43,15 @@ async function main() {
     );
 
   const snapshot = await buildSnapshot(files);
+  const serialized = JSON.stringify(snapshot);
+  const size = Buffer.byteLength(serialized, "utf-8");
+
+  if (size > SNAPSHOT_BYTE_BUDGET) {
+    throw new Error(formatBudgetError(snapshot, size));
+  }
 
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
-  await fs.writeFile(OUTPUT_PATH, JSON.stringify(snapshot));
+  await fs.writeFile(OUTPUT_PATH, serialized);
 }
 
 async function buildSnapshot(files: string[]) {
@@ -90,6 +100,36 @@ function listTrackedFiles() {
   });
 
   return output.split("\0").filter(Boolean);
+}
+
+function formatBudgetError(snapshot: Record<string, string>, size: number) {
+  const largest = Object.entries(snapshot)
+    .map(([filePath, contents]) => ({
+      filePath,
+      bytes: Buffer.byteLength(contents, "utf-8"),
+    }))
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, BUDGET_REPORT_ENTRIES)
+    .map(
+      ({ filePath, bytes }) =>
+        `  ${formatBytes(bytes).padStart(9)}  ${filePath}`,
+    )
+    .join("\n");
+
+  return [
+    `Source snapshot is ${formatBytes(size)} across ${Object.keys(snapshot).length} files, over the ${formatBytes(SNAPSHOT_BYTE_BUDGET)} budget.`,
+    "",
+    "Prefer excluding files the docs assistant does not need to read, by adding a SOURCE_SNAPSHOT_EXCLUDE pattern in this script, over raising the budget.",
+    "",
+    "Largest entries:",
+    largest,
+  ].join("\n");
+}
+
+function formatBytes(bytes: number) {
+  return bytes >= 1_000_000
+    ? `${(bytes / 1_000_000).toFixed(1)} MB`
+    : `${Math.round(bytes / 1_000)} KB`;
 }
 
 await main();

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -7,7 +7,7 @@ const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
 const OUTPUT_DIR = path.join(DOCS_ROOT, "generated");
 const OUTPUT_PATH = path.join(OUTPUT_DIR, "source-snapshot.json");
 const READ_CONCURRENCY = 32;
-// Every serverless instance parses the snapshot at module scope and the repo sandbox materializes it again, costing roughly 14x its byte size in resident memory.
+// Measured single-flight: one materialized repo sandbox costs roughly 14x the snapshot's byte size in resident memory. Sandboxes are built per request, so concurrent repo-tool calls multiply that term.
 const SNAPSHOT_BYTE_BUDGET = 64_000_000;
 const BUDGET_REPORT_ENTRIES = 15;
 const SOURCE_SNAPSHOT_EXCLUDE = [

--- a/apps/docs/scripts/source-snapshot-budget.mts
+++ b/apps/docs/scripts/source-snapshot-budget.mts
@@ -1,0 +1,37 @@
+// Measured single-flight: one materialized repo sandbox costs roughly 14x the snapshot's byte size in resident memory. Sandboxes are built per request, so concurrent repo-tool calls multiply that term.
+export const SNAPSHOT_BYTE_BUDGET = 64_000_000;
+
+const BUDGET_REPORT_ENTRIES = 15;
+
+export function formatBytes(bytes: number) {
+  return bytes >= 1_000_000
+    ? `${(bytes / 1_000_000).toFixed(1)} MB`
+    : `${Math.round(bytes / 1_000)} KB`;
+}
+
+export function formatBudgetError(
+  snapshot: Record<string, string>,
+  size: number,
+) {
+  const largest = Object.entries(snapshot)
+    .map(([filePath, contents]) => ({
+      filePath,
+      bytes: Buffer.byteLength(contents, "utf-8"),
+    }))
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, BUDGET_REPORT_ENTRIES)
+    .map(
+      ({ filePath, bytes }) =>
+        `  ${formatBytes(bytes).padStart(9)}  ${filePath}`,
+    )
+    .join("\n");
+
+  return [
+    `Source snapshot is ${formatBytes(size)} across ${Object.keys(snapshot).length} files, over the ${formatBytes(SNAPSHOT_BYTE_BUDGET)} budget.`,
+    "",
+    "Prefer excluding files the docs assistant does not need to read, by adding a SOURCE_SNAPSHOT_EXCLUDE pattern in generate-source-snapshot.mts, over raising the budget.",
+    "",
+    "Largest entries:",
+    largest,
+  ].join("\n");
+}

--- a/apps/docs/scripts/source-snapshot-budget.test.ts
+++ b/apps/docs/scripts/source-snapshot-budget.test.ts
@@ -52,7 +52,6 @@ describe("formatBudgetError", () => {
     );
     const report = formatBudgetError(snapshot(entries), 70_000_000);
 
-    expect(report.split("\n").slice(-15)).toHaveLength(15);
     expect(report.split("Largest entries:\n")[1]!.split("\n")).toHaveLength(15);
   });
 

--- a/apps/docs/scripts/source-snapshot-budget.test.ts
+++ b/apps/docs/scripts/source-snapshot-budget.test.ts
@@ -1,0 +1,72 @@
+import {
+  SNAPSHOT_BYTE_BUDGET,
+  formatBudgetError,
+  formatBytes,
+} from "./source-snapshot-budget.mts";
+
+describe("formatBytes", () => {
+  it("switches to megabytes at a megabyte", () => {
+    expect(formatBytes(999_999)).toBe("1000 KB");
+    expect(formatBytes(1_000_000)).toBe("1.0 MB");
+    expect(formatBytes(27_123_049)).toBe("27.1 MB");
+  });
+});
+
+describe("formatBudgetError", () => {
+  const snapshot = (entries: Record<string, number>) =>
+    Object.fromEntries(
+      Object.entries(entries).map(([name, size]) => [name, "x".repeat(size)]),
+    );
+
+  it("reports the overage, the file count, and the budget", () => {
+    const report = formatBudgetError(
+      snapshot({ "a.ts": 2_000_000, "b.ts": 1_000 }),
+      70_000_000,
+    );
+
+    expect(report).toContain("Source snapshot is 70.0 MB across 2 files");
+    expect(report).toContain(`over the ${formatBytes(SNAPSHOT_BYTE_BUDGET)}`);
+    expect(report).toContain("SOURCE_SNAPSHOT_EXCLUDE");
+  });
+
+  it("lists the largest entries first", () => {
+    const report = formatBudgetError(
+      snapshot({ "small.ts": 1_000, "huge.ts": 900_000, "mid.ts": 20_000 }),
+      70_000_000,
+    );
+    const listed = report
+      .slice(report.indexOf("Largest entries:"))
+      .split("\n")
+      .slice(1);
+
+    expect(listed).toEqual([
+      "     900 KB  huge.ts",
+      "      20 KB  mid.ts",
+      "       1 KB  small.ts",
+    ]);
+  });
+
+  it("caps the list so a repo-wide overage stays readable", () => {
+    const entries = Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`file-${index}.ts`, 1_000]),
+    );
+    const report = formatBudgetError(snapshot(entries), 70_000_000);
+
+    expect(report.split("\n").slice(-15)).toHaveLength(15);
+    expect(report.split("Largest entries:\n")[1]!.split("\n")).toHaveLength(15);
+  });
+
+  it("measures utf-8 bytes rather than string length", () => {
+    const report = formatBudgetError(
+      { "ascii.ts": "x".repeat(3_000), "emoji.ts": "🙂".repeat(1_000) },
+      70_000_000,
+    );
+    const listed = report
+      .slice(report.indexOf("Largest entries:"))
+      .split("\n")
+      .slice(1);
+
+    expect(listed[0]).toBe("       4 KB  emoji.ts");
+    expect(listed[1]).toBe("       3 KB  ascii.ts");
+  });
+});


### PR DESCRIPTION
closes #6716

## problem

`apps/docs/generated/source-snapshot.json` is built from `git ls-files` minus lockfiles and binaries, read at module scope by three call sites, and handed whole to `createBashTool`, which materializes it again into an in-memory filesystem. nothing measures it.

#6715 removed the `maxFiles: 5000` ceiling that had been standing in for a budget. it never was one: bash-tool checks the count after `streamFiles` has already read every file into memory, so it capped nothing and only converted repo growth into a silent production outage. the constraint that actually exists is bytes, and it is a build-time property.

## root cause

`generate-source-snapshot.mts` serialized the snapshot and wrote it without ever looking at its size, so the only thing that noticed growth was a runtime failure in production, on an arbitrary later deploy rather than on the change that caused it.

## change

`generate-source-snapshot.mts` now measures the serialized snapshot and refuses to emit one over `SNAPSHOT_BYTE_BUDGET`. when it trips it prints the total, the file count, and the 15 largest entries, so the usual fix is one more exclude pattern rather than a bigger number. the budget constant and its report live in `scripts/source-snapshot-budget.mts` because the generator is a top-level-await script that runs on import, so nothing in it can be imported without building a 27 MB snapshot as a side effect; that mirrors the `generated-docs/extract.mts` plus `extract.test.ts` shape already in this directory.

the budget is 64 MB, picked from measured growth rather than rounded up from today's size. summing `git ls-tree --long` blob sizes under the generator's own exclude list, one sample per month:

| date | files | raw MB |
| --- | --- | --- |
| 2025-09-30 | 1139 | 3.66 |
| 2026-01-30 | 1497 | 5.72 |
| 2026-04-30 | 2694 | 10.75 |
| 2026-06-30 | 3565 | 16.61 |
| 2026-07-31 | 3880 | 19.82 |
| 2026-08-31 | 4974 | 27.18 |
| today | 5078 | 27.69 |

growth is superlinear (7.6x in a year, the last two monthly deltas being +3.2 MB and +7.4 MB), so a 40 MB budget would trip in about six weeks and become a number someone raises every quarter. 64 MB is roughly five months of headroom, and it sits under the memory ceiling that motivates the budget: #6715 measured 416 MB RSS for a 29 MB snapshot through `createBashTool`, about 14x.

that 14x is a single-flight measurement, and the sandbox is built per request (`createRepoTools()` at `app/api/doc/chat/route.ts:378`, `createSourceMapTools()` via `app/api/xulux/chat/tools.ts:52`), so resident memory is roughly `base + snapshot + N x sandbox` for N concurrent chats that actually invoked a repo tool. the constant records that assumption so the next person to move the number sees what it rests on. the per-request construction is the real ceiling and a byte budget cannot fix a term that multiplies by concurrency, so it is filed as #6736 rather than widened into this PR.

the exclude list also picks up `uv.lock`. it already dropped `pnpm-lock.yaml`, `package-lock.json`, and `yarn.lock`, but was never updated when the Python packages arrived, so five `uv.lock` files (2.07 MB, 7.1% of the snapshot) were being shipped to a source-reading assistant. that is an omission, not a trade-off; `api-surface` (2.64 MB) and the CHANGELOGs (1.97 MB) are trade-offs and are deliberately left in, and the diagnostic will surface them if the budget ever trips.

the new workflow runs the generator itself rather than a second script that re-declares the exclude list and the budget. an exclude list that drifts out of sync is exactly the bug being fixed here, so there is one copy. Node 24 runs the `.mts` file natively, which makes the job `install: false` and sub-second, matching the shape of the existing Unmanaged Pins and Workspace Ranges jobs. it carries no `paths:` filter on purpose: the snapshot is built from every tracked file, and `code-quality.yaml` (which already excludes `apps/docs` from its build job, deferring to Vercel) does not watch `python/**`, so a Python-only PR could grow the snapshot unseen.

## verification

- `node scripts/generate-source-snapshot.mts` from `apps/docs`: exits 0, and the emitted snapshot drops from 29,194,004 to 27,123,049 bytes (5078 to 5073 files, measured on the same tree) with zero `uv.lock` entries left.
- failure path, with the budget temporarily lowered to 20 MB: exits 1, leaves the previously written snapshot untouched rather than overwriting it with an over-budget one, and prints

```
Source snapshot is 27.1 MB across 5076 files, over the 20.0 MB budget.

Prefer excluding files the docs assistant does not need to read, by adding a SOURCE_SNAPSHOT_EXCLUDE pattern in generate-source-snapshot.mts, over raising the budget.

Largest entries:
     828 KB  api-surface/assistant-stream.ts
     252 KB  packages/react/CHANGELOG.md
     244 KB  api-surface/assistant-ui__react.ts
     ...
```

- the failure sets `process.exitCode` and returns rather than calling `process.exit`, so Node drains stderr before exiting; writes to a pipe are asynchronous and `process.exit` can truncate them.
- `scripts/source-snapshot-budget.test.ts` covers the KB to MB boundary, the header line, largest-first ordering, the 15-entry cap, and that entries are sized in UTF-8 bytes rather than string length. the cap assertion was checked against a mutant: raising `BUDGET_REPORT_ENTRIES` to 40 fails it.
- `npx tsx ./scripts/generate-source-snapshot.mts`, the path `pnpm -C apps/docs build` actually takes: same byte count. `tsc -p scripts/tsconfig.json --noEmit` clean.
- `oxlint` and `oxfmt --check` clean; `node scripts/check-unmanaged-pins.mjs` passes over 17 workflows including the new one; the workflow YAML parses.
- checked that nothing consumes a lock file from the snapshot: the three `readFileSync` consumers and `create-demo-zip`'s manifests (which throw on a missing key) reference none.

## public surface

none. `@assistant-ui/docs` is `private: true`, so no changeset. no exports, api-reference output, or templates touched. one new workflow, Source Snapshot Budget, runs on every pull request.