### PR TITLE
fix(react-markdown): keep multiline display math nested in its list item or blockquote

### DIFF
--- a/.changeset/custom-math-tag-fencing.md
+++ b/.changeset/custom-math-tag-fencing.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: fence multiline [/math] bodies so remark-math finds the closing delimiter

--- a/.changeset/display-math-container-nesting.md
+++ b/.changeset/display-math-container-nesting.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep multiline display math nested in its list item or blockquote

--- a/.changeset/preprocess-skip-code-spans.md
+++ b/.changeset/preprocess-skip-code-spans.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep code spans and fences inert when normalizing math delimiters

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -100,6 +100,32 @@ describe("rewriteLatexBracketDelimiters", () => {
       "\\(a `b` c\\)",
     );
   });
+
+  it("rewrites across a lone literal backtick", () => {
+    expect(rewriteLatexBracketDelimiters("Use \\(x ` y\\) here")).toBe(
+      "Use $x ` y$ here",
+    );
+  });
+
+  it("protects an unclosed fence still streaming in", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\(x\\)\nstill streaming")).toBe(
+      "```\n\\(x\\)\nstill streaming",
+    );
+  });
+
+  it("leaves a delimiter inside a tilde fence as written", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\[a\nb\\]\n~~~\n\\(x\\)")).toBe(
+      "~~~\n\\[a\nb\\]\n~~~\n$x$",
+    );
+  });
+
+  it("protects an unclosed tilde fence to the end of the input", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
+  });
+
+  it("rewrites around a mid-line tilde run", () => {
+    expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
+  });
 });
 
 describe("rewriteCustomMathTags", () => {

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -175,6 +175,9 @@ describe("rewriteCustomMathTags", () => {
 
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+    expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
+      "[/inline][/inline] rest",
+    );
   });
 });
 

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -152,6 +152,30 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
     ).toBe("$a$ `[/inline]x[/inline]`");
   });
+
+  it("fences a multiline math tag body", () => {
+    expect(
+      rewriteCustomMathTags(
+        "[/math]\\begin{aligned}\na&=b\n\\end{aligned}[/math]\nDone.",
+      ),
+    ).toBe("$$\n\\begin{aligned}\na&=b\n\\end{aligned}\n$$\nDone.");
+  });
+
+  it("gives the fence markers their own lines mid-paragraph", () => {
+    expect(rewriteCustomMathTags("Thus [/math]a\nb[/math] therefore.")).toBe(
+      "Thus \n$$\na\nb\n$$\n therefore.",
+    );
+  });
+
+  it("keeps a single-line math tag body on its line", () => {
+    expect(rewriteCustomMathTags("See [/math]x=1[/math] ok.")).toBe(
+      "See $$x=1$$ ok.",
+    );
+  });
+
+  it("leaves an empty math tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -66,6 +66,40 @@ describe("rewriteLatexBracketDelimiters", () => {
       "plain $x$ text",
     );
   });
+
+  it("leaves a delimiter inside an inline code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("a `\\(x\\)` b")).toBe(
+      "a `\\(x\\)` b",
+    );
+  });
+
+  it("leaves a delimiter inside a fenced block as written", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\[a\nb\\]\n```")).toBe(
+      "```\n\\[a\nb\\]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a\\) `\\(x\\)` \\(b\\)")).toBe(
+      "$a$ `\\(x\\)` $b$",
+    );
+  });
+
+  it("does not treat an escaped backtick as a code opener", () => {
+    expect(rewriteLatexBracketDelimiters("\\` \\(x\\)")).toBe("\\` $x$");
+  });
+
+  it("fences a multiline display body directly after a code span", () => {
+    expect(rewriteLatexBracketDelimiters("`c` \\[a\nb\\] d")).toBe(
+      "`c` \n$$\na\nb\n$$\n d",
+    );
+  });
+
+  it("leaves a delimiter pair straddling a code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a `b` c\\)")).toBe(
+      "\\(a `b` c\\)",
+    );
+  });
 });
 
 describe("rewriteCustomMathTags", () => {
@@ -74,12 +108,36 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
     ).toBe("$$a+b$$ and $c$");
   });
+
+  it("leaves a tag inside an inline code span as written", () => {
+    expect(rewriteCustomMathTags("`[/math]x[/math]`")).toBe(
+      "`[/math]x[/math]`",
+    );
+  });
+
+  it("leaves a tag inside a fenced block as written", () => {
+    expect(rewriteCustomMathTags("```\n[/inline]x[/inline]\n```")).toBe(
+      "```\n[/inline]x[/inline]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(
+      rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
+    ).toBe("$a$ `[/inline]x[/inline]`");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {
   it("normalizes both bracket delimiters and custom tags", () => {
     expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
       "$x$ $$y$$",
+    );
+  });
+
+  it("keeps code inert for both delimiter families", () => {
+    expect(normalizeMathDelimiters("`\\(x\\)` and `[/math]y[/math]`")).toBe(
+      "`\\(x\\)` and `[/math]y[/math]`",
     );
   });
 });

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -40,9 +40,35 @@ describe("rewriteLatexBracketDelimiters", () => {
     );
   });
 
-  it("lifts a multiline display body out of its list item", () => {
+  it("keeps an indented display body nested in its list item", () => {
+    expect(
+      rewriteLatexBracketDelimiters(
+        "1. Expand:\n   \\[\n   a = b\n   c = d\n   \\]",
+      ),
+    ).toBe("1. Expand:\n   $$\n   a = b\n   c = d\n   $$");
+  });
+
+  it("keeps a prefixed display body nested in its blockquote", () => {
+    expect(rewriteLatexBracketDelimiters("> Expand \\[\n> a\n> b\n> \\]")).toBe(
+      "> Expand \n> $$\n> a\n> b\n> $$",
+    );
+  });
+
+  it("keeps text after the closing delimiter off the fence line", () => {
+    expect(
+      rewriteLatexBracketDelimiters("1. x:\n   \\[\n   a\n   b\n   \\] done"),
+    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n done");
+  });
+
+  it("lifts an unprefixed multiline display body out of its list item", () => {
     expect(rewriteLatexBracketDelimiters("- item \\[\na\nb\n\\]\n- next")).toBe(
       "- item \n$$\na\nb\n$$\n- next",
+    );
+  });
+
+  it("lifts a body whose lines do not share the closing prefix", () => {
+    expect(rewriteLatexBracketDelimiters("> Expand \\[\na\n> b\n> \\]")).toBe(
+      "> Expand \n$$\na\n> b\n>\n$$",
     );
   });
 
@@ -178,6 +204,12 @@ describe("rewriteCustomMathTags", () => {
     expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
       "[/inline][/inline] rest",
     );
+  });
+
+  it("keeps an indented math tag body nested in its list item", () => {
+    expect(
+      rewriteCustomMathTags("1. Expand:\n   [/math]\n   a\n   b\n   [/math]"),
+    ).toBe("1. Expand:\n   $$\n   a\n   b\n   $$");
   });
 });
 

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -54,10 +54,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     );
   });
 
-  it("keeps text after the closing delimiter off the fence line", () => {
+  it("keeps trailing text nested below the closing fence line", () => {
     expect(
       rewriteLatexBracketDelimiters("1. x:\n   \\[\n   a\n   b\n   \\] done"),
-    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n done");
+    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n    done");
+  });
+
+  it("keeps a body opened beside a list marker nested in the item", () => {
+    expect(
+      rewriteLatexBracketDelimiters(
+        "1. Expand: \\[\n   a = b\n   c = d\n   \\]",
+      ),
+    ).toBe("1. Expand: \n   $$\n   a = b\n   c = d\n   $$");
   });
 
   it("lifts an unprefixed multiline display body out of its list item", () => {

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -146,10 +146,17 @@ function emitNestedDisplayMath(
 
   let lead: string;
   if (CONTAINER_PREFIX.test(beforeOnLine)) lead = "";
-  else if (beforeOnLine.startsWith(closingPrefix)) lead = `\n${closingPrefix}`;
+  else if (
+    beforeOnLine.startsWith(closingPrefix) ||
+    (/^[ \t]*$/.test(closingPrefix) &&
+      beforeOnLine.length >= closingPrefix.length)
+  )
+    lead = `\n${closingPrefix}`;
   else return null;
 
-  return `${lead}$$\n${middle}\n${closingPrefix}$$${tail}`;
+  return `${lead}$$\n${middle}\n${closingPrefix}$$${
+    tail === "" ? "" : `\n${closingPrefix}`
+  }`;
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -111,19 +111,43 @@ function rewriteOutsideCode(
 }
 
 /**
+ * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
+ * one span for a single-line body, and for a body spanning lines the fenced
+ * form, on lines the `$$` markers own. remark-math parses multiline `$$` as a
+ * flow construct: the opening marker has to start a line and the closing marker
+ * to end one, and it reads whatever else shares those lines as fence metadata
+ * rather than as math.
+ *
+ * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
+ * open a fence that never closes.
+ */
+function emitDisplayMath(
+  match: string,
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  followedBy: string,
+): string {
+  const trimmed = body.trim();
+  if (trimmed === "") return match;
+  if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const afterStart = offset + match.length;
+  const after = afterStart === source.length ? followedBy : source[afterStart]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
+  const tail = after === "" || after === "\n" ? "" : "\n";
+  return `${lead}$$\n${trimmed}\n$$${tail}`;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
- * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
- * leading backslash is accepted, since models emit both depending on escaping.
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display, fenced when the
+ * body spans lines — see {@link emitDisplayMath}). A single or double leading
+ * backslash is accepted, since models emit both depending on escaping.
  * remark-math only recognizes the dollar form, so without this rewrite bracket
  * math renders as plain text.
- *
- * A display body spanning lines is emitted fenced, on lines the `$$` markers own.
- * remark-math parses multiline `$$` as a flow construct: the opening marker has to
- * start a line and the closing marker to end one, and it reads whatever else shares
- * those lines as fence metadata rather than as math.
- *
- * A pair wrapping nothing is left as written: `$$$$` would itself open a fence that
- * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
   return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
@@ -134,19 +158,8 @@ export function rewriteLatexBracketDelimiters(text: string): string {
       })
       .replace(
         LATEX_DISPLAY_DELIMITER,
-        (match: string, body: string, offset: number, source: string) => {
-          const trimmed = body.trim();
-          if (trimmed === "") return match;
-          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
-
-          const before = offset === 0 ? precededBy : source[offset - 1]!;
-          const afterStart = offset + match.length;
-          const after =
-            afterStart === source.length ? followedBy : source[afterStart]!;
-          const lead = before === "" || before === "\n" ? "" : "\n";
-          const tail = after === "" || after === "\n" ? "" : "\n";
-          return `${lead}$$\n${trimmed}\n$$${tail}`;
-        },
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       ),
   );
 }
@@ -156,12 +169,17 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
 
 /**
  * Rewrites the custom math tags some models emit to dollar delimiters:
- * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ * `[/math]...[/math]` becomes `$$...$$` (fenced when the body spans lines — see
+ * {@link emitDisplayMath}) and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return rewriteOutsideCode(text, (segment) =>
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
     segment
-      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(
+        MATH_TAG,
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
+      )
       .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
   );
 }

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -110,6 +110,48 @@ function rewriteOutsideCode(
   return out;
 }
 
+const CONTAINER_PREFIX = /^[ \t>]*$/;
+
+/**
+ * Fenced emission for a display body written inside a markdown container (a
+ * list item or blockquote): when the closing delimiter sits on its own line
+ * behind a container prefix that every body line shares, the `$$` markers and
+ * body keep that prefix, so the block stays nested where the source put it
+ * instead of landing at the root column after the container. Returns null when
+ * the source carries no such prefix.
+ */
+function emitNestedDisplayMath(
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  tail: string,
+): string | null {
+  const firstNewline = body.indexOf("\n");
+  const lastNewline = body.lastIndexOf("\n");
+  if (body.slice(0, firstNewline).trim() !== "") return null;
+  const closingPrefix = body.slice(lastNewline + 1);
+  if (closingPrefix === "" || !CONTAINER_PREFIX.test(closingPrefix))
+    return null;
+
+  const middle = body.slice(firstNewline + 1, lastNewline);
+  if (middle === "") return null;
+  if (!middle.split("\n").every((line) => line.startsWith(closingPrefix)))
+    return null;
+
+  let lineStart = offset;
+  while (lineStart > 0 && source[lineStart - 1] !== "\n") lineStart--;
+  if (lineStart === 0 && precededBy !== "" && precededBy !== "\n") return null;
+  const beforeOnLine = source.slice(lineStart, offset);
+
+  let lead: string;
+  if (CONTAINER_PREFIX.test(beforeOnLine)) lead = "";
+  else if (beforeOnLine.startsWith(closingPrefix)) lead = `\n${closingPrefix}`;
+  else return null;
+
+  return `${lead}$$\n${middle}\n${closingPrefix}$$${tail}`;
+}
+
 /**
  * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
  * one span for a single-line body, and for a body spanning lines the fenced
@@ -118,8 +160,10 @@ function rewriteOutsideCode(
  * to end one, and it reads whatever else shares those lines as fence metadata
  * rather than as math.
  *
- * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
- * open a fence that never closes.
+ * A body written behind a markdown container prefix keeps it (see
+ * {@link emitNestedDisplayMath}); otherwise the fence is emitted at the root
+ * column. A delimiter pair wrapping nothing is left as written: `$$$$` would
+ * itself open a fence that never closes.
  */
 function emitDisplayMath(
   match: string,
@@ -133,11 +177,15 @@ function emitDisplayMath(
   if (trimmed === "") return match;
   if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-  const before = offset === 0 ? precededBy : source[offset - 1]!;
   const afterStart = offset + match.length;
   const after = afterStart === source.length ? followedBy : source[afterStart]!;
-  const lead = before === "" || before === "\n" ? "" : "\n";
   const tail = after === "" || after === "\n" ? "" : "\n";
+
+  const nested = emitNestedDisplayMath(body, offset, source, precededBy, tail);
+  if (nested !== null) return nested;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
   return `${lead}$$\n${trimmed}\n$$${tail}`;
 }
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -13,6 +13,48 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 /**
+ * Applies `rewrite` to the stretches of `text` outside code spans and fences,
+ * copying code through verbatim, so a delimiter shown as code is never
+ * rewritten. `\x` escapes are stepped over when scanning so an escaped
+ * backtick does not open a span, an unclosed run reads as literal backticks,
+ * and a delimiter pair straddling a code boundary stays as written. Each
+ * stretch is passed the characters adjacent to it so the rewrite can make
+ * line-boundary decisions that survive the split.
+ */
+function rewriteOutsideCode(
+  text: string,
+  rewrite: (segment: string, precededBy: string, followedBy: string) => string,
+): string {
+  let out = "";
+  let index = 0;
+  let plainStart = 0;
+
+  const flush = (end: number, followedBy: string) => {
+    const segment = text.slice(plainStart, end);
+    if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
+  };
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 2;
+    } else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
+      flush(index, "`");
+      out += text.slice(index, codeEnd);
+      index = codeEnd;
+      plainStart = codeEnd;
+    } else {
+      index += 1;
+    }
+  }
+  flush(text.length, "");
+
+  return out;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
  * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
  * leading backslash is accepted, since models emit both depending on escaping.
@@ -28,25 +70,29 @@ const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
  * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
-  return text
-    .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
-      const trimmed = body.trim();
-      return trimmed === "" ? match : `$${trimmed}$`;
-    })
-    .replace(
-      LATEX_DISPLAY_DELIMITER,
-      (match: string, body: string, offset: number, source: string) => {
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
+    segment
+      .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
         const trimmed = body.trim();
-        if (trimmed === "") return match;
-        if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+        return trimmed === "" ? match : `$${trimmed}$`;
+      })
+      .replace(
+        LATEX_DISPLAY_DELIMITER,
+        (match: string, body: string, offset: number, source: string) => {
+          const trimmed = body.trim();
+          if (trimmed === "") return match;
+          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-        const before = source.slice(0, offset);
-        const after = source.slice(offset + match.length);
-        const lead = before === "" || before.endsWith("\n") ? "" : "\n";
-        const tail = after === "" || after.startsWith("\n") ? "" : "\n";
-        return `${lead}$$\n${trimmed}\n$$${tail}`;
-      },
-    );
+          const before = offset === 0 ? precededBy : source[offset - 1]!;
+          const afterStart = offset + match.length;
+          const after =
+            afterStart === source.length ? followedBy : source[afterStart]!;
+          const lead = before === "" || before === "\n" ? "" : "\n";
+          const tail = after === "" || after === "\n" ? "" : "\n";
+          return `${lead}$$\n${trimmed}\n$$${tail}`;
+        },
+      ),
+  );
 }
 
 const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
@@ -57,9 +103,11 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
  * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return text
-    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
-    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+  return rewriteOutsideCode(text, (segment) =>
+    segment
+      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+  );
 }
 
 /**

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -180,7 +180,10 @@ export function rewriteCustomMathTags(text: string): string {
         (match: string, body: string, offset: number, source: string) =>
           emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       )
-      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+      .replace(INLINE_TAG, (match: string, body: string) => {
+        const trimmed = body.trim();
+        return trimmed === "" ? match : `$${trimmed}$`;
+      }),
   );
 }
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -12,14 +12,58 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+
+/**
+ * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
+ * which the caller has verified starts a line: the end of the first later line
+ * carrying a closing run of at least the same length, or the end of `text`
+ * when none does — an unclosed fence reads as code to the end of the input,
+ * which keeps a fence that is still streaming in inert.
+ */
+function tildeFenceEnd(text: string, start: number): number {
+  const fenceLength = runLength(text, start, "~");
+  let lineStart = text.indexOf("\n", start);
+  while (lineStart !== -1) {
+    const lineEnd = text.indexOf("\n", lineStart + 1);
+    const line = text.slice(
+      lineStart + 1,
+      lineEnd === -1 ? undefined : lineEnd,
+    );
+    const close = TILDE_FENCE_CLOSE.exec(line);
+    if (close && close[1]!.length >= fenceLength) {
+      return lineEnd === -1 ? text.length : lineEnd;
+    }
+    lineStart = lineEnd;
+  }
+  return text.length;
+}
+
+/** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
+function atLineStart(text: string, index: number): boolean {
+  let cursor = index;
+  let indent = 0;
+  while (cursor > 0 && text[cursor - 1] === " " && indent < 3) {
+    cursor--;
+    indent++;
+  }
+  return cursor === 0 || text[cursor - 1] === "\n";
+}
+
 /**
  * Applies `rewrite` to the stretches of `text` outside code spans and fences,
  * copying code through verbatim, so a delimiter shown as code is never
  * rewritten. `\x` escapes are stepped over when scanning so an escaped
- * backtick does not open a span, an unclosed run reads as literal backticks,
- * and a delimiter pair straddling a code boundary stays as written. Each
- * stretch is passed the characters adjacent to it so the rewrite can make
- * line-boundary decisions that survive the split.
+ * backtick does not open a span, and a delimiter pair straddling a code
+ * boundary stays as written. Each stretch is passed the characters adjacent to
+ * it so the rewrite can make line-boundary decisions that survive the split.
+ *
+ * Backtick regions follow `codeSpanEnd`'s reading, shared with
+ * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
+ * literal text, an unclosed three-plus run is a fence still streaming in and
+ * protects to the end of the input, and fences are not line-anchored. Tilde
+ * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
+ * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */
 function rewriteOutsideCode(
   text: string,
@@ -34,17 +78,29 @@ function rewriteOutsideCode(
     if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
   };
 
+  const copyVerbatim = (to: number) => {
+    flush(index, text[index]!);
+    out += text.slice(index, to);
+    index = to;
+    plainStart = to;
+  };
+
   while (index < text.length) {
     const char = text[index];
     if (char === "\\") {
       index += 2;
     } else if (char === "`") {
+      const run = runLength(text, index, "`");
       const end = codeSpanEnd(text, index);
-      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
-      flush(index, "`");
-      out += text.slice(index, codeEnd);
-      index = codeEnd;
-      plainStart = codeEnd;
+      if (end !== -1) copyVerbatim(end);
+      else if (run >= 3) copyVerbatim(text.length);
+      else index += run;
+    } else if (
+      char === "~" &&
+      runLength(text, index, "~") >= 3 &&
+      atLineStart(text, index)
+    ) {
+      copyVerbatim(tildeFenceEnd(text, index));
     } else {
       index += 1;
     }

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -100,6 +100,32 @@ describe("rewriteLatexBracketDelimiters", () => {
       "\\(a `b` c\\)",
     );
   });
+
+  it("rewrites across a lone literal backtick", () => {
+    expect(rewriteLatexBracketDelimiters("Use \\(x ` y\\) here")).toBe(
+      "Use $x ` y$ here",
+    );
+  });
+
+  it("protects an unclosed fence still streaming in", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\(x\\)\nstill streaming")).toBe(
+      "```\n\\(x\\)\nstill streaming",
+    );
+  });
+
+  it("leaves a delimiter inside a tilde fence as written", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\[a\nb\\]\n~~~\n\\(x\\)")).toBe(
+      "~~~\n\\[a\nb\\]\n~~~\n$x$",
+    );
+  });
+
+  it("protects an unclosed tilde fence to the end of the input", () => {
+    expect(rewriteLatexBracketDelimiters("~~~\n\\(x\\)")).toBe("~~~\n\\(x\\)");
+  });
+
+  it("rewrites around a mid-line tilde run", () => {
+    expect(rewriteLatexBracketDelimiters("a ~~~ \\(x\\)")).toBe("a ~~~ $x$");
+  });
 });
 
 describe("rewriteCustomMathTags", () => {

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -175,6 +175,9 @@ describe("rewriteCustomMathTags", () => {
 
   it("leaves an empty math tag pair as written", () => {
     expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+    expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
+      "[/inline][/inline] rest",
+    );
   });
 });
 

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -152,6 +152,30 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
     ).toBe("$a$ `[/inline]x[/inline]`");
   });
+
+  it("fences a multiline math tag body", () => {
+    expect(
+      rewriteCustomMathTags(
+        "[/math]\\begin{aligned}\na&=b\n\\end{aligned}[/math]\nDone.",
+      ),
+    ).toBe("$$\n\\begin{aligned}\na&=b\n\\end{aligned}\n$$\nDone.");
+  });
+
+  it("gives the fence markers their own lines mid-paragraph", () => {
+    expect(rewriteCustomMathTags("Thus [/math]a\nb[/math] therefore.")).toBe(
+      "Thus \n$$\na\nb\n$$\n therefore.",
+    );
+  });
+
+  it("keeps a single-line math tag body on its line", () => {
+    expect(rewriteCustomMathTags("See [/math]x=1[/math] ok.")).toBe(
+      "See $$x=1$$ ok.",
+    );
+  });
+
+  it("leaves an empty math tag pair as written", () => {
+    expect(rewriteCustomMathTags("[/math][/math]")).toBe("[/math][/math]");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -66,6 +66,40 @@ describe("rewriteLatexBracketDelimiters", () => {
       "plain $x$ text",
     );
   });
+
+  it("leaves a delimiter inside an inline code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("a `\\(x\\)` b")).toBe(
+      "a `\\(x\\)` b",
+    );
+  });
+
+  it("leaves a delimiter inside a fenced block as written", () => {
+    expect(rewriteLatexBracketDelimiters("```\n\\[a\nb\\]\n```")).toBe(
+      "```\n\\[a\nb\\]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a\\) `\\(x\\)` \\(b\\)")).toBe(
+      "$a$ `\\(x\\)` $b$",
+    );
+  });
+
+  it("does not treat an escaped backtick as a code opener", () => {
+    expect(rewriteLatexBracketDelimiters("\\` \\(x\\)")).toBe("\\` $x$");
+  });
+
+  it("fences a multiline display body directly after a code span", () => {
+    expect(rewriteLatexBracketDelimiters("`c` \\[a\nb\\] d")).toBe(
+      "`c` \n$$\na\nb\n$$\n d",
+    );
+  });
+
+  it("leaves a delimiter pair straddling a code span as written", () => {
+    expect(rewriteLatexBracketDelimiters("\\(a `b` c\\)")).toBe(
+      "\\(a `b` c\\)",
+    );
+  });
 });
 
 describe("rewriteCustomMathTags", () => {
@@ -74,12 +108,36 @@ describe("rewriteCustomMathTags", () => {
       rewriteCustomMathTags("[/math]a+b[/math] and [/inline]c[/inline]"),
     ).toBe("$$a+b$$ and $c$");
   });
+
+  it("leaves a tag inside an inline code span as written", () => {
+    expect(rewriteCustomMathTags("`[/math]x[/math]`")).toBe(
+      "`[/math]x[/math]`",
+    );
+  });
+
+  it("leaves a tag inside a fenced block as written", () => {
+    expect(rewriteCustomMathTags("```\n[/inline]x[/inline]\n```")).toBe(
+      "```\n[/inline]x[/inline]\n```",
+    );
+  });
+
+  it("rewrites prose on the same line as a code span", () => {
+    expect(
+      rewriteCustomMathTags("[/inline]a[/inline] `[/inline]x[/inline]`"),
+    ).toBe("$a$ `[/inline]x[/inline]`");
+  });
 });
 
 describe("normalizeMathDelimiters", () => {
   it("normalizes both bracket delimiters and custom tags", () => {
     expect(normalizeMathDelimiters("\\(x\\) [/math]y[/math]")).toBe(
       "$x$ $$y$$",
+    );
+  });
+
+  it("keeps code inert for both delimiter families", () => {
+    expect(normalizeMathDelimiters("`\\(x\\)` and `[/math]y[/math]`")).toBe(
+      "`\\(x\\)` and `[/math]y[/math]`",
     );
   });
 });

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -40,9 +40,35 @@ describe("rewriteLatexBracketDelimiters", () => {
     );
   });
 
-  it("lifts a multiline display body out of its list item", () => {
+  it("keeps an indented display body nested in its list item", () => {
+    expect(
+      rewriteLatexBracketDelimiters(
+        "1. Expand:\n   \\[\n   a = b\n   c = d\n   \\]",
+      ),
+    ).toBe("1. Expand:\n   $$\n   a = b\n   c = d\n   $$");
+  });
+
+  it("keeps a prefixed display body nested in its blockquote", () => {
+    expect(rewriteLatexBracketDelimiters("> Expand \\[\n> a\n> b\n> \\]")).toBe(
+      "> Expand \n> $$\n> a\n> b\n> $$",
+    );
+  });
+
+  it("keeps text after the closing delimiter off the fence line", () => {
+    expect(
+      rewriteLatexBracketDelimiters("1. x:\n   \\[\n   a\n   b\n   \\] done"),
+    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n done");
+  });
+
+  it("lifts an unprefixed multiline display body out of its list item", () => {
     expect(rewriteLatexBracketDelimiters("- item \\[\na\nb\n\\]\n- next")).toBe(
       "- item \n$$\na\nb\n$$\n- next",
+    );
+  });
+
+  it("lifts a body whose lines do not share the closing prefix", () => {
+    expect(rewriteLatexBracketDelimiters("> Expand \\[\na\n> b\n> \\]")).toBe(
+      "> Expand \n$$\na\n> b\n>\n$$",
     );
   });
 
@@ -178,6 +204,12 @@ describe("rewriteCustomMathTags", () => {
     expect(rewriteCustomMathTags("[/inline][/inline] rest")).toBe(
       "[/inline][/inline] rest",
     );
+  });
+
+  it("keeps an indented math tag body nested in its list item", () => {
+    expect(
+      rewriteCustomMathTags("1. Expand:\n   [/math]\n   a\n   b\n   [/math]"),
+    ).toBe("1. Expand:\n   $$\n   a\n   b\n   $$");
   });
 });
 

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -54,10 +54,18 @@ describe("rewriteLatexBracketDelimiters", () => {
     );
   });
 
-  it("keeps text after the closing delimiter off the fence line", () => {
+  it("keeps trailing text nested below the closing fence line", () => {
     expect(
       rewriteLatexBracketDelimiters("1. x:\n   \\[\n   a\n   b\n   \\] done"),
-    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n done");
+    ).toBe("1. x:\n   $$\n   a\n   b\n   $$\n    done");
+  });
+
+  it("keeps a body opened beside a list marker nested in the item", () => {
+    expect(
+      rewriteLatexBracketDelimiters(
+        "1. Expand: \\[\n   a = b\n   c = d\n   \\]",
+      ),
+    ).toBe("1. Expand: \n   $$\n   a = b\n   c = d\n   $$");
   });
 
   it("lifts an unprefixed multiline display body out of its list item", () => {

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -146,10 +146,17 @@ function emitNestedDisplayMath(
 
   let lead: string;
   if (CONTAINER_PREFIX.test(beforeOnLine)) lead = "";
-  else if (beforeOnLine.startsWith(closingPrefix)) lead = `\n${closingPrefix}`;
+  else if (
+    beforeOnLine.startsWith(closingPrefix) ||
+    (/^[ \t]*$/.test(closingPrefix) &&
+      beforeOnLine.length >= closingPrefix.length)
+  )
+    lead = `\n${closingPrefix}`;
   else return null;
 
-  return `${lead}$$\n${middle}\n${closingPrefix}$$${tail}`;
+  return `${lead}$$\n${middle}\n${closingPrefix}$$${
+    tail === "" ? "" : `\n${closingPrefix}`
+  }`;
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -111,19 +111,43 @@ function rewriteOutsideCode(
 }
 
 /**
+ * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
+ * one span for a single-line body, and for a body spanning lines the fenced
+ * form, on lines the `$$` markers own. remark-math parses multiline `$$` as a
+ * flow construct: the opening marker has to start a line and the closing marker
+ * to end one, and it reads whatever else shares those lines as fence metadata
+ * rather than as math.
+ *
+ * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
+ * open a fence that never closes.
+ */
+function emitDisplayMath(
+  match: string,
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  followedBy: string,
+): string {
+  const trimmed = body.trim();
+  if (trimmed === "") return match;
+  if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const afterStart = offset + match.length;
+  const after = afterStart === source.length ? followedBy : source[afterStart]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
+  const tail = after === "" || after === "\n" ? "" : "\n";
+  return `${lead}$$\n${trimmed}\n$$${tail}`;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
- * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
- * leading backslash is accepted, since models emit both depending on escaping.
+ * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display, fenced when the
+ * body spans lines — see {@link emitDisplayMath}). A single or double leading
+ * backslash is accepted, since models emit both depending on escaping.
  * remark-math only recognizes the dollar form, so without this rewrite bracket
  * math renders as plain text.
- *
- * A display body spanning lines is emitted fenced, on lines the `$$` markers own.
- * remark-math parses multiline `$$` as a flow construct: the opening marker has to
- * start a line and the closing marker to end one, and it reads whatever else shares
- * those lines as fence metadata rather than as math.
- *
- * A pair wrapping nothing is left as written: `$$$$` would itself open a fence that
- * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
   return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
@@ -134,19 +158,8 @@ export function rewriteLatexBracketDelimiters(text: string): string {
       })
       .replace(
         LATEX_DISPLAY_DELIMITER,
-        (match: string, body: string, offset: number, source: string) => {
-          const trimmed = body.trim();
-          if (trimmed === "") return match;
-          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
-
-          const before = offset === 0 ? precededBy : source[offset - 1]!;
-          const afterStart = offset + match.length;
-          const after =
-            afterStart === source.length ? followedBy : source[afterStart]!;
-          const lead = before === "" || before === "\n" ? "" : "\n";
-          const tail = after === "" || after === "\n" ? "" : "\n";
-          return `${lead}$$\n${trimmed}\n$$${tail}`;
-        },
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       ),
   );
 }
@@ -156,12 +169,17 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
 
 /**
  * Rewrites the custom math tags some models emit to dollar delimiters:
- * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
+ * `[/math]...[/math]` becomes `$$...$$` (fenced when the body spans lines — see
+ * {@link emitDisplayMath}) and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return rewriteOutsideCode(text, (segment) =>
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
     segment
-      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(
+        MATH_TAG,
+        (match: string, body: string, offset: number, source: string) =>
+          emitDisplayMath(match, body, offset, source, precededBy, followedBy),
+      )
       .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
   );
 }

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -110,6 +110,48 @@ function rewriteOutsideCode(
   return out;
 }
 
+const CONTAINER_PREFIX = /^[ \t>]*$/;
+
+/**
+ * Fenced emission for a display body written inside a markdown container (a
+ * list item or blockquote): when the closing delimiter sits on its own line
+ * behind a container prefix that every body line shares, the `$$` markers and
+ * body keep that prefix, so the block stays nested where the source put it
+ * instead of landing at the root column after the container. Returns null when
+ * the source carries no such prefix.
+ */
+function emitNestedDisplayMath(
+  body: string,
+  offset: number,
+  source: string,
+  precededBy: string,
+  tail: string,
+): string | null {
+  const firstNewline = body.indexOf("\n");
+  const lastNewline = body.lastIndexOf("\n");
+  if (body.slice(0, firstNewline).trim() !== "") return null;
+  const closingPrefix = body.slice(lastNewline + 1);
+  if (closingPrefix === "" || !CONTAINER_PREFIX.test(closingPrefix))
+    return null;
+
+  const middle = body.slice(firstNewline + 1, lastNewline);
+  if (middle === "") return null;
+  if (!middle.split("\n").every((line) => line.startsWith(closingPrefix)))
+    return null;
+
+  let lineStart = offset;
+  while (lineStart > 0 && source[lineStart - 1] !== "\n") lineStart--;
+  if (lineStart === 0 && precededBy !== "" && precededBy !== "\n") return null;
+  const beforeOnLine = source.slice(lineStart, offset);
+
+  let lead: string;
+  if (CONTAINER_PREFIX.test(beforeOnLine)) lead = "";
+  else if (beforeOnLine.startsWith(closingPrefix)) lead = `\n${closingPrefix}`;
+  else return null;
+
+  return `${lead}$$\n${middle}\n${closingPrefix}$$${tail}`;
+}
+
 /**
  * Emits a display-math body in the `$$` form remark-math parses: `$$body$$` on
  * one span for a single-line body, and for a body spanning lines the fenced
@@ -118,8 +160,10 @@ function rewriteOutsideCode(
  * to end one, and it reads whatever else shares those lines as fence metadata
  * rather than as math.
  *
- * A delimiter pair wrapping nothing is left as written: `$$$$` would itself
- * open a fence that never closes.
+ * A body written behind a markdown container prefix keeps it (see
+ * {@link emitNestedDisplayMath}); otherwise the fence is emitted at the root
+ * column. A delimiter pair wrapping nothing is left as written: `$$$$` would
+ * itself open a fence that never closes.
  */
 function emitDisplayMath(
   match: string,
@@ -133,11 +177,15 @@ function emitDisplayMath(
   if (trimmed === "") return match;
   if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-  const before = offset === 0 ? precededBy : source[offset - 1]!;
   const afterStart = offset + match.length;
   const after = afterStart === source.length ? followedBy : source[afterStart]!;
-  const lead = before === "" || before === "\n" ? "" : "\n";
   const tail = after === "" || after === "\n" ? "" : "\n";
+
+  const nested = emitNestedDisplayMath(body, offset, source, precededBy, tail);
+  if (nested !== null) return nested;
+
+  const before = offset === 0 ? precededBy : source[offset - 1]!;
+  const lead = before === "" || before === "\n" ? "" : "\n";
   return `${lead}$$\n${trimmed}\n$$${tail}`;
 }
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -13,6 +13,48 @@ const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
 /**
+ * Applies `rewrite` to the stretches of `text` outside code spans and fences,
+ * copying code through verbatim, so a delimiter shown as code is never
+ * rewritten. `\x` escapes are stepped over when scanning so an escaped
+ * backtick does not open a span, an unclosed run reads as literal backticks,
+ * and a delimiter pair straddling a code boundary stays as written. Each
+ * stretch is passed the characters adjacent to it so the rewrite can make
+ * line-boundary decisions that survive the split.
+ */
+function rewriteOutsideCode(
+  text: string,
+  rewrite: (segment: string, precededBy: string, followedBy: string) => string,
+): string {
+  let out = "";
+  let index = 0;
+  let plainStart = 0;
+
+  const flush = (end: number, followedBy: string) => {
+    const segment = text.slice(plainStart, end);
+    if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
+  };
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 2;
+    } else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
+      flush(index, "`");
+      out += text.slice(index, codeEnd);
+      index = codeEnd;
+      plainStart = codeEnd;
+    } else {
+      index += 1;
+    }
+  }
+  flush(text.length, "");
+
+  return out;
+}
+
+/**
  * Rewrites LaTeX bracket delimiters to dollar delimiters: `\(...\)` becomes
  * `$...$` (inline) and `\[...\]` becomes `$$...$$` (display). A single or double
  * leading backslash is accepted, since models emit both depending on escaping.
@@ -28,25 +70,29 @@ const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
  * never closes.
  */
 export function rewriteLatexBracketDelimiters(text: string): string {
-  return text
-    .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
-      const trimmed = body.trim();
-      return trimmed === "" ? match : `$${trimmed}$`;
-    })
-    .replace(
-      LATEX_DISPLAY_DELIMITER,
-      (match: string, body: string, offset: number, source: string) => {
+  return rewriteOutsideCode(text, (segment, precededBy, followedBy) =>
+    segment
+      .replace(LATEX_INLINE_DELIMITER, (match: string, body: string) => {
         const trimmed = body.trim();
-        if (trimmed === "") return match;
-        if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
+        return trimmed === "" ? match : `$${trimmed}$`;
+      })
+      .replace(
+        LATEX_DISPLAY_DELIMITER,
+        (match: string, body: string, offset: number, source: string) => {
+          const trimmed = body.trim();
+          if (trimmed === "") return match;
+          if (!trimmed.includes("\n")) return `$$${trimmed}$$`;
 
-        const before = source.slice(0, offset);
-        const after = source.slice(offset + match.length);
-        const lead = before === "" || before.endsWith("\n") ? "" : "\n";
-        const tail = after === "" || after.startsWith("\n") ? "" : "\n";
-        return `${lead}$$\n${trimmed}\n$$${tail}`;
-      },
-    );
+          const before = offset === 0 ? precededBy : source[offset - 1]!;
+          const afterStart = offset + match.length;
+          const after =
+            afterStart === source.length ? followedBy : source[afterStart]!;
+          const lead = before === "" || before === "\n" ? "" : "\n";
+          const tail = after === "" || after === "\n" ? "" : "\n";
+          return `${lead}$$\n${trimmed}\n$$${tail}`;
+        },
+      ),
+  );
 }
 
 const MATH_TAG = /\[\/math\]([\s\S]*?)\[\/math\]/g;
@@ -57,9 +103,11 @@ const INLINE_TAG = /\[\/inline\]([\s\S]*?)\[\/inline\]/g;
  * `[/math]...[/math]` becomes `$$...$$` and `[/inline]...[/inline]` becomes `$...$`.
  */
 export function rewriteCustomMathTags(text: string): string {
-  return text
-    .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
-    .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`);
+  return rewriteOutsideCode(text, (segment) =>
+    segment
+      .replace(MATH_TAG, (_, body: string) => `$$${body.trim()}$$`)
+      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+  );
 }
 
 /**

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -180,7 +180,10 @@ export function rewriteCustomMathTags(text: string): string {
         (match: string, body: string, offset: number, source: string) =>
           emitDisplayMath(match, body, offset, source, precededBy, followedBy),
       )
-      .replace(INLINE_TAG, (_, body: string) => `$${body.trim()}$`),
+      .replace(INLINE_TAG, (match: string, body: string) => {
+        const trimmed = body.trim();
+        return trimmed === "" ? match : `$${trimmed}$`;
+      }),
   );
 }
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -12,14 +12,58 @@
 const LATEX_INLINE_DELIMITER = /\\{1,2}\(([^\n]+?)\\{1,2}\)/g;
 const LATEX_DISPLAY_DELIMITER = /\\{1,2}\[([\s\S]+?)\\{1,2}\]/g;
 
+const TILDE_FENCE_CLOSE = /^ {0,3}(~{3,})[ \t]*$/;
+
+/**
+ * End index (exclusive) of the tilde fence opened by the `~` run at `start`,
+ * which the caller has verified starts a line: the end of the first later line
+ * carrying a closing run of at least the same length, or the end of `text`
+ * when none does — an unclosed fence reads as code to the end of the input,
+ * which keeps a fence that is still streaming in inert.
+ */
+function tildeFenceEnd(text: string, start: number): number {
+  const fenceLength = runLength(text, start, "~");
+  let lineStart = text.indexOf("\n", start);
+  while (lineStart !== -1) {
+    const lineEnd = text.indexOf("\n", lineStart + 1);
+    const line = text.slice(
+      lineStart + 1,
+      lineEnd === -1 ? undefined : lineEnd,
+    );
+    const close = TILDE_FENCE_CLOSE.exec(line);
+    if (close && close[1]!.length >= fenceLength) {
+      return lineEnd === -1 ? text.length : lineEnd;
+    }
+    lineStart = lineEnd;
+  }
+  return text.length;
+}
+
+/** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
+function atLineStart(text: string, index: number): boolean {
+  let cursor = index;
+  let indent = 0;
+  while (cursor > 0 && text[cursor - 1] === " " && indent < 3) {
+    cursor--;
+    indent++;
+  }
+  return cursor === 0 || text[cursor - 1] === "\n";
+}
+
 /**
  * Applies `rewrite` to the stretches of `text` outside code spans and fences,
  * copying code through verbatim, so a delimiter shown as code is never
  * rewritten. `\x` escapes are stepped over when scanning so an escaped
- * backtick does not open a span, an unclosed run reads as literal backticks,
- * and a delimiter pair straddling a code boundary stays as written. Each
- * stretch is passed the characters adjacent to it so the rewrite can make
- * line-boundary decisions that survive the split.
+ * backtick does not open a span, and a delimiter pair straddling a code
+ * boundary stays as written. Each stretch is passed the characters adjacent to
+ * it so the rewrite can make line-boundary decisions that survive the split.
+ *
+ * Backtick regions follow `codeSpanEnd`'s reading, shared with
+ * {@link escapeCurrencyDollars}: an unclosed one- or two-backtick run is
+ * literal text, an unclosed three-plus run is a fence still streaming in and
+ * protects to the end of the input, and fences are not line-anchored. Tilde
+ * fences are line-anchored per CommonMark: a `~~~` run starting a line opens
+ * one, and it closes on a line carrying only an at-least-as-long tilde run.
  */
 function rewriteOutsideCode(
   text: string,
@@ -34,17 +78,29 @@ function rewriteOutsideCode(
     if (segment !== "") out += rewrite(segment, out.slice(-1), followedBy);
   };
 
+  const copyVerbatim = (to: number) => {
+    flush(index, text[index]!);
+    out += text.slice(index, to);
+    index = to;
+    plainStart = to;
+  };
+
   while (index < text.length) {
     const char = text[index];
     if (char === "\\") {
       index += 2;
     } else if (char === "`") {
+      const run = runLength(text, index, "`");
       const end = codeSpanEnd(text, index);
-      const codeEnd = end === -1 ? index + runLength(text, index, "`") : end;
-      flush(index, "`");
-      out += text.slice(index, codeEnd);
-      index = codeEnd;
-      plainStart = codeEnd;
+      if (end !== -1) copyVerbatim(end);
+      else if (run >= 3) copyVerbatim(text.length);
+      else index += run;
+    } else if (
+      char === "~" &&
+      runLength(text, index, "~") >= 3 &&
+      atLineStart(text, index)
+    ) {
+      copyVerbatim(tildeFenceEnd(text, index));
     } else {
       index += 1;
     }

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 6000,
-      "gzip": 2553
+      "min": 6072,
+      "gzip": 2557
     },
     "./code-fence": {
       "min": 84,
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 8380,
-      "gzip": 3575
+      "min": 8452,
+      "gzip": 3578
     }
   },
   "@assistant-ui/react-syntax-highlighter": {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,60 +1,60 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 36291,
-      "gzip": 13055
+      "min": 35846,
+      "gzip": 12817
     }
   },
   "@assistant-ui/cloud-ai-sdk": {
     ".": {
       "min": 14841,
-      "gzip": 5109
+      "gzip": 5139
     }
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 32191,
-      "gzip": 10869
+      "min": 31298,
+      "gzip": 10659
     },
     "./internal": {
-      "min": 121183,
-      "gzip": 30953
+      "min": 119010,
+      "gzip": 30236
     },
     "./react": {
-      "min": 270425,
-      "gzip": 74149
+      "min": 267177,
+      "gzip": 73212
     },
     "./store": {
-      "min": 90624,
-      "gzip": 30050
+      "min": 89174,
+      "gzip": 29589
     },
     "./store/internal": {
-      "min": 21420,
-      "gzip": 7876
+      "min": 21187,
+      "gzip": 7813
     }
   },
   "@assistant-ui/eve": {
     ".": {
-      "min": 11040,
-      "gzip": 4187
+      "min": 10667,
+      "gzip": 4076
     }
   },
   "@assistant-ui/react": {
     ".": {
-      "min": 130416,
-      "gzip": 42329
+      "min": 129681,
+      "gzip": 41986
     }
   },
   "@assistant-ui/react-a2a": {
     ".": {
       "min": 27557,
-      "gzip": 8344
+      "gzip": 8345
     }
   },
   "@assistant-ui/react-ag-ui": {
     ".": {
-      "min": 74627,
-      "gzip": 19567
+      "min": 73305,
+      "gzip": 19159
     }
   },
   "@assistant-ui/react-ai-sdk": {
@@ -66,45 +66,45 @@
   "@assistant-ui/react-data-stream": {
     ".": {
       "min": 4229,
-      "gzip": 1744
+      "gzip": 1759
     }
   },
   "@assistant-ui/react-devtools": {
     ".": {
       "min": 159811,
-      "gzip": 45518
+      "gzip": 45492
     }
   },
   "@assistant-ui/react-generative-ui": {
     ".": {
       "min": 33889,
-      "gzip": 11071
+      "gzip": 11010
     },
     "./a2ui": {
       "min": 8638,
-      "gzip": 3128
+      "gzip": 3119
     },
     "./ir": {
       "min": 1623,
-      "gzip": 885
+      "gzip": 863
     },
     "./slack": {
-      "min": 22625,
-      "gzip": 7371
+      "min": 22590,
+      "gzip": 7356
     },
     "./teams": {
-      "min": 12504,
-      "gzip": 4581
+      "min": 12524,
+      "gzip": 4600
     }
   },
   "@assistant-ui/react-google-adk": {
     ".": {
-      "min": 34831,
-      "gzip": 10434
+      "min": 34587,
+      "gzip": 10334
     },
     "./server": {
       "min": 6139,
-      "gzip": 2161
+      "gzip": 2173
     }
   },
   "@assistant-ui/react-hook-form": {
@@ -115,46 +115,46 @@
   },
   "@assistant-ui/react-ink": {
     ".": {
-      "min": 63654,
-      "gzip": 18341
+      "min": 62987,
+      "gzip": 18140
     },
     "./internal": {
       "min": 427,
-      "gzip": 205
+      "gzip": 203
     }
   },
   "@assistant-ui/react-ink-markdown": {
     ".": {
       "min": 2116,
-      "gzip": 1121
+      "gzip": 1130
     }
   },
   "@assistant-ui/react-langchain": {
     ".": {
-      "min": 13438,
-      "gzip": 4951
+      "min": 13468,
+      "gzip": 4971
     },
     "./converter": {
       "min": 3719,
-      "gzip": 1460
+      "gzip": 1466
     }
   },
   "@assistant-ui/react-langgraph": {
     ".": {
       "min": 26127,
-      "gzip": 9090
+      "gzip": 9078
     }
   },
   "@assistant-ui/react-lexical": {
     ".": {
       "min": 14436,
-      "gzip": 5119
+      "gzip": 5126
     }
   },
   "@assistant-ui/react-markdown": {
     ".": {
       "min": 5013,
-      "gzip": 2147
+      "gzip": 2142
     },
     "./code-fence": {
       "min": 84,
@@ -163,96 +163,96 @@
   },
   "@assistant-ui/react-mcp": {
     ".": {
-      "min": 42855,
-      "gzip": 13913
+      "min": 42357,
+      "gzip": 13677
     }
   },
   "@assistant-ui/react-native": {
     ".": {
-      "min": 31744,
-      "gzip": 8661
+      "min": 31684,
+      "gzip": 8638
     },
     "./internal": {
       "min": 427,
-      "gzip": 205
+      "gzip": 203
     }
   },
   "@assistant-ui/react-o11y": {
     ".": {
       "min": 9693,
-      "gzip": 3789
+      "gzip": 3794
     }
   },
   "@assistant-ui/react-opencode": {
     ".": {
       "min": 37417,
-      "gzip": 10648
+      "gzip": 10657
     }
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41590,
-      "gzip": 12017
+      "min": 41471,
+      "gzip": 11977
     },
     "./node": {
       "min": 17413,
-      "gzip": 5561
+      "gzip": 5580
     }
   },
   "@assistant-ui/react-streamdown": {
     ".": {
       "min": 7241,
-      "gzip": 3153
+      "gzip": 3130
     }
   },
   "@assistant-ui/react-syntax-highlighter": {
     ".": {
       "min": 498,
-      "gzip": 274
+      "gzip": 271
     },
     "./full": {
       "min": 405,
-      "gzip": 250
+      "gzip": 248
     }
   },
   "@assistant-ui/store": {
     ".": {
       "min": 16139,
-      "gzip": 6181
+      "gzip": 6202
     },
     "./client": {
       "min": 17074,
-      "gzip": 6381
+      "gzip": 6411
     },
     "./internal": {
       "min": 843,
-      "gzip": 441
+      "gzip": 442
     }
   },
   "@assistant-ui/tap": {
     ".": {
       "min": 19564,
-      "gzip": 7232
+      "gzip": 7249
     },
     "./react-shim": {
       "min": 7589,
-      "gzip": 3030
+      "gzip": 3045
     },
     "./react-shim/compiler-runtime": {
       "min": 861,
-      "gzip": 557
+      "gzip": 560
     },
     "./standalone-shim": {
       "min": 8359,
-      "gzip": 3372
+      "gzip": 3380
     },
     "./standalone-shim/compiler-runtime": {
       "min": 934,
-      "gzip": 579
+      "gzip": 582
     },
     "./standalone-shim/jsx-dev-runtime": {
       "min": 268,
-      "gzip": 213
+      "gzip": 214
     },
     "./standalone-shim/jsx-runtime": {
       "min": 296,
@@ -261,42 +261,42 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 15447,
-      "gzip": 5095
+      "min": 15430,
+      "gzip": 5082
     }
   },
   "assistant-stream": {
     ".": {
-      "min": 57356,
-      "gzip": 16121
+      "min": 57339,
+      "gzip": 16126
     },
     "./resumable": {
       "min": 16391,
-      "gzip": 5490
+      "gzip": 5497
     },
     "./resumable/ioredis": {
-      "min": 5830,
-      "gzip": 2316
+      "min": 5294,
+      "gzip": 2073
     },
     "./resumable/redis": {
-      "min": 6126,
-      "gzip": 2422
+      "min": 5572,
+      "gzip": 2171
     },
     "./utils": {
       "min": 14549,
-      "gzip": 4604
+      "gzip": 4617
     }
   },
   "heat-graph": {
     ".": {
       "min": 4248,
-      "gzip": 1885
+      "gzip": 1888
     }
   },
   "safe-content-frame": {
     ".": {
       "min": 3278,
-      "gzip": 1513
+      "gzip": 1519
     },
     "./shadow_dom": {
       "min": 81,

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 5013,
-      "gzip": 2142
+      "min": 5604,
+      "gzip": 2383
     },
     "./code-fence": {
       "min": 84,
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 7241,
-      "gzip": 3130
+      "min": 7984,
+      "gzip": 3403
     }
   },
   "@assistant-ui/react-syntax-highlighter": {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 6072,
-      "gzip": 2557
+      "min": 6636,
+      "gzip": 2773
     },
     "./code-fence": {
       "min": 84,
@@ -201,8 +201,8 @@
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 8452,
-      "gzip": 3578
+      "min": 9016,
+      "gzip": 3797
     }
   },
   "@assistant-ui/react-syntax-highlighter": {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -1,60 +1,60 @@
 {
   "@assistant-ui/ai-sdk": {
     ".": {
-      "min": 35846,
-      "gzip": 12817
+      "min": 36291,
+      "gzip": 13055
     }
   },
   "@assistant-ui/cloud-ai-sdk": {
     ".": {
       "min": 14841,
-      "gzip": 5139
+      "gzip": 5109
     }
   },
   "@assistant-ui/core": {
     ".": {
-      "min": 31298,
-      "gzip": 10659
+      "min": 32191,
+      "gzip": 10869
     },
     "./internal": {
-      "min": 119010,
-      "gzip": 30236
+      "min": 121183,
+      "gzip": 30953
     },
     "./react": {
-      "min": 267177,
-      "gzip": 73212
+      "min": 270425,
+      "gzip": 74149
     },
     "./store": {
-      "min": 89174,
-      "gzip": 29589
+      "min": 90624,
+      "gzip": 30050
     },
     "./store/internal": {
-      "min": 21187,
-      "gzip": 7813
+      "min": 21420,
+      "gzip": 7876
     }
   },
   "@assistant-ui/eve": {
     ".": {
-      "min": 10667,
-      "gzip": 4076
+      "min": 11040,
+      "gzip": 4187
     }
   },
   "@assistant-ui/react": {
     ".": {
-      "min": 129681,
-      "gzip": 41986
+      "min": 130416,
+      "gzip": 42329
     }
   },
   "@assistant-ui/react-a2a": {
     ".": {
       "min": 27557,
-      "gzip": 8345
+      "gzip": 8344
     }
   },
   "@assistant-ui/react-ag-ui": {
     ".": {
-      "min": 73305,
-      "gzip": 19159
+      "min": 74627,
+      "gzip": 19567
     }
   },
   "@assistant-ui/react-ai-sdk": {
@@ -66,45 +66,45 @@
   "@assistant-ui/react-data-stream": {
     ".": {
       "min": 4229,
-      "gzip": 1759
+      "gzip": 1744
     }
   },
   "@assistant-ui/react-devtools": {
     ".": {
       "min": 159811,
-      "gzip": 45492
+      "gzip": 45518
     }
   },
   "@assistant-ui/react-generative-ui": {
     ".": {
       "min": 33889,
-      "gzip": 11010
+      "gzip": 11071
     },
     "./a2ui": {
       "min": 8638,
-      "gzip": 3119
+      "gzip": 3128
     },
     "./ir": {
       "min": 1623,
-      "gzip": 863
+      "gzip": 885
     },
     "./slack": {
-      "min": 22590,
-      "gzip": 7356
+      "min": 22625,
+      "gzip": 7371
     },
     "./teams": {
-      "min": 12524,
-      "gzip": 4600
+      "min": 12504,
+      "gzip": 4581
     }
   },
   "@assistant-ui/react-google-adk": {
     ".": {
-      "min": 34587,
-      "gzip": 10334
+      "min": 34831,
+      "gzip": 10434
     },
     "./server": {
       "min": 6139,
-      "gzip": 2173
+      "gzip": 2161
     }
   },
   "@assistant-ui/react-hook-form": {
@@ -115,46 +115,46 @@
   },
   "@assistant-ui/react-ink": {
     ".": {
-      "min": 62987,
-      "gzip": 18140
+      "min": 63654,
+      "gzip": 18341
     },
     "./internal": {
       "min": 427,
-      "gzip": 203
+      "gzip": 205
     }
   },
   "@assistant-ui/react-ink-markdown": {
     ".": {
       "min": 2116,
-      "gzip": 1130
+      "gzip": 1121
     }
   },
   "@assistant-ui/react-langchain": {
     ".": {
-      "min": 13468,
-      "gzip": 4971
+      "min": 13438,
+      "gzip": 4951
     },
     "./converter": {
       "min": 3719,
-      "gzip": 1466
+      "gzip": 1460
     }
   },
   "@assistant-ui/react-langgraph": {
     ".": {
       "min": 26127,
-      "gzip": 9078
+      "gzip": 9090
     }
   },
   "@assistant-ui/react-lexical": {
     ".": {
       "min": 14436,
-      "gzip": 5126
+      "gzip": 5119
     }
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 5604,
-      "gzip": 2383
+      "min": 6000,
+      "gzip": 2553
     },
     "./code-fence": {
       "min": 84,
@@ -163,96 +163,96 @@
   },
   "@assistant-ui/react-mcp": {
     ".": {
-      "min": 42357,
-      "gzip": 13677
+      "min": 42855,
+      "gzip": 13913
     }
   },
   "@assistant-ui/react-native": {
     ".": {
-      "min": 31684,
-      "gzip": 8638
+      "min": 31744,
+      "gzip": 8661
     },
     "./internal": {
       "min": 427,
-      "gzip": 203
+      "gzip": 205
     }
   },
   "@assistant-ui/react-o11y": {
     ".": {
       "min": 9693,
-      "gzip": 3794
+      "gzip": 3789
     }
   },
   "@assistant-ui/react-opencode": {
     ".": {
       "min": 37417,
-      "gzip": 10657
+      "gzip": 10648
     }
   },
   "@assistant-ui/react-pi": {
     ".": {
-      "min": 41471,
-      "gzip": 11977
+      "min": 41590,
+      "gzip": 12017
     },
     "./node": {
       "min": 17413,
-      "gzip": 5580
+      "gzip": 5561
     }
   },
   "@assistant-ui/react-streamdown": {
     ".": {
-      "min": 7984,
-      "gzip": 3403
+      "min": 8380,
+      "gzip": 3575
     }
   },
   "@assistant-ui/react-syntax-highlighter": {
     ".": {
       "min": 498,
-      "gzip": 271
+      "gzip": 274
     },
     "./full": {
       "min": 405,
-      "gzip": 248
+      "gzip": 250
     }
   },
   "@assistant-ui/store": {
     ".": {
       "min": 16139,
-      "gzip": 6202
+      "gzip": 6181
     },
     "./client": {
       "min": 17074,
-      "gzip": 6411
+      "gzip": 6381
     },
     "./internal": {
       "min": 843,
-      "gzip": 442
+      "gzip": 441
     }
   },
   "@assistant-ui/tap": {
     ".": {
       "min": 19564,
-      "gzip": 7249
+      "gzip": 7232
     },
     "./react-shim": {
       "min": 7589,
-      "gzip": 3045
+      "gzip": 3030
     },
     "./react-shim/compiler-runtime": {
       "min": 861,
-      "gzip": 560
+      "gzip": 557
     },
     "./standalone-shim": {
       "min": 8359,
-      "gzip": 3380
+      "gzip": 3372
     },
     "./standalone-shim/compiler-runtime": {
       "min": 934,
-      "gzip": 582
+      "gzip": 579
     },
     "./standalone-shim/jsx-dev-runtime": {
       "min": 268,
-      "gzip": 214
+      "gzip": 213
     },
     "./standalone-shim/jsx-runtime": {
       "min": 296,
@@ -261,42 +261,42 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 15430,
-      "gzip": 5082
+      "min": 15447,
+      "gzip": 5095
     }
   },
   "assistant-stream": {
     ".": {
-      "min": 57339,
-      "gzip": 16126
+      "min": 57356,
+      "gzip": 16121
     },
     "./resumable": {
       "min": 16391,
-      "gzip": 5497
+      "gzip": 5490
     },
     "./resumable/ioredis": {
-      "min": 5294,
-      "gzip": 2073
+      "min": 5830,
+      "gzip": 2316
     },
     "./resumable/redis": {
-      "min": 5572,
-      "gzip": 2171
+      "min": 6126,
+      "gzip": 2422
     },
     "./utils": {
       "min": 14549,
-      "gzip": 4617
+      "gzip": 4604
     }
   },
   "heat-graph": {
     ".": {
       "min": 4248,
-      "gzip": 1888
+      "gzip": 1885
     }
   },
   "safe-content-frame": {
     ".": {
       "min": 3278,
-      "gzip": 1519
+      "gzip": 1513
     },
     "./shadow_dom": {
       "min": 81,


### PR DESCRIPTION
Closes #6783. Stacked on #6797 (which stacks on #6795) — the first two commits are those PRs; this PR's own change is the last commit. Merge in order and this rebases to just it.

## Problem

#6778 gives the `$$` markers their own lines by inserting bare newlines, so a multiline display body never carries the source line's markdown container prefix. A display block written inside a list item or blockquote lands at the root column, after the container, instead of staying nested — the body renders as display math (the #6774 fix holds) but is visually ejected from its list or quote. Before #6778 the same input kept its nesting but not display rendering; this keeps both.

## Change

`emitNestedDisplayMath` in the shared display emitter: when the closing delimiter sits on its own line behind a container prefix (whitespace and `>` runs) that every body line shares, the `$$` markers and body keep that prefix. The `> ` case repeats the prefix onto the inserted lead line rather than measuring it, per the issue. Both delimiter families get it through the shared emitter from #6797. Sources with no reusable prefix — an unprefixed body, mixed prefixes, or a match whose line context is unknowable at a code-span boundary — keep today's root-column behavior. A whitespace-prefixed body opened beside a list marker or other prose stays nested (the lead line takes the closing prefix), and the inserted tail line carries the prefix too, so trailing text after the closing delimiter stays in the container.

The emitted forms are exactly the two the issue verified against the pinned `remark-math@6.0.0`: the indented list form parses to `math(meta: null)` with the full body, and the `> ` blockquote form parses the same way.

## Verification

- On the base branch, the issue's list input produces the root-column form; with this change `"1. Expand:\n   \[\n   a = b\n   c = d\n   \]"` emits `1. Expand:\n   $$\n   a = b\n   c = d\n   $$`.
- 56 tests pass in each package. The former "lifts a multiline display body out of its list item" pin is replaced by nested-list, nested-blockquote, and trailing-text cases, plus explicit pins that unprefixed and mixed-prefix bodies keep the lifted fallback.

## Public surface

No API changes. Changeset: patch for `@assistant-ui/react-markdown` and `@assistant-ui/react-streamdown`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Yy2mPnvdYCLrDHId6Rbf6YltsPEK9TXD4SA-f8rCC9JSaN4pCCeBbmPEk9o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
