### PR TITLE
fix(ai-sdk): stop re-sending an unchanged persisted message

### DIFF
--- a/.changeset/6746-skip-unchanged-cloud-message-updates.md
+++ b/.changeset/6746-skip-unchanged-cloud-message-updates.md
@@ -4,4 +4,4 @@
 
 fix(ai-sdk): stop re-sending a persisted message whose content is unchanged
 
-run stop persistence decided what to write by comparing external store object identity against a baseline rebuilt from the visible branch only. a message that left the visible branch lost its baseline, so returning to that branch made it look changed and re-sent an identical `update` for it (the cloud answers 409 for a user message, and the failure retried on every later run stop). the baseline is now kept per persisted inner message as its encoded storage content, so an update is issued only when the payload actually differs.
+returning to an earlier branch and continuing the conversation no longer re-sends an identical `update` for the messages already on that branch. with cloud persistence the redundant write for the user message was rejected with a 409 and retried on every later run stop. an update is now issued only when the encoded payload actually differs from what was last written.

--- a/.changeset/6746-skip-unchanged-cloud-message-updates.md
+++ b/.changeset/6746-skip-unchanged-cloud-message-updates.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix(ai-sdk): stop re-sending a persisted message whose content is unchanged
+
+run stop persistence decided what to write by comparing external store object identity against a baseline rebuilt from the visible branch only. a message that left the visible branch lost its baseline, so returning to that branch made it look changed and re-sent an identical `update` for it (the cloud answers 409 for a user message, and the failure retried on every later run stop). the baseline is now kept per persisted inner message as its encoded storage content, so an update is issued only when the payload actually differs.

--- a/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.test.ts
@@ -1180,6 +1180,70 @@ describe("useExternalHistory persistence", () => {
     expect(reportTelemetry).not.toHaveBeenCalled();
   });
 
+  it("skips updates for a persisted message restored by a branch switch", async () => {
+    const { append, update, runCycle, flush } = createPersistenceHarness(true);
+    const completeStatus: ThreadAssistantMessage["status"] = {
+      type: "complete",
+      reason: "stop",
+    };
+    const createUserMessage = (
+      id: string,
+      inner: InnerMessage,
+    ): ThreadMessage => {
+      const message: ThreadMessage = {
+        id,
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+        attachments: [],
+        createdAt: new Date(),
+        metadata: { custom: {} },
+      };
+      bindExternalStoreMessage(message, [inner]);
+      return message;
+    };
+    const branchA = () => [
+      createUserMessage("user-a", { id: "inner-user-a", parts: ["question"] }),
+      createAssistantMessage(
+        completeStatus,
+        [{ id: "inner-assistant-a", parts: ["answer"] }],
+        "assistant-a",
+      ),
+    ];
+
+    await runCycle(branchA());
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(2));
+
+    await runCycle([
+      createUserMessage("user-b", { id: "inner-user-b", parts: ["edited"] }),
+      createAssistantMessage(
+        completeStatus,
+        [{ id: "inner-assistant-b", parts: ["answer"] }],
+        "assistant-b",
+      ),
+    ]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(4));
+
+    append.mockClear();
+    update.mockClear();
+
+    await runCycle([
+      ...branchA(),
+      createUserMessage("user-c", { id: "inner-user-c", parts: ["follow-up"] }),
+      createAssistantMessage(
+        completeStatus,
+        [{ id: "inner-assistant-c", parts: ["answer"] }],
+        "assistant-c",
+      ),
+    ]);
+    await flush();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(append.mock.calls.map(([item]) => item.message.id)).toEqual([
+      "inner-user-c",
+      "inner-assistant-c",
+    ]);
+  });
+
   it("absorbs agentic flickers without losing change detection", async () => {
     const { append, update, reportTelemetry, runCycle, flush, step } =
       createPersistenceHarness(true);

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -75,6 +75,7 @@ export const useExternalHistory = <TMessage>(
 
   const historyIds = useRef(new Set<string>());
   const deferredTelemetryIds = useRef(new Set<string>());
+  // `content` is a snapshot taken at write time rather than a re-encode of `source`, because a retained message object can be mutated in place by the runtime that produced it.
   const persistedInnerMessages = useRef(
     new Map<string, { source: TMessage; content: string }>(),
   );

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -5,6 +5,7 @@ import type {
   ThreadHistoryAdapter,
   ThreadMessage,
   MessageFormatAdapter,
+  MessageFormatItem,
   MessageFormatRepository,
   ExportedMessageRepository,
 } from "@assistant-ui/core";
@@ -49,15 +50,10 @@ const isAwaitingToolApproval = (message: ThreadMessage) =>
   message.status?.type === "requires-action" &&
   message.status.reason === "tool-calls";
 
-const snapshotExternalMessages = <TMessage>(
-  messages: readonly ThreadMessage[],
-) =>
-  new Map<string, TMessage[]>(
-    messages.map((message) => [
-      message.id,
-      [...getExternalStoreMessages<TMessage>(message)],
-    ]),
-  );
+const encodeContent = <TMessage>(
+  storageFormatAdapter: MessageFormatAdapter<TMessage, any>,
+  item: MessageFormatItem<TMessage>,
+) => JSON.stringify(storageFormatAdapter.encode(item));
 
 export const useExternalHistory = <TMessage>(
   runtimeRef: RefObject<AssistantRuntime>,
@@ -78,9 +74,10 @@ export const useExternalHistory = <TMessage>(
   const [hasLoaded, setHasLoaded] = useState(false);
 
   const historyIds = useRef(new Set<string>());
-  const persistedInnerIds = useRef(new Set<string>());
   const deferredTelemetryIds = useRef(new Set<string>());
-  const persistedExternalMessages = useRef(new Map<string, TMessage[]>());
+  const persistedInnerMessages = useRef(
+    new Map<string, { source: TMessage; content: string }>(),
+  );
 
   const onSetMessagesRef = useRef(onSetMessages);
   useEffect(() => {
@@ -107,8 +104,12 @@ export const useExternalHistory = <TMessage>(
         const repo = await formatAdapter.load();
         if (repo && repo.messages.length > 0) {
           for (const m of repo.messages) {
-            persistedInnerIds.current.add(
+            persistedInnerMessages.current.set(
               storageFormatAdapter.getId(m.message),
+              {
+                source: m.message,
+                content: encodeContent(storageFormatAdapter, m),
+              },
             );
           }
           const converted = toExportedMessageRepository(toThreadMessages, repo);
@@ -129,10 +130,6 @@ export const useExternalHistory = <TMessage>(
               deferredTelemetryIds.current.add(m.message.id);
             }
           }
-          persistedExternalMessages.current =
-            snapshotExternalMessages<TMessage>(
-              converted.messages.map((m) => m.message),
-            );
         }
       } catch (error) {
         console.error("Failed to load message history:", error);
@@ -294,23 +291,8 @@ export const useExternalHistory = <TMessage>(
 
       persistInFlightRef.current = persistInFlightRef.current
         .then(async () => {
-          const changedRunMessageIds = new Set<string>();
-          for (const message of latest.messages) {
-            const externalMessages =
-              getExternalStoreMessages<TMessage>(message);
-            const previous = persistedExternalMessages.current.get(message.id);
-            if (
-              previous === undefined ||
-              previous.length !== externalMessages.length ||
-              externalMessages.some((item, index) => item !== previous[index])
-            ) {
-              changedRunMessageIds.add(message.id);
-            }
-          }
-
           const { messages } = latest;
           let lastInnerMessageId: string | null = null;
-          const failedUpdateIds = new Set<string>();
 
           const getLastInnerId = (msgs: TMessage[]): string | null =>
             msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
@@ -343,13 +325,7 @@ export const useExternalHistory = <TMessage>(
               continue;
             }
 
-            const isPersistedMessage = historyIds.current.has(message.id);
-            if (isPersistedMessage && !changedRunMessageIds.has(message.id)) {
-              lastInnerMessageId =
-                getLastInnerId(innerMessages) ?? lastInnerMessageId;
-              continue;
-            }
-            if (!isPersistedMessage) {
+            if (!historyIds.current.has(message.id)) {
               historyIds.current.add(message.id);
               deferredTelemetryIds.current.add(message.id);
             }
@@ -357,15 +333,31 @@ export const useExternalHistory = <TMessage>(
             const batchItems = toBatchItems(innerMessages);
             for (const item of batchItems) {
               const innerId = storageFormatAdapter.getId(item.message);
-              if (!persistedInnerIds.current.has(innerId)) {
+              const persisted = persistedInnerMessages.current.get(innerId);
+              if (!persisted) {
                 await adapter.append(item);
-                persistedInnerIds.current.add(innerId);
-              } else if (durationMs !== undefined) {
-                try {
-                  await adapter.update?.(item, innerId);
-                } catch {
-                  // A failed update drops the message from the refreshed baseline so it retries on the next run stop.
-                  failedUpdateIds.add(message.id);
+                persistedInnerMessages.current.set(innerId, {
+                  source: item.message,
+                  content: encodeContent(storageFormatAdapter, item),
+                });
+              } else if (
+                persisted.source !== item.message &&
+                durationMs !== undefined &&
+                adapter.update
+              ) {
+                const content = encodeContent(storageFormatAdapter, item);
+                if (content === persisted.content) {
+                  persisted.source = item.message;
+                } else {
+                  try {
+                    await adapter.update(item, innerId);
+                    persistedInnerMessages.current.set(innerId, {
+                      source: item.message,
+                      content,
+                    });
+                  } catch {
+                    // A failed update leaves the stale baseline behind so the next run stop retries it.
+                  }
                 }
               }
             }
@@ -378,14 +370,6 @@ export const useExternalHistory = <TMessage>(
               adapter.reportTelemetry?.(batchItems, telemetryOptions);
             }
           }
-
-          const nextSnapshot = snapshotExternalMessages<TMessage>(
-            latest.messages,
-          );
-          for (const id of failedUpdateIds) {
-            nextSnapshot.delete(id);
-          }
-          persistedExternalMessages.current = nextSnapshot;
         })
         .catch((error) => {
           console.error("Failed to persist message history:", error);
@@ -430,9 +414,8 @@ export const useExternalHistory = <TMessage>(
 
         historyIds.current.delete(messageId);
         deferredTelemetryIds.current.delete(messageId);
-        persistedExternalMessages.current.delete(messageId);
         for (const item of itemsToDelete) {
-          persistedInnerIds.current.delete(
+          persistedInnerMessages.current.delete(
             storageFormatAdapter.getId(item.message),
           );
         }


### PR DESCRIPTION
closes #6746

## Problem

with `useChatRuntime({ cloud })`, this sequence makes run stop persistence issue a `PUT /v1/threads/{thread}/messages/{message}` for the original user message with its content unchanged, and the cloud answers 409:

1. send a message and let the reply finish
2. edit that user message (a second branch is created and its reply finishes)
3. switch back to the first branch and send a follow up there

the failed update is retried on every later run stop, so the console gains a `Failed to load resource: 409` per turn. the same turn also re-sends the branch's assistant reply; the cloud accepts that one, so only the user message's 409 is visible. nothing user visible breaks, but every turn on a restored branch writes messages it does not need to.

## Root cause

`useExternalHistory` decided what to write by comparing external store object identity against a baseline map keyed by `ThreadMessage.id`, and that map was rebuilt wholesale from `latest.messages` at the end of every persist pass. `latest.messages` is only the visible branch, so persisting branch B dropped branch A's entries. returning to branch A left `previous === undefined` for its messages, which marked them changed, skipped the persisted-message short circuit, and fell into the `durationMs !== undefined` update branch. that branch had no content check at all, so it re-sent an identical payload. the failure then deleted the message from the refreshed baseline to force a retry, which reproduced the same PUT on the next run stop.

object identity was the wrong judge for a second reason: it reports changed whenever the runtime rebuilds a message object, which is exactly what a branch switch does.

## Change

the write decision now compares the encoded storage content of each persisted inner message, which is the payload the PUT actually carries (`FormattedCloudPersistence` sends `adapter.encode(item)` verbatim).

`persistedExternalMessages`, `snapshotExternalMessages`, `changedRunMessageIds`, `failedUpdateIds`, and `persistedInnerIds` are replaced by one map keyed by inner message id holding `{ source, content }`. `content` is `JSON.stringify(encode(item))` and is the only thing correctness rests on; `source` is just a cache key so an untouched object skips re-encoding. an update is issued only when the encoded content differs from what was last written.

keying by inner id and writing only on a successful append or update means the baseline no longer forgets a message that leaves the visible branch, so the bug disappears at its source rather than being filtered at the call site. two things fall out of that: the `failedUpdateIds` retry hack is gone, because a failed update simply leaves the stale baseline in place and the next run stop finds the mismatch on its own; and the same content check closes the identity churn false positives that #5047 narrowed but did not remove.

## Verification

- `pnpm -C packages/ai-sdk test` 258/258 green (25 files), including a new `skips updates for a persisted message restored by a branch switch` case that walks branch A, an edited branch B, a return to branch A with rebuilt objects, and a follow up run
- that new test fails on the unfixed source with `expected "vi.fn()" to not be called at all, but actually been called 2 times`, matching the report (the user message plus its assistant reply)
- `pnpm -C packages/ai-sdk test:react-compiler` 1/1 green
- `pnpm -C packages/cloud test` 111/111 green
- `pnpm -C packages/x-performance test` 77/77 green, counter contracts included
- `pnpm lint` no errors, formatting clean
- `tsc --noEmit` in `packages/ai-sdk` reports the same 12 pre-existing errors as `main`, none in the touched files

## Public surface

no exports change. `@assistant-ui/ai-sdk` patch changeset added. no docs or api-reference output affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5NqYU3WG0xJt0CYH7oy3pO9QjDKhKv1aLqw2YAGI_zKDJvHXOhF2MK-57DQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->