### PR TITLE
fix(react): keep trigger callbacks commit-safe

### DIFF
--- a/.changeset/calm-triggers-commit.md
+++ b/.changeset/calm-triggers-commit.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): keep trigger callbacks commit-safe

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverAction.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverAction.tsx
@@ -5,7 +5,7 @@ import type {
   Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
-import { useEffect, useRef, type FC } from "react";
+import { useEffect, useInsertionEffect, useRef, type FC } from "react";
 import { useTriggerBehaviorRegistration } from "./TriggerPopover";
 import type { TriggerBehavior } from "./triggerSelectionResource";
 
@@ -42,7 +42,9 @@ export const ComposerPrimitiveTriggerPopoverAction: FC<
 > = ({ formatter, onExecute, removeOnExecute }) => {
   const { register } = useTriggerBehaviorRegistration();
   const onExecuteRef = useRef(onExecute);
-  onExecuteRef.current = onExecute;
+  useInsertionEffect(() => {
+    onExecuteRef.current = onExecute;
+  }, [onExecute]);
 
   useEffect(() => {
     const behavior: TriggerBehavior = {

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverBehavior.test.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverBehavior.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { Suspense, type ReactNode } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Unstable_TriggerItem } from "@assistant-ui/core";
+import type { TriggerBehavior } from "./triggerSelectionResource";
+
+const mocks = vi.hoisted(() => ({ register: vi.fn() }));
+
+vi.mock("./TriggerPopover", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./TriggerPopover")>()),
+  useTriggerBehaviorRegistration: () => ({ register: mocks.register }),
+}));
+
+import { ComposerPrimitiveTriggerPopoverAction } from "./TriggerPopoverAction";
+import { ComposerPrimitiveTriggerPopoverDirective } from "./TriggerPopoverDirective";
+
+const item: Unstable_TriggerItem = {
+  id: "item-1",
+  type: "test",
+  label: "Item",
+};
+
+const verifyCommittedCallback = async (
+  renderBehavior: (callback: (item: Unstable_TriggerItem) => void) => ReactNode,
+  invoke: (behavior: TriggerBehavior) => void,
+) => {
+  let behavior: TriggerBehavior | undefined;
+  mocks.register.mockImplementation((next: TriggerBehavior) => {
+    behavior = next;
+    return () => {};
+  });
+
+  let suspend = false;
+  const suspended = new Promise<never>(() => {});
+  const renderProbe = vi.fn();
+  const Suspender = () => {
+    if (suspend) throw suspended;
+    return null;
+  };
+  const Probe = () => {
+    renderProbe();
+    return null;
+  };
+  const View = ({
+    callback,
+  }: {
+    callback: (item: Unstable_TriggerItem) => void;
+  }) => (
+    <Suspense fallback={null}>
+      {renderBehavior(callback)}
+      <Probe />
+      <Suspender />
+    </Suspense>
+  );
+
+  const committed = vi.fn();
+  const abandoned = vi.fn();
+  const view = render(<View callback={committed} />);
+
+  await waitFor(() => expect(behavior).toBeDefined());
+  renderProbe.mockClear();
+
+  suspend = true;
+  view.rerender(<View callback={abandoned} />);
+  await waitFor(() => expect(renderProbe).toHaveBeenCalled());
+
+  invoke(behavior!);
+  expect(committed).toHaveBeenCalledExactlyOnceWith(item);
+  expect(abandoned).not.toHaveBeenCalled();
+
+  suspend = false;
+  view.rerender(<View callback={abandoned} />);
+  invoke(behavior!);
+  expect(abandoned).toHaveBeenCalledExactlyOnceWith(item);
+};
+
+describe("TriggerPopover behavior callbacks", () => {
+  beforeEach(() => {
+    mocks.register.mockReset();
+  });
+
+  it("keeps the committed action callback during abandoned renders", async () => {
+    await verifyCommittedCallback(
+      (onExecute) => (
+        <ComposerPrimitiveTriggerPopoverAction onExecute={onExecute} />
+      ),
+      (behavior) => {
+        if (behavior.kind !== "action") throw new Error("Expected action");
+        behavior.onExecute(item);
+      },
+    );
+  });
+
+  it("keeps the committed directive callback during abandoned renders", async () => {
+    await verifyCommittedCallback(
+      (onInserted) => (
+        <ComposerPrimitiveTriggerPopoverDirective onInserted={onInserted} />
+      ),
+      (behavior) => {
+        if (behavior.kind !== "directive") {
+          throw new Error("Expected directive");
+        }
+        behavior.onInserted?.(item);
+      },
+    );
+  });
+});

--- a/packages/react/src/primitives/composer/trigger/TriggerPopoverDirective.tsx
+++ b/packages/react/src/primitives/composer/trigger/TriggerPopoverDirective.tsx
@@ -5,7 +5,7 @@ import type {
   Unstable_TriggerItem,
 } from "@assistant-ui/core";
 import { unstable_defaultDirectiveFormatter } from "@assistant-ui/core";
-import { useEffect, useRef, type FC } from "react";
+import { useEffect, useInsertionEffect, useRef, type FC } from "react";
 import { useTriggerBehaviorRegistration } from "./TriggerPopover";
 import type { TriggerBehavior } from "./triggerSelectionResource";
 
@@ -39,7 +39,9 @@ export const ComposerPrimitiveTriggerPopoverDirective: FC<
 > = ({ formatter, onInserted }) => {
   const { register } = useTriggerBehaviorRegistration();
   const onInsertedRef = useRef(onInserted);
-  onInsertedRef.current = onInserted;
+  useInsertionEffect(() => {
+    onInsertedRef.current = onInserted;
+  }, [onInserted]);
 
   useEffect(() => {
     const behavior: TriggerBehavior = {


### PR DESCRIPTION
## Problem

Trigger action and directive callbacks can be replaced by props from a concurrent render that never commits. A committed popover can then execute callbacks from an abandoned account, workspace, or configuration render.

A focused Suspense reproduction on current main committed callback A, rendered callback B behind a suspended boundary, and invoked the still-committed trigger behavior. Both action and directive behaviors incorrectly called B.

## Root cause

`TriggerPopoverAction` and `TriggerPopoverDirective` wrote their callback refs during render. Concurrent renders can mutate those shared refs even when React abandons the render.

## Change

Publish callback ref updates from `useInsertionEffect`, so registered trigger behaviors observe only committed callback props while keeping their existing stable registration. Add regression coverage for abandoned and subsequently committed renders for both behavior kinds.

## Verification

- Confirmed both regression cases fail before the fix and pass afterward
- `vitest run src/primitives/composer/trigger` (58 tests, type checking enabled)
- Focused `oxlint` and `oxfmt --check` on the changed files
- `aui-build` in `packages/react`
- `node scripts/check-changesets.mjs`

## Public surface

`@assistant-ui/react` behavior fix with a patch changeset. No exports, documentation, templates, or API-reference output changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CC_YOxp3iHZ_UDkxm9A0kzxlcRrGTG2-Oe9n6nngs_4j5si1rLATk5GpJIw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->