### PR TITLE
fix(ai-sdk): mark stopped runs as cancelled

### DIFF
--- a/.changeset/fuzzy-runs-cancel.md
+++ b/.changeset/fuzzy-runs-cancel.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/core": patch
+---
+
+fix: report stopped AI SDK runs as cancelled

--- a/.changeset/fuzzy-runs-cancel.md
+++ b/.changeset/fuzzy-runs-cancel.md
@@ -3,4 +3,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: report stopped AI SDK runs as cancelled
+fix: report a stopped AI SDK run as cancelled instead of complete

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1723,6 +1723,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 
@@ -6062,7 +6063,7 @@ declare const generateErrorMessageId: () => string;
 
 declare const generateId: (size?: number) => string;
 
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue, isCancelled?: boolean) => MessageStatus;
 
 declare const getExternalStoreMessages: <T>(input: {
   messages: readonly ThreadMessage[];

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1723,7 +1723,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1059,6 +1059,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1059,7 +1059,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -4657,7 +4657,7 @@ declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: strin
 
 declare const generateId: (size?: number) => string;
 
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue, isCancelled?: boolean) => MessageStatus;
 
 declare global {
   interface Window {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -688,7 +688,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -688,6 +688,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -707,7 +707,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -707,6 +707,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -4178,7 +4178,7 @@ declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: strin
 
 declare const generateId: (size?: number) => string;
 
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue, isCancelled?: boolean) => MessageStatus;
 
 declare global {
   interface Window {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2118,6 +2118,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 
@@ -6034,7 +6035,7 @@ declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: strin
 
 declare const generateId: (size?: number) => string;
 
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue, isCancelled?: boolean) => MessageStatus;
 
 declare const getExternalStoreMessages: <T>(input: {
   messages: readonly ThreadMessage[];

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2118,7 +2118,7 @@ type ExternalMessageConverterMessage = (ThreadMessageLike & {
 type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -164,6 +164,7 @@ describe("useAISDKRuntime", () => {
   });
 
   it("marks stopped output cancelled and clears the marker for the next run", async () => {
+    let resolveStop!: () => void;
     const chat = createChatHelpers([
       {
         id: "assistant-1",
@@ -172,10 +173,12 @@ describe("useAISDKRuntime", () => {
       },
     ]);
     chat.status = "streaming";
-    chat.stop = vi.fn(() => {
-      chat.status = "ready";
-      return Promise.resolve();
-    });
+    chat.stop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        }),
+    );
 
     const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
 
@@ -183,6 +186,15 @@ describe("useAISDKRuntime", () => {
       result.current.thread.cancelRun();
     });
     rerender();
+
+    expect(
+      result.current.thread.getState().messages.at(-1)?.status,
+    ).toMatchObject({ type: "running" });
+
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
 
     await waitFor(() => {
       expect(
@@ -193,7 +205,35 @@ describe("useAISDKRuntime", () => {
       });
     });
 
+    await act(async () => {
+      resolveStop();
+      await Promise.resolve();
+    });
+
     act(() => {
+      chat.setMessages([
+        {
+          id: "assistant-2",
+          role: "assistant",
+          parts: [{ type: "text", text: "replacement" }],
+        },
+      ]);
+      rerender();
+    });
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({ type: "complete", reason: "unknown" });
+    });
+
+    act(() => {
+      chat.setMessages([
+        {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "partial" }],
+        },
+      ]);
       result.current.thread.append({
         role: "user",
         content: [{ type: "text", text: "continue" }],
@@ -599,7 +639,7 @@ describe("useAISDKRuntime", () => {
     ).rejects.toThrow("Runtime does not support resuming runs.");
   });
 
-  it("forwards onResumeToolCall so runtime.thread.resumeToolCall is delivered to the adapter", async () => {
+  it("forwards onResumeToolCall and preserves synchronous errors", async () => {
     const chat = createChatHelpers([
       {
         id: "a1",
@@ -638,6 +678,17 @@ describe("useAISDKRuntime", () => {
       toolCallId: "tc-42",
       payload: { answer: "yes" },
     });
+    const error = new Error("resume failed");
+    onResumeToolCall.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() =>
+      result.current.thread
+        .getMessageById("a1")
+        .getMessagePartByToolCallId("tc-42")
+        .resumeToolCall({ answer: "yes" }),
+    ).toThrow(error);
   });
 
   it("throws when resumeToolCall is called without an onResumeToolCall adapter", async () => {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -280,6 +280,75 @@ describe("useAISDKRuntime", () => {
     });
   });
 
+  it("marks output cancelled while a client tool is still executing", async () => {
+    let resolveTool!: (value: string) => void;
+    const execute = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveTool = resolve;
+        }),
+    );
+    const chat = createChatHelpers();
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+    const unregister = result.current.registerModelContextProvider({
+      getModelContext: () => ({
+        tools: {
+          weather: {
+            parameters: { type: "object", properties: {} },
+            execute,
+          },
+        },
+      }),
+    });
+
+    try {
+      act(() => {
+        chat.setMessages([
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-weather",
+                toolCallId: "tool-1",
+                state: "input-available",
+                input: { city: "London" },
+              },
+            ],
+          },
+        ]);
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(execute).toHaveBeenCalledOnce();
+        expect(result.current.thread.getState().isRunning).toBe(true);
+      });
+
+      act(() => {
+        result.current.thread.cancelRun();
+        chat.setMessages([
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "stopped" }],
+          },
+        ]);
+        resolveTool("sunny");
+        rerender();
+      });
+
+      await waitFor(() => {
+        expect(
+          result.current.thread.getState().messages.at(-1)?.status,
+        ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+      });
+    } finally {
+      unregister();
+    }
+  });
+
   it("reports non-AbortError cancellation failures", async () => {
     const stopError = new Error("stop failed");
     const chat = createChatHelpers();

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -257,6 +257,29 @@ describe("useAISDKRuntime", () => {
     });
   });
 
+  it("does not mark completed output cancelled when already idle", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "finished" }],
+      },
+    ]);
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    act(() => {
+      result.current.thread.cancelRun();
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({ type: "complete", reason: "unknown" });
+    });
+  });
+
   it("reports non-AbortError cancellation failures", async () => {
     const stopError = new Error("stop failed");
     const chat = createChatHelpers();

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -136,10 +136,11 @@ describe("useAISDKRuntime", () => {
     abortError.name = "AbortError";
     const chat = createChatHelpers();
     let stopCalls = 0;
+    let rejectStop!: (error: unknown) => void;
     chat.stop = () => {
       stopCalls += 1;
       return new Promise((_, reject) => {
-        setTimeout(() => reject(abortError), 5);
+        rejectStop = reject;
       });
     };
     const consoleError = vi
@@ -151,7 +152,7 @@ describe("useAISDKRuntime", () => {
       const unhandledRejections = await captureUnhandledRejections(async () => {
         await act(async () => {
           result.current.thread.cancelRun();
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          rejectStop(abortError);
         });
       });
 
@@ -254,6 +255,100 @@ describe("useAISDKRuntime", () => {
         type: "complete",
         reason: "unknown",
       });
+    });
+  });
+
+  it("keeps the stopped output cancelled through the next turn", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial", state: "streaming" }],
+      },
+    ]);
+    chat.status = "streaming";
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    await act(async () => {
+      result.current.thread.cancelRun();
+    });
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+    });
+
+    act(() => {
+      chat.setMessages([
+        ...chat.messages,
+        { id: "u2", role: "user", parts: [{ type: "text", text: "next" }] },
+        {
+          id: "assistant-2",
+          role: "assistant",
+          parts: [{ type: "text", text: "answer" }],
+        },
+      ]);
+      rerender();
+    });
+
+    await waitFor(() => {
+      const messages = result.current.thread.getState().messages;
+      expect(
+        messages.find((message) => message.id === "assistant-1")?.status,
+      ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+      expect(messages.at(-1)?.status).toMatchObject({
+        type: "complete",
+        reason: "unknown",
+      });
+    });
+  });
+
+  it("retracts the cancellation when the provider picks the message back up", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial", state: "streaming" }],
+      },
+    ]);
+    chat.status = "streaming";
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    await act(async () => {
+      result.current.thread.cancelRun();
+    });
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+    });
+
+    act(() => {
+      chat.status = "streaming";
+      rerender();
+    });
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({ type: "complete", reason: "unknown" });
     });
   });
 
@@ -736,7 +831,7 @@ describe("useAISDKRuntime", () => {
     ).rejects.toThrow("Runtime does not support resuming runs.");
   });
 
-  it("forwards onResumeToolCall and preserves synchronous errors", async () => {
+  it("forwards onResumeToolCall so runtime.thread.resumeToolCall is delivered to the adapter", async () => {
     const chat = createChatHelpers([
       {
         id: "a1",
@@ -775,17 +870,6 @@ describe("useAISDKRuntime", () => {
       toolCallId: "tc-42",
       payload: { answer: "yes" },
     });
-    const error = new Error("resume failed");
-    onResumeToolCall.mockImplementationOnce(() => {
-      throw error;
-    });
-
-    expect(() =>
-      result.current.thread
-        .getMessageById("a1")
-        .getMessagePartByToolCallId("tc-42")
-        .resumeToolCall({ answer: "yes" }),
-    ).toThrow(error);
   });
 
   it("throws when resumeToolCall is called without an onResumeToolCall adapter", async () => {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -163,7 +163,7 @@ describe("useAISDKRuntime", () => {
     }
   });
 
-  it("marks stopped output cancelled and clears the marker for the next run", async () => {
+  it("marks only the stopped output cancelled", async () => {
     let resolveStop!: () => void;
     const chat = createChatHelpers([
       {
@@ -234,13 +234,18 @@ describe("useAISDKRuntime", () => {
           parts: [{ type: "text", text: "partial" }],
         },
       ]);
-      result.current.thread.append({
-        role: "user",
-        content: [{ type: "text", text: "continue" }],
-      });
+      chat.status = "streaming";
+      rerender();
     });
-    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalledOnce());
-    rerender();
+
+    expect(
+      result.current.thread.getState().messages.at(-1)?.status,
+    ).toMatchObject({ type: "running" });
+
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
 
     await waitFor(() => {
       expect(

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -27,6 +27,7 @@ const createChatHelpers = (messages: any[] = []) => {
   let currentMessages = [...messages];
 
   const chatHelpers: any = {
+    id: "chat-1",
     status: "ready",
     error: null,
     messages: currentMessages,
@@ -147,8 +148,11 @@ describe("useAISDKRuntime", () => {
 
     try {
       const { result } = renderHook(() => useAISDKRuntime(chat));
-      const unhandledRejections = await captureUnhandledRejections(() => {
-        result.current.thread.cancelRun();
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        await act(async () => {
+          result.current.thread.cancelRun();
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        });
       });
 
       expect(stopCalls).toBe(1);
@@ -157,6 +161,55 @@ describe("useAISDKRuntime", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("marks stopped output cancelled and clears the marker for the next run", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "partial", state: "streaming" }],
+      },
+    ]);
+    chat.status = "streaming";
+    chat.stop = vi.fn(() => {
+      chat.status = "ready";
+      return Promise.resolve();
+    });
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    act(() => {
+      result.current.thread.cancelRun();
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+    });
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "continue" }],
+      });
+    });
+    await waitFor(() => expect(chat.sendMessage).toHaveBeenCalledOnce());
+    rerender();
+
+    await waitFor(() => {
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status,
+      ).toMatchObject({
+        type: "complete",
+        reason: "unknown",
+      });
+    });
   });
 
   it("reports non-AbortError cancellation failures", async () => {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -235,7 +235,10 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
-  const [cancelledChatId, setCancelledChatId] = useState<string | null>(null);
+  const [cancelledMessage, setCancelledMessage] = useState<{
+    chatId: string;
+    messageId: string;
+  } | null>(null);
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
   );
@@ -252,10 +255,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     chatHelpers.status === "submitted" || chatHelpers.status === "streaming";
   const isRunning = providerIsRunning || hasExecutingTools;
 
-  useEffect(() => {
-    if (providerIsRunning) setCancelledChatId(null);
-  }, [providerIsRunning]);
-
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 
   // Flag the streaming message optimistic: its id can be swapped for a server
@@ -264,8 +263,8 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const isCancelled =
     !providerIsRunning &&
     lastMessage?.role === "assistant" &&
-    cancelledChatId !== null &&
-    cancelledChatId === chatHelpers.id;
+    cancelledMessage?.chatId === chatHelpers.id &&
+    cancelledMessage.messageId === lastMessage.id;
   const optimisticMessageId =
     isRunning && lastMessage?.role === "assistant" ? lastMessage.id : undefined;
 
@@ -461,18 +460,22 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     onCancel: async () => {
       const message = chatHelpers.messages.at(-1);
-      setCancelledChatId(message?.role === "assistant" ? chatHelpers.id : null);
+      setCancelledMessage(
+        message?.role === "assistant"
+          ? { chatId: chatHelpers.id, messageId: message.id }
+          : null,
+      );
       try {
         await chatHelpers.stop();
       } catch (error) {
         if (!(error instanceof Error && error.name === "AbortError")) {
-          setCancelledChatId(null);
+          setCancelledMessage(null);
           throw error;
         }
       }
     },
     onNew: async (message) => {
-      setCancelledChatId(null);
+      setCancelledMessage(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -492,7 +495,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       });
     },
     onEdit: async (message) => {
-      setCancelledChatId(null);
+      setCancelledMessage(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -532,7 +535,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       );
     },
     onReload: async (parentId: string | null, config) => {
-      setCancelledChatId(null);
+      setCancelledMessage(null);
       lastRunConfigRef.current = config.runConfig;
       const newMessages = sliceMessagesUntil(chatHelpers.messages, parentId);
       chatHelpers.setMessages(newMessages);
@@ -546,7 +549,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       isError,
       modelContent,
     }) => {
-      setCancelledChatId(null);
+      setCancelledMessage(null);
       const options = { metadata: lastRunConfigRef.current };
       if (isError) {
         return Promise.resolve(
@@ -575,7 +578,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       }
     },
     onRespondToToolApproval: ({ approvalId, approved, reason }) => {
-      setCancelledChatId(null);
+      setCancelledMessage(null);
       return Promise.resolve(
         chatHelpers.addToolApprovalResponse({
           id: approvalId,
@@ -593,14 +596,14 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
     ...(onResume && {
       onResume: async (config) => {
-        setCancelledChatId(null);
+        setCancelledMessage(null);
         await onResume(config);
       },
     }),
     ...(onResumeToolCall && {
-      onResumeToolCall: async (options) => {
-        setCancelledChatId(null);
-        await onResumeToolCall(options);
+      onResumeToolCall: (options) => {
+        setCancelledMessage(null);
+        onResumeToolCall(options);
       },
     }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -470,7 +470,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onCancel: async () => {
       const message = chatHelpers.messages.at(-1);
       setCancelledMessage(
-        providerIsRunning && message?.role === "assistant"
+        isRunning && message?.role === "assistant"
           ? { chatId: chatHelpers.id, messageId: message.id }
           : null,
       );

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   useEffect,
   useInsertionEffect,
   useMemo,
@@ -216,6 +217,8 @@ const useGeneratedSuggestions = (
   return suggestions;
 };
 
+const NO_CANCELLED_MESSAGE_IDS: ReadonlySet<string> = new Set();
+
 export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>,
   adapter: AISDKRuntimeAdapter<UI_MESSAGE> = {},
@@ -235,9 +238,9 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
-  const [cancelledMessage, setCancelledMessage] = useState<{
+  const [cancelledMessages, setCancelledMessages] = useState<{
     chatId: string;
-    messageId: string;
+    ids: ReadonlySet<string>;
   } | null>(null);
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
@@ -256,26 +259,49 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const isRunning = providerIsRunning || hasExecutingTools;
   const wasProviderRunningRef = useRef(providerIsRunning);
 
-  useEffect(() => {
-    const wasProviderRunning = wasProviderRunningRef.current;
-    wasProviderRunningRef.current = providerIsRunning;
-    if (!wasProviderRunning && providerIsRunning) {
-      setCancelledMessage(null);
-    }
-  }, [providerIsRunning]);
-
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 
   // Flag the streaming message optimistic: its id can be swapped for a server
   // id mid-run, and the repository then drops the orphaned pre-swap id (#4037).
   const lastMessage = chatHelpers.messages.at(-1);
-  const isCancelled =
-    !providerIsRunning &&
-    lastMessage?.role === "assistant" &&
-    cancelledMessage?.chatId === chatHelpers.id &&
-    cancelledMessage.messageId === lastMessage.id;
   const optimisticMessageId =
     isRunning && lastMessage?.role === "assistant" ? lastMessage.id : undefined;
+
+  const cancelledMessageIds =
+    cancelledMessages?.chatId === chatHelpers.id
+      ? cancelledMessages.ids
+      : NO_CANCELLED_MESSAGE_IDS;
+
+  const retractCancellation = useCallback(
+    (chatId: string, messageId: string) => {
+      setCancelledMessages((prev) => {
+        if (prev?.chatId !== chatId || !prev.ids.has(messageId)) return prev;
+        const ids = new Set(prev.ids);
+        ids.delete(messageId);
+        return { chatId, ids };
+      });
+    },
+    [],
+  );
+
+  // A provider run that resumes the stopped response retracts its cancellation;
+  // a run that starts a new response leaves the stopped one marked.
+  const resumedMessageId =
+    providerIsRunning && lastMessage?.role === "assistant"
+      ? lastMessage.id
+      : undefined;
+
+  useEffect(() => {
+    const wasProviderRunning = wasProviderRunningRef.current;
+    wasProviderRunningRef.current = providerIsRunning;
+    if (wasProviderRunning || !resumedMessageId) return;
+    retractCancellation(chatHelpers.id, resumedMessageId);
+  }, [
+    providerIsRunning,
+    resumedMessageId,
+    chatHelpers.id,
+    retractCancellation,
+  ]);
 
   const messages = AISDKMessageConverter.useThreadMessages({
     isRunning,
@@ -290,14 +316,14 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         mcpAppMetadataCache: mcpAppMetadataCacheRef.current,
         ...(optimisticMessageId && { optimisticMessageId }),
         ...(chatHelpers.error && { error: chatHelpers.error.message }),
-        ...(isCancelled && { isCancelled: true }),
+        ...(cancelledMessageIds.size > 0 && { cancelledMessageIds }),
       }),
       [
         toolStatuses,
         messageTiming,
         optimisticMessageId,
         chatHelpers.error,
-        isCancelled,
+        cancelledMessageIds,
       ],
     ),
   });
@@ -469,22 +495,31 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     onCancel: async () => {
       const message = chatHelpers.messages.at(-1);
-      setCancelledMessage(
-        isRunning && message?.role === "assistant"
-          ? { chatId: chatHelpers.id, messageId: message.id }
-          : null,
-      );
+      const cancelledId =
+        isRunning && message?.role === "assistant" ? message.id : undefined;
+      if (cancelledId) {
+        const liveIds = new Set(chatHelpers.messages.map((m) => m.id));
+        setCancelledMessages((prev) => {
+          const kept =
+            prev?.chatId === chatHelpers.id
+              ? [...prev.ids].filter((id) => liveIds.has(id))
+              : [];
+          return {
+            chatId: chatHelpers.id,
+            ids: new Set([...kept, cancelledId]),
+          };
+        });
+      }
       try {
         await chatHelpers.stop();
       } catch (error) {
         if (!(error instanceof Error && error.name === "AbortError")) {
-          setCancelledMessage(null);
+          if (cancelledId) retractCancellation(chatHelpers.id, cancelledId);
           throw error;
         }
       }
     },
     onNew: async (message) => {
-      setCancelledMessage(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -504,7 +539,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       });
     },
     onEdit: async (message) => {
-      setCancelledMessage(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -544,7 +578,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       );
     },
     onReload: async (parentId: string | null, config) => {
-      setCancelledMessage(null);
       lastRunConfigRef.current = config.runConfig;
       const newMessages = sliceMessagesUntil(chatHelpers.messages, parentId);
       chatHelpers.setMessages(newMessages);
@@ -558,7 +591,6 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       isError,
       modelContent,
     }) => {
-      setCancelledMessage(null);
       const options = { metadata: lastRunConfigRef.current };
       if (isError) {
         return Promise.resolve(
@@ -586,35 +618,23 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         );
       }
     },
-    onRespondToToolApproval: ({ approvalId, approved, reason }) => {
-      setCancelledMessage(null);
-      return Promise.resolve(
+    onRespondToToolApproval: ({ approvalId, approved, reason }) =>
+      Promise.resolve(
         chatHelpers.addToolApprovalResponse({
           id: approvalId,
           approved,
           ...(reason != null && { reason }),
           options: { metadata: lastRunConfigRef.current },
         }),
-      );
-    },
+      ),
     ...pickExternalStoreSharedOptions(adapter),
     ...(adapter.unstable_messageRepositoryInstance && {
       unstable_messageRepositoryInstance:
         adapter.unstable_messageRepositoryInstance,
     }),
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
-    ...(onResume && {
-      onResume: async (config) => {
-        setCancelledMessage(null);
-        await onResume(config);
-      },
-    }),
-    ...(onResumeToolCall && {
-      onResumeToolCall: (options) => {
-        setCancelledMessage(null);
-        onResumeToolCall(options);
-      },
-    }),
+    ...(onResume && { onResume }),
+    ...(onResumeToolCall && { onResumeToolCall }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
     adapters: {
       attachments: vercelAttachmentAdapter,

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -254,6 +254,15 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const providerIsRunning =
     chatHelpers.status === "submitted" || chatHelpers.status === "streaming";
   const isRunning = providerIsRunning || hasExecutingTools;
+  const wasProviderRunningRef = useRef(providerIsRunning);
+
+  useEffect(() => {
+    const wasProviderRunning = wasProviderRunningRef.current;
+    wasProviderRunningRef.current = providerIsRunning;
+    if (!wasProviderRunning && providerIsRunning) {
+      setCancelledMessage(null);
+    }
+  }, [providerIsRunning]);
 
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -235,6 +235,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});
+  const [cancelledChatId, setCancelledChatId] = useState<string | null>(null);
   const toolArgsKeyOrderCacheRef = useRef<Map<string, Map<string, string[]>>>(
     new Map(),
   );
@@ -251,11 +252,20 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     chatHelpers.status === "submitted" || chatHelpers.status === "streaming";
   const isRunning = providerIsRunning || hasExecutingTools;
 
+  useEffect(() => {
+    if (providerIsRunning) setCancelledChatId(null);
+  }, [providerIsRunning]);
+
   const messageTiming = useStreamingTiming(chatHelpers.messages, isRunning);
 
   // Flag the streaming message optimistic: its id can be swapped for a server
   // id mid-run, and the repository then drops the orphaned pre-swap id (#4037).
   const lastMessage = chatHelpers.messages.at(-1);
+  const isCancelled =
+    !providerIsRunning &&
+    lastMessage?.role === "assistant" &&
+    cancelledChatId !== null &&
+    cancelledChatId === chatHelpers.id;
   const optimisticMessageId =
     isRunning && lastMessage?.role === "assistant" ? lastMessage.id : undefined;
 
@@ -272,8 +282,15 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         mcpAppMetadataCache: mcpAppMetadataCacheRef.current,
         ...(optimisticMessageId && { optimisticMessageId }),
         ...(chatHelpers.error && { error: chatHelpers.error.message }),
+        ...(isCancelled && { isCancelled: true }),
       }),
-      [toolStatuses, messageTiming, optimisticMessageId, chatHelpers.error],
+      [
+        toolStatuses,
+        messageTiming,
+        optimisticMessageId,
+        chatHelpers.error,
+        isCancelled,
+      ],
     ),
   });
 
@@ -443,15 +460,19 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       runtimeRef.current.thread.import(exportedRepo);
     },
     onCancel: async () => {
+      const message = chatHelpers.messages.at(-1);
+      setCancelledChatId(message?.role === "assistant" ? chatHelpers.id : null);
       try {
         await chatHelpers.stop();
       } catch (error) {
         if (!(error instanceof Error && error.name === "AbortError")) {
+          setCancelledChatId(null);
           throw error;
         }
       }
     },
     onNew: async (message) => {
+      setCancelledChatId(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -471,6 +492,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       });
     },
     onEdit: async (message) => {
+      setCancelledChatId(null);
       const createMessage = (
         customToCreateMessage ?? toCreateMessage
       )<UI_MESSAGE>(message);
@@ -510,6 +532,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       );
     },
     onReload: async (parentId: string | null, config) => {
+      setCancelledChatId(null);
       lastRunConfigRef.current = config.runConfig;
       const newMessages = sliceMessagesUntil(chatHelpers.messages, parentId);
       chatHelpers.setMessages(newMessages);
@@ -523,6 +546,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       isError,
       modelContent,
     }) => {
+      setCancelledChatId(null);
       const options = { metadata: lastRunConfigRef.current };
       if (isError) {
         return Promise.resolve(
@@ -550,23 +574,35 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         );
       }
     },
-    onRespondToToolApproval: ({ approvalId, approved, reason }) =>
-      Promise.resolve(
+    onRespondToToolApproval: ({ approvalId, approved, reason }) => {
+      setCancelledChatId(null);
+      return Promise.resolve(
         chatHelpers.addToolApprovalResponse({
           id: approvalId,
           approved,
           ...(reason != null && { reason }),
           options: { metadata: lastRunConfigRef.current },
         }),
-      ),
+      );
+    },
     ...pickExternalStoreSharedOptions(adapter),
     ...(adapter.unstable_messageRepositoryInstance && {
       unstable_messageRepositoryInstance:
         adapter.unstable_messageRepositoryInstance,
     }),
     ...(suggestionAdapter ? { suggestions: generatedSuggestions } : {}),
-    ...(onResume && { onResume }),
-    ...(onResumeToolCall && { onResumeToolCall }),
+    ...(onResume && {
+      onResume: async (config) => {
+        setCancelledChatId(null);
+        await onResume(config);
+      },
+    }),
+    ...(onResumeToolCall && {
+      onResumeToolCall: async (options) => {
+        setCancelledChatId(null);
+        await onResumeToolCall(options);
+      },
+    }),
     ...(unstable_onBranchChange && { unstable_onBranchChange }),
     adapters: {
       attachments: vercelAttachmentAdapter,

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -470,7 +470,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     onCancel: async () => {
       const message = chatHelpers.messages.at(-1);
       setCancelledMessage(
-        message?.role === "assistant"
+        providerIsRunning && message?.role === "assistant"
           ? { chatId: chatHelpers.id, messageId: message.id }
           : null,
       );

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -131,7 +131,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
             message: cache,
             generatedFallbackMessages,
           },
-          state.metadata.isCancelled,
+          state.metadata.cancelledMessageIds,
         ),
     );
 

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -131,6 +131,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
             message: cache,
             generatedFallbackMessages,
           },
+          state.metadata.isCancelled,
         ),
     );
 

--- a/packages/core/src/runtime/utils/auto-status.test.ts
+++ b/packages/core/src/runtime/utils/auto-status.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getAutoStatus } from "./auto-status";
+
+describe("getAutoStatus", () => {
+  it.each([
+    [
+      { type: "running" },
+      getAutoStatus(true, true, false, false, undefined, true),
+    ],
+    [
+      { type: "requires-action", reason: "interrupt" },
+      getAutoStatus(true, false, true, true, undefined, true),
+    ],
+    [
+      { type: "requires-action", reason: "tool-calls" },
+      getAutoStatus(true, false, false, true, undefined, true),
+    ],
+  ])(
+    "keeps higher-priority statuses ahead of cancellation",
+    (expected, status) => {
+      expect(status).toMatchObject(expected);
+    },
+  );
+});

--- a/packages/core/src/runtime/utils/auto-status.test.ts
+++ b/packages/core/src/runtime/utils/auto-status.test.ts
@@ -2,23 +2,46 @@ import { describe, expect, it } from "vitest";
 import { getAutoStatus } from "./auto-status";
 
 describe("getAutoStatus", () => {
+  it("reports a cancelled message as incomplete", () => {
+    expect(
+      getAutoStatus(true, false, false, false, undefined, true),
+    ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+  });
+
+  it("keeps a cancelled message incomplete once a later message arrives", () => {
+    expect(
+      getAutoStatus(false, false, false, false, undefined, true),
+    ).toMatchObject({ type: "incomplete", reason: "cancelled" });
+  });
+
+  it("reports an uncancelled message as complete", () => {
+    expect(
+      getAutoStatus(true, false, false, false, undefined, false),
+    ).toMatchObject({ type: "complete", reason: "unknown" });
+  });
+
   it.each([
     [
+      "running",
       { type: "running" },
-      getAutoStatus(true, true, false, false, undefined, true),
+      [true, true, false, false, undefined] as const,
     ],
     [
+      "an interrupted tool call",
       { type: "requires-action", reason: "interrupt" },
-      getAutoStatus(true, false, true, true, undefined, true),
+      [true, false, true, true, undefined] as const,
     ],
     [
+      "a pending tool call",
       { type: "requires-action", reason: "tool-calls" },
-      getAutoStatus(true, false, false, true, undefined, true),
+      [true, false, false, true, undefined] as const,
     ],
-  ])(
-    "keeps higher-priority statuses ahead of cancellation",
-    (expected, status) => {
-      expect(status).toMatchObject(expected);
-    },
-  );
+    [
+      "an error",
+      { type: "incomplete", reason: "error", error: "boom" },
+      [true, false, false, false, "boom"] as const,
+    ],
+  ])("keeps %s ahead of cancellation", (_label, expected, args) => {
+    expect(getAutoStatus(...args, true)).toMatchObject(expected);
+  });
 });

--- a/packages/core/src/runtime/utils/auto-status.test.ts
+++ b/packages/core/src/runtime/utils/auto-status.test.ts
@@ -21,27 +21,37 @@ describe("getAutoStatus", () => {
   });
 
   it.each([
-    [
-      "running",
-      { type: "running" },
-      [true, true, false, false, undefined] as const,
-    ],
+    ["running", { type: "running" }, true, false, false, undefined],
     [
       "an interrupted tool call",
       { type: "requires-action", reason: "interrupt" },
-      [true, false, true, true, undefined] as const,
+      false,
+      true,
+      true,
+      undefined,
     ],
     [
       "a pending tool call",
       { type: "requires-action", reason: "tool-calls" },
-      [true, false, false, true, undefined] as const,
+      false,
+      false,
+      true,
+      undefined,
     ],
     [
       "an error",
       { type: "incomplete", reason: "error", error: "boom" },
-      [true, false, false, false, "boom"] as const,
+      false,
+      false,
+      false,
+      "boom",
     ],
-  ])("keeps %s ahead of cancellation", (_label, expected, args) => {
-    expect(getAutoStatus(...args, true)).toMatchObject(expected);
-  });
+  ])(
+    "keeps %s ahead of cancellation",
+    (_label, expected, isRunning, interrupted, pending, error) => {
+      expect(
+        getAutoStatus(true, isRunning, interrupted, pending, error, true),
+      ).toMatchObject(expected);
+    },
+  );
 });

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -88,15 +88,15 @@ export const getAutoStatus = (
     );
   }
 
-  if (isLast && isCancelled) return AUTO_STATUS_CANCELLED;
-
   return isLast && isRunning
     ? AUTO_STATUS_RUNNING
     : hasInterruptedToolCalls
       ? AUTO_STATUS_INTERRUPT
       : hasPendingToolCalls
         ? AUTO_STATUS_PENDING
-        : AUTO_STATUS_COMPLETE;
+        : isLast && isCancelled
+          ? AUTO_STATUS_CANCELLED
+          : AUTO_STATUS_COMPLETE;
 };
 
 export const getContentAutoStatus = (

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -36,6 +36,15 @@ const AUTO_STATUS_COMPLETE = Object.freeze(
     { [symbolAutoStatus]: true },
   ),
 );
+const AUTO_STATUS_CANCELLED = Object.freeze(
+  Object.assign(
+    {
+      type: "incomplete" as const,
+      reason: "cancelled" as const,
+    },
+    { [symbolAutoStatus]: true },
+  ),
+);
 
 const AUTO_STATUS_PENDING = Object.freeze(
   Object.assign(
@@ -66,6 +75,7 @@ export const getAutoStatus = (
   hasInterruptedToolCalls: boolean,
   hasPendingToolCalls: boolean,
   error?: ReadonlyJSONValue,
+  isCancelled?: boolean,
 ): MessageStatus => {
   if (isLast && error) {
     return Object.assign(
@@ -77,6 +87,8 @@ export const getAutoStatus = (
       { [symbolAutoStatus]: true },
     );
   }
+
+  if (isLast && isCancelled) return AUTO_STATUS_CANCELLED;
 
   return isLast && isRunning
     ? AUTO_STATUS_RUNNING

--- a/packages/core/src/runtime/utils/auto-status.ts
+++ b/packages/core/src/runtime/utils/auto-status.ts
@@ -94,7 +94,7 @@ export const getAutoStatus = (
       ? AUTO_STATUS_INTERRUPT
       : hasPendingToolCalls
         ? AUTO_STATUS_PENDING
-        : isLast && isCancelled
+        : isCancelled
           ? AUTO_STATUS_CANCELLED
           : AUTO_STATUS_COMPLETE;
 };

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -157,6 +157,30 @@ describe("convertExternalMessageChunk", () => {
     });
   });
 
+  it("cancels a joined chunk when any joined message was stopped", () => {
+    const generatedFallbackMessages = new WeakSet<object>();
+    const result = convertExternalMessageChunk(
+      {
+        inputs: [{}, {}],
+        outputs: [
+          { id: "m1", role: "assistant" as const, content: "first" },
+          { id: "m2", role: "assistant" as const, content: "second" },
+        ],
+      },
+      0,
+      1,
+      false,
+      undefined,
+      { message: undefined, generatedFallbackMessages },
+      new Set(["m2"]),
+    );
+
+    expect(result.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
   it("cancels an earlier message that is no longer the last one", () => {
     const cancelled = new Set(["m1"]);
     const generatedFallbackMessages = new WeakSet<object>();

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -6,29 +6,6 @@ import {
   type ExternalMessageConverterCallback,
   type ExternalMessageConverterCallbackResult,
 } from "./external-message-conversion";
-import { getAutoStatus } from "./auto-status";
-
-describe("getAutoStatus", () => {
-  it.each([
-    [
-      { type: "running" },
-      getAutoStatus(true, true, false, false, undefined, true),
-    ],
-    [
-      { type: "requires-action", reason: "interrupt" },
-      getAutoStatus(true, false, true, true, undefined, true),
-    ],
-    [
-      { type: "requires-action", reason: "tool-calls" },
-      getAutoStatus(true, false, false, true, undefined, true),
-    ],
-  ])(
-    "keeps higher-priority statuses ahead of cancellation",
-    (expected, status) => {
-      expect(status).toMatchObject(expected);
-    },
-  );
-});
 
 describe("convertExternalMessageCallback", () => {
   it.each([

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -110,4 +110,49 @@ describe("convertExternalMessageChunk", () => {
 
     expect(second).toBe(first);
   });
+
+  it("replaces a cached complete status after cancellation", () => {
+    const input = {};
+    const chunk = {
+      inputs: [input],
+      outputs: [{ role: "assistant" as const, content: "partial" }],
+    };
+    const generatedFallbackMessages = new WeakSet<object>();
+    const first = convertExternalMessageChunk(chunk, 0, 1, false, undefined, {
+      message: undefined,
+      generatedFallbackMessages,
+    });
+
+    const second = convertExternalMessageChunk(
+      chunk,
+      0,
+      1,
+      false,
+      undefined,
+      { message: first, generatedFallbackMessages },
+      true,
+    );
+
+    expect(first.status).toMatchObject({ type: "complete", reason: "unknown" });
+    expect(second).not.toBe(first);
+    expect(second.status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+
+    const failed = convertExternalMessageChunk(
+      chunk,
+      0,
+      1,
+      false,
+      "failed",
+      { message: second, generatedFallbackMessages },
+      true,
+    );
+    expect(failed.status).toMatchObject({
+      type: "incomplete",
+      reason: "error",
+      error: "failed",
+    });
+  });
 });

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -6,6 +6,29 @@ import {
   type ExternalMessageConverterCallback,
   type ExternalMessageConverterCallbackResult,
 } from "./external-message-conversion";
+import { getAutoStatus } from "./auto-status";
+
+describe("getAutoStatus", () => {
+  it.each([
+    [
+      { type: "running" },
+      getAutoStatus(true, true, false, false, undefined, true),
+    ],
+    [
+      { type: "requires-action", reason: "interrupt" },
+      getAutoStatus(true, false, true, true, undefined, true),
+    ],
+    [
+      { type: "requires-action", reason: "tool-calls" },
+      getAutoStatus(true, false, false, true, undefined, true),
+    ],
+  ])(
+    "keeps higher-priority statuses ahead of cancellation",
+    (expected, status) => {
+      expect(status).toMatchObject(expected);
+    },
+  );
+});
 
 describe("convertExternalMessageCallback", () => {
   it.each([

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -115,8 +115,9 @@ describe("convertExternalMessageChunk", () => {
     const input = {};
     const chunk = {
       inputs: [input],
-      outputs: [{ role: "assistant" as const, content: "partial" }],
+      outputs: [{ id: "m1", role: "assistant" as const, content: "partial" }],
     };
+    const cancelled = new Set(["m1"]);
     const generatedFallbackMessages = new WeakSet<object>();
     const first = convertExternalMessageChunk(chunk, 0, 1, false, undefined, {
       message: undefined,
@@ -130,7 +131,7 @@ describe("convertExternalMessageChunk", () => {
       false,
       undefined,
       { message: first, generatedFallbackMessages },
-      true,
+      cancelled,
     );
 
     expect(first.status).toMatchObject({ type: "complete", reason: "unknown" });
@@ -147,12 +148,39 @@ describe("convertExternalMessageChunk", () => {
       false,
       "failed",
       { message: second, generatedFallbackMessages },
-      true,
+      cancelled,
     );
     expect(failed.status).toMatchObject({
       type: "incomplete",
       reason: "error",
       error: "failed",
+    });
+  });
+
+  it("cancels an earlier message that is no longer the last one", () => {
+    const cancelled = new Set(["m1"]);
+    const generatedFallbackMessages = new WeakSet<object>();
+    const build = (id: string, idx: number) =>
+      convertExternalMessageChunk(
+        {
+          inputs: [{}],
+          outputs: [{ id, role: "assistant" as const, content: "text" }],
+        },
+        idx,
+        2,
+        false,
+        undefined,
+        { message: undefined, generatedFallbackMessages },
+        cancelled,
+      );
+
+    expect(build("m1", 0).status).toMatchObject({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+    expect(build("m2", 1).status).toMatchObject({
+      type: "complete",
+      reason: "unknown",
     });
   });
 });

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -387,7 +387,10 @@ export const convertExternalMessageChunk = <T>(
   const isLast = idx === chunkCount - 1;
   const joined = joinExternalMessages(message.outputs);
   const isCancelled =
-    joined.id != null && cancelledMessageIds?.has(joined.id) === true;
+    cancelledMessageIds !== undefined &&
+    message.outputs.some(
+      (output) => output.id != null && cancelledMessageIds.has(output.id),
+    );
   const hasInterruptedToolCalls =
     typeof joined.content === "object" &&
     joined.content.some(isInterruptedToolCall);

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -46,6 +46,7 @@ export type ExternalMessageConverterMessage =
 export type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 
@@ -381,6 +382,7 @@ export const convertExternalMessageChunk = <T>(
   isRunning: boolean,
   error: ReadonlyJSONValue | undefined,
   cache?: ExternalMessageConversionCache,
+  isCancelled?: boolean,
 ) => {
   const isLast = idx === chunkCount - 1;
   const joined = joinExternalMessages(message.outputs);
@@ -396,6 +398,7 @@ export const convertExternalMessageChunk = <T>(
     hasInterruptedToolCalls,
     hasPendingToolCalls,
     isLast ? error : undefined,
+    isCancelled,
   );
   const fallbackId = `${FALLBACK_ID_PREFIX}${idx}`;
 
@@ -491,6 +494,8 @@ export const convertExternalMessages = <T extends WeakKey>(
       chunks.length,
       isRunning,
       metadata.error,
+      undefined,
+      metadata.isCancelled,
     ),
   );
   return completeExternalMessageConversion(result, metadata.error);

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -389,7 +389,10 @@ export const convertExternalMessageChunk = <T>(
   const isCancelled =
     cancelledMessageIds !== undefined &&
     message.outputs.some(
-      (output) => output.id != null && cancelledMessageIds.has(output.id),
+      (output) =>
+        output.role !== "tool" &&
+        output.id != null &&
+        cancelledMessageIds.has(output.id),
     );
   const hasInterruptedToolCalls =
     typeof joined.content === "object" &&

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -46,6 +46,7 @@ export type ExternalMessageConverterMessage =
 export type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
+  /** Marks the current last message as cancelled during automatic status derivation. */
   readonly isCancelled?: boolean;
   readonly messageTiming?: Record<string, MessageTiming>;
 };

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -46,8 +46,7 @@ export type ExternalMessageConverterMessage =
 export type ExternalMessageConverterMetadata = {
   readonly toolStatuses?: Record<string, ToolExecutionStatus>;
   readonly error?: ReadonlyJSONValue;
-  /** Marks the current last message as cancelled during automatic status derivation. */
-  readonly isCancelled?: boolean;
+  readonly cancelledMessageIds?: ReadonlySet<string>;
   readonly messageTiming?: Record<string, MessageTiming>;
 };
 
@@ -383,10 +382,12 @@ export const convertExternalMessageChunk = <T>(
   isRunning: boolean,
   error: ReadonlyJSONValue | undefined,
   cache?: ExternalMessageConversionCache,
-  isCancelled?: boolean,
+  cancelledMessageIds?: ReadonlySet<string>,
 ) => {
   const isLast = idx === chunkCount - 1;
   const joined = joinExternalMessages(message.outputs);
+  const isCancelled =
+    joined.id != null && cancelledMessageIds?.has(joined.id) === true;
   const hasInterruptedToolCalls =
     typeof joined.content === "object" &&
     joined.content.some(isInterruptedToolCall);
@@ -496,7 +497,7 @@ export const convertExternalMessages = <T extends WeakKey>(
       isRunning,
       metadata.error,
       undefined,
-      metadata.isCancelled,
+      metadata.cancelledMessageIds,
     ),
   );
   return completeExternalMessageConversion(result, metadata.error);


### PR DESCRIPTION
## problem

stopping a partial AI SDK response leaves the last assistant message with `status: { type: "complete" }`. consumers therefore cannot distinguish a user-stopped response from a normally completed one, so a "you stopped this response" affordance (the kit already ships `StoppedRun`) has nothing to key off. this reproduces on current main and differs from LocalRuntime, which reports `incomplete` / `cancelled`.

closes #6745.

## root cause

the AI SDK cancel path stops the provider and consumes the expected `AbortError`, but no cancellation state reaches external-message conversion. once the provider and any client-side tool execution stop, automatic status derivation falls through to `complete`.

## change

`useAISDKRuntime` records the ids of assistant messages whose run the user stopped, scoped to the current AI SDK chat, and passes them through converter metadata as `cancelledMessageIds`. `convertExternalMessageChunk` resolves the flag per message, so `getAutoStatus` reports `incomplete` / `cancelled` for a stopped response and keeps reporting it once later turns arrive. running, tool-interrupt, pending-tool and error states retain precedence.

cancellation is retracted by exactly one rule: a provider run that starts while the stopped message is still the tail resumes that response, so its cancellation is dropped; a run that starts a new response leaves the stopped one marked. that single rule replaces per-handler resets, so `onResume`, `onResumeToolCall` and `onRespondToToolApproval` stay passed through untouched. calling `cancelRun()` while idle does not mark an already-completed response, while an executing client tool still counts as an active run.

the record is runtime-local. AI SDK `UIMessage` storage does not carry assistant-ui message status, so the status survives later turns within the session but not a remount; persisting it would need a new storage metadata contract. other adapters keep their provider-specific cancellation handling and ignore the new metadata field.

## verification

- the two runtime regressions fail as `complete` / `unknown` against the pre-fix runtime and pass as `incomplete` / `cancelled` with it.
- `@assistant-ui/ai-sdk` 263 tests and `@assistant-ui/core` 1648 tests pass, including new cases for cross-turn durability, cancellation retraction on resume, per-message resolution in the converter, status precedence, cached-status replacement and idle cancel.
- `@assistant-ui/react` (529), `@assistant-ui/eve` (161), `@assistant-ui/react-langchain` (125), `@assistant-ui/react-langgraph` (305) and `@assistant-ui/react-google-adk` (326) pass unchanged.
- `scripts/check-api-surface.mjs` passes over all 40 surface files, including the full `tsc --noEmit`.
- `pnpm lint` and `pnpm changesets:check` pass.

## public surface

`ExternalMessageConverterMetadata` gains an optional `cancelledMessageIds`, and `getAutoStatus` gains an optional trailing `isCancelled`. both are additive. stopped-run status behavior changes in `@assistant-ui/ai-sdk`. patch changesets for `@assistant-ui/ai-sdk` and `@assistant-ui/core`; api-surface snapshots regenerated. no documentation or template changes.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yJfPrqIcFLtwChuRfSFNjktAtaImK7KgGFgiHqqRP63-avCcMyGix5CEqzk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
