### PR TITLE
feat(docs): ground the home demo in the docs and offer follow-ups

### DIFF
--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: Request) {
 
     // Basic validation: only accept short system prompts to limit abuse surface
     const MAX_SYSTEM_LENGTH = 4000;
-    const groundInDocs = req.headers.get("sec-fetch-site") !== "cross-site";
+    const groundInDocs = req.headers.get("sec-fetch-site") === "same-origin";
     const system = [
       typeof rawSystem === "string" && rawSystem.length <= MAX_SYSTEM_LENGTH
         ? rawSystem

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -69,9 +69,7 @@ export async function POST(req: Request) {
 
     // Basic validation: only accept short system prompts to limit abuse surface
     const MAX_SYSTEM_LENGTH = 4000;
-    const groundInDocs = !req.headers.get("origin")
-      ? true
-      : new URL(req.url).origin === req.headers.get("origin");
+    const groundInDocs = req.headers.get("sec-fetch-site") !== "cross-site";
     const system = [
       typeof rawSystem === "string" && rawSystem.length <= MAX_SYSTEM_LENGTH
         ? rawSystem

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -10,11 +10,14 @@ import {
 } from "@/lib/anonymous-session";
 import { validateGeneralChatInput } from "@/lib/validate-input";
 import { resolveChatModel } from "@/lib/ai/provider";
+import { createSearchDocsTool } from "@/lib/ai/search-docs";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
 import { AISDKToolkit } from "@assistant-ui/ai-sdk";
 import docsToolkit from "@/lib/docs-toolkit";
 import {
   convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
   pruneMessages,
   stepCountIs,
   streamText,
@@ -23,6 +26,9 @@ import {
 export const maxDuration = 300;
 
 const aiToolkit = new AISDKToolkit({ toolkit: docsToolkit });
+
+const SEARCH_DOCS_SYSTEM_INSTRUCTION =
+  "When the user asks about assistant-ui (its APIs, components, runtimes, setup, or documentation), call search_docs before answering and answer from its results. Cite the pages you used inline as markdown links with their titles. Never cite a page search_docs did not return.";
 
 function corsHeaders(req: Request) {
   const origin = req.headers.get("origin") ?? "";
@@ -63,10 +69,14 @@ export async function POST(req: Request) {
 
     // Basic validation: only accept short system prompts to limit abuse surface
     const MAX_SYSTEM_LENGTH = 4000;
-    const system =
+    const system = [
       typeof rawSystem === "string" && rawSystem.length <= MAX_SYSTEM_LENGTH
         ? rawSystem
-        : undefined;
+        : undefined,
+      SEARCH_DOCS_SYSTEM_INSTRUCTION,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
 
     const inputError = validateGeneralChatInput(messages);
     if (inputError) {
@@ -75,6 +85,7 @@ export async function POST(req: Request) {
 
     const { model, providerOptions, reasoning } = resolveChatModel(config);
     const distinctId = getDistinctId(req);
+    const origin = new URL(req.url).origin;
 
     const prunedMessages = pruneMessages({
       messages: await convertToModelMessages(
@@ -83,41 +94,52 @@ export async function POST(req: Request) {
       reasoning: "none",
     });
 
-    const result = streamText({
-      model,
-      ...(providerOptions ? { providerOptions } : {}),
-      ...(system ? { system } : {}),
-      messages: prunedMessages,
-      maxOutputTokens: reasoning ? 16384 : 4096,
-      stopWhen: stepCountIs(10),
-      tools: await aiToolkit.tools({ frontend: tools }),
-      ...posthogTelemetry({
-        distinctId,
-        spanName: "general_chat",
-        source: "general_chat",
-      }),
-      onError: ({ error }) => {
-        console.error(error);
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        const result = streamText({
+          model,
+          ...(providerOptions ? { providerOptions } : {}),
+          ...(system ? { system } : {}),
+          messages: prunedMessages,
+          maxOutputTokens: reasoning ? 16384 : 4096,
+          stopWhen: stepCountIs(10),
+          tools: {
+            ...(await aiToolkit.tools({ frontend: tools })),
+            search_docs: createSearchDocsTool({ writer, origin }),
+          },
+          ...posthogTelemetry({
+            distinctId,
+            spanName: "general_chat",
+            source: "general_chat",
+          }),
+          onError: ({ error }) => {
+            console.error(error);
+          },
+        });
+
+        writer.merge(
+          result.toUIMessageStream({
+            sendReasoning: true,
+            // gets usage and modelId for assistant-cloud telemetry reports
+            messageMetadata: ({ part }) => {
+              if (part.type === "finish-step") {
+                return {
+                  modelId: part.response.modelId,
+                };
+              }
+              if (part.type === "finish") {
+                return {
+                  usage: part.totalUsage,
+                };
+              }
+              return undefined;
+            },
+          }),
+        );
       },
     });
 
-    const response = result.toUIMessageStreamResponse({
-      sendReasoning: true,
-      // gets usage and modelId for assistant-cloud telemetry reports
-      messageMetadata: ({ part }) => {
-        if (part.type === "finish-step") {
-          return {
-            modelId: part.response.modelId,
-          };
-        }
-        if (part.type === "finish") {
-          return {
-            usage: part.totalUsage,
-          };
-        }
-        return undefined;
-      },
-    });
+    const response = createUIMessageStreamResponse({ stream });
 
     return withCors(req, response);
   } catch (e) {

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -69,11 +69,14 @@ export async function POST(req: Request) {
 
     // Basic validation: only accept short system prompts to limit abuse surface
     const MAX_SYSTEM_LENGTH = 4000;
+    const groundInDocs = !req.headers.get("origin")
+      ? true
+      : new URL(req.url).origin === req.headers.get("origin");
     const system = [
       typeof rawSystem === "string" && rawSystem.length <= MAX_SYSTEM_LENGTH
         ? rawSystem
         : undefined,
-      SEARCH_DOCS_SYSTEM_INSTRUCTION,
+      groundInDocs ? SEARCH_DOCS_SYSTEM_INSTRUCTION : undefined,
     ]
       .filter(Boolean)
       .join("\n\n");
@@ -86,6 +89,16 @@ export async function POST(req: Request) {
     const { model, providerOptions, reasoning } = resolveChatModel(config);
     const distinctId = getDistinctId(req);
     const origin = new URL(req.url).origin;
+
+    const frontendTools = await aiToolkit.tools({ frontend: tools });
+    if (groundInDocs && "search_docs" in frontendTools) {
+      return withCors(
+        req,
+        new Response("search_docs is reserved on this endpoint", {
+          status: 400,
+        }),
+      );
+    }
 
     const prunedMessages = pruneMessages({
       messages: await convertToModelMessages(
@@ -103,10 +116,12 @@ export async function POST(req: Request) {
           messages: prunedMessages,
           maxOutputTokens: reasoning ? 16384 : 4096,
           stopWhen: stepCountIs(10),
-          tools: {
-            ...(await aiToolkit.tools({ frontend: tools })),
-            search_docs: createSearchDocsTool({ writer, origin }),
-          },
+          tools: groundInDocs
+            ? {
+                ...frontendTools,
+                search_docs: createSearchDocsTool({ writer, origin }),
+              }
+            : frontendTools,
           ...posthogTelemetry({
             distinctId,
             spanName: "general_chat",

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -65,11 +65,19 @@ export async function POST(req: Request) {
     if (rateLimitResponse) return withCors(req, rateLimitResponse);
 
     const body = await req.json();
-    const { messages, system: rawSystem, tools, config } = body;
+    const {
+      messages,
+      system: rawSystem,
+      tools,
+      config,
+      searchDocs: searchDocsRequested,
+    } = body;
 
     // Basic validation: only accept short system prompts to limit abuse surface
     const MAX_SYSTEM_LENGTH = 4000;
-    const groundInDocs = req.headers.get("sec-fetch-site") === "same-origin";
+    const groundInDocs =
+      searchDocsRequested === true &&
+      req.headers.get("sec-fetch-site") === "same-origin";
     const system = [
       typeof rawSystem === "string" && rawSystem.length <= MAX_SYSTEM_LENGTH
         ? rawSystem

--- a/apps/docs/app/api/suggestions/route.test.ts
+++ b/apps/docs/app/api/suggestions/route.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/anonymous-session", async (importOriginal) => ({
 
 vi.mock("@/lib/rate-limit", async (importOriginal) => ({
   ...(await importOriginal()),
-  checkPublicAssistantRateLimit: mocks.checkRateLimit,
+  checkFollowUpSuggestionRateLimit: mocks.checkRateLimit,
 }));
 
 vi.mock("@/lib/ai/provider", async (importOriginal) => ({
@@ -57,18 +57,56 @@ describe("POST /api/suggestions", () => {
     expect(mocks.getModel).not.toHaveBeenCalled();
   });
 
-  it("rejects an oversized prompt", async () => {
+  it("rejects a prompt that is missing or blank", async () => {
     mocks.requireSession.mockReturnValue({
       id: "session_1234567890",
       expiresAt: Date.now() + 60_000,
     });
     mocks.checkRateLimit.mockResolvedValue(null);
 
-    const response = await POST(request("x".repeat(12_001)));
+    const response = await POST(request("   "));
 
     expect(response.status).toBe(400);
     expect(await response.text()).toBe("Invalid prompt");
     expect(mocks.getModel).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed body without failing as a server error", async () => {
+    mocks.requireSession.mockReturnValue({
+      id: "session_1234567890",
+      expiresAt: Date.now() + 60_000,
+    });
+    mocks.checkRateLimit.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("https://www.assistant-ui.com/api/suggestions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{ not json",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.getModel).not.toHaveBeenCalled();
+  });
+
+  it("keeps the tail of a long transcript instead of rejecting it", async () => {
+    mocks.requireSession.mockReturnValue({
+      id: "session_1234567890",
+      expiresAt: Date.now() + 60_000,
+    });
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.getModel.mockReturnValue({});
+    mocks.getDistinctId.mockReturnValue("distinct_1234567890");
+    mocks.generateText.mockResolvedValue({ text: "One" });
+
+    const prompt = `${"x".repeat(30_000)}TAIL`;
+    const response = await POST(request(prompt));
+
+    expect(response.status).toBe(200);
+    const sent = mocks.generateText.mock.calls[0]![0].prompt as string;
+    expect(sent).toHaveLength(24_000);
+    expect(sent.endsWith("TAIL")).toBe(true);
   });
 
   it("returns three trimmed suggestions", async () => {

--- a/apps/docs/app/api/suggestions/route.test.ts
+++ b/apps/docs/app/api/suggestions/route.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_MODEL_ID } from "@/lib/model";
+
+const mocks = vi.hoisted(() => ({
+  requireSession: vi.fn(),
+  checkRateLimit: vi.fn(),
+  getModel: vi.fn(),
+  getDistinctId: vi.fn(),
+  generateText: vi.fn(),
+}));
+
+vi.mock("@/lib/anonymous-session", async (importOriginal) => ({
+  ...(await importOriginal()),
+  requirePublicAssistantSession: mocks.requireSession,
+}));
+
+vi.mock("@/lib/rate-limit", async (importOriginal) => ({
+  ...(await importOriginal()),
+  checkPublicAssistantRateLimit: mocks.checkRateLimit,
+}));
+
+vi.mock("@/lib/ai/provider", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getModel: mocks.getModel,
+}));
+
+vi.mock("@/lib/posthog-server", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getDistinctId: mocks.getDistinctId,
+}));
+
+vi.mock("ai", async (importOriginal) => ({
+  ...(await importOriginal()),
+  generateText: mocks.generateText,
+}));
+
+import { POST } from "./route";
+
+const request = (prompt: unknown) =>
+  new Request("https://www.assistant-ui.com/api/suggestions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ prompt }),
+  });
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/suggestions", () => {
+  it("returns the session guard response unchanged", async () => {
+    const denied = new Response("website required", { status: 403 });
+    mocks.requireSession.mockReturnValue(denied);
+
+    expect(await POST(request("Hello"))).toBe(denied);
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.getModel).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized prompt", async () => {
+    mocks.requireSession.mockReturnValue({
+      id: "session_1234567890",
+      expiresAt: Date.now() + 60_000,
+    });
+    mocks.checkRateLimit.mockResolvedValue(null);
+
+    const response = await POST(request("x".repeat(12_001)));
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Invalid prompt");
+    expect(mocks.getModel).not.toHaveBeenCalled();
+  });
+
+  it("returns three trimmed suggestions", async () => {
+    const model = {};
+    mocks.requireSession.mockReturnValue({
+      id: "session_1234567890",
+      expiresAt: Date.now() + 60_000,
+    });
+    mocks.checkRateLimit.mockResolvedValue(null);
+    mocks.getModel.mockReturnValue(model);
+    mocks.getDistinctId.mockReturnValue("distinct_1234567890");
+    mocks.generateText.mockResolvedValue({
+      text: " - \"Ask a deeper question\"\n2. “Draw a diagram”\n• 'Remember this preference'",
+    });
+
+    const response = await POST(request("Explain thread state"));
+
+    expect(await response.json()).toEqual({
+      suggestions: [
+        "Ask a deeper question",
+        "Draw a diagram",
+        "Remember this preference",
+      ],
+    });
+    expect(mocks.getModel).toHaveBeenCalledWith(DEFAULT_MODEL_ID);
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model,
+        prompt: "Explain thread state",
+        maxOutputTokens: 160,
+      }),
+    );
+  });
+});

--- a/apps/docs/app/api/suggestions/route.test.ts
+++ b/apps/docs/app/api/suggestions/route.test.ts
@@ -90,7 +90,7 @@ describe("POST /api/suggestions", () => {
     expect(mocks.getModel).not.toHaveBeenCalled();
   });
 
-  it("keeps the tail of a long transcript instead of rejecting it", async () => {
+  it("keeps the task instruction and the newest turns of a long transcript", async () => {
     mocks.requireSession.mockReturnValue({
       id: "session_1234567890",
       expiresAt: Date.now() + 60_000,
@@ -100,13 +100,14 @@ describe("POST /api/suggestions", () => {
     mocks.getDistinctId.mockReturnValue("distinct_1234567890");
     mocks.generateText.mockResolvedValue({ text: "One" });
 
-    const prompt = `${"x".repeat(30_000)}TAIL`;
+    const prompt = `HEAD${"x".repeat(30_000)}TAIL`;
     const response = await POST(request(prompt));
 
     expect(response.status).toBe(200);
     const sent = mocks.generateText.mock.calls[0]![0].prompt as string;
-    expect(sent).toHaveLength(24_000);
+    expect(sent.startsWith("HEAD")).toBe(true);
     expect(sent.endsWith("TAIL")).toBe(true);
+    expect(sent.length).toBeLessThan(prompt.length);
   });
 
   it("returns three trimmed suggestions", async () => {

--- a/apps/docs/app/api/suggestions/route.ts
+++ b/apps/docs/app/api/suggestions/route.ts
@@ -1,0 +1,43 @@
+import { getDistinctId } from "@/lib/posthog-server";
+import { requirePublicAssistantSession } from "@/lib/anonymous-session";
+import { checkPublicAssistantRateLimit } from "@/lib/rate-limit";
+import { getModel } from "@/lib/ai/provider";
+import { posthogTelemetry } from "@/lib/ai/telemetry";
+import { parseFollowUpSuggestions } from "@/lib/follow-ups";
+import { DEFAULT_MODEL_ID } from "@/lib/model";
+import { generateText } from "ai";
+
+export async function POST(req: Request): Promise<Response> {
+  try {
+    const session = requirePublicAssistantSession(req);
+    if (session instanceof Response) return session;
+
+    const rateLimitResponse = await checkPublicAssistantRateLimit(
+      req,
+      session.id,
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
+    const body = await req.json();
+    const { prompt } = body;
+    if (typeof prompt !== "string" || prompt.length > 12_000) {
+      return new Response("Invalid prompt", { status: 400 });
+    }
+
+    const { text } = await generateText({
+      model: getModel(DEFAULT_MODEL_ID),
+      prompt,
+      maxOutputTokens: 160,
+      ...posthogTelemetry({
+        distinctId: getDistinctId(req),
+        spanName: "follow_up_suggestions",
+        source: "follow_up_suggestions",
+      }),
+    });
+
+    return Response.json({ suggestions: parseFollowUpSuggestions(text, 3) });
+  } catch (e) {
+    console.error("[api/suggestions]", e);
+    return new Response("Request failed", { status: 500 });
+  }
+}

--- a/apps/docs/app/api/suggestions/route.ts
+++ b/apps/docs/app/api/suggestions/route.ts
@@ -8,16 +8,21 @@ import { DEFAULT_MODEL_ID } from "@/lib/model";
 import { generateText } from "ai";
 
 const MAX_PROMPT_LENGTH = 24_000;
+const PROMPT_HEAD_LENGTH = 2_000;
+
+function boundPrompt(prompt: string): string {
+  if (prompt.length <= MAX_PROMPT_LENGTH) return prompt;
+  const head = prompt.slice(0, PROMPT_HEAD_LENGTH);
+  const tail = prompt.slice(-(MAX_PROMPT_LENGTH - PROMPT_HEAD_LENGTH));
+  return `${head}\n\n[...]\n\n${tail}`;
+}
 
 export async function POST(req: Request): Promise<Response> {
   try {
     const session = requirePublicAssistantSession(req);
     if (session instanceof Response) return session;
 
-    const rateLimitResponse = await checkFollowUpSuggestionRateLimit(
-      req,
-      session.id,
-    );
+    const rateLimitResponse = await checkFollowUpSuggestionRateLimit(req);
     if (rateLimitResponse) return rateLimitResponse;
 
     const body = await req.json().catch(() => null);
@@ -28,7 +33,7 @@ export async function POST(req: Request): Promise<Response> {
 
     const { text } = await generateText({
       model: getModel(DEFAULT_MODEL_ID),
-      prompt: prompt.slice(-MAX_PROMPT_LENGTH),
+      prompt: boundPrompt(prompt),
       maxOutputTokens: 160,
       ...posthogTelemetry({
         distinctId: getDistinctId(req),

--- a/apps/docs/app/api/suggestions/route.ts
+++ b/apps/docs/app/api/suggestions/route.ts
@@ -10,11 +10,15 @@ import { generateText } from "ai";
 const MAX_PROMPT_LENGTH = 24_000;
 const PROMPT_HEAD_LENGTH = 2_000;
 
+const PROMPT_SEPARATOR = "\n\n[...]\n\n";
+
 function boundPrompt(prompt: string): string {
   if (prompt.length <= MAX_PROMPT_LENGTH) return prompt;
   const head = prompt.slice(0, PROMPT_HEAD_LENGTH);
-  const tail = prompt.slice(-(MAX_PROMPT_LENGTH - PROMPT_HEAD_LENGTH));
-  return `${head}\n\n[...]\n\n${tail}`;
+  const tail = prompt.slice(
+    -(MAX_PROMPT_LENGTH - PROMPT_HEAD_LENGTH - PROMPT_SEPARATOR.length),
+  );
+  return `${head}${PROMPT_SEPARATOR}${tail}`;
 }
 
 export async function POST(req: Request): Promise<Response> {

--- a/apps/docs/app/api/suggestions/route.ts
+++ b/apps/docs/app/api/suggestions/route.ts
@@ -1,32 +1,34 @@
 import { getDistinctId } from "@/lib/posthog-server";
 import { requirePublicAssistantSession } from "@/lib/anonymous-session";
-import { checkPublicAssistantRateLimit } from "@/lib/rate-limit";
+import { checkFollowUpSuggestionRateLimit } from "@/lib/rate-limit";
 import { getModel } from "@/lib/ai/provider";
 import { posthogTelemetry } from "@/lib/ai/telemetry";
 import { parseFollowUpSuggestions } from "@/lib/follow-ups";
 import { DEFAULT_MODEL_ID } from "@/lib/model";
 import { generateText } from "ai";
 
+const MAX_PROMPT_LENGTH = 24_000;
+
 export async function POST(req: Request): Promise<Response> {
   try {
     const session = requirePublicAssistantSession(req);
     if (session instanceof Response) return session;
 
-    const rateLimitResponse = await checkPublicAssistantRateLimit(
+    const rateLimitResponse = await checkFollowUpSuggestionRateLimit(
       req,
       session.id,
     );
     if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await req.json();
-    const { prompt } = body;
-    if (typeof prompt !== "string" || prompt.length > 12_000) {
+    const body = await req.json().catch(() => null);
+    const prompt = (body as { prompt?: unknown } | null)?.prompt;
+    if (typeof prompt !== "string" || prompt.trim().length === 0) {
       return new Response("Invalid prompt", { status: 400 });
     }
 
     const { text } = await generateText({
       model: getModel(DEFAULT_MODEL_ID),
-      prompt,
+      prompt: prompt.slice(-MAX_PROMPT_LENGTH),
       maxOutputTokens: 160,
       ...posthogTelemetry({
         distinctId: getDistinctId(req),

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -164,6 +164,7 @@ const homeEffortPreference = createPersistedPreference<string>({
 
 const groupAssistantParts = groupPartByType({
   reasoning: ["group-chainOfThought", "group-reasoning"],
+  source: ["group-source"],
   "tool-call": ["group-chainOfThought", "group-tool"],
   "standalone-tool-call": [],
 });
@@ -734,6 +735,7 @@ function SpecimenThread(): ReactNode {
               <ArrowDownIcon className="size-4" />
             </button>
           </ThreadPrimitive.ScrollToBottom>
+          <SpecimenFollowUps />
           <SpecimenComposer />
           <AuiIf condition={isNewChatView}>
             <div className="min-h-8">
@@ -771,10 +773,13 @@ const SUGGESTIONS = [
       "Draw the request flow of a streaming chat app as a mermaid sequence diagram, then explain it briefly.",
   },
   {
-    label: "Write a debounce function",
-    prompt: "Write a debounce function in TypeScript",
+    label: "Add a thread list",
+    prompt: "How do I add a thread list to an assistant-ui app?",
   },
 ];
+
+const suggestionChipClass =
+  "border-foreground/10 bg-background text-muted-foreground hover:border-foreground/25 hover:text-foreground rounded-control h-8 border px-3 text-[13px] transition-colors";
 
 function SpecimenSuggestions(): ReactNode {
   return (
@@ -784,12 +789,39 @@ function SpecimenSuggestions(): ReactNode {
           key={suggestion.prompt}
           prompt={suggestion.prompt}
           send
-          className="border-foreground/10 bg-background text-muted-foreground hover:border-foreground/25 hover:text-foreground rounded-control h-8 border px-3 text-[13px] transition-colors"
+          className={suggestionChipClass}
         >
           {suggestion.label}
         </ThreadPrimitive.Suggestion>
       ))}
     </div>
+  );
+}
+
+function SpecimenFollowUps(): ReactNode {
+  const suggestions = useAuiState((s) => s.thread.suggestions);
+
+  return (
+    <AuiIf
+      condition={(s) =>
+        !s.thread.isEmpty &&
+        !s.thread.isRunning &&
+        s.thread.suggestions.length > 0
+      }
+    >
+      <div className="animate-in fade-in flex [scrollbar-width:none] gap-2 overflow-x-auto duration-200 motion-reduce:animate-none [&::-webkit-scrollbar]:hidden">
+        {suggestions.map((suggestion) => (
+          <ThreadPrimitive.Suggestion
+            key={suggestion.prompt}
+            prompt={suggestion.prompt}
+            send
+            className={cn(suggestionChipClass, "shrink-0 whitespace-nowrap")}
+          >
+            {suggestion.prompt}
+          </ThreadPrimitive.Suggestion>
+        ))}
+      </div>
+    </AuiIf>
   );
 }
 
@@ -1044,6 +1076,8 @@ function SpecimenAssistantMessage(): ReactNode {
                   </ReasoningRoot>
                 );
               }
+              case "group-source":
+                return null;
               case "text":
                 return part.text === "" && part.status?.type === "running" ? (
                   <TraceLine live label="thinking" />
@@ -1052,6 +1086,8 @@ function SpecimenAssistantMessage(): ReactNode {
                 );
               case "reasoning":
                 return <Reasoning {...part} />;
+              case "source":
+                return null;
               case "tool-call":
                 return part.toolUI ?? <SpecimenToolCall {...part} />;
               case "data":
@@ -1075,6 +1111,7 @@ function SpecimenAssistantMessage(): ReactNode {
             }
           }}
         </MessagePrimitive.GroupedParts>
+        <SpecimenSources />
         <SpecimenMessageError />
       </div>
       <div className="mt-2 flex items-center gap-1.5 empty:hidden">
@@ -1082,6 +1119,40 @@ function SpecimenAssistantMessage(): ReactNode {
         <SpecimenAssistantActionBar />
       </div>
     </MessagePrimitive.Root>
+  );
+}
+
+function SpecimenSources(): ReactNode {
+  const content = useAuiState((s) => s.message.content);
+  const seen = new Set<string>();
+  const sources = content.flatMap((part) => {
+    if (
+      part.type !== "source" ||
+      part.sourceType !== "url" ||
+      seen.has(part.url)
+    ) {
+      return [];
+    }
+    seen.add(part.url);
+    return part;
+  });
+  if (sources.length === 0) return null;
+
+  return (
+    <div className="text-muted-foreground mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[12px] [font-variant-ligatures:none]">
+      <span className="text-muted-foreground/50">sources</span>
+      {sources.map((source) => (
+        <a
+          key={source.url}
+          href={source.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="decoration-foreground/20 hover:text-foreground hover:decoration-foreground/60 max-w-[40ch] truncate underline underline-offset-[3px] transition-colors"
+        >
+          {source.title || new URL(source.url).hostname}
+        </a>
+      ))}
+    </div>
   );
 }
 
@@ -1267,16 +1338,31 @@ function SpecimenDisclosureTrigger({
 
 function SpecimenToolCall({
   toolName,
+  args,
   status,
 }: ToolCallMessagePartProps): ReactNode {
   const isRunning = status?.type === "running";
   const duration = useToolDuration(isRunning);
+  const searchQuery =
+    toolName === "search_docs" && typeof args.query === "string"
+      ? args.query
+      : undefined;
 
   return (
     <TraceLine
       live={isRunning}
-      label={isRunning ? "running" : "ran"}
-      detail={toolName}
+      label={
+        searchQuery !== undefined
+          ? isRunning
+            ? "searching"
+            : "searched"
+          : isRunning
+            ? "running"
+            : "ran"
+      }
+      detail={
+        searchQuery !== undefined ? `the docs for “${searchQuery}”` : toolName
+      }
       {...(duration !== null ? { meta: formatDuration(duration) } : {})}
     />
   );

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -1122,6 +1122,17 @@ function SpecimenAssistantMessage(): ReactNode {
   );
 }
 
+function isCited(text: string, url: string): boolean {
+  let from = 0;
+  for (;;) {
+    const at = text.indexOf(url, from);
+    if (at === -1) return false;
+    const next = text[at + url.length];
+    if (next === undefined || !/[\w#?/-]/.test(next)) return true;
+    from = at + url.length;
+  }
+}
+
 function sourceLabel(url: string, title: string | undefined): string {
   if (title) return title;
   try {
@@ -1142,7 +1153,7 @@ function SpecimenSources(): ReactNode {
       part.type !== "source" ||
       part.sourceType !== "url" ||
       seen.has(part.url) ||
-      !text.includes(part.url)
+      !isCited(text, part.url)
     ) {
       return [];
     }

--- a/apps/docs/components/pages/home/home-thread.tsx
+++ b/apps/docs/components/pages/home/home-thread.tsx
@@ -164,7 +164,7 @@ const homeEffortPreference = createPersistedPreference<string>({
 
 const groupAssistantParts = groupPartByType({
   reasoning: ["group-chainOfThought", "group-reasoning"],
-  source: ["group-source"],
+  source: ["group-chainOfThought", "group-source"],
   "tool-call": ["group-chainOfThought", "group-tool"],
   "standalone-tool-call": [],
 });
@@ -1122,14 +1122,27 @@ function SpecimenAssistantMessage(): ReactNode {
   );
 }
 
+function sourceLabel(url: string, title: string | undefined): string {
+  if (title) return title;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 function SpecimenSources(): ReactNode {
   const content = useAuiState((s) => s.message.content);
+  const text = content
+    .flatMap((part) => (part.type === "text" ? part.text : []))
+    .join("\n");
   const seen = new Set<string>();
   const sources = content.flatMap((part) => {
     if (
       part.type !== "source" ||
       part.sourceType !== "url" ||
-      seen.has(part.url)
+      seen.has(part.url) ||
+      !text.includes(part.url)
     ) {
       return [];
     }
@@ -1149,7 +1162,7 @@ function SpecimenSources(): ReactNode {
           rel="noopener noreferrer"
           className="decoration-foreground/20 hover:text-foreground hover:decoration-foreground/60 max-w-[40ch] truncate underline underline-offset-[3px] transition-colors"
         >
-          {source.title || new URL(source.url).hostname}
+          {sourceLabel(source.url, source.title)}
         </a>
       ))}
     </div>

--- a/apps/docs/components/pages/home/thread-specimen.tsx
+++ b/apps/docs/components/pages/home/thread-specimen.tsx
@@ -96,7 +96,7 @@ export function ThreadSpecimen() {
   return (
     <section aria-label="Thread" className="flex flex-col gap-3">
       <div className="border-foreground/10 rounded-document h-[min(52rem,88svh)] overflow-hidden border">
-        <DocsRuntimeProvider devtools={false}>
+        <DocsRuntimeProvider devtools={false} followUps>
           {expanded
             ? createPortal(
                 <div

--- a/apps/docs/lib/ai/search-docs.test.ts
+++ b/apps/docs/lib/ai/search-docs.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SearchRecord } from "@/lib/search/types";
-import { searchDocs } from "./search-docs";
+vi.mock("@/lib/search/pages", () => ({
+  buildSearchIndex: () => records,
+}));
+
+import { createSearchDocsTool, searchDocs } from "./search-docs";
 
 const records: SearchRecord[] = [
   {
@@ -56,5 +60,36 @@ describe("searchDocs", () => {
   it("returns no results for empty or all-stopword queries", () => {
     expect(searchDocs(records, "", 5)).toEqual([]);
     expect(searchDocs(records, "the and or", 5)).toEqual([]);
+  });
+});
+
+describe("createSearchDocsTool", () => {
+  it("writes one absolute source part per returned page", async () => {
+    const written: unknown[] = [];
+    const tool = createSearchDocsTool({
+      writer: { write: (part: unknown) => written.push(part) } as never,
+      origin: "https://www.assistant-ui.com",
+    });
+
+    const output = (await tool.execute!(
+      { query: "thread list" },
+      {
+        toolCallId: "1",
+        messages: [],
+      },
+    )) as { results: { url: string; title: string }[] };
+
+    expect(output.results.map((page) => page.url)).toEqual([
+      "https://www.assistant-ui.com/docs/ui/thread-list",
+      "https://www.assistant-ui.com/docs/runtimes/custom",
+    ]);
+    expect(written).toEqual(
+      output.results.map((page) => ({
+        type: "source-url",
+        sourceId: page.url,
+        url: page.url,
+        title: page.title,
+      })),
+    );
   });
 });

--- a/apps/docs/lib/ai/search-docs.test.ts
+++ b/apps/docs/lib/ai/search-docs.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { SearchRecord } from "@/lib/search/types";
+import { searchDocs } from "./search-docs";
+
+const records: SearchRecord[] = [
+  {
+    url: "/docs/ui/thread-list",
+    title: "Thread List",
+    description: "Render and manage conversation history.",
+    headings: [{ id: "usage", content: "Usage" }],
+  },
+  {
+    url: "/docs/runtimes/custom",
+    title: "Custom Runtime",
+    description: "Connect an external store.",
+    headings: [{ id: "thread-list", content: "Thread List" }],
+  },
+];
+
+describe("searchDocs", () => {
+  it("ranks a title match above a heading-only match", () => {
+    expect(
+      searchDocs(records, "thread list", 5).map((page) => page.url),
+    ).toEqual(["/docs/ui/thread-list", "/docs/runtimes/custom"]);
+  });
+
+  it("deduplicates urls", () => {
+    expect(
+      searchDocs([...records, records[0]!], "thread list", 5),
+    ).toHaveLength(2);
+  });
+
+  it("caps results at the limit", () => {
+    const matchingRecords = [
+      ...records,
+      {
+        url: "/docs/ui/thread-list-item",
+        title: "Thread List Item",
+        description: "Render one thread.",
+        headings: [],
+      },
+    ];
+
+    expect(searchDocs(matchingRecords, "thread list", 2)).toHaveLength(2);
+  });
+
+  it("falls back to pages that match part of the query", () => {
+    expect(
+      searchDocs(records, "thread list runtime", 5).map((page) => page.url),
+    ).toEqual(
+      expect.arrayContaining(["/docs/ui/thread-list", "/docs/runtimes/custom"]),
+    );
+    expect(searchDocs(records, "thread list runtime", 5)).toHaveLength(2);
+  });
+
+  it("returns no results for empty or all-stopword queries", () => {
+    expect(searchDocs(records, "", 5)).toEqual([]);
+    expect(searchDocs(records, "the and or", 5)).toEqual([]);
+  });
+});

--- a/apps/docs/lib/ai/search-docs.test.ts
+++ b/apps/docs/lib/ai/search-docs.test.ts
@@ -4,6 +4,27 @@ vi.mock("@/lib/search/pages", () => ({
   buildSearchIndex: () => records,
 }));
 
+vi.mock("@/lib/source", () => ({
+  source: {
+    getPages: () => [
+      {
+        url: "/docs/ui/thread-list",
+        data: {
+          structuredData: () => ({
+            contents: [
+              { content: "An unrelated opening paragraph." },
+              { content: "Render the thread list beside your thread." },
+            ],
+          }),
+        },
+      },
+    ],
+  },
+  getTapDocsPages: () => [],
+  design: { getPages: () => [] },
+  elementsDocs: { getPages: () => [] },
+}));
+
 import { createSearchDocsTool, searchDocs } from "./search-docs";
 
 const records: SearchRecord[] = [
@@ -91,5 +112,25 @@ describe("createSearchDocsTool", () => {
         title: page.title,
       })),
     );
+  });
+
+  it("excerpts the paragraphs that match the query", async () => {
+    const tool = createSearchDocsTool({
+      writer: { write: () => {} } as never,
+      origin: "https://www.assistant-ui.com",
+    });
+
+    const output = (await tool.execute!(
+      { query: "thread list" },
+      {
+        toolCallId: "1",
+        messages: [],
+      },
+    )) as { results: { url: string; excerpt?: string }[] };
+
+    expect(output.results[0]?.excerpt).toBe(
+      "Render the thread list beside your thread.",
+    );
+    expect(output.results[1]?.excerpt).toBeUndefined();
   });
 });

--- a/apps/docs/lib/ai/search-docs.test.ts
+++ b/apps/docs/lib/ai/search-docs.test.ts
@@ -1,25 +1,42 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SearchRecord } from "@/lib/search/types";
-vi.mock("@/lib/search/pages", () => ({
-  buildSearchIndex: () => records,
+const mocks = vi.hoisted(() => ({
+  records: [
+    {
+      url: "/docs/ui/thread-list",
+      title: "Thread List",
+      description: "Render and manage conversation history.",
+      headings: [{ id: "usage", content: "Usage" }],
+    },
+    {
+      url: "/docs/runtimes/custom",
+      title: "Custom Runtime",
+      description: "Connect an external store.",
+      headings: [{ id: "thread-list", content: "Thread List" }],
+    },
+  ],
+  pages: [
+    {
+      url: "/docs/ui/thread-list",
+      data: {
+        structuredData: () => ({
+          contents: [
+            { content: "An unrelated opening paragraph." },
+            { content: "Render the thread list beside your thread." },
+          ],
+        }),
+      },
+    },
+  ],
+}));
+
+vi.mock("@/lib/search/pages", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/search/pages")>()),
+  buildSearchIndex: () => mocks.records,
 }));
 
 vi.mock("@/lib/source", () => ({
-  source: {
-    getPages: () => [
-      {
-        url: "/docs/ui/thread-list",
-        data: {
-          structuredData: () => ({
-            contents: [
-              { content: "An unrelated opening paragraph." },
-              { content: "Render the thread list beside your thread." },
-            ],
-          }),
-        },
-      },
-    ],
-  },
+  source: { getPages: () => mocks.pages },
   getTapDocsPages: () => [],
   design: { getPages: () => [] },
   elementsDocs: { getPages: () => [] },
@@ -27,20 +44,7 @@ vi.mock("@/lib/source", () => ({
 
 import { createSearchDocsTool, searchDocs } from "./search-docs";
 
-const records: SearchRecord[] = [
-  {
-    url: "/docs/ui/thread-list",
-    title: "Thread List",
-    description: "Render and manage conversation history.",
-    headings: [{ id: "usage", content: "Usage" }],
-  },
-  {
-    url: "/docs/runtimes/custom",
-    title: "Custom Runtime",
-    description: "Connect an external store.",
-    headings: [{ id: "thread-list", content: "Thread List" }],
-  },
-];
+const records: SearchRecord[] = mocks.records;
 
 describe("searchDocs", () => {
   it("ranks a title match above a heading-only match", () => {

--- a/apps/docs/lib/ai/search-docs.ts
+++ b/apps/docs/lib/ai/search-docs.ts
@@ -1,0 +1,170 @@
+import { searchOtherPages, tokenize } from "@/lib/search/query";
+import type { SearchGroup, SearchRecord } from "@/lib/search/types";
+import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
+import z from "zod";
+
+const STOP_WORDS = new Set([
+  "about",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "can",
+  "do",
+  "does",
+  "for",
+  "from",
+  "how",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "should",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+  "would",
+  "you",
+  "your",
+]);
+
+type SearchDocsResult = {
+  url: string;
+  title: string;
+  description: string;
+  headings: string[];
+};
+
+export function searchDocs(
+  records: SearchRecord[],
+  query: string,
+  limit: number,
+): SearchDocsResult[] {
+  const tokens = tokenize(query).filter((token) => !STOP_WORDS.has(token));
+  if (tokens.length === 0 || limit <= 0) return [];
+
+  const recordsByUrl = new Map<string, SearchRecord>();
+  for (const record of records) {
+    if (!recordsByUrl.has(record.url)) recordsByUrl.set(record.url, record);
+  }
+
+  const pages = [...recordsByUrl.values()];
+  const rank = (terms: string[]) =>
+    searchOtherPages(pages, terms.join(" "), "");
+
+  let groups = rank(tokens);
+  if (groups.length === 0 && tokens.length > 1) {
+    const partial = new Map<string, { group: SearchGroup; hits: number }>();
+    for (const token of tokens) {
+      for (const group of rank([token])) {
+        const entry = partial.get(group.pageUrl);
+        if (entry) entry.hits += 1;
+        else partial.set(group.pageUrl, { group, hits: 1 });
+      }
+    }
+    groups = [...partial.values()]
+      .sort((a, b) => b.hits - a.hits)
+      .map((entry) => entry.group);
+  }
+
+  return groups.slice(0, limit).flatMap((group) => {
+    const record = recordsByUrl.get(group.pageUrl);
+    if (!record) return [];
+    return {
+      url: record.url,
+      title: record.title,
+      description: record.description,
+      headings: record.headings.map((heading) => heading.content),
+    };
+  });
+}
+
+let searchIndexPromise: Promise<SearchRecord[]> | undefined;
+
+function getSearchIndex() {
+  searchIndexPromise ??= import("@/lib/search/pages").then(
+    ({ buildSearchIndex }) => buildSearchIndex(),
+  );
+  return searchIndexPromise;
+}
+
+async function getExcerpt(url: string) {
+  const [{ getLLMText }, sourceModule] = await Promise.all([
+    import("@/lib/get-llm-text"),
+    import("@/lib/source"),
+  ]);
+  const page =
+    sourceModule.source.getPages().find((page) => page.url === url) ??
+    sourceModule.getTapDocsPages().find((page) => page.url === url) ??
+    sourceModule.design.getPages().find((page) => page.url === url) ??
+    sourceModule.elementsDocs.getPages().find((page) => page.url === url);
+  if (!page) return undefined;
+
+  return (await getLLMText(page)).replace(/\s+/g, " ").trim().slice(0, 600);
+}
+
+export function createSearchDocsTool({
+  writer,
+  origin,
+}: {
+  writer: UIMessageStreamWriter;
+  origin: string;
+}) {
+  return tool({
+    description:
+      "Search the assistant-ui documentation for APIs, components, runtimes, setup, and usage guidance.",
+    inputSchema: zodSchema(
+      z.object({
+        query: z
+          .string()
+          .describe(
+            "A short phrase of distinctive documentation terms, with filler words omitted.",
+          ),
+      }),
+    ),
+    execute: async ({ query }) => {
+      const matches = searchDocs(await getSearchIndex(), query, 5);
+      const results = await Promise.all(
+        matches.map(async (match, index) => {
+          const result = {
+            ...match,
+            url: new URL(match.url, origin).href,
+          };
+          if (index >= 3) return result;
+
+          try {
+            const excerpt = await getExcerpt(match.url);
+            return excerpt === undefined ? result : { ...result, excerpt };
+          } catch {
+            return result;
+          }
+        }),
+      );
+
+      for (const page of matches) {
+        writer.write({
+          type: "source-url",
+          sourceId: page.url,
+          url: new URL(page.url, origin).href,
+          title: page.title,
+        });
+      }
+
+      return { results };
+    },
+  });
+}

--- a/apps/docs/lib/ai/search-docs.ts
+++ b/apps/docs/lib/ai/search-docs.ts
@@ -47,6 +47,7 @@ type SearchDocsResult = {
   title: string;
   description: string;
   headings: string[];
+  matches: string[];
 };
 
 export function searchDocs(
@@ -89,6 +90,10 @@ export function searchDocs(
       title: record.title,
       description: record.description,
       headings: record.headings.map((heading) => heading.content),
+      matches: group.items
+        .filter((item) => item.type !== "page")
+        .slice(0, 4)
+        .map((item) => item.content.replace(/\s+/g, " ").trim().slice(0, 300)),
     };
   });
 }
@@ -96,25 +101,13 @@ export function searchDocs(
 let searchIndexPromise: Promise<SearchRecord[]> | undefined;
 
 function getSearchIndex() {
-  searchIndexPromise ??= import("@/lib/search/pages").then(
-    ({ buildSearchIndex }) => buildSearchIndex(),
-  );
+  searchIndexPromise ??= import("@/lib/search/pages")
+    .then(({ buildSearchIndex }) => buildSearchIndex())
+    .catch((error: unknown) => {
+      searchIndexPromise = undefined;
+      throw error;
+    });
   return searchIndexPromise;
-}
-
-async function getExcerpt(url: string) {
-  const [{ getLLMText }, sourceModule] = await Promise.all([
-    import("@/lib/get-llm-text"),
-    import("@/lib/source"),
-  ]);
-  const page =
-    sourceModule.source.getPages().find((page) => page.url === url) ??
-    sourceModule.getTapDocsPages().find((page) => page.url === url) ??
-    sourceModule.design.getPages().find((page) => page.url === url) ??
-    sourceModule.elementsDocs.getPages().find((page) => page.url === url);
-  if (!page) return undefined;
-
-  return (await getLLMText(page)).replace(/\s+/g, " ").trim().slice(0, 600);
 }
 
 export function createSearchDocsTool({
@@ -137,29 +130,17 @@ export function createSearchDocsTool({
       }),
     ),
     execute: async ({ query }) => {
-      const matches = searchDocs(await getSearchIndex(), query, 5);
-      const results = await Promise.all(
-        matches.map(async (match, index) => {
-          const result = {
-            ...match,
-            url: new URL(match.url, origin).href,
-          };
-          if (index >= 3) return result;
+      const pages = searchDocs(await getSearchIndex(), query, 5);
+      const results = pages.map((page) => ({
+        ...page,
+        url: new URL(page.url, origin).href,
+      }));
 
-          try {
-            const excerpt = await getExcerpt(match.url);
-            return excerpt === undefined ? result : { ...result, excerpt };
-          } catch {
-            return result;
-          }
-        }),
-      );
-
-      for (const page of matches) {
+      for (const page of results) {
         writer.write({
           type: "source-url",
           sourceId: page.url,
-          url: new URL(page.url, origin).href,
+          url: page.url,
           title: page.title,
         });
       }

--- a/apps/docs/lib/ai/search-docs.ts
+++ b/apps/docs/lib/ai/search-docs.ts
@@ -105,38 +105,39 @@ function getSearchIndex() {
   return searchIndexPromise;
 }
 
-const excerptCache = new Map<string, string | undefined>();
+const paragraphCache = new Map<string, readonly string[]>();
 
-async function getExcerpt(
-  url: string,
-  terms: string[],
-): Promise<string | undefined> {
-  const cacheKey = `${url}\u0000${terms.join(" ")}`;
-  if (excerptCache.has(cacheKey)) return excerptCache.get(cacheKey);
+async function getParagraphs(url: string): Promise<readonly string[]> {
+  const cached = paragraphCache.get(url);
+  if (cached) return cached;
 
-  const excerpt = await buildExcerpt(url, terms).catch(() => undefined);
-  excerptCache.set(cacheKey, excerpt);
-  return excerpt;
+  const paragraphs = await loadParagraphs(url).catch(() => []);
+  if (paragraphs.length > 0) paragraphCache.set(url, paragraphs);
+  return paragraphs;
 }
 
-async function buildExcerpt(
-  url: string,
-  terms: string[],
-): Promise<string | undefined> {
+async function loadParagraphs(url: string): Promise<string[]> {
   const sourceModule = await import("@/lib/source");
   const page =
     sourceModule.source.getPages().find((page) => page.url === url) ??
     sourceModule.getTapDocsPages().find((page) => page.url === url) ??
     sourceModule.design.getPages().find((page) => page.url === url) ??
     sourceModule.elementsDocs.getPages().find((page) => page.url === url);
-  if (!page) return undefined;
+  if (!page) return [];
 
   const { contents } = (await page.data.structuredData()) as {
     contents?: { content?: string }[];
   };
-  const paragraphs = (contents ?? [])
+  return (contents ?? [])
     .map((entry) => entry.content?.replace(/\s+/g, " ").trim() ?? "")
     .filter((text) => text.length > 0);
+}
+
+async function getExcerpt(
+  url: string,
+  terms: string[],
+): Promise<string | undefined> {
+  const paragraphs = await getParagraphs(url);
   if (paragraphs.length === 0) return undefined;
 
   const scored = paragraphs

--- a/apps/docs/lib/ai/search-docs.ts
+++ b/apps/docs/lib/ai/search-docs.ts
@@ -47,7 +47,6 @@ type SearchDocsResult = {
   title: string;
   description: string;
   headings: string[];
-  matches: string[];
 };
 
 export function searchDocs(
@@ -90,10 +89,6 @@ export function searchDocs(
       title: record.title,
       description: record.description,
       headings: record.headings.map((heading) => heading.content),
-      matches: group.items
-        .filter((item) => item.type !== "page")
-        .slice(0, 4)
-        .map((item) => item.content.replace(/\s+/g, " ").trim().slice(0, 300)),
     };
   });
 }
@@ -108,6 +103,58 @@ function getSearchIndex() {
       throw error;
     });
   return searchIndexPromise;
+}
+
+const excerptCache = new Map<string, string | undefined>();
+
+async function getExcerpt(
+  url: string,
+  terms: string[],
+): Promise<string | undefined> {
+  const cacheKey = `${url}\u0000${terms.join(" ")}`;
+  if (excerptCache.has(cacheKey)) return excerptCache.get(cacheKey);
+
+  const excerpt = await buildExcerpt(url, terms).catch(() => undefined);
+  excerptCache.set(cacheKey, excerpt);
+  return excerpt;
+}
+
+async function buildExcerpt(
+  url: string,
+  terms: string[],
+): Promise<string | undefined> {
+  const sourceModule = await import("@/lib/source");
+  const page =
+    sourceModule.source.getPages().find((page) => page.url === url) ??
+    sourceModule.getTapDocsPages().find((page) => page.url === url) ??
+    sourceModule.design.getPages().find((page) => page.url === url) ??
+    sourceModule.elementsDocs.getPages().find((page) => page.url === url);
+  if (!page) return undefined;
+
+  const { contents } = (await page.data.structuredData()) as {
+    contents?: { content?: string }[];
+  };
+  const paragraphs = (contents ?? [])
+    .map((entry) => entry.content?.replace(/\s+/g, " ").trim() ?? "")
+    .filter((text) => text.length > 0);
+  if (paragraphs.length === 0) return undefined;
+
+  const scored = paragraphs
+    .map((text, order) => {
+      const haystack = text.toLowerCase();
+      const score = terms.filter((term) => haystack.includes(term)).length;
+      return { text, order, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.order - b.order)
+    .slice(0, 3)
+    .sort((a, b) => a.order - b.order);
+
+  const chosen = scored.length > 0 ? scored : [{ text: paragraphs[0]! }];
+  return chosen
+    .map((entry) => entry.text)
+    .join(" ")
+    .slice(0, 600);
 }
 
 export function createSearchDocsTool({
@@ -131,10 +178,15 @@ export function createSearchDocsTool({
     ),
     execute: async ({ query }) => {
       const pages = searchDocs(await getSearchIndex(), query, 5);
-      const results = pages.map((page) => ({
-        ...page,
-        url: new URL(page.url, origin).href,
-      }));
+      const terms = tokenize(query).filter((token) => !STOP_WORDS.has(token));
+      const results = await Promise.all(
+        pages.map(async (page, index) => {
+          const absolute = { ...page, url: new URL(page.url, origin).href };
+          if (index >= 3) return absolute;
+          const excerpt = await getExcerpt(page.url, terms);
+          return excerpt === undefined ? absolute : { ...absolute, excerpt };
+        }),
+      );
 
       for (const page of results) {
         writer.write({

--- a/apps/docs/lib/follow-ups.test.ts
+++ b/apps/docs/lib/follow-ups.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { parseFollowUpSuggestions } from "./follow-ups";
+
+describe("parseFollowUpSuggestions", () => {
+  it("normalizes lines, omits duplicates, and keeps the requested count", () => {
+    expect(
+      parseFollowUpSuggestions(
+        " - \"Ask a deeper question\"\n2. “Draw a diagram”\n• Ask a deeper question\n\n(3) 'Remember this preference'\n4. Omit this",
+        3,
+      ),
+    ).toEqual([
+      "Ask a deeper question",
+      "Draw a diagram",
+      "Remember this preference",
+    ]);
+  });
+});

--- a/apps/docs/lib/follow-ups.ts
+++ b/apps/docs/lib/follow-ups.ts
@@ -1,0 +1,20 @@
+export function parseFollowUpSuggestions(
+  text: string,
+  count: number,
+): string[] {
+  const limit = Math.max(0, Math.floor(count));
+  const seen = new Set<string>();
+
+  return text.split("\n").flatMap((line) => {
+    const suggestion = line
+      .trim()
+      .replace(/^(?:(?:[-*•]+|\d+[.)]|\(\d+\))\s*)+/, "")
+      .trim()
+      .replace(/^["'“‘]+|["'”’]+$/g, "")
+      .trim();
+
+    if (!suggestion || seen.has(suggestion) || seen.size >= limit) return [];
+    seen.add(suggestion);
+    return [suggestion];
+  });
+}

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -182,6 +182,11 @@ const getPublicAssistantRateLimits = async () => {
         "1d",
       ),
     }),
+    followUpGlobalAlert: new Ratelimit({
+      redis,
+      prefix: "aui:follow-up:global:alert",
+      limiter: Ratelimit.fixedWindow(1, "10m"),
+    }),
     xuluxDownloadIpBurst: new Ratelimit({
       redis,
       prefix: "aui:xulux-download:ip:burst",
@@ -354,6 +359,18 @@ export async function checkFollowUpSuggestionRateLimit(
 
     const globalDaily = await limits.followUpGlobalDaily.limit("all");
     if (!globalDaily.success) {
+      const alert = await limits.followUpGlobalAlert
+        .limit("all")
+        .catch(() => null);
+      if (alert?.success) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            message: "follow_up_global_daily_exhausted",
+            requestId: request.headers.get("x-vercel-id"),
+          }),
+        );
+      }
       return limitResponse("Follow-up daily limit exceeded", globalDaily.reset);
     }
 

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -337,7 +337,6 @@ export async function checkPublicAssistantRateLimit(
 
 export async function checkFollowUpSuggestionRateLimit(
   request: Request,
-  sessionId: string,
 ): Promise<Response | null> {
   return runRateLimitChecks(request, "follow_up", async (limits) => {
     const ip = getClientIp(request);
@@ -348,7 +347,7 @@ export async function checkFollowUpSuggestionRateLimit(
       return limitResponse("Follow-up rate limit exceeded", burst.reset);
     }
 
-    const daily = await limits.followUpIpDaily.limit(`${ip}:${sessionId}`);
+    const daily = await limits.followUpIpDaily.limit(ip);
     if (!daily.success) {
       return limitResponse("Follow-up daily limit exceeded", daily.reset);
     }

--- a/apps/docs/lib/rate-limit.ts
+++ b/apps/docs/lib/rate-limit.ts
@@ -155,6 +155,33 @@ const getPublicAssistantRateLimits = async () => {
       prefix: "aui:mcp-template:global:alert",
       limiter: Ratelimit.fixedWindow(1, "10m"),
     }),
+    followUpIpBurst: new Ratelimit({
+      redis,
+      prefix: "aui:follow-up:ip:burst",
+      limiter: Ratelimit.fixedWindow(10, "60s"),
+    }),
+    followUpIpDaily: new Ratelimit({
+      redis,
+      prefix: "aui:follow-up:ip:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_FOLLOW_UP_REQUESTS_PER_IP_PER_DAY,
+          300,
+        ),
+        "1d",
+      ),
+    }),
+    followUpGlobalDaily: new Ratelimit({
+      redis,
+      prefix: "aui:follow-up:global:daily",
+      limiter: Ratelimit.fixedWindow(
+        positiveSafeInteger(
+          process.env.AUI_FOLLOW_UP_GLOBAL_REQUESTS_PER_DAY,
+          20_000,
+        ),
+        "1d",
+      ),
+    }),
     xuluxDownloadIpBurst: new Ratelimit({
       redis,
       prefix: "aui:xulux-download:ip:burst",
@@ -304,6 +331,33 @@ export async function checkPublicAssistantRateLimit(
         globalDaily.reset,
       );
     }
+    return null;
+  });
+}
+
+export async function checkFollowUpSuggestionRateLimit(
+  request: Request,
+  sessionId: string,
+): Promise<Response | null> {
+  return runRateLimitChecks(request, "follow_up", async (limits) => {
+    const ip = getClientIp(request);
+    if (!ip) return missingClientIpResponse(request, "follow_up");
+
+    const burst = await limits.followUpIpBurst.limit(ip);
+    if (!burst.success) {
+      return limitResponse("Follow-up rate limit exceeded", burst.reset);
+    }
+
+    const daily = await limits.followUpIpDaily.limit(`${ip}:${sessionId}`);
+    if (!daily.success) {
+      return limitResponse("Follow-up daily limit exceeded", daily.reset);
+    }
+
+    const globalDaily = await limits.followUpGlobalDaily.limit("all");
+    if (!globalDaily.success) {
+      return limitResponse("Follow-up daily limit exceeded", globalDaily.reset);
+    }
+
     return null;
   });
 }

--- a/apps/docs/runtimes/chat-runtime.ts
+++ b/apps/docs/runtimes/chat-runtime.ts
@@ -93,15 +93,18 @@ export function useDocsChatRuntime({
   cloud,
   adapters,
   sendAutomatically = false,
+  searchDocs = false,
 }: {
   api?: string;
   cloud?: AssistantCloud;
   adapters?: Adapters;
   sendAutomatically?: boolean;
+  searchDocs?: boolean;
 } = {}) {
   return useChatRuntime({
     transport: new AssistantChatTransport({
       ...(api ? { api } : {}),
+      ...(searchDocs ? { body: { searchDocs: true } } : {}),
       fetch: anonymousSessionFetch,
     }),
     ...(sendAutomatically

--- a/apps/docs/runtimes/chat-runtime.ts
+++ b/apps/docs/runtimes/chat-runtime.ts
@@ -5,6 +5,7 @@ import {
   AssistantCloud,
   WebSpeechDictationAdapter,
   WebSpeechSynthesisAdapter,
+  createSuggestionAdapter,
 } from "@assistant-ui/react";
 import {
   AssistantChatTransport,
@@ -15,6 +16,34 @@ import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { anonymousSessionFetch } from "@/lib/anonymous-session-client";
 
 type Adapters = UseChatRuntimeOptions["adapters"];
+
+export const followUpSuggestionAdapter = createSuggestionAdapter({
+  count: 3,
+  maxMessages: 6,
+  instructions:
+    "Prefer follow-ups that exercise a different capability than the last reply: a deeper question on the same topic, a request to visualize or diagram it, or a request to remember a preference. Keep each under 60 characters.",
+  async complete({ prompt, signal }) {
+    try {
+      const response = await anonymousSessionFetch("/api/suggestions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt }),
+        ...(signal ? { signal } : {}),
+      });
+      if (!response.ok) return [];
+
+      const body = (await response.json()) as { suggestions?: unknown };
+      return Array.isArray(body.suggestions)
+        ? body.suggestions.filter(
+            (suggestion): suggestion is string =>
+              typeof suggestion === "string",
+          )
+        : [];
+    } catch {
+      return [];
+    }
+  },
+});
 
 export function useAnonymousCloud() {
   return useMemo(

--- a/apps/docs/runtimes/docs.tsx
+++ b/apps/docs/runtimes/docs.tsx
@@ -13,6 +13,7 @@ import { DevToolsModal } from "@assistant-ui/react-devtools";
 import { feedbackAdapter } from "@/lib/feedback-adapter";
 import docsToolkit from "@/lib/docs-toolkit";
 import {
+  followUpSuggestionAdapter,
   useAnonymousCloud,
   useDocsChatRuntime,
   useSpeechAdapters,
@@ -40,9 +41,11 @@ const DOCS_SUGGESTIONS = [
 export function DocsRuntimeProvider({
   children,
   devtools = true,
+  followUps = false,
 }: {
   children: ReactNode;
   devtools?: boolean;
+  followUps?: boolean;
 }) {
   const cloud = useAnonymousCloud();
   const speech = useSpeechAdapters({ dictation: true });
@@ -52,8 +55,9 @@ export function DocsRuntimeProvider({
       ...speech,
       feedback: feedbackAdapter,
       attachments: new CloudFileAttachmentAdapter(cloud),
+      ...(followUps ? { suggestion: followUpSuggestionAdapter } : {}),
     }),
-    [cloud, speech],
+    [cloud, followUps, speech],
   );
 
   const runtime = useDocsChatRuntime({

--- a/apps/docs/runtimes/docs.tsx
+++ b/apps/docs/runtimes/docs.tsx
@@ -64,6 +64,7 @@ export function DocsRuntimeProvider({
     cloud,
     adapters,
     sendAutomatically: true,
+    searchDocs: followUps,
   });
 
   const aui = useAui({


### PR DESCRIPTION
## problem

the home demo answered from the model alone. it could state something about assistant-ui that our docs contradict, and a reader had no path from an answer to the page it came from. after a reply, the thread also went dead: the empty-state suggestions are gone by then, so there was nothing to click.

## change

- a `search_docs` tool searches the existing docs index (`lib/search/query`, the same ranking the site search uses) and returns the top pages with an excerpt for the first three. the system instruction tells the model to call it before answering an assistant-ui question and to cite only pages it returned.
- the route moves onto `createUIMessageStream` so the tool can write `source-url` parts while the answer streams. the metadata callback that feeds assistant-cloud telemetry is unchanged, it just rides on `toUIMessageStream` now.
- cited pages render under the message as one mono reference line of underlined titles, not as cards or favicon pills. the search trace line reads `searched the docs for "…"` with the real query instead of the tool id.
- after each reply, follow-up suggestions come from `/api/suggestions` through the runtime's suggestion adapter, behind the same anonymous session and rate limit as the chat route. they render with the same chip class as the empty-state suggestions, in a row that scrolls rather than wrapping.
- one empty-state suggestion swaps to a docs question so the search path is reachable from a cold thread.

## verification

- [x] `apps/docs`: `npx vitest run lib/ai/search-docs.test.ts lib/follow-ups.test.ts` -> 6 pass.
- [x] `tsc --noEmit` on `apps/docs`, oxlint and oxfmt on every touched file.
- [x] browser, dev server on the branch: asked how to add a thread list. two `searched the docs for "…"` trace lines with durations, inline links to the ThreadList pages, a `sources` line listing six pages, and three follow-up chips above the composer. server log shows `POST /api/chat 200` then `POST /api/suggestions 200`.

## public surface

- docs app only. no published package changes, so no changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Uq15L3_sR7Pka8ssKj7834eFGZKEgIo7Rm-lvP2V6-ezTrAVLtX0fmesV1o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->