### PR TITLE
perf(tap): update only dirty child resources

### DIFF
--- a/.changeset/steady-resources-render.md
+++ b/.changeset/steady-resources-render.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+perf: update only dirty child resources when a resource list stays stable

--- a/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
+++ b/packages/tap/src/__tests__/basic/tapResources.basic.test.ts
@@ -356,6 +356,48 @@ describe("useResources - Basic Functionality", () => {
       commitResourceFiber(fiber);
       expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
     });
+
+    it("the dirty-child fast path discards clean child work from an abandoned pass", () => {
+      const events: string[] = [];
+      let setSibling: ((value: number) => void) | null = null;
+      const EffectChild = resource(({ value }: { value: number }) => {
+        useEffect(() => {
+          events.push(`setup:${value}`);
+          return () => events.push(`cleanup:${value}`);
+        }, [value]);
+        return value;
+      });
+      const StatefulSibling = resource(() => {
+        const [value, setValue] = useState(0);
+        setSibling = setValue;
+        return value;
+      });
+      const sibling = withKey("sibling", StatefulSibling(), []);
+      const committedElements = [
+        withKey("effect", EffectChild({ value: 1 }), [1]),
+        sibling,
+      ];
+      const abandonedElements = [
+        withKey("effect", EffectChild({ value: 2 }), [2]),
+        sibling,
+      ];
+      const fiber = createTestResource((elements: typeof committedElements) =>
+        useResources(elements),
+      );
+
+      expect(renderTest(fiber, committedElements)).toEqual([1, 0]);
+      expect(events).toEqual(["setup:1"]);
+
+      void renderResourceFiber(fiber, [abandonedElements]);
+      setSibling!(1);
+
+      expect(getCommittedValue(fiber)).toEqual([1, 1]);
+      expect(events).toEqual(["setup:1"]);
+
+      unmountResourceFiber(fiber);
+      commitResourceFiber(fiber);
+      expect(events).toEqual(["setup:1", "cleanup:1", "setup:1"]);
+    });
   });
 
   describe("Teardown", () => {

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "../test-utils";
 import { resource } from "../../core/resource";
 import { withKey } from "../../core/withKey";
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { useState as useResourceState } from "../../react-hooks/useState";
 import { useEffect as useResourceEffect } from "../../react-hooks/useEffect";
 import {
@@ -180,6 +180,61 @@ describe("@assistant-ui/tap/react resource API", () => {
       // a is dirty -> re-renders despite unchanged deps; b bails.
       expect(values).toEqual([5, 0]);
       expect(renders).toEqual({ a: 2, b: 1 });
+    });
+
+    it("preserves a child dispatch scheduled during its commit effect", () => {
+      let setValue = (_value: number) => {};
+      const useItem = () => {
+        const [value, set] = useResourceState(0);
+        setValue = set;
+        useResourceEffect(() => {
+          if (value === 1) set(2);
+        }, [value]);
+        return value;
+      };
+      const Item = resource(useItem);
+      const elements = [withKey("item", Item(), ["item"])];
+
+      let values: number[] = [];
+      function App() {
+        values = useResources(elements);
+        return null;
+      }
+
+      render(<App />);
+      expect(values).toEqual([0]);
+      act(() => setValue(1));
+      expect(values).toEqual([2]);
+    });
+
+    it("keeps caller mutation before commit out of the next render", () => {
+      const setters: Record<string, (n: number) => void> = {};
+      const useItem = (id: string) => {
+        const [value, setValue] = useResourceState(0);
+        setters[id] = setValue;
+        return value;
+      };
+      const Item = resource(useItem);
+      const elements = [
+        withKey("a", Item("a"), ["a"]),
+        withKey("b", Item("b"), ["b"]),
+      ];
+
+      let values: number[] = [];
+      const renderValues: number[][] = [];
+      function App() {
+        values = useResources(elements);
+        renderValues.push(values.slice());
+        useLayoutEffect(() => {
+          values[1] = 99;
+        }, [values]);
+        return null;
+      }
+
+      render(<App />);
+      act(() => setters.a!(5));
+      expect(renderValues.at(-1)).toEqual([5, 0]);
+      expect(values).toEqual([5, 99]);
     });
 
     it("only visits dirty children when the element list is unchanged", () => {

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -182,6 +182,40 @@ describe("@assistant-ui/tap/react resource API", () => {
       expect(renders).toEqual({ a: 2, b: 1 });
     });
 
+    it("only visits dirty children when the element list is unchanged", () => {
+      const setters: Record<string, (n: number) => void> = {};
+      const useItem = (id: string) => {
+        const [value, setValue] = useResourceState(0);
+        setters[id] = setValue;
+        return value;
+      };
+      const Item = resource(useItem);
+      const accessed = new Set<string>();
+      const elements = new Proxy(
+        [withKey("a", Item("a"), ["a"]), withKey("b", Item("b"), ["b"])],
+        {
+          get(target, property, receiver) {
+            if (property === "0" || property === "1") accessed.add(property);
+            return Reflect.get(target, property, receiver);
+          },
+        },
+      );
+
+      let values: number[] = [];
+      function App() {
+        values = useResources(elements);
+        return null;
+      }
+
+      render(<App />);
+      values[1] = 99;
+      accessed.clear();
+      act(() => setters.a!(5));
+
+      expect(values).toEqual([5, 0]);
+      expect(accessed).toEqual(new Set(["0"]));
+    });
+
     it("re-renders a child with unchanged deps when its tap context changes", () => {
       const TestContext = createContext("default");
       let renders = 0;
@@ -203,6 +237,32 @@ describe("@assistant-ui/tap/react resource API", () => {
       expect(renderTest(parent, "b")).toEqual(["b"]);
       expect(parent.contextDeps).toBeNull();
       expect(renders).toBe(2);
+    });
+
+    it("keeps clean child context dependencies after a sibling update", () => {
+      const TestContext = createContext("default");
+      let setValue = (_value: number) => {};
+      const Dirty = resource(() => {
+        const [value, set] = useResourceState(0);
+        setValue = set;
+        return value;
+      });
+      const Context = resource(() => useResourceContext(TestContext));
+      const innerElements = [
+        withKey("dirty", Dirty(), []),
+        withKey("context", Context(), []),
+      ];
+      const Nested = resource(() => useResources(innerElements));
+      const outerElements = [withKey("nested", Nested(), [])];
+      const root = createTestResource((context: string) =>
+        useContextProvider(TestContext, context, () =>
+          useResources(outerElements),
+        ),
+      );
+
+      expect(renderTest(root, "a")).toEqual([[0, "a"]]);
+      flushTapSync(() => setValue(1));
+      expect(renderTest(root, "b")).toEqual([[1, "b"]]);
     });
   });
 

--- a/packages/tap/src/__tests__/react/useResource.test.tsx
+++ b/packages/tap/src/__tests__/react/useResource.test.tsx
@@ -235,6 +235,40 @@ describe("@assistant-ui/tap/react resource API", () => {
       act(() => setters.a!(5));
       expect(renderValues.at(-1)).toEqual([5, 0]);
       expect(values).toEqual([5, 99]);
+
+      act(() => setters.a!(10));
+      expect(renderValues.at(-1)).toEqual([10, 0]);
+      expect(values).toEqual([10, 99]);
+    });
+
+    it("keeps rendering clean children when a stable list has no deps", () => {
+      const renders: Record<string, number> = {};
+      const effects: Record<string, number> = {};
+      const setters: Record<string, (n: number) => void> = {};
+      const useItem = (id: string) => {
+        renders[id] = (renders[id] ?? 0) + 1;
+        const [value, setValue] = useResourceState(0);
+        setters[id] = setValue;
+        useResourceEffect(() => {
+          effects[id] = (effects[id] ?? 0) + 1;
+        });
+        return value;
+      };
+      const Item = resource(useItem);
+      const elements = [withKey("a", Item("a")), withKey("b", Item("b"))];
+
+      function App() {
+        useResources(elements);
+        return null;
+      }
+
+      render(<App />);
+      expect(renders).toEqual({ a: 1, b: 1 });
+      expect(effects).toEqual({ a: 1, b: 1 });
+
+      act(() => setters.a!(5));
+      expect(renders).toEqual({ a: 2, b: 2 });
+      expect(effects).toEqual({ a: 2, b: 2 });
     });
 
     it("only visits dirty children when the element list is unchanged", () => {

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -15,7 +15,7 @@ import {
   hasContextDepsChanged,
 } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 import { depsShallowEqual } from "./utils/depsShallowEqual";
 
@@ -40,6 +40,12 @@ type FiberState = {
   // Last committed deps + value, used to decide and serve a bailout.
   committedDeps: readonly unknown[] | undefined;
   committedValue: unknown;
+};
+
+type RenderResult<T> = {
+  values: T[];
+  commitKeys: readonly (string | number)[] | null;
+  keyToIndex: ReadonlyMap<string | number, number>;
 };
 
 // Looked up by key (not captured) so it survives fiber replacement on remount.
@@ -75,18 +81,67 @@ export function useResources<E extends ResourceElement<any>>(
   elements: readonly E[],
 ): ExtractResourceReturnType<E>[] {
   const [fibers] = useState(() => new Map<string | number, FiberState>());
+  const committedElements = useRef<readonly E[] | null>(null);
+  const committedValues = useRef<ExtractResourceReturnType<E>[] | null>(null);
+  const committedKeyToIndex = useRef<ReadonlyMap<
+    string | number,
+    number
+  > | null>(null);
+  const pendingStructuralChange = useRef(false);
+  const needsFullCommit = useRef(false);
 
   // Process each element
 
   const { version, createFiber } = useResourceFiberHost();
   const hasAnyContextDepsChanged = hasAnyChildContextDepsChanged(fibers);
 
-  const val = useRenderMemo(
+  const rendered = useRenderMemo<RenderResult<ExtractResourceReturnType<E>>>(
     () => {
       void version;
 
-      const seenKeys = new Set<string | number>();
+      if (
+        committedElements.current === elements &&
+        committedValues.current !== null &&
+        committedKeyToIndex.current !== null &&
+        !pendingStructuralChange.current &&
+        !hasAnyContextDepsChanged
+      ) {
+        const values = committedValues.current.slice();
+        const commitKeys: Array<string | number> = [];
+
+        for (const [key, state] of fibers) {
+          if (!state.isDirty) {
+            if (typeof state.next === "object") {
+              discardWipRender(state.fiber);
+              state.next = "skip";
+            }
+            if (state.fiber.contextDeps) {
+              bubbleContextDeps(state.fiber, state.fiber.contextDeps);
+            }
+            continue;
+          }
+          const index = committedKeyToIndex.current.get(key);
+          if (index === undefined) continue;
+
+          const element = elements[index]!;
+          const value = renderResourceFiber(
+            state.fiber,
+            element.args,
+          ) as ExtractResourceReturnType<E>;
+          state.next = { value, deps: element.deps };
+          values[index] = value;
+          commitKeys.push(key);
+        }
+
+        return {
+          values,
+          commitKeys,
+          keyToIndex: committedKeyToIndex.current,
+        };
+      }
+
       const values: any[] = [];
+      const keyToIndex = new Map<string | number, number>();
       let newCount = 0;
 
       for (let i = 0; i < elements.length; i++) {
@@ -99,9 +154,9 @@ export function useResources<E extends ResourceElement<any>>(
           );
         }
 
-        if (seenKeys.has(elementKey))
+        if (keyToIndex.has(elementKey))
           throw new Error(`Duplicate key ${elementKey} in useResources`);
-        seenKeys.add(elementKey);
+        keyToIndex.set(elementKey, i);
 
         let state = fibers.get(elementKey);
         if (!state) {
@@ -117,6 +172,7 @@ export function useResources<E extends ResourceElement<any>>(
             committedValue: undefined,
           };
           newCount++;
+          pendingStructuralChange.current = true;
           fibers.set(elementKey, state);
         } else if (state.fiber.hook !== element.hook) {
           const fiber = createFiber(element.hook, element.key, () =>
@@ -124,6 +180,7 @@ export function useResources<E extends ResourceElement<any>>(
           );
           const value = renderResourceFiber(fiber, element.args);
           state.next = { value: value, deps: element.deps, remount: fiber };
+          pendingStructuralChange.current = true;
         } else if (canReuse(state, element.deps)) {
           if (typeof state.next === "object") {
             discardWipRender(state.fiber);
@@ -147,21 +204,23 @@ export function useResources<E extends ResourceElement<any>>(
       // Clean up removed fibers (only if there might be stale ones)
       if (fibers.size > values.length - newCount) {
         for (const key of fibers.keys()) {
-          if (!seenKeys.has(key)) {
+          if (!keyToIndex.has(key)) {
             fibers.get(key)!.next = "delete";
+            pendingStructuralChange.current = true;
           }
         }
       }
 
-      return values;
+      return { values, commitKeys: null, keyToIndex };
     },
     [elements, fibers, createFiber, version],
     hasAnyContextDepsChanged,
   );
-
+  const val = rendered.values;
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      needsFullCommit.current = true;
       for (const key of fibers.keys()) {
         unmountResourceFiber(fibers.get(key)!.fiber);
       }
@@ -171,7 +230,12 @@ export function useResources<E extends ResourceElement<any>>(
   useEffect(() => {
     void val; // as a performance optimization, we only run if the results have changed
 
-    for (const [key, state] of fibers.entries()) {
+    const entries =
+      rendered.commitKeys === null || needsFullCommit.current
+        ? fibers.entries()
+        : rendered.commitKeys.map((key) => [key, fibers.get(key)!] as const);
+
+    for (const [key, state] of entries) {
       const next = state.next;
       if (next === "delete") {
         unmountResourceFiber(state.fiber);
@@ -193,7 +257,14 @@ export function useResources<E extends ResourceElement<any>>(
         state.next = "skip";
       }
     }
-  }, [val, fibers]);
+
+    committedElements.current = elements;
+    // The returned array is caller-visible and may be mutated after render.
+    committedValues.current = val.slice();
+    committedKeyToIndex.current = rendered.keyToIndex;
+    pendingStructuralChange.current = false;
+    needsFullCommit.current = false;
+  }, [elements, fibers, rendered, val]);
 
   return val;
 }

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -47,6 +47,7 @@ type RenderResult<T> = {
   exposedValues: T[];
   commitKeys: readonly (string | number)[] | null;
   keyToIndex: ReadonlyMap<string | number, number>;
+  supportsDirtyChildUpdates: boolean;
 };
 
 // Looked up by key (not captured) so it survives fiber replacement on remount.
@@ -88,6 +89,7 @@ export function useResources<E extends ResourceElement<any>>(
     string | number,
     number
   > | null>(null);
+  const supportsDirtyChildUpdates = useRef(false);
   const pendingStructuralChange = useRef(false);
   const needsFullCommit = useRef(false);
 
@@ -104,6 +106,7 @@ export function useResources<E extends ResourceElement<any>>(
         committedElements.current === elements &&
         committedValues.current !== null &&
         committedKeyToIndex.current !== null &&
+        supportsDirtyChildUpdates.current &&
         !pendingStructuralChange.current &&
         !hasAnyContextDepsChanged
       ) {
@@ -139,15 +142,18 @@ export function useResources<E extends ResourceElement<any>>(
           exposedValues: values.slice(),
           commitKeys,
           keyToIndex: committedKeyToIndex.current,
+          supportsDirtyChildUpdates: true,
         };
       }
 
       const values: any[] = [];
       const keyToIndex = new Map<string | number, number>();
       let newCount = 0;
+      let nextSupportsDirtyChildUpdates = true;
 
       for (let i = 0; i < elements.length; i++) {
         const element = elements[i]!;
+        if (element.deps === undefined) nextSupportsDirtyChildUpdates = false;
 
         const elementKey = element.key;
         if (elementKey === undefined) {
@@ -218,6 +224,7 @@ export function useResources<E extends ResourceElement<any>>(
         exposedValues: values.slice(),
         commitKeys: null,
         keyToIndex,
+        supportsDirtyChildUpdates: nextSupportsDirtyChildUpdates,
       };
     },
     [elements, fibers, createFiber, version],
@@ -268,6 +275,7 @@ export function useResources<E extends ResourceElement<any>>(
     committedElements.current = elements;
     committedValues.current = rendered.values;
     committedKeyToIndex.current = rendered.keyToIndex;
+    supportsDirtyChildUpdates.current = rendered.supportsDirtyChildUpdates;
     pendingStructuralChange.current = false;
     needsFullCommit.current = false;
   }, [elements, fibers, rendered, val]);

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -44,6 +44,7 @@ type FiberState = {
 
 type RenderResult<T> = {
   values: T[];
+  exposedValues: T[];
   commitKeys: readonly (string | number)[] | null;
   keyToIndex: ReadonlyMap<string | number, number>;
 };
@@ -135,6 +136,7 @@ export function useResources<E extends ResourceElement<any>>(
 
         return {
           values,
+          exposedValues: values.slice(),
           commitKeys,
           keyToIndex: committedKeyToIndex.current,
         };
@@ -211,12 +213,17 @@ export function useResources<E extends ResourceElement<any>>(
         }
       }
 
-      return { values, commitKeys: null, keyToIndex };
+      return {
+        values,
+        exposedValues: values.slice(),
+        commitKeys: null,
+        keyToIndex,
+      };
     },
     [elements, fibers, createFiber, version],
     hasAnyContextDepsChanged,
   );
-  const val = rendered.values;
+  const val = rendered.exposedValues;
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -250,17 +257,16 @@ export function useResources<E extends ResourceElement<any>>(
           unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
+        state.isDirty = false;
         commitResourceFiber(state.fiber);
         state.committedDeps = next.deps;
         state.committedValue = next.value;
-        state.isDirty = false;
         state.next = "skip";
       }
     }
 
     committedElements.current = elements;
-    // The returned array is caller-visible and may be mutated after render.
-    committedValues.current = val.slice();
+    committedValues.current = rendered.values;
     committedKeyToIndex.current = rendered.keyToIndex;
     pendingStructuralChange.current = false;
     needsFullCommit.current = false;

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -231,8 +231,8 @@
   },
   "@assistant-ui/tap": {
     ".": {
-      "min": 19564,
-      "gzip": 7232
+      "min": 20307,
+      "gzip": 7498
     },
     "./react-shim": {
       "min": 7589,


### PR DESCRIPTION
## Problem

Follow-up to #6729. The store-scoping continuation is #6756.

A stable keyed resource list still rebuilt the output array and processed every child when only one child became dirty. Large lists therefore paid work proportional to their total size for a local update.

## Root cause

useResources committed the full resource collection on each update. It did not preserve the committed element index or reuse clean child results when the list and context dependencies were unchanged.

## Change

- Keep a keyed index for the committed resource list.
- Reuse clean child values when the element list and context dependencies stay stable.
- Update only dirty child resources on the dependency-aware path.
- Preserve updates dispatched by a child during its commit effect.
- Preserve the public returned-array ownership boundary so caller mutation cannot corrupt committed state.
- Keep the full-render behavior when any child has no dependency array.
- Fall back to the full path for element-list, key, or context changes.
- Cover dirty-child updates, commit-time dispatch, reordered inputs, context dependencies, and caller mutation.

This PR is stacked on #6729 so its diff contains only the tap resource change.

## Verification

- pnpm -C packages/tap test — 51 files, 586 tests passed
- pnpm --filter @assistant-ui/tap build
- pnpm -C packages/x-performance exec vitest bench --run bench/useResources.bench.tsx
- node scripts/generate-api-surface.mjs --check --filter @assistant-ui/tap
- pnpm size:check
- pnpm changesets:check
- pnpm lint

The focused 500-child benchmark measured the dependency-aware dirty-child update at about 0.08 ms, compared with about 0.91 ms for the path that must update all children.

## Public surface

Affected package: @assistant-ui/tap.

No exports or signatures change. No documentation or templates change. Includes a patch changeset for @assistant-ui/tap.