### PR TITLE
fix(docs): serve the repo sandbox from disk instead of copying it per request

### DIFF
--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -1,7 +1,5 @@
 import { getLLMText } from "@/lib/get-llm-text";
 import { getDistinctId } from "@/lib/posthog-server";
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import { injectQuoteContext } from "@assistant-ui/ai-sdk";
 import { checkPublicAssistantRateLimit } from "@/lib/rate-limit";
 import { requirePublicAssistantSession } from "@/lib/anonymous-session";
@@ -15,7 +13,7 @@ import {
 import { getModel } from "@/lib/ai/provider";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
 import { frontendTools } from "@assistant-ui/ai-sdk";
-import { createBashTool } from "bash-tool";
+import { createRepoSandbox } from "@/lib/repo-sandbox";
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -29,37 +27,6 @@ import {
 import type * as PageTree from "fumadocs-core/page-tree";
 import type { UIMessage, UIMessageChunk } from "ai";
 import z from "zod";
-
-const SOURCE_SNAPSHOT_PATH = path.join(
-  process.cwd(),
-  "generated",
-  "source-snapshot.json",
-);
-
-function loadSourceSnapshot(): Record<string, string> {
-  try {
-    return JSON.parse(readFileSync(SOURCE_SNAPSHOT_PATH, "utf-8")) as Record<
-      string,
-      string
-    >;
-  } catch (error) {
-    if (
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      console.warn(
-        `Missing source snapshot at ${SOURCE_SNAPSHOT_PATH}; repo tools will be unavailable until generate:docs runs.`,
-      );
-      return {};
-    }
-
-    throw error;
-  }
-}
-
-const SOURCE_SNAPSHOT = loadSourceSnapshot();
 
 function normalizeSegment(name: string): string {
   return name.toLowerCase().replace(/\s+/g, "-");
@@ -214,22 +181,7 @@ export async function* withReadDocSources(
 }
 
 function createRepoTools() {
-  let bashToolkitPromise: Promise<
-    Awaited<ReturnType<typeof createBashTool>>
-  > | null = null;
-
-  const getBashToolkit = () => {
-    if (!bashToolkitPromise) {
-      bashToolkitPromise = createBashTool({
-        files: SOURCE_SNAPSHOT,
-        destination: "/repo",
-        maxFiles: 0,
-        maxOutputLength: 15000,
-      });
-    }
-
-    return bashToolkitPromise;
-  };
+  const getBashToolkit = createRepoSandbox();
 
   return {
     bash: tool({

--- a/apps/docs/app/api/xulux/chat/tools/learn-source-map-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/learn-source-map-tools.ts
@@ -1,13 +1,13 @@
 import { createBashTool } from "bash-tool";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
+import { createRepoSandbox } from "@/lib/repo-sandbox";
 import { resolveStageFiles } from "@/lib/xulux/learn/stage-source";
 import { getLearnCourse, getLearnStep } from "@/lib/xulux/learn/registry";
 import type {
   LearnContext,
   LearnCourseStepResult,
 } from "@/lib/xulux/learn/types";
-import { getRepoSourceSnapshot } from "./source-map-tools";
 
 type LearnSourceMapOptions = {
   courseId: string;
@@ -20,23 +20,14 @@ export function createLearnSourceMapTools({
   courseId,
   getStageId,
 }: LearnSourceMapOptions) {
-  let repoToolkitPromise: ReturnType<typeof createBashTool> | null = null;
+  const getRepoToolkit = createRepoSandbox({ toolPrompt: "" });
   const courseToolkitPromises = new Map<
     string,
     ReturnType<typeof createBashTool>
   >();
 
   const getToolkit = async (scope: "repo" | "course") => {
-    if (scope === "repo") {
-      repoToolkitPromise ??= createBashTool({
-        files: getRepoSourceSnapshot(),
-        destination: "/repo",
-        maxFiles: 0,
-        maxOutputLength: 15000,
-        promptOptions: { toolPrompt: "" },
-      });
-      return repoToolkitPromise;
-    }
+    if (scope === "repo") return getRepoToolkit();
 
     const stageId = getStageId();
     if (!stageId) return null;

--- a/apps/docs/app/api/xulux/chat/tools/source-map-tools.ts
+++ b/apps/docs/app/api/xulux/chat/tools/source-map-tools.ts
@@ -1,61 +1,9 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { createBashTool } from "bash-tool";
+import { createRepoSandbox } from "@/lib/repo-sandbox";
 import { tool, zodSchema } from "ai";
 import z from "zod";
 
-const SOURCE_SNAPSHOT_PATH = path.join(
-  process.cwd(),
-  "generated",
-  "source-snapshot.json",
-);
-
-function loadSourceSnapshot(): Record<string, string> {
-  try {
-    return JSON.parse(readFileSync(SOURCE_SNAPSHOT_PATH, "utf-8")) as Record<
-      string,
-      string
-    >;
-  } catch (error) {
-    if (
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code === "ENOENT"
-    ) {
-      console.warn(
-        `Missing source snapshot at ${SOURCE_SNAPSHOT_PATH}; repo tools will be unavailable until generate:docs runs.`,
-      );
-      return {};
-    }
-
-    throw error;
-  }
-}
-
-const SOURCE_SNAPSHOT = loadSourceSnapshot();
-
-export function getRepoSourceSnapshot() {
-  return SOURCE_SNAPSHOT;
-}
-
 export function createSourceMapTools() {
-  let bashToolkitPromise: Promise<
-    Awaited<ReturnType<typeof createBashTool>>
-  > | null = null;
-
-  const getBashToolkit = () => {
-    if (!bashToolkitPromise) {
-      bashToolkitPromise = createBashTool({
-        files: SOURCE_SNAPSHOT,
-        destination: "/repo",
-        maxFiles: 0,
-        maxOutputLength: 15000,
-        promptOptions: { toolPrompt: "" },
-      });
-    }
-    return bashToolkitPromise;
-  };
+  const getBashToolkit = createRepoSandbox({ toolPrompt: "" });
 
   return {
     inspectSourceMap: tool({

--- a/apps/docs/lib/repo-sandbox.test.ts
+++ b/apps/docs/lib/repo-sandbox.test.ts
@@ -92,7 +92,7 @@ describe("createRepoSandbox", () => {
     for (const command of [
       "cat /etc/passwd",
       "cat /repo/../../../../etc/passwd",
-      "ls /Users",
+      `ls ${mocks.sourceRoot}`,
     ]) {
       expect(await run(getToolkit, `${command} 2>&1 | head -1`)).toContain(
         "No such file or directory",

--- a/apps/docs/lib/repo-sandbox.test.ts
+++ b/apps/docs/lib/repo-sandbox.test.ts
@@ -75,6 +75,31 @@ describe("createRepoSandbox", () => {
     );
   });
 
+  it("keeps the shell usable outside the mount", async () => {
+    const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+    expect(await run(getToolkit, "cat /repo/absent 2>/dev/null; echo $?")).toBe(
+      "1",
+    );
+    expect(
+      await run(getToolkit, "echo hi > /tmp/out.txt && cat /tmp/out.txt"),
+    ).toBe("hi");
+  });
+
+  it("cannot reach the host filesystem outside the mounted root", async () => {
+    const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+    for (const command of [
+      "cat /etc/passwd",
+      "cat /repo/../../../../etc/passwd",
+      "ls /Users",
+    ]) {
+      expect(await run(getToolkit, `${command} 2>&1 | head -1`)).toContain(
+        "No such file or directory",
+      );
+    }
+  });
+
   it("falls back to an empty mount before the tree is generated", async () => {
     const generated = mocks.sourceRoot;
     mocks.sourceRoot = path.join(tmpdir(), "repo-sandbox-absent");

--- a/apps/docs/lib/repo-sandbox.test.ts
+++ b/apps/docs/lib/repo-sandbox.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createRepoSandbox } from "./repo-sandbox";
+
+const mocks = vi.hoisted(() => ({ sourceRoot: "" }));
+
+vi.mock("./repo-source", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./repo-source")>()),
+  repoSourceRoot: () => mocks.sourceRoot,
+}));
+
+const SOURCE_FILES = {
+  "AGENTS.md": "# assistant-ui\n",
+  "packages/core/src/index.ts": "export const useLocalRuntime = 1;\n",
+};
+
+beforeAll(async () => {
+  mocks.sourceRoot = await mkdtemp(path.join(tmpdir(), "repo-sandbox-"));
+
+  for (const [filePath, contents] of Object.entries(SOURCE_FILES)) {
+    const target = path.join(mocks.sourceRoot, filePath);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, contents);
+  }
+});
+
+afterAll(async () => {
+  await rm(mocks.sourceRoot, { recursive: true, force: true });
+});
+
+const run = async (
+  getToolkit: ReturnType<typeof createRepoSandbox>,
+  command: string,
+) => {
+  const { sandbox } = await getToolkit();
+  const { stdout, stderr } = await sandbox.executeCommand(command);
+  return `${stdout}${stderr}`.trim();
+};
+
+describe("createRepoSandbox", () => {
+  it("serves reads from the generated source tree", async () => {
+    const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+    expect(await run(getToolkit, "cat /repo/AGENTS.md")).toBe("# assistant-ui");
+    expect(await run(getToolkit, "grep -rl useLocalRuntime /repo")).toBe(
+      "/repo/packages/core/src/index.ts",
+    );
+  });
+
+  it("keeps one sandbox per factory so a request sees its own writes", async () => {
+    const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+    await run(getToolkit, "echo tampered > /repo/AGENTS.md");
+
+    expect(await run(getToolkit, "cat /repo/AGENTS.md")).toBe("tampered");
+  });
+
+  it("isolates writes, overwrites, and deletes between factories", async () => {
+    const writer = createRepoSandbox({ toolPrompt: "" });
+    const reader = createRepoSandbox({ toolPrompt: "" });
+
+    await run(writer, "echo leaked > /repo/pwned.txt");
+    await run(writer, "echo tampered > /repo/AGENTS.md");
+    await run(writer, "rm /repo/packages/core/src/index.ts");
+
+    expect(await run(reader, "cat /repo/pwned.txt")).toContain(
+      "No such file or directory",
+    );
+    expect(await run(reader, "cat /repo/AGENTS.md")).toBe("# assistant-ui");
+    expect(await run(reader, "cat /repo/packages/core/src/index.ts")).toBe(
+      "export const useLocalRuntime = 1;",
+    );
+  });
+
+  it("never writes through to the source tree on disk", async () => {
+    const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+    await run(getToolkit, "echo leaked > /repo/pwned.txt");
+    await run(getToolkit, "rm /repo/AGENTS.md");
+
+    expect(existsSync(path.join(mocks.sourceRoot, "pwned.txt"))).toBe(false);
+    expect(
+      readFileSync(path.join(mocks.sourceRoot, "AGENTS.md"), "utf-8"),
+    ).toBe("# assistant-ui\n");
+  });
+});

--- a/apps/docs/lib/repo-sandbox.test.ts
+++ b/apps/docs/lib/repo-sandbox.test.ts
@@ -75,6 +75,25 @@ describe("createRepoSandbox", () => {
     );
   });
 
+  it("falls back to an empty mount before the tree is generated", async () => {
+    const generated = mocks.sourceRoot;
+    mocks.sourceRoot = path.join(tmpdir(), "repo-sandbox-absent");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const getToolkit = createRepoSandbox({ toolPrompt: "" });
+
+      expect(await run(getToolkit, "ls /repo")).toBe("");
+      expect(await run(getToolkit, "cat /repo/AGENTS.md")).toContain(
+        "No such file or directory",
+      );
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+      mocks.sourceRoot = generated;
+    }
+  });
+
   it("never writes through to the source tree on disk", async () => {
     const getToolkit = createRepoSandbox({ toolPrompt: "" });
 

--- a/apps/docs/lib/repo-sandbox.ts
+++ b/apps/docs/lib/repo-sandbox.ts
@@ -1,0 +1,66 @@
+import { existsSync } from "node:fs";
+import { createBashTool } from "bash-tool";
+import { Bash, OverlayFs } from "just-bash";
+import { repoSourceRoot } from "./repo-source";
+
+const REPO_MOUNT = "/repo";
+const MAX_OUTPUT_LENGTH = 15000;
+const MAX_SANDBOX_WRITE_BYTES = 16 * 1024 * 1024;
+
+type RepoToolkit = Awaited<ReturnType<typeof createBashTool>>;
+
+let sourceRoot: string | null | undefined;
+
+function resolveSourceRoot() {
+  if (sourceRoot !== undefined) return sourceRoot;
+
+  const root = repoSourceRoot();
+  sourceRoot = existsSync(root) ? root : null;
+
+  if (sourceRoot === null) {
+    console.warn(
+      `Missing repo source tree at ${root}; repo tools will be unavailable until generate:source-snapshot runs.`,
+    );
+  }
+
+  return sourceRoot;
+}
+
+/**
+ * The mount is writable, so a shared sandbox would carry one visitor's edits
+ * into the next request. Each caller gets its own copy-on-write overlay on the
+ * deployed source tree, which costs its own writes rather than a second copy.
+ */
+export function createRepoSandbox(options: { toolPrompt?: string } = {}) {
+  let toolkitPromise: Promise<RepoToolkit> | null = null;
+  return () => (toolkitPromise ??= createRepoToolkit(options));
+}
+
+function createRepoToolkit({ toolPrompt }: { toolPrompt?: string }) {
+  const promptOptions =
+    toolPrompt === undefined ? {} : { promptOptions: { toolPrompt } };
+  const root = resolveSourceRoot();
+
+  if (root === null) {
+    return createBashTool({
+      files: {},
+      destination: REPO_MOUNT,
+      maxOutputLength: MAX_OUTPUT_LENGTH,
+      ...promptOptions,
+    });
+  }
+
+  return createBashTool({
+    sandbox: new Bash({
+      fs: new OverlayFs({
+        root,
+        mountPoint: REPO_MOUNT,
+        maxMemoryBytes: MAX_SANDBOX_WRITE_BYTES,
+      }),
+      cwd: REPO_MOUNT,
+    }),
+    destination: REPO_MOUNT,
+    maxOutputLength: MAX_OUTPUT_LENGTH,
+    ...promptOptions,
+  });
+}

--- a/apps/docs/lib/repo-sandbox.ts
+++ b/apps/docs/lib/repo-sandbox.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { createBashTool } from "bash-tool";
-import { Bash, OverlayFs } from "just-bash";
+import { Bash, InMemoryFs, OverlayFs } from "just-bash";
 import { repoSourceRoot } from "./repo-source";
 
 const REPO_MOUNT = "/repo";
@@ -8,23 +8,6 @@ const MAX_OUTPUT_LENGTH = 15000;
 const MAX_SANDBOX_WRITE_BYTES = 16 * 1024 * 1024;
 
 type RepoToolkit = Awaited<ReturnType<typeof createBashTool>>;
-
-let sourceRoot: string | null | undefined;
-
-function resolveSourceRoot() {
-  if (sourceRoot !== undefined) return sourceRoot;
-
-  const root = repoSourceRoot();
-  sourceRoot = existsSync(root) ? root : null;
-
-  if (sourceRoot === null) {
-    console.warn(
-      `Missing repo source tree at ${root}; repo tools will be unavailable until generate:source-snapshot runs.`,
-    );
-  }
-
-  return sourceRoot;
-}
 
 /**
  * The mount is writable, so a shared sandbox would carry one visitor's edits
@@ -37,30 +20,30 @@ export function createRepoSandbox(options: { toolPrompt?: string } = {}) {
 }
 
 function createRepoToolkit({ toolPrompt }: { toolPrompt?: string }) {
-  const promptOptions =
-    toolPrompt === undefined ? {} : { promptOptions: { toolPrompt } };
-  const root = resolveSourceRoot();
+  const root = repoSourceRoot();
 
-  if (root === null) {
-    return createBashTool({
-      files: {},
-      destination: REPO_MOUNT,
-      maxOutputLength: MAX_OUTPUT_LENGTH,
-      ...promptOptions,
+  return createBashTool({
+    sandbox: new Bash({ fs: createRepoFs(root), cwd: REPO_MOUNT }),
+    destination: REPO_MOUNT,
+    maxOutputLength: MAX_OUTPUT_LENGTH,
+    ...(toolPrompt === undefined ? {} : { promptOptions: { toolPrompt } }),
+  });
+}
+
+// The tree is missing only before generate:source-snapshot has run, so the empty
+// mount keeps a local dev server usable and recovers as soon as it does run.
+function createRepoFs(root: string) {
+  if (existsSync(root)) {
+    return new OverlayFs({
+      root,
+      mountPoint: REPO_MOUNT,
+      maxMemoryBytes: MAX_SANDBOX_WRITE_BYTES,
     });
   }
 
-  return createBashTool({
-    sandbox: new Bash({
-      fs: new OverlayFs({
-        root,
-        mountPoint: REPO_MOUNT,
-        maxMemoryBytes: MAX_SANDBOX_WRITE_BYTES,
-      }),
-      cwd: REPO_MOUNT,
-    }),
-    destination: REPO_MOUNT,
-    maxOutputLength: MAX_OUTPUT_LENGTH,
-    ...promptOptions,
-  });
+  console.warn(
+    `Missing repo source tree at ${root}; repo tools will be unavailable until generate:source-snapshot runs.`,
+  );
+
+  return new InMemoryFs({}, { maxTotalBytes: MAX_SANDBOX_WRITE_BYTES });
 }

--- a/apps/docs/lib/repo-source.test.ts
+++ b/apps/docs/lib/repo-source.test.ts
@@ -1,8 +1,26 @@
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadRepoSourceSnapshot, repoSourceRoot } from "./repo-source";
+
+const reads = vi.hoisted(() => ({ inFlight: 0, peak: 0 }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    readFile: async (...args: Parameters<typeof actual.readFile>) => {
+      reads.inFlight += 1;
+      reads.peak = Math.max(reads.peak, reads.inFlight);
+      try {
+        return await actual.readFile(...args);
+      } finally {
+        reads.inFlight -= 1;
+      }
+    },
+  };
+});
 
 const roots: string[] = [];
 
@@ -18,6 +36,11 @@ async function createSourceTree(files: Record<string, string>) {
 
   return root;
 }
+
+beforeEach(() => {
+  reads.inFlight = 0;
+  reads.peak = 0;
+});
 
 afterEach(async () => {
   await Promise.all(
@@ -52,6 +75,21 @@ describe("loadRepoSourceSnapshot", () => {
     await expect(loadRepoSourceSnapshot(root)).resolves.toEqual({
       "emoji.md": "🙂 ok\n",
     });
+  });
+
+  it("bounds concurrent reads so a large tree cannot exhaust file descriptors", async () => {
+    const files = Object.fromEntries(
+      Array.from({ length: 400 }, (_, index) => [
+        `packages/p${index % 20}/file-${index}.ts`,
+        `export const n = ${index};\n`,
+      ]),
+    );
+    const root = await createSourceTree(files);
+
+    const snapshot = await loadRepoSourceSnapshot(root);
+
+    expect(Object.keys(snapshot)).toHaveLength(400);
+    expect(reads.peak).toBeLessThanOrEqual(32);
   });
 
   it("rejects when the tree is missing", async () => {

--- a/apps/docs/lib/repo-source.test.ts
+++ b/apps/docs/lib/repo-source.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadRepoSourceSnapshot, repoSourceRoot } from "./repo-source";
+
+const roots: string[] = [];
+
+async function createSourceTree(files: Record<string, string>) {
+  const root = await mkdtemp(path.join(tmpdir(), "repo-source-"));
+  roots.push(root);
+
+  for (const [filePath, contents] of Object.entries(files)) {
+    const target = path.join(root, filePath);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, contents);
+  }
+
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+describe("repoSourceRoot", () => {
+  it("resolves a dotted generated tree that source globs skip", () => {
+    expect(repoSourceRoot()).toBe(
+      path.join(process.cwd(), "generated", ".repo-source"),
+    );
+  });
+});
+
+describe("loadRepoSourceSnapshot", () => {
+  it("keys nested files by their posix path relative to the root", async () => {
+    const root = await createSourceTree({
+      "AGENTS.md": "# assistant-ui\n",
+      "packages/core/src/index.ts": "export const a = 1;\n",
+    });
+
+    await expect(loadRepoSourceSnapshot(root)).resolves.toEqual({
+      "AGENTS.md": "# assistant-ui\n",
+      "packages/core/src/index.ts": "export const a = 1;\n",
+    });
+  });
+
+  it("reads contents as utf-8", async () => {
+    const root = await createSourceTree({ "emoji.md": "🙂 ok\n" });
+
+    await expect(loadRepoSourceSnapshot(root)).resolves.toEqual({
+      "emoji.md": "🙂 ok\n",
+    });
+  });
+
+  it("rejects when the tree is missing", async () => {
+    await expect(
+      loadRepoSourceSnapshot(path.join(tmpdir(), "repo-source-absent")),
+    ).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/apps/docs/lib/repo-source.ts
+++ b/apps/docs/lib/repo-source.ts
@@ -1,0 +1,41 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+export type RepoSourceSnapshot = Record<string, string>;
+
+// A dot directory keeps this verbatim copy of the monorepo out of the wildcard
+// globs that scan the app for sources: TypeScript's include, vitest's test
+// discovery, and the bundler's module rules all skip dotted directories.
+export function repoSourceRoot() {
+  return path.join(process.cwd(), "generated", ".repo-source");
+}
+
+export async function loadRepoSourceSnapshot(
+  sourceRoot = repoSourceRoot(),
+): Promise<RepoSourceSnapshot> {
+  const snapshot: RepoSourceSnapshot = {};
+  await collectInto(snapshot, sourceRoot, "");
+  return snapshot;
+}
+
+async function collectInto(
+  snapshot: RepoSourceSnapshot,
+  directory: string,
+  prefix: string,
+) {
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      if (entry.isDirectory()) {
+        await collectInto(snapshot, entryPath, relativePath);
+        return;
+      }
+
+      snapshot[relativePath] = await readFile(entryPath, "utf-8");
+    }),
+  );
+}

--- a/apps/docs/lib/repo-source.ts
+++ b/apps/docs/lib/repo-source.ts
@@ -7,9 +7,9 @@ export type RepoSourceSnapshot = Record<string, string>;
 // open per file and exhausts a 1024 descriptor limit well before the tree ends.
 const READ_CONCURRENCY = 32;
 
-// A dot directory keeps this verbatim copy of the monorepo out of the wildcard
-// globs that scan the app for sources: TypeScript's include, vitest's test
-// discovery, and the bundler's module rules all skip dotted directories.
+// A dot directory keeps this verbatim copy of the monorepo out of TypeScript's
+// include and the bundler's module rules, which both skip dotted directories.
+// Vitest discovers them, so it needs the explicit exclude in vitest.config.ts.
 export function repoSourceRoot() {
   return path.join(process.cwd(), "generated", ".repo-source");
 }
@@ -17,7 +17,7 @@ export function repoSourceRoot() {
 export async function loadRepoSourceSnapshot(
   sourceRoot = repoSourceRoot(),
 ): Promise<RepoSourceSnapshot> {
-  const filePaths = await listFiles(sourceRoot, "");
+  const filePaths = await listFiles(sourceRoot);
   const snapshot: RepoSourceSnapshot = {};
   let index = 0;
 
@@ -40,21 +40,43 @@ export async function loadRepoSourceSnapshot(
   return snapshot;
 }
 
-async function listFiles(directory: string, prefix: string): Promise<string[]> {
-  const entries = await readdir(directory, { withFileTypes: true });
+// Level by level rather than depth first: a recursive walk serializes every
+// readdir in the tree behind its predecessor, which costs more than the reads.
+async function listFiles(sourceRoot: string): Promise<string[]> {
   const filePaths: string[] = [];
+  let level = [{ directory: sourceRoot, prefix: "" }];
 
-  for (const entry of entries) {
-    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+  while (level.length > 0) {
+    const nextLevel: typeof level = [];
 
-    if (entry.isDirectory()) {
-      filePaths.push(
-        ...(await listFiles(path.join(directory, entry.name), relativePath)),
+    for (let start = 0; start < level.length; start += READ_CONCURRENCY) {
+      const batch = level.slice(start, start + READ_CONCURRENCY);
+      const listings = await Promise.all(
+        batch.map(({ directory }) =>
+          readdir(directory, { withFileTypes: true }),
+        ),
       );
-      continue;
+
+      listings.forEach((entries, index) => {
+        const { directory, prefix } = batch[index]!;
+
+        for (const entry of entries) {
+          const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+          if (entry.isDirectory()) {
+            nextLevel.push({
+              directory: path.join(directory, entry.name),
+              prefix: relativePath,
+            });
+            continue;
+          }
+
+          filePaths.push(relativePath);
+        }
+      });
     }
 
-    filePaths.push(relativePath);
+    level = nextLevel;
   }
 
   return filePaths;

--- a/apps/docs/lib/repo-source.ts
+++ b/apps/docs/lib/repo-source.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 
 export type RepoSourceSnapshot = Record<string, string>;
 
+// Matches the generator's bound. Reading the tree unbounded keeps a descriptor
+// open per file and exhausts a 1024 descriptor limit well before the tree ends.
+const READ_CONCURRENCY = 32;
+
 // A dot directory keeps this verbatim copy of the monorepo out of the wildcard
 // globs that scan the app for sources: TypeScript's include, vitest's test
 // discovery, and the bundler's module rules all skip dotted directories.
@@ -13,29 +17,45 @@ export function repoSourceRoot() {
 export async function loadRepoSourceSnapshot(
   sourceRoot = repoSourceRoot(),
 ): Promise<RepoSourceSnapshot> {
+  const filePaths = await listFiles(sourceRoot, "");
   const snapshot: RepoSourceSnapshot = {};
-  await collectInto(snapshot, sourceRoot, "");
+  let index = 0;
+
+  async function worker() {
+    while (index < filePaths.length) {
+      const relativePath = filePaths[index++]!;
+      snapshot[relativePath] = await readFile(
+        path.join(sourceRoot, relativePath),
+        "utf-8",
+      );
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(READ_CONCURRENCY, filePaths.length) }, () =>
+      worker(),
+    ),
+  );
+
   return snapshot;
 }
 
-async function collectInto(
-  snapshot: RepoSourceSnapshot,
-  directory: string,
-  prefix: string,
-) {
+async function listFiles(directory: string, prefix: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
+  const filePaths: string[] = [];
 
-  await Promise.all(
-    entries.map(async (entry) => {
-      const entryPath = path.join(directory, entry.name);
-      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
 
-      if (entry.isDirectory()) {
-        await collectInto(snapshot, entryPath, relativePath);
-        return;
-      }
+    if (entry.isDirectory()) {
+      filePaths.push(
+        ...(await listFiles(path.join(directory, entry.name), relativePath)),
+      );
+      continue;
+    }
 
-      snapshot[relativePath] = await readFile(entryPath, "utf-8");
-    }),
-  );
+    filePaths.push(relativePath);
+  }
+
+  return filePaths;
 }

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
+import { loadRepoSourceSnapshot } from "@/lib/repo-source";
 import {
   DEMO_DOWNLOAD_MANIFESTS,
   getDemoDownloadManifest,
@@ -16,13 +15,8 @@ import { createZip, type ZipFileMap } from "./zip";
 
 type SourceSnapshot = Record<string, string>;
 
-export async function loadSourceSnapshot(snapshotPath = defaultSnapshotPath()) {
-  const raw = await readFile(snapshotPath, "utf8");
-  return JSON.parse(raw) as SourceSnapshot;
-}
-
 export async function createDemoZip(slug: string) {
-  const snapshot = await loadSourceSnapshot();
+  const snapshot = await loadRepoSourceSnapshot();
   return createZip(createDemoFileMap(slug, snapshot));
 }
 
@@ -85,10 +79,6 @@ export function getDemoArchiveFilename(slug: DemoDownloadSlug) {
 
 export function supportedDemoSlugs() {
   return Object.keys(DEMO_DOWNLOAD_MANIFESTS) as DemoDownloadSlug[];
-}
-
-function defaultSnapshotPath() {
-  return path.join(process.cwd(), "generated", "source-snapshot.json");
 }
 
 function assertSnapshotFile(snapshot: SourceSnapshot, snapshotKey: string) {

--- a/apps/docs/lib/xulux/learn/next-step-result.ts
+++ b/apps/docs/lib/xulux/learn/next-step-result.ts
@@ -1,4 +1,4 @@
-import { loadSourceSnapshot } from "../demo-downloads/create-demo-zip";
+import { loadRepoSourceSnapshot } from "@/lib/repo-source";
 import { compareStageFiles } from "./stage-diff";
 import { resolveStageFilesFromSnapshot } from "./stage-source";
 import { getNextStep } from "./registry";
@@ -27,7 +27,7 @@ export async function resolveNextCourseStep(
 
   const stepIndex = course.steps.findIndex(({ id }) => id === next.step.id);
   const stage = getLearnStage(context.courseId, next.step.stageId);
-  const snapshot = await loadSourceSnapshot();
+  const snapshot = await loadRepoSourceSnapshot();
   const currentFiles = resolveStageFilesFromSnapshot(
     context.courseId,
     stage.id,

--- a/apps/docs/lib/xulux/learn/stage-source.ts
+++ b/apps/docs/lib/xulux/learn/stage-source.ts
@@ -1,4 +1,4 @@
-import { loadSourceSnapshot } from "../demo-downloads/create-demo-zip";
+import { loadRepoSourceSnapshot } from "@/lib/repo-source";
 import { createZip } from "../demo-downloads/zip";
 import { getLearnCourse, getLearnStage } from "./registry";
 import type { LearnCourseDefinition } from "./types";
@@ -13,7 +13,7 @@ export async function resolveStageFiles(
   return resolveStageFilesFromSnapshot(
     courseId,
     stageId,
-    await loadSourceSnapshot(),
+    await loadRepoSourceSnapshot(),
   );
 }
 

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -80,6 +80,7 @@ const config: NextConfig = {
     "/api/doc/chat": REPO_SOURCE_TRACE,
     "/api/xulux/chat": REPO_SOURCE_TRACE,
     "/api/xulux/demo-download": REPO_SOURCE_TRACE,
+    "/api/xulux/learn/chat": REPO_SOURCE_TRACE,
     "/api/xulux/learn/download": REPO_SOURCE_TRACE,
     "/api/xulux/learn/source": REPO_SOURCE_TRACE,
   },

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -11,6 +11,10 @@ const isDev = process.env.NODE_ENV === "development";
 
 const apiCatalogDiscoveryPaths = ["/(.*)"];
 
+// The repo source tree is read at runtime through paths the file tracer cannot
+// follow, so every route that reaches it has to name it.
+const REPO_SOURCE_TRACE = ["./generated/.repo-source/**/*"];
+
 const deployEnv = process.env.VERCEL_ENV ?? process.env.NODE_ENV;
 const faviconVariant =
   deployEnv === "preview" || deployEnv === "development"
@@ -73,6 +77,11 @@ const config: NextConfig = {
       "./components/demo/elements/*.tsx",
       "../../packages/ui/src/components/react/assistant-ui/elements/*.tsx",
     ],
+    "/api/doc/chat": REPO_SOURCE_TRACE,
+    "/api/xulux/chat": REPO_SOURCE_TRACE,
+    "/api/xulux/demo-download": REPO_SOURCE_TRACE,
+    "/api/xulux/learn/download": REPO_SOURCE_TRACE,
+    "/api/xulux/learn/source": REPO_SOURCE_TRACE,
   },
   headers: async () => [
     {

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -11,6 +11,7 @@ const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
 const OUTPUT_DIR = path.join(DOCS_ROOT, "generated");
 const OUTPUT_PATH = path.join(OUTPUT_DIR, ".repo-source");
 const READ_CONCURRENCY = 32;
+const WRITE_CONCURRENCY = 32;
 const SOURCE_SNAPSHOT_EXCLUDE = [
   /pnpm-lock\.yaml$/,
   /package-lock\.json$/,
@@ -60,19 +61,32 @@ async function main() {
 }
 
 async function writeSnapshot(snapshot: Record<string, string>) {
-  const createdDirectories = new Set<string>();
+  const entries = Object.entries(snapshot);
+  const directories = new Set(
+    entries.map(([filePath]) => path.dirname(path.join(OUTPUT_PATH, filePath))),
+  );
 
-  for (const [filePath, contents] of Object.entries(snapshot)) {
-    const target = path.join(OUTPUT_PATH, filePath);
-    const directory = path.dirname(target);
-
-    if (!createdDirectories.has(directory)) {
-      await fs.mkdir(directory, { recursive: true });
-      createdDirectories.add(directory);
-    }
-
-    await fs.writeFile(target, contents);
+  for (const directory of directories) {
+    await fs.mkdir(directory, { recursive: true });
   }
+
+  let index = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = index++;
+      if (currentIndex >= entries.length) return;
+
+      const [filePath, contents] = entries[currentIndex]!;
+      await fs.writeFile(path.join(OUTPUT_PATH, filePath), contents);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(WRITE_CONCURRENCY, entries.length) }, () =>
+      worker(),
+    ),
+  );
 }
 
 async function buildSnapshot(files: string[]) {

--- a/apps/docs/scripts/generate-source-snapshot.mts
+++ b/apps/docs/scripts/generate-source-snapshot.mts
@@ -9,7 +9,7 @@ import {
 const DOCS_ROOT = process.cwd();
 const REPO_ROOT = path.resolve(DOCS_ROOT, "../..");
 const OUTPUT_DIR = path.join(DOCS_ROOT, "generated");
-const OUTPUT_PATH = path.join(OUTPUT_DIR, "source-snapshot.json");
+const OUTPUT_PATH = path.join(OUTPUT_DIR, ".repo-source");
 const READ_CONCURRENCY = 32;
 const SOURCE_SNAPSHOT_EXCLUDE = [
   /pnpm-lock\.yaml$/,
@@ -44,8 +44,10 @@ async function main() {
     );
 
   const snapshot = await buildSnapshot(files);
-  const serialized = JSON.stringify(snapshot);
-  const size = Buffer.byteLength(serialized, "utf-8");
+  const size = Object.values(snapshot).reduce(
+    (total, contents) => total + Buffer.byteLength(contents, "utf-8"),
+    0,
+  );
 
   if (size > SNAPSHOT_BYTE_BUDGET) {
     console.error(formatBudgetError(snapshot, size));
@@ -53,8 +55,24 @@ async function main() {
     return;
   }
 
-  await fs.mkdir(OUTPUT_DIR, { recursive: true });
-  await fs.writeFile(OUTPUT_PATH, serialized);
+  await fs.rm(OUTPUT_PATH, { recursive: true, force: true });
+  await writeSnapshot(snapshot);
+}
+
+async function writeSnapshot(snapshot: Record<string, string>) {
+  const createdDirectories = new Set<string>();
+
+  for (const [filePath, contents] of Object.entries(snapshot)) {
+    const target = path.join(OUTPUT_PATH, filePath);
+    const directory = path.dirname(target);
+
+    if (!createdDirectories.has(directory)) {
+      await fs.mkdir(directory, { recursive: true });
+      createdDirectories.add(directory);
+    }
+
+    await fs.writeFile(target, contents);
+  }
 }
 
 async function buildSnapshot(files: string[]) {

--- a/apps/docs/scripts/source-snapshot-budget.mts
+++ b/apps/docs/scripts/source-snapshot-budget.mts
@@ -1,4 +1,4 @@
-// Measured single-flight: one materialized repo sandbox costs roughly 14x the snapshot's byte size in resident memory. Sandboxes are built per request, so concurrent repo-tool calls multiply that term.
+// The repo sandboxes read this tree from disk through a per-request copy-on-write overlay, so its size bounds the deployed function bundle rather than resident memory.
 export const SNAPSHOT_BYTE_BUDGET = 64_000_000;
 
 const BUDGET_REPORT_ENTRIES = 15;

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { defaultExclude } from "vitest/config";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -7,6 +8,9 @@ export default {
   test: {
     environment: "node",
     globals: true,
+    // The generated repo source tree is a verbatim copy of the monorepo, and
+    // vitest discovers dotted directories, so its tests would be collected here.
+    exclude: [...defaultExclude, "generated/.repo-source/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem

the docs assistant's `/repo` sandbox was rebuilt in memory on every request that touched a repo tool. `createRepoTools()`, `createSourceMapTools()` and the `repo` scope of `createLearnSourceMapTools()` each closed over their own `bashToolkitPromise`, and each one materialized the whole 27 MB `generated/source-snapshot.json` into a fresh `InMemoryFs`. resident memory was therefore `base + snapshot + N x sandbox`, and both routes are long running (`maxDuration = 300` and `800`), so overlap is the normal case.

measured on the real snapshot (5016 files, 27.6 MB), node 24, `--expose-gc`, settled between rows:

```
baseline                 rss=  90  heapUsed=  17  external=   4
snapshot (5016 files)    rss= 180  heapUsed=  51  external=   4
hold sandbox 1           rss= 380  heapUsed=  55  external=  30
hold sandbox 4           rss= 491  heapUsed=  64  external= 109
hold sandbox 8           rss= 546  heapUsed=  75  external= 213
```

`external` grows a flat 26 MB per sandbox: every request retains its own copy of the repo's bytes.

#6736 also floated hoisting the toolkit to module scope, and asked whether that would be safe. it is not. the mount is fully writable, and state persists for the life of the toolkit:

```
echo 'LEAKED SECRET' > /repo/pwned.txt   -> cat /repo/pwned.txt -> LEAKED SECRET
echo '# tampered'   > /repo/README.md    -> cat /repo/README.md -> # tampered
rm /repo/src/a.ts                        -> ls /repo/src        -> (empty)
```

on two endpoints behind only an anonymous session and a rate limit, a shared sandbox is one visitor editing the source another visitor's model reads. `>` is interpreter-level, so a command allowlist cannot close it either.

## Root cause

`createBashTool({ files })` streams every entry through `Buffer.from(content)` and `.toString("utf-8")` into a fresh `filesWithDestination` map, then hands it to `new Bash({ files })`, which stores the bodies as `Uint8Array`. nothing in that input varies per request (`destination: "/repo"`, fixed `maxOutputLength`, a module-scope snapshot), so the copy buys nothing but the isolation that per-request construction already provides.

the snapshot only had to be an in-memory record because it shipped as a single JSON blob. `just-bash` has supported a copy-on-write overlay on a real directory for exactly this shape.

## Change

`generate:source-snapshot` writes the tracked files as a real tree instead of one JSON blob, and each request mounts that tree through its own `OverlayFs`. reads are served from the deployed tree; writes land in a per-request memory layer and never touch disk. per-request construction stays, because that is what keeps requests isolated, but it is now O(1) in snapshot size.

- `lib/repo-source.ts` owns where the tree lives and loads it back into a `Record<string, string>` for the demo-zip and Learn paths that still want one.
- `lib/repo-sandbox.ts` owns `createRepoSandbox()`, one memoized `/repo` toolkit per request. it replaces three near-identical copies of the old factory. the copy-on-write layer is capped at 16 MiB rather than just-bash's 1 GiB default, since it is the only per-request memory left.
- the JSON blob is gone. `loadSourceSnapshot` became `loadRepoSourceSnapshot` over the tree, so there is one artifact rather than two and the byte budget still bounds one thing.
- `maxFiles` is dropped from the repo sandboxes: with no `files` to upload there is nothing to count. the Learn `course` scope keeps its own `maxFiles: 500`.

the tree lives at `generated/.repo-source`, and the leading dot is load-bearing. a 5076-file mirror of the monorepo sitting in plain sight inside `apps/docs/` is visible to every glob that scans the app: vitest collected its test files as this app's own, tsc type-checked it, and turbopack pulled 1606 mirrored `.tsx` into the unrelated `/api/mcp` bundle. typescript and the bundler both skip dotted directories, which fixes two of those at the source; vitest discovers dotted paths, so `vitest.config.ts` carries the one explicit exclude.

`next.config.ts` names the tree in `outputFileTracingIncludes` for the five routes that reach it. the tracer statically folded the old `path.join(process.cwd(), ..., "source-snapshot.json")` but cannot glob a directory. keys are picomatched against the normalized app route with `dot: true` (next 16.3.4 `collect-build-traces.js`), so the route paths and the dotted glob are both the shapes that match.

the comment above `SNAPSHOT_BYTE_BUDGET` claimed one sandbox costs roughly 14x the snapshot's bytes in resident memory. that reads the 416 MB in #6715 as the sandbox's own cost when it was whole-process RSS after building one. the measured marginal cost was about 29 MB retained, roughly 1.05x the snapshot's bytes. the budget now describes what it actually bounds: the deployed function bundle.

## Verification

memory, same method as above, against the shipped `createRepoSandbox` with 8 sandboxes held concurrently:

```
baseline      rss= 172  heapUsed=  27  external=   7
request 1     rss= 211  heapUsed=  29  external=   7
request 8     rss= 247  heapUsed=  29  external=   7
```

+75 MB for 8 concurrent, heap and external flat, on top of no module-scope snapshot at all. the same 8 cost +366 MB before, plus the ~90 MB the snapshot held for the life of the instance.

`next build` exits 0 and the emitted `.nft.json` files confirm the tracing end to end: all five named routes trace 5076 unique files from the tree, `/api/mcp` and `/api/chat` trace zero. mcp traced 1606 of them before the dotted directory, which is the regression that move fixes.

`pnpm vitest run` in `apps/docs`: 63 files, 542 tests, all passing, including 8 new ones. the sandbox tests pin what #6736 could not settle: writes, overwrites and deletes in one request are invisible to another, and none of them reach the tree on disk.

```
request A: cat pwned.txt -> LEAKED   | head -1 AGENTS.md -> # tampered     | CLAUDE.md -> No such file
request B: cat pwned.txt -> No such  | head -1 AGENTS.md -> # assistant-ui | CLAUDE.md -> @AGENTS.md
disk:      pwned.txt=false  CLAUDE.md=true
```

latency improves too: constructing a toolkit drops from 124-221ms to 0-1ms. `grep -r` is about 1.6x slower reading off disk and `find` about 2.5x faster, for a lower total per conversation.

`pnpm lint` clean. the auto-generated bash tool prompt is unchanged: `/usr/bin` discovery still works through the overlay, so the doc chat route's tool description keeps its tool list.

## Public surface

none. `@assistant-ui/docs` is `private: true`, so no changeset. no exports, api-reference output, or templates touched. `generated/source-snapshot.json` is no longer read by anything; an existing local copy is orphaned and gitignored.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ROys9945Uqs9GrgtmqNIWExPx-CR19UrIkEC9ATO9Enj04V38cJuUz5oD2E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->