### PR TITLE
feat(docs): home thread and chat markdown follow the site design law

### DIFF
--- a/apps/docs/components/assistant-ui/elements/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/elements/markdown-text.tsx
@@ -4,7 +4,6 @@ import "@assistant-ui/react-markdown/styles/dot.css";
 import "katex/dist/katex.min.css";
 
 import {
-  type CodeHeaderProps,
   MarkdownTextPrimitive,
   unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
   useIsMarkdownCodeBlock,
@@ -12,18 +11,20 @@ import {
 import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import { type FC, memo, useState } from "react";
-import { CheckIcon, CopyIcon } from "lucide-react";
+import { type ComponentProps, memo } from "react";
 import dynamic from "next/dynamic";
 
-import { SyntaxHighlighter } from "@/components/assistant-ui/elements/shiki-highlighter.aui";
-import { TooltipIconButton } from "@/components/assistant-ui/elements/tooltip-icon-button";
+import {
+  type HighlighterProps,
+  SyntaxHighlighter as ShikiSyntaxHighlighter,
+} from "@/components/assistant-ui/elements/shiki-highlighter.aui";
+import { CodeBlock } from "@/components/ui/code-block";
 import { preprocessMath } from "@/lib/markdown-math";
 import { cn } from "@/lib/utils";
 
 // The diagram engine only loads once a mermaid fence arrives, so every other
 // route that renders markdown keeps it out of its initial chunk.
-const MermaidDiagram = dynamic(
+const LazyMermaidDiagram = dynamic(
   () =>
     import("@/components/assistant-ui/elements/mermaid-diagram.aui").then(
       (mod) => mod.MermaidDiagram,
@@ -33,11 +34,38 @@ const MermaidDiagram = dynamic(
     loading: () => (
       <div
         aria-hidden
-        className="aui-mermaid-skeleton bg-muted h-32 animate-pulse rounded-b-lg"
+        className="aui-mermaid-skeleton bg-muted rounded-b-document h-32 animate-pulse"
       />
     ),
   },
 );
+
+// Fenced code and mermaid fences render inside the site's CodeBlock, the same
+// code sheet the docs pages use, so the kit highlighter only supplies tokens
+// and its own chrome is reset.
+const codeSheetReset =
+  "[&_pre]:rounded-none [&_pre]:border-0 [&_pre]:bg-transparent! [&_pre]:px-3.5 [&_pre]:py-0 [&_pre]:text-[12.5px] [&_pre]:overflow-visible";
+
+const SyntaxHighlighter = (props: HighlighterProps) => (
+  <CodeBlock
+    title={props.language || undefined}
+    copyText={props.code.trim()}
+    className="my-3"
+  >
+    <ShikiSyntaxHighlighter {...props} className={codeSheetReset} />
+  </CodeBlock>
+);
+
+const MermaidDiagram = (props: ComponentProps<typeof LazyMermaidDiagram>) => (
+  <CodeBlock title="mermaid" copyText={props.code.trim()} className="my-3">
+    <LazyMermaidDiagram
+      {...props}
+      className="-my-1.5 rounded-none bg-transparent"
+    />
+  </CodeBlock>
+);
+
+const NoCodeHeader = () => null;
 
 const remarkPlugins = [remarkGfm, remarkMath];
 const rehypePlugins = [rehypeKatex];
@@ -52,7 +80,7 @@ const MarkdownTextImpl = () => {
       rehypePlugins={rehypePlugins}
       componentsByLanguage={componentsByLanguage}
       preprocess={preprocessMath}
-      className="aui-md"
+      className="aui-md [&_.katex-display]:overflow-x-auto [&_.katex-display]:overflow-y-hidden [&_.katex-display]:py-1"
       components={defaultComponents}
       defer
     />
@@ -61,56 +89,9 @@ const MarkdownTextImpl = () => {
 
 export const MarkdownText = memo(MarkdownTextImpl);
 
-const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const onCopy = () => {
-    if (!code || isCopied) return;
-    copyToClipboard(code);
-  };
-
-  return (
-    <div className="aui-code-header-root border-border/50 bg-muted/50 mt-3 flex items-center justify-between rounded-t-xl border border-b-0 px-3.5 py-1.5 text-xs">
-      <span className="aui-code-header-language text-muted-foreground font-medium lowercase">
-        {language}
-      </span>
-      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
-        {!isCopied && (
-          <CopyIcon className="animate-in zoom-in-75 fade-in duration-150" />
-        )}
-        {isCopied && (
-          <CheckIcon className="animate-in zoom-in-50 fade-in duration-200 ease-out" />
-        )}
-      </TooltipIconButton>
-    </div>
-  );
-};
-
-const useCopyToClipboard = ({
-  copiedDuration = 3000,
-}: {
-  copiedDuration?: number;
-} = {}) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
-
-  const copyToClipboard = (value: string) => {
-    if (!value || typeof navigator === "undefined" || !navigator.clipboard) {
-      return;
-    }
-
-    navigator.clipboard.writeText(value).then(
-      () => {
-        setIsCopied(true);
-        setTimeout(() => setIsCopied(false), copiedDuration);
-      },
-      () => {},
-    );
-  };
-
-  return { isCopied, copyToClipboard };
-};
-
 const defaultComponents = memoizeMarkdownComponents({
   SyntaxHighlighter,
+  CodeHeader: NoCodeHeader,
   h1: ({ className, ...props }) => (
     <h1
       className={cn(
@@ -228,7 +209,7 @@ const defaultComponents = memoizeMarkdownComponents({
   th: ({ className, ...props }) => (
     <th
       className={cn(
-        "aui-md-th bg-muted px-3 py-1.5 text-start font-medium first:rounded-ss-lg last:rounded-se-lg [[align=center]]:text-center [[align=right]]:text-right",
+        "aui-md-th border-foreground/10 bg-foreground/[0.025] dark:bg-foreground/[0.04] first:rounded-ss-document last:rounded-se-document border-b px-3 py-1.5 text-start font-medium [[align=center]]:text-center [[align=right]]:text-right",
         className,
       )}
       {...props}
@@ -237,20 +218,14 @@ const defaultComponents = memoizeMarkdownComponents({
   td: ({ className, ...props }) => (
     <td
       className={cn(
-        "aui-md-td border-muted-foreground/20 border-s border-b px-3 py-1.5 text-start last:border-e [[align=center]]:text-center [[align=right]]:text-right",
+        "aui-md-td border-foreground/10 border-b px-3 py-1.5 text-start [[align=center]]:text-center [[align=right]]:text-right",
         className,
       )}
       {...props}
     />
   ),
   tr: ({ className, ...props }) => (
-    <tr
-      className={cn(
-        "aui-md-tr m-0 border-b p-0 first:border-t [&:last-child>td:first-child]:rounded-es-lg [&:last-child>td:last-child]:rounded-ee-lg",
-        className,
-      )}
-      {...props}
-    />
+    <tr className={cn("aui-md-tr m-0 p-0", className)} {...props} />
   ),
   li: ({ className, ...props }) => (
     <li className={cn("aui-md-li leading-relaxed", className)} {...props} />
@@ -289,5 +264,4 @@ const defaultComponents = memoizeMarkdownComponents({
       />
     );
   },
-  CodeHeader,
 });

--- a/apps/docs/components/assistant-ui/elements/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/elements/markdown-text.tsx
@@ -49,7 +49,7 @@ const codeSheetReset =
 const SyntaxHighlighter = (props: HighlighterProps) => (
   <CodeBlock
     title={props.language || undefined}
-    copyText={props.code.trim()}
+    copyText={props.code}
     className="my-3"
   >
     <ShikiSyntaxHighlighter {...props} className={codeSheetReset} />
@@ -57,7 +57,7 @@ const SyntaxHighlighter = (props: HighlighterProps) => (
 );
 
 const MermaidDiagram = (props: ComponentProps<typeof LazyMermaidDiagram>) => (
-  <CodeBlock title="mermaid" copyText={props.code.trim()} className="my-3">
+  <CodeBlock title="mermaid" copyText={props.code} className="my-3">
     <LazyMermaidDiagram
       {...props}
       className="-my-1.5 rounded-none bg-transparent"

--- a/apps/docs/components/pages/docs/assistant/markdown.tsx
+++ b/apps/docs/components/pages/docs/assistant/markdown.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import "@assistant-ui/react-markdown/styles/dot.css";
-import "react-shiki/css";
 
 import {
-  type CodeHeaderProps,
   MarkdownTextPrimitive,
   type SyntaxHighlighterProps,
   unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
@@ -12,7 +10,6 @@ import {
 } from "@assistant-ui/react-markdown";
 import remarkGfm from "remark-gfm";
 import {
-  type CSSProperties,
   type FC,
   type ReactNode,
   memo,
@@ -21,11 +18,10 @@ import {
   useRef,
   useState,
 } from "react";
-import { CheckIcon, CopyIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import ShikiHighlighter from "react-shiki";
 import Link from "next/link";
-import { useCopyToClipboard } from "@assistant-ui/ui/hooks/use-copy-to-clipboard";
+import { CodeBlock } from "@/components/ui/code-block";
 
 const MarkdownTextImpl = () => {
   return (
@@ -39,33 +35,6 @@ const MarkdownTextImpl = () => {
 };
 
 export const MarkdownText = memo(MarkdownTextImpl);
-
-const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const onCopy = () => {
-    if (!code || isCopied) return;
-    copyToClipboard(code);
-  };
-
-  return (
-    <div className="border-border/50 bg-muted/50 mt-2.5 flex items-center justify-between rounded-t-lg border border-b-0 px-3 py-1.5 text-xs">
-      <span className="text-muted-foreground font-medium lowercase">
-        {language}
-      </span>
-      <button
-        type="button"
-        onClick={onCopy}
-        className="text-muted-foreground hover:bg-muted hover:text-foreground flex size-6 items-center justify-center rounded-md transition-colors"
-      >
-        {isCopied ? (
-          <CheckIcon className="size-3.5" />
-        ) : (
-          <CopyIcon className="size-3.5" />
-        )}
-      </button>
-    </div>
-  );
-};
 
 const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
   const [expanded, setExpanded] = useState(false);
@@ -136,28 +105,29 @@ const CollapsibleCode: FC<{ children: ReactNode }> = ({ children }) => {
   );
 };
 
+const codeSheetReset =
+  "[&_pre]:rounded-none [&_pre]:border-0 [&_pre]:bg-transparent! [&_pre]:px-3.5 [&_pre]:py-0 [&_pre]:text-[12.5px] [&_pre]:overflow-visible";
+
 const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
+  const trimmed = code.trim();
   return (
     <CollapsibleCode>
-      <ShikiHighlighter
-        language={language}
-        theme={{ dark: "github-dark-default", light: "github-light-default" }}
-        addDefaultStyles={false}
-        showLanguage={false}
-        showLineNumbers
-        defaultColor={false}
-        className="[&_pre]:border-border/50 [&_pre]:bg-muted/30 [&_pre]:scrollbar-none [&_pre]:overflow-x-auto [&_pre]:rounded-t-none [&_pre]:rounded-b-lg [&_pre]:border [&_pre]:border-t-0 [&_pre]:py-3 [&_pre]:pr-3 [&_pre]:pl-1 [&_pre]:text-xs [&_pre]:leading-relaxed"
-        style={
-          {
-            "--line-numbers-foreground": "var(--color-muted-foreground)",
-            "--line-numbers-width": "2ch",
-            "--line-numbers-padding-left": "0",
-            "--line-numbers-padding-right": "1ch",
-          } as CSSProperties
-        }
+      <CodeBlock
+        title={language || undefined}
+        copyText={trimmed}
+        className="my-2.5"
       >
-        {code.trim()}
-      </ShikiHighlighter>
+        <ShikiHighlighter
+          language={language}
+          theme={{ dark: "github-dark-default", light: "github-light-default" }}
+          addDefaultStyles={false}
+          showLanguage={false}
+          defaultColor={false}
+          className={codeSheetReset}
+        >
+          {trimmed}
+        </ShikiHighlighter>
+      </CodeBlock>
     </CollapsibleCode>
   );
 };
@@ -314,15 +284,11 @@ const markdownComponents = memoizeMarkdownComponents({
   tr: (props) => <tr {...props} />,
   pre: ({ className, children, ...props }) => (
     <CollapsibleCode>
-      <pre
-        className={cn(
-          "border-border/50 bg-muted/30 overflow-x-auto rounded-t-none rounded-b-lg border border-t-0 p-3 text-xs leading-relaxed",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </pre>
+      <CodeBlock className="my-2.5">
+        <pre className={cn("overflow-visible", className)} {...props}>
+          {children}
+        </pre>
+      </CodeBlock>
     </CollapsibleCode>
   ),
   code: function Code({ className, ...props }) {
@@ -338,5 +304,5 @@ const markdownComponents = memoizeMarkdownComponents({
       />
     );
   },
-  CodeHeader,
+  CodeHeader: () => null,
 });

--- a/apps/docs/components/pages/docs/assistant/markdown.tsx
+++ b/apps/docs/components/pages/docs/assistant/markdown.tsx
@@ -114,7 +114,8 @@ const SyntaxHighlighter: FC<SyntaxHighlighterProps> = ({ code, language }) => {
     <CollapsibleCode>
       <CodeBlock
         title={language || undefined}
-        copyText={trimmed}
+        copyText={code}
+        lineNumbers
         className="my-2.5"
       >
         <ShikiHighlighter

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -61,6 +61,7 @@ import {
   UserMessageAttachments,
 } from "@/components/assistant-ui/elements/attachment.aui";
 import { ContextDisplay } from "@/components/assistant-ui/elements/context-display.aui";
+import { ShimmerLabel } from "@/components/assistant-ui/elements/surfaces";
 import { File } from "@/components/assistant-ui/elements/file";
 import { Image } from "@/components/assistant-ui/elements/image";
 import { MarkdownText } from "@/components/assistant-ui/elements/markdown-text";
@@ -76,7 +77,6 @@ import {
   ReasoningContent,
   ReasoningRoot,
   ReasoningText,
-  ReasoningTrigger,
 } from "@/components/assistant-ui/elements/reasoning.aui";
 import {
   ThreadListSearch,
@@ -85,10 +85,10 @@ import {
 import {
   ToolGroupContent,
   ToolGroupRoot,
-  ToolGroupTrigger,
 } from "@/components/assistant-ui/elements/tool-group.aui";
 import { FeedbackActions } from "@/components/pages/docs/assistant/assistant-action-bar";
 import { docsModelOptions } from "@/components/pages/docs/assistant/docs-model-options";
+import { CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -97,7 +97,7 @@ import {
   formatDuration,
   useToolDuration,
 } from "@/components/shared/trace-line";
-import { typeEyebrow } from "@/components/shared/type";
+import { typeEyebrow, typeSection } from "@/components/shared/type";
 import {
   DEFAULT_MODEL_ID,
   getContextWindow,
@@ -684,9 +684,7 @@ function SpecimenThread(): ReactNode {
       >
         <AuiIf condition={isNewChatView}>
           <div className="animate-in fade-in slide-in-from-bottom-1 mx-auto mb-8 flex w-full max-w-(--thread-max-width) flex-col items-center text-center duration-200">
-            <p className="font-display text-2xl font-[550] tracking-[-0.01em]">
-              How can I help you today?
-            </p>
+            <p className={typeSection}>How can I help you today?</p>
           </div>
         </AuiIf>
         <AuiIf condition={isHistoryLoadingView}>
@@ -731,7 +729,7 @@ function SpecimenThread(): ReactNode {
             <button
               type="button"
               aria-label="Scroll to bottom"
-              className="border-foreground/10 bg-background hover:border-foreground/25 rounded-capsule absolute -top-11 z-10 grid size-8 place-items-center self-center border transition-colors disabled:invisible"
+              className="border-foreground/10 bg-background hover:border-foreground/25 rounded-control absolute -top-11 z-10 grid size-8 place-items-center self-center border transition-colors disabled:invisible"
             >
               <ArrowDownIcon className="size-4" />
             </button>
@@ -811,7 +809,7 @@ function SpecimenComposer(): ReactNode {
   return (
     <ComposerPrimitive.Root className="w-full">
       <ComposerPrimitive.AttachmentDropzone asChild>
-        <div className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 data-[dragging=true]:border-foreground/40 rounded-thread flex flex-col border transition-colors data-[dragging=true]:border-dashed">
+        <div className="border-foreground/10 bg-muted/30 focus-within:border-foreground/25 data-[dragging=true]:border-foreground/40 rounded-thread flex flex-col border transition-colors data-[dragging=true]:border-dashed">
           <ComposerQuotePreview className="bg-foreground/[0.04] rounded-control mx-3 mt-3" />
           <div className="has-[.aui-attachment-root]:px-3 has-[.aui-attachment-root]:pt-3">
             <ComposerAttachments />
@@ -848,10 +846,10 @@ function SpecimenComposer(): ReactNode {
             </div>
             <div className="flex shrink-0 items-center gap-1">
               <AuiIf condition={(s) => !s.thread.isEmpty}>
-                <ContextDisplay.Ring
+                <ContextDisplay.Text
                   modelContextWindow={getContextWindow(model)}
                   side="top"
-                  className="text-muted-foreground hover:text-foreground size-8"
+                  className="text-muted-foreground hover:text-foreground rounded-control h-8 px-2 text-[11px] hover:bg-transparent"
                 />
               </AuiIf>
               <AuiIf
@@ -886,7 +884,7 @@ function SpecimenComposer(): ReactNode {
                   <button
                     type="button"
                     aria-label="Send message"
-                    className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full transition-opacity disabled:opacity-40"
+                    className="bg-primary text-primary-foreground rounded-control grid size-8 place-items-center transition-opacity disabled:opacity-40"
                   >
                     <ArrowUpIcon className="size-4.5" />
                   </button>
@@ -897,7 +895,7 @@ function SpecimenComposer(): ReactNode {
                   <button
                     type="button"
                     aria-label="Stop generating"
-                    className="bg-primary text-primary-foreground grid size-8 place-items-center rounded-full"
+                    className="bg-primary text-primary-foreground rounded-control grid size-8 place-items-center"
                   >
                     <SquareIcon className="size-3.5 fill-current" />
                   </button>
@@ -917,7 +915,7 @@ function SpecimenEditComposer(): ReactNode {
       data-role="user"
       className="mx-auto flex w-full max-w-(--thread-max-width) flex-col items-end"
     >
-      <ComposerPrimitive.Root className="border-foreground/10 bg-muted/25 focus-within:border-foreground/25 rounded-thread flex w-full max-w-[85%] flex-col border transition-colors">
+      <ComposerPrimitive.Root className="border-foreground/10 bg-muted/30 focus-within:border-foreground/25 rounded-thread flex w-full max-w-[85%] flex-col border transition-colors">
         <ComposerPrimitive.Input asChild>
           <textarea
             autoFocus
@@ -1009,24 +1007,39 @@ function SpecimenAssistantMessage(): ReactNode {
             switch (part.type) {
               case "group-chainOfThought":
                 return <div>{children}</div>;
-              case "group-tool":
+              case "group-tool": {
                 if (part.indices.length === 1) return <>{children}</>;
+                const running = part.status.type === "running";
                 return (
-                  <ToolGroupRoot variant="ghost">
-                    <ToolGroupTrigger
-                      count={part.indices.length}
-                      active={part.status.type === "running"}
+                  <ToolGroupRoot variant="ghost" className="my-1">
+                    <SpecimenDisclosureTrigger
+                      live={running}
+                      label={running ? "running" : "ran"}
+                      detail={`${part.indices.length} tools`}
                     />
-                    <ToolGroupContent>{children}</ToolGroupContent>
+                    <ToolGroupContent className={disclosureContentClass}>
+                      {children}
+                    </ToolGroupContent>
                   </ToolGroupRoot>
                 );
+              }
               case "group-reasoning": {
                 const running = part.status.type === "running";
                 return (
-                  <ReasoningRoot streaming={running}>
-                    <ReasoningTrigger active={running} />
-                    <ReasoningContent aria-busy={running}>
-                      <ReasoningText>{children}</ReasoningText>
+                  <ReasoningRoot
+                    variant="ghost"
+                    streaming={running}
+                    className="my-1 mb-3"
+                  >
+                    <SpecimenDisclosureTrigger
+                      live={running}
+                      label={running ? "thinking" : "reasoning"}
+                    />
+                    <ReasoningContent
+                      aria-busy={running}
+                      className={disclosureContentClass}
+                    >
+                      <ReasoningText className="ps-0">{children}</ReasoningText>
                     </ReasoningContent>
                   </ReasoningRoot>
                 );
@@ -1083,7 +1096,7 @@ function SpecimenMessageError(): ReactNode {
     <MessagePrimitive.Error>
       <ErrorPrimitive.Root
         className={cn(
-          "mt-2 border-l-2 pl-3 text-[12.5px]",
+          "mt-2 border-l-2 pl-3 text-[13px]",
           notice
             ? "border-foreground/20 text-muted-foreground"
             : "border-destructive/60 text-destructive",
@@ -1177,7 +1190,7 @@ function SpecimenAssistantActionBar(): ReactNode {
       </ActionBarMorePrimitive.Root>
       <MessageTiming
         side="bottom"
-        className="text-muted-foreground/70 hover:text-foreground ms-1 rounded-none p-1 hover:bg-transparent"
+        className="text-muted-foreground/70 hover:text-foreground ms-1 rounded-none p-1 text-[11px] hover:bg-transparent"
       />
     </ActionBarPrimitive.Root>
   );
@@ -1192,7 +1205,7 @@ function SpecimenBranchPicker({
     <BranchPickerPrimitive.Root
       hideWhenSingleBranch
       className={cn(
-        "text-muted-foreground inline-flex items-center text-[12px] tabular-nums",
+        "text-muted-foreground inline-flex items-center font-mono text-[11px] tabular-nums",
         className,
       )}
     >
@@ -1202,7 +1215,7 @@ function SpecimenBranchPicker({
       >
         <ChevronLeftIcon className="size-4" />
       </BranchPickerPrimitive.Previous>
-      <span className="font-medium">
+      <span>
         <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
       </span>
       <BranchPickerPrimitive.Next
@@ -1212,6 +1225,43 @@ function SpecimenBranchPicker({
         <ChevronRightIcon className="size-4" />
       </BranchPickerPrimitive.Next>
     </BranchPickerPrimitive.Root>
+  );
+}
+
+const disclosureContentClass = "border-foreground/10 ms-[5px] border-s ps-4";
+
+function SpecimenDisclosureTrigger({
+  live,
+  label,
+  detail,
+}: {
+  live: boolean;
+  label: string;
+  detail?: string;
+}): ReactNode {
+  return (
+    <CollapsibleTrigger className="group/trigger my-1 flex max-w-full items-center gap-2 text-left font-mono text-[12px] outline-none [font-variant-ligatures:none] focus-visible:underline">
+      <ChevronRightIcon
+        aria-hidden
+        className={cn(
+          "size-3 shrink-0 transition-transform group-data-open/trigger:rotate-90 group-data-panel-open/trigger:rotate-90",
+          live ? "text-blue-500" : "text-muted-foreground/50",
+        )}
+      />
+      <span className="text-muted-foreground group-hover/trigger:text-foreground min-w-0 truncate transition-colors">
+        {live ? (
+          <ShimmerLabel>
+            {label}
+            {detail ? ` ${detail}` : null}
+          </ShimmerLabel>
+        ) : (
+          <>
+            {label}
+            {detail ? ` ${detail}` : null}
+          </>
+        )}
+      </span>
+    </CollapsibleTrigger>
   );
 }
 

--- a/apps/docs/lib/markdown-math.test.ts
+++ b/apps/docs/lib/markdown-math.test.ts
@@ -37,6 +37,12 @@ describe("closeDisplayMathFences", () => {
     );
   });
 
+  it("closes at the opening fence's indent, not the content's", () => {
+    expect(closeDisplayMathFences("$$\n    a = b$$\ntext")).toBe(
+      "$$\n    a = b\n$$\ntext",
+    );
+  });
+
   it("keeps a fenced equation inside its list item", () => {
     expect(
       closeDisplayMathFences("1. Expand:\n   $$S_n = a + ar$$\n2. Subtract."),

--- a/apps/docs/lib/markdown-math.test.ts
+++ b/apps/docs/lib/markdown-math.test.ts
@@ -31,8 +31,14 @@ describe("closeDisplayMathFences", () => {
     expect(closeDisplayMathFences("$$a\n= b\n$$")).toBe("$$\na\n= b\n$$");
   });
 
-  it("leaves one line display math at the start of a line alone", () => {
-    expect(closeDisplayMathFences("$$a = b$$\ntext")).toBe("$$a = b$$\ntext");
+  it("fences one line display math that stands alone on its line", () => {
+    expect(closeDisplayMathFences("$$a = b$$\ntext")).toBe(
+      "$$\na = b\n$$\ntext",
+    );
+  });
+
+  it("leaves two display expressions on one line alone", () => {
+    expect(closeDisplayMathFences("$$a$$ and $$b$$")).toBe("$$a$$ and $$b$$");
   });
 
   it("keeps an aligned environment that opens on the fence line", () => {
@@ -189,9 +195,9 @@ describe("preprocessMath", () => {
     ).toBe(`Match $n$ with:\n${code}\nUse \`\\(x\\)\`.`);
   });
 
-  it("normalizes display math that spans lines", () => {
+  it("fences a bracket block so it centers like every display equation", () => {
     expect(preprocessMath("Sum:\n\\[\na = b\n\\]\nDone.")).toBe(
-      normalizeMathDelimiters("Sum:\n\\[\na = b\n\\]\nDone."),
+      "Sum:\n$$\na = b\n$$\nDone.",
     );
   });
 });

--- a/apps/docs/lib/markdown-math.test.ts
+++ b/apps/docs/lib/markdown-math.test.ts
@@ -37,6 +37,15 @@ describe("closeDisplayMathFences", () => {
     );
   });
 
+  it("keeps a fenced equation inside its list item", () => {
+    expect(
+      closeDisplayMathFences("1. Expand:\n   $$S_n = a + ar$$\n2. Subtract."),
+    ).toBe("1. Expand:\n   $$\n   S_n = a + ar\n   $$\n2. Subtract.");
+    expect(closeDisplayMathFences("- Sum:\n  $$\n  a$$\n- Next")).toBe(
+      "- Sum:\n  $$\n  a\n  $$\n- Next",
+    );
+  });
+
   it("leaves two display expressions on one line alone", () => {
     expect(closeDisplayMathFences("$$a$$ and $$b$$")).toBe("$$a$$ and $$b$$");
   });

--- a/apps/docs/lib/markdown-math.ts
+++ b/apps/docs/lib/markdown-math.ts
@@ -10,6 +10,8 @@ const MATH_FENCE_WITH_CONTENT = /^ {0,3}\$\$(?!\$)[ \t]*(\S.*?)[ \t\r]*$/;
 const MATH_ONE_LINE = /^ {0,3}\$\$(?!\$)[ \t]*(\S.*?\S|\S)[ \t]*\$\$[ \t\r]*$/;
 const TRAILING_MATH_FENCE = /\S[ \t]*\$\$[ \t\r]*$/;
 
+const indentOf = (line: string) => /^[ \t]*/.exec(line)![0];
+
 const closesFence = (line: string, fence: string) => {
   const close = CODE_FENCE_CLOSE.exec(line)?.[1];
   return (
@@ -44,7 +46,10 @@ export function closeDisplayMathFences(text: string): string {
 
     if (inMath) {
       if (!line.startsWith("$$") && TRAILING_MATH_FENCE.test(line)) {
-        out.push(line.replace(/[ \t]*\$\$[ \t\r]*$/, ""), "$$");
+        out.push(
+          line.replace(/[ \t]*\$\$[ \t\r]*$/, ""),
+          `${indentOf(line)}$$`,
+        );
         inMath = false;
       } else {
         out.push(line);
@@ -52,15 +57,16 @@ export function closeDisplayMathFences(text: string): string {
       continue;
     }
 
+    const indent = indentOf(line);
     const oneLine = MATH_ONE_LINE.exec(line)?.[1];
     if (oneLine !== undefined && !oneLine.includes("$$")) {
-      out.push("$$", oneLine, "$$");
+      out.push(`${indent}$$`, `${indent}${oneLine}`, `${indent}$$`);
       continue;
     }
 
     const opener = MATH_FENCE_WITH_CONTENT.exec(line)?.[1];
     if (opener !== undefined && !opener.includes("$$")) {
-      out.push("$$", opener);
+      out.push(`${indent}$$`, `${indent}${opener}`);
       inMath = true;
       continue;
     }

--- a/apps/docs/lib/markdown-math.ts
+++ b/apps/docs/lib/markdown-math.ts
@@ -7,6 +7,7 @@ const CODE_FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
 const CODE_FENCE_CLOSE = /^ {0,3}(`{3,}|~{3,})[ \t\r]*$/;
 const MATH_FENCE = /^ {0,3}\$\$[ \t\r]*$/;
 const MATH_FENCE_WITH_CONTENT = /^ {0,3}\$\$(?!\$)[ \t]*(\S.*?)[ \t\r]*$/;
+const MATH_ONE_LINE = /^ {0,3}\$\$(?!\$)[ \t]*(\S.*?\S|\S)[ \t]*\$\$[ \t\r]*$/;
 const TRAILING_MATH_FENCE = /\S[ \t]*\$\$[ \t\r]*$/;
 
 const closesFence = (line: string, fence: string) => {
@@ -20,7 +21,9 @@ const closesFence = (line: string, fence: string) => {
 // display block when the closing fence sits on its own line; models often
 // start the first equation line with `$$` and end the last one with `$$`,
 // which drops the first line and turns the rest of the reply into one
-// unterminated formula.
+// unterminated formula. A `$$…$$` line standing alone is inline math to
+// remark-math, so it renders left aligned while fenced blocks center; it
+// becomes a fenced block so every display equation sits the same way.
 export function closeDisplayMathFences(text: string): string {
   const out: string[] = [];
   let codeFence: string | undefined;
@@ -46,6 +49,12 @@ export function closeDisplayMathFences(text: string): string {
       } else {
         out.push(line);
       }
+      continue;
+    }
+
+    const oneLine = MATH_ONE_LINE.exec(line)?.[1];
+    if (oneLine !== undefined && !oneLine.includes("$$")) {
+      out.push("$$", oneLine, "$$");
       continue;
     }
 

--- a/apps/docs/lib/markdown-math.ts
+++ b/apps/docs/lib/markdown-math.ts
@@ -30,6 +30,7 @@ export function closeDisplayMathFences(text: string): string {
   const out: string[] = [];
   let codeFence: string | undefined;
   let inMath = false;
+  let mathIndent = "";
 
   for (const line of text.split("\n")) {
     if (codeFence !== undefined) {
@@ -40,16 +41,14 @@ export function closeDisplayMathFences(text: string): string {
 
     if (MATH_FENCE.test(line)) {
       inMath = !inMath;
+      if (inMath) mathIndent = indentOf(line);
       out.push(line);
       continue;
     }
 
     if (inMath) {
       if (!line.startsWith("$$") && TRAILING_MATH_FENCE.test(line)) {
-        out.push(
-          line.replace(/[ \t]*\$\$[ \t\r]*$/, ""),
-          `${indentOf(line)}$$`,
-        );
+        out.push(line.replace(/[ \t]*\$\$[ \t\r]*$/, ""), `${mathIndent}$$`);
         inMath = false;
       } else {
         out.push(line);
@@ -68,6 +67,7 @@ export function closeDisplayMathFences(text: string): string {
     if (opener !== undefined && !opener.includes("$$")) {
       out.push(`${indent}$$`, `${indent}${opener}`);
       inMath = true;
+      mathIndent = indent;
       continue;
     }
 

--- a/packages/ui/src/components/react/assistant-ui/elements/mermaid-diagram.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/mermaid-diagram.tsx
@@ -320,7 +320,7 @@ const MermaidDiagramImpl: FC<MermaidDiagramProps> = ({
       <div
         data-slot="mermaid-diagram"
         className={cn(
-          "aui-mermaid-diagram bg-muted rounded-b-lg p-2 [&_svg]:mx-auto",
+          "aui-mermaid-diagram bg-muted overflow-x-auto rounded-b-lg p-2 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full",
           className,
         )}
         dangerouslySetInnerHTML={{ __html: result.svg }}

--- a/packages/ui/src/components/react/ui/base/code-block.tsx
+++ b/packages/ui/src/components/react/ui/base/code-block.tsx
@@ -16,6 +16,8 @@ export interface CodeBlockProps extends Omit<
   copyText?: string;
   /** Called after the copy button writes the clipboard. */
   onCopied?: () => void;
+  /** Numbers the lines when the `pre` does not carry `data-line-numbers` itself. */
+  lineNumbers?: boolean;
 }
 
 function CopyButton({
@@ -63,13 +65,14 @@ function CopyButton({
  * shiki's inline colors or `--shiki-light`, and in dark mode fall back to
  * `--shiki-dark`. Lines render as blocks on a `w-max` surface so
  * highlighted rows paint past the scroll fold, and `data-line-numbers` on the
- * `pre` turns on a CSS counter gutter.
+ * `pre` (or the `lineNumbers` prop) turns on a CSS counter gutter.
  */
 export function CodeBlock({
   title,
   viewportClassName,
   copyText,
   onCopied,
+  lineNumbers,
   className,
   children,
   ...props
@@ -115,6 +118,8 @@ export function CodeBlock({
           "[&_pre[data-line-numbers]]:[counter-reset:line]",
           "[&_pre[data-line-numbers]_.line]:relative [&_pre[data-line-numbers]_.line]:pl-8 [&_pre[data-line-numbers]_.line]:[counter-increment:line]",
           "[&_pre[data-line-numbers]_.line]:before:text-muted-foreground/40 [&_pre[data-line-numbers]_.line]:before:absolute [&_pre[data-line-numbers]_.line]:before:left-0 [&_pre[data-line-numbers]_.line]:before:w-5 [&_pre[data-line-numbers]_.line]:before:text-right [&_pre[data-line-numbers]_.line]:before:tabular-nums [&_pre[data-line-numbers]_.line]:before:[content:counter(line)]",
+          lineNumbers &&
+            "[&_.line]:before:text-muted-foreground/40 [counter-reset:line] [&_.line]:relative [&_.line]:pl-8 [&_.line]:[counter-increment:line] [&_.line]:before:absolute [&_.line]:before:left-0 [&_.line]:before:w-5 [&_.line]:before:text-right [&_.line]:before:tabular-nums [&_.line]:before:[content:counter(line)]",
           viewportClassName,
         )}
       >

--- a/packages/ui/src/components/react/ui/radix/code-block.tsx
+++ b/packages/ui/src/components/react/ui/radix/code-block.tsx
@@ -16,6 +16,8 @@ export interface CodeBlockProps extends Omit<
   copyText?: string;
   /** Called after the copy button writes the clipboard. */
   onCopied?: () => void;
+  /** Numbers the lines when the `pre` does not carry `data-line-numbers` itself. */
+  lineNumbers?: boolean;
 }
 
 function CopyButton({
@@ -63,13 +65,14 @@ function CopyButton({
  * shiki's inline colors or `--shiki-light`, and in dark mode fall back to
  * `--shiki-dark`. Lines render as blocks on a `w-max` surface so
  * highlighted rows paint past the scroll fold, and `data-line-numbers` on the
- * `pre` turns on a CSS counter gutter.
+ * `pre` (or the `lineNumbers` prop) turns on a CSS counter gutter.
  */
 export function CodeBlock({
   title,
   viewportClassName,
   copyText,
   onCopied,
+  lineNumbers,
   className,
   children,
   ...props
@@ -115,6 +118,8 @@ export function CodeBlock({
           "[&_pre[data-line-numbers]]:[counter-reset:line]",
           "[&_pre[data-line-numbers]_.line]:relative [&_pre[data-line-numbers]_.line]:pl-8 [&_pre[data-line-numbers]_.line]:[counter-increment:line]",
           "[&_pre[data-line-numbers]_.line]:before:text-muted-foreground/40 [&_pre[data-line-numbers]_.line]:before:absolute [&_pre[data-line-numbers]_.line]:before:left-0 [&_pre[data-line-numbers]_.line]:before:w-5 [&_pre[data-line-numbers]_.line]:before:text-right [&_pre[data-line-numbers]_.line]:before:tabular-nums [&_pre[data-line-numbers]_.line]:before:[content:counter(line)]",
+          lineNumbers &&
+            "[&_.line]:before:text-muted-foreground/40 [counter-reset:line] [&_.line]:relative [&_.line]:pl-8 [&_.line]:[counter-increment:line] [&_.line]:before:absolute [&_.line]:before:left-0 [&_.line]:before:w-5 [&_.line]:before:text-right [&_.line]:before:tabular-nums [&_.line]:before:[content:counter(line)]",
           viewportClassName,
         )}
       >


### PR DESCRIPTION
## summary

- the landing page thread reads like the rest of the site: reasoning and grouped tool calls are ghost disclosures in the trace grammar (one rotating chevron, blue while live, content behind a hairline rule) instead of the kit's outlined cards, send, stop, and scroll to bottom are 8px controls instead of circles, the empty state uses the `typeSection` role, branch counts and timing are mono figures, and the percentage context ring becomes `ContextDisplay.Text` (`12.4k / 1.1M`)
- fenced code in both chat renderers (`apps/docs/components/assistant-ui/elements/markdown-text.tsx`, used by the home thread, the example pages, and the playground, and `apps/docs/components/pages/docs/assistant/markdown.tsx`, the Ask AI panel) now renders inside the site's `CodeBlock`, the same code sheet every docs page `pre` uses; the kit highlighter only supplies tokens and its own chrome is reset, mermaid fences render as a `CodeBlock` plate, the Ask AI panel drops `react-shiki/css`
- markdown tables become printed matter (header field panel and row hairlines only, document corners) and KaTeX display blocks scroll horizontally instead of overflowing
- `packages/ui` mermaid element keeps its SVG inside the column (`overflow-x-auto`, `max-w-full`), which is what let a wide sequence diagram bleed out of the home thread frame
- `closeDisplayMathFences` also fences a `$$…$$` that stands alone on its line, so every display equation centers the same way (a single line inside a paragraph is still inline math)

## test plan

### already verified

- [x] oxlint and oxfmt on the changed files -> clean
- [x] `apps/docs` vitest `lib/markdown-math.test.ts` -> 27 passed
- [x] `tsc --noEmit` in `apps/docs` -> 0 errors
- [x] browser pass on the home thread with reasoning + mermaid, a KaTeX derivation, a table + code reply, and a two tool weather turn: disclosures collapse and expand, the mermaid plate stays inside the column, code sheets and the Ask AI panel's code block match the docs pages' `CodeBlock`, light, dark, and a 390px viewport

### reviewer should verify

- [ ] an example page that shares the docs markdown renderer (`/examples/chatgpt`, `/examples/claude`) shows the site code sheet in replies; this is intentional, the docs renderer is the one accepted override and it now carries the house register everywhere

## notes

- design audit behind this change: 21 surfaces compared against `apps/docs/content/design.md`; 10 already conformed, 11 changed here
- `packages/ui` and `apps/docs` are private, so no changeset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wMZTmPS49vb_pxAkd3HsXtkLRTJQ5YGayEnD-9kscmsw03JS4bGqgjzORuI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->