### PR TITLE
refactor(assistant-stream): drop the redis client members the resumable store never calls

### DIFF
--- a/.changeset/redis-like-client-narrow.md
+++ b/.changeset/redis-like-client-narrow.md
@@ -3,3 +3,5 @@
 ---
 
 refactor: drop the redis client members the resumable store never calls
+
+`RedisLikeClient` no longer declares `set`, `expire`, `exists` or `xAdd`, `PipelineCommand` no longer has a `"set"` variant, and `NodeRedisLike` no longer requires `expire`, `exists`, `xAdd` or the non-NX `set` overload; no public API accepts a `RedisLikeClient`, so this only affects code that typed a value against the interface directly.

--- a/.changeset/redis-like-client-narrow.md
+++ b/.changeset/redis-like-client-narrow.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: drop the redis client members the resumable store never calls

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -924,14 +924,8 @@ interface NodeRedisLike {
     NX: true;
     EX: number;
   }): Promise<string | null>;
-  set(key: string, value: string, options: {
-    EX: number;
-  }): Promise<string | null>;
   get(key: string): Promise<string | null>;
-  expire(key: string, seconds: number): Promise<unknown>;
-  exists(key: string): Promise<number>;
   del(keys: string | string[]): Promise<unknown>;
-  xAdd(key: string, id: string, fields: NodeRedisFields): Promise<string>;
   sendCommand<T = unknown>(args: ReadonlyArray<string | Buffer>, options?: {
     typeMapping?: Record<number, unknown>;
   }): Promise<T>;
@@ -941,11 +935,7 @@ interface NodeRedisLike {
 interface NodeRedisMultiCommand {
   xAdd(key: string, id: string, fields: NodeRedisFields): NodeRedisMultiCommand;
   expire(key: string, seconds: number): NodeRedisMultiCommand;
-  set(key: string, value: string, options: {
-    EX: number;
-  }): NodeRedisMultiCommand;
   execAsPipeline(): Promise<unknown>;
-  exec(): Promise<unknown>;
 }
 
 type NodeRole = "all" | "master" | "slave";
@@ -1019,11 +1009,6 @@ type PipelineCommand = {
 } | {
   readonly type: "expire";
   readonly key: string;
-  readonly ttlSec: number;
-} | {
-  readonly type: "set";
-  readonly key: string;
-  readonly value: string;
   readonly ttlSec: number;
 };
 
@@ -24155,12 +24140,8 @@ type RedisKey = string | Buffer;
 
 interface RedisLikeClient {
   setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
-  set(key: string, value: string, ttlSec: number): Promise<void>;
   get(key: string): Promise<string | null>;
-  expire(key: string, ttlSec: number): Promise<void>;
-  exists(key: string): Promise<boolean>;
   del(keys: string[]): Promise<void>;
-  xAdd(key: string, fields: Record<string, string | Uint8Array>): Promise<string>;
   xRange(key: string, start: string, end: string): Promise<Array<{
     id: string;
     fields: Record<string, string | Uint8Array>;

--- a/packages/assistant-stream/src/resumable/stores/ioredis.ts
+++ b/packages/assistant-stream/src/resumable/stores/ioredis.ts
@@ -33,26 +33,12 @@ function adapt(client: IoRedisLike): RedisLikeClient {
       const result = await client.set(key, value, "EX", ttlSec, "NX");
       return result === "OK";
     },
-    async set(key, value, ttlSec) {
-      await client.set(key, value, "EX", ttlSec);
-    },
     async get(key) {
       return client.get(key);
-    },
-    async expire(key, ttlSec) {
-      await client.expire(key, ttlSec);
-    },
-    async exists(key) {
-      const result = await client.exists(key);
-      return result > 0;
     },
     async del(keys) {
       if (keys.length === 0) return;
       await client.del(...keys);
-    },
-    async xAdd(key, fields) {
-      const id = await client.xadd(key, "*", ...toFieldArgs(fields));
-      return id ?? "";
     },
     async xRange(key, start, end) {
       const entries = await client.xrangeBuffer(key, start, end);
@@ -93,9 +79,6 @@ function applyPipelineCommand(
       return;
     case "expire":
       pipe.expire(cmd.key, cmd.ttlSec);
-      return;
-    case "set":
-      pipe.set(cmd.key, cmd.value, "EX", cmd.ttlSec);
       return;
   }
 }

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -31,7 +31,7 @@ class FakeRedisClient implements RedisLikeClient {
     return true;
   }
 
-  async set(key: string, value: string): Promise<void> {
+  private setString(key: string, value: string): void {
     this.strings.set(key, value);
   }
 
@@ -41,12 +41,6 @@ class FakeRedisClient implements RedisLikeClient {
     this.onNextGet = undefined;
     await onNextGet?.();
     return value;
-  }
-
-  async expire(): Promise<void> {}
-
-  async exists(key: string): Promise<boolean> {
-    return this.strings.has(key) || this.streams.has(key);
   }
 
   async del(keys: string[]): Promise<void> {
@@ -91,9 +85,6 @@ class FakeRedisClient implements RedisLikeClient {
         case "xAdd":
           await this.xAdd(command.key, command.fields);
           break;
-        case "set":
-          await this.set(command.key, command.value);
-          break;
         case "expire":
           break;
       }
@@ -104,7 +95,7 @@ class FakeRedisClient implements RedisLikeClient {
     if (this.strings.get(options.metaKey) !== options.expectedMeta)
       return false;
     await this.xAdd(options.dataKey, options.fields);
-    await this.set(options.metaKey, options.nextMeta);
+    this.setString(options.metaKey, options.nextMeta);
     return true;
   }
 }

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -27,13 +27,7 @@ export type PipelineCommand =
       readonly key: string;
       readonly fields: Record<string, string | Uint8Array>;
     }
-  | { readonly type: "expire"; readonly key: string; readonly ttlSec: number }
-  | {
-      readonly type: "set";
-      readonly key: string;
-      readonly value: string;
-      readonly ttlSec: number;
-    };
+  | { readonly type: "expire"; readonly key: string; readonly ttlSec: number };
 
 export type RedisFinalizeOptions = {
   readonly metaKey: string;
@@ -82,15 +76,8 @@ export function finalizeIfUnchangedArgs(
  */
 export interface RedisLikeClient {
   setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
-  set(key: string, value: string, ttlSec: number): Promise<void>;
   get(key: string): Promise<string | null>;
-  expire(key: string, ttlSec: number): Promise<void>;
-  exists(key: string): Promise<boolean>;
   del(keys: string[]): Promise<void>;
-  xAdd(
-    key: string,
-    fields: Record<string, string | Uint8Array>,
-  ): Promise<string>;
   xRange(
     key: string,
     start: string,

--- a/packages/assistant-stream/src/resumable/stores/redis.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis.ts
@@ -16,13 +16,7 @@ type NodeRedisFields = Record<string, string | Buffer>;
 interface NodeRedisMultiCommand {
   xAdd(key: string, id: string, fields: NodeRedisFields): NodeRedisMultiCommand;
   expire(key: string, seconds: number): NodeRedisMultiCommand;
-  set(
-    key: string,
-    value: string,
-    options: { EX: number },
-  ): NodeRedisMultiCommand;
   execAsPipeline(): Promise<unknown>;
-  exec(): Promise<unknown>;
 }
 
 /** Structural subset of node-redis v5 used by the adapter. */
@@ -32,16 +26,8 @@ export interface NodeRedisLike {
     value: string,
     options: { NX: true; EX: number },
   ): Promise<string | null>;
-  set(
-    key: string,
-    value: string,
-    options: { EX: number },
-  ): Promise<string | null>;
   get(key: string): Promise<string | null>;
-  expire(key: string, seconds: number): Promise<unknown>;
-  exists(key: string): Promise<number>;
   del(keys: string | string[]): Promise<unknown>;
-  xAdd(key: string, id: string, fields: NodeRedisFields): Promise<string>;
   sendCommand<T = unknown>(
     args: ReadonlyArray<string | Buffer>,
     options?: { typeMapping?: Record<number, unknown> },
@@ -67,25 +53,12 @@ function adapt(client: NodeRedisLike): RedisLikeClient {
       const result = await client.set(key, value, { NX: true, EX: ttlSec });
       return result === "OK";
     },
-    async set(key, value, ttlSec) {
-      await client.set(key, value, { EX: ttlSec });
-    },
     async get(key) {
       return client.get(key);
-    },
-    async expire(key, ttlSec) {
-      await client.expire(key, ttlSec);
-    },
-    async exists(key) {
-      const result = await client.exists(key);
-      return result > 0;
     },
     async del(keys) {
       if (keys.length === 0) return;
       await client.del(keys.length === 1 ? keys[0]! : keys);
-    },
-    async xAdd(key, fields) {
-      return client.xAdd(key, "*", toNodeFields(fields));
     },
     async xRange(key, start, end) {
       const reply = await client.sendCommand<unknown>(
@@ -123,8 +96,6 @@ function applyPipelineCommand(
       return chain.xAdd(cmd.key, "*", toNodeFields(cmd.fields));
     case "expire":
       return chain.expire(cmd.key, cmd.ttlSec);
-    case "set":
-      return chain.set(cmd.key, cmd.value, { EX: cmd.ttlSec });
   }
 }
 

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
@@ -57,8 +57,6 @@ class RedisLikeClient(Protocol):
 
     async def get(self, key: str) -> str | None: ...
 
-    async def exists(self, key: str) -> bool: ...
-
     async def delete(self, keys: list[str]) -> None: ...
 
     async def xrange(
@@ -352,10 +350,6 @@ class _RedisAsyncioAdapter:
             return value.decode("utf-8")
         return str(value)
 
-    async def exists(self, key: str) -> bool:
-        result = await self._client.exists(key)
-        return int(result) > 0
-
     async def delete(self, keys: list[str]) -> None:
         if not keys:
             return
@@ -387,8 +381,6 @@ class _RedisAsyncioAdapter:
                 pipe.xadd(cmd["key"], dict(cmd["fields"]))
             elif cmd_type == "expire":
                 pipe.expire(cmd["key"], cmd["ttlSec"])
-            elif cmd_type == "set":
-                pipe.set(cmd["key"], cmd["value"], ex=cmd["ttlSec"])
         await pipe.execute()
 
     async def finalize_if_unchanged(self, options: dict[str, Any]) -> bool:

--- a/python/assistant-stream/tests/test_resumable_redis_unit.py
+++ b/python/assistant-stream/tests/test_resumable_redis_unit.py
@@ -34,9 +34,6 @@ class FakeRedisLikeClient:
             await callback()
         return value
 
-    async def exists(self, key: str) -> bool:
-        return key in self.values or key in self.streams
-
     async def delete(self, keys: list[str]) -> None:
         for key in keys:
             self.values.pop(key, None)
@@ -55,8 +52,6 @@ class FakeRedisLikeClient:
         for command in commands:
             if command["type"] == "xAdd":
                 await self.xadd(command["key"], command["fields"])
-            elif command["type"] == "set":
-                self.values[command["key"]] = command["value"]
             elif command["type"] != "expire":
                 raise AssertionError(
                     f"unhandled pipeline command: {command['type']}"


### PR DESCRIPTION
## Problem

`RedisResumableStreamStore` talks to redis through `RedisLikeClient`, but the interface declares four methods the store never calls. `rg 'this\.client\.' redis-impl.ts` returns ten hits covering `setNX`, `get`, `del`, `xRange`, `pipeline` and `finalizeIfUnchanged`; `set`, `expire`, `exists` and `xAdd` have no caller.

`PipelineCommand`'s `"set"` variant joins them as of #6737. that PR replaced the non-atomic finalize fallback with `finalizeIfUnchanged`, and the fallback was the variant's only construction site:

```diff
-      { type: "set", key: metaKey, value: meta, ttlSec },
-      { type: "xAdd", key: dataKey, fields },
-      { type: "expire", key: dataKey, ttlSec },
```

both adapters still translated it, and so did both test fakes.

closes #6786.

## Root cause

the contract was written as a redis facade rather than as the port the store actually needs, so members outlived their callers instead of being removed with them.

## Change

`RedisLikeClient` keeps the six methods the store calls; `PipelineCommand` keeps `xAdd` and `expire`.

that cascades into the node-redis adapter, whose exported `NodeRedisLike` documents itself as the "structural subset of node-redis v5 used by the adapter": `expire`, `exists`, `xAdd` and the non-NX `set` overload are no longer used by it, and `NodeRedisMultiCommand` loses `set` plus `exec`, which was already dead (only `execAsPipeline` is ever awaited). narrowing a parameter type only widens what callers may pass, and the comment goes back to being true.

the python port carried the same drift: its `RedisLikeClient` protocol declared `exists` with no caller, and `_RedisAsyncioAdapter.pipeline` still had the `"set"` branch. both are gone, keeping the two ports on one contract.

kept the interface narrow rather than documenting it as a deliberate redis subset, because it is not one: there is no `ttl`, `xLen`, `unlink` or `scan`, and the shapes are store-shaped anyway (`setNX(key, value, ttlSec)` collapses `SET NX EX`; `finalizeIfUnchanged` is a bespoke lua call, not a redis command).

## Verification

`packages/assistant-stream` run against a real redis so the adapter translation is actually exercised rather than skipped:

```
REDIS_URL=redis://127.0.0.1:6399 pnpm --filter assistant-stream test
  test:v6         531 passed (531)
  test:peer-v5    531 passed (531)
  test:types:peer-v5  clean
```

both legs include the 22 redis integration tests that skip without a server, so node-redis v5/v6 and ioredis v5/v6 all round-trip through the narrowed pipeline.

python, same server:

```
REDIS_URL=redis://127.0.0.1:6399 uv run --extra dev --extra langgraph pytest -q
  182 passed
```

that turns on the 7 redis adapter tests that otherwise skip.

`pnpm lint` clean on the touched files, `pnpm changesets:check` passes, `pnpm api-surface` regenerated.

## Public surface

- `assistant-stream`: `RedisLikeClient` loses `set`, `expire`, `exists`, `xAdd`; `PipelineCommand` loses its `"set"` variant; `NodeRedisLike` loses `expire`, `exists`, `xAdd` and the non-NX `set` overload. no export is removed, and no public entry accepts a `RedisLikeClient`: `RedisResumableStreamStore` is not exported, `createRedisResumableStreamStore` takes `NodeRedisLike`, `createIoredisResumableStreamStore` takes `IoRedisLike`. runtime behavior is unchanged.
- `assistant-stream` (python): `RedisLikeClient` protocol loses `exists`.
- `api-surface/assistant-stream.ts` regenerated.
- changeset: `assistant-stream` patch.
- docs: none. no page references `RedisLikeClient`; the custom-store guide points at `ResumableStreamStore`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.vPGnSk7VwL1ljclsR1KIpuY4hqDj2_nILzSdMeSH3jg7arRzxZhmDOX2fhE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->