### PR TITLE
fix(react): stop live completion work after unmount

### DIFF
--- a/.changeset/calm-completions-stop.md
+++ b/.changeset/calm-completions-stop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: prevent queued live completion requests from starting after unmount

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -78,6 +78,33 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("keeps an in-flight fetch when the debounce changes", async () => {
+    let resolve!: (items: readonly Unstable_TriggerItem[]) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<readonly Unstable_TriggerItem[]>((r) => {
+          resolve = r;
+        }),
+    );
+    const { result, rerender } = renderHook(
+      ({ debounceMs }) =>
+        unstable_useLiveCompletionAdapter({ fetcher, debounceMs }),
+      { initialProps: { debounceMs: 0 } },
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    rerender({ debounceMs: 50 });
+    await act(async () => resolve([item("alice")]));
+
+    expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("settles loading when a suspended adapter is shown again", async () => {
     const fetcher = vi.fn(() => new Promise<never>(() => {}));
     const suspended = new Promise<never>(() => {});

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -139,6 +139,47 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(fetcher).toHaveBeenCalledWith("alice");
   });
 
+  it("drops a hidden search superseded by a cached query", async () => {
+    const fetcher = vi.fn(async (query: string) => [item(query)]);
+    const suspended = new Promise<never>(() => {});
+    let committed!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
+    const Harness = ({ blocked }: { blocked: boolean }) => {
+      const current = unstable_useLiveCompletionAdapter({
+        fetcher,
+        debounceMs: 0,
+      });
+      useLayoutEffect(() => {
+        committed = current;
+      }, [current]);
+      if (blocked) throw suspended;
+      return null;
+    };
+    const view = (blocked: boolean) => (
+      <Suspense fallback={null}>
+        <Harness blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view(false));
+
+    await act(async () => {
+      committed.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(committed.adapter.search!("alice")).toEqual([item("alice")]);
+
+    await act(async () => rendered.rerender(view(true)));
+    committed.adapter.search!("bob");
+    await Promise.resolve();
+    committed.adapter.search!("alice");
+    await Promise.resolve();
+
+    await act(async () => rendered.rerender(view(false)));
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher).toHaveBeenCalledWith("alice");
+  });
+
   it("settles loading when a suspended adapter is shown again", async () => {
     const fetcher = vi.fn(() => new Promise<never>(() => {}));
     const suspended = new Promise<never>(() => {});

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -62,6 +62,19 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("does not start a queued fetch after unmount", async () => {
+    const fetcher = vi.fn(async () => []);
+    const { result, unmount } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    result.current.adapter.search!("alice");
+    unmount();
+    await vi.runAllTimersAsync();
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("does not fetch when disabled and clears cached items", async () => {
     const fetcher = vi.fn(async () => [item("a")]);
     const { result, rerender } = renderHook(

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -70,6 +70,9 @@ describe("unstable_useLiveCompletionAdapter", () => {
 
     result.current.adapter.search!("alice");
     unmount();
+    await Promise.resolve();
+
+    expect(vi.getTimerCount()).toBe(0);
     await vi.runAllTimersAsync();
 
     expect(fetcher).not.toHaveBeenCalled();

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { startTransition, Suspense } from "react";
+import { startTransition, Suspense, useLayoutEffect } from "react";
 import { act, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Unstable_TriggerItem } from "@assistant-ui/core";
@@ -78,11 +78,17 @@ describe("unstable_useLiveCompletionAdapter", () => {
   it("settles loading when a suspended adapter is shown again", async () => {
     const fetcher = vi.fn(() => new Promise<never>(() => {}));
     const suspended = new Promise<never>(() => {});
-    let current!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
+    let committed!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
     const Harness = ({ blocked }: { blocked: boolean }) => {
-      current = unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 });
+      const current = unstable_useLiveCompletionAdapter({
+        fetcher,
+        debounceMs: 0,
+      });
+      useLayoutEffect(() => {
+        committed = current;
+      }, [current]);
       if (blocked) throw suspended;
-      return null;
+      return <output data-testid="status">{String(current.isLoading)}</output>;
     };
     const view = (blocked: boolean) => (
       <Suspense fallback={null}>
@@ -92,16 +98,16 @@ describe("unstable_useLiveCompletionAdapter", () => {
     const rendered = render(view(false));
 
     await act(async () => {
-      current.adapter.search!("alice");
+      committed.adapter.search!("alice");
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(fetcher).toHaveBeenCalledOnce();
-    expect(current.isLoading).toBe(true);
+    expect(rendered.getByTestId("status").textContent).toBe("true");
 
     await act(async () => rendered.rerender(view(true)));
     await act(async () => rendered.rerender(view(false)));
 
-    expect(current.isLoading).toBe(false);
+    expect(rendered.getByTestId("status").textContent).toBe("false");
   });
 
   it("does not fetch when disabled and clears cached items", async () => {

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -105,6 +105,40 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("replays a search queued while the adapter is hidden", async () => {
+    const fetcher = vi.fn(async () => []);
+    const suspended = new Promise<never>(() => {});
+    let committed!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
+    const Harness = ({ blocked }: { blocked: boolean }) => {
+      const current = unstable_useLiveCompletionAdapter({
+        fetcher,
+        debounceMs: 0,
+      });
+      useLayoutEffect(() => {
+        committed = current;
+      }, [current]);
+      if (blocked) throw suspended;
+      return null;
+    };
+    const view = (blocked: boolean) => (
+      <Suspense fallback={null}>
+        <Harness blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view(false));
+
+    await act(async () => rendered.rerender(view(true)));
+    committed.adapter.search!("alice");
+    await Promise.resolve();
+
+    expect(vi.getTimerCount()).toBe(0);
+    await act(async () => rendered.rerender(view(false)));
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher).toHaveBeenCalledWith("alice");
+  });
+
   it("settles loading when a suspended adapter is shown again", async () => {
     const fetcher = vi.fn(() => new Promise<never>(() => {}));
     const suspended = new Promise<never>(() => {});

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -75,6 +75,35 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("settles loading when a suspended adapter is shown again", async () => {
+    const fetcher = vi.fn(() => new Promise<never>(() => {}));
+    const suspended = new Promise<never>(() => {});
+    let current!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
+    const Harness = ({ blocked }: { blocked: boolean }) => {
+      current = unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 });
+      if (blocked) throw suspended;
+      return null;
+    };
+    const view = (blocked: boolean) => (
+      <Suspense fallback={null}>
+        <Harness blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view(false));
+
+    await act(async () => {
+      current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(current.isLoading).toBe(true);
+
+    await act(async () => rendered.rerender(view(true)));
+    await act(async () => rendered.rerender(view(false)));
+
+    expect(current.isLoading).toBe(false);
+  });
+
   it("does not fetch when disabled and clears cached items", async () => {
     const fetcher = vi.fn(async () => [item("a")]);
     const { result, rerender } = renderHook(

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -483,6 +483,54 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
   });
 
+  it("re-arms a failed query when its retry is hidden", async () => {
+    const fetcher = vi
+      .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce([item("alice")]);
+    const suspended = new Promise<never>(() => {});
+    let committed!: ReturnType<typeof unstable_useLiveCompletionAdapter>;
+    const Harness = ({ blocked }: { blocked: boolean }) => {
+      const current = unstable_useLiveCompletionAdapter({
+        fetcher,
+        debounceMs: 0,
+      });
+      useLayoutEffect(() => {
+        committed = current;
+      }, [current]);
+      if (blocked) throw suspended;
+      return null;
+    };
+    const view = (blocked: boolean) => (
+      <Suspense fallback={null}>
+        <Harness blocked={blocked} />
+      </Suspense>
+    );
+    const rendered = render(view(false));
+
+    await act(async () => {
+      committed.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      committed.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    await act(async () => rendered.rerender(view(true)));
+    await act(async () => rendered.rerender(view(false)));
+    await act(async () => {
+      committed.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
   it("drops an in-flight fetch when the query returns to a cached value", async () => {
     const resolvers: Record<
       string,

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -72,6 +72,12 @@ export function unstable_useLiveCompletionAdapter(
     failed: boolean;
   }>({ query: NO_QUERY, items: [], failed: false });
   const [isLoading, setIsLoading] = useState(false);
+  const isLoadingRef = useRef(false);
+
+  const updateLoading = useCallback((value: boolean) => {
+    isLoadingRef.current = value;
+    setIsLoading(value);
+  }, []);
 
   const fetcherRef = useRef(fetcher);
   // The debounce timer must only observe fetchers from committed renders.
@@ -113,7 +119,7 @@ export function unstable_useLiveCompletionAdapter(
       pendingQueryRef.current = query;
       cancelTimer();
       const token = ++tokenRef.current;
-      setIsLoading(true);
+      updateLoading(true);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         if (inactiveRef.current) {
@@ -128,19 +134,19 @@ export function unstable_useLiveCompletionAdapter(
               if (token !== tokenRef.current) return;
               pendingRetryQueryRef.current = null;
               setState({ query, items, failed: false });
-              setIsLoading(false);
+              updateLoading(false);
             },
             () => {
               if (token !== tokenRef.current) return;
               pendingQueryRef.current = null;
               pendingRetryQueryRef.current = null;
               setState({ query, items: [], failed: true });
-              setIsLoading(false);
+              updateLoading(false);
             },
           );
       }, debounceMs);
     },
-    [enabled, debounceMs, cancelTimer, rearmPendingRetry],
+    [enabled, debounceMs, cancelTimer, rearmPendingRetry, updateLoading],
   );
 
   const invalidatePending = useCallback(() => {
@@ -148,10 +154,12 @@ export function unstable_useLiveCompletionAdapter(
     cancelTimer();
     pendingQueryRef.current = null;
     tokenRef.current += 1;
-    setIsLoading(false);
-  }, [cancelTimer, rearmPendingRetry]);
+    updateLoading(false);
+  }, [cancelTimer, rearmPendingRetry, updateLoading]);
 
   const cacheKeyRef = useRef(cacheKey);
+  // Effect disconnection can orphan loading work; settle it only after the
+  // hook is committed again without a replacement request.
   useLayoutEffect(() => {
     if (cacheKeyRef.current === cacheKey) return;
     cacheKeyRef.current = cacheKey;
@@ -178,16 +186,16 @@ export function unstable_useLiveCompletionAdapter(
       timerRef.current === null &&
       pendingQueryRef.current === null
     ) {
-      setIsLoading(false);
+      updateLoading(false);
     }
     return () => {
       inactiveRef.current = true;
-      settleLoadingOnCommitRef.current ||= pendingQueryRef.current !== null;
+      settleLoadingOnCommitRef.current ||= isLoadingRef.current;
       cancelTimer();
       pendingQueryRef.current = null;
       tokenRef.current += 1;
     };
-  }, [cancelTimer]);
+  }, [cancelTimer, updateLoading]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -85,6 +85,7 @@ export function unstable_useLiveCompletionAdapter(
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
   const inactiveRef = useRef(true);
+  const deferredQueryRef = useRef<string | null>(null);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -103,6 +104,10 @@ export function unstable_useLiveCompletionAdapter(
   const scheduleFetch = useCallback(
     (query: string) => {
       if (!enabled) return;
+      if (inactiveRef.current) {
+        deferredQueryRef.current = query;
+        return;
+      }
       if (pendingQueryRef.current === query) return;
       rearmPendingRetry();
       if (retryableQueryRef.current === query) {
@@ -171,11 +176,14 @@ export function unstable_useLiveCompletionAdapter(
 
   useLayoutEffect(() => {
     inactiveRef.current = false;
+    const deferredQuery = deferredQueryRef.current;
+    deferredQueryRef.current = null;
+    if (deferredQuery !== null) scheduleFetch(deferredQuery);
     return () => {
       inactiveRef.current = true;
       invalidatePending();
     };
-  }, [invalidatePending]);
+  }, [invalidatePending, scheduleFetch]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -120,12 +120,6 @@ export function unstable_useLiveCompletionAdapter(
       setIsLoading(true);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        if (inactiveRef.current) {
-          rearmPendingRetry();
-          pendingQueryRef.current = null;
-          setIsLoading(false);
-          return;
-        }
         Promise.resolve()
           .then(() => fetcherRef.current(query))
           .then(
@@ -147,6 +141,11 @@ export function unstable_useLiveCompletionAdapter(
     },
     [enabled, debounceMs, cancelTimer, rearmPendingRetry],
   );
+
+  const scheduleFetchRef = useRef(scheduleFetch);
+  useLayoutEffect(() => {
+    scheduleFetchRef.current = scheduleFetch;
+  }, [scheduleFetch]);
 
   const invalidatePending = useCallback(() => {
     rearmPendingRetry();
@@ -174,16 +173,18 @@ export function unstable_useLiveCompletionAdapter(
     );
   }, [enabled, invalidatePending]);
 
+  // Render-time searches can outlive an abandoned render, so they only arm
+  // request work after this hook commits.
   useLayoutEffect(() => {
     inactiveRef.current = false;
     const deferredQuery = deferredQueryRef.current;
     deferredQueryRef.current = null;
-    if (deferredQuery !== null) scheduleFetch(deferredQuery);
+    if (deferredQuery !== null) scheduleFetchRef.current(deferredQuery);
     return () => {
       inactiveRef.current = true;
       invalidatePending();
     };
-  }, [invalidatePending, scheduleFetch]);
+  }, [invalidatePending]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -85,7 +85,7 @@ export function unstable_useLiveCompletionAdapter(
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
   const inactiveRef = useRef(true);
-  const hasCommittedRef = useRef(false);
+  const settleLoadingOnCommitRef = useRef(false);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -118,6 +118,7 @@ export function unstable_useLiveCompletionAdapter(
         timerRef.current = null;
         if (inactiveRef.current) {
           pendingQueryRef.current = null;
+          settleLoadingOnCommitRef.current = true;
           return;
         }
         Promise.resolve()
@@ -169,11 +170,11 @@ export function unstable_useLiveCompletionAdapter(
   }, [enabled, invalidatePending]);
 
   useLayoutEffect(() => {
-    const reactivated = hasCommittedRef.current && inactiveRef.current;
+    const settleLoading = settleLoadingOnCommitRef.current;
+    settleLoadingOnCommitRef.current = false;
     inactiveRef.current = false;
-    hasCommittedRef.current = true;
     if (
-      reactivated &&
+      settleLoading &&
       timerRef.current === null &&
       pendingQueryRef.current === null
     ) {
@@ -181,6 +182,7 @@ export function unstable_useLiveCompletionAdapter(
     }
     return () => {
       inactiveRef.current = true;
+      settleLoadingOnCommitRef.current ||= pendingQueryRef.current !== null;
       cancelTimer();
       pendingQueryRef.current = null;
       tokenRef.current += 1;

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -116,6 +116,7 @@ export function unstable_useLiveCompletionAdapter(
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         if (inactiveRef.current) {
+          rearmPendingRetry();
           pendingQueryRef.current = null;
           setIsLoading(false);
           return;
@@ -172,12 +173,9 @@ export function unstable_useLiveCompletionAdapter(
     inactiveRef.current = false;
     return () => {
       inactiveRef.current = true;
-      cancelTimer();
-      pendingQueryRef.current = null;
-      tokenRef.current += 1;
-      setIsLoading(false);
+      invalidatePending();
     };
-  }, [cancelTimer]);
+  }, [invalidatePending]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -72,12 +72,6 @@ export function unstable_useLiveCompletionAdapter(
     failed: boolean;
   }>({ query: NO_QUERY, items: [], failed: false });
   const [isLoading, setIsLoading] = useState(false);
-  const isLoadingRef = useRef(false);
-
-  const updateLoading = useCallback((value: boolean) => {
-    isLoadingRef.current = value;
-    setIsLoading(value);
-  }, []);
 
   const fetcherRef = useRef(fetcher);
   // The debounce timer must only observe fetchers from committed renders.
@@ -91,7 +85,6 @@ export function unstable_useLiveCompletionAdapter(
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
   const inactiveRef = useRef(true);
-  const settleLoadingOnCommitRef = useRef(false);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -119,12 +112,12 @@ export function unstable_useLiveCompletionAdapter(
       pendingQueryRef.current = query;
       cancelTimer();
       const token = ++tokenRef.current;
-      updateLoading(true);
+      setIsLoading(true);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
         if (inactiveRef.current) {
           pendingQueryRef.current = null;
-          settleLoadingOnCommitRef.current = true;
+          setIsLoading(false);
           return;
         }
         Promise.resolve()
@@ -134,19 +127,19 @@ export function unstable_useLiveCompletionAdapter(
               if (token !== tokenRef.current) return;
               pendingRetryQueryRef.current = null;
               setState({ query, items, failed: false });
-              updateLoading(false);
+              setIsLoading(false);
             },
             () => {
               if (token !== tokenRef.current) return;
               pendingQueryRef.current = null;
               pendingRetryQueryRef.current = null;
               setState({ query, items: [], failed: true });
-              updateLoading(false);
+              setIsLoading(false);
             },
           );
       }, debounceMs);
     },
-    [enabled, debounceMs, cancelTimer, rearmPendingRetry, updateLoading],
+    [enabled, debounceMs, cancelTimer, rearmPendingRetry],
   );
 
   const invalidatePending = useCallback(() => {
@@ -154,12 +147,10 @@ export function unstable_useLiveCompletionAdapter(
     cancelTimer();
     pendingQueryRef.current = null;
     tokenRef.current += 1;
-    updateLoading(false);
-  }, [cancelTimer, rearmPendingRetry, updateLoading]);
+    setIsLoading(false);
+  }, [cancelTimer, rearmPendingRetry]);
 
   const cacheKeyRef = useRef(cacheKey);
-  // Effect disconnection can orphan loading work; settle it only after the
-  // hook is committed again without a replacement request.
   useLayoutEffect(() => {
     if (cacheKeyRef.current === cacheKey) return;
     cacheKeyRef.current = cacheKey;
@@ -178,24 +169,15 @@ export function unstable_useLiveCompletionAdapter(
   }, [enabled, invalidatePending]);
 
   useLayoutEffect(() => {
-    const settleLoading = settleLoadingOnCommitRef.current;
-    settleLoadingOnCommitRef.current = false;
     inactiveRef.current = false;
-    if (
-      settleLoading &&
-      timerRef.current === null &&
-      pendingQueryRef.current === null
-    ) {
-      updateLoading(false);
-    }
     return () => {
       inactiveRef.current = true;
-      settleLoadingOnCommitRef.current ||= isLoadingRef.current;
       cancelTimer();
       pendingQueryRef.current = null;
       tokenRef.current += 1;
+      setIsLoading(false);
     };
-  }, [cancelTimer, updateLoading]);
+  }, [cancelTimer]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -84,7 +84,7 @@ export function unstable_useLiveCompletionAdapter(
   const pendingQueryRef = useRef<string | null>(null);
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
-  const mountedRef = useRef(false);
+  const unmountedRef = useRef(false);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -102,7 +102,7 @@ export function unstable_useLiveCompletionAdapter(
 
   const scheduleFetch = useCallback(
     (query: string) => {
-      if (!mountedRef.current || !enabled) return;
+      if (unmountedRef.current || !enabled) return;
       if (pendingQueryRef.current === query) return;
       rearmPendingRetry();
       if (retryableQueryRef.current === query) {
@@ -164,9 +164,9 @@ export function unstable_useLiveCompletionAdapter(
   }, [enabled, invalidatePending]);
 
   useLayoutEffect(() => {
-    mountedRef.current = true;
+    unmountedRef.current = false;
     return () => {
-      mountedRef.current = false;
+      unmountedRef.current = true;
       cancelTimer();
       pendingQueryRef.current = null;
       tokenRef.current += 1;

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -84,7 +84,8 @@ export function unstable_useLiveCompletionAdapter(
   const pendingQueryRef = useRef<string | null>(null);
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
-  const unmountedRef = useRef(false);
+  const inactiveRef = useRef(true);
+  const hasCommittedRef = useRef(false);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -102,7 +103,7 @@ export function unstable_useLiveCompletionAdapter(
 
   const scheduleFetch = useCallback(
     (query: string) => {
-      if (unmountedRef.current || !enabled) return;
+      if (!enabled) return;
       if (pendingQueryRef.current === query) return;
       rearmPendingRetry();
       if (retryableQueryRef.current === query) {
@@ -115,6 +116,10 @@ export function unstable_useLiveCompletionAdapter(
       setIsLoading(true);
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
+        if (inactiveRef.current) {
+          pendingQueryRef.current = null;
+          return;
+        }
         Promise.resolve()
           .then(() => fetcherRef.current(query))
           .then(
@@ -164,11 +169,18 @@ export function unstable_useLiveCompletionAdapter(
   }, [enabled, invalidatePending]);
 
   useLayoutEffect(() => {
-    const reactivated = unmountedRef.current;
-    unmountedRef.current = false;
-    if (reactivated) setIsLoading(false);
+    const reactivated = hasCommittedRef.current && inactiveRef.current;
+    inactiveRef.current = false;
+    hasCommittedRef.current = true;
+    if (
+      reactivated &&
+      timerRef.current === null &&
+      pendingQueryRef.current === null
+    ) {
+      setIsLoading(false);
+    }
     return () => {
-      unmountedRef.current = true;
+      inactiveRef.current = true;
       cancelTimer();
       pendingQueryRef.current = null;
       tokenRef.current += 1;

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -201,13 +201,21 @@ export function unstable_useLiveCompletionAdapter(
         // queueMicrotask so they are not dispatched while another component renders.
         if (query !== state.query || retryableQueryRef.current === query) {
           queueMicrotask(() => scheduleFetch(query));
-        } else if (
-          pendingQueryRef.current !== null &&
-          pendingQueryRef.current !== query
-        ) {
-          // the query returned to a cached value while a fetch for a different
-          // query is in flight; drop it so its result cannot overwrite the cache
-          queueMicrotask(invalidatePending);
+        } else {
+          queueMicrotask(() => {
+            if (
+              deferredQueryRef.current !== null &&
+              deferredQueryRef.current !== query
+            ) {
+              deferredQueryRef.current = null;
+            }
+            if (
+              pendingQueryRef.current !== null &&
+              pendingQueryRef.current !== query
+            ) {
+              invalidatePending();
+            }
+          });
         }
         return state.items;
       },

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -84,6 +84,7 @@ export function unstable_useLiveCompletionAdapter(
   const pendingQueryRef = useRef<string | null>(null);
   const retryableQueryRef = useRef<string | null>(null);
   const pendingRetryQueryRef = useRef<string | null>(null);
+  const mountedRef = useRef(false);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -101,7 +102,7 @@ export function unstable_useLiveCompletionAdapter(
 
   const scheduleFetch = useCallback(
     (query: string) => {
-      if (!enabled) return;
+      if (!mountedRef.current || !enabled) return;
       if (pendingQueryRef.current === query) return;
       rearmPendingRetry();
       if (retryableQueryRef.current === query) {
@@ -162,7 +163,15 @@ export function unstable_useLiveCompletionAdapter(
     );
   }, [enabled, invalidatePending]);
 
-  useEffect(() => cancelTimer, [cancelTimer]);
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      cancelTimer();
+      pendingQueryRef.current = null;
+      tokenRef.current += 1;
+    };
+  }, [cancelTimer]);
 
   // Arm retries only after the failed state commits. Arming during rejection
   // would let the failure render immediately schedule another request.

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -164,7 +164,9 @@ export function unstable_useLiveCompletionAdapter(
   }, [enabled, invalidatePending]);
 
   useLayoutEffect(() => {
+    const reactivated = unmountedRef.current;
     unmountedRef.current = false;
+    if (reactivated) setIsLoading(false);
     return () => {
       unmountedRef.current = true;
       cancelTimer();


### PR DESCRIPTION
## Problem

A live-completion search queues its debounced request setup in a microtask. If the component unmounts before that microtask runs, the old cleanup sees no timer to clear. The queued task then creates a timer and calls the application fetcher after teardown. A focused regression test reproduces one fetch after unmount.

## Root cause

Cleanup covered existing debounce timers and stale fetch results, but did not guard request setup that had already been queued and had not run yet.

## Change

Track whether the layout effect is active and defer queued queries until the next committed layout effect. A microtask that runs after permanent teardown therefore creates neither a state update nor a timer, while valid concurrent and Suspense renders retain their query. A committed function ref keeps lifecycle cleanup stable when options change, and cleanup uses the existing retry-aware invalidation path. Returning to a cached query also clears superseded deferred work before reveal.

## Verification

- pnpm --filter @assistant-ui/react exec vitest run src/unstable/useLiveCompletionAdapter.test.tsx
- pnpm --filter @assistant-ui/react test
- pnpm --filter @assistant-ui/react build
- focused oxlint and oxfmt checks
- pnpm changesets:check

The unmount regression fails with one fetch on the previous implementation and now passes with zero fetches and zero timers after the queued microtask. Additional regressions cover deferred replay after reveal, superseding a hidden search with a cached query, an interrupted retry, and a debounce change during an in-flight request. The new stale-query regression fetches twice on the prior implementation and only once with the fix. The focused suite passes 20 tests, and the full React suite passes 535 tests with no type errors.

## Public surface

No exports, API reference, documentation, or templates change. A patch changeset for @assistant-ui/react is included.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Bsa0iFg40Umxptcux6IrT_noCOupLBG-DR3XNumKl1AoS3MXS26Y5BjQgrc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->