### PR TITLE
fix(core): keep model context hooks commit-safe

### DIFF
--- a/.changeset/curly-chairs-commit.md
+++ b/.changeset/curly-chairs-commit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep model context callbacks scoped to committed React renders

--- a/packages/core/src/react/model-context/modelContextHooks.test.tsx
+++ b/packages/core/src/react/model-context/modelContextHooks.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { startTransition, Suspense } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { aui, getProvider, resetProvider } = vi.hoisted(() => {
+  type TestProvider = {
+    getModelContext: () => {
+      system?: string | undefined;
+      tools?:
+        | Record<string, { execute?: (() => unknown) | undefined }>
+        | undefined;
+    };
+  };
+  let provider: TestProvider | undefined;
+
+  return {
+    aui: {
+      modelContext: {
+        register: vi.fn((nextProvider: TestProvider) => {
+          provider = nextProvider;
+          return () => {
+            if (provider === nextProvider) provider = undefined;
+          };
+        }),
+      },
+    },
+    getProvider: () => provider,
+    resetProvider: () => {
+      provider = undefined;
+    },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => aui,
+}));
+
+import { useAssistantContext } from "./useAssistantContext";
+import { useAuiToolOverrides } from "./useAuiToolOverrides";
+
+afterEach(() => {
+  cleanup();
+  resetProvider();
+});
+
+describe("model context hooks", () => {
+  it("keeps assistant context scoped to the committed render", async () => {
+    const pending = new Promise<never>(() => {});
+    const Probe = ({ value, suspend }: { value: string; suspend: boolean }) => {
+      useAssistantContext({ getContext: () => value });
+      if (suspend) throw pending;
+      return null;
+    };
+
+    const view = render(
+      <Suspense fallback={null}>
+        <Probe value="workspace-a" suspend={false} />
+      </Suspense>,
+    );
+    await waitFor(() => expect(getProvider()).toBeDefined());
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(
+          <Suspense fallback={null}>
+            <Probe value="workspace-b" suspend />
+          </Suspense>,
+        );
+      });
+    });
+
+    expect(getProvider()?.getModelContext().system).toBe("workspace-a");
+  });
+
+  it("keeps tool overrides scoped to the committed render", async () => {
+    const pending = new Promise<never>(() => {});
+    const Probe = ({ value, suspend }: { value: string; suspend: boolean }) => {
+      useAuiToolOverrides({ search: { execute: () => value } });
+      if (suspend) throw pending;
+      return null;
+    };
+
+    const view = render(
+      <Suspense fallback={null}>
+        <Probe value="workspace-a" suspend={false} />
+      </Suspense>,
+    );
+    await waitFor(() => expect(getProvider()).toBeDefined());
+
+    act(() => {
+      startTransition(() => {
+        view.rerender(
+          <Suspense fallback={null}>
+            <Probe value="workspace-b" suspend />
+          </Suspense>,
+        );
+      });
+    });
+
+    expect(getProvider()?.getModelContext().tools?.search?.execute?.()).toBe(
+      "workspace-a",
+    );
+  });
+});

--- a/packages/core/src/react/model-context/modelContextHooks.test.tsx
+++ b/packages/core/src/react/model-context/modelContextHooks.test.tsx
@@ -49,8 +49,10 @@ afterEach(() => {
 describe("model context hooks", () => {
   it("keeps assistant context scoped to the committed render", async () => {
     const pending = new Promise<never>(() => {});
+    const renderB = vi.fn();
     const Probe = ({ value, suspend }: { value: string; suspend: boolean }) => {
       useAssistantContext({ getContext: () => value });
+      if (value === "workspace-b") renderB();
       if (suspend) throw pending;
       return null;
     };
@@ -72,13 +74,24 @@ describe("model context hooks", () => {
       });
     });
 
+    expect(renderB).toHaveBeenCalled();
     expect(getProvider()?.getModelContext().system).toBe("workspace-a");
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <Probe value="workspace-b" suspend={false} />
+      </Suspense>,
+    );
+
+    expect(getProvider()?.getModelContext().system).toBe("workspace-b");
   });
 
   it("keeps tool overrides scoped to the committed render", async () => {
     const pending = new Promise<never>(() => {});
+    const renderB = vi.fn();
     const Probe = ({ value, suspend }: { value: string; suspend: boolean }) => {
       useAuiToolOverrides({ search: { execute: () => value } });
+      if (value === "workspace-b") renderB();
       if (suspend) throw pending;
       return null;
     };
@@ -100,8 +113,19 @@ describe("model context hooks", () => {
       });
     });
 
+    expect(renderB).toHaveBeenCalled();
     expect(getProvider()?.getModelContext().tools?.search?.execute?.()).toBe(
       "workspace-a",
+    );
+
+    view.rerender(
+      <Suspense fallback={null}>
+        <Probe value="workspace-b" suspend={false} />
+      </Suspense>,
+    );
+
+    expect(getProvider()?.getModelContext().tools?.search?.execute?.()).toBe(
+      "workspace-b",
     );
   });
 });

--- a/packages/core/src/react/model-context/useAssistantContext.ts
+++ b/packages/core/src/react/model-context/useAssistantContext.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useInsertionEffect, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { AssistantContextConfig } from "../..";
 
@@ -8,7 +8,7 @@ export const useAssistantContext = (config: AssistantContextConfig) => {
   const { getContext, disabled = false } = config;
   const aui = useAui();
   const getContextRef = useRef(getContext);
-  useLayoutEffect(() => {
+  useInsertionEffect(() => {
     getContextRef.current = getContext;
   }, [getContext]);
 

--- a/packages/core/src/react/model-context/useAssistantContext.ts
+++ b/packages/core/src/react/model-context/useAssistantContext.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { AssistantContextConfig } from "../..";
 
@@ -8,7 +8,9 @@ export const useAssistantContext = (config: AssistantContextConfig) => {
   const { getContext, disabled = false } = config;
   const aui = useAui();
   const getContextRef = useRef(getContext);
-  getContextRef.current = getContext;
+  useLayoutEffect(() => {
+    getContextRef.current = getContext;
+  }, [getContext]);
 
   useEffect(() => {
     if (disabled) return;

--- a/packages/core/src/react/model-context/useAuiToolOverrides.ts
+++ b/packages/core/src/react/model-context/useAuiToolOverrides.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { Tool } from "assistant-stream";
 
@@ -25,7 +25,9 @@ type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
 export function useAuiToolOverrides(overrides: AuiToolOverrides): void {
   const aui = useAui();
   const overridesRef = useRef(overrides);
-  overridesRef.current = overrides;
+  useLayoutEffect(() => {
+    overridesRef.current = overrides;
+  }, [overrides]);
 
   useEffect(() => {
     return aui.modelContext.register({

--- a/packages/core/src/react/model-context/useAuiToolOverrides.ts
+++ b/packages/core/src/react/model-context/useAuiToolOverrides.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useEffect, useInsertionEffect, useRef } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { Tool } from "assistant-stream";
 
@@ -25,7 +25,7 @@ type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
 export function useAuiToolOverrides(overrides: AuiToolOverrides): void {
   const aui = useAui();
   const overridesRef = useRef(overrides);
-  useLayoutEffect(() => {
+  useInsertionEffect(() => {
     overridesRef.current = overrides;
   }, [overrides]);
 


### PR DESCRIPTION
## Problem

`useAssistantContext` and `useAuiToolOverrides` could expose values from a React render that suspended and never committed. A focused workspace A to B reproduction kept A visible, suspended B, and observed both A's system context and tool executor returning B's values.

## Root cause

Both hooks assigned their live callback refs during render. The registered model-context providers outlive an interrupted render and read those shared refs imperatively, so work-in-progress values could escape into the committed tree.

## Change

Publish the latest context getter and tool overrides in the layout commit phase. The existing provider registrations stay stable, while abandoned renders can no longer alter what they expose.

Add focused concurrent-render tests for the system-context and tool-override paths.

## Verification

- Confirmed both tests fail against the pre-fix render-phase assignments
- `pnpm --filter @assistant-ui/core exec vitest run src/react/model-context/modelContextHooks.test.tsx`
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm changesets:check`
- `git diff --check`

## Public surface

Affected package: `@assistant-ui/core` (patch changeset). No exports, types, documentation, templates, or API-reference output change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2h1XDafCexjxTxOl3f21vrOLERf0cqagX-fOTuluw87xa6_7HqRWFfU1Ov0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->