### PR TITLE
fix(core): keep a pending human() interrupt when execution starts

### DIFF
--- a/.changeset/human-interrupt-before-execution-start.md
+++ b/.changeset/human-interrupt-before-execution-start.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep a frontend tool's pending `human()` interrupt when execution starts
+
+a tool whose `execute` awaits `human()` before any other await had its `interrupt` status overwritten by the `executing` status the execution-start callback writes, so the approval prompt never rendered and the run never settled.

--- a/examples/with-webmcp/app/toolkit.tsx
+++ b/examples/with-webmcp/app/toolkit.tsx
@@ -36,7 +36,7 @@ export default defineToolkit({
     // the approval prompt behind a disclosure the user has no reason to open.
     display: "standalone",
     description:
-      "Remove every completed task from the user's task list. Requires the user's approval.",
+      "Remove every completed task from the user's task list. The UI asks the user to confirm before anything is removed, so call this directly instead of asking first.",
     parameters: z.object({}),
     execute: async (_args, { human }) => {
       "use client";

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -137,6 +137,17 @@ produces: every entry pending in a snapshot closes in the same
 every call, and an execution parked on `human()` reports `interrupt` rather
 than `executing`, which `_hasExecutingTools` does not count.
 
+That holds even when `execute` opens with `await human()`. The stream
+fires `onExecutionStart` only after `execute` returns, because until then
+it cannot tell a frontend tool from one without an `execute`, so by the
+time the callback runs the body has already parked its resolver and set
+`interrupt`. `_onExecutionStart` still registers the execution for
+`_onExecutionEnd` but leaves the status alone when this execution's own
+request is pending. The check is keyed on the request's execution id,
+not on the status map: a pipeline restart (F.4) clears `_executing` but
+keeps the status map, and a stale `interrupt` must not stop the fresh
+execution from reporting `executing` (#6763).
+
 A call the adapter reports as client-owned (A.9) closes as soon as its
 arguments parse, because the adapter has already said the provider will
 not answer it. Ownership says who answers a call, not whether it is

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -247,6 +247,96 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
+  it("keeps a human-input interrupt that execute requests before its first await", async () => {
+    const execute = vi.fn(async (_args, { human }) => ({
+      approved: (await human({ request: "approve" })) === true,
+    }));
+    const getTools = () => ({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    let statuses: Record<string, ToolExecutionStatus> = {};
+    const onStatusesChange = (s: ReadonlyMap<string, ToolExecutionStatus>) => {
+      statuses = Object.fromEntries(s);
+    };
+
+    const tracker = new ToolInvocationTracker(getTools, {
+      onResult,
+      onStatusesChange,
+    });
+    tracker.setState(createState([], false));
+    tracker.setState(
+      createState(
+        [createAssistantMessage('{"query":"London"}', { query: "London" })],
+        false,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(statuses["tool-1"]?.type).toBe("interrupt");
+    });
+
+    expect(tracker.resume("tool-1", true)).toBe(true);
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolCallId: "tool-1",
+          result: { approved: true },
+        }),
+      );
+    });
+    expect(statuses).toEqual({});
+  });
+
+  it("marks a fresh execution as executing when an earlier one left a human-input request behind", async () => {
+    const execute = vi
+      .fn()
+      .mockImplementationOnce((_args, { human }) =>
+        human({ request: "approve" }),
+      )
+      .mockImplementationOnce(() => new Promise(() => {}));
+    const getTools = () => ({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    let statuses: Record<string, ToolExecutionStatus> = {};
+    const tracker = new ToolInvocationTracker(getTools, {
+      onResult: vi.fn(),
+      onStatusesChange: (s: ReadonlyMap<string, ToolExecutionStatus>) => {
+        statuses = Object.fromEntries(s);
+      },
+    });
+    tracker.setState(createState([], false));
+    tracker.setState(
+      createState(
+        [createAssistantMessage('{"query":"London"}', { query: "London" })],
+        false,
+      ),
+    );
+    await waitFor(() => {
+      expect(statuses["tool-1"]?.type).toBe("interrupt");
+    });
+
+    killPipeline(tracker);
+    tracker.setState(
+      createState(
+        [createAssistantMessage('{"query":"Paris"}', { query: "Paris" })],
+        false,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(statuses["tool-1"]?.type).toBe("executing");
+    });
+  });
+
   it("does not auto-submit a parse-error result for a non-executable tool whose divergent argsText closes", async () => {
     // Same close-gating mismatch as the executable case, but for a tool with
     // no frontend execute. Closing on the divergent complete snapshot would

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -504,6 +504,7 @@ export class ToolInvocationTracker {
     if (entry.skipExecute) return;
 
     this._executing.add(executionId!);
+    if (this._humanInput.get(toolCallId)?.executionId === executionId) return;
     this._setStatus(toolCallId, { type: "executing" });
   }
 

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -504,6 +504,7 @@ export class ToolInvocationTracker {
     if (entry.skipExecute) return;
 
     this._executing.add(executionId!);
+    // execute can park human() before onExecutionStart; preserve this execution's interrupt.
     if (this._humanInput.get(toolCallId)?.executionId === executionId) return;
     this._setStatus(toolCallId, { type: "executing" });
   }

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1211,6 +1211,7 @@ describe("useEveAgentRuntime extras wiring", () => {
     mockUseEveAgent.mockReturnValue(agent as never);
     const { result, rerender } = renderHook(() => useEveAgentRuntime());
 
+    let humanRequests = 0;
     const humanRejections: unknown[] = [];
     act(() => {
       result.current.registerModelContextProvider({
@@ -1222,6 +1223,7 @@ describe("useEveAgentRuntime extras wiring", () => {
                 _args: unknown,
                 context: { human: (payload: unknown) => Promise<unknown> },
               ) => {
+                humanRequests += 1;
                 try {
                   return await context.human({ request: "approve" });
                 } catch (error) {
@@ -1241,7 +1243,7 @@ describe("useEveAgentRuntime extras wiring", () => {
     rerender();
 
     await waitFor(() => {
-      expect(result.current.thread.getState().isRunning).toBe(true);
+      expect(humanRequests).toBe(2);
     });
 
     act(() => {


### PR DESCRIPTION
Closes #6763

A frontend tool whose `execute` starts with `await human(...)` never shows its approval prompt on the AI SDK runtime: the part sits in its running state, the thread never settles, and the parked `human()` promise is never resumed. Found by driving `examples/with-webmcp` with a real model; its `clear_completed_tasks` tool is exactly this shape.

## Mechanism

`ToolExecutionStream` calls `execute` first and fires `onExecutionStart` only after it returns, because it cannot know the tool is frontend-executed until then. The tool body runs synchronously up to its first `await`, so when that await is `human()`, the tracker has already parked the resolver and set status `interrupt` by the time `_onExecutionStart` runs. That handler then wrote `executing` unconditionally, replacing the interrupt. `convertMessage` only emits `part.interrupt` for status `interrupt`, so `render` never sees it.

## Fix

`_onExecutionStart` still registers the execution (so `_onExecutionEnd` and the settled-resolver bookkeeping are unchanged) but skips the `executing` write when this execution's own human-input request is already pending. The check is keyed on `_humanInput`'s execution id rather than on the status map: a pipeline restart clears `_executing` but leaves `_statuses` and `_humanInput` alone, and a status-keyed check would have suppressed the write for the fresh execution that follows.

## Tests

- `keeps a human-input interrupt that execute requests before its first await`: drives the `execute` path (the existing `human()` test uses `streamCall`, which never reaches `onExecutionStart`) with a synchronous `human()`, asserts the status stays `interrupt`, then resumes and asserts the result lands and the status clears. Fails on main with `executing`.
- `marks a fresh execution as executing when an earlier one left a human-input request behind`: kills the pipeline while a request is pending, promotes a new execution with changed args, asserts it reports `executing`. Fails with a status-keyed guard.

The second commit rewords the example's `clear_completed_tasks` description. With "Requires the user's approval" the model asked in prose first on every run and only called the tool after a "yes", so the real approval UI took two turns to appear. The gate is enforced by `human()`, not by the model.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HwQyUxcC19Y_u9W_QJ3e7zC9e4-IsprtEbEosa-CbdHnmjmRoxfoGQiyHFs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->