### PR TITLE
fix(react-langchain): convert malformed messages instead of throwing

### DIFF
--- a/.changeset/langchain-converter-guards.md
+++ b/.changeset/langchain-converter-guards.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+fix: convert messages without a type or with non-array content instead of throwing

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1136,6 +1136,18 @@ describe("convertLangChainBaseMessage malformed messages", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
   });
 
+  it("stays silent about non-array content outside development", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      convertLangChainBaseMessage(humanMessage(true), {});
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("warns once in development about non-array content", () => {
     vi.stubEnv("NODE_ENV", "development");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1096,6 +1096,37 @@ describe("convertLangChainBaseMessage malformed messages", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
   });
 
+  it("renders a message without a type or content as empty system text", () => {
+    const result = convertLangChainBaseMessage(
+      { id: "msg-6" } as LangChainBaseMessage,
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("skips null entries inside a content array", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([null, { type: "text", text: "kept" }, undefined]),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "kept" }]);
+  });
+
+  it("skips null entries when collecting system text", () => {
+    const result = convertLangChainBaseMessage(
+      {
+        _getType: () => "system",
+        id: "msg-7",
+        content: [null, { type: "text", text: "kept" }],
+      },
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "kept" }]);
+  });
+
   it("converts a system message with object content to empty text", () => {
     const result = convertLangChainBaseMessage(
       { _getType: () => "system", id: "msg-5", content: { text: "x" } },

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AppendMessage } from "@assistant-ui/core";
 import { convertExternalMessages } from "@assistant-ui/core/react";
 import {
   convertLangChainBaseMessage,
   getMessageContent,
+  getMessageType,
 } from "./convertMessages";
 import type { LangChainBaseMessage, UIMessage } from "./types";
 
@@ -1045,5 +1046,78 @@ describe("convertLangChainBaseMessage tool messages", () => {
         {},
       ),
     ).toThrow(/does not match existing tool call/);
+  });
+});
+
+describe("convertLangChainBaseMessage malformed messages", () => {
+  it("reports an unknown type for a message without _getType or type", () => {
+    const message = { id: "msg-3", content: "hello" } as LangChainBaseMessage;
+
+    expect(getMessageType(message)).toBe("unknown");
+    expect(convertLangChainBaseMessage(message, {})).toEqual({
+      role: "system",
+      id: "msg-3",
+      content: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  it("converts a human message with null content to empty content", () => {
+    expect(
+      contentOf(convertLangChainBaseMessage(humanMessage(null), {})),
+    ).toEqual([]);
+  });
+
+  it("keeps tool calls when an ai message carries object content", () => {
+    const result = convertLangChainBaseMessage(
+      {
+        ...aiMessage({ text: "not an array" }),
+        tool_calls: [{ id: "call-1", name: "lookup", args: { q: "x" } }],
+      },
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "lookup",
+        args: { q: "x" },
+        argsText: '{"q":"x"}',
+      },
+    ]);
+  });
+
+  it("converts a system message with null content to empty text", () => {
+    const result = convertLangChainBaseMessage(
+      { _getType: () => "system", id: "msg-4", content: null },
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("converts a system message with object content to empty text", () => {
+    const result = convertLangChainBaseMessage(
+      { _getType: () => "system", id: "msg-5", content: { text: "x" } },
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("warns once in development about non-array content", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      convertLangChainBaseMessage(humanMessage(42), {});
+      convertLangChainBaseMessage(humanMessage(42), {});
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        "Ignoring message content that is neither a string nor an array: number",
+      );
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -45,7 +45,10 @@ export const getMessageType = (message: LangChainBaseMessage): string => {
 
 const contentBlocks = (content: unknown): readonly LangChainContentBlock[] => {
   if (content == null) return [];
-  if (Array.isArray(content)) return content;
+  if (Array.isArray(content))
+    return content.filter(
+      (block) => typeof block === "object" && block !== null,
+    );
   warnOnceInDevelopment(
     `Ignoring message content that is neither a string nor an array: ${typeof content}`,
   );
@@ -159,7 +162,7 @@ export const convertLangChainBaseMessage = (
             text:
               typeof message.content === "string"
                 ? message.content
-                : JSON.stringify(message.content),
+                : (JSON.stringify(message.content) ?? ""),
           },
         ],
       };

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -21,27 +21,49 @@ type LangChainMessageConverterMetadata =
     messageTiming?: Record<string, MessageTiming>;
   };
 
+const warnedMalformedMessages = new Set<string>();
+const warnOnceInDevelopment = (message: string) => {
+  if (
+    typeof process === "undefined" ||
+    process?.env?.NODE_ENV !== "development"
+  )
+    return;
+  if (warnedMalformedMessages.has(message)) return;
+  warnedMalformedMessages.add(message);
+  console.warn(message);
+};
+
 export const getMessageType = (message: LangChainBaseMessage): string => {
   if (typeof message._getType === "function") return message._getType();
   if ("type" in message)
     return (message as Record<string, unknown>).type as string;
-  throw new Error("Cannot determine message type");
+  warnOnceInDevelopment(
+    "Cannot determine message type; rendering the message as system text",
+  );
+  return "unknown";
+};
+
+const contentBlocks = (content: unknown): readonly LangChainContentBlock[] => {
+  if (content == null) return [];
+  if (Array.isArray(content)) return content;
+  warnOnceInDevelopment(
+    `Ignoring message content that is neither a string nor an array: ${typeof content}`,
+  );
+  return [];
 };
 
 const contentToParts = (content: unknown) => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
 
-  const parts = content as readonly LangChainContentBlock[];
-  return parts
+  return contentBlocks(content)
     .map(convertLangChainContentBlock)
     .filter((part) => part !== null && part !== undefined);
 };
 
 const getStringContent = (content: unknown): string => {
   if (typeof content === "string") return content;
-  const parts = content as readonly LangChainContentBlock[];
-  return parts
+  return contentBlocks(content)
     .filter((c): c is { type: "text"; text: string } => c.type === "text")
     .map((c) => c.text)
     .join("");


### PR DESCRIPTION
## Problem

One malformed message in a `@assistant-ui/react-langchain` thread throws inside `convertLangChainBaseMessage`, so `useExternalMessageConverter` fails and the whole thread stops rendering. Three sites throw:

- a message with neither `_getType` nor `type` (`getMessageType` throws `Cannot determine message type`)
- a human or ai message whose `content` is `null` or a non-array object (`contentToParts` casts and calls `.map`)
- a system message whose `content` is `null` or a non-array object (`getStringContent` casts and calls `.filter`)

Repro on current main: `convertLangChainBaseMessage({ id: "m", content: "hi" } as LangChainBaseMessage, {})` throws; `convertLangChainBaseMessage({ _getType: () => "human", content: null }, {})` throws `TypeError`.

This is the "sibling langchain converter guard" follow-up advertised in #6359, which hardened the langgraph stream loop with the same skip-and-warn posture.

## Root cause

`LangChainBaseMessage.content` is typed `unknown`, but both content helpers cast it straight to `readonly LangChainContentBlock[]` without checking, and `getMessageType` treats a missing type as fatal instead of as a degraded message.

## Change

- `getMessageType` returns `"unknown"` instead of throwing. It is an in-package helper (not exported from the barrel or the `./converter` subpath), so the change is confined to its call sites, all of which tolerate it: the converter falls through to its existing default branch and renders the message as system text (the same rendering LangChain's `ChatMessage` already gets today), the four `useStreamRuntime` sites compare against `"ai"`, `"human"`, and `"tool"`, and `streamingTiming` compares against `"ai"`.
- The default branch now stringifies `undefined` content to `""` so the typeless path cannot emit a text part without a string.
- `contentToParts` and `getStringContent` share a `contentBlocks` guard: `null` or `undefined` content becomes empty (silently, mirroring the langgraph converter), any other non-string non-array content becomes empty with a warning, and `null` or `undefined` entries inside a content array are skipped. The langgraph converter has the same array-entry gap and is left for a follow-up.
- Warnings are emitted once per distinct message and only when `NODE_ENV === "development"`, the same gate `react-langgraph`'s `warnForUnknownMessageType` uses, because a converter reruns on every render.

## Verification

- Ten new tests in `packages/react-langchain/src/convertMessages.test.ts`: one per guarded site, the `"unknown"` fallback, a message with neither type nor content, null array entries on both content paths, the system branch with object content, the once-per-process dev warning, and silence outside development; the guard tests each throw on main without its guard (`TypeError: Cannot read properties of null (reading 'map')`, `(reading 'filter')`, `Error: Cannot determine message type`) and passes with it.
- `pnpm -C packages/react-langchain test`: 135 passed.
- `pnpm turbo build --filter=@assistant-ui/react-langchain...`, `pnpm size:check`, `pnpm changesets:check`, oxlint and oxfmt on the touched files.

## Public surface

- `@assistant-ui/react-langchain`: `convertLangChainBaseMessage` no longer throws on the inputs above; no exports added or removed.
- Changeset: patch for `@assistant-ui/react-langchain`.
- No docs or api-reference changes.
