### PR TITLE
fix(react-markdown): keep code spans and fences inert when normalizing math delimiters

### DIFF
--- a/.changeset/preprocess-skip-code-spans.md
+++ b/.changeset/preprocess-skip-code-spans.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep code spans and fences inert when normalizing math delimiters

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -100,6 +100,32 @@ describe("rewriteLatexBracketDelimiters", () => {
       "\\(a `b` c\\)",
     );
   });
+
+  it("rewrites across a lone literal backtick", () => {
+    expect(rewriteLatexBracketDelimiters("Use \\(x ` y\\) here")).toBe(
+      "Use $x ` y$ here",
+    );
+  });
+
+  it("protects an unclosed fence still streaming in", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\(x\\)\nstill streaming")).toBe(
+      "```\n\\(x\\)\nstill streaming",
+    );
+  });
+
+  it("leaves a delimiter inside a tilde fence as written", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\[a\nb\\]\n~~~\n\\(x\\)")).toBe(
+      "~~~\n\\[a\nb\\]\n~~~\n$x$",
+    );
+  });
+
+  it("protects an unclosed tilde fence to the end of the input", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
+  });
+
+  it("rewrites around a mid-line tilde run", () => {
+    expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
+  });
 });
 
 describe("rewriteCustomMathTags", () => {

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -66,6 +66,40 @@ describe("rewriteLatexBracketDelimiters", () => {
       "plain $x$ text",
     );
   });
+
+  it("leaves a delimiter inside an inline code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("a `\\(x\\)` b")).toBe(
+      "a `\\(x\\)` b",
+    );
+  });
+
+  it("leaves a delimiter inside a fenced block as written", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\[a\nb\\]\n```")).toBe(
+      "```\n\\[a\nb\\]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a\\) `\\(x\\)` \\(b\\)")).toBe(
+      "$a$ `\\(x\\)` $b$",
+    );
+  });
+
+  it("does not treat an escaped backtick as a code opener", () => {
+    expect(rewriteLatexBracketDelimiters("\\` \\(x\\)")).toBe("\\` $x$");
+  });
+
+  it("fences a multiline display body directly after a code span", () => {
+    expect(rewriteLatexBracketDelimiters("`c` \\[a\nb\\] d")).toBe(
+      "`c` \n$$\na\nb\n$$\n d",
+    );
+  });
+
+  it("leaves a delimiter pair straddling a code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a `b` c\\)")).toBe(
+      "\\(a `b` c\\)",
+    );
+  });
 });
 
 describe("rewriteCustomMathTags", () => {
@@ -74,12 +108,36 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
     ).toBe("$$a+b$$ and $c$");
   });
+
+  it("leaves a tag inside an inline code span as written", () => {
+    expect(rewriteCustomMathTags("`[/math]x[/math]`")).toBe(
+      "`[/math]x[/math]`",
+    );
+  });
+
+  it("leaves a tag inside a fenced block as written", () => {
+    expect(rewriteCustomMathTags("```\n[/inline]x[/inline]\n```")).toBe(
+      "```\n[/inline]x[/inline]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(
+      rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
+    ).toBe("$a$ `[/inline]x[/inline]`");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {
   it("normalizes both bracket delimiters and custom tags", () => {
     expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
       "$x$ $$y$$",
+    );
+  });
+
+  it("keeps code inert for both delimiter families", () => {
+    expect(normalizeMathDelimiters("`\\(x\\)` and `[/math]y[/math]`")).toBe(
+      "`\\(x\\)` and `[/math]y[/math]`",
     );
   });
 });

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -135,6 +135,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
   });
 
+  it("closes a blockquoted fence whose closer omits the marker space", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n>~~~\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n>~~~\n\nafter $x$");
+  });
+
+  it("closes an indented root fence with an unindented closer", () => {
+    expect(
+      rewriteLatexBracketDelimiters("  ~~~\n\\[a\\]\n~~~\nafter \\(x\\)"),
+    ).toBe("  ~~~\n\\[a\\]\n~~~\nafter $x$");
+  });
+
   it("does not open a fence from a four-space indented marker", () => {
     expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
       "    > ~~~\n$x$",

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -147,6 +147,13 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("  ~~~\n\\[a\\]\n~~~\nafter $x$");
   });
 
+  it("does not close a root fence on a quoted tilde line inside it", () => {
+    const fenced = "~~~\n> ~~~\n\\(x\\) still code\n~~~\nafter \\(y\\)";
+    expect(rewriteLatexBracketDelimiters(fenced)).toBe(
+      "~~~\n> ~~~\n\\(x\\) still code\n~~~\nafter $y$",
+    );
+  });
+
   it("does not open a fence from a four-space indented marker", () => {
     expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
       "    > ~~~\n$x$",

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -129,6 +129,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("~~~\r\n\\[a\\]\r\n~~~\r\nafter $x$");
   });
 
+  it("closes a tilde fence opened inside a blockquote", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n> ~~~\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
+  });
+
+  it("does not open a fence from a four-space indented marker", () => {
+    expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
+      "    > ~~~\n$x$",
+    );
+  });
+
   it("protects a tilde fence nested in a blockquote", () => {
     const quoted = "> ~~~\n> \\[a\\]\n> ~~~";
     expect(rewriteLatexBracketDelimiters(quoted)).toBe(quoted);

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -123,6 +123,22 @@ describe("rewriteLatexBracketDelimiters", () => {
     expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
   });
 
+  it("closes a tilde fence written with CRLF line endings", () => {
+    expect(
+      rewriteLatexBracketDelimiters("~~~\r\n\\[a\\]\r\n~~~\r\nafter \\(x\\)"),
+    ).toBe("~~~\r\n\\[a\\]\r\n~~~\r\nafter $x$");
+  });
+
+  it("protects a tilde fence nested in a blockquote", () => {
+    const quoted = "> ~~~\n> \\[a\\]\n> ~~~";
+    expect(rewriteLatexBracketDelimiters(quoted)).toBe(quoted);
+  });
+
+  it("leaves custom math tags inside a tilde fence as written", () => {
+    const fenced = "~~~\n[/math]x[/math]\n~~~";
+    expect(rewriteCustomMathTags(fenced)).toBe(fenced);
+  });
+
   it("rewrites around a mid-line tilde run", () => {
     expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
   });

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -13,6 +13,7 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
+const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -23,19 +24,25 @@ const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
+  // A fence opened inside a blockquote closes on a line carrying the same
+  // container prefix, so that prefix is stripped before the closer is read.
+  const prefix = containerPrefix(text, start);
   let lineStart = text.indexOf("\n", start);
+
   while (lineStart !== -1) {
     const lineEnd = text.indexOf("\n", lineStart + 1);
     const line = text.slice(
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const close = TILDE_FENCE_CLOSE.exec(line);
+    const body = line.startsWith(prefix) ? line.slice(prefix.length) : line;
+    const close = TILDE_FENCE_CLOSE.exec(body);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
     lineStart = lineEnd;
   }
+
   return text.length;
 }
 
@@ -49,10 +56,17 @@ function atLineStart(text: string, index: number): boolean {
   }
   if (cursor === 0 || text[cursor - 1] === "\n") return true;
 
-  // A fence keeps its meaning inside a blockquote, so the container prefix of
-  // the line counts as line start.
+  // A fence keeps its meaning inside a blockquote, so a line carrying only
+  // blockquote markers still opens one. Four spaces would make it an indented
+  // code block instead, so the marker may carry at most three.
   const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
-  return /^[ \t]*(?:>[ \t]?)+[ \t]*$/.test(text.slice(lineStart, cursor));
+  return /^ {0,3}(?:>[ \t]?)+$/.test(text.slice(lineStart, cursor));
+}
+
+/** The blockquote prefix of the line `index` sits on, "" when there is none. */
+function containerPrefix(text: string, index: number): string {
+  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
+  return CONTAINER_OPENER.exec(text.slice(lineStart))?.[0] ?? "";
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -12,8 +12,11 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
-const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
+// The closer may carry the same blockquote prefix the opener did, and matching
+// it by shape rather than by exact string keeps `> ~~~` and `>~~~` equivalent.
+// Reading a closer leniently is the safe bias: a missed one protects the rest of
+// the document as code and suppresses every rewrite after it.
+const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -24,9 +27,6 @@ const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
-  // A fence opened inside a blockquote closes on a line carrying the same
-  // container prefix, so that prefix is stripped before the closer is read.
-  const prefix = containerPrefix(text, start);
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -35,8 +35,7 @@ function tildeFenceEnd(text: string, start: number): number {
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const body = line.startsWith(prefix) ? line.slice(prefix.length) : line;
-    const close = TILDE_FENCE_CLOSE.exec(body);
+    const close = TILDE_FENCE_CLOSE.exec(line);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
@@ -61,12 +60,6 @@ function atLineStart(text: string, index: number): boolean {
   // code block instead, so the marker may carry at most three.
   const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
   return /^ {0,3}(?:>[ \t]?)+$/.test(text.slice(lineStart, cursor));
-}
-
-/** The blockquote prefix of the line `index` sits on, "" when there is none. */
-function containerPrefix(text: string, index: number): string {
-  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
-  return CONTAINER_OPENER.exec(text.slice(lineStart))?.[0] ?? "";
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -13,6 +13,48 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 /**
+ * Applies `rewrite` to the stretches of `text` outside code spans and fences,
+ * copying code through verbatim, so a delimiter shown as code is never
+ * rewritten. `\x` escapes are stepped over when scanning so an escaped
+ * backtick does not open a span, an unclosed run reads as literal backticks,
+ * and a delimiter pair straddling a code boundary stays as written. Each
+ * stretch is passed the characters adjacent to it so the rewrite can make
+ * line-boundary decisions that survive the split.
+ */
+function rewriteOutsideCode(
+  text: string,
+  rewrite: (segment: string, precededBy: string, followedBy: string) => string,
+): string {
+  let out = "";
+  let index = 0;
+  let plainStart = 0;
+
+  const flush = (end: number, followedBy: string) => {
+    const segment = text.slice(plainStart, end);
+    if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
+  };
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 2;
+    } else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
+      flush(index, "`");
+      out += text.slice(index, codeEnd);
+      index = codeEnd;
+      plainStart = codeEnd;
+    } else {
+      index += 1;
+    }
+  }
+  flush(text.length, "");
+
+  return out;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
  * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
  * leading backslash is accepted, since models emit both depending on escaping.
@@ -28,25 +70,29 @@ const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
  * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
-  return text
-    .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
-      const trimmed = body.trim();
-      return trimmed === "" ? match : `$${trimmed}$`;
-    })
-    .replace(
-      LATEX_DISPLAY_DELIMITER,
-      (match: string, body: string, offset: number, source: string) => {
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
+    segment
+      .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
         const trimmed = body.trim();
-        if (trimmed === "") return match;
-        if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+        return trimmed === "" ? match : `$${trimmed}$`;
+      })
+      .replace(
+        LATEX_DISPLAY_DELIMITER,
+        (match: string, body: string, offset: number, source: string) => {
+          const trimmed = body.trim();
+          if (trimmed === "") return match;
+          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-        const before = source.slice(0, offset);
-        const after = source.slice(offset + match.length);
-        const lead = before === "" || before.endsWith("\n") ? "" : "\n";
-        const tail = after === "" || after.startsWith("\n") ? "" : "\n";
-        return `${lead}$$\n${trimmed}\n$$${tail}`;
-      },
-    );
+          const before = offset === 0 ? precededBy : source[offset - 1]!;
+          const afterStart = offset + match.length;
+          const after =
+            afterStart === source.length ? followedBy : source[afterStart]!;
+          const lead = before === "" || before === "\n" ? "" : "\n";
+          const tail = after === "" || after === "\n" ? "" : "\n";
+          return `${lead}$$\n${trimmed}\n$$${tail}`;
+        },
+      ),
+  );
 }
 
 const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
@@ -57,9 +103,11 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
  * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return text
-    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
-    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+  return rewriteOutsideCode(text, (segment) =>
+    segment
+      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+  );
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -12,7 +12,7 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -47,7 +47,12 @@ function atLineStart(text: string, index: number): boolean {
     cursor--;
     indent++;
   }
-  return cursor === 0 || text[cursor - 1] === "\n";
+  if (cursor === 0 || text[cursor - 1] === "\n") return true;
+
+  // A fence keeps its meaning inside a blockquote, so the container prefix of
+  // the line counts as line start.
+  const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
+  return /^[ \t]*(?:>[ \t]?)+[ \t]*$/.test(text.slice(lineStart, cursor));
 }
 
 /**
@@ -58,10 +63,12 @@ function atLineStart(text: string, index: number): boolean {
  * boundary stays as written. Each stretch is passed the characters adjacent to
  * it so the rewrite can make line-boundary decisions that survive the split.
  *
- * Backtick regions follow `codeSpanEnd`'s reading, shared with
- * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
- * literal text, an unclosed three-plus run is a fence still streaming in and
- * protects to the end of the input, and fences are not line-anchored. Tilde
+ * Backtick regions are found with `codeSpanEnd`, which {@link
+ * escapeCurrencyDollars} also uses, and read as CommonMark does: an unclosed
+ * one- or two-backtick run is literal text, an unclosed three-plus run is a
+ * fence still streaming in and protects to the end of the input, and fences are
+ * not line-anchored. The unclosed three-plus case is where this walker and
+ * `escapeCurrencyDollars` differ, since that one treats the run as literal. Tilde
  * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
  * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -12,14 +12,58 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+
+/**
+ * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
+ * which the caller has verified starts a line: the end of the first later line
+ * carrying a closing run of at least the same length, or the end of `text`
+ * when none does — an unclosed fence reads as code to the end of the input,
+ * which keeps a fence that is still streaming in inert.
+ */
+function tildeFenceEnd(text: string, start: number): number {
+  const fenceLength = runLength(text, start, "~");
+  let lineStart = text.indexOf("\n", start);
+  while (lineStart !== -1) {
+    const lineEnd = text.indexOf("\n", lineStart + 1);
+    const line = text.slice(
+      lineStart + 1,
+      lineEnd === -1 ? undefined : lineEnd,
+    );
+    const close = TILDE_FENCE_CLOSE.exec(line);
+    if (close && close[1]!.length >= fenceLength) {
+      return lineEnd === -1 ? text.length : lineEnd;
+    }
+    lineStart = lineEnd;
+  }
+  return text.length;
+}
+
+/** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
+function atLineStart(text: string, index: number): boolean {
+  let cursor = index;
+  let indent = 0;
+  while (cursor > 0 && text[cursor - 1] === " " && indent < 3) {
+    cursor--;
+    indent++;
+  }
+  return cursor === 0 || text[cursor - 1] === "\n";
+}
+
 /**
  * Applies `rewrite` to the stretches of `text` outside code spans and fences,
  * copying code through verbatim, so a delimiter shown as code is never
  * rewritten. `\x` escapes are stepped over when scanning so an escaped
- * backtick does not open a span, an unclosed run reads as literal backticks,
- * and a delimiter pair straddling a code boundary stays as written. Each
- * stretch is passed the characters adjacent to it so the rewrite can make
- * line-boundary decisions that survive the split.
+ * backtick does not open a span, and a delimiter pair straddling a code
+ * boundary stays as written. Each stretch is passed the characters adjacent to
+ * it so the rewrite can make line-boundary decisions that survive the split.
+ *
+ * Backtick regions follow `codeSpanEnd`'s reading, shared with
+ * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
+ * literal text, an unclosed three-plus run is a fence still streaming in and
+ * protects to the end of the input, and fences are not line-anchored. Tilde
+ * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
+ * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */
 function rewriteOutsideCode(
   text: string,
@@ -34,17 +78,29 @@ function rewriteOutsideCode(
     if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
   };
 
+  const copyVerbatim = (to: number) => {
+    flush(index, text[index]!);
+    out += text.slice(index, to);
+    index = to;
+    plainStart = to;
+  };
+
   while (index < text.length) {
     const char = text[index];
     if (char === "\\") {
       index += 2;
     } else if (char === "`") {
+      const run = runLength(text, index, "`");
       const end = codeSpanEnd(text, index);
-      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
-      flush(index, "`");
-      out += text.slice(index, codeEnd);
-      index = codeEnd;
-      plainStart = codeEnd;
+      if (end !== -1) copyVerbatim(end);
+      else if (run >= 3) copyVerbatim(text.length);
+      else index += run;
+    } else if (
+      char === "~" &&
+      runLength(text, index, "~") >= 3 &&
+      atLineStart(text, index)
+    ) {
+      copyVerbatim(tildeFenceEnd(text, index));
     } else {
       index += 1;
     }

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -12,11 +12,13 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-// The closer may carry the same blockquote prefix the opener did, and matching
-// it by shape rather than by exact string keeps `> ~~~` and `>~~~` equivalent.
-// Reading a closer leniently is the safe bias: a missed one protects the rest of
-// the document as code and suppresses every rewrite after it.
-const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
+// A closer has to sit in the same container as its opener: a root fence is not
+// closed by a quoted line, and a quoted fence is closed by one however its
+// marker is spaced. Matching the prefix by shape rather than as a literal keeps
+// `> ~~~` and `>~~~` equivalent.
+const TILDE_FENCE_CLOSE_ROOT = /^ {0,3}(~{3,})[ \t\r]*$/;
+const TILDE_FENCE_CLOSE_QUOTED = /^ {0,3}(?:>[ \t]?)+ {0,3}(~{3,})[ \t\r]*$/;
+const LINE_IS_QUOTED = /^ {0,3}(?:>[ \t]?)+/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -27,6 +29,10 @@ const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
+  const openerLine = text.slice(text.lastIndexOf("\n", start - 1) + 1, start);
+  const closer = LINE_IS_QUOTED.test(openerLine)
+    ? TILDE_FENCE_CLOSE_QUOTED
+    : TILDE_FENCE_CLOSE_ROOT;
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -35,7 +41,7 @@ function tildeFenceEnd(text: string, start: number): number {
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const close = TILDE_FENCE_CLOSE.exec(line);
+    const close = closer.exec(line);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -100,6 +100,32 @@ describe("rewriteLatexBracketDelimiters", () => {
       "\\(a `b` c\\)",
     );
   });
+
+  it("rewrites across a lone literal backtick", () => {
+    expect(rewriteLatexBracketDelimiters("Use \\(x ` y\\) here")).toBe(
+      "Use $x ` y$ here",
+    );
+  });
+
+  it("protects an unclosed fence still streaming in", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\(x\\)\nstill streaming")).toBe(
+      "```\n\\(x\\)\nstill streaming",
+    );
+  });
+
+  it("leaves a delimiter inside a tilde fence as written", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\[a\nb\\]\n~~~\n\\(x\\)")).toBe(
+      "~~~\n\\[a\nb\\]\n~~~\n$x$",
+    );
+  });
+
+  it("protects an unclosed tilde fence to the end of the input", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
+  });
+
+  it("rewrites around a mid-line tilde run", () => {
+    expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
+  });
 });
 
 describe("rewriteCustomMathTags", () => {

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -66,6 +66,40 @@ describe("rewriteLatexBracketDelimiters", () => {
       "plain $x$ text",
     );
   });
+
+  it("leaves a delimiter inside an inline code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("a `\\(x\\)` b")).toBe(
+      "a `\\(x\\)` b",
+    );
+  });
+
+  it("leaves a delimiter inside a fenced block as written", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\[a\nb\\]\n```")).toBe(
+      "```\n\\[a\nb\\]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a\\) `\\(x\\)` \\(b\\)")).toBe(
+      "$a$ `\\(x\\)` $b$",
+    );
+  });
+
+  it("does not treat an escaped backtick as a code opener", () => {
+    expect(rewriteLatexBracketDelimiters("\\` \\(x\\)")).toBe("\\` $x$");
+  });
+
+  it("fences a multiline display body directly after a code span", () => {
+    expect(rewriteLatexBracketDelimiters("`c` \\[a\nb\\] d")).toBe(
+      "`c` \n$$\na\nb\n$$\n d",
+    );
+  });
+
+  it("leaves a delimiter pair straddling a code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a `b` c\\)")).toBe(
+      "\\(a `b` c\\)",
+    );
+  });
 });
 
 describe("rewriteCustomMathTags", () => {
@@ -74,12 +108,36 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
     ).toBe("$$a+b$$ and $c$");
   });
+
+  it("leaves a tag inside an inline code span as written", () => {
+    expect(rewriteCustomMathTags("`[/math]x[/math]`")).toBe(
+      "`[/math]x[/math]`",
+    );
+  });
+
+  it("leaves a tag inside a fenced block as written", () => {
+    expect(rewriteCustomMathTags("```\n[/inline]x[/inline]\n```")).toBe(
+      "```\n[/inline]x[/inline]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(
+      rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
+    ).toBe("$a$ `[/inline]x[/inline]`");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {
   it("normalizes both bracket delimiters and custom tags", () => {
     expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
       "$x$ $$y$$",
+    );
+  });
+
+  it("keeps code inert for both delimiter families", () => {
+    expect(normalizeMathDelimiters("`\\(x\\)` and `[/math]y[/math]`")).toBe(
+      "`\\(x\\)` and `[/math]y[/math]`",
     );
   });
 });

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -135,6 +135,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
   });
 
+  it("closes a blockquoted fence whose closer omits the marker space", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n>~~~\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n>~~~\n\nafter $x$");
+  });
+
+  it("closes an indented root fence with an unindented closer", () => {
+    expect(
+      rewriteLatexBracketDelimiters("  ~~~\n\\[a\\]\n~~~\nafter \\(x\\)"),
+    ).toBe("  ~~~\n\\[a\\]\n~~~\nafter $x$");
+  });
+
   it("does not open a fence from a four-space indented marker", () => {
     expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
       "    > ~~~\n$x$",

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -147,6 +147,13 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("  ~~~\n\\[a\\]\n~~~\nafter $x$");
   });
 
+  it("does not close a root fence on a quoted tilde line inside it", () => {
+    const fenced = "~~~\n> ~~~\n\\(x\\) still code\n~~~\nafter \\(y\\)";
+    expect(rewriteLatexBracketDelimiters(fenced)).toBe(
+      "~~~\n> ~~~\n\\(x\\) still code\n~~~\nafter $y$",
+    );
+  });
+
   it("does not open a fence from a four-space indented marker", () => {
     expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
       "    > ~~~\n$x$",

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -129,6 +129,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("~~~\r\n\\[a\\]\r\n~~~\r\nafter $x$");
   });
 
+  it("closes a tilde fence opened inside a blockquote", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n> ~~~\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
+  });
+
+  it("does not open a fence from a four-space indented marker", () => {
+    expect(rewriteLatexBracketDelimiters("    > ~~~\n\\(x\\)")).toBe(
+      "    > ~~~\n$x$",
+    );
+  });
+
   it("protects a tilde fence nested in a blockquote", () => {
     const quoted = "> ~~~\n> \\[a\\]\n> ~~~";
     expect(rewriteLatexBracketDelimiters(quoted)).toBe(quoted);

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -123,6 +123,22 @@ describe("rewriteLatexBracketDelimiters", () => {
     expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
   });
 
+  it("closes a tilde fence written with CRLF line endings", () => {
+    expect(
+      rewriteLatexBracketDelimiters("~~~\r\n\\[a\\]\r\n~~~\r\nafter \\(x\\)"),
+    ).toBe("~~~\r\n\\[a\\]\r\n~~~\r\nafter $x$");
+  });
+
+  it("protects a tilde fence nested in a blockquote", () => {
+    const quoted = "> ~~~\n> \\[a\\]\n> ~~~";
+    expect(rewriteLatexBracketDelimiters(quoted)).toBe(quoted);
+  });
+
+  it("leaves custom math tags inside a tilde fence as written", () => {
+    const fenced = "~~~\n[/math]x[/math]\n~~~";
+    expect(rewriteCustomMathTags(fenced)).toBe(fenced);
+  });
+
   it("rewrites around a mid-line tilde run", () => {
     expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
   });

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -13,6 +13,7 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
+const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -23,19 +24,25 @@ const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
+  // A fence opened inside a blockquote closes on a line carrying the same
+  // container prefix, so that prefix is stripped before the closer is read.
+  const prefix = containerPrefix(text, start);
   let lineStart = text.indexOf("\n", start);
+
   while (lineStart !== -1) {
     const lineEnd = text.indexOf("\n", lineStart + 1);
     const line = text.slice(
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const close = TILDE_FENCE_CLOSE.exec(line);
+    const body = line.startsWith(prefix) ? line.slice(prefix.length) : line;
+    const close = TILDE_FENCE_CLOSE.exec(body);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
     lineStart = lineEnd;
   }
+
   return text.length;
 }
 
@@ -49,10 +56,17 @@ function atLineStart(text: string, index: number): boolean {
   }
   if (cursor === 0 || text[cursor - 1] === "\n") return true;
 
-  // A fence keeps its meaning inside a blockquote, so the container prefix of
-  // the line counts as line start.
+  // A fence keeps its meaning inside a blockquote, so a line carrying only
+  // blockquote markers still opens one. Four spaces would make it an indented
+  // code block instead, so the marker may carry at most three.
   const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
-  return /^[ \t]*(?:>[ \t]?)+[ \t]*$/.test(text.slice(lineStart, cursor));
+  return /^ {0,3}(?:>[ \t]?)+$/.test(text.slice(lineStart, cursor));
+}
+
+/** The blockquote prefix of the line `index` sits on, "" when there is none. */
+function containerPrefix(text: string, index: number): string {
+  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
+  return CONTAINER_OPENER.exec(text.slice(lineStart))?.[0] ?? "";
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -12,8 +12,11 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
-const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
+// The closer may carry the same blockquote prefix the opener did, and matching
+// it by shape rather than by exact string keeps `> ~~~` and `>~~~` equivalent.
+// Reading a closer leniently is the safe bias: a missed one protects the rest of
+// the document as code and suppresses every rewrite after it.
+const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -24,9 +27,6 @@ const CONTAINER_OPENER = /^ {0,3}(?:>[ \t]?)*(?= {0,3}~)/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
-  // A fence opened inside a blockquote closes on a line carrying the same
-  // container prefix, so that prefix is stripped before the closer is read.
-  const prefix = containerPrefix(text, start);
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -35,8 +35,7 @@ function tildeFenceEnd(text: string, start: number): number {
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const body = line.startsWith(prefix) ? line.slice(prefix.length) : line;
-    const close = TILDE_FENCE_CLOSE.exec(body);
+    const close = TILDE_FENCE_CLOSE.exec(line);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
@@ -61,12 +60,6 @@ function atLineStart(text: string, index: number): boolean {
   // code block instead, so the marker may carry at most three.
   const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
   return /^ {0,3}(?:>[ \t]?)+$/.test(text.slice(lineStart, cursor));
-}
-
-/** The blockquote prefix of the line `index` sits on, "" when there is none. */
-function containerPrefix(text: string, index: number): string {
-  const lineStart = text.lastIndexOf("\n", index - 1) + 1;
-  return CONTAINER_OPENER.exec(text.slice(lineStart))?.[0] ?? "";
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -13,6 +13,48 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 /**
+ * Applies `rewrite` to the stretches of `text` outside code spans and fences,
+ * copying code through verbatim, so a delimiter shown as code is never
+ * rewritten. `\x` escapes are stepped over when scanning so an escaped
+ * backtick does not open a span, an unclosed run reads as literal backticks,
+ * and a delimiter pair straddling a code boundary stays as written. Each
+ * stretch is passed the characters adjacent to it so the rewrite can make
+ * line-boundary decisions that survive the split.
+ */
+function rewriteOutsideCode(
+  text: string,
+  rewrite: (segment: string, precededBy: string, followedBy: string) => string,
+): string {
+  let out = "";
+  let index = 0;
+  let plainStart = 0;
+
+  const flush = (end: number, followedBy: string) => {
+    const segment = text.slice(plainStart, end);
+    if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
+  };
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 2;
+    } else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
+      flush(index, "`");
+      out += text.slice(index, codeEnd);
+      index = codeEnd;
+      plainStart = codeEnd;
+    } else {
+      index += 1;
+    }
+  }
+  flush(text.length, "");
+
+  return out;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
  * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
  * leading backslash is accepted, since models emit both depending on escaping.
@@ -28,25 +70,29 @@ const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
  * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
-  return text
-    .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
-      const trimmed = body.trim();
-      return trimmed === "" ? match : `$${trimmed}$`;
-    })
-    .replace(
-      LATEX_DISPLAY_DELIMITER,
-      (match: string, body: string, offset: number, source: string) => {
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
+    segment
+      .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
         const trimmed = body.trim();
-        if (trimmed === "") return match;
-        if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+        return trimmed === "" ? match : `$${trimmed}$`;
+      })
+      .replace(
+        LATEX_DISPLAY_DELIMITER,
+        (match: string, body: string, offset: number, source: string) => {
+          const trimmed = body.trim();
+          if (trimmed === "") return match;
+          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-        const before = source.slice(0, offset);
-        const after = source.slice(offset + match.length);
-        const lead = before === "" || before.endsWith("\n") ? "" : "\n";
-        const tail = after === "" || after.startsWith("\n") ? "" : "\n";
-        return `${lead}$$\n${trimmed}\n$$${tail}`;
-      },
-    );
+          const before = offset === 0 ? precededBy : source[offset - 1]!;
+          const afterStart = offset + match.length;
+          const after =
+            afterStart === source.length ? followedBy : source[afterStart]!;
+          const lead = before === "" || before === "\n" ? "" : "\n";
+          const tail = after === "" || after === "\n" ? "" : "\n";
+          return `${lead}$$\n${trimmed}\n$$${tail}`;
+        },
+      ),
+  );
 }
 
 const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
@@ -57,9 +103,11 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
  * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return text
-    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
-    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+  return rewriteOutsideCode(text, (segment) =>
+    segment
+      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+  );
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -12,7 +12,7 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t\r]*$/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -47,7 +47,12 @@ function atLineStart(text: string, index: number): boolean {
     cursor--;
     indent++;
   }
-  return cursor === 0 || text[cursor - 1] === "\n";
+  if (cursor === 0 || text[cursor - 1] === "\n") return true;
+
+  // A fence keeps its meaning inside a blockquote, so the container prefix of
+  // the line counts as line start.
+  const lineStart = text.lastIndexOf("\n", cursor - 1) + 1;
+  return /^[ \t]*(?:>[ \t]?)+[ \t]*$/.test(text.slice(lineStart, cursor));
 }
 
 /**
@@ -58,10 +63,12 @@ function atLineStart(text: string, index: number): boolean {
  * boundary stays as written. Each stretch is passed the characters adjacent to
  * it so the rewrite can make line-boundary decisions that survive the split.
  *
- * Backtick regions follow `codeSpanEnd`'s reading, shared with
- * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
- * literal text, an unclosed three-plus run is a fence still streaming in and
- * protects to the end of the input, and fences are not line-anchored. Tilde
+ * Backtick regions are found with `codeSpanEnd`, which {@link
+ * escapeCurrencyDollars} also uses, and read as CommonMark does: an unclosed
+ * one- or two-backtick run is literal text, an unclosed three-plus run is a
+ * fence still streaming in and protects to the end of the input, and fences are
+ * not line-anchored. The unclosed three-plus case is where this walker and
+ * `escapeCurrencyDollars` differ, since that one treats the run as literal. Tilde
  * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
  * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -12,14 +12,58 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+
+/**
+ * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
+ * which the caller has verified starts a line: the end of the first later line
+ * carrying a closing run of at least the same length, or the end of `text`
+ * when none does — an unclosed fence reads as code to the end of the input,
+ * which keeps a fence that is still streaming in inert.
+ */
+function tildeFenceEnd(text: string, start: number): number {
+  const fenceLength = runLength(text, start, "~");
+  let lineStart = text.indexOf("\n", start);
+  while (lineStart !== -1) {
+    const lineEnd = text.indexOf("\n", lineStart + 1);
+    const line = text.slice(
+      lineStart + 1,
+      lineEnd === -1 ? undefined : lineEnd,
+    );
+    const close = TILDE_FENCE_CLOSE.exec(line);
+    if (close && close[1]!.length >= fenceLength) {
+      return lineEnd === -1 ? text.length : lineEnd;
+    }
+    lineStart = lineEnd;
+  }
+  return text.length;
+}
+
+/** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
+function atLineStart(text: string, index: number): boolean {
+  let cursor = index;
+  let indent = 0;
+  while (cursor > 0 && text[cursor - 1] === " " && indent < 3) {
+    cursor--;
+    indent++;
+  }
+  return cursor === 0 || text[cursor - 1] === "\n";
+}
+
 /**
  * Applies `rewrite` to the stretches of `text` outside code spans and fences,
  * copying code through verbatim, so a delimiter shown as code is never
  * rewritten. `\x` escapes are stepped over when scanning so an escaped
- * backtick does not open a span, an unclosed run reads as literal backticks,
- * and a delimiter pair straddling a code boundary stays as written. Each
- * stretch is passed the characters adjacent to it so the rewrite can make
- * line-boundary decisions that survive the split.
+ * backtick does not open a span, and a delimiter pair straddling a code
+ * boundary stays as written. Each stretch is passed the characters adjacent to
+ * it so the rewrite can make line-boundary decisions that survive the split.
+ *
+ * Backtick regions follow `codeSpanEnd`'s reading, shared with
+ * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
+ * literal text, an unclosed three-plus run is a fence still streaming in and
+ * protects to the end of the input, and fences are not line-anchored. Tilde
+ * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
+ * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */
 function rewriteOutsideCode(
   text: string,
@@ -34,17 +78,29 @@ function rewriteOutsideCode(
     if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
   };
 
+  const copyVerbatim = (to: number) => {
+    flush(index, text[index]!);
+    out += text.slice(index, to);
+    index = to;
+    plainStart = to;
+  };
+
   while (index < text.length) {
     const char = text[index];
     if (char === "\\") {
       index += 2;
     } else if (char === "`") {
+      const run = runLength(text, index, "`");
       const end = codeSpanEnd(text, index);
-      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
-      flush(index, "`");
-      out += text.slice(index, codeEnd);
-      index = codeEnd;
-      plainStart = codeEnd;
+      if (end !== -1) copyVerbatim(end);
+      else if (run >= 3) copyVerbatim(text.length);
+      else index += run;
+    } else if (
+      char === "~" &&
+      runLength(text, index, "~") >= 3 &&
+      atLineStart(text, index)
+    ) {
+      copyVerbatim(tildeFenceEnd(text, index));
     } else {
       index += 1;
     }

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -12,11 +12,13 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
-// The closer may carry the same blockquote prefix the opener did, and matching
-// it by shape rather than by exact string keeps `> ~~~` and `>~~~` equivalent.
-// Reading a closer leniently is the safe bias: a missed one protects the rest of
-// the document as code and suppresses every rewrite after it.
-const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
+// A closer has to sit in the same container as its opener: a root fence is not
+// closed by a quoted line, and a quoted fence is closed by one however its
+// marker is spaced. Matching the prefix by shape rather than as a literal keeps
+// `> ~~~` and `>~~~` equivalent.
+const TILDE_FENCE_CLOSE_ROOT = /^ {0,3}(~{3,})[ \t\r]*$/;
+const TILDE_FENCE_CLOSE_QUOTED = /^ {0,3}(?:>[ \t]?)+ {0,3}(~{3,})[ \t\r]*$/;
+const LINE_IS_QUOTED = /^ {0,3}(?:>[ \t]?)+/;
 
 /**
  * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
@@ -27,6 +29,10 @@ const TILDE_FENCE_CLOSE = /^ {0,3}(?:>[ \t]?)* {0,3}(~{3,})[ \t\r]*$/;
  */
 function tildeFenceEnd(text: string, start: number): number {
   const fenceLength = runLength(text, start, "~");
+  const openerLine = text.slice(text.lastIndexOf("\n", start - 1) + 1, start);
+  const closer = LINE_IS_QUOTED.test(openerLine)
+    ? TILDE_FENCE_CLOSE_QUOTED
+    : TILDE_FENCE_CLOSE_ROOT;
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -35,7 +41,7 @@ function tildeFenceEnd(text: string, start: number): number {
       lineStart + 1,
       lineEnd === -1 ? undefined : lineEnd,
     );
-    const close = TILDE_FENCE_CLOSE.exec(line);
+    const close = closer.exec(line);
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,60 +1,60 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 36291,
-      "gzip": 13055
+      "min": 35846,
+      "gzip": 12817
     }
   },
   "@assistant-ui/cloud-ai-sdk": {
     ".": {
       "min": 14841,
-      "gzip": 5109
+      "gzip": 5139
     }
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 32191,
-      "gzip": 10869
+      "min": 31298,
+      "gzip": 10659
     },
     "./internal": {
-      "min": 121183,
-      "gzip": 30953
+      "min": 119010,
+      "gzip": 30236
     },
     "./react": {
-      "min": 270425,
-      "gzip": 74149
+      "min": 267177,
+      "gzip": 73212
     },
     "./store": {
-      "min": 90624,
-      "gzip": 30050
+      "min": 89174,
+      "gzip": 29589
     },
     "./store/internal": {
-      "min": 21420,
-      "gzip": 7876
+      "min": 21187,
+      "gzip": 7813
     }
   },
   "@assistant-ui/eve": {
     ".": {
-      "min": 11040,
-      "gzip": 4187
+      "min": 10667,
+      "gzip": 4076
     }
   },
   "@assistant-ui/react": {
     ".": {
-      "min": 130416,
-      "gzip": 42329
+      "min": 129681,
+      "gzip": 41986
     }
   },
   "@assistant-ui/react-a2a": {
     ".": {
       "min": 27557,
-      "gzip": 8344
+      "gzip": 8345
     }
   },
   "@assistant-ui/react-ag-ui": {
     ".": {
-      "min": 74627,
-      "gzip": 19567
+      "min": 73305,
+      "gzip": 19159
     }
   },
   "@assistant-ui/react-ai-sdk": {
@@ -66,45 +66,45 @@
   "@assistant-ui/react-data-stream": {
     ".": {
       "min": 4229,
-      "gzip": 1744
+      "gzip": 1759
     }
   },
   "@assistant-ui/react-devtools": {
     ".": {
       "min": 159811,
-      "gzip": 45518
+      "gzip": 45492
     }
   },
   "@assistant-ui/react-generative-ui": {
     ".": {
       "min": 33889,
-      "gzip": 11071
+      "gzip": 11010
     },
     "./a2ui": {
       "min": 8638,
-      "gzip": 3128
+      "gzip": 3119
     },
     "./ir": {
       "min": 1623,
-      "gzip": 885
+      "gzip": 863
     },
     "./slack": {
-      "min": 22625,
-      "gzip": 7371
+      "min": 22590,
+      "gzip": 7356
     },
     "./teams": {
-      "min": 12504,
-      "gzip": 4581
+      "min": 12524,
+      "gzip": 4600
     }
   },
   "@assistant-ui/react-google-adk": {
     ".": {
-      "min": 34831,
-      "gzip": 10434
+      "min": 34587,
+      "gzip": 10334
     },
     "./server": {
       "min": 6139,
-      "gzip": 2161
+      "gzip": 2173
     }
   },
   "@assistant-ui/react-hook-form": {
@@ -115,46 +115,46 @@
   },
   "@assistant-ui/react-ink": {
     ".": {
-      "min": 63654,
-      "gzip": 18341
+      "min": 62987,
+      "gzip": 18140
     },
     "./internal": {
       "min": 427,
-      "gzip": 205
+      "gzip": 203
     }
   },
   "@assistant-ui/react-ink-markdown": {
     ".": {
       "min": 2116,
-      "gzip": 1121
+      "gzip": 1130
     }
   },
   "@assistant-ui/react-langchain": {
     ".": {
-      "min": 13438,
-      "gzip": 4951
+      "min": 13468,
+      "gzip": 4971
     },
     "./converter": {
       "min": 3719,
-      "gzip": 1460
+      "gzip": 1466
     }
   },
   "@assistant-ui/react-langgraph": {
     ".": {
       "min": 26127,
-      "gzip": 9090
+      "gzip": 9078
     }
   },
   "@assistant-ui/react-lexical": {
     ".": {
       "min": 14436,
-      "gzip": 5119
+      "gzip": 5126
     }
   },
   "@assistant-ui/react-markdown": {
     ".": {
       "min": 5013,
-      "gzip": 2147
+      "gzip": 2142
     },
     "./code-fence": {
       "min": 84,
@@ -163,96 +163,96 @@
   },
   "@assistant-ui/react-mcp": {
     ".": {
-      "min": 42855,
-      "gzip": 13913
+      "min": 42357,
+      "gzip": 13677
     }
   },
   "@assistant-ui/react-native": {
     ".": {
-      "min": 31744,
-      "gzip": 8661
+      "min": 31684,
+      "gzip": 8638
     },
     "./internal": {
       "min": 427,
-      "gzip": 205
+      "gzip": 203
     }
   },
   "@assistant-ui/react-o11y": {
     ".": {
       "min": 9693,
-      "gzip": 3789
+      "gzip": 3794
     }
   },
   "@assistant-ui/react-opencode": {
     ".": {
       "min": 37417,
-      "gzip": 10648
+      "gzip": 10657
     }
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41590,
-      "gzip": 12017
+      "min": 41471,
+      "gzip": 11977
     },
     "./node": {
       "min": 17413,
-      "gzip": 5561
+      "gzip": 5580
     }
   },
   "@assistant-ui/react-streamdown": {
     ".": {
       "min": 7241,
-      "gzip": 3153
+      "gzip": 3130
     }
   },
   "@assistant-ui/react-syntax-highlighter": {
     ".": {
       "min": 498,
-      "gzip": 274
+      "gzip": 271
     },
     "./full": {
       "min": 405,
-      "gzip": 250
+      "gzip": 248
     }
   },
   "@assistant-ui/store": {
     ".": {
       "min": 16139,
-      "gzip": 6181
+      "gzip": 6202
     },
     "./client": {
       "min": 17074,
-      "gzip": 6381
+      "gzip": 6411
     },
     "./internal": {
       "min": 843,
-      "gzip": 441
+      "gzip": 442
     }
   },
   "@assistant-ui/tap": {
     ".": {
       "min": 19564,
-      "gzip": 7232
+      "gzip": 7249
     },
     "./react-shim": {
       "min": 7589,
-      "gzip": 3030
+      "gzip": 3045
     },
     "./react-shim/compiler-runtime": {
       "min": 861,
-      "gzip": 557
+      "gzip": 560
     },
     "./standalone-shim": {
       "min": 8359,
-      "gzip": 3372
+      "gzip": 3380
     },
     "./standalone-shim/compiler-runtime": {
       "min": 934,
-      "gzip": 579
+      "gzip": 582
     },
     "./standalone-shim/jsx-dev-runtime": {
       "min": 268,
-      "gzip": 213
+      "gzip": 214
     },
     "./standalone-shim/jsx-runtime": {
       "min": 296,
@@ -261,42 +261,42 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 15447,
-      "gzip": 5095
+      "min": 15430,
+      "gzip": 5082
     }
   },
   "assistant-stream": {
     ".": {
-      "min": 57356,
-      "gzip": 16121
+      "min": 57339,
+      "gzip": 16126
     },
     "./resumable": {
       "min": 16391,
-      "gzip": 5490
+      "gzip": 5497
     },
     "./resumable/ioredis": {
-      "min": 5830,
-      "gzip": 2316
+      "min": 5294,
+      "gzip": 2073
     },
     "./resumable/redis": {
-      "min": 6126,
-      "gzip": 2422
+      "min": 5572,
+      "gzip": 2171
     },
     "./utils": {
       "min": 14549,
-      "gzip": 4604
+      "gzip": 4617
     }
   },
   "heat-graph": {
     ".": {
       "min": 4248,
-      "gzip": 1885
+      "gzip": 1888
     }
   },
   "safe-content-frame": {
     ".": {
       "min": 3278,
-      "gzip": 1513
+      "gzip": 1519
     },
     "./shadow_dom": {
       "min": 81,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 5013,
-      "gzip": 2142
+      "min": 5604,
+      "gzip": 2383
     },
     "./code-fence": {
       "min": 84,
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 7241,
-      "gzip": 3130
+      "min": 7984,
+      "gzip": 3403
     }
   },
   "@assistant-ui/react-syntax-highlighter": {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,60 +1,60 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 35846,
-      "gzip": 12817
+      "min": 36291,
+      "gzip": 13055
     }
   },
   "@assistant-ui/cloud-ai-sdk": {
     ".": {
       "min": 14841,
-      "gzip": 5139
+      "gzip": 5109
     }
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 31298,
-      "gzip": 10659
+      "min": 32191,
+      "gzip": 10869
     },
     "./internal": {
-      "min": 119010,
-      "gzip": 30236
+      "min": 121183,
+      "gzip": 30953
     },
     "./react": {
-      "min": 267177,
-      "gzip": 73212
+      "min": 270425,
+      "gzip": 74149
     },
     "./store": {
-      "min": 89174,
-      "gzip": 29589
+      "min": 90624,
+      "gzip": 30050
     },
     "./store/internal": {
-      "min": 21187,
-      "gzip": 7813
+      "min": 21420,
+      "gzip": 7876
     }
   },
   "@assistant-ui/eve": {
     ".": {
-      "min": 10667,
-      "gzip": 4076
+      "min": 11040,
+      "gzip": 4187
     }
   },
   "@assistant-ui/react": {
     ".": {
-      "min": 129681,
-      "gzip": 41986
+      "min": 130416,
+      "gzip": 42329
     }
   },
   "@assistant-ui/react-a2a": {
     ".": {
       "min": 27557,
-      "gzip": 8345
+      "gzip": 8344
     }
   },
   "@assistant-ui/react-ag-ui": {
     ".": {
-      "min": 73305,
-      "gzip": 19159
+      "min": 74627,
+      "gzip": 19567
     }
   },
   "@assistant-ui/react-ai-sdk": {
@@ -66,45 +66,45 @@
   "@assistant-ui/react-data-stream": {
     ".": {
       "min": 4229,
-      "gzip": 1759
+      "gzip": 1744
     }
   },
   "@assistant-ui/react-devtools": {
     ".": {
       "min": 159811,
-      "gzip": 45492
+      "gzip": 45518
     }
   },
   "@assistant-ui/react-generative-ui": {
     ".": {
       "min": 33889,
-      "gzip": 11010
+      "gzip": 11071
     },
     "./a2ui": {
       "min": 8638,
-      "gzip": 3119
+      "gzip": 3128
     },
     "./ir": {
       "min": 1623,
-      "gzip": 863
+      "gzip": 885
     },
     "./slack": {
-      "min": 22590,
-      "gzip": 7356
+      "min": 22625,
+      "gzip": 7371
     },
     "./teams": {
-      "min": 12524,
-      "gzip": 4600
+      "min": 12504,
+      "gzip": 4581
     }
   },
   "@assistant-ui/react-google-adk": {
     ".": {
-      "min": 34587,
-      "gzip": 10334
+      "min": 34831,
+      "gzip": 10434
     },
     "./server": {
       "min": 6139,
-      "gzip": 2173
+      "gzip": 2161
     }
   },
   "@assistant-ui/react-hook-form": {
@@ -115,46 +115,46 @@
   },
   "@assistant-ui/react-ink": {
     ".": {
-      "min": 62987,
-      "gzip": 18140
+      "min": 63654,
+      "gzip": 18341
     },
     "./internal": {
       "min": 427,
-      "gzip": 203
+      "gzip": 205
     }
   },
   "@assistant-ui/react-ink-markdown": {
     ".": {
       "min": 2116,
-      "gzip": 1130
+      "gzip": 1121
     }
   },
   "@assistant-ui/react-langchain": {
     ".": {
-      "min": 13468,
-      "gzip": 4971
+      "min": 13438,
+      "gzip": 4951
     },
     "./converter": {
       "min": 3719,
-      "gzip": 1466
+      "gzip": 1460
     }
   },
   "@assistant-ui/react-langgraph": {
     ".": {
       "min": 26127,
-      "gzip": 9078
+      "gzip": 9090
     }
   },
   "@assistant-ui/react-lexical": {
     ".": {
       "min": 14436,
-      "gzip": 5126
+      "gzip": 5119
     }
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 5604,
-      "gzip": 2383
+      "min": 6000,
+      "gzip": 2553
     },
     "./code-fence": {
       "min": 84,
@@ -163,96 +163,96 @@
   },
   "@assistant-ui/react-mcp": {
     ".": {
-      "min": 42357,
-      "gzip": 13677
+      "min": 42855,
+      "gzip": 13913
     }
   },
   "@assistant-ui/react-native": {
     ".": {
-      "min": 31684,
-      "gzip": 8638
+      "min": 31744,
+      "gzip": 8661
     },
     "./internal": {
       "min": 427,
-      "gzip": 203
+      "gzip": 205
     }
   },
   "@assistant-ui/react-o11y": {
     ".": {
       "min": 9693,
-      "gzip": 3794
+      "gzip": 3789
     }
   },
   "@assistant-ui/react-opencode": {
     ".": {
       "min": 37417,
-      "gzip": 10657
+      "gzip": 10648
     }
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41471,
-      "gzip": 11977
+      "min": 41590,
+      "gzip": 12017
     },
     "./node": {
       "min": 17413,
-      "gzip": 5580
+      "gzip": 5561
     }
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 7984,
-      "gzip": 3403
+      "min": 8380,
+      "gzip": 3575
     }
   },
   "@assistant-ui/react-syntax-highlighter": {
     ".": {
       "min": 498,
-      "gzip": 271
+      "gzip": 274
     },
     "./full": {
       "min": 405,
-      "gzip": 248
+      "gzip": 250
     }
   },
   "@assistant-ui/store": {
     ".": {
       "min": 16139,
-      "gzip": 6202
+      "gzip": 6181
     },
     "./client": {
       "min": 17074,
-      "gzip": 6411
+      "gzip": 6381
     },
     "./internal": {
       "min": 843,
-      "gzip": 442
+      "gzip": 441
     }
   },
   "@assistant-ui/tap": {
     ".": {
       "min": 19564,
-      "gzip": 7249
+      "gzip": 7232
     },
     "./react-shim": {
       "min": 7589,
-      "gzip": 3045
+      "gzip": 3030
     },
     "./react-shim/compiler-runtime": {
       "min": 861,
-      "gzip": 560
+      "gzip": 557
     },
     "./standalone-shim": {
       "min": 8359,
-      "gzip": 3380
+      "gzip": 3372
     },
     "./standalone-shim/compiler-runtime": {
       "min": 934,
-      "gzip": 582
+      "gzip": 579
     },
     "./standalone-shim/jsx-dev-runtime": {
       "min": 268,
-      "gzip": 214
+      "gzip": 213
     },
     "./standalone-shim/jsx-runtime": {
       "min": 296,
@@ -261,42 +261,42 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 15430,
-      "gzip": 5082
+      "min": 15447,
+      "gzip": 5095
     }
   },
   "assistant-stream": {
     ".": {
-      "min": 57339,
-      "gzip": 16126
+      "min": 57356,
+      "gzip": 16121
     },
     "./resumable": {
       "min": 16391,
-      "gzip": 5497
+      "gzip": 5490
     },
     "./resumable/ioredis": {
-      "min": 5294,
-      "gzip": 2073
+      "min": 5830,
+      "gzip": 2316
     },
     "./resumable/redis": {
-      "min": 5572,
-      "gzip": 2171
+      "min": 6126,
+      "gzip": 2422
     },
     "./utils": {
       "min": 14549,
-      "gzip": 4617
+      "gzip": 4604
     }
   },
   "heat-graph": {
     ".": {
       "min": 4248,
-      "gzip": 1888
+      "gzip": 1885
     }
   },
   "safe-content-frame": {
     ".": {
       "min": 3278,
-      "gzip": 1519
+      "gzip": 1513
     },
     "./shadow_dom": {
       "min": 81,


### PR DESCRIPTION
Closes #6767.

## Problem

`rewriteLatexBracketDelimiters` and `rewriteCustomMathTags` are plain regex replaces over the whole text, so a code span or fenced block containing `\(x\)`, `\[x\]`, or `[/math]` tags is rewritten to dollar delimiters before markdown parses it — a reply that shows a LaTeX snippet *as code* renders changed code. `escapeCurrencyDollars` in the same module already steps over code through `codeSpanEnd`, so the module's documented preprocessors disagreed on whether code is inert.

Repro on main: `normalizeMathDelimiters("a `\\(x\\)` b")` → `` a `$x$` b ``.

## Change

A `rewriteOutsideCode` walker built on the existing `codeSpanEnd`/`runLength` machinery splits the text at code spans and fences, copies code through verbatim, and applies the rewrite only to the stretches between. Both rewriters now run through it. The walker matches `escapeCurrencyDollars`'s conventions: `\x` escapes are stepped over while scanning (an escaped backtick does not open a span), and an unclosed backtick run reads as literal backticks.

Two consequences the tests pin:

- Line-boundary decisions for multiline display fencing survive the split — each stretch is passed its adjacent characters, so a `\[a\nb\]` right after an inline code span still gets fenced correctly.
- A delimiter pair straddling a code boundary (`\(a `b` c\)`) is now left as written rather than rewritten with the code inside; code is inert as a boundary too.

`packages/react-streamdown/src/preprocess.ts` carries the same helper and gets the identical change, its test file the identical additions.

## Verification

- The inline-code repro fails on main (`a `\(x\)` b` → `` a `$x$` b ``) and passes with the fix.
- Both suites: 47 tests pass in react-markdown, 47 in react-streamdown (the 37 pre-existing behaviors all unchanged; 10 new cases cover fenced blocks, inline spans, prose sharing a line with a code span, escaped backticks, fence-adjacent display math, and straddling pairs for both delimiter families).

## Size

The walker adds ~411 B gzip to `@assistant-ui/react-markdown .` (2142 -> 2553) and ~422 B to `@assistant-ui/react-streamdown .` (3153 -> 3575), including the tilde-fence lane; the budget diff touches only those two entries, measured against a fresh build of both packages.

## Public surface

No API changes. Changeset: patch for `@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.c6cT0Q0RNbX-4CbTvecPrCjyNfESh9BExDchh2xqje5AJIRFi3MrXJgW6jU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
