### PR TITLE
feat(docs): home demo gains edit, branches, feedback, voice, and quoting

### DIFF
--- a/apps/docs/components/pages/docs/assistant/assistant-action-bar.tsx
+++ b/apps/docs/components/pages/docs/assistant/assistant-action-bar.tsx
@@ -44,7 +44,21 @@ function getErrorDetails(error: unknown): {
   };
 }
 
-export function AssistantActionBar(): ReactNode {
+export type FeedbackSurface = "home_thread";
+
+/**
+ * Thumbs up and down for the current assistant message, with the reason
+ * popover on the negative path. Records the feedback funnel in analytics and
+ * marks the message through the runtime's feedback adapter. Renders nothing
+ * while the message is streaming or has no prose to rate.
+ */
+export function FeedbackActions({
+  surface,
+  onOpenChange,
+}: {
+  surface?: FeedbackSurface;
+  onOpenChange?: ((open: boolean) => void) | undefined;
+} = {}): ReactNode {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const feedbackShownForMessageRef = useRef<string | null>(null);
   const feedbackSubmissionStartedRef = useRef<string | null>(null);
@@ -79,6 +93,7 @@ export function AssistantActionBar(): ReactNode {
     () => ({
       threadId,
       messageId,
+      ...(surface ? { surface } : {}),
       user_question_length: userQuestionLength,
       assistant_response_length: assistantResponseLength,
       tool_calls_count: toolCallsCount,
@@ -87,6 +102,7 @@ export function AssistantActionBar(): ReactNode {
     [
       assistantResponseLength,
       messageId,
+      surface,
       threadId,
       toolCallsCount,
       toolNames,
@@ -102,10 +118,16 @@ export function AssistantActionBar(): ReactNode {
     analytics.assistant.feedbackShown(feedbackBaseProps);
   }, [assistantHasText, feedbackBaseProps, isRunning, messageId]);
 
-  // Don't show feedback buttons while message is still streaming or if no content
+  useEffect(() => () => onOpenChange?.(false), [onOpenChange]);
+
   if (isRunning || !assistantHasText) {
     return null;
   }
+
+  const setOpen = (open: boolean) => {
+    setPopoverOpen(open);
+    onOpenChange?.(open);
+  };
 
   const handlePositiveFeedback = () => {
     if (submittedFeedback || feedbackSubmissionStartedRef.current === messageId)
@@ -171,18 +193,7 @@ export function AssistantActionBar(): ReactNode {
   };
 
   return (
-    <ActionBarPrimitive.Root className="mt-2 flex items-center gap-1.5">
-      <ActionBarPrimitive.Copy
-        aria-label="Copy response"
-        className="text-muted-foreground/70 hover:text-foreground p-1 transition-colors"
-      >
-        <AuiIf condition={(s) => s.message.isCopied}>
-          <CheckIcon className="size-4" />
-        </AuiIf>
-        <AuiIf condition={(s) => !s.message.isCopied}>
-          <CopyIcon className="size-4" />
-        </AuiIf>
-      </ActionBarPrimitive.Copy>
+    <>
       <button
         type="button"
         onClick={handlePositiveFeedback}
@@ -203,12 +214,12 @@ export function AssistantActionBar(): ReactNode {
 
       <FeedbackPopover
         open={popoverOpen}
-        onOpenChange={setPopoverOpen}
+        onOpenChange={setOpen}
         onSubmit={handleNegativeFeedback}
       >
         <button
           type="button"
-          onClick={() => setPopoverOpen(true)}
+          onClick={() => setOpen(true)}
           disabled={!!submittedFeedback}
           aria-label={
             submittedFeedback === "negative"
@@ -224,6 +235,33 @@ export function AssistantActionBar(): ReactNode {
           <ThumbsDownIcon className="size-4" />
         </button>
       </FeedbackPopover>
+    </>
+  );
+}
+
+export function AssistantActionBar(): ReactNode {
+  const content = useAuiState((s) => s.message.content);
+  const isRunning = useAuiState((s) => s.message.status?.type === "running");
+
+  // Don't show feedback buttons while message is still streaming or if no content
+  if (isRunning || !hasNonWhitespaceText(content)) {
+    return null;
+  }
+
+  return (
+    <ActionBarPrimitive.Root className="mt-2 flex items-center gap-1.5">
+      <ActionBarPrimitive.Copy
+        aria-label="Copy response"
+        className="text-muted-foreground/70 hover:text-foreground p-1 transition-colors"
+      >
+        <AuiIf condition={(s) => s.message.isCopied}>
+          <CheckIcon className="size-4" />
+        </AuiIf>
+        <AuiIf condition={(s) => !s.message.isCopied}>
+          <CopyIcon className="size-4" />
+        </AuiIf>
+      </ActionBarPrimitive.Copy>
+      <FeedbackActions />
     </ActionBarPrimitive.Root>
   );
 }

--- a/apps/docs/components/pages/docs/assistant/assistant-action-bar.tsx
+++ b/apps/docs/components/pages/docs/assistant/assistant-action-bar.tsx
@@ -44,7 +44,7 @@ function getErrorDetails(error: unknown): {
   };
 }
 
-export type FeedbackSurface = "home_thread";
+export type FeedbackSurface = "docs_assistant" | "home_thread";
 
 /**
  * Thumbs up and down for the current assistant message, with the reason
@@ -56,9 +56,9 @@ export function FeedbackActions({
   surface,
   onOpenChange,
 }: {
-  surface?: FeedbackSurface;
+  surface: FeedbackSurface;
   onOpenChange?: ((open: boolean) => void) | undefined;
-} = {}): ReactNode {
+}): ReactNode {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const feedbackShownForMessageRef = useRef<string | null>(null);
   const feedbackSubmissionStartedRef = useRef<string | null>(null);
@@ -93,7 +93,7 @@ export function FeedbackActions({
     () => ({
       threadId,
       messageId,
-      ...(surface ? { surface } : {}),
+      surface,
       user_question_length: userQuestionLength,
       assistant_response_length: assistantResponseLength,
       tool_calls_count: toolCallsCount,
@@ -261,7 +261,7 @@ export function AssistantActionBar(): ReactNode {
           <CopyIcon className="size-4" />
         </AuiIf>
       </ActionBarPrimitive.Copy>
-      <FeedbackActions />
+      <FeedbackActions surface="docs_assistant" />
     </ActionBarPrimitive.Root>
   );
 }

--- a/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
+++ b/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
@@ -52,7 +52,11 @@ export function FeedbackPopover({
   };
 
   return (
-    <Popover.Root open={open} onOpenChange={handleOpenChange}>
+    <Popover.Root
+      open={open}
+      onOpenChange={handleOpenChange}
+      modal="trap-focus"
+    >
       {isValidElement(children) ? (
         <Popover.Trigger render={children as ReactElement} />
       ) : (

--- a/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
+++ b/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
@@ -59,10 +59,16 @@ export function FeedbackPopover({
         <Popover.Trigger>{children}</Popover.Trigger>
       )}
       <Popover.Portal>
-        <Popover.Positioner sideOffset={5} align="start">
+        <Popover.Positioner
+          sideOffset={5}
+          align="start"
+          className="isolate z-50"
+        >
           <Popover.Popup className="border-border bg-popover z-50 w-72 rounded-lg border p-4">
             <div className="space-y-3">
-              <p className="text-sm font-medium">What went wrong?</p>
+              <Popover.Title className="text-sm font-medium">
+                What went wrong?
+              </Popover.Title>
               <div className="space-y-2">
                 {CATEGORIES.map((cat) => (
                   <label

--- a/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
+++ b/apps/docs/components/pages/docs/assistant/feedback-popover.tsx
@@ -101,18 +101,23 @@ export function FeedbackPopover({
                 )}
                 rows={2}
               />
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={!category}
-                className={cn(
-                  "bg-primary text-primary-foreground w-full rounded-md px-3 py-1.5 text-sm font-medium",
-                  "disabled:cursor-not-allowed disabled:opacity-50",
-                  "hover:bg-primary/90",
-                )}
-              >
-                Submit
-              </button>
+              <div className="flex items-center gap-2">
+                <Popover.Close className="text-muted-foreground hover:text-foreground rounded-md px-3 py-1.5 text-sm transition-colors">
+                  Cancel
+                </Popover.Close>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={!category}
+                  className={cn(
+                    "bg-primary text-primary-foreground flex-1 rounded-md px-3 py-1.5 text-sm font-medium",
+                    "disabled:cursor-not-allowed disabled:opacity-50",
+                    "hover:bg-primary/90",
+                  )}
+                >
+                  Submit
+                </button>
+              </div>
             </div>
             <Popover.Arrow className="fill-popover" />
           </Popover.Popup>

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -63,6 +63,7 @@ import {
   useToolDuration,
 } from "@/components/shared/trace-line";
 import { typeEyebrow } from "@/components/shared/type";
+import { describePublicAssistantError } from "@/lib/public-assistant-errors";
 import { cn } from "@/lib/utils";
 
 const isNewChatView = (s: AssistantState) =>
@@ -89,16 +90,6 @@ const getMessageErrorText = (s: AssistantState): string | undefined => {
     typeof error.message === "string"
   ) {
     return error.message;
-  }
-  return undefined;
-};
-
-const describePublicAssistantError = (text: string): string | undefined => {
-  if (/limit exceeded/i.test(text)) {
-    return "The demo is rate limited right now. Try again in a little while.";
-  }
-  if (/temporarily unavailable/i.test(text)) {
-    return "The demo is temporarily unavailable. Try again later.";
   }
   return undefined;
 };
@@ -626,7 +617,7 @@ function SpecimenUserMessage(): ReactNode {
         <UserMessageAttachments />
       </div>
       <div className="relative max-w-[80%]">
-        <div className="bg-muted rounded-thread px-4 py-2 text-[15px] wrap-break-word empty:hidden">
+        <div className="peer bg-muted rounded-thread px-4 py-2 text-[15px] wrap-break-word empty:hidden">
           <MessagePrimitive.Quote>
             {(quote) => <QuoteBlock {...quote} />}
           </MessagePrimitive.Quote>
@@ -637,7 +628,7 @@ function SpecimenUserMessage(): ReactNode {
         <ActionBarPrimitive.Root
           hideWhenRunning
           autohide="not-last"
-          className="absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-1.5"
+          className="absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-1.5 peer-empty:hidden"
         >
           <ActionBarPrimitive.Edit
             aria-label="Edit message"

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -63,7 +63,10 @@ import {
   useToolDuration,
 } from "@/components/shared/trace-line";
 import { typeEyebrow } from "@/components/shared/type";
-import { describePublicAssistantError } from "@/lib/public-assistant-errors";
+import {
+  describePublicAssistantError,
+  unwrapErrorEnvelope,
+} from "@/lib/public-assistant-errors";
 import { cn } from "@/lib/utils";
 
 const isNewChatView = (s: AssistantState) =>
@@ -705,6 +708,8 @@ function SpecimenMessageError(): ReactNode {
       >
         {notice ? (
           <p>{notice}</p>
+        ) : errorText !== undefined ? (
+          <p className="line-clamp-2">{unwrapErrorEnvelope(errorText)}</p>
         ) : (
           <ErrorPrimitive.Message className="line-clamp-2" />
         )}

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import {
+  ActionBarMorePrimitive,
   ActionBarPrimitive,
   type AssistantState,
   AuiIf,
+  BranchPickerPrimitive,
   ComposerPrimitive,
   ErrorPrimitive,
+  type FileMessagePartComponent,
+  type ImageMessagePartComponent,
   MessagePrimitive,
   ThreadListItemMorePrimitive,
   ThreadListItemPrimitive,
@@ -20,8 +24,12 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   CopyIcon,
+  DownloadIcon,
   Maximize2Icon,
+  MicIcon,
   Minimize2Icon,
   MoreHorizontalIcon,
   PencilIcon,
@@ -29,16 +37,26 @@ import {
   RefreshCwIcon,
   SquareIcon,
   TrashIcon,
+  Volume2Icon,
 } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   ComposerAttachments,
   UserMessageAttachments,
 } from "@/components/assistant-ui/elements/attachment.aui";
+import { File } from "@/components/assistant-ui/elements/file";
+import { Image } from "@/components/assistant-ui/elements/image";
+import { MarkdownText } from "@/components/assistant-ui/elements/markdown-text";
+import { MessageTiming } from "@/components/assistant-ui/elements/message-timing.aui";
+import {
+  ComposerQuotePreview,
+  QuoteBlock,
+  SelectionToolbar,
+} from "@/components/assistant-ui/elements/quote.aui";
+import { Reasoning } from "@/components/assistant-ui/elements/reasoning.aui";
+import { FeedbackActions } from "@/components/pages/docs/assistant/assistant-action-bar";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { MarkdownText } from "@/components/assistant-ui/elements/markdown-text";
-import { Reasoning } from "@/components/assistant-ui/elements/reasoning.aui";
 import {
   TraceLine,
   formatDuration,
@@ -56,6 +74,43 @@ const isHistoryLoadingView = (s: AssistantState) =>
   s.thread.isLoading &&
   !s.thread.isDisabled &&
   !s.threads.isLoading;
+
+const getMessageErrorText = (s: AssistantState): string | undefined => {
+  const status = s.message.status;
+  if (status?.type !== "incomplete" || status.reason !== "error") {
+    return undefined;
+  }
+  const error = status.error;
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return undefined;
+};
+
+const describePublicAssistantError = (text: string): string | undefined => {
+  if (/limit exceeded/i.test(text)) {
+    return "The demo is rate limited right now. Try again in a little while.";
+  }
+  if (/temporarily unavailable/i.test(text)) {
+    return "The demo is temporarily unavailable. Try again later.";
+  }
+  return undefined;
+};
+
+const actionButtonClass =
+  "text-muted-foreground/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-40 p-1 transition-colors";
+
+const menuContentClass =
+  "bg-popover text-popover-foreground border-foreground/10 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out rounded-surface z-50 min-w-28 overflow-hidden border p-1";
+
+const menuItemClass =
+  "hover:bg-muted focus:bg-muted flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] outline-none select-none";
 
 export function HomeThread({
   expanded = false,
@@ -262,9 +317,6 @@ function SidebarThreadRename({
   );
 }
 
-const threadMenuItemClass =
-  "hover:bg-muted focus:bg-muted flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[13px] outline-none select-none";
-
 function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
   return (
     <ThreadListItemMorePrimitive.Root sharedFocusGroup>
@@ -281,17 +333,17 @@ function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
         side="right"
         align="start"
         sideOffset={6}
-        className="bg-popover text-popover-foreground border-foreground/10 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out rounded-surface z-[70] min-w-28 overflow-hidden border p-1"
+        className={menuContentClass}
       >
         <ThreadListItemMorePrimitive.Item
-          className={threadMenuItemClass}
+          className={menuItemClass}
           onSelect={onRename}
         >
           <PencilIcon className="size-3.5" />
           Rename
         </ThreadListItemMorePrimitive.Item>
         <ThreadListItemPrimitive.Archive asChild>
-          <ThreadListItemMorePrimitive.Item className={threadMenuItemClass}>
+          <ThreadListItemMorePrimitive.Item className={menuItemClass}>
             <ArchiveIcon className="size-3.5" />
             Archive
           </ThreadListItemMorePrimitive.Item>
@@ -299,7 +351,7 @@ function SidebarThreadMore({ onRename }: { onRename: () => void }): ReactNode {
         <ThreadListItemPrimitive.Delete asChild>
           <ThreadListItemMorePrimitive.Item
             className={cn(
-              threadMenuItemClass,
+              menuItemClass,
               "text-destructive hover:bg-destructive/10 hover:text-destructive focus:bg-destructive/10 focus:text-destructive",
             )}
           >
@@ -357,6 +409,7 @@ function SpecimenThread(): ReactNode {
         <div className="mb-12 flex flex-col gap-y-6 empty:hidden">
           <ThreadPrimitive.Messages>
             {({ message }) => {
+              if (message.composer.isEditing) return <SpecimenEditComposer />;
               if (message.role === "user") return <SpecimenUserMessage />;
               if (message.role === "assistant")
                 return <SpecimenAssistantMessage />;
@@ -390,6 +443,7 @@ function SpecimenThread(): ReactNode {
           </AuiIf>
         </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
+      <SelectionToolbar className="border-foreground/10 rounded-control" />
     </ThreadPrimitive.Root>
   );
 }
@@ -431,54 +485,136 @@ function SpecimenSuggestions(): ReactNode {
 function SpecimenComposer(): ReactNode {
   return (
     <ComposerPrimitive.Root className="w-full">
-      <div className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 rounded-thread flex flex-col border transition-colors">
-        <div className="has-[.aui-attachment-root]:px-3 has-[.aui-attachment-root]:pt-3">
-          <ComposerAttachments />
-        </div>
-        <ComposerPrimitive.Input asChild>
-          <textarea
-            placeholder="Send a message..."
-            rows={1}
-            className="placeholder:text-muted-foreground field-sizing-content max-h-48 min-h-12 w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-base leading-6 focus:outline-none"
-          />
-        </ComposerPrimitive.Input>
-        <div className="flex items-center justify-between px-2.5 pb-2.5">
-          <ComposerPrimitive.AddAttachment asChild>
-            <button
-              type="button"
-              aria-label="Add attachment"
-              className="text-muted-foreground hover:text-foreground rounded-control grid size-8 place-items-center transition-colors"
-            >
-              <PlusIcon className="size-4.5" />
-            </button>
-          </ComposerPrimitive.AddAttachment>
-          <AuiIf condition={(s) => !s.thread.isRunning}>
-            <ComposerPrimitive.Send asChild>
+      <ComposerPrimitive.AttachmentDropzone asChild>
+        <div className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 data-[dragging=true]:border-foreground/40 rounded-thread flex flex-col border transition-colors data-[dragging=true]:border-dashed">
+          <ComposerQuotePreview className="bg-foreground/[0.04] rounded-control mx-3 mt-3" />
+          <div className="has-[.aui-attachment-root]:px-3 has-[.aui-attachment-root]:pt-3">
+            <ComposerAttachments />
+          </div>
+          <ComposerPrimitive.Input asChild>
+            <textarea
+              placeholder="Send a message..."
+              rows={1}
+              className="placeholder:text-muted-foreground field-sizing-content max-h-48 min-h-12 w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-base leading-6 focus:outline-none"
+            />
+          </ComposerPrimitive.Input>
+          <div className="flex items-center justify-between px-2.5 pb-2.5">
+            <ComposerPrimitive.AddAttachment asChild>
               <button
                 type="button"
-                aria-label="Send message"
-                className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full transition-opacity disabled:opacity-40"
+                aria-label="Add attachment"
+                className="text-muted-foreground hover:text-foreground rounded-control grid size-8 place-items-center transition-colors"
               >
-                <ArrowUpIcon className="size-4.5" />
+                <PlusIcon className="size-4.5" />
               </button>
-            </ComposerPrimitive.Send>
-          </AuiIf>
-          <AuiIf condition={(s) => s.thread.isRunning}>
-            <ComposerPrimitive.Cancel asChild>
-              <button
-                type="button"
-                aria-label="Stop generating"
-                className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full"
+            </ComposerPrimitive.AddAttachment>
+            <div className="flex items-center gap-1">
+              <AuiIf
+                condition={(s) =>
+                  s.thread.capabilities.dictation &&
+                  s.composer.dictation == null
+                }
               >
-                <SquareIcon className="size-3.5 fill-current" />
-              </button>
-            </ComposerPrimitive.Cancel>
-          </AuiIf>
+                <ComposerPrimitive.Dictate asChild>
+                  <button
+                    type="button"
+                    aria-label="Start voice input"
+                    className="text-muted-foreground hover:text-foreground rounded-control grid size-8 place-items-center transition-colors disabled:opacity-40"
+                  >
+                    <MicIcon className="size-4.5" />
+                  </button>
+                </ComposerPrimitive.Dictate>
+              </AuiIf>
+              <AuiIf condition={(s) => s.composer.dictation != null}>
+                <ComposerPrimitive.StopDictation asChild>
+                  <button
+                    type="button"
+                    aria-label="Stop voice input"
+                    className="text-destructive rounded-control grid size-8 place-items-center transition-colors"
+                  >
+                    <SquareIcon className="size-3.5 animate-pulse fill-current" />
+                  </button>
+                </ComposerPrimitive.StopDictation>
+              </AuiIf>
+              <AuiIf condition={(s) => !s.thread.isRunning}>
+                <ComposerPrimitive.Send asChild>
+                  <button
+                    type="button"
+                    aria-label="Send message"
+                    className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full transition-opacity disabled:opacity-40"
+                  >
+                    <ArrowUpIcon className="size-4.5" />
+                  </button>
+                </ComposerPrimitive.Send>
+              </AuiIf>
+              <AuiIf condition={(s) => s.thread.isRunning}>
+                <ComposerPrimitive.Cancel asChild>
+                  <button
+                    type="button"
+                    aria-label="Stop generating"
+                    className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full"
+                  >
+                    <SquareIcon className="size-3.5 fill-current" />
+                  </button>
+                </ComposerPrimitive.Cancel>
+              </AuiIf>
+            </div>
+          </div>
         </div>
-      </div>
+      </ComposerPrimitive.AttachmentDropzone>
     </ComposerPrimitive.Root>
   );
 }
+
+function SpecimenEditComposer(): ReactNode {
+  return (
+    <MessagePrimitive.Root
+      data-role="user"
+      className="mx-auto flex w-full max-w-(--thread-max-width) flex-col items-end"
+    >
+      <ComposerPrimitive.Root className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 rounded-thread flex w-full max-w-[85%] flex-col border transition-colors">
+        <ComposerPrimitive.Input asChild>
+          <textarea
+            autoFocus
+            aria-label="Edit message"
+            rows={1}
+            className="field-sizing-content max-h-48 min-h-12 w-full resize-none bg-transparent px-4 pt-3.5 pb-1 text-[15px] leading-6 focus:outline-none"
+          />
+        </ComposerPrimitive.Input>
+        <div className="flex items-center justify-end gap-1.5 px-2.5 pb-2.5">
+          <ComposerPrimitive.Cancel asChild>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground rounded-control h-8 px-3 text-[13px] transition-colors"
+            >
+              Cancel
+            </button>
+          </ComposerPrimitive.Cancel>
+          <ComposerPrimitive.Send asChild>
+            <button
+              type="button"
+              className="bg-primary text-primary-foreground rounded-control h-8 px-3 text-[13px] font-medium transition-opacity disabled:opacity-40"
+            >
+              Update
+            </button>
+          </ComposerPrimitive.Send>
+        </div>
+      </ComposerPrimitive.Root>
+    </MessagePrimitive.Root>
+  );
+}
+
+const UserFilePart: FileMessagePartComponent = (part) => (
+  <div className="py-1">
+    <File {...part} />
+  </div>
+);
+
+const UserImagePart: ImageMessagePartComponent = (part) => (
+  <div className="py-1">
+    <Image {...part} />
+  </div>
+);
 
 function SpecimenUserMessage(): ReactNode {
   return (
@@ -489,9 +625,29 @@ function SpecimenUserMessage(): ReactNode {
       <div className="w-full has-[.aui-attachment-root]:mb-2">
         <UserMessageAttachments />
       </div>
-      <div className="bg-muted rounded-thread max-w-[80%] px-4 py-2 text-[15px] wrap-break-word empty:hidden">
-        <MessagePrimitive.Parts />
+      <div className="relative max-w-[80%]">
+        <div className="bg-muted rounded-thread px-4 py-2 text-[15px] wrap-break-word empty:hidden">
+          <MessagePrimitive.Quote>
+            {(quote) => <QuoteBlock {...quote} />}
+          </MessagePrimitive.Quote>
+          <MessagePrimitive.Parts
+            components={{ File: UserFilePart, Image: UserImagePart }}
+          />
+        </div>
+        <ActionBarPrimitive.Root
+          hideWhenRunning
+          autohide="not-last"
+          className="absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-1.5"
+        >
+          <ActionBarPrimitive.Edit
+            aria-label="Edit message"
+            className={actionButtonClass}
+          >
+            <PencilIcon className="size-4" />
+          </ActionBarPrimitive.Edit>
+        </ActionBarPrimitive.Root>
       </div>
+      <SpecimenBranchPicker className="-me-1 mt-1" />
     </MessagePrimitive.Root>
   );
 }
@@ -514,39 +670,169 @@ function SpecimenAssistantMessage(): ReactNode {
             if (part.type === "tool-call")
               return part.toolUI ?? <SpecimenToolCall {...part} />;
             if (part.type === "data") return part.dataRendererUI;
+            if (part.type === "image")
+              return (
+                <div className="py-1">
+                  <Image {...part} />
+                </div>
+              );
+            if (part.type === "file")
+              return (
+                <div className="py-1">
+                  <File {...part} />
+                </div>
+              );
             return null;
           }}
         </MessagePrimitive.Parts>
-        <MessagePrimitive.Error>
-          <ErrorPrimitive.Root className="border-destructive/60 text-destructive mt-2 border-l-2 pl-3 text-[12.5px]">
-            <ErrorPrimitive.Message className="line-clamp-2" />
-          </ErrorPrimitive.Root>
-        </MessagePrimitive.Error>
+        <SpecimenMessageError />
       </div>
-      <ActionBarPrimitive.Root
-        hideWhenRunning
-        autohide="not-last"
-        className="mt-2 flex items-center gap-1.5"
-      >
-        <ActionBarPrimitive.Copy
-          aria-label="Copy response"
-          className="text-muted-foreground/70 hover:text-foreground p-1 transition-colors"
-        >
-          <AuiIf condition={(s) => s.message.isCopied}>
-            <CheckIcon className="size-4" />
-          </AuiIf>
-          <AuiIf condition={(s) => !s.message.isCopied}>
-            <CopyIcon className="size-4" />
-          </AuiIf>
-        </ActionBarPrimitive.Copy>
-        <ActionBarPrimitive.Reload
-          aria-label="Regenerate response"
-          className="text-muted-foreground/70 hover:text-foreground p-1 transition-colors"
-        >
-          <RefreshCwIcon className="size-4" />
-        </ActionBarPrimitive.Reload>
-      </ActionBarPrimitive.Root>
+      <div className="mt-2 flex items-center gap-1.5 empty:hidden">
+        <SpecimenBranchPicker />
+        <SpecimenAssistantActionBar />
+      </div>
     </MessagePrimitive.Root>
+  );
+}
+
+function SpecimenMessageError(): ReactNode {
+  const errorText = useAuiState(getMessageErrorText);
+  const notice =
+    errorText === undefined
+      ? undefined
+      : describePublicAssistantError(errorText);
+
+  return (
+    <MessagePrimitive.Error>
+      <ErrorPrimitive.Root
+        className={cn(
+          "mt-2 border-l-2 pl-3 text-[12.5px]",
+          notice
+            ? "border-foreground/20 text-muted-foreground"
+            : "border-destructive/60 text-destructive",
+        )}
+      >
+        {notice ? (
+          <p>{notice}</p>
+        ) : (
+          <ErrorPrimitive.Message className="line-clamp-2" />
+        )}
+      </ErrorPrimitive.Root>
+    </MessagePrimitive.Error>
+  );
+}
+
+function SpecimenAssistantActionBar(): ReactNode {
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+
+  return (
+    <ActionBarPrimitive.Root
+      hideWhenRunning
+      autohide={feedbackOpen ? "never" : "not-last"}
+      className="flex items-center gap-1.5"
+    >
+      <ActionBarPrimitive.Copy
+        aria-label="Copy response"
+        className={actionButtonClass}
+      >
+        <AuiIf condition={(s) => s.message.isCopied}>
+          <CheckIcon className="size-4" />
+        </AuiIf>
+        <AuiIf condition={(s) => !s.message.isCopied}>
+          <CopyIcon className="size-4" />
+        </AuiIf>
+      </ActionBarPrimitive.Copy>
+      <FeedbackActions surface="home_thread" onOpenChange={setFeedbackOpen} />
+      <AuiIf
+        condition={(s) =>
+          s.thread.capabilities.speech && s.message.speech == null
+        }
+      >
+        <ActionBarPrimitive.Speak
+          aria-label="Read aloud"
+          className={actionButtonClass}
+        >
+          <Volume2Icon className="size-4" />
+        </ActionBarPrimitive.Speak>
+      </AuiIf>
+      <AuiIf condition={(s) => s.message.speech != null}>
+        <ActionBarPrimitive.StopSpeaking
+          aria-label="Stop reading"
+          className={cn(actionButtonClass, "text-foreground")}
+        >
+          <SquareIcon className="size-3.5 fill-current" />
+        </ActionBarPrimitive.StopSpeaking>
+      </AuiIf>
+      <ActionBarPrimitive.Reload
+        aria-label="Regenerate response"
+        className={actionButtonClass}
+      >
+        <RefreshCwIcon className="size-4" />
+      </ActionBarPrimitive.Reload>
+      <ActionBarMorePrimitive.Root>
+        <ActionBarMorePrimitive.Trigger asChild>
+          <button
+            type="button"
+            aria-label="More actions"
+            className={cn(
+              actionButtonClass,
+              "data-[state=open]:text-foreground",
+            )}
+          >
+            <MoreHorizontalIcon className="size-4" />
+          </button>
+        </ActionBarMorePrimitive.Trigger>
+        <ActionBarMorePrimitive.Content
+          side="bottom"
+          align="start"
+          sideOffset={6}
+          className={menuContentClass}
+        >
+          <ActionBarPrimitive.ExportMarkdown asChild>
+            <ActionBarMorePrimitive.Item className={menuItemClass}>
+              <DownloadIcon className="size-3.5" />
+              Export as Markdown
+            </ActionBarMorePrimitive.Item>
+          </ActionBarPrimitive.ExportMarkdown>
+        </ActionBarMorePrimitive.Content>
+      </ActionBarMorePrimitive.Root>
+      <MessageTiming
+        side="bottom"
+        className="text-muted-foreground/70 hover:text-foreground ms-1 rounded-none p-1 hover:bg-transparent"
+      />
+    </ActionBarPrimitive.Root>
+  );
+}
+
+function SpecimenBranchPicker({
+  className,
+}: {
+  className?: string;
+}): ReactNode {
+  return (
+    <BranchPickerPrimitive.Root
+      hideWhenSingleBranch
+      className={cn(
+        "text-muted-foreground inline-flex items-center text-[12px] tabular-nums",
+        className,
+      )}
+    >
+      <BranchPickerPrimitive.Previous
+        aria-label="Previous version"
+        className={actionButtonClass}
+      >
+        <ChevronLeftIcon className="size-4" />
+      </BranchPickerPrimitive.Previous>
+      <span className="font-medium">
+        <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
+      </span>
+      <BranchPickerPrimitive.Next
+        aria-label="Next version"
+        className={actionButtonClass}
+      >
+        <ChevronRightIcon className="size-4" />
+      </BranchPickerPrimitive.Next>
+    </BranchPickerPrimitive.Root>
   );
 }
 

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -17,13 +17,20 @@ export function ThreadSpecimen() {
         ? document.activeElement
         : null;
     overlayRef.current?.focus();
-    const isInsidePopup = (target: EventTarget | null) => {
+    // Menus and dialogs close themselves on Escape; the selection toolbar does
+    // not, so it only counts as its own layer for focus, not for Escape.
+    const isInsideLayer = (target: EventTarget | null, selector: string) => {
       if (!(target instanceof Element)) return false;
-      const layer = target.closest(
-        '[role="menu"], [role="dialog"], [data-slot="selection-toolbar"]',
-      );
+      const layer = target.closest(selector);
       return layer !== null && layer !== overlayRef.current;
     };
+    const isInsidePopup = (target: EventTarget | null) =>
+      isInsideLayer(target, '[role="menu"], [role="dialog"]');
+    const isInsideFocusLayer = (target: EventTarget | null) =>
+      isInsideLayer(
+        target,
+        '[role="menu"], [role="dialog"], [data-slot="selection-toolbar"]',
+      );
     const onKey = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
       if (event.key === "Escape") {
@@ -34,7 +41,7 @@ export function ThreadSpecimen() {
       if (event.key !== "Tab") return;
       const root = overlayRef.current;
       if (!root) return;
-      if (isInsidePopup(document.activeElement)) return;
+      if (isInsideFocusLayer(document.activeElement)) return;
       const focusables = Array.from(
         root.querySelectorAll<HTMLElement>(
           'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
@@ -65,7 +72,7 @@ export function ThreadSpecimen() {
       const root = overlayRef.current;
       const target = event.target;
       if (!root || !(target instanceof HTMLElement)) return;
-      if (root.contains(target) || isInsidePopup(target)) return;
+      if (root.contains(target) || isInsideFocusLayer(target)) return;
       root.focus();
     };
     document.addEventListener("keydown", onKey);

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -17,15 +17,22 @@ export function ThreadSpecimen() {
         ? document.activeElement
         : null;
     overlayRef.current?.focus();
+    const isInsidePopup = (target: EventTarget | null) => {
+      if (!(target instanceof Element)) return false;
+      const layer = target.closest('[role="menu"], [role="dialog"]');
+      return layer !== null && layer !== overlayRef.current;
+    };
     const onKey = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
       if (event.key === "Escape") {
+        if (isInsidePopup(event.target)) return;
         setExpanded(false);
         return;
       }
       if (event.key !== "Tab") return;
       const root = overlayRef.current;
       if (!root) return;
+      if (isInsidePopup(document.activeElement)) return;
       const focusables = Array.from(
         root.querySelectorAll<HTMLElement>(
           'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
@@ -80,7 +87,7 @@ export function ThreadSpecimen() {
                   aria-modal="true"
                   aria-label="Thread fullscreen"
                   tabIndex={-1}
-                  className="bg-background fixed inset-0 z-[60] overflow-hidden outline-none"
+                  className="bg-background fixed inset-0 z-50 overflow-hidden outline-none"
                 >
                   {thread}
                 </div>,

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -59,10 +59,19 @@ export function ThreadSpecimen() {
         first.focus();
       }
     };
+    const onFocusIn = (event: FocusEvent) => {
+      const root = overlayRef.current;
+      const target = event.target;
+      if (!root || !(target instanceof HTMLElement)) return;
+      if (root.contains(target) || isInsidePopup(target)) return;
+      root.focus();
+    };
     document.addEventListener("keydown", onKey);
+    document.addEventListener("focusin", onFocusIn);
     document.documentElement.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
+      document.removeEventListener("focusin", onFocusIn);
       document.documentElement.style.overflow = "";
       previouslyFocused?.focus();
     };

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -19,7 +19,9 @@ export function ThreadSpecimen() {
     overlayRef.current?.focus();
     const isInsidePopup = (target: EventTarget | null) => {
       if (!(target instanceof Element)) return false;
-      const layer = target.closest('[role="menu"], [role="dialog"]');
+      const layer = target.closest(
+        '[role="menu"], [role="dialog"], [data-slot="selection-toolbar"]',
+      );
       return layer !== null && layer !== overlayRef.current;
     };
     const onKey = (event: KeyboardEvent) => {

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -110,6 +110,7 @@ export const analytics = {
     feedbackShown: (props: {
       threadId: string;
       messageId: string;
+      surface?: "home_thread";
       user_question_length: number;
       assistant_response_length: number;
       tool_calls_count: number;
@@ -121,6 +122,7 @@ export const analytics = {
     feedbackClicked: (props: {
       threadId: string;
       messageId: string;
+      surface?: "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"
@@ -140,6 +142,7 @@ export const analytics = {
     feedbackSubmitFailed: (props: {
       threadId: string;
       messageId: string;
+      surface?: "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"
@@ -221,6 +224,7 @@ export const analytics = {
     feedbackSubmitted: (props: {
       threadId: string;
       messageId: string;
+      surface?: "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"

--- a/apps/docs/lib/analytics.ts
+++ b/apps/docs/lib/analytics.ts
@@ -110,7 +110,7 @@ export const analytics = {
     feedbackShown: (props: {
       threadId: string;
       messageId: string;
-      surface?: "home_thread";
+      surface?: "docs_assistant" | "home_thread";
       user_question_length: number;
       assistant_response_length: number;
       tool_calls_count: number;
@@ -122,7 +122,7 @@ export const analytics = {
     feedbackClicked: (props: {
       threadId: string;
       messageId: string;
-      surface?: "home_thread";
+      surface?: "docs_assistant" | "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"
@@ -142,7 +142,7 @@ export const analytics = {
     feedbackSubmitFailed: (props: {
       threadId: string;
       messageId: string;
-      surface?: "home_thread";
+      surface?: "docs_assistant" | "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"
@@ -224,7 +224,7 @@ export const analytics = {
     feedbackSubmitted: (props: {
       threadId: string;
       messageId: string;
-      surface?: "home_thread";
+      surface?: "docs_assistant" | "home_thread";
       type: "positive" | "negative";
       category?:
         | "wrong_information"

--- a/apps/docs/lib/anonymous-session-client.test.ts
+++ b/apps/docs/lib/anonymous-session-client.test.ts
@@ -37,6 +37,24 @@ describe("anonymous session client", () => {
     );
   });
 
+  it("unwraps the JSON error envelope of a refused bootstrap", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: "Anonymous sessions are issued through the website." },
+          { status: 403 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const { ensureAnonymousSession } =
+      await import("./anonymous-session-client");
+
+    await expect(ensureAnonymousSession()).rejects.toThrow(
+      "Anonymous sessions are issued through the website.",
+    );
+  });
+
   it("starts a browser session before a public assistant request", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/docs/lib/anonymous-session-client.test.ts
+++ b/apps/docs/lib/anonymous-session-client.test.ts
@@ -22,6 +22,21 @@ describe("anonymous session client", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("surfaces the session route's body when bootstrap is refused", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("Anonymous session limit exceeded", { status: 429 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const { ensureAnonymousSession } =
+      await import("./anonymous-session-client");
+
+    await expect(ensureAnonymousSession()).rejects.toThrow(
+      "Anonymous session limit exceeded",
+    );
+  });
+
   it("starts a browser session before a public assistant request", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/docs/lib/anonymous-session-client.ts
+++ b/apps/docs/lib/anonymous-session-client.ts
@@ -3,6 +3,20 @@ let sessionToken: string | null = null;
 
 const ANONYMOUS_SESSION_HEADER = "x-assistant-ui-anonymous-session";
 
+// The session route refuses with either a plain text limit body or a JSON
+// `{ error }` envelope; the message that reaches the chat error rail is the
+// human readable part of whichever it sent.
+async function readRefusalMessage(response: Response): Promise<string> {
+  const text = await response.text();
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    if (typeof parsed?.error === "string" && parsed.error) return parsed.error;
+  } catch {
+    // not JSON
+  }
+  return text || "Unable to start an anonymous session";
+}
+
 export function ensureAnonymousSession(): Promise<void> {
   sessionPromise ??= fetch("/api/anonymous-session", {
     cache: "no-store",
@@ -10,9 +24,7 @@ export function ensureAnonymousSession(): Promise<void> {
   })
     .then(async (response) => {
       if (!response.ok) {
-        throw new Error(
-          (await response.text()) || "Unable to start an anonymous session",
-        );
+        throw new Error(await readRefusalMessage(response));
       }
       if (response.status === 204) return;
 

--- a/apps/docs/lib/anonymous-session-client.ts
+++ b/apps/docs/lib/anonymous-session-client.ts
@@ -10,7 +10,9 @@ export function ensureAnonymousSession(): Promise<void> {
   })
     .then(async (response) => {
       if (!response.ok) {
-        throw new Error("Unable to start an anonymous session");
+        throw new Error(
+          (await response.text()) || "Unable to start an anonymous session",
+        );
       }
       if (response.status === 204) return;
 

--- a/apps/docs/lib/public-assistant-errors.test.ts
+++ b/apps/docs/lib/public-assistant-errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE,
+  describePublicAssistantError,
+  publicAssistantLimitMessage,
+} from "./public-assistant-errors";
+
+describe("describePublicAssistantError", () => {
+  it("recognises every limit message the public routes emit", () => {
+    for (const subject of [
+      "Rate",
+      "Daily usage",
+      "Anonymous session",
+      "Template download usage",
+    ]) {
+      expect(
+        describePublicAssistantError(publicAssistantLimitMessage(subject)),
+      ).toMatch(/rate limited/);
+    }
+    expect(describePublicAssistantError("429 Too Many Requests")).toMatch(
+      /rate limited/,
+    );
+  });
+
+  it("recognises the unavailable response and gateway wording", () => {
+    expect(
+      describePublicAssistantError(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE),
+    ).toMatch(/temporarily unavailable/);
+    expect(describePublicAssistantError("503 Service Unavailable")).toMatch(
+      /temporarily unavailable/,
+    );
+  });
+
+  it("leaves other errors to the default error rail", () => {
+    expect(
+      describePublicAssistantError("Failed to fetch the chat response."),
+    ).toBeUndefined();
+  });
+});

--- a/apps/docs/lib/public-assistant-errors.test.ts
+++ b/apps/docs/lib/public-assistant-errors.test.ts
@@ -4,7 +4,24 @@ import {
   PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE,
   describePublicAssistantError,
   publicAssistantLimitMessage,
+  unwrapErrorEnvelope,
 } from "./public-assistant-errors";
+
+describe("unwrapErrorEnvelope", () => {
+  it("returns the envelope's error string and leaves plain text alone", () => {
+    expect(
+      unwrapErrorEnvelope(
+        JSON.stringify({
+          error: "A valid anonymous browser session is required.",
+        }),
+      ),
+    ).toBe("A valid anonymous browser session is required.");
+    expect(unwrapErrorEnvelope("Failed to fetch the chat response.")).toBe(
+      "Failed to fetch the chat response.",
+    );
+    expect(unwrapErrorEnvelope("{not json")).toBe("{not json");
+  });
+});
 
 describe("describePublicAssistantError", () => {
   it("recognises every limit message the public routes emit", () => {

--- a/apps/docs/lib/public-assistant-errors.test.ts
+++ b/apps/docs/lib/public-assistant-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  PUBLIC_ASSISTANT_LIMITS,
   PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE,
   describePublicAssistantError,
   publicAssistantLimitMessage,
@@ -7,12 +8,7 @@ import {
 
 describe("describePublicAssistantError", () => {
   it("recognises every limit message the public routes emit", () => {
-    for (const subject of [
-      "Rate",
-      "Daily usage",
-      "Anonymous session",
-      "Template download usage",
-    ]) {
+    for (const subject of PUBLIC_ASSISTANT_LIMITS) {
       expect(
         describePublicAssistantError(publicAssistantLimitMessage(subject)),
       ).toMatch(/rate limited/);
@@ -31,9 +27,12 @@ describe("describePublicAssistantError", () => {
     );
   });
 
-  it("leaves other errors to the default error rail", () => {
+  it("leaves model and transport errors to the default error rail", () => {
     expect(
       describePublicAssistantError("Failed to fetch the chat response."),
+    ).toBeUndefined();
+    expect(
+      describePublicAssistantError("context length limit exceeded"),
     ).toBeUndefined();
   });
 });

--- a/apps/docs/lib/public-assistant-errors.test.ts
+++ b/apps/docs/lib/public-assistant-errors.test.ts
@@ -18,6 +18,21 @@ describe("describePublicAssistantError", () => {
     );
   });
 
+  it("reads a JSON error envelope before matching", () => {
+    expect(
+      describePublicAssistantError(
+        JSON.stringify({ error: publicAssistantLimitMessage("Rate") }),
+      ),
+    ).toMatch(/rate limited/);
+    expect(
+      describePublicAssistantError(
+        JSON.stringify({
+          error: "Anonymous session protection is not configured.",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
   it("recognises the unavailable response and gateway wording", () => {
     expect(
       describePublicAssistantError(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE),

--- a/apps/docs/lib/public-assistant-errors.ts
+++ b/apps/docs/lib/public-assistant-errors.ts
@@ -24,15 +24,27 @@ const LIMIT_MESSAGES = new Set<string>(
   PUBLIC_ASSISTANT_LIMITS.map(publicAssistantLimitMessage),
 );
 
+const unwrapErrorEnvelope = (text: string): string => {
+  const body = text.trim();
+  if (!body.startsWith("{")) return body;
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    return typeof parsed?.error === "string" ? parsed.error.trim() : body;
+  } catch {
+    return body;
+  }
+};
+
 /**
- * Maps the plain text bodies the public assistant routes answer with (and the
- * gateway wording that can replace them) to copy a visitor can act on. Model
- * or provider errors that merely mention a limit are left to the error rail.
+ * Maps the bodies the public assistant routes answer with (plain text limits,
+ * JSON `{ error }` envelopes, and the gateway wording that can replace them) to
+ * copy a visitor can act on. Model or provider errors that merely mention a
+ * limit are left to the error rail.
  */
 export const describePublicAssistantError = (
   text: string,
 ): string | undefined => {
-  const body = text.trim();
+  const body = unwrapErrorEnvelope(text);
   if (LIMIT_MESSAGES.has(body) || /too many requests|\b429\b/i.test(body)) {
     return "The demo is rate limited right now. Try again in a little while.";
   }

--- a/apps/docs/lib/public-assistant-errors.ts
+++ b/apps/docs/lib/public-assistant-errors.ts
@@ -24,7 +24,8 @@ const LIMIT_MESSAGES = new Set<string>(
   PUBLIC_ASSISTANT_LIMITS.map(publicAssistantLimitMessage),
 );
 
-const unwrapErrorEnvelope = (text: string): string => {
+/** Reads the human readable message out of a JSON `{ error }` envelope. */
+export const unwrapErrorEnvelope = (text: string): string => {
   const body = text.trim();
   if (!body.startsWith("{")) return body;
   try {

--- a/apps/docs/lib/public-assistant-errors.ts
+++ b/apps/docs/lib/public-assistant-errors.ts
@@ -1,0 +1,26 @@
+const LIMIT_SUFFIX = "limit exceeded";
+
+export const PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE =
+  "Public assistant temporarily unavailable";
+
+export const publicAssistantLimitMessage = (subject: string) =>
+  `${subject} ${LIMIT_SUFFIX}`;
+
+/**
+ * Maps the plain text bodies the public assistant routes answer with (and the
+ * gateway wording that can replace them) to copy a visitor can act on.
+ */
+export const describePublicAssistantError = (
+  text: string,
+): string | undefined => {
+  if (text.includes(LIMIT_SUFFIX) || /too many requests|\b429\b/i.test(text)) {
+    return "The demo is rate limited right now. Try again in a little while.";
+  }
+  if (
+    text.includes(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE) ||
+    /service unavailable|\b503\b/i.test(text)
+  ) {
+    return "The demo is temporarily unavailable. Try again later.";
+  }
+  return undefined;
+};

--- a/apps/docs/lib/public-assistant-errors.ts
+++ b/apps/docs/lib/public-assistant-errors.ts
@@ -1,24 +1,44 @@
-const LIMIT_SUFFIX = "limit exceeded";
+export const PUBLIC_ASSISTANT_LIMITS = [
+  "Rate",
+  "Daily usage",
+  "Daily anonymous session",
+  "Public assistant usage",
+  "Anonymous session",
+  "Template tool rate",
+  "Template tool daily",
+  "Template tool usage",
+  "Template download rate",
+  "Template download daily",
+  "Template download usage",
+] as const;
+
+export type PublicAssistantLimit = (typeof PUBLIC_ASSISTANT_LIMITS)[number];
 
 export const PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE =
   "Public assistant temporarily unavailable";
 
-export const publicAssistantLimitMessage = (subject: string) =>
-  `${subject} ${LIMIT_SUFFIX}`;
+export const publicAssistantLimitMessage = (subject: PublicAssistantLimit) =>
+  `${subject} limit exceeded`;
+
+const LIMIT_MESSAGES = new Set<string>(
+  PUBLIC_ASSISTANT_LIMITS.map(publicAssistantLimitMessage),
+);
 
 /**
  * Maps the plain text bodies the public assistant routes answer with (and the
- * gateway wording that can replace them) to copy a visitor can act on.
+ * gateway wording that can replace them) to copy a visitor can act on. Model
+ * or provider errors that merely mention a limit are left to the error rail.
  */
 export const describePublicAssistantError = (
   text: string,
 ): string | undefined => {
-  if (text.includes(LIMIT_SUFFIX) || /too many requests|\b429\b/i.test(text)) {
+  const body = text.trim();
+  if (LIMIT_MESSAGES.has(body) || /too many requests|\b429\b/i.test(body)) {
     return "The demo is rate limited right now. Try again in a little while.";
   }
   if (
-    text.includes(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE) ||
-    /service unavailable|\b503\b/i.test(text)
+    body === PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE ||
+    /service unavailable|\b503\b/i.test(body)
   ) {
     return "The demo is temporarily unavailable. Try again later.";
   }

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -1,4 +1,8 @@
 const isDev = process.env.NODE_ENV === "development";
+import {
+  PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE,
+  publicAssistantLimitMessage,
+} from "@/lib/public-assistant-errors";
 
 function positiveSafeInteger(
   value: string | undefined,
@@ -195,7 +199,7 @@ async function runRateLimitChecks(
         error: error instanceof Error ? error.message : String(error),
       }),
     );
-    return new Response("Public assistant temporarily unavailable", {
+    return new Response(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE, {
       status: 503,
     });
   }
@@ -209,7 +213,7 @@ function missingClientIpResponse(request: Request, surface: string): Response {
       requestId: request.headers.get("x-vercel-id"),
     }),
   );
-  return new Response("Public assistant temporarily unavailable", {
+  return new Response(PUBLIC_ASSISTANT_UNAVAILABLE_MESSAGE, {
     status: 503,
   });
 }
@@ -232,18 +236,21 @@ export async function checkPublicAssistantRateLimit(
 
     const ipBurst = await limits.ipBurst.limit(ip);
     if (!ipBurst.success) {
-      return limitResponse("Rate limit exceeded", ipBurst.reset);
+      return limitResponse(publicAssistantLimitMessage("Rate"), ipBurst.reset);
     }
 
     const ipDaily = await limits.ipDaily.limit(ip);
     if (!ipDaily.success) {
-      return limitResponse("Daily usage limit exceeded", ipDaily.reset);
+      return limitResponse(
+        publicAssistantLimitMessage("Daily usage"),
+        ipDaily.reset,
+      );
     }
 
     const sessionDaily = await limits.sessionDaily.limit(sessionId);
     if (!sessionDaily.success) {
       return limitResponse(
-        "Daily anonymous session limit exceeded",
+        publicAssistantLimitMessage("Daily anonymous session"),
         sessionDaily.reset,
       );
     }
@@ -261,7 +268,7 @@ export async function checkPublicAssistantRateLimit(
         );
       }
       return limitResponse(
-        "Public assistant usage limit exceeded",
+        publicAssistantLimitMessage("Public assistant usage"),
         globalDaily.reset,
       );
     }
@@ -278,11 +285,17 @@ export async function checkAnonymousSessionIssuanceRateLimit(
 
     const burst = await limits.sessionIssuanceBurst.limit(ip);
     if (!burst.success) {
-      return limitResponse("Anonymous session limit exceeded", burst.reset);
+      return limitResponse(
+        publicAssistantLimitMessage("Anonymous session"),
+        burst.reset,
+      );
     }
     const daily = await limits.sessionIssuanceDaily.limit(ip);
     if (!daily.success) {
-      return limitResponse("Anonymous session limit exceeded", daily.reset);
+      return limitResponse(
+        publicAssistantLimitMessage("Anonymous session"),
+        daily.reset,
+      );
     }
     return null;
   });
@@ -297,12 +310,18 @@ export async function checkMcpTemplateToolRateLimit(
 
     const burst = await limits.mcpTemplateIpBurst.limit(ip);
     if (!burst.success) {
-      return limitResponse("Template tool rate limit exceeded", burst.reset);
+      return limitResponse(
+        publicAssistantLimitMessage("Template tool rate"),
+        burst.reset,
+      );
     }
 
     const daily = await limits.mcpTemplateIpDaily.limit(ip);
     if (!daily.success) {
-      return limitResponse("Template tool daily limit exceeded", daily.reset);
+      return limitResponse(
+        publicAssistantLimitMessage("Template tool daily"),
+        daily.reset,
+      );
     }
 
     const globalDaily = await limits.mcpTemplateGlobalDaily.limit("all");
@@ -320,7 +339,7 @@ export async function checkMcpTemplateToolRateLimit(
         );
       }
       return limitResponse(
-        "Template tool usage limit exceeded",
+        publicAssistantLimitMessage("Template tool usage"),
         globalDaily.reset,
       );
     }
@@ -338,7 +357,7 @@ export async function checkXuluxDownloadProxyRateLimit(
     const burst = await limits.xuluxDownloadIpBurst.limit(ip);
     if (!burst.success) {
       return limitResponse(
-        "Template download rate limit exceeded",
+        publicAssistantLimitMessage("Template download rate"),
         burst.reset,
       );
     }
@@ -346,7 +365,7 @@ export async function checkXuluxDownloadProxyRateLimit(
     const daily = await limits.xuluxDownloadIpDaily.limit(ip);
     if (!daily.success) {
       return limitResponse(
-        "Template download daily limit exceeded",
+        publicAssistantLimitMessage("Template download daily"),
         daily.reset,
       );
     }
@@ -366,7 +385,7 @@ export async function checkXuluxDownloadProxyRateLimit(
         );
       }
       return limitResponse(
-        "Template download usage limit exceeded",
+        publicAssistantLimitMessage("Template download usage"),
         globalDaily.reset,
       );
     }
@@ -380,7 +399,7 @@ export async function checkRateLimit(req: Request): Promise<Response | null> {
     const ip = req.headers.get("x-forwarded-for") ?? "ip";
     const { success } = await ratelimit.limit(ip);
     if (!success) {
-      return new Response("Rate limit exceeded", { status: 429 });
+      return new Response(publicAssistantLimitMessage("Rate"), { status: 429 });
     }
   }
   return null;

--- a/apps/docs/runtimes/chat-runtime.ts
+++ b/apps/docs/runtimes/chat-runtime.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import {
   AssistantCloud,
   WebSpeechDictationAdapter,
@@ -27,15 +27,35 @@ export function useAnonymousCloud() {
   );
 }
 
+const subscribeToNothing = () => () => {};
+const dictationUnsupportedOnServer = () => false;
+
+// The server snapshot reports no support, so hydration matches and the mic
+// only appears in browsers that can listen.
+const useDictationSupported = () =>
+  useSyncExternalStore(
+    subscribeToNothing,
+    WebSpeechDictationAdapter.isSupported,
+    dictationUnsupportedOnServer,
+  );
+
 // Speech and dictation adapters carry per-utterance state, so a surface keeps
 // one instance rather than rebuilding them on every render.
 export function useSpeechAdapters({ dictation = false } = {}) {
+  const dictationSupported = useDictationSupported() && dictation;
+
+  const speech = useMemo(() => new WebSpeechSynthesisAdapter(), []);
+  const dictationAdapter = useMemo(
+    () => (dictationSupported ? new WebSpeechDictationAdapter() : undefined),
+    [dictationSupported],
+  );
+
   return useMemo(
     () => ({
-      speech: new WebSpeechSynthesisAdapter(),
-      ...(dictation ? { dictation: new WebSpeechDictationAdapter() } : {}),
+      speech,
+      ...(dictationAdapter ? { dictation: dictationAdapter } : {}),
     }),
-    [dictation],
+    [speech, dictationAdapter],
   );
 }
 


### PR DESCRIPTION
## problem

the landing page thread demo rendered a fraction of what its runtime already provides. `DocsRuntimeProvider` passes speech, dictation, feedback, and cloud attachment adapters, and the chat route already injects quote context, but the thread had no control for editing a message, stepping through branches, rating a reply, reading it aloud, dictating, quoting a selection, dropping files, exporting, or seeing response timing. next to ChatGPT class chat surfaces the demo read as a widget.

## change

- `home-thread.tsx`: user messages get a hover edit action, an inline edit composer, and a branch picker; assistant messages get thumbs with the reason popover, read aloud and stop, regenerate, a more menu with markdown export, a timing badge, and a branch picker; the composer gets a drag and drop zone, the dictation mic, and the quote preview; a selection toolbar offers quote; image and file parts render on both roles; 429 and 503 replies from the public route show a calm notice instead of a red error.
- `assistant-action-bar.tsx` and `analytics.ts`: the thumbs pair with its popover, analytics funnel, and `submitFeedback` call becomes `FeedbackActions`, shared by the docs assistant and the home demo, with an optional analytics `surface` so the two funnels stay separable.
- `thread-specimen.tsx` and `feedback-popover.tsx`: the fullscreen overlay moves from `z-[60]` to `z-50` so body portals (Radix menus, Base UI popovers, kit tooltips) win by DOM order; escape and tab inside a menu or dialog stay with that layer; the popover positioner carries its own stacking context and its heading names the dialog.
- `chat-runtime.ts`: the dictation adapter is created only where `WebSpeechDictationAdapter.isSupported()`, read after hydration through `useSyncExternalStore`, so Firefox never shows a mic that throws.

## verification

- `oxlint` and `oxfmt --check` clean on the changed files; `tsc --noEmit` in `apps/docs` reports 0 errors.
- browser pass on the dev server (Chrome, 1440 wide and a 500 wide window): edit a message and confirm `2 / 2`, step back to `1 / 2` and forward; thumbs up marks the message and disables both; thumbs down opens the popover, survives the pointer leaving an older message, submits, and the message shows the submitted state; read aloud toggles to stop while `speechSynthesis.speaking` is true; selecting text shows the quote toolbar, quoting fills the composer preview, and the sent message carries the quote block; a synthetic file drag sets `data-dragging="true"` with the dashed border; the more menu shows export as markdown; the timing badge appears once a stream ends; in fullscreen the more menu and the feedback popover render above the overlay, escape closes only the popup, tab inside the popup is not hijacked, and a plain escape still exits; reloading the thread restores both branches and the quote from the cloud.

## public surface

none. `apps/docs` only, no published package, no changeset.

## notes

- a "you stopped this response" notice was built and removed again: the AI SDK runtime reports a stopped run as `complete`, so nothing can render it; tracked in #6745.
- editing a persisted message and continuing on the original branch makes the runtime re-send that message to the cloud, which answers 409 on every later run; harmless to the demo, tracked in #6746.
- the second wave (grouped tool calls, model picker, context ring, math, mermaid, sidebar search and groups, shortcuts) follows on top of this branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.68ozNcAnTyKCLvZlXO5OoHQ_L8uHoBriUTrC-pFMWx8FkJ0lLPEXYnspo8Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->