### PR TITLE
fix(react-a2a): preserve raw zero-byte files

### DIFF
--- a/.changeset/calm-files-smile.md
+++ b/.changeset/calm-files-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: preserve zero-byte files when converting messages to A2A parts

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -514,6 +514,20 @@ describe("contentPartsToA2AParts", () => {
     expect(result).toEqual([{ raw: "ZmlsZQ==", mediaType: "text/csv" }]);
   });
 
+  it("preserves raw zero-byte file data", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "",
+        mimeType: "text/plain",
+        filename: "empty.txt",
+      },
+    ]);
+    expect(result).toEqual([
+      { raw: "", mediaType: "text/plain", filename: "empty.txt" },
+    ]);
+  });
+
   it("falls back to the attachment MIME type when the file part MIME is empty", () => {
     const result = contentPartsToA2AParts(
       [{ type: "file", data: "ZmlsZQ==", mimeType: "" }],

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -139,7 +139,7 @@ export function contentPartsToA2AParts(
           };
         }
         case "file": {
-          if (typeof part.data !== "string" || !part.data) return null;
+          if (typeof part.data !== "string") return null;
           const declaredMimeType = part.mimeType || fallbackMimeType;
           const source = resolveFilePartSource({
             data: part.data,


### PR DESCRIPTION
## Problem

`contentPartsToA2AParts()` drops raw zero-byte file parts because an empty base64 string is treated like missing data. A file such as `{ type: "file", data: "", mimeType: "text/plain" }` therefore disappears from the outgoing A2A message on current main.

## Root cause

The file converter used a truthiness check after confirming the data type. Empty strings are valid raw base64 for zero-byte files, so the check rejected a valid payload.

## Change

Accept every string file payload, including the empty string, while continuing to skip missing and non-string data.

## Verification

- Confirmed the focused regression fails before the change and passes afterward.
- `node_modules/.bin/vitest run src/conversions.test.ts` (90 tests)
- `node_modules/.bin/aui-build`
- `node scripts/check-changesets.mjs`
- `git diff --check`

## Public surface

`@assistant-ui/react-a2a` behavior changes for zero-byte file conversion. No exports or API types change. Includes a patch changeset.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.R7evxWakCudZ37yCogHtZzV3TQ_GNIMvjunRcq45ciiEOsmX-yNnIGw_TNI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->