### PR TITLE
fix(docs): meter the MCP docs tools and stream the template archive

### DIFF
--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -40,12 +40,16 @@ AUI_PUBLIC_ASSISTANT_REQUESTS_PER_SESSION_PER_DAY=500
 AUI_PUBLIC_ASSISTANT_REQUESTS_PER_IP_PER_DAY=2000
 AUI_PUBLIC_ASSISTANT_GLOBAL_REQUESTS_PER_DAY=20000
 AUI_ANONYMOUS_SESSIONS_PER_IP_PER_DAY=1000
-# The hosted MCP endpoint has no browser session to key on, so its two
-# sandbox-calling template tools are limited by IP alone. The docs tools are
-# in-process and stay unlimited.
+# The hosted MCP endpoint has no browser session to key on, so both of its tool
+# families are limited by IP alone. The two sandbox-calling template tools get
+# the tighter budget.
 AUI_MCP_TEMPLATE_REQUESTS_PER_IP_PER_DAY=500
 AUI_MCP_TEMPLATE_GLOBAL_REQUESTS_PER_DAY=5000
-# The template download proxy buffers a whole sandbox archive per request, so it is
+# The docs tools stay in-process but render MDX per call, so they carry a wider
+# budget rather than none.
+AUI_MCP_DOCS_REQUESTS_PER_IP_PER_DAY=5000
+AUI_MCP_DOCS_GLOBAL_REQUESTS_PER_DAY=100000
+# The template download proxy streams a whole sandbox archive per request, so it is
 # limited by IP and by a global daily ceiling on top of the browser session.
 AUI_XULUX_DOWNLOAD_REQUESTS_PER_IP_PER_DAY=200
 AUI_XULUX_DOWNLOAD_GLOBAL_REQUESTS_PER_DAY=2000

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -350,6 +350,28 @@ describe("POST /api/mcp", () => {
     expect(mocks.checkDocsRateLimit).toHaveBeenCalledTimes(2);
   });
 
+  it("meters the dynamic docs resource before it reaches the page", async () => {
+    mocks.checkDocsRateLimit.mockResolvedValueOnce(
+      new Response("Docs tool rate limit exceeded", {
+        status: 429,
+        headers: { "Retry-After": "12" },
+      }),
+    );
+
+    const denied = await requestMcp("resources/read", {
+      uri: "assistant-ui://docs/getting-started",
+    });
+
+    expect(denied.error?.message).toContain("Docs tool rate limit exceeded");
+
+    const allowed = await requestMcp("resources/read", {
+      uri: "assistant-ui://docs/getting-started",
+    });
+
+    expect(allowed.error?.message).toContain("Page not found");
+    expect(mocks.checkDocsRateLimit).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps the docs budget off the sandbox-calling template tools", async () => {
     mocks.fetchTemplateContract.mockResolvedValue(null);
 

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -4,11 +4,13 @@ const mocks = vi.hoisted(() => ({
   fetchPreviewSession: vi.fn(),
   fetchTemplateContract: vi.fn(),
   checkTemplateRateLimit: vi.fn(),
+  checkDocsRateLimit: vi.fn(),
 }));
 
 vi.mock("@/lib/rate-limit", async (importOriginal) => ({
   ...(await importOriginal()),
   checkMcpTemplateToolRateLimit: mocks.checkTemplateRateLimit,
+  checkMcpDocsToolRateLimit: mocks.checkDocsRateLimit,
 }));
 
 vi.mock("@/lib/xulux/sandbox-contract", async (importOriginal) => ({
@@ -323,15 +325,78 @@ describe("POST /api/mcp", () => {
     });
   });
 
-  it("leaves the in-process docs tools unmetered", async () => {
+  it("meters every in-process tool against the docs budget", async () => {
     await requestMcp("tools/call", { name: "list_templates", arguments: {} });
     await requestMcp("tools/call", {
       name: "search_docs",
       arguments: { query: "runtime" },
     });
     await requestMcp("tools/call", { name: "get_navigation", arguments: {} });
+    await requestMcp("tools/call", { name: "list_pages", arguments: {} });
 
+    expect(mocks.checkDocsRateLimit).toHaveBeenCalledTimes(4);
+    expect(mocks.checkDocsRateLimit.mock.calls[0]?.[0]).toMatchObject({
+      url: `${ORIGIN}/api/mcp`,
+    });
     expect(mocks.checkTemplateRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("meters the docs resources that repeat the tool work", async () => {
+    await requestMcp("resources/read", {
+      uri: "assistant-ui://navigation",
+    });
+    await requestMcp("resources/list", {});
+
+    expect(mocks.checkDocsRateLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the docs budget off the sandbox-calling template tools", async () => {
+    mocks.fetchTemplateContract.mockResolvedValue(null);
+
+    await requestMcp("tools/call", {
+      name: "read_template",
+      arguments: { templateId: "base-assistant-ui" },
+    });
+
+    expect(mocks.checkTemplateRateLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.checkDocsRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a throttled docs tool without rendering the page", async () => {
+    mocks.checkDocsRateLimit.mockResolvedValueOnce(
+      new Response("Docs tool rate limit exceeded", {
+        status: 429,
+        headers: { "Retry-After": "12" },
+      }),
+    );
+
+    const response = await requestMcp("tools/call", {
+      name: "read_page",
+      arguments: { path: "docs/getting-started" },
+    });
+    const result = getToolCallResult(response);
+    const text = result.content.find((block) => block.type === "text")?.text;
+
+    expect(result.isError).toBe(true);
+    expect(text).toBe("Docs tool rate limit exceeded. Retry in 12s.");
+  });
+
+  it("does not tell an MCP client the public assistant is down for docs tools", async () => {
+    mocks.checkDocsRateLimit.mockResolvedValueOnce(
+      new Response("Public assistant temporarily unavailable", { status: 503 }),
+    );
+
+    const response = await requestMcp("tools/call", {
+      name: "search_docs",
+      arguments: { query: "runtime" },
+    });
+    const result = getToolCallResult(response);
+    const text = result.content.find((block) => block.type === "text")?.text;
+
+    expect(result.isError).toBe(true);
+    expect(text).toBe(
+      "The assistant-ui docs tools are temporarily unavailable.",
+    );
   });
 
   it("surfaces a throttled template tool without reaching the sandbox", async () => {

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -403,7 +403,7 @@ describe("POST /api/mcp", () => {
     expect(text).toBe("Docs tool rate limit exceeded. Retry in 12s.");
   });
 
-  it("does not tell an MCP client the public assistant is down for docs tools", async () => {
+  it("serves the docs tools unmetered when the rate-limit store is down", async () => {
     mocks.checkDocsRateLimit.mockResolvedValueOnce(
       new Response("Public assistant temporarily unavailable", { status: 503 }),
     );
@@ -413,11 +413,10 @@ describe("POST /api/mcp", () => {
       arguments: { query: "runtime" },
     });
     const result = getToolCallResult(response);
-    const text = result.content.find((block) => block.type === "text")?.text;
 
-    expect(result.isError).toBe(true);
-    expect(text).toBe(
-      "The assistant-ui docs tools are temporarily unavailable.",
+    expect(result.isError).toBeFalsy();
+    expect(result.content.find((block) => block.type === "text")?.text).toBe(
+      "[]",
     );
   });
 

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -460,35 +460,33 @@ function registerResources(server: McpServer, request: NextRequest) {
   );
 }
 
-async function requireBudget(
-  denial: Response | null,
-  unavailable: string,
-  suffix = "",
-) {
-  if (!denial) return;
-  if (denial.status !== 429) throw new Error(unavailable);
-
+async function throttleMessage(denial: Response, suffix: string) {
   const retryAfter = denial.headers.get("Retry-After");
-  throw new Error(
+  return (
     `${await denial.text()}.` +
-      (retryAfter ? ` Retry in ${retryAfter}s.` : "") +
-      suffix,
+    (retryAfter ? ` Retry in ${retryAfter}s.` : "") +
+    suffix
   );
 }
 
 async function requireTemplateToolBudget(request: NextRequest) {
-  return requireBudget(
-    await checkMcpTemplateToolRateLimit(request),
-    "Template tools are temporarily unavailable. The assistant-ui docs tools remain available.",
-    " The assistant-ui docs tools remain available.",
-  );
+  const denial = await checkMcpTemplateToolRateLimit(request);
+  if (!denial) return;
+
+  const suffix = " The assistant-ui docs tools remain available.";
+  if (denial.status !== 429) {
+    throw new Error(`Template tools are temporarily unavailable.${suffix}`);
+  }
+  throw new Error(await throttleMessage(denial, suffix));
 }
 
 async function requireDocsToolBudget(request: NextRequest) {
-  return requireBudget(
-    await checkMcpDocsToolRateLimit(request),
-    "The assistant-ui docs tools are temporarily unavailable.",
-  );
+  const denial = await checkMcpDocsToolRateLimit(request);
+  // These tools cost one in-process render and nothing external, so a
+  // rate-limit store outage serves them unmetered rather than taking the
+  // surface down with it. Only an exhausted budget refuses.
+  if (denial?.status !== 429) return;
+  throw new Error(await throttleMessage(denial, ""));
 }
 
 function buildMcpServer(request: NextRequest) {

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -7,7 +7,10 @@ import {
 } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { getLLMText } from "@/lib/get-llm-text";
-import { checkMcpTemplateToolRateLimit } from "@/lib/rate-limit";
+import {
+  checkMcpDocsToolRateLimit,
+  checkMcpTemplateToolRateLimit,
+} from "@/lib/rate-limit";
 import {
   SEARCH_DOCS_RESULT_LIMIT,
   docsToolDefinitions,
@@ -34,6 +37,10 @@ import {
 import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
 
 export const revalidate = false;
+// One sandbox call bounds the template tools at 30s and the rest is in-process
+// rendering, so this sits well under the platform default and an overrun
+// surfaces here rather than at the CDN in front of it.
+export const maxDuration = 120;
 
 const templateToolDefinitions = [
   {
@@ -400,35 +407,44 @@ function templateVarToPath(value: string | string[] | undefined): string {
   return Array.isArray(value) ? value.join("/") : (value ?? "");
 }
 
-function registerResources(server: McpServer, requestUrl: string) {
+function registerResources(server: McpServer, request: NextRequest) {
+  const requestUrl = request.url;
+
   server.registerResource(
     "assistant-ui docs navigation",
     "assistant-ui://navigation",
     { mimeType: "application/json" },
-    async (uri) => ({
-      contents: [
-        {
-          uri: uri.href,
-          mimeType: "application/json",
-          text: JSON.stringify(getNavigation(), null, 2),
-        },
-      ],
-    }),
+    async (uri) => {
+      await requireDocsToolBudget(request);
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(getNavigation(), null, 2),
+          },
+        ],
+      };
+    },
   );
 
   server.registerResource(
     "assistant-ui docs pages",
     new ResourceTemplate("assistant-ui://{+path}", {
-      list: async () => ({
-        resources: allPages().map(({ page }) => ({
-          uri: `assistant-ui://${stripLeadingSlashes(page.url)}`,
-          name: page.data.title,
-          mimeType: "text/markdown",
-        })),
-      }),
+      list: async () => {
+        await requireDocsToolBudget(request);
+        return {
+          resources: allPages().map(({ page }) => ({
+            uri: `assistant-ui://${stripLeadingSlashes(page.url)}`,
+            name: page.data.title,
+            mimeType: "text/markdown",
+          })),
+        };
+      },
     }),
     { mimeType: "text/markdown" },
     async (uri, variables) => {
+      await requireDocsToolBudget(request);
       const path = templateVarToPath(variables["path"]);
       const page = await readPage(path, requestUrl);
       return {
@@ -444,21 +460,34 @@ function registerResources(server: McpServer, requestUrl: string) {
   );
 }
 
-async function requireTemplateToolBudget(request: NextRequest) {
-  const denial = await checkMcpTemplateToolRateLimit(request);
+async function requireBudget(
+  denial: Response | null,
+  unavailable: string,
+  suffix = "",
+) {
   if (!denial) return;
-
-  if (denial.status !== 429) {
-    throw new Error(
-      "Template tools are temporarily unavailable. The assistant-ui docs tools remain available.",
-    );
-  }
+  if (denial.status !== 429) throw new Error(unavailable);
 
   const retryAfter = denial.headers.get("Retry-After");
   throw new Error(
     `${await denial.text()}.` +
       (retryAfter ? ` Retry in ${retryAfter}s.` : "") +
-      " The assistant-ui docs tools remain available.",
+      suffix,
+  );
+}
+
+async function requireTemplateToolBudget(request: NextRequest) {
+  return requireBudget(
+    await checkMcpTemplateToolRateLimit(request),
+    "Template tools are temporarily unavailable. The assistant-ui docs tools remain available.",
+    " The assistant-ui docs tools remain available.",
+  );
+}
+
+async function requireDocsToolBudget(request: NextRequest) {
+  return requireBudget(
+    await checkMcpDocsToolRateLimit(request),
+    "The assistant-ui docs tools are temporarily unavailable.",
   );
 }
 
@@ -476,7 +505,11 @@ function buildMcpServer(request: NextRequest) {
       description: listPagesTool.description,
       inputSchema: listPagesInputSchema,
     },
-    ({ path }) => toolResult(() => listPages(path)),
+    ({ path }) =>
+      toolResult(async () => {
+        await requireDocsToolBudget(request);
+        return listPages(path);
+      }),
   );
 
   server.registerTool(
@@ -485,7 +518,11 @@ function buildMcpServer(request: NextRequest) {
       description: getNavigationTool.description,
       inputSchema: getNavigationInputSchema,
     },
-    () => toolResult(() => getNavigation()),
+    () =>
+      toolResult(async () => {
+        await requireDocsToolBudget(request);
+        return getNavigation();
+      }),
   );
 
   server.registerTool(
@@ -494,7 +531,11 @@ function buildMcpServer(request: NextRequest) {
       description: searchDocsTool.description,
       inputSchema: searchDocsInputSchema,
     },
-    ({ query }) => toolResult(() => searchDocs(query)),
+    ({ query }) =>
+      toolResult(async () => {
+        await requireDocsToolBudget(request);
+        return searchDocs(query);
+      }),
   );
 
   server.registerTool(
@@ -503,7 +544,11 @@ function buildMcpServer(request: NextRequest) {
       description: readPageTool.description,
       inputSchema: readPageInputSchema,
     },
-    ({ path }) => toolResult(() => readPage(path, requestUrl)),
+    ({ path }) =>
+      toolResult(async () => {
+        await requireDocsToolBudget(request);
+        return readPage(path, requestUrl);
+      }),
   );
 
   server.registerTool(
@@ -512,7 +557,11 @@ function buildMcpServer(request: NextRequest) {
       description: listTemplatesTool.description,
       inputSchema: listTemplatesInputSchema,
     },
-    () => toolResult(() => listTemplates(buildXuluxMcpCatalog(requestOrigin))),
+    () =>
+      toolResult(async () => {
+        await requireDocsToolBudget(request);
+        return listTemplates(buildXuluxMcpCatalog(requestOrigin));
+      }),
   );
 
   server.registerTool(
@@ -557,7 +606,7 @@ function buildMcpServer(request: NextRequest) {
     }),
   );
 
-  registerResources(server, requestUrl);
+  registerResources(server, request);
 
   return server;
 }

--- a/apps/docs/app/api/xulux/download-proxy/route.test.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.test.ts
@@ -213,6 +213,35 @@ describe("GET /api/xulux/download-proxy access boundary", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("releases the upstream body when the declared size is too large", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+
+    let cancelled = false;
+    const oversized = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(oversized, {
+        status: 200,
+        headers: {
+          "content-type": "application/zip",
+          "content-length": String(64 * 1024 * 1024),
+        },
+      }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(413);
+    expect(cancelled).toBe(true);
+  });
+
   it("keeps a metered archive out of shared caches", async () => {
     mocks.requireSession.mockReturnValue(session);
     mocks.checkRateLimit.mockResolvedValue(null);

--- a/apps/docs/app/api/xulux/download-proxy/route.test.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.test.ts
@@ -145,6 +145,74 @@ describe("GET /api/xulux/download-proxy access boundary", () => {
     ).rejects.toThrow("Archive too large.");
   });
 
+  it("drops the upstream content-length when the body was decoded", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3, 4, 5, 6]), {
+        status: 200,
+        headers: {
+          "content-type": "application/zip",
+          "content-length": "3",
+          "content-encoding": "gzip",
+        },
+      }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBeNull();
+  });
+
+  it("forwards the upstream content-length when nothing decoded the body", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "application/zip", "content-length": "3" },
+      }),
+    );
+
+    const response = await GET(request());
+
+    expect(response.headers.get("content-length")).toBe("3");
+  });
+
+  it("does not wait out an upstream that holds its error body open", async () => {
+    vi.useFakeTimers();
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+
+    let cancelled = false;
+    const stalled = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(stalled, { status: 500 }),
+    );
+
+    const pending = GET(request());
+    await vi.advanceTimersByTimeAsync(5_000);
+    const response = await pending;
+
+    expect(response.status).toBe(502);
+    expect(cancelled).toBe(true);
+    vi.useRealTimers();
+  });
+
   it("keeps a metered archive out of shared caches", async () => {
     mocks.requireSession.mockReturnValue(session);
     mocks.checkRateLimit.mockResolvedValue(null);

--- a/apps/docs/app/api/xulux/download-proxy/route.test.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.test.ts
@@ -72,6 +72,79 @@ describe("GET /api/xulux/download-proxy access boundary", () => {
     expect(mocks.fetchSandboxResource).not.toHaveBeenCalled();
   });
 
+  it("streams the archive rather than buffering it before responding", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+
+    let push!: (chunk: Uint8Array) => void;
+    let finish!: () => void;
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        push = (chunk) => controller.enqueue(chunk);
+        finish = () => controller.close();
+      },
+    });
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(upstreamBody, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      }),
+    );
+
+    const response = await GET(request());
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+    push(new Uint8Array([1, 2]));
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: new Uint8Array([1, 2]),
+    });
+
+    finish();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it("cuts off an archive that outgrows the ceiling mid-stream", async () => {
+    mocks.requireSession.mockReturnValue(session);
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.resolveSandboxDownloadUrl.mockReturnValue(
+      new URL("https://demo.bl.run/api/download"),
+    );
+
+    const megabyte = new Uint8Array(1024 * 1024);
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(megabyte);
+      },
+    });
+    mocks.fetchSandboxResource.mockResolvedValue(
+      new Response(upstreamBody, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      }),
+    );
+
+    const response = await GET(request());
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+    await expect(
+      (async () => {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) return;
+        }
+      })(),
+    ).rejects.toThrow("Archive too large.");
+  });
+
   it("keeps a metered archive out of shared caches", async () => {
     mocks.requireSession.mockReturnValue(session);
     mocks.checkRateLimit.mockResolvedValue(null);

--- a/apps/docs/app/api/xulux/download-proxy/route.test.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.test.ts
@@ -43,6 +43,7 @@ const request = () =>
   );
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -210,7 +211,6 @@ describe("GET /api/xulux/download-proxy access boundary", () => {
 
     expect(response.status).toBe(502);
     expect(cancelled).toBe(true);
-    vi.useRealTimers();
   });
 
   it("keeps a metered archive out of shared caches", async () => {

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -15,6 +15,44 @@ const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB ceiling
 // Bounds the wait for the sandbox to respond. It deliberately stops at the
 // headers so a slow client cannot look like a stalled sandbox.
 const SANDBOX_RESPONSE_TIMEOUT_MS = 30_000;
+// The response-scoped deadline is gone by the time an error body is read, so
+// this bounds that read on its own rather than letting it hold the invocation.
+const ERROR_BODY_TIMEOUT_MS = 5_000;
+const ERROR_BODY_MAX_BYTES = 4_096;
+
+async function readBoundedText(response: Response) {
+  const body = response.body;
+  if (!body) return "";
+
+  const reader = body.getReader();
+  const timer = setTimeout(() => {
+    void reader.cancel().catch(() => {});
+  }, ERROR_BODY_TIMEOUT_MS);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (total < ERROR_BODY_MAX_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } catch {
+    return "";
+  } finally {
+    clearTimeout(timer);
+    void reader.cancel().catch(() => {});
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
 
 function limitArchiveSize(body: ReadableStream<Uint8Array>) {
   let total = 0;
@@ -77,6 +115,7 @@ export async function GET(req: Request) {
     });
 
     if (upstream.status >= 300 && upstream.status < 400) {
+      void upstream.body?.cancel().catch(() => {});
       return NextResponse.json(
         { error: "Redirects are not allowed." },
         { status: 400 },
@@ -84,7 +123,7 @@ export async function GET(req: Request) {
     }
 
     if (!upstream.ok) {
-      const details = await upstream.text().catch(() => "");
+      const details = await readBoundedText(upstream);
       return NextResponse.json(
         {
           error: `Upstream responded ${upstream.status}.`,
@@ -121,7 +160,10 @@ export async function GET(req: Request) {
       headers: {
         "Content-Type":
           upstream.headers.get("content-type") ?? "application/octet-stream",
-        ...(contentLengthHeader
+        // fetch decodes the body but leaves the encoded content-length on the
+        // response, so forwarding it under an encoding declares a byte count
+        // this route will never write.
+        ...(contentLengthHeader && !upstream.headers.has("content-encoding")
           ? { "Content-Length": contentLengthHeader }
           : {}),
         "Cache-Control": "private, max-age=3600",

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -7,43 +7,29 @@ import { resolveSandboxDownloadUrl } from "@/lib/xulux/sandbox-download-url";
 import { getXuluxHostedTemplatesCatalog } from "@/lib/xulux/templates-catalog";
 
 export const runtime = "nodejs";
+// The platform default, stated so the ceiling is reviewable rather than
+// inherited. The archive streams for as long as the client takes to read it.
+export const maxDuration = 300;
 
 const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB ceiling
-// Covers the full body read, so it stops a stalled connection rather than
-// capping throughput; a 50 MB archive must not be truncated mid-download.
-const ARCHIVE_TIMEOUT_MS = 300_000;
+// Bounds the wait for the sandbox to respond. It deliberately stops at the
+// headers so a slow client cannot look like a stalled sandbox.
+const SANDBOX_RESPONSE_TIMEOUT_MS = 30_000;
 
-async function readLimitedBody(
-  body: ReadableStream<Uint8Array>,
-): Promise<ArrayBuffer | null> {
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+function limitArchiveSize(body: ReadableStream<Uint8Array>) {
   let total = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      total += value.byteLength;
-      if (total > MAX_ZIP_BYTES) {
-        await reader.cancel("Archive too large.");
-        return null;
-      }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  const result = new ArrayBuffer(total);
-  const view = new Uint8Array(result);
-  let offset = 0;
-  for (const chunk of chunks) {
-    view.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        total += chunk.byteLength;
+        if (total > MAX_ZIP_BYTES) {
+          controller.error(new Error("Archive too large."));
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
 }
 
 export async function GET(req: Request) {
@@ -86,7 +72,8 @@ export async function GET(req: Request) {
   try {
     const upstream = await fetchSandboxResource(upstreamUrl, {
       redirect: "manual",
-      timeoutMs: ARCHIVE_TIMEOUT_MS,
+      timeoutMs: SANDBOX_RESPONSE_TIMEOUT_MS,
+      timeoutScope: "response",
     });
 
     if (upstream.status >= 300 && upstream.status < 400) {
@@ -129,19 +116,14 @@ export async function GET(req: Request) {
       );
     }
 
-    const responseBody = await readLimitedBody(body);
-    if (!responseBody) {
-      return NextResponse.json(
-        { error: "Archive too large." },
-        { status: 413 },
-      );
-    }
-
-    return new NextResponse(responseBody, {
+    return new NextResponse(limitArchiveSize(body), {
       status: 200,
       headers: {
         "Content-Type":
           upstream.headers.get("content-type") ?? "application/octet-stream",
+        ...(contentLengthHeader
+          ? { "Content-Length": contentLengthHeader }
+          : {}),
         "Cache-Control": "private, max-age=3600",
       },
     });

--- a/apps/docs/app/api/xulux/download-proxy/route.ts
+++ b/apps/docs/app/api/xulux/download-proxy/route.ts
@@ -35,8 +35,10 @@ async function readBoundedText(response: Response) {
     while (total < ERROR_BODY_MAX_BYTES) {
       const { done, value } = await reader.read();
       if (done) break;
-      chunks.push(value);
-      total += value.byteLength;
+      const room = ERROR_BODY_MAX_BYTES - total;
+      const chunk = value.byteLength > room ? value.subarray(0, room) : value;
+      chunks.push(chunk);
+      total += chunk.byteLength;
     }
   } catch {
     return "";
@@ -141,6 +143,7 @@ export async function GET(req: Request) {
       contentLength !== undefined &&
       (!Number.isFinite(contentLength) || contentLength > MAX_ZIP_BYTES)
     ) {
+      void upstream.body?.cancel().catch(() => {});
       return NextResponse.json(
         { error: "Archive too large." },
         { status: 413 },

--- a/apps/docs/lib/rate-limit.test.ts
+++ b/apps/docs/lib/rate-limit.test.ts
@@ -46,6 +46,7 @@ vi.mock("@upstash/ratelimit", async (importOriginal) => ({
 
 import {
   checkAnonymousSessionIssuanceRateLimit,
+  checkMcpDocsToolRateLimit,
   checkMcpTemplateToolRateLimit,
   checkPublicAssistantRateLimit,
   checkXuluxDownloadProxyRateLimit,
@@ -355,6 +356,105 @@ describe("MCP template tool rate limits", () => {
     expect(response?.status).toBe(503);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("mcp_template_rate_limit_unavailable"),
+    );
+  });
+});
+
+describe("MCP docs tool rate limits", () => {
+  const request = () =>
+    new Request("https://www.assistant-ui.com/api/mcp", {
+      method: "POST",
+      headers: { "x-vercel-forwarded-for": "203.0.113.10" },
+    });
+
+  it("sits well above the sandbox-calling lane", async () => {
+    await checkMcpDocsToolRateLimit(request());
+
+    expect(mocks.configs.get("aui:mcp-docs:ip:burst")).toEqual({
+      limit: 60,
+      window: "60s",
+    });
+    expect(mocks.configs.get("aui:mcp-docs:ip:daily")).toEqual({
+      limit: 5_000,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:mcp-docs:global:daily")).toEqual({
+      limit: 100_000,
+      window: "1d",
+    });
+    expect(mocks.configs.get("aui:mcp-docs:global:alert")).toEqual({
+      limit: 1,
+      window: "10m",
+    });
+  });
+
+  it("keys the per-client buckets by IP, the ceiling globally", async () => {
+    await expect(checkMcpDocsToolRateLimit(request())).resolves.toBeNull();
+
+    expect(mocks.calls).toEqual([
+      { prefix: "aui:mcp-docs:ip:burst", key: "203.0.113.10" },
+      { prefix: "aui:mcp-docs:ip:daily", key: "203.0.113.10" },
+      { prefix: "aui:mcp-docs:global:daily", key: "all" },
+    ]);
+  });
+
+  it.each([
+    ["aui:mcp-docs:ip:burst", 1],
+    ["aui:mcp-docs:ip:daily", 2],
+    ["aui:mcp-docs:global:daily", 4],
+  ] as const)(
+    "stops after an exhausted %s limit",
+    async (prefix, expectedCalls) => {
+      mocks.results.set(prefix, false);
+
+      const response = await checkMcpDocsToolRateLimit(request());
+
+      expect(response?.status).toBe(429);
+      expect(response?.headers.get("retry-after")).toBe("30");
+      expect(mocks.calls).toHaveLength(expectedCalls);
+    },
+  );
+
+  it("rate limits the global ceiling alert", async () => {
+    mocks.results.set("aui:mcp-docs:global:daily", false);
+    mocks.results.set("aui:mcp-docs:global:alert", false);
+
+    const response = await checkMcpDocsToolRateLimit(request());
+
+    expect(response?.status).toBe(429);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once when the global ceiling is reached", async () => {
+    mocks.results.set("aui:mcp-docs:global:daily", false);
+
+    await checkMcpDocsToolRateLimit(request());
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_docs_global_limit_exceeded"),
+    );
+  });
+
+  it("fails closed when no client IP is available", async () => {
+    const response = await checkMcpDocsToolRateLimit(
+      new Request("https://www.assistant-ui.com/api/mcp", { method: "POST" }),
+    );
+
+    expect(response?.status).toBe(503);
+    expect(mocks.calls).toHaveLength(0);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_docs_client_ip_missing"),
+    );
+  });
+
+  it("fails closed when the rate-limit store is unavailable", async () => {
+    mocks.errors.set("aui:mcp-docs:ip:burst", new Error("Redis down"));
+
+    const response = await checkMcpDocsToolRateLimit(request());
+
+    expect(response?.status).toBe(503);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("mcp_docs_rate_limit_unavailable"),
     );
   });
 });

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -87,6 +87,38 @@ const getPublicAssistantRateLimits = async () => {
         "1d",
       ),
     }),
+    mcpDocsIpBurst: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-docs:ip:burst",
+      limiter: Ratelimit.fixedWindow(60, "60s"),
+    }),
+    mcpDocsIpDaily: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-docs:ip:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_MCP_DOCS_REQUESTS_PER_IP_PER_DAY,
+          5_000,
+        ),
+        "1d",
+      ),
+    }),
+    mcpDocsGlobalDaily: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-docs:global:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_MCP_DOCS_GLOBAL_REQUESTS_PER_DAY,
+          100_000,
+        ),
+        "1d",
+      ),
+    }),
+    mcpDocsGlobalAlert: new Ratelimit({
+      redis,
+      prefix: "aui:mcp-docs:global:alert",
+      limiter: Ratelimit.fixedWindow(1, "10m"),
+    }),
     mcpTemplateIpBurst: new Ratelimit({
       redis,
       prefix: "aui:mcp-template:ip:burst",
@@ -283,6 +315,43 @@ export async function checkAnonymousSessionIssuanceRateLimit(
     const daily = await limits.sessionIssuanceDaily.limit(ip);
     if (!daily.success) {
       return limitResponse("Anonymous session limit exceeded", daily.reset);
+    }
+    return null;
+  });
+}
+
+export async function checkMcpDocsToolRateLimit(
+  request: Request,
+): Promise<Response | null> {
+  return runRateLimitChecks(request, "mcp_docs", async (limits) => {
+    const ip = getClientIp(request);
+    if (!ip) return missingClientIpResponse(request, "mcp_docs");
+
+    const burst = await limits.mcpDocsIpBurst.limit(ip);
+    if (!burst.success) {
+      return limitResponse("Docs tool rate limit exceeded", burst.reset);
+    }
+
+    const daily = await limits.mcpDocsIpDaily.limit(ip);
+    if (!daily.success) {
+      return limitResponse("Docs tool daily limit exceeded", daily.reset);
+    }
+
+    const globalDaily = await limits.mcpDocsGlobalDaily.limit("all");
+    if (!globalDaily.success) {
+      const alert = await limits.mcpDocsGlobalAlert
+        .limit("all")
+        .catch(() => null);
+      if (alert?.success) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            message: "mcp_docs_global_limit_exceeded",
+            requestId: request.headers.get("x-vercel-id"),
+          }),
+        );
+      }
+      return limitResponse("Docs tool usage limit exceeded", globalDaily.reset);
     }
     return null;
   });

--- a/apps/docs/lib/xulux/fetch-sandbox.test.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.test.ts
@@ -123,6 +123,31 @@ describe("fetchSandboxResource", () => {
     expect(mocks.fetch.mock.calls[0]?.[1]).not.toHaveProperty("timeoutMs");
   });
 
+  it("keeps the deadline over the response body by default", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response("ok"));
+
+    await fetchSandboxResource("https://sandbox.example.com/session", {
+      timeoutMs: 20,
+    });
+    const signal = mocks.fetch.mock.calls[0]?.[1]?.signal;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("releases the deadline at the response headers when scoped to it", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response("ok"));
+
+    await fetchSandboxResource("https://sandbox.example.com/archive", {
+      timeoutMs: 20,
+      timeoutScope: "response",
+    });
+    const signal = mocks.fetch.mock.calls[0]?.[1]?.signal;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(signal?.aborted).toBe(false);
+  });
+
   it("stops retrying once the budget is spent, whatever the error", async () => {
     mocks.fetch.mockImplementation(async (_url, init) => {
       await new Promise((_resolve, reject) => {

--- a/apps/docs/lib/xulux/fetch-sandbox.ts
+++ b/apps/docs/lib/xulux/fetch-sandbox.ts
@@ -9,9 +9,12 @@ const RETRY_DELAY_MS = 300;
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface SandboxFetchInit extends RequestInit {
-  // Budget for the whole call, retries and response body included, so a
-  // streamed archive needs a wider value than a JSON call.
+  // Budget shared by every attempt.
   timeoutMs?: number;
+  // "call" keeps the budget over the response body; "response" releases it once
+  // the headers arrive, so a body handed straight to the client is bounded by
+  // the route's maxDuration rather than by its throughput.
+  timeoutScope?: "call" | "response";
 }
 
 function isRetryableFetchError(error: unknown) {
@@ -49,19 +52,31 @@ export async function fetchSandboxResource(
   url: string | URL,
   init?: SandboxFetchInit,
 ): Promise<Response> {
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal, ...requestInit } = init ?? {};
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    timeoutScope = "call",
+    signal,
+    ...requestInit
+  } = init ?? {};
   const deadline = AbortSignal.timeout(timeoutMs);
-  const abort = signal ? AbortSignal.any([signal, deadline]) : deadline;
+  const gate = new AbortController();
+  const forwardDeadline = () => gate.abort(deadline.reason);
+  deadline.addEventListener("abort", forwardDeadline, { once: true });
+  const abort = signal ? AbortSignal.any([signal, gate.signal]) : gate.signal;
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     try {
-      return await fetch(url, {
+      const response = await fetch(url, {
         ...requestInit,
         cache: "no-store",
         headers: mergeHeaders(requestInit.headers),
         signal: abort,
       });
+      if (timeoutScope === "response") {
+        deadline.removeEventListener("abort", forwardDeadline);
+      }
+      return response;
     } catch (error) {
       lastError = error;
       if (


### PR DESCRIPTION
closes #6696
closes #6739

## Problem

two gaps left over from the review rounds on #6689, both on public unauthenticated routes in `apps/docs`.

**no route had a verified execution ceiling.** #6689 briefly added `maxDuration = 60` to `/api/mcp` and then removed it, because 60 is a ceiling only if the platform default is higher, and nobody had written down what the default was. rather than ship an unverifiable number it left the route on the default and bounded the outbound call instead. that bound turned out to be unreachable (below).

**`/api/mcp` meters only its two sandbox-calling tools.** `requireTemplateToolBudget` guards `read_template` and `preview_template`. `list_pages`, `get_navigation`, `search_docs`, `read_page` and `list_templates` have no budget, and those are the CPU-bound ones: `read_page` runs a full unified rehype to remark pipeline per call through `getLLMText`, and `list_pages` and `search_docs` rebuild an array over every docs page (442 `.md`/`.mdx` files today) on every call. after #6689 metered the sandbox calls, a `read_page` loop is the cheapest anonymous amplifier left on the endpoint.

## Root cause

the ceiling question was answerable all along, against the wrong table. the pre-fluid limits (15s default on Pro) are what made `maxDuration = 60` look like a widening. with fluid compute the default is 300s, so that line would have been a 5x tightening. a value above the plan maximum fails the deploy rather than being silently clamped, so the `maxDuration = 800` already shipping on the chat routes is itself proof the ceiling sits above it.

that makes `ARCHIVE_TIMEOUT_MS = 300_000` on `/api/xulux/download-proxy` dead code. the route sets no `maxDuration`, so it runs at the 300s default, and the abort deadline only starts after the session check and the rate limit have run. the platform terminates the invocation first, every time. the effect is identical to having no timeout: a stalled sandbox burns the whole invocation and returns a 504 instead of a clean 502.

lowering the number alone would not have worked either. `fetchSandboxResource` attaches its deadline to the fetch, and that signal aborts the response body too. the route buffers the archive today, so that is harmless; the moment the body is streamed on to the client, a body-inclusive deadline stops being a stall detector and becomes a throughput cap, which is exactly what the constant's comment says it was trying to avoid.

on the metering side, `.env.example` said the docs tools "are in-process and stay unlimited", so this was a decision rather than an oversight. it reads differently now that the per-call cost is an MDX render.

## Change

**let a sandbox fetch stop its deadline at the response headers.** `SandboxFetchInit` gains `timeoutScope: "call" | "response"`. the deadline is still one `AbortSignal.timeout` shared across attempts, but it now reaches the fetch through a gate controller whose forwarding is detached once the response resolves. `"call"` stays the default, so the JSON callers in `sandbox-contract.ts` keep today's whole-call budget.

**stream the template archive.** `readLimitedBody` is replaced by a counting `TransformStream`, so bytes reach the client as they arrive instead of after a 50 MB buffer. this is the follow-up #6718 deferred as "a different mechanism from metering". it also matters for reachability: a CDN proxy fronts production and applies a shorter read timeout to a response whose bytes have not started flowing, so the buffering version was cut off well before its `maxDuration` regardless of what that said. the upfront `content-length` 413 is unchanged, and upstream's `content-length` is passed through so the client keeps a progress bar. once past the headers a size overrun can only error the stream, which is the correct signal for an upstream that sent more than it declared.

with the body no longer held, the outbound bound becomes a time-to-respond bound at 30s under `timeoutScope: "response"`, and it can actually fire.

**give the docs tools their own budget.** `mcpDocs*` in `lib/rate-limit.ts` mirrors the `mcpTemplate*` family (same Redis client, `getClientIp`, `limitResponse`, throttled alert, fail-closed path):

| prefix | limit | env |
|---|---|---|
| `aui:mcp-docs:ip:burst` | 60 per 60s | |
| `aui:mcp-docs:ip:daily` | 5000 | `AUI_MCP_DOCS_REQUESTS_PER_IP_PER_DAY` |
| `aui:mcp-docs:global:daily` | 100000 | `AUI_MCP_DOCS_GLOBAL_REQUESTS_PER_DAY` |
| `aui:mcp-docs:global:alert` | 1 per 10m | |

the two lanes also get opposite postures on store trouble, which is the one place this deliberately does not mirror the sibling. refusing a template tool when the budget cannot be read is cheaper than serving it, because that call spends sandbox egress. a docs tool costs one in-process render and nothing external, so failing closed there would trade a free-to-serve outage of a publicly documented integration for protection against the smaller cost. `requireDocsToolBudget` therefore returns on anything that is not a 429, and an exhausted budget still refuses.

the width is likewise deliberate: docs reads are normal agent traffic (one task can be a `list_pages` plus a dozen `read_page` calls), so throttling them at the sandbox rate would break real clients to bound a cost that is orders of magnitude smaller.

**meter every unauthenticated entry point, not just the tools.** the resources surface reaches the same functions: `assistant-ui://{+path}` reads call `readPage`, `resources/list` calls `allPages()`, and `assistant-ui://navigation` calls `getNavigation()`. metering `tools/call` alone would have been bypassable by switching to `resources/read`, so all three resource paths take the budget too. `list_templates` joins the docs lane rather than the template lane: it is in-process catalog assembly, not a sandbox call. the result is one rule with no holes on this endpoint: every unauthenticated entry point on `/api/mcp` consumes exactly one budget. the same `getLLMText` render is still reachable unmetered through the public `llms.mdx` routes, which are a different surface with a different fix (they are cacheable in a way `/api/mcp` is not); that is #6742.

`requireTemplateToolBudget` is factored into a shared `requireBudget`. the docs variant drops the "the assistant-ui docs tools remain available" suffix, which is meaningless when the docs tools are the throttled ones.

**state the ceilings.** `/api/mcp` gets `maxDuration = 120`: one sandbox call bounds the template tools at 30s and the rest is in-process rendering, so this is generous for the real worst case and well under the default. `/api/xulux/download-proxy` states `maxDuration = 300`, which is the value it already ran at, so the ceiling is reviewable rather than inherited.

**out of scope.** the `llms.mdx` catch-alls are #6742. `/api/xulux/demo-download` and `/api/xulux/learn/download` are still public and unmetered. they build a zip in-process rather than spending sandbox egress, so they are a different cost class, same as in #6718. the remaining scope of #6101 (a signed anonymous session as a durable identity boundary, requiring auth for Xulux) is untouched.

## Verification

- `pnpm --filter @assistant-ui/docs vitest run` -> 60 files / 515 tests green, up from 507 on `main` at the same commit
- `pnpm lint` (oxlint + oxfmt) -> clean
- `npx tsc --noEmit -p apps/docs/tsconfig.json` -> no errors in the changed files

new tests, each of which fails without its change:

- `fetch-sandbox.test.ts`: the default scope's deadline still aborts after the response resolves; `"response"` scope does not
- `download-proxy/route.test.ts`: headers return and the first chunk is readable while the upstream stream is still open (the buffering version blocks until close), and a body that outgrows the 50 MB ceiling errors the stream mid-flight
- `route.test.ts`: all five in-process tools take the docs budget and none of them touch the template budget, both metered resource paths take it, the sandbox-calling tools still take only the template budget, and a throttled docs tool reports the 429 without rendering the page

the existing test named "leaves the in-process docs tools unmetered" is renamed and inverted, since that assertion was the defect.

## Public surface

`apps/docs` only, which is `private: true`, so no changeset. no published package changes.

two new optional env vars, `AUI_MCP_DOCS_REQUESTS_PER_IP_PER_DAY` and `AUI_MCP_DOCS_GLOBAL_REQUESTS_PER_DAY`, both documented in `.env.example` with the defaults above; unset falls back to those defaults. two stale comments in `.env.example` are corrected in passing, since this change makes both of them false.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ecYa_3zDpuKcSNkD8IIwXKntngQSnYDA9WLebN0Zo6TCxmalaCv0DnprPKM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

