### PR TITLE
chore: require maintainer review for tap and store

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 
 # Public API surface snapshots require maintainer review.
 /api-surface/ @assistant-ui/maintainers
+
+# The reactive primitives every runtime is built on require maintainer review.
+/packages/tap/ @assistant-ui/maintainers
+/packages/store/ @assistant-ui/maintainers


### PR DESCRIPTION
## Problem

`packages/tap` and `packages/store` are the reactive primitives every runtime is built on, and nothing required a maintainer to look at a change there. CODEOWNERS already covers CI policy (`/.github/`) and the public API surface snapshots (`/api-surface/`); the two packages whose behavior every other package inherits were not on the list.

## Change

two entries in `.github/CODEOWNERS`, `/packages/tap/` and `/packages/store/`, owned by `@assistant-ui/maintainers`, the same team the existing entries name.

CODEOWNERS is the lever for this rather than a ruleset edit, because of how the three active rulesets on `main` divide up:

- `Always`, which nobody bypasses, sets `required_approving_review_count: 0`, so it requires no review at all.
- `Bypass-Maintainer` requires one approval from the maintainers team on `*`, but the `maintain` repository role bypasses it.
- `Bypass-Admin` sets `require_code_owner_review: true`, and only the `admin` role bypasses it.

so an outside contributor is already stopped by the blanket rule, while anyone holding `maintain` is not. CODEOWNERS is what reaches that gap: a PR touching tap or store now needs a maintainers-team approval from everyone except repo admins. That is the same reach the existing `/api-surface/` and `/.github/workflows/` entries have, and like them it is still skipped by an `--admin` merge.

## Verification

- `/packages/tap/` and `/packages/store/` each match real tracked files (109 and 63 respectively), so neither entry is a dead pattern.
- the owner resolves to `@assistant-ui/maintainers`, team id `15592476`, which is the same team `Bypass-Maintainer` already names as its required reviewer.
- `gh api repos/assistant-ui/assistant-ui/codeowners/errors` reports 0 on `main`, and the new lines reuse the syntax of the three entries already in the file.

## Public surface

None. no package, export, doc page, api-reference output, template, or changeset is affected; `.github/CODEOWNERS` is the whole diff.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.b8rlGdWLh7i7dq4evbk1N_AHDeAoQHkBWT8ssERrid60qDkY481aRtKvHlg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->