### PR TITLE
fix(react-markdown): fence multiline [/math] bodies so remark-math finds the closing delimiter

### DIFF
--- a/.changeset/custom-math-tag-fencing.md
+++ b/.changeset/custom-math-tag-fencing.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: fence multiline [/math] bodies so remark-math finds the closing delimiter

--- a/.changeset/custom-math-tag-fencing.md
+++ b/.changeset/custom-math-tag-fencing.md
@@ -4,3 +4,7 @@
 ---
 
 fix: fence multiline [/math] bodies so remark-math finds the closing delimiter
+
+a multiline `[/math]` body was emitted with its first line beside the opening `$$`, which remark-math reads as fence metadata before scanning to the end of the input for a closer, so the body's first line was lost and the rest of the reply rendered as one parse error. it is now fenced through the same emitter the bracket delimiters use.
+
+a tag pair wrapping nothing is left as written, for the reason an empty bracket pair already was: `$$$$` opens a fence that never closes, and `$$` does the same inline.

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -222,6 +222,9 @@ describe("rewriteCustomMathTags", () => {
 
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+    expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
+      "[/inline][/inline] rest",
+    );
   });
 });
 

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -220,6 +220,22 @@ describe("rewriteCustomMathTags", () => {
     );
   });
 
+  it("does not add a blank line before a CRLF suffix", () => {
+    expect(rewriteCustomMathTags("[/math]\na\nb\n[/math]\r\nrest")).toBe(
+      "$$\na\nb\n$$\r\nrest",
+    );
+  });
+
+  it("rewrites a custom tag after an unclosed inline backtick run", () => {
+    expect(rewriteCustomMathTags("a ` b [/math]x[/math]")).toBe("a ` b $$x$$");
+  });
+
+  it("rewrites a custom tag after a mid-line code span", () => {
+    expect(rewriteCustomMathTags("a `code` [/math]x[/math]")).toBe(
+      "a `code` $$x$$",
+    );
+  });
+
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
     expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -226,6 +226,15 @@ describe("rewriteCustomMathTags", () => {
       "[/inline][/inline] rest",
     );
   });
+
+  it("leaves a whitespace-only tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math] \n [/math]\nrest")).toBe(
+      "[/math] \n [/math]\nrest",
+    );
+    expect(rewriteCustomMathTags("[/inline]   [/inline] rest")).toBe(
+      "[/inline]   [/inline] rest",
+    );
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -199,6 +199,30 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
     ).toBe("$a$ `[/inline]x[/inline]`");
   });
+
+  it("fences a multiline math tag body", () => {
+    expect(
+      rewriteCustomMathTags(
+        "[/math]\\begin{aligned}\na&=b\n\\end{aligned}[/math]\nDone.",
+      ),
+    ).toBe("$$\n\\begin{aligned}\na&=b\n\\end{aligned}\n$$\nDone.");
+  });
+
+  it("gives the fence markers their own lines mid-paragraph", () => {
+    expect(rewriteCustomMathTags("Thus [/math]a\nb[/math] therefore.")).toBe(
+      "Thus \n$$\na\nb\n$$\n therefore.",
+    );
+  });
+
+  it("keeps a single-line math tag body on its line", () => {
+    expect(rewriteCustomMathTags("See [/math]x=1[/math] ok.")).toBe(
+      "See $$x=1$$ ok.",
+    );
+  });
+
+  it("leaves an empty math tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -200,7 +200,10 @@ export function rewriteCustomMathTags(text: string): string {
         (match: string, body: string, offset: number, source: string) =>
           emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       )
-      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+      .replace(INLINE_TAG, (match: string, body: string) => {
+        const trimmed = body.trim();
+        return trimmed === "" ? match : `$${trimmed}$`;
+      }),
   );
 }
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -156,8 +156,12 @@ function emitDisplayMath(
   const before = offset === 0 ? precededBy : source[offset - 1]!;
   const afterStart = offset + match.length;
   const after = afterStart === source.length ? followedBy : source[afterStart]!;
-  const lead = before === "" || before === "\n" ? "" : "\n";
-  const tail = after === "" || after === "\n" ? "" : "\n";
+  // A CRLF document puts the carriage return next to the match, so both endings
+  // count as already being at a line boundary.
+  const endsLine = (char: string) =>
+    char === "" || char === "\n" || char === "\r";
+  const lead = endsLine(before) ? "" : "\n";
+  const tail = endsLine(after) ? "" : "\n";
   return `${lead}$$\n${trimmed}\n$$${tail}`;
 }
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -131,19 +131,43 @@ function rewriteOutsideCode(
 }
 
 /**
+ * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
+ * one span for a single-line body, and for a body spanning lines the fenced
+ * form, on lines the `$$` markers own. remark-math parses multiline `$$` as a
+ * flow construct: the opening marker has to start a line and the closing marker
+ * to end one, and it reads whatever else shares those lines as fence metadata
+ * rather than as math.
+ *
+ * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
+ * open a fence that never closes.
+ */
+function emitDisplayMath(
+  match: string,
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  followedBy: string,
+): string {
+  const trimmed = body.trim();
+  if (trimmed === "") return match;
+  if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const afterStart = offset + match.length;
+  const after = afterStart === source.length ? followedBy : source[afterStart]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
+  const tail = after === "" || after === "\n" ? "" : "\n";
+  return `${lead}$$\n${trimmed}\n$$${tail}`;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
- * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
- * leading backslash is accepted, since models emit both depending on escaping.
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display, fenced when the
+ * body spans lines — see {@link emitDisplayMath}). A single or double leading
+ * backslash is accepted, since models emit both depending on escaping.
  * remark-math only recognizes the dollar form, so without this rewrite bracket
  * math renders as plain text.
- *
- * A display body spanning lines is emitted fenced, on lines the `$$` markers own.
- * remark-math parses multiline `$$` as a flow construct: the opening marker has to
- * start a line and the closing marker to end one, and it reads whatever else shares
- * those lines as fence metadata rather than as math.
- *
- * A pair wrapping nothing is left as written: `$$$$` would itself open a fence that
- * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
   return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
@@ -154,19 +178,8 @@ export function rewriteLatexBracketDelimiters(text: string): string {
       })
       .replace(
         LATEX_DISPLAY_DELIMITER,
-        (match: string, body: string, offset: number, source: string) => {
-          const trimmed = body.trim();
-          if (trimmed === "") return match;
-          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
-
-          const before = offset === 0 ? precededBy : source[offset - 1]!;
-          const afterStart = offset + match.length;
-          const after =
-            afterStart === source.length ? followedBy : source[afterStart]!;
-          const lead = before === "" || before === "\n" ? "" : "\n";
-          const tail = after === "" || after === "\n" ? "" : "\n";
-          return `${lead}$$\n${trimmed}\n$$${tail}`;
-        },
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       ),
   );
 }
@@ -176,12 +189,17 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
 
 /**
  * Rewrites the custom math tags some models emit to dollar delimiters:
- * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ * `[/math]...[/math]` becomes `$$...$$` (fenced when the body spans lines — see
+ * {@link emitDisplayMath}) and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return rewriteOutsideCode(text, (segment) =>
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
     segment
-      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(
+        MATH_TAG,
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
+      )
       .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
   );
 }

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -222,6 +222,9 @@ describe("rewriteCustomMathTags", () => {
 
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+    expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
+      "[/inline][/inline] rest",
+    );
   });
 });
 

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -220,6 +220,22 @@ describe("rewriteCustomMathTags", () => {
     );
   });
 
+  it("does not add a blank line before a CRLF suffix", () => {
+    expect(rewriteCustomMathTags("[/math]\na\nb\n[/math]\r\nrest")).toBe(
+      "$$\na\nb\n$$\r\nrest",
+    );
+  });
+
+  it("rewrites a custom tag after an unclosed inline backtick run", () => {
+    expect(rewriteCustomMathTags("a ` b [/math]x[/math]")).toBe("a ` b $$x$$");
+  });
+
+  it("rewrites a custom tag after a mid-line code span", () => {
+    expect(rewriteCustomMathTags("a `code` [/math]x[/math]")).toBe(
+      "a `code` $$x$$",
+    );
+  });
+
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
     expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -226,6 +226,15 @@ describe("rewriteCustomMathTags", () => {
       "[/inline][/inline] rest",
     );
   });
+
+  it("leaves a whitespace-only tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math] \n [/math]\nrest")).toBe(
+      "[/math] \n [/math]\nrest",
+    );
+    expect(rewriteCustomMathTags("[/inline]   [/inline] rest")).toBe(
+      "[/inline]   [/inline] rest",
+    );
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -199,6 +199,30 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
     ).toBe("$a$ `[/inline]x[/inline]`");
   });
+
+  it("fences a multiline math tag body", () => {
+    expect(
+      rewriteCustomMathTags(
+        "[/math]\\begin{aligned}\na&=b\n\\end{aligned}[/math]\nDone.",
+      ),
+    ).toBe("$$\n\\begin{aligned}\na&=b\n\\end{aligned}\n$$\nDone.");
+  });
+
+  it("gives the fence markers their own lines mid-paragraph", () => {
+    expect(rewriteCustomMathTags("Thus [/math]a\nb[/math] therefore.")).toBe(
+      "Thus \n$$\na\nb\n$$\n therefore.",
+    );
+  });
+
+  it("keeps a single-line math tag body on its line", () => {
+    expect(rewriteCustomMathTags("See [/math]x=1[/math] ok.")).toBe(
+      "See $$x=1$$ ok.",
+    );
+  });
+
+  it("leaves an empty math tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -200,7 +200,10 @@ export function rewriteCustomMathTags(text: string): string {
         (match: string, body: string, offset: number, source: string) =>
           emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       )
-      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+      .replace(INLINE_TAG, (match: string, body: string) => {
+        const trimmed = body.trim();
+        return trimmed === "" ? match : `$${trimmed}$`;
+      }),
   );
 }
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -156,8 +156,12 @@ function emitDisplayMath(
   const before = offset === 0 ? precededBy : source[offset - 1]!;
   const afterStart = offset + match.length;
   const after = afterStart === source.length ? followedBy : source[afterStart]!;
-  const lead = before === "" || before === "\n" ? "" : "\n";
-  const tail = after === "" || after === "\n" ? "" : "\n";
+  // A CRLF document puts the carriage return next to the match, so both endings
+  // count as already being at a line boundary.
+  const endsLine = (char: string) =>
+    char === "" || char === "\n" || char === "\r";
+  const lead = endsLine(before) ? "" : "\n";
+  const tail = endsLine(after) ? "" : "\n";
   return `${lead}$$\n${trimmed}\n$$${tail}`;
 }
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -131,19 +131,43 @@ function rewriteOutsideCode(
 }
 
 /**
+ * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
+ * one span for a single-line body, and for a body spanning lines the fenced
+ * form, on lines the `$$` markers own. remark-math parses multiline `$$` as a
+ * flow construct: the opening marker has to start a line and the closing marker
+ * to end one, and it reads whatever else shares those lines as fence metadata
+ * rather than as math.
+ *
+ * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
+ * open a fence that never closes.
+ */
+function emitDisplayMath(
+  match: string,
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  followedBy: string,
+): string {
+  const trimmed = body.trim();
+  if (trimmed === "") return match;
+  if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const afterStart = offset + match.length;
+  const after = afterStart === source.length ? followedBy : source[afterStart]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
+  const tail = after === "" || after === "\n" ? "" : "\n";
+  return `${lead}$$\n${trimmed}\n$$${tail}`;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
- * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
- * leading backslash is accepted, since models emit both depending on escaping.
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display, fenced when the
+ * body spans lines — see {@link emitDisplayMath}). A single or double leading
+ * backslash is accepted, since models emit both depending on escaping.
  * remark-math only recognizes the dollar form, so without this rewrite bracket
  * math renders as plain text.
- *
- * A display body spanning lines is emitted fenced, on lines the `$$` markers own.
- * remark-math parses multiline `$$` as a flow construct: the opening marker has to
- * start a line and the closing marker to end one, and it reads whatever else shares
- * those lines as fence metadata rather than as math.
- *
- * A pair wrapping nothing is left as written: `$$$$` would itself open a fence that
- * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
   return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
@@ -154,19 +178,8 @@ export function rewriteLatexBracketDelimiters(text: string): string {
       })
       .replace(
         LATEX_DISPLAY_DELIMITER,
-        (match: string, body: string, offset: number, source: string) => {
-          const trimmed = body.trim();
-          if (trimmed === "") return match;
-          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
-
-          const before = offset === 0 ? precededBy : source[offset - 1]!;
-          const afterStart = offset + match.length;
-          const after =
-            afterStart === source.length ? followedBy : source[afterStart]!;
-          const lead = before === "" || before === "\n" ? "" : "\n";
-          const tail = after === "" || after === "\n" ? "" : "\n";
-          return `${lead}$$\n${trimmed}\n$$${tail}`;
-        },
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       ),
   );
 }
@@ -176,12 +189,17 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
 
 /**
  * Rewrites the custom math tags some models emit to dollar delimiters:
- * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ * `[/math]...[/math]` becomes `$$...$$` (fenced when the body spans lines — see
+ * {@link emitDisplayMath}) and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return rewriteOutsideCode(text, (segment) =>
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
     segment
-      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(
+        MATH_TAG,
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
+      )
       .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
   );
 }

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 6000,
-      "gzip": 2553
+      "min": 6072,
+      "gzip": 2557
     },
     "./code-fence": {
       "min": 84,
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 8380,
-      "gzip": 3575
+      "min": 8452,
+      "gzip": 3578
     }
   },
   "@assistant-ui/react-syntax-highlighter": {


### PR DESCRIPTION
Closes #6782. Stacked on #6795 (the first commit is that PR's code-span fix; this PR's own change is the second commit — merge #6795 first and this rebases to just it).

## Problem

`rewriteCustomMathTags` rewrites `[/math] body [/math]` to `$$body$$` on one logical span — the shape `rewriteLatexBracketDelimiters` had before #6778. When the body spans lines, the opening `$$` shares its line with the body's first line, so remark-math reads that line as fence metadata and never finds a standalone closing fence: the body's first line is lost and the block runs to the end of the input, which KaTeX renders as one parse error containing the rest of the reply. Verified against the pinned `remark-math@6.0.0` with the issue's `\begin{aligned}` repro.

## Change

The display-math emission (single-line span vs multiline fenced form, plus the empty-pair guard) moves into one shared `emitDisplayMath`, and both rewriters call it — per the issue's note that the two helpers should share the emitter rather than each carrying a copy. `[/math]` bodies now get exactly #6778's treatment: `$$` markers on their own lines, with lead/tail newlines only when the match does not already sit on line boundaries. The `[/inline]` path is inline single-dollar math and is unchanged.

One behavior rides along via the shared guard: an empty `[/math][/math]` pair is now left as written instead of emitting `$$$$`, which itself opened a fence that never closes — the same guard #6778 gave empty bracket pairs.

## Verification

- The issue's repro fails on main (`$$\begin{aligned}` on one line) and now produces `$$\n\begin{aligned}\na&=b\n\end{aligned}\n$$\nDone.`, which remark-math parses with `meta: null` and the full body intact.
- 51 tests pass in each package: all prior behaviors unchanged, plus the multiline fencing, mid-paragraph marker lines, single-line span, and empty-pair cases for the tag family.

## Public surface

No API changes. Changeset: patch for `@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.h3GuXVgfD9oyUvVyqjFokaGQhdYSSNk9wfwE3T8qwig0hcncc0l6_K6GMzE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->