### PR TITLE
fix(assistant-stream): fence stale Redis finalization

### DIFF
--- a/.changeset/calm-streams-finalize.md
+++ b/.changeset/calm-streams-finalize.md
@@ -3,3 +3,5 @@
 ---
 
 fix: prevent stale Redis producers from finalizing replacement streams
+
+`RedisLikeClient` now requires a `finalizeIfUnchanged` method; no public API accepts a `RedisLikeClient`, so this only affects code that typed a value against the interface directly.

--- a/.changeset/calm-streams-finalize.md
+++ b/.changeset/calm-streams-finalize.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: prevent stale Redis producers from finalizing replacement streams

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -24166,7 +24166,7 @@ interface RedisLikeClient {
     fields: Record<string, string | Uint8Array>;
   }>>;
   pipeline(commands: readonly PipelineCommand[]): Promise<void>;
-  finalizeIfUnchanged?(options: RedisFinalizeOptions): Promise<boolean>;
+  finalizeIfUnchanged(options: RedisFinalizeOptions): Promise<boolean>;
 }
 
 type RedisOptions = CommonRedisOptions & SentinelConnectionOptions & StandaloneConnectionOptions;

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -24142,6 +24142,15 @@ interface RedisCommander<Context extends ClientContext = {
   ]): Result<number, Context>;
 }
 
+type RedisFinalizeOptions = {
+  readonly metaKey: string;
+  readonly expectedMeta: string;
+  readonly nextMeta: string;
+  readonly dataKey: string;
+  readonly fields: Record<string, string>;
+  readonly ttlSec: number;
+};
+
 type RedisKey = string | Buffer;
 
 interface RedisLikeClient {
@@ -24157,6 +24166,7 @@ interface RedisLikeClient {
     fields: Record<string, string | Uint8Array>;
   }>>;
   pipeline(commands: readonly PipelineCommand[]): Promise<void>;
+  finalizeIfUnchanged?(options: RedisFinalizeOptions): Promise<boolean>;
 }
 
 type RedisOptions = CommonRedisOptions & SentinelConnectionOptions & StandaloneConnectionOptions;
@@ -24756,7 +24766,7 @@ declare const getPartialJsonObjectMeta: (obj: Record<symbol, unknown>) => Partia
 declare const hasHimportCoordinator: unique symbol;
 
 declare namespace entry_resumable_exports {
-  export { CreateResumableAssistantStreamResponseOptions, CreateResumeAssistantStreamResponseOptions, InMemoryResumableStreamStoreOptions, RESUMABLE_STREAM_ID_HEADER, RedisLikeClient, RedisResumableStreamStoreOptions, ResumableStreamAcquireOptions, ResumableStreamContext, ResumableStreamContextOptions, ResumableStreamEntry, ResumableStreamError, ResumableStreamErrorCode, ResumableStreamRole, ResumableStreamStatus, ResumableStreamStore, createInMemoryResumableStreamStore, createResumableAssistantStreamResponse, createResumableStreamContext, createResumeAssistantStreamResponse };
+  export { CreateResumableAssistantStreamResponseOptions, CreateResumeAssistantStreamResponseOptions, InMemoryResumableStreamStoreOptions, RESUMABLE_STREAM_ID_HEADER, RedisFinalizeOptions, RedisLikeClient, RedisResumableStreamStoreOptions, ResumableStreamAcquireOptions, ResumableStreamContext, ResumableStreamContextOptions, ResumableStreamEntry, ResumableStreamError, ResumableStreamErrorCode, ResumableStreamRole, ResumableStreamStatus, ResumableStreamStore, createInMemoryResumableStreamStore, createResumableAssistantStreamResponse, createResumableStreamContext, createResumeAssistantStreamResponse };
 }
 
 declare namespace entry_root_exports {

--- a/apps/docs/content/docs/guides/resumable-streams.mdx
+++ b/apps/docs/content/docs/guides/resumable-streams.mdx
@@ -208,7 +208,7 @@ Key by `remoteId ?? id` under a recognizable prefix, read lazily. A brand-new th
 
 The core package ships `createInMemoryResumableStreamStore` for development and tests. State lives in a process-local `Map`, so it does not survive a server restart. Useful options include `defaultTtlMs`, `maxChunkBytes`, `maxEntriesPerStream`, `maxStreams`, and `gcIntervalMs` for periodic eviction.
 
-For production, use one of the optional Redis adapters via the `assistant-stream/resumable/redis` (node-redis v5) or `assistant-stream/resumable/ioredis` sub-paths. Both adapters batch the per-append `XADD` and TTL refresh into a single pipelined round trip, store chunk values as binary, and accept the same `keyPrefix`, `defaultTtlMs`, `pollIntervalMs`, and `maxChunkBytes` options. Cluster routing works because each stream's keys share a `{streamId}` hash tag.
+For production, use one of the optional Redis adapters via the `assistant-stream/resumable/redis` (node-redis v5) or `assistant-stream/resumable/ioredis` sub-paths. Both adapters batch the per-append `XADD` and TTL refresh into a single pipelined round trip, store chunk values as binary, and accept the same `keyPrefix`, `defaultTtlMs`, `pollIntervalMs`, and `maxChunkBytes` options. Cluster routing works because each stream's keys share a `{streamId}` hash tag. Finalization runs as a server-side script, so the endpoint must allow `EVAL`; a Redis-compatible service with scripting disabled needs a custom `ResumableStreamStore` instead.
 
 ```ts title="/lib/resumable-context.ts"
 import {

--- a/packages/assistant-stream/src/resumable/index.ts
+++ b/packages/assistant-stream/src/resumable/index.ts
@@ -28,6 +28,7 @@ export {
 } from "./stores/InMemoryResumableStreamStore";
 
 export type {
+  RedisFinalizeOptions,
   RedisLikeClient,
   RedisResumableStreamStoreOptions,
 } from "./stores/redis-impl";

--- a/packages/assistant-stream/src/resumable/stores/ioredis.ts
+++ b/packages/assistant-stream/src/resumable/stores/ioredis.ts
@@ -5,11 +5,26 @@ import type {
 } from "ioredis";
 import {
   RedisResumableStreamStore,
+  type RedisFinalizeOptions,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
 } from "./redis-impl";
 import type { ResumableStreamStore } from "../types";
+
+const FINALIZE_IF_UNCHANGED_SCRIPT = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+local xadd = { "XADD", KEYS[2], "*" }
+for i = 4, #ARGV do
+  table.insert(xadd, ARGV[i])
+end
+redis.call(unpack(xadd))
+redis.call("EXPIRE", KEYS[2], ARGV[3])
+redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+return 1
+`;
 
 export type IoRedisLike = IoRedis | IoRedisCluster;
 
@@ -69,7 +84,26 @@ function adapt(client: IoRedisLike): RedisLikeClient {
         if (err) throw err;
       }
     },
+    async finalizeIfUnchanged(options) {
+      const result = await client.eval(
+        FINALIZE_IF_UNCHANGED_SCRIPT,
+        2,
+        options.metaKey,
+        options.dataKey,
+        options.expectedMeta,
+        options.nextMeta,
+        String(options.ttlSec),
+        ...toIoRedisFieldArgs(options),
+      );
+      return result === 1;
+    },
   };
+}
+
+function toIoRedisFieldArgs(
+  options: RedisFinalizeOptions,
+): Array<string | Buffer> {
+  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
 }
 
 function applyPipelineCommand(

--- a/packages/assistant-stream/src/resumable/stores/ioredis.ts
+++ b/packages/assistant-stream/src/resumable/stores/ioredis.ts
@@ -4,9 +4,10 @@ import type {
   Redis as IoRedis,
 } from "ioredis";
 import {
+  FINALIZE_IF_UNCHANGED_KEY_COUNT,
   FINALIZE_IF_UNCHANGED_SCRIPT,
   RedisResumableStreamStore,
-  redisFinalizeFieldArgs,
+  finalizeIfUnchangedArgs,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
@@ -74,13 +75,8 @@ function adapt(client: IoRedisLike): RedisLikeClient {
     async finalizeIfUnchanged(options) {
       const result = await client.eval(
         FINALIZE_IF_UNCHANGED_SCRIPT,
-        2,
-        options.metaKey,
-        options.dataKey,
-        options.expectedMeta,
-        options.nextMeta,
-        String(options.ttlSec),
-        ...redisFinalizeFieldArgs(options),
+        FINALIZE_IF_UNCHANGED_KEY_COUNT,
+        ...finalizeIfUnchangedArgs(options),
       );
       return result === 1;
     },

--- a/packages/assistant-stream/src/resumable/stores/ioredis.ts
+++ b/packages/assistant-stream/src/resumable/stores/ioredis.ts
@@ -4,27 +4,14 @@ import type {
   Redis as IoRedis,
 } from "ioredis";
 import {
+  FINALIZE_IF_UNCHANGED_SCRIPT,
   RedisResumableStreamStore,
-  type RedisFinalizeOptions,
+  redisFinalizeFieldArgs,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
 } from "./redis-impl";
 import type { ResumableStreamStore } from "../types";
-
-const FINALIZE_IF_UNCHANGED_SCRIPT = `
-if redis.call("GET", KEYS[1]) ~= ARGV[1] then
-  return 0
-end
-local xadd = { "XADD", KEYS[2], "*" }
-for i = 4, #ARGV do
-  table.insert(xadd, ARGV[i])
-end
-redis.call(unpack(xadd))
-redis.call("EXPIRE", KEYS[2], ARGV[3])
-redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
-return 1
-`;
 
 export type IoRedisLike = IoRedis | IoRedisCluster;
 
@@ -93,17 +80,11 @@ function adapt(client: IoRedisLike): RedisLikeClient {
         options.expectedMeta,
         options.nextMeta,
         String(options.ttlSec),
-        ...toIoRedisFieldArgs(options),
+        ...redisFinalizeFieldArgs(options),
       );
       return result === 1;
     },
   };
-}
-
-function toIoRedisFieldArgs(
-  options: RedisFinalizeOptions,
-): Array<string | Buffer> {
-  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
 }
 
 function applyPipelineCommand(

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -188,16 +188,29 @@ describe("RedisResumableStreamStore", () => {
     await expect(store.status("current")).resolves.toBe("done");
   });
 
-  it("retains pipeline finalization without the atomic capability", async () => {
+  it("does not resurrect a stream whose metadata expired mid-finalize", async () => {
     const client = new FakeRedisClient();
-    Object.defineProperty(client, "finalizeIfUnchanged", { value: undefined });
-    const store = new RedisResumableStreamStore(client);
+    const keyPrefix = "test";
+    const streamId = "expired";
+    const store = new RedisResumableStreamStore(client, { keyPrefix });
+    await store.acquire(streamId);
 
-    await store.acquire("stream");
-    await store.append("stream", encoder.encode("chunk"));
-    await store.finalize("stream", "done");
+    let resumeFinalizer!: () => void;
+    const finalizerPaused = new Promise<void>((resolve) => {
+      client.onNextGet = () =>
+        new Promise<void>((resume) => {
+          resumeFinalizer = resume;
+          resolve();
+        });
+    });
+    const finalizing = store.finalize(streamId, "done");
+    await finalizerPaused;
 
-    await expect(store.status("stream")).resolves.toBe("done");
+    client.strings.delete(`${keyPrefix}:{${streamId}}:meta`);
+    resumeFinalizer();
+    await finalizing;
+
+    await expect(store.status(streamId)).resolves.toBe("missing");
   });
 
   it("fences a superseded producer out of the reacquired stream", async () => {

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   RedisResumableStreamStore,
+  type RedisFinalizeOptions,
   type PipelineCommand,
   type RedisLikeClient,
 } from "./redis-impl";
@@ -18,6 +19,7 @@ class FakeRedisClient implements RedisLikeClient {
     }>
   >();
   onFirstAcquire: (() => Promise<void>) | undefined;
+  onNextGet: (() => Promise<void>) | undefined;
   private nextStreamId = 0;
 
   async setNX(key: string, value: string): Promise<boolean> {
@@ -34,7 +36,11 @@ class FakeRedisClient implements RedisLikeClient {
   }
 
   async get(key: string): Promise<string | null> {
-    return this.strings.get(key) ?? null;
+    const value = this.strings.get(key) ?? null;
+    const onNextGet = this.onNextGet;
+    this.onNextGet = undefined;
+    await onNextGet?.();
+    return value;
   }
 
   async expire(): Promise<void> {}
@@ -92,6 +98,14 @@ class FakeRedisClient implements RedisLikeClient {
           break;
       }
     }
+  }
+
+  async finalizeIfUnchanged(options: RedisFinalizeOptions): Promise<boolean> {
+    if (this.strings.get(options.metaKey) !== options.expectedMeta)
+      return false;
+    await this.xAdd(options.dataKey, options.fields);
+    await this.set(options.metaKey, options.nextMeta);
+    return true;
   }
 }
 
@@ -206,6 +220,34 @@ describe("RedisResumableStreamStore", () => {
       chunks.push(decoder.decode(entry.chunk));
     }
     expect(chunks).toEqual(["fresh"]);
+  });
+
+  it("does not let a stale finalizer overwrite a reacquired stream", async () => {
+    const client = new FakeRedisClient();
+    const keyPrefix = "test";
+    const streamId = "finalize-race";
+    const metaKey = `${keyPrefix}:{${streamId}}:meta`;
+    const staleStore = new RedisResumableStreamStore(client, { keyPrefix });
+    const freshStore = new RedisResumableStreamStore(client, { keyPrefix });
+    await staleStore.acquire(streamId);
+
+    let resumeFinalizer!: () => void;
+    const finalizerPaused = new Promise<void>((resolve) => {
+      client.onNextGet = () =>
+        new Promise<void>((resume) => {
+          resumeFinalizer = resume;
+          resolve();
+        });
+    });
+    const finalizing = staleStore.finalize(streamId, "done");
+    await finalizerPaused;
+
+    client.strings.delete(metaKey);
+    await expect(freshStore.acquire(streamId)).resolves.toBe("producer");
+    resumeFinalizer();
+    await finalizing;
+
+    await expect(freshStore.status(streamId)).resolves.toBe("streaming");
   });
 
   it("stops an existing reader when the stream generation changes", async () => {

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -273,6 +273,9 @@ describe("RedisResumableStreamStore", () => {
     await finalizing;
 
     await expect(freshStore.status(streamId)).resolves.toBe("streaming");
+    await expect(
+      staleStore.append(streamId, encoder.encode("stale")),
+    ).rejects.toThrow(/superseded/);
   });
 
   it("stops an existing reader when the stream generation changes", async () => {

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -188,6 +188,18 @@ describe("RedisResumableStreamStore", () => {
     await expect(store.status("current")).resolves.toBe("done");
   });
 
+  it("retains pipeline finalization without the atomic capability", async () => {
+    const client = new FakeRedisClient();
+    Object.defineProperty(client, "finalizeIfUnchanged", { value: undefined });
+    const store = new RedisResumableStreamStore(client);
+
+    await store.acquire("stream");
+    await store.append("stream", encoder.encode("chunk"));
+    await store.finalize("stream", "done");
+
+    await expect(store.status("stream")).resolves.toBe("done");
+  });
+
   it("fences a superseded producer out of the reacquired stream", async () => {
     const client = new FakeRedisClient();
     const keyPrefix = "test";

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -248,6 +248,9 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       fields,
       ttlSec,
     });
+    // Keeping the fencing token when the compare-and-finalize loses is what
+    // makes a later append from this superseded producer throw instead of
+    // writing into the replacement generation.
     if (!finalized) return;
     this.acquiredGenerations.delete(streamId);
   }

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -44,6 +44,8 @@ export type RedisFinalizeOptions = {
   readonly ttlSec: number;
 };
 
+// `XADD *` is non-deterministic; Redis 5.x and 6.x configured with
+// `lua-replicate-commands no` reject it unless effects replication is requested.
 export const FINALIZE_IF_UNCHANGED_SCRIPT = `
 redis.replicate_commands()
 if redis.call("GET", KEYS[1]) ~= ARGV[1] then
@@ -59,16 +61,24 @@ redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
 return 1
 `;
 
-export function redisFinalizeFieldArgs(
+export const FINALIZE_IF_UNCHANGED_KEY_COUNT = 2;
+
+export function finalizeIfUnchangedArgs(
   options: RedisFinalizeOptions,
 ): string[] {
-  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
+  return [
+    options.metaKey,
+    options.dataKey,
+    options.expectedMeta,
+    options.nextMeta,
+    String(options.ttlSec),
+    ...Object.entries(options.fields).flat(),
+  ];
 }
 
 /**
  * Structural Redis-client interface. The bundled `redis` and `ioredis`
- * adapters wrap their respective clients to satisfy it; custom or proxied
- * clients can implement it directly.
+ * adapters wrap their respective clients to satisfy it.
  */
 export interface RedisLikeClient {
   setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
@@ -91,11 +101,10 @@ export interface RedisLikeClient {
   /** Executes the commands as a single pipeline batch (one round trip). */
   pipeline(commands: readonly PipelineCommand[]): Promise<void>;
   /**
-   * Atomically finalizes a stream only while its metadata is unchanged.
-   * Clients that omit this retain non-atomic pipeline finalization and cannot
-   * fence a replacement acquisition that races with finalization.
+   * Atomically finalizes a stream only while its metadata is unchanged, so a
+   * producer superseded by a newer acquisition cannot finalize the replacement.
    */
-  finalizeIfUnchanged?(options: RedisFinalizeOptions): Promise<boolean>;
+  finalizeIfUnchanged(options: RedisFinalizeOptions): Promise<boolean>;
 }
 
 export type RedisResumableStreamStoreOptions = {
@@ -231,23 +240,15 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       fields[FIELD_ERROR] = error ?? "Stream errored";
     }
     const dataKey = this.dataKey(streamId, existing.generation);
-    if (this.client.finalizeIfUnchanged) {
-      const finalized = await this.client.finalizeIfUnchanged({
-        metaKey,
-        expectedMeta: existingRaw,
-        nextMeta: meta,
-        dataKey,
-        fields,
-        ttlSec,
-      });
-      if (!finalized) return;
-    } else {
-      await this.client.pipeline([
-        { type: "set", key: metaKey, value: meta, ttlSec },
-        { type: "xAdd", key: dataKey, fields },
-        { type: "expire", key: dataKey, ttlSec },
-      ]);
-    }
+    const finalized = await this.client.finalizeIfUnchanged({
+      metaKey,
+      expectedMeta: existingRaw,
+      nextMeta: meta,
+      dataKey,
+      fields,
+      ttlSec,
+    });
+    if (!finalized) return;
     this.acquiredGenerations.delete(streamId);
   }
 

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -35,6 +35,15 @@ export type PipelineCommand =
       readonly ttlSec: number;
     };
 
+export type RedisFinalizeOptions = {
+  readonly metaKey: string;
+  readonly expectedMeta: string;
+  readonly nextMeta: string;
+  readonly dataKey: string;
+  readonly fields: Record<string, string>;
+  readonly ttlSec: number;
+};
+
 /**
  * Structural Redis-client interface. The bundled `redis` and `ioredis`
  * adapters wrap their respective clients to satisfy it; custom or proxied
@@ -60,6 +69,11 @@ export interface RedisLikeClient {
   >;
   /** Executes the commands as a single pipeline batch (one round trip). */
   pipeline(commands: readonly PipelineCommand[]): Promise<void>;
+  /**
+   * Atomically finalizes a stream only while its metadata is unchanged.
+   * Custom clients may omit this to retain the pre-existing pipeline behavior.
+   */
+  finalizeIfUnchanged?(options: RedisFinalizeOptions): Promise<boolean>;
 }
 
 export type RedisResumableStreamStoreOptions = {
@@ -167,7 +181,11 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
   ): Promise<void> {
     validateStreamId(streamId);
     const metaKey = this.metaKey(streamId);
-    const existing = await this.readMeta(streamId);
+    const existingRaw = await this.client.get(metaKey);
+    if (existingRaw === null) {
+      throw new Error(`Stream not found: ${streamId}`);
+    }
+    const existing = parseMeta(existingRaw);
     if (!existing) {
       throw new Error(`Stream not found: ${streamId}`);
     }
@@ -191,12 +209,26 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       fields[FIELD_ERROR] = error ?? "Stream errored";
     }
     const dataKey = this.dataKey(streamId, existing.generation);
-    await this.client.pipeline([
+    const commands: readonly PipelineCommand[] = [
       { type: "set", key: metaKey, value: meta, ttlSec },
       { type: "xAdd", key: dataKey, fields },
       { type: "expire", key: dataKey, ttlSec },
-    ]);
+    ];
+    let finalized = true;
+    if (this.client.finalizeIfUnchanged) {
+      finalized = await this.client.finalizeIfUnchanged({
+        metaKey,
+        expectedMeta: existingRaw,
+        nextMeta: meta,
+        dataKey,
+        fields,
+        ttlSec,
+      });
+    } else {
+      await this.client.pipeline(commands);
+    }
     this.acquiredGenerations.delete(streamId);
+    if (!finalized) return;
   }
 
   async *read(

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -91,7 +91,8 @@ export interface RedisLikeClient {
   pipeline(commands: readonly PipelineCommand[]): Promise<void>;
   /**
    * Atomically finalizes a stream only while its metadata is unchanged.
-   * Custom clients may omit this to retain the pre-existing pipeline behavior.
+   * Clients that omit this retain non-atomic pipeline finalization and cannot
+   * fence a replacement acquisition that races with finalization.
    */
   finalizeIfUnchanged?(options: RedisFinalizeOptions): Promise<boolean>;
 }

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -45,6 +45,7 @@ export type RedisFinalizeOptions = {
 };
 
 export const FINALIZE_IF_UNCHANGED_SCRIPT = `
+redis.replicate_commands()
 if redis.call("GET", KEYS[1]) ~= ARGV[1] then
   return 0
 end

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -44,6 +44,26 @@ export type RedisFinalizeOptions = {
   readonly ttlSec: number;
 };
 
+export const FINALIZE_IF_UNCHANGED_SCRIPT = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+local xadd = { "XADD", KEYS[2], "*" }
+for i = 4, #ARGV do
+  table.insert(xadd, ARGV[i])
+end
+redis.call(unpack(xadd))
+redis.call("EXPIRE", KEYS[2], ARGV[3])
+redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+return 1
+`;
+
+export function redisFinalizeFieldArgs(
+  options: RedisFinalizeOptions,
+): string[] {
+  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
+}
+
 /**
  * Structural Redis-client interface. The bundled `redis` and `ioredis`
  * adapters wrap their respective clients to satisfy it; custom or proxied
@@ -209,14 +229,8 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       fields[FIELD_ERROR] = error ?? "Stream errored";
     }
     const dataKey = this.dataKey(streamId, existing.generation);
-    const commands: readonly PipelineCommand[] = [
-      { type: "set", key: metaKey, value: meta, ttlSec },
-      { type: "xAdd", key: dataKey, fields },
-      { type: "expire", key: dataKey, ttlSec },
-    ];
-    let finalized = true;
     if (this.client.finalizeIfUnchanged) {
-      finalized = await this.client.finalizeIfUnchanged({
+      const finalized = await this.client.finalizeIfUnchanged({
         metaKey,
         expectedMeta: existingRaw,
         nextMeta: meta,
@@ -224,11 +238,15 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
         fields,
         ttlSec,
       });
+      if (!finalized) return;
     } else {
-      await this.client.pipeline(commands);
+      await this.client.pipeline([
+        { type: "set", key: metaKey, value: meta, ttlSec },
+        { type: "xAdd", key: dataKey, fields },
+        { type: "expire", key: dataKey, ttlSec },
+      ]);
     }
     this.acquiredGenerations.delete(streamId);
-    if (!finalized) return;
   }
 
   async *read(

--- a/packages/assistant-stream/src/resumable/stores/redis.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.test.ts
@@ -38,9 +38,39 @@ type Adapter = {
         maxChunkBytes: number;
       }>,
     ) => ResumableStreamStore;
+    deleteKey: (key: string) => Promise<void>;
+    pauseNextGet: (pause: () => Promise<void>) => void;
     cleanup: () => Promise<void>;
   }>;
 };
+
+function withPausableGet<
+  T extends { get(key: string): Promise<string | null> },
+>(
+  client: T,
+): { client: T; pauseNextGet: (pause: () => Promise<void>) => void } {
+  let nextGetPause: (() => Promise<void>) | undefined;
+  return {
+    client: new Proxy(client, {
+      get(target, property) {
+        if (property === "get") {
+          return async (key: string) => {
+            const value = await client.get(key);
+            const pause = nextGetPause;
+            nextGetPause = undefined;
+            await pause?.();
+            return value;
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }),
+    pauseNextGet(pause) {
+      nextGetPause = pause;
+    },
+  };
+}
 
 const adapters: Adapter[] = [
   {
@@ -49,9 +79,10 @@ const adapters: Adapter[] = [
       const client: RedisClientType = createClient({ url: REDIS_URL });
       client.on("error", () => {});
       await client.connect();
+      const pausable = withPausableGet(client);
       const keyPrefix = `${KEY_PREFIX_BASE}:nr:${suiteCounter++}`;
       const makeStore = (overrides?: { maxChunkBytes?: number }) =>
-        createRedisResumableStreamStore(client, {
+        createRedisResumableStreamStore(pausable.client, {
           keyPrefix,
           pollIntervalMs: 25,
           ...overrides,
@@ -60,6 +91,10 @@ const adapters: Adapter[] = [
         store: makeStore(),
         keyPrefix,
         makeStore,
+        deleteKey: async (key) => {
+          await client.del(key);
+        },
+        pauseNextGet: pausable.pauseNextGet,
         cleanup: async () => {
           const keys = await client.keys(`${keyPrefix}:*`);
           if (keys.length > 0) await client.del(keys);
@@ -73,9 +108,10 @@ const adapters: Adapter[] = [
     setup: async () => {
       const client = new IoRedis(REDIS_URL, { lazyConnect: true });
       await client.connect();
+      const pausable = withPausableGet(client);
       const keyPrefix = `${KEY_PREFIX_BASE}:io:${suiteCounter++}`;
       const makeStore = (overrides?: { maxChunkBytes?: number }) =>
-        createIoredisResumableStreamStore(client, {
+        createIoredisResumableStreamStore(pausable.client, {
           keyPrefix,
           pollIntervalMs: 25,
           ...overrides,
@@ -84,6 +120,10 @@ const adapters: Adapter[] = [
         store: makeStore(),
         keyPrefix,
         makeStore,
+        deleteKey: async (key) => {
+          await client.del(key);
+        },
+        pauseNextGet: pausable.pauseNextGet,
         cleanup: async () => {
           const keys = await client.keys(`${keyPrefix}:*`);
           if (keys.length > 0) await client.del(...keys);
@@ -102,12 +142,18 @@ for (const adapter of adapters) {
       let makeStore: (overrides?: {
         maxChunkBytes?: number;
       }) => ResumableStreamStore;
+      let keyPrefix: string;
+      let deleteKey: (key: string) => Promise<void>;
+      let pauseNextGet: (pause: () => Promise<void>) => void;
       let cleanup: () => Promise<void>;
 
       beforeAll(async () => {
         const ctx = await adapter.setup();
         store = ctx.store;
         makeStore = ctx.makeStore;
+        keyPrefix = ctx.keyPrefix;
+        deleteKey = ctx.deleteKey;
+        pauseNextGet = ctx.pauseNextGet;
         cleanup = ctx.cleanup;
       });
 
@@ -160,6 +206,36 @@ for (const adapter of adapters) {
         await store.acquire(id);
         await store.finalize(id, "error", "boom");
         expect(await store.status(id)).toBe("error");
+      });
+
+      it("does not let a stale finalizer overwrite a reacquired stream", async () => {
+        const id = `id-${Math.random()}`;
+        const staleStore = makeStore();
+        const freshStore = makeStore();
+        await staleStore.acquire(id);
+
+        let resumeFinalizer!: () => void;
+        const finalizerPaused = new Promise<void>((resolve) => {
+          pauseNextGet(
+            () =>
+              new Promise<void>((resume) => {
+                resumeFinalizer = resume;
+                resolve();
+              }),
+          );
+        });
+        const finalizing = staleStore.finalize(id, "done");
+        await finalizerPaused;
+
+        await deleteKey(`${keyPrefix}:{${id}}:meta`);
+        await expect(freshStore.acquire(id)).resolves.toBe("producer");
+        resumeFinalizer();
+        await finalizing;
+
+        await expect(freshStore.status(id)).resolves.toBe("streaming");
+        await expect(staleStore.append(id, bytes("stale"))).rejects.toThrow(
+          /superseded/,
+        );
       });
 
       it("read throws on error finalize after draining buffered entries", async () => {

--- a/packages/assistant-stream/src/resumable/stores/redis.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.ts
@@ -1,5 +1,6 @@
 import {
   RedisResumableStreamStore,
+  type RedisFinalizeOptions,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
@@ -7,6 +8,20 @@ import {
 import type { ResumableStreamStore } from "../types";
 
 const RESP_BLOB_STRING = 36;
+
+const FINALIZE_IF_UNCHANGED_SCRIPT = `
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+  return 0
+end
+local xadd = { "XADD", KEYS[2], "*" }
+for i = 4, #ARGV do
+  table.insert(xadd, ARGV[i])
+end
+redis.call(unpack(xadd))
+redis.call("EXPIRE", KEYS[2], ARGV[3])
+redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+return 1
+`;
 
 type NodeRedisFields = Record<string, string | Buffer>;
 
@@ -99,7 +114,27 @@ function adapt(client: NodeRedisLike): RedisLikeClient {
       }
       await chain.execAsPipeline();
     },
+    async finalizeIfUnchanged(options) {
+      const result = await client.sendCommand<number>([
+        "EVAL",
+        FINALIZE_IF_UNCHANGED_SCRIPT,
+        "2",
+        options.metaKey,
+        options.dataKey,
+        options.expectedMeta,
+        options.nextMeta,
+        String(options.ttlSec),
+        ...toNodeFieldArgs(options),
+      ]);
+      return result === 1;
+    },
   };
+}
+
+function toNodeFieldArgs(
+  options: RedisFinalizeOptions,
+): Array<string | Buffer> {
+  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
 }
 
 function applyPipelineCommand(

--- a/packages/assistant-stream/src/resumable/stores/redis.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.ts
@@ -1,7 +1,8 @@
 import {
+  FINALIZE_IF_UNCHANGED_KEY_COUNT,
   FINALIZE_IF_UNCHANGED_SCRIPT,
   RedisResumableStreamStore,
-  redisFinalizeFieldArgs,
+  finalizeIfUnchangedArgs,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
@@ -105,13 +106,8 @@ function adapt(client: NodeRedisLike): RedisLikeClient {
       const result = await client.sendCommand<number>([
         "EVAL",
         FINALIZE_IF_UNCHANGED_SCRIPT,
-        "2",
-        options.metaKey,
-        options.dataKey,
-        options.expectedMeta,
-        options.nextMeta,
-        String(options.ttlSec),
-        ...redisFinalizeFieldArgs(options),
+        String(FINALIZE_IF_UNCHANGED_KEY_COUNT),
+        ...finalizeIfUnchangedArgs(options),
       ]);
       return result === 1;
     },

--- a/packages/assistant-stream/src/resumable/stores/redis.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.ts
@@ -1,6 +1,7 @@
 import {
+  FINALIZE_IF_UNCHANGED_SCRIPT,
   RedisResumableStreamStore,
-  type RedisFinalizeOptions,
+  redisFinalizeFieldArgs,
   type PipelineCommand,
   type RedisLikeClient,
   type RedisResumableStreamStoreOptions,
@@ -8,20 +9,6 @@ import {
 import type { ResumableStreamStore } from "../types";
 
 const RESP_BLOB_STRING = 36;
-
-const FINALIZE_IF_UNCHANGED_SCRIPT = `
-if redis.call("GET", KEYS[1]) ~= ARGV[1] then
-  return 0
-end
-local xadd = { "XADD", KEYS[2], "*" }
-for i = 4, #ARGV do
-  table.insert(xadd, ARGV[i])
-end
-redis.call(unpack(xadd))
-redis.call("EXPIRE", KEYS[2], ARGV[3])
-redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
-return 1
-`;
 
 type NodeRedisFields = Record<string, string | Buffer>;
 
@@ -124,17 +111,11 @@ function adapt(client: NodeRedisLike): RedisLikeClient {
         options.expectedMeta,
         options.nextMeta,
         String(options.ttlSec),
-        ...toNodeFieldArgs(options),
+        ...redisFinalizeFieldArgs(options),
       ]);
       return result === 1;
     },
   };
-}
-
-function toNodeFieldArgs(
-  options: RedisFinalizeOptions,
-): Array<string | Buffer> {
-  return Object.entries(options.fields).flatMap(([key, value]) => [key, value]);
 }
 
 function applyPipelineCommand(

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -275,12 +275,12 @@
       "gzip": 5490
     },
     "./resumable/ioredis": {
-      "min": 5294,
-      "gzip": 2063
+      "min": 5977,
+      "gzip": 2343
     },
     "./resumable/redis": {
-      "min": 5572,
-      "gzip": 2160
+      "min": 6273,
+      "gzip": 2455
     },
     "./utils": {
       "min": 14549,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -275,12 +275,12 @@
       "gzip": 5490
     },
     "./resumable/ioredis": {
-      "min": 5977,
-      "gzip": 2343
+      "min": 5830,
+      "gzip": 2316
     },
     "./resumable/redis": {
-      "min": 6273,
-      "gzip": 2455
+      "min": 6126,
+      "gzip": 2422
     },
     "./utils": {
       "min": 14549,


### PR DESCRIPTION
## Problem

A TypeScript Redis resumable-stream producer can read its generation metadata, pause, and then finalize after that metadata expires and another producer acquires the same stream ID. The stale producer then overwrites the replacement generation as complete. A deterministic regression test reproduces that interleaving.

## Root cause

The generation check was a separate `GET` before an unconditional finalization pipeline, leaving a race between validation and mutation.

## Change

Add an atomic finalization capability to the structural Redis client. The bundled node-redis and ioredis adapters implement it with one shared Redis-side compare-and-finalize script, so metadata comparison, terminal stream entry, and TTL updates cannot interleave with a replacement acquisition. The `EVAL` positional layout lives in one builder beside the script, so the `ARGV` ordering the Lua reads is written once rather than spelled out per adapter.

The capability is required rather than optional. `RedisResumableStreamStore` is not exported, and both public factories route their client through `adapt()`, which always supplies `finalizeIfUnchanged`, so no external consumer can construct a store from a client that lacks it and a fallback branch for such clients would be unreachable.

This PR is intentionally scoped to the TypeScript/npm Redis stores. The separately published Python store does not yet use generation-scoped data keys, so parity there requires a broader storage migration rather than copying this finalization hook; this PR does not claim to fix the Python implementation.

## Verification

- `pnpm --filter assistant-stream exec vitest run src/resumable/stores/redis-impl.test.ts`
- `pnpm --filter assistant-stream test` (both ioredis legs, 531 passed each)
- live Redis 8 race test against node-redis and ioredis v6: 23 passed
- live Redis 8 race test against the ioredis v5 peer leg: 23 passed
- `pnpm --filter assistant-stream build`
- `pnpm api-surface:check`
- `pnpm size:check`
- `pnpm changesets:check`

The live regression test pauses after the stale metadata read and reacquires before the Lua comparison. It fails without the atomic guard and passes for both bundled adapters with it. The unit suite also pins the behavior change the compare-and-finalize introduces: a finalize whose metadata expired without a reacquisition now no-ops instead of resurrecting a `done` record.

## Public surface

The TypeScript `assistant-stream` package adds `RedisLikeClient.finalizeIfUnchanged` and its `RedisFinalizeOptions` type. The API surface, size budgets, and patch changeset are updated. `apps/docs/content/docs/guides/resumable-streams.mdx` gains one sentence stating that the bundled adapters now finalize through a server-side script and therefore need `EVAL`. No api-reference page covers these exports, and there are no template changes.
