### PR TITLE
fix(docs): jump the page search to the matched block

### DIFF
--- a/apps/docs/components/shared/search-dialog.tsx
+++ b/apps/docs/components/shared/search-dialog.tsx
@@ -35,9 +35,9 @@ import {
   collectPageTextMatches,
 } from "@/lib/search/collect-page";
 import { loadSearchIndex } from "@/lib/search/load-index";
+import { revealPageMatch } from "@/lib/search/reveal";
 import {
   highlightMatches,
-  isCurrentPage,
   searchEntries,
   searchOtherPages,
   tokenize,
@@ -121,7 +121,7 @@ function ResultButton({
   nested: boolean;
   showBreadcrumb: boolean;
   tokens: string[];
-  onSelect: (url: string) => void;
+  onSelect: (item: SearchHit) => void;
   onHover: (index: number) => void;
 }) {
   return (
@@ -131,7 +131,7 @@ function ResultButton({
       role="option"
       aria-selected={selected}
       data-index={index}
-      onClick={() => onSelect(item.url)}
+      onClick={() => onSelect(item)}
       onMouseEnter={() => onHover(index)}
       className={cn(
         "group flex w-full cursor-pointer items-center gap-2.5 rounded-lg py-2 pr-3 text-left transition-colors",
@@ -260,7 +260,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   }, [askAIFn, inputValue, onOpenChange]);
 
   const handleSelect = useCallback(
-    (url: string) => {
+    (item: SearchHit) => {
       if (searchTrackingTimeout.current) {
         clearTimeout(searchTrackingTimeout.current);
         if (query.length >= 2 && query !== lastTrackedQuery.current) {
@@ -271,23 +271,22 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
         }
       }
 
-      const position = results.findIndex((result) => result.url === url);
-      analytics.search.resultClicked(query, url, position);
+      const position = results.findIndex((result) => result.id === item.id);
+      analytics.search.resultClicked(query, item.url, position);
       onOpenChange(false);
 
-      const hash = url.includes("#") ? (url.split("#")[1] ?? "") : "";
-      if (hash && isCurrentPage(url, pathname)) {
-        const target = document.getElementById(hash);
-        if (target) {
-          target.scrollIntoView({ block: "start" });
-          window.history.replaceState(null, "", url);
-          return;
-        }
+      if (item.element?.isConnected) {
+        window.history.replaceState(null, "", item.url);
+        revealPageMatch(
+          item.element,
+          item.type === "heading" ? "start" : "center",
+        );
+        return;
       }
 
-      router.push(url);
+      router.push(item.url);
     },
-    [onOpenChange, pathname, query, results, router],
+    [onOpenChange, query, results, router],
   );
 
   useEffect(() => {
@@ -323,7 +322,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
         setSelectedIndex((index) => Math.max(index - 1, 0));
       } else if (event.key === "Enter" && results[selectedIndex]) {
         event.preventDefault();
-        handleSelect(results[selectedIndex].url);
+        handleSelect(results[selectedIndex]);
       }
     },
     [handleSelect, results, selectedIndex],

--- a/apps/docs/content/design.md
+++ b/apps/docs/content/design.md
@@ -137,7 +137,7 @@ Use these names. Do not invent a sibling, do not extrapolate one from another pr
 
 **Layout**: `PageFrame` with `pad` of `hero`, `heroBody`, or `sub`, and `PageCopy`, both in `components/shared/page-frame.tsx`.
 
-**Motion** (`apps/docs/styles/animate.css`): `hero-word`, `hero-word-ink`, `hero-caret`, `hero-rise`, `hero-glint`, `code-cascade`, `line-hot`, `stage-progress`. Motion explains a state change, preserves continuity, or confirms an action. It never gates reading. Every one of these is disabled under `prefers-reduced-motion`, and any new keyframe must be too.
+**Motion** (`apps/docs/styles/animate.css`): `hero-word`, `hero-word-ink`, `hero-caret`, `hero-rise`, `hero-glint`, `code-cascade`, `line-hot`, `stage-progress`, `search-reveal`. Motion explains a state change, preserves continuity, or confirms an action. It never gates reading. Every one of these is disabled under `prefers-reduced-motion`, and any new keyframe must be too.
 
 **Components**: `packages/ui/src/components/react/ui/{base,radix}`, shipped as identical twins. Base is the standard and the radix twin mirrors it markup for markup. A new component lands in both or it does not land. Chat surfaces build on the assistant-ui primitives, not on a parallel widget.
 

--- a/apps/docs/lib/search/collect-page.test.ts
+++ b/apps/docs/lib/search/collect-page.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { collectPageEntries, collectPageTextMatches } from "./collect-page";
+
+function renderPage(html: string) {
+  document.body.innerHTML = `<article data-page-content="">${html}</article>`;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("collectPageEntries", () => {
+  it("carries the heading node so a heading without an id is still reachable", () => {
+    renderPage(`
+      <h2 id="formats">Formats</h2>
+      <h2>Anonymous section</h2>
+    `);
+
+    const entries = collectPageEntries("/docs/tools/interactables");
+
+    expect(entries.map((entry) => entry.url)).toEqual([
+      "/docs/tools/interactables#formats",
+      "/docs/tools/interactables",
+    ]);
+    expect(entries.map((entry) => entry.element?.tagName)).toEqual([
+      "H2",
+      "H2",
+    ]);
+  });
+});
+
+describe("collectPageTextMatches", () => {
+  it("carries the matched block, not just its section anchor", () => {
+    renderPage(`
+      <h2 id="formats">Formats</h2>
+      <p>A formatter receives one snapshot entry.</p>
+      <p>Something else entirely here.</p>
+    `);
+
+    const [match, ...rest] = collectPageTextMatches(
+      "/docs/tools/interactables",
+      "formatter receives",
+    );
+
+    expect(rest).toHaveLength(0);
+    expect(match?.url).toBe("/docs/tools/interactables#formats");
+    expect(match?.element?.textContent).toContain("A formatter receives");
+  });
+
+  it("carries a block that sits above every anchored heading", () => {
+    renderPage(`
+      <p>Interactables let agents and users edit the same tool UI.</p>
+      <h2 id="formats">Formats</h2>
+    `);
+
+    const [match] = collectPageTextMatches(
+      "/docs/tools/interactables",
+      "interactables let agents",
+    );
+
+    expect(match?.url).toBe("/docs/tools/interactables");
+    expect(match?.element?.tagName).toBe("P");
+  });
+});

--- a/apps/docs/lib/search/collect-page.ts
+++ b/apps/docs/lib/search/collect-page.ts
@@ -55,7 +55,7 @@ export function collectPageEntries(
     entries.push(entry);
   };
 
-  for (const heading of root.querySelectorAll("h1, h2, h3, h4")) {
+  for (const heading of root.querySelectorAll<HTMLElement>("h1, h2, h3, h4")) {
     if (isSkipped(heading)) continue;
     const content = normalizeText(heading.textContent);
     if (!content || /^[$#>]/.test(content)) continue;
@@ -65,6 +65,7 @@ export function collectPageEntries(
       url: `${pathname}${hash}`,
       content,
       type: "heading",
+      element: heading,
     });
   }
 
@@ -82,7 +83,7 @@ export function collectPageTextMatches(
   const entries: Omit<SearchHit, "score">[] = [];
   const seen = new Set<string>();
 
-  for (const element of root.querySelectorAll("p, li, td, th")) {
+  for (const element of root.querySelectorAll<HTMLElement>("p, li, td, th")) {
     if (isSkipped(element)) continue;
     if (element.closest("h1, h2, h3, h4")) continue;
     const content = normalizeText(element.textContent);
@@ -100,6 +101,7 @@ export function collectPageTextMatches(
       url,
       content: excerpt,
       type: "text",
+      element,
     });
     if (entries.length >= 8) break;
   }

--- a/apps/docs/lib/search/query.test.ts
+++ b/apps/docs/lib/search/query.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   highlightMatches,
-  isCurrentPage,
   searchEntries,
   searchOtherPages,
   scoreText,
@@ -108,13 +107,5 @@ describe("highlightMatches", () => {
     expect(highlightMatches("assistant-ui", ["s"])).toEqual([
       { type: "text", content: "assistant-ui" },
     ]);
-  });
-});
-
-describe("isCurrentPage", () => {
-  it("ignores hashes and trailing slashes", () => {
-    expect(isCurrentPage("/elements/thread/#root", "/elements/thread/")).toBe(
-      true,
-    );
   });
 });

--- a/apps/docs/lib/search/query.ts
+++ b/apps/docs/lib/search/query.ts
@@ -15,10 +15,6 @@ export function normalizePath(path: string): string {
   return bare;
 }
 
-export function isCurrentPage(url: string, pathname: string): boolean {
-  return normalizePath(url) === normalizePath(pathname);
-}
-
 export function tokenize(query: string): string[] {
   return query
     .toLowerCase()

--- a/apps/docs/lib/search/reveal.test.ts
+++ b/apps/docs/lib/search/reveal.test.ts
@@ -9,15 +9,11 @@ function nextFrames(count: number) {
   }
 }
 
-function paragraph(text: string, { inView = false } = {}) {
+function paragraph(text: string) {
   const element = document.createElement("p");
   element.textContent = text;
   document.body.append(element);
   element.scrollIntoView = vi.fn();
-  element.getBoundingClientRect = vi.fn(
-    () =>
-      ({ top: inView ? 100 : 4000, bottom: inView ? 140 : 4040 }) as DOMRect,
-  );
   return element;
 }
 
@@ -87,19 +83,26 @@ describe("the reveal mark", () => {
     expect(element.hasAttribute("data-search-reveal")).toBe(true);
   });
 
-  it("does not mark while a smooth scroll has yet to take its first step", () => {
+  it("marks promptly when the scroll lands instantly", () => {
     const element = paragraph("a formatter receives one snapshot entry");
     let offset = 0;
     vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
+    element.scrollIntoView = vi.fn(() => {
+      offset = 3670;
+    });
 
     revealPageMatch(element, "center");
-    nextFrames(6);
-    expect(element.hasAttribute("data-search-reveal")).toBe(false);
+    nextFrames(5);
 
-    offset = 400;
-    nextFrames(1);
-    offset = 900;
-    nextFrames(1);
+    expect(element.hasAttribute("data-search-reveal")).toBe(true);
+  });
+
+  it("falls back to marking when the target needs no scroll at all", () => {
+    const element = paragraph("a formatter receives one snapshot entry");
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => 0);
+
+    revealPageMatch(element, "center");
+    nextFrames(3);
     expect(element.hasAttribute("data-search-reveal")).toBe(false);
 
     nextFrames(4);
@@ -107,12 +110,10 @@ describe("the reveal mark", () => {
   });
 
   it("marks the target and expires on its own", () => {
-    const element = paragraph("a formatter receives one snapshot entry", {
-      inView: true,
-    });
+    const element = paragraph("a formatter receives one snapshot entry");
 
     revealPageMatch(element, "center");
-    nextFrames(5);
+    nextFrames(8);
     expect(element.hasAttribute("data-search-reveal")).toBe(true);
 
     vi.advanceTimersByTime(2400);
@@ -122,15 +123,13 @@ describe("the reveal mark", () => {
   it("drops a reveal still waiting on the scroll lock when another is selected", () => {
     document.documentElement.setAttribute("data-base-ui-scroll-locked", "");
     const first = paragraph("a formatter receives one snapshot entry");
-    const second = paragraph("the snapshot carries a shallow diff", {
-      inView: true,
-    });
+    const second = paragraph("the snapshot carries a shallow diff");
 
     revealPageMatch(first, "center");
     nextFrames(2);
     revealPageMatch(second, "center");
     document.documentElement.removeAttribute("data-base-ui-scroll-locked");
-    nextFrames(5);
+    nextFrames(8);
 
     expect(first.scrollIntoView).not.toHaveBeenCalled();
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
@@ -140,9 +139,7 @@ describe("the reveal mark", () => {
 
   it("drops a reveal still waiting on the scroll to land when another is selected", () => {
     const first = paragraph("a formatter receives one snapshot entry");
-    const second = paragraph("the snapshot carries a shallow diff", {
-      inView: true,
-    });
+    const second = paragraph("the snapshot carries a shallow diff");
     let offset = 0;
     vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
 
@@ -153,7 +150,7 @@ describe("the reveal mark", () => {
     expect(first.scrollIntoView).toHaveBeenCalled();
 
     revealPageMatch(second, "center");
-    nextFrames(6);
+    nextFrames(8);
 
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
     expect(second.hasAttribute("data-search-reveal")).toBe(true);
@@ -163,17 +160,13 @@ describe("the reveal mark", () => {
   });
 
   it("moves off the previous target when another match is revealed", () => {
-    const first = paragraph("a formatter receives one snapshot entry", {
-      inView: true,
-    });
-    const second = paragraph("the snapshot carries a shallow diff", {
-      inView: true,
-    });
+    const first = paragraph("a formatter receives one snapshot entry");
+    const second = paragraph("the snapshot carries a shallow diff");
 
     revealPageMatch(first, "center");
-    nextFrames(5);
+    nextFrames(8);
     revealPageMatch(second, "center");
-    nextFrames(5);
+    nextFrames(8);
 
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
     expect(second.hasAttribute("data-search-reveal")).toBe(true);

--- a/apps/docs/lib/search/reveal.test.ts
+++ b/apps/docs/lib/search/reveal.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSearchMark, revealPageMatch } from "./reveal";
+
+function nextFrames(count: number) {
+  for (let i = 0; i < count; i += 1) {
+    vi.advanceTimersToNextFrame();
+  }
+}
+
+function paragraph(text: string) {
+  const element = document.createElement("p");
+  element.textContent = text;
+  document.body.append(element);
+  element.scrollIntoView = vi.fn();
+  return element;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  clearSearchMark();
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+  document.documentElement.removeAttribute("data-base-ui-scroll-locked");
+  vi.useRealTimers();
+});
+
+describe("revealPageMatch", () => {
+  it("waits for the page scroll lock to lift before scrolling", () => {
+    document.documentElement.setAttribute("data-base-ui-scroll-locked", "");
+    const element = paragraph("a formatter receives one snapshot entry");
+
+    revealPageMatch(element, "center");
+    nextFrames(3);
+    expect(element.scrollIntoView).not.toHaveBeenCalled();
+
+    document.documentElement.removeAttribute("data-base-ui-scroll-locked");
+    nextFrames(1);
+    expect(element.scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+  });
+
+  it("scrolls once the frame budget runs out even if the lock never lifts", () => {
+    document.documentElement.setAttribute("data-base-ui-scroll-locked", "");
+    const element = paragraph("a formatter receives one snapshot entry");
+
+    revealPageMatch(element, "start");
+    nextFrames(61);
+
+    expect(element.scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+
+  it("skips a target detached before the lock lifted", () => {
+    const element = paragraph("a formatter receives one snapshot entry");
+    element.remove();
+
+    revealPageMatch(element, "center");
+    nextFrames(1);
+
+    expect(element.scrollIntoView).not.toHaveBeenCalled();
+  });
+});
+
+describe("the reveal mark", () => {
+  it("holds off until the smooth scroll has landed", () => {
+    const element = paragraph("a formatter receives one snapshot entry");
+    let offset = 0;
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
+
+    revealPageMatch(element, "center");
+    nextFrames(1);
+
+    for (let step = 0; step < 4; step += 1) {
+      offset += 400;
+      nextFrames(1);
+      expect(element.hasAttribute("data-search-reveal")).toBe(false);
+    }
+
+    nextFrames(2);
+    expect(element.hasAttribute("data-search-reveal")).toBe(true);
+  });
+
+  it("marks the target and expires on its own", () => {
+    const element = paragraph("a formatter receives one snapshot entry");
+
+    revealPageMatch(element, "center");
+    nextFrames(3);
+    expect(element.hasAttribute("data-search-reveal")).toBe(true);
+
+    vi.advanceTimersByTime(2400);
+    expect(element.hasAttribute("data-search-reveal")).toBe(false);
+  });
+
+  it("moves off the previous target when another match is revealed", () => {
+    const first = paragraph("a formatter receives one snapshot entry");
+    const second = paragraph("the snapshot carries a shallow diff");
+
+    revealPageMatch(first, "center");
+    nextFrames(3);
+    revealPageMatch(second, "center");
+    nextFrames(3);
+
+    expect(first.hasAttribute("data-search-reveal")).toBe(false);
+    expect(second.hasAttribute("data-search-reveal")).toBe(true);
+  });
+});

--- a/apps/docs/lib/search/reveal.test.ts
+++ b/apps/docs/lib/search/reveal.test.ts
@@ -9,11 +9,15 @@ function nextFrames(count: number) {
   }
 }
 
-function paragraph(text: string) {
+function paragraph(text: string, { inView = false } = {}) {
   const element = document.createElement("p");
   element.textContent = text;
   document.body.append(element);
   element.scrollIntoView = vi.fn();
+  element.getBoundingClientRect = vi.fn(
+    () =>
+      ({ top: inView ? 100 : 4000, bottom: inView ? 140 : 4040 }) as DOMRect,
+  );
   return element;
 }
 
@@ -79,15 +83,36 @@ describe("the reveal mark", () => {
       expect(element.hasAttribute("data-search-reveal")).toBe(false);
     }
 
-    nextFrames(2);
+    nextFrames(4);
+    expect(element.hasAttribute("data-search-reveal")).toBe(true);
+  });
+
+  it("does not mark while a smooth scroll has yet to take its first step", () => {
+    const element = paragraph("a formatter receives one snapshot entry");
+    let offset = 0;
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
+
+    revealPageMatch(element, "center");
+    nextFrames(6);
+    expect(element.hasAttribute("data-search-reveal")).toBe(false);
+
+    offset = 400;
+    nextFrames(1);
+    offset = 900;
+    nextFrames(1);
+    expect(element.hasAttribute("data-search-reveal")).toBe(false);
+
+    nextFrames(4);
     expect(element.hasAttribute("data-search-reveal")).toBe(true);
   });
 
   it("marks the target and expires on its own", () => {
-    const element = paragraph("a formatter receives one snapshot entry");
+    const element = paragraph("a formatter receives one snapshot entry", {
+      inView: true,
+    });
 
     revealPageMatch(element, "center");
-    nextFrames(3);
+    nextFrames(5);
     expect(element.hasAttribute("data-search-reveal")).toBe(true);
 
     vi.advanceTimersByTime(2400);
@@ -97,13 +122,15 @@ describe("the reveal mark", () => {
   it("drops a reveal still waiting on the scroll lock when another is selected", () => {
     document.documentElement.setAttribute("data-base-ui-scroll-locked", "");
     const first = paragraph("a formatter receives one snapshot entry");
-    const second = paragraph("the snapshot carries a shallow diff");
+    const second = paragraph("the snapshot carries a shallow diff", {
+      inView: true,
+    });
 
     revealPageMatch(first, "center");
     nextFrames(2);
     revealPageMatch(second, "center");
     document.documentElement.removeAttribute("data-base-ui-scroll-locked");
-    nextFrames(3);
+    nextFrames(5);
 
     expect(first.scrollIntoView).not.toHaveBeenCalled();
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
@@ -113,7 +140,9 @@ describe("the reveal mark", () => {
 
   it("drops a reveal still waiting on the scroll to land when another is selected", () => {
     const first = paragraph("a formatter receives one snapshot entry");
-    const second = paragraph("the snapshot carries a shallow diff");
+    const second = paragraph("the snapshot carries a shallow diff", {
+      inView: true,
+    });
     let offset = 0;
     vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
 
@@ -124,7 +153,7 @@ describe("the reveal mark", () => {
     expect(first.scrollIntoView).toHaveBeenCalled();
 
     revealPageMatch(second, "center");
-    nextFrames(4);
+    nextFrames(6);
 
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
     expect(second.hasAttribute("data-search-reveal")).toBe(true);
@@ -134,13 +163,17 @@ describe("the reveal mark", () => {
   });
 
   it("moves off the previous target when another match is revealed", () => {
-    const first = paragraph("a formatter receives one snapshot entry");
-    const second = paragraph("the snapshot carries a shallow diff");
+    const first = paragraph("a formatter receives one snapshot entry", {
+      inView: true,
+    });
+    const second = paragraph("the snapshot carries a shallow diff", {
+      inView: true,
+    });
 
     revealPageMatch(first, "center");
-    nextFrames(3);
+    nextFrames(5);
     revealPageMatch(second, "center");
-    nextFrames(3);
+    nextFrames(5);
 
     expect(first.hasAttribute("data-search-reveal")).toBe(false);
     expect(second.hasAttribute("data-search-reveal")).toBe(true);

--- a/apps/docs/lib/search/reveal.test.ts
+++ b/apps/docs/lib/search/reveal.test.ts
@@ -94,6 +94,45 @@ describe("the reveal mark", () => {
     expect(element.hasAttribute("data-search-reveal")).toBe(false);
   });
 
+  it("drops a reveal still waiting on the scroll lock when another is selected", () => {
+    document.documentElement.setAttribute("data-base-ui-scroll-locked", "");
+    const first = paragraph("a formatter receives one snapshot entry");
+    const second = paragraph("the snapshot carries a shallow diff");
+
+    revealPageMatch(first, "center");
+    nextFrames(2);
+    revealPageMatch(second, "center");
+    document.documentElement.removeAttribute("data-base-ui-scroll-locked");
+    nextFrames(3);
+
+    expect(first.scrollIntoView).not.toHaveBeenCalled();
+    expect(first.hasAttribute("data-search-reveal")).toBe(false);
+    expect(second.scrollIntoView).toHaveBeenCalled();
+    expect(second.hasAttribute("data-search-reveal")).toBe(true);
+  });
+
+  it("drops a reveal still waiting on the scroll to land when another is selected", () => {
+    const first = paragraph("a formatter receives one snapshot entry");
+    const second = paragraph("the snapshot carries a shallow diff");
+    let offset = 0;
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => offset);
+
+    revealPageMatch(first, "center");
+    nextFrames(1);
+    offset += 400;
+    nextFrames(1);
+    expect(first.scrollIntoView).toHaveBeenCalled();
+
+    revealPageMatch(second, "center");
+    nextFrames(4);
+
+    expect(first.hasAttribute("data-search-reveal")).toBe(false);
+    expect(second.hasAttribute("data-search-reveal")).toBe(true);
+
+    vi.advanceTimersByTime(2400);
+    expect(second.hasAttribute("data-search-reveal")).toBe(false);
+  });
+
   it("moves off the previous target when another match is revealed", () => {
     const first = paragraph("a formatter receives one snapshot entry");
     const second = paragraph("the snapshot carries a shallow diff");

--- a/apps/docs/lib/search/reveal.ts
+++ b/apps/docs/lib/search/reveal.ts
@@ -1,0 +1,80 @@
+const REVEAL_ATTRIBUTE = "data-search-reveal";
+const REVEAL_DURATION_MS = 2400;
+const UNLOCK_FRAME_BUDGET = 60;
+const SETTLE_FRAME_BUDGET = 150;
+
+let clearMark: (() => void) | undefined;
+
+function waitFor(ready: () => boolean, budget: number, run: () => void): void {
+  let frames = 0;
+
+  const tick = () => {
+    if (frames >= budget || ready()) {
+      run();
+      return;
+    }
+    frames += 1;
+    requestAnimationFrame(tick);
+  };
+
+  requestAnimationFrame(tick);
+}
+
+function isPageScrollLocked(): boolean {
+  const html = document.documentElement;
+  if (html.hasAttribute("data-base-ui-scroll-locked")) return true;
+  return /hidden|clip/.test(getComputedStyle(html).overflowY);
+}
+
+function whenScrollSettles(run: () => void): void {
+  let previous = Number.NaN;
+
+  waitFor(
+    () => {
+      const offset = window.scrollY;
+      const settled = offset === previous;
+      previous = offset;
+      return settled;
+    },
+    SETTLE_FRAME_BUDGET,
+    run,
+  );
+}
+
+export function clearSearchMark(): void {
+  clearMark?.();
+}
+
+function markMatch(element: HTMLElement): void {
+  element.setAttribute(REVEAL_ATTRIBUTE, "");
+
+  const timer = window.setTimeout(clearSearchMark, REVEAL_DURATION_MS);
+  clearMark = () => {
+    window.clearTimeout(timer);
+    element.removeAttribute(REVEAL_ATTRIBUTE);
+    clearMark = undefined;
+  };
+}
+
+export function revealPageMatch(
+  element: HTMLElement,
+  block: ScrollLogicalPosition,
+): void {
+  clearSearchMark();
+
+  /**
+   * A dialog holds the page scroll while it closes: the document is clamped to
+   * one viewport and its scroll offset is restored when the lock lifts, so a
+   * scroll issued before then is discarded.
+   */
+  waitFor(
+    () => !isPageScrollLocked(),
+    UNLOCK_FRAME_BUDGET,
+    () => {
+      if (!element.isConnected) return;
+
+      element.scrollIntoView({ block });
+      whenScrollSettles(() => markMatch(element));
+    },
+  );
+}

--- a/apps/docs/lib/search/reveal.ts
+++ b/apps/docs/lib/search/reveal.ts
@@ -2,6 +2,7 @@ const REVEAL_ATTRIBUTE = "data-search-reveal";
 const REVEAL_DURATION_MS = 2400;
 const UNLOCK_FRAME_BUDGET = 60;
 const SETTLE_FRAME_BUDGET = 150;
+const SETTLE_STABLE_FRAMES = 3;
 
 let clearMark: (() => void) | undefined;
 let cancelPending: (() => void) | undefined;
@@ -37,15 +38,23 @@ function isPageScrollLocked(): boolean {
   return /hidden|clip/.test(getComputedStyle(html).overflowY);
 }
 
-function whenScrollSettles(run: () => void): () => void {
+function isInView(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  return rect.top >= 0 && rect.bottom <= window.innerHeight;
+}
+
+function whenScrollSettles(expectMove: boolean, run: () => void): () => void {
   let previous = Number.NaN;
+  let stable = 0;
+  let moved = !expectMove;
 
   return waitFor(
     () => {
       const offset = window.scrollY;
-      const settled = offset === previous;
+      if (!Number.isNaN(previous) && offset !== previous) moved = true;
+      stable = offset === previous ? stable + 1 : 0;
       previous = offset;
-      return settled;
+      return moved && stable >= SETTLE_STABLE_FRAMES;
     },
     SETTLE_FRAME_BUDGET,
     run,
@@ -83,10 +92,15 @@ export function revealPageMatch(
     () => !isPageScrollLocked(),
     UNLOCK_FRAME_BUDGET,
     () => {
+      cancelPending = undefined;
       if (!element.isConnected) return;
 
+      const expectMove = !isInView(element);
       element.scrollIntoView({ block });
-      cancelPending = whenScrollSettles(() => markMatch(element));
+      cancelPending = whenScrollSettles(expectMove, () => {
+        cancelPending = undefined;
+        markMatch(element);
+      });
     },
   );
 }

--- a/apps/docs/lib/search/reveal.ts
+++ b/apps/docs/lib/search/reveal.ts
@@ -3,6 +3,7 @@ const REVEAL_DURATION_MS = 2400;
 const UNLOCK_FRAME_BUDGET = 60;
 const SETTLE_FRAME_BUDGET = 150;
 const SETTLE_STABLE_FRAMES = 3;
+const SETTLE_MOVE_GRACE_FRAMES = 5;
 
 let clearMark: (() => void) | undefined;
 let cancelPending: (() => void) | undefined;
@@ -38,23 +39,23 @@ function isPageScrollLocked(): boolean {
   return /hidden|clip/.test(getComputedStyle(html).overflowY);
 }
 
-function isInView(element: HTMLElement): boolean {
-  const rect = element.getBoundingClientRect();
-  return rect.top >= 0 && rect.bottom <= window.innerHeight;
-}
-
-function whenScrollSettles(expectMove: boolean, run: () => void): () => void {
-  let previous = Number.NaN;
+function whenScrollSettles(origin: number, run: () => void): () => void {
+  let previous = origin;
   let stable = 0;
-  let moved = !expectMove;
+  let frames = 0;
+  let moved = false;
 
   return waitFor(
     () => {
       const offset = window.scrollY;
-      if (!Number.isNaN(previous) && offset !== previous) moved = true;
+      if (offset !== previous) moved = true;
       stable = offset === previous ? stable + 1 : 0;
       previous = offset;
-      return moved && stable >= SETTLE_STABLE_FRAMES;
+      frames += 1;
+      return (
+        (moved || frames >= SETTLE_MOVE_GRACE_FRAMES) &&
+        stable >= SETTLE_STABLE_FRAMES
+      );
     },
     SETTLE_FRAME_BUDGET,
     run,
@@ -95,9 +96,9 @@ export function revealPageMatch(
       cancelPending = undefined;
       if (!element.isConnected) return;
 
-      const expectMove = !isInView(element);
+      const origin = window.scrollY;
       element.scrollIntoView({ block });
-      cancelPending = whenScrollSettles(expectMove, () => {
+      cancelPending = whenScrollSettles(origin, () => {
         cancelPending = undefined;
         markMatch(element);
       });

--- a/apps/docs/lib/search/reveal.ts
+++ b/apps/docs/lib/search/reveal.ts
@@ -4,11 +4,18 @@ const UNLOCK_FRAME_BUDGET = 60;
 const SETTLE_FRAME_BUDGET = 150;
 
 let clearMark: (() => void) | undefined;
+let cancelPending: (() => void) | undefined;
 
-function waitFor(ready: () => boolean, budget: number, run: () => void): void {
+function waitFor(
+  ready: () => boolean,
+  budget: number,
+  run: () => void,
+): () => void {
   let frames = 0;
+  let cancelled = false;
 
   const tick = () => {
+    if (cancelled) return;
     if (frames >= budget || ready()) {
       run();
       return;
@@ -18,6 +25,10 @@ function waitFor(ready: () => boolean, budget: number, run: () => void): void {
   };
 
   requestAnimationFrame(tick);
+
+  return () => {
+    cancelled = true;
+  };
 }
 
 function isPageScrollLocked(): boolean {
@@ -26,10 +37,10 @@ function isPageScrollLocked(): boolean {
   return /hidden|clip/.test(getComputedStyle(html).overflowY);
 }
 
-function whenScrollSettles(run: () => void): void {
+function whenScrollSettles(run: () => void): () => void {
   let previous = Number.NaN;
 
-  waitFor(
+  return waitFor(
     () => {
       const offset = window.scrollY;
       const settled = offset === previous;
@@ -60,6 +71,7 @@ export function revealPageMatch(
   element: HTMLElement,
   block: ScrollLogicalPosition,
 ): void {
+  cancelPending?.();
   clearSearchMark();
 
   /**
@@ -67,14 +79,14 @@ export function revealPageMatch(
    * one viewport and its scroll offset is restored when the lock lifts, so a
    * scroll issued before then is discarded.
    */
-  waitFor(
+  cancelPending = waitFor(
     () => !isPageScrollLocked(),
     UNLOCK_FRAME_BUDGET,
     () => {
       if (!element.isConnected) return;
 
       element.scrollIntoView({ block });
-      whenScrollSettles(() => markMatch(element));
+      cancelPending = whenScrollSettles(() => markMatch(element));
     },
   );
 }

--- a/apps/docs/lib/search/types.ts
+++ b/apps/docs/lib/search/types.ts
@@ -18,6 +18,7 @@ export type SearchHit = {
   content: string;
   type: SearchHitType;
   score: number;
+  element?: HTMLElement;
 };
 
 export type SearchGroup = {

--- a/apps/docs/styles/animate.css
+++ b/apps/docs/styles/animate.css
@@ -191,3 +191,30 @@
     animation: none;
   }
 }
+
+@keyframes search-reveal {
+  0%,
+  45% {
+    background-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+    box-shadow: 0 0 0 0.3rem
+      color-mix(in oklab, var(--foreground) 14%, transparent);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: 0 0 0 0.3rem transparent;
+  }
+}
+
+[data-search-reveal] {
+  border-radius: 2px;
+  animation: search-reveal 2.4s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-search-reveal] {
+    animation: none;
+    background-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+    box-shadow: 0 0 0 0.3rem
+      color-mix(in oklab, var(--foreground) 14%, transparent);
+  }
+}

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -284,22 +284,6 @@
   code {
     font-variant-ligatures: none;
   }
-  [data-search-reveal] {
-    border-radius: 2px;
-    animation: aui-search-reveal 2.4s ease-out forwards;
-  }
-  @keyframes aui-search-reveal {
-    0%,
-    45% {
-      background-color: color-mix(in oklab, var(--foreground) 14%, transparent);
-      box-shadow: 0 0 0 0.3rem
-        color-mix(in oklab, var(--foreground) 14%, transparent);
-    }
-    100% {
-      background-color: transparent;
-      box-shadow: 0 0 0 0.3rem transparent;
-    }
-  }
   body[data-scroll-locked] {
     margin-right: 0 !important;
     padding-right: 0 !important;

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -284,6 +284,22 @@
   code {
     font-variant-ligatures: none;
   }
+  [data-search-reveal] {
+    border-radius: 2px;
+    animation: aui-search-reveal 2.4s ease-out forwards;
+  }
+  @keyframes aui-search-reveal {
+    0%,
+    45% {
+      background-color: color-mix(in oklab, var(--foreground) 14%, transparent);
+      box-shadow: 0 0 0 0.3rem
+        color-mix(in oklab, var(--foreground) 14%, transparent);
+    }
+    100% {
+      background-color: transparent;
+      box-shadow: 0 0 0 0.3rem transparent;
+    }
+  }
   body[data-scroll-locked] {
     margin-right: 0 !important;
     padding-right: 0 !important;


### PR DESCRIPTION
## Problem

The docs command palette finds text on the current page but cannot take you to it.

On `/docs/tools/interactables`, searching "formatter receives" and pressing Enter puts `#customizing-the-format` in the address bar while the page stays at scroll 0, with the match sitting 4112px down. Searching a paragraph that has no heading above it ("allow both agents") is worse: from scroll 6000 the page jumps to the top and keeps the stale hash from the previous jump. Even when a jump did land, it landed on the section heading, never on the sentence that matched.

## Root cause

Three layers, all in `search-dialog.tsx` and `collect-page.ts`.

`handleSelect` called `onOpenChange(false)` and then `scrollIntoView` synchronously. Base UI 1.7.0 still holds the page scroll at that moment: the lock is released a `setTimeout(0)` after the popup unmounts at the end of its close animation. In the branch this site hits (verified through `data-base-ui-scroll-locked` on `<html>`), the lock sets `body { position: relative; height: 100dvh; overflow: hidden }` and restores `html.scrollTop` on cleanup, so a scroll issued before the lock lifts is either impossible or undone.

`collectPageTextMatches` had the matched DOM node in hand and threw it away, keeping only `pathname#<nearest heading id>`. When `headingAnchor()` found nothing, the url collapsed to the bare pathname and selection fell through to `router.push(pathname)`, a same-url push that scrolls to the top.

## Change

On-page hits now carry the node they were collected from (`SearchHit.element`), so selection reveals that element instead of resolving a hash back to one. `searchEntries` already spreads each entry, so the ranking path is untouched.

`lib/search/reveal.ts` waits for the dialog's scroll lock to lift before scrolling, checking both lock shapes (the `data-base-ui-scroll-locked` attribute, and the viewport scroller's computed `overflow-y` for the `scrollbar-gutter` branch) with a frame budget so it always proceeds. Text hits center, heading hits top-align, and the existing `scroll-padding-top` on `<html>` keeps the sticky header clear. The match is then marked with a short ink wash (`data-search-reveal` plus a keyframe in `globals.css`), applied once the smooth scroll settles rather than at scroll time, so the cue is not consumed by a 1.6s flight.

The old `getElementById(hash)` branch is gone: with the node on the hit it was unreachable, since on-page hits always carry an element and `searchOtherPages` skips the current page. `isCurrentPage` was left with no callers and is removed with it.

Two notes on the shape. The match cue is block-level rather than the CSS Custom Highlight API: Lightning CSS rejects `::highlight()` as an unrecognized pseudo-element, so the rule never reaches the stylesheet. And the revealed element is not focused; a programmatic focus on a `tabindex="-1"` paragraph draws Chrome's blue focus ring, which reads as an input and breaks the site's blue-means-live rule, and suppressing it after the mark expires would mean parking a permanent attribute on every element ever revealed. Moving the reading position for keyboard and screen reader users is a real gap, filed separately.

## Verification

Browser pass against a dev server on the branch, `/docs/tools/interactables`, all three hit shapes:

| hit | scroll | url | mark |
| --- | --- | --- | --- |
| text with anchor, "formatter receives" | 0 to 3670 | `#customizing-the-format` | paragraph at 478px of a 900px viewport |
| text without anchor, "allow both agents" | 6000 back to 0 | hash cleared | paragraph at 208px |
| heading, "companion tools" | 0 to 5951 | `#companion-tools` | h2 at 192px |

The same three paths on main are the failures described above. Light and dark both checked for the wash.

- `pnpm -C apps/docs test` 74 files / 637 tests green, including 7 new in `reveal.test.ts` and 3 in `collect-page.test.ts`
- `npx tsc --noEmit -p apps/docs/tsconfig.json` clean for the changed files (45 pre-existing errors elsewhere in untouched files)
- `npx oxlint` leaves only the 2 `set-state-in-effect` warnings already on main for this file

## Public surface

`@assistant-ui/docs` only, which is private, so no changeset. No published package, export, doc page, or api-reference output changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nNAE63hr938-F55k7gC6w41lyl19_tj-kWsa6zc-dyfsZpp8kgYaVSg7Vhw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->