### PR TITLE
fix(docs): send playground chat telemetry

### DIFF
--- a/.github/workflows/axiom-annotation.yaml
+++ b/.github/workflows/axiom-annotation.yaml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   annotate:
+    # A fork's own main pushes never carry the secret, so without this the job
+    # would fail on every one of them.
+    if: github.repository == 'assistant-ui/assistant-ui'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/axiom-annotation.yaml
+++ b/.github/workflows/axiom-annotation.yaml
@@ -16,9 +16,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+        with:
+          fetch-depth: 1
+
+      # The docs app runs the same script as its Vercel ignore command, so a
+      # commit Vercel declines to build must not be marked as shipped either.
+      - name: Decide whether this commit ships
+        id: ships
+        env:
+          VERCEL_GIT_COMMIT_REF: ${{ github.ref_name }}
+          VERCEL_GIT_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          if bash scripts/vercel-ignore-changeset-release.sh; then
+            echo "ships=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ships=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Marks the deploy on every Axiom chart this repository's telemetry lands
       # on, so a latency or error step can be lined up against what shipped.
       - name: Record the deploy
+        if: steps.ships.outputs.ships == 'true'
         env:
           AXIOM_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
@@ -28,8 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${AXIOM_TOKEN:-}" ]; then
-            echo "AXIOM_API_TOKEN is not set; skipping the annotation."
-            exit 0
+            echo "AXIOM_API_TOKEN is not set, so this deploy would go unmarked." >&2
+            exit 1
           fi
           jq -nc \
             --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/.github/workflows/axiom-annotation.yaml
+++ b/.github/workflows/axiom-annotation.yaml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: axiom-annotation-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   annotate:
     # A fork's own main pushes never carry the secret, so without this the job

--- a/.github/workflows/axiom-annotation.yaml
+++ b/.github/workflows/axiom-annotation.yaml
@@ -1,0 +1,45 @@
+name: Axiom deploy annotation
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: axiom-annotation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  annotate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Marks the deploy on every Axiom chart this repository's telemetry lands
+      # on, so a latency or error step can be lined up against what shipped.
+      - name: Record the deploy
+        env:
+          AXIOM_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AXIOM_TOKEN:-}" ]; then
+            echo "AXIOM_API_TOKEN is not set; skipping the annotation."
+            exit 0
+          fi
+          jq -nc \
+            --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg title "${REPOSITORY}@${SHA:0:7}" \
+            --arg description "${COMMIT_MESSAGE%%$'\n'*}" \
+            --arg url "${COMMIT_URL}" \
+            --argjson datasets '["vercel","traces"]' \
+            '{type: "deploy", time: $time, title: $title, description: $description, url: $url, datasets: $datasets}' \
+          | curl --fail-with-body --silent --show-error \
+              -X POST https://api.axiom.co/v2/annotations \
+              -H "Authorization: Bearer ${AXIOM_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data @-

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -17,7 +17,9 @@ NEXT_PUBLIC_APP_URL=
 NEXT_PUBLIC_POSTHOG_API_KEY=
 
 # Axiom OTel export for LLM traces. Both must be set for the exporter to
-# attach; leaving either blank disables only the Axiom leg.
+# attach; leaving either blank disables only the Axiom leg. This is an ingest
+# token; the deploy annotation workflow uses a separate annotations-scoped one
+# under the AXIOM_API_TOKEN repository secret.
 AXIOM_TOKEN=
 AXIOM_DATASET=
 # Optional. Defaults to api.axiom.co; set to api.eu.axiom.co for an EU org.

--- a/apps/docs/app/api/playground-chat/route.test.ts
+++ b/apps/docs/app/api/playground-chat/route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+  getModel: vi.fn(),
+  getDistinctId: vi.fn(),
+  streamText: vi.fn(),
+}));
+
+vi.mock("@/lib/feature-flags", async (importOriginal) => ({
+  ...(await importOriginal()),
+  isAiPlaygroundEnabled: true,
+}));
+
+vi.mock("@/lib/rate-limit", async (importOriginal) => ({
+  ...(await importOriginal()),
+  checkRateLimit: mocks.checkRateLimit,
+}));
+
+vi.mock("@/lib/ai/provider", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getModel: mocks.getModel,
+}));
+
+vi.mock("@/lib/validate-input", async (importOriginal) => ({
+  ...(await importOriginal()),
+  validateGeneralChatInput: () => null,
+}));
+
+vi.mock("@/lib/posthog-server", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getDistinctId: mocks.getDistinctId,
+}));
+
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal()),
+  convertToModelMessages: (messages: unknown) => messages,
+  pruneMessages: ({ messages }: { messages: unknown }) => messages,
+  stepCountIs: () => () => false,
+  streamText: mocks.streamText,
+}));
+
+import { POST } from "./route";
+
+const request = () =>
+  new Request("https://www.assistant-ui.com/api/playground-chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      messages: [
+        { role: "user", parts: [{ type: "text", text: "make it red" }] },
+      ],
+      tools: {},
+      builderConfig: {},
+    }),
+  });
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/playground-chat telemetry", () => {
+  it("reports under its own capability so it separates from the other chat routes", async () => {
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.getModel.mockReturnValue({});
+    mocks.getDistinctId.mockReturnValue("distinct_1234567890");
+    mocks.streamText.mockReturnValue({
+      toUIMessageStreamResponse: () => new Response(null, { status: 200 }),
+    });
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    const options = mocks.streamText.mock.calls[0]?.[0];
+    expect(options.telemetry.functionId).toBe("playground_chat");
+    expect(options.runtimeContext.$ai_span_name).toBe("playground_chat");
+    expect(options.runtimeContext.posthog_distinct_id).toBe(
+      "distinct_1234567890",
+    );
+  });
+
+  it("does not reach the model when the rate limit answers", async () => {
+    mocks.checkRateLimit.mockResolvedValue(
+      new Response("limited", { status: 429 }),
+    );
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(429);
+    expect(mocks.getModel).not.toHaveBeenCalled();
+    expect(mocks.streamText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/docs/app/api/playground-chat/route.ts
+++ b/apps/docs/app/api/playground-chat/route.ts
@@ -1,6 +1,8 @@
+import { getDistinctId } from "@/lib/posthog-server";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateGeneralChatInput } from "@/lib/validate-input";
 import { getModel } from "@/lib/ai/provider";
+import { posthogTelemetry } from "@/lib/ai/telemetry";
 import { isAiPlaygroundEnabled } from "@/lib/feature-flags";
 import { frontendTools } from "@assistant-ui/ai-sdk";
 import { NextResponse } from "next/server";
@@ -158,6 +160,7 @@ export async function POST(req: Request) {
     }
 
     const model = getModel();
+    const distinctId = getDistinctId(req);
 
     const prunedMessages = pruneMessages({
       messages: await convertToModelMessages(messages),
@@ -173,6 +176,11 @@ export async function POST(req: Request) {
       maxOutputTokens: 4000,
       stopWhen: stepCountIs(3),
       tools: frontendTools(tools),
+      ...posthogTelemetry({
+        distinctId,
+        spanName: "playground_chat",
+        source: "playground_chat",
+      }),
       onError: async ({ error }) => {
         console.error("[api/playground-chat]", error);
       },


### PR DESCRIPTION
`/api/chat`, `/api/doc/chat` and `/api/xulux/chat` all report through `posthogTelemetry`, so the playground was the one model call in the docs app producing no gen_ai span. it is small traffic (68 requests over the last 7 days) but it is the only gap left in an app that is otherwise fully instrumented, and it is the route where a bad model config is least likely to be noticed.

capability is spelled `playground_chat` so it separates from the other three in both posthog and axiom.

also adds a `push: main` workflow that posts a deploy annotation to axiom, so a latency or error step lines up against what shipped.

## verification

`tsc --noEmit` and `pnpm test` in `apps/docs` pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.M-KtC9R4EvBtKa_RnH0clcEnv2N8h6OVrLVgnbn5kSCUVsfjfz0mFk4L8Hs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->