### PR TITLE
fix(eve): show resumed session history at its real times, not "just now"

### DIFF
--- a/.changeset/eve-durable-createdat.md
+++ b/.changeset/eve-durable-createdat.md
@@ -4,4 +4,4 @@
 
 fix: show resumed session history at its real times, not "just now"
 
-`createdAt` now comes from the `meta.at` of each message's own stream event, so a resumed session renders yesterday's messages at yesterday's times. Messages with no durable event (optimistic sends) keep the first-observation wall clock.
+`createdAt` now comes from the `meta.at` of each message's own stream event, so a resumed session renders yesterday's messages at yesterday's times. A confirmed message therefore carries eve's server clock rather than the client's first-observation clock, which is what keeps its time stable across reloads and devices; optimistic and failed sends have no durable event and keep the client wall clock.

--- a/.changeset/eve-durable-createdat.md
+++ b/.changeset/eve-durable-createdat.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: show resumed session history at its real times, not "just now"
+
+`createdAt` now comes from the `meta.at` of each message's own stream event, so a resumed session renders yesterday's messages at yesterday's times. Messages with no durable event (optimistic sends) keep the first-observation wall clock.

--- a/packages/eve/src/deriveCreatedAt.test.ts
+++ b/packages/eve/src/deriveCreatedAt.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import type { MessageStreamEvent } from "eve/client";
+
+import {
+  collectTurnTimestamps,
+  createTurnTimestampCache,
+} from "./deriveCreatedAt";
+
+const TURN = "turn_1";
+
+const turnStarted = (at: string, turnId = TURN) =>
+  ({
+    type: "turn.started",
+    data: { sequence: 1, turnId },
+    meta: { at, id: `evt_${at}` },
+  }) as const satisfies MessageStreamEvent;
+
+const messageReceived = (at: string, turnId = TURN) =>
+  ({
+    type: "message.received",
+    data: { message: "hi", sequence: 2, turnId },
+    meta: { at, id: `evt_${at}` },
+  }) as const satisfies MessageStreamEvent;
+
+const compactionRequested = (at: string, turnId = TURN) =>
+  ({
+    type: "compaction.requested",
+    data: {
+      modelId: "m",
+      sequence: 3,
+      sessionId: "s",
+      turnId,
+      usageInputTokens: null,
+    },
+    meta: { at, id: `evt_${at}` },
+  }) as const satisfies MessageStreamEvent;
+
+const stepStarted = (at: string, turnId = TURN) =>
+  ({
+    type: "step.started",
+    data: { modelId: "m", sequence: 4, stepIndex: 0, turnId },
+    meta: { at, id: `evt_${at}` },
+  }) as const satisfies MessageStreamEvent;
+
+describe("collectTurnTimestamps", () => {
+  it("stamps the user at message.received and the assistant at step.started, skipping the turn's other events", () => {
+    const timestamps = collectTurnTimestamps(
+      [
+        turnStarted("2026-01-02T10:00:00.000Z"),
+        messageReceived("2026-01-02T10:00:01.000Z"),
+        compactionRequested("2026-01-02T10:00:02.000Z"),
+        stepStarted("2026-01-02T10:02:00.000Z"),
+        stepStarted("2026-01-02T10:03:00.000Z"),
+      ],
+      createTurnTimestampCache(),
+    );
+
+    expect(timestamps.get(TURN)?.user).toEqual(
+      new Date("2026-01-02T10:00:01.000Z"),
+    );
+    expect(timestamps.get(TURN)?.assistant).toEqual(
+      new Date("2026-01-02T10:02:00.000Z"),
+    );
+    expect(timestamps.get("turn_other")?.user).toBe(undefined);
+  });
+
+  it("resumes the scan at appended events and keeps the map identity when they teach nothing", () => {
+    const cache = createTurnTimestampCache();
+    const events = [
+      turnStarted("2026-01-02T10:00:00.000Z"),
+      messageReceived("2026-01-02T10:00:01.000Z"),
+    ];
+    const first = collectTurnTimestamps(events, cache);
+    expect(first.get(TURN)?.assistant).toBe(undefined);
+
+    const quiet = [
+      ...events,
+      turnStarted("2026-01-02T10:00:02.000Z", "turn_2"),
+    ];
+    expect(collectTurnTimestamps(quiet, cache)).toBe(first);
+
+    const timestamps = collectTurnTimestamps(
+      [...quiet, stepStarted("2026-01-02T10:02:00.000Z")],
+      cache,
+    );
+    expect(timestamps.get(TURN)?.user).toEqual(
+      new Date("2026-01-02T10:00:01.000Z"),
+    );
+    expect(timestamps.get(TURN)?.assistant).toEqual(
+      new Date("2026-01-02T10:02:00.000Z"),
+    );
+  });
+
+  it("stamps an assistant created by a turn ending before its first step", () => {
+    const timestamps = collectTurnTimestamps(
+      [
+        messageReceived("2026-01-02T10:00:01.000Z"),
+        {
+          type: "turn.cancelled",
+          data: { sequence: 3, turnId: TURN },
+          meta: { at: "2026-01-02T10:00:05.000Z", id: "evt_cancel" },
+        },
+      ],
+      createTurnTimestampCache(),
+    );
+
+    expect(timestamps.get(TURN)?.assistant).toEqual(
+      new Date("2026-01-02T10:00:05.000Z"),
+    );
+  });
+
+  it("skips malformed events without throwing", () => {
+    const events = [
+      { type: "message.received", data: null, meta: { at: "x", id: "e1" } },
+      { type: "step.started", meta: { at: "2026-01-01T00:00:00Z", id: "e2" } },
+      {
+        type: "message.received",
+        data: { turnId: 42 },
+        meta: { at: "x", id: "e3" },
+      },
+      {
+        type: "message.received",
+        data: { message: "hi", sequence: 2, turnId: TURN },
+        meta: { at: "not a date", id: "e4" },
+      },
+      { type: "step.started", data: { stepIndex: 0, turnId: TURN } },
+      stepStarted("2026-01-02T10:02:00.000Z"),
+    ] as never as readonly MessageStreamEvent[];
+
+    const timestamps = collectTurnTimestamps(
+      events,
+      createTurnTimestampCache(),
+    );
+
+    expect(timestamps.get(TURN)?.user).toBe(undefined);
+    expect(timestamps.get(TURN)?.assistant).toEqual(
+      new Date("2026-01-02T10:02:00.000Z"),
+    );
+  });
+
+  it("re-derives from scratch when the log is replaced, so a recurring turn id serves the new session's stamps", () => {
+    const cache = createTurnTimestampCache();
+    collectTurnTimestamps(
+      [
+        messageReceived("2026-01-02T10:00:01.000Z"),
+        stepStarted("2026-01-02T10:02:00.000Z"),
+      ],
+      cache,
+    );
+
+    const timestamps = collectTurnTimestamps(
+      [messageReceived("2026-03-01T09:00:01.000Z")],
+      cache,
+    );
+
+    expect(timestamps.get(TURN)?.user).toEqual(
+      new Date("2026-03-01T09:00:01.000Z"),
+    );
+    expect(timestamps.get(TURN)?.assistant).toBe(undefined);
+  });
+});

--- a/packages/eve/src/deriveCreatedAt.test.ts
+++ b/packages/eve/src/deriveCreatedAt.test.ts
@@ -35,6 +35,19 @@ const compactionRequested = (at: string, turnId = TURN) =>
     meta: { at, id: `evt_${at}` },
   }) as const satisfies MessageStreamEvent;
 
+const messageAppended = (at: string, turnId = TURN) =>
+  ({
+    type: "message.appended",
+    data: {
+      messageDelta: "he",
+      messageSoFar: "he",
+      sequence: 4,
+      stepIndex: 0,
+      turnId,
+    },
+    meta: { at, id: `evt_${at}` },
+  }) as const satisfies MessageStreamEvent;
+
 const stepStarted = (at: string, turnId = TURN) =>
   ({
     type: "step.started",
@@ -106,6 +119,22 @@ describe("collectTurnTimestamps", () => {
 
     expect(timestamps.get(TURN)?.assistant).toEqual(
       new Date("2026-01-02T10:00:05.000Z"),
+    );
+  });
+
+  it("stamps the assistant from the turn's first message-creating event when no step.started precedes it", () => {
+    const timestamps = collectTurnTimestamps(
+      [
+        turnStarted("2026-01-02T10:00:00.000Z"),
+        messageReceived("2026-01-02T10:00:01.000Z"),
+        compactionRequested("2026-01-02T10:00:02.000Z"),
+        messageAppended("2026-01-02T10:02:00.000Z"),
+      ],
+      createTurnTimestampCache(),
+    );
+
+    expect(timestamps.get(TURN)?.assistant).toEqual(
+      new Date("2026-01-02T10:02:00.000Z"),
     );
   });
 

--- a/packages/eve/src/deriveCreatedAt.ts
+++ b/packages/eve/src/deriveCreatedAt.ts
@@ -10,11 +10,32 @@ export type TurnTimestampCache = {
   timestamps: ReadonlyMap<string, TurnTimestamps>;
 };
 
+/**
+ * The reducer cases eve projects into a message: `message.received` creates
+ * `${turnId}:user`, and every assistant entry reaches `updateAssistantMessage`,
+ * which creates `${turnId}:assistant` for a turn that has none. It enumerates
+ * that reducer across the `>=0.32.0` peer range rather than stating a rule
+ * about turn ids, because `turn.started` and the compaction events carry one
+ * before the model runs. An event eve adds to the creating set later is absent
+ * here and falls back to the wall clock instead of stamping a wrong time.
+ */
 const ROLE_BY_EVENT_TYPE: Partial<
   Record<MessageStreamEvent["type"], keyof TurnTimestamps>
 > = {
   "message.received": "user",
   "step.started": "assistant",
+  "reasoning.appended": "assistant",
+  "reasoning.completed": "assistant",
+  "action.input.appended": "assistant",
+  "actions.requested": "assistant",
+  "input.requested": "assistant",
+  "action.result": "assistant",
+  "action.partial": "assistant",
+  "authorization.required": "assistant",
+  "authorization.completed": "assistant",
+  "message.appended": "assistant",
+  "message.completed": "assistant",
+  "result.completed": "assistant",
   "turn.completed": "assistant",
   "turn.cancelled": "assistant",
 };

--- a/packages/eve/src/deriveCreatedAt.ts
+++ b/packages/eve/src/deriveCreatedAt.ts
@@ -1,0 +1,75 @@
+import type { MessageStreamEvent } from "eve/client";
+
+export type TurnTimestamps = {
+  readonly user?: Date;
+  readonly assistant?: Date;
+};
+
+export type TurnTimestampCache = {
+  lastEvents: readonly MessageStreamEvent[];
+  timestamps: ReadonlyMap<string, TurnTimestamps>;
+};
+
+const ROLE_BY_EVENT_TYPE: Partial<
+  Record<MessageStreamEvent["type"], keyof TurnTimestamps>
+> = {
+  "message.received": "user",
+  "step.started": "assistant",
+  "turn.completed": "assistant",
+  "turn.cancelled": "assistant",
+};
+
+export const createTurnTimestampCache = (): TurnTimestampCache => ({
+  lastEvents: [],
+  timestamps: new Map(),
+});
+
+/**
+ * Eve appends to its log (`[...events, event]`), so a snapshot that keeps the
+ * previous scan's last element by identity shares the whole prefix and the
+ * scan resumes there. Any other snapshot is re-derived into a fresh map: turn
+ * ids are per-session sequence numbers that recur after `reset()`, so entries
+ * must not outlive the log that produced them. Re-derivation is also what
+ * makes the render-phase cache writes safe when React discards a render.
+ */
+export const collectTurnTimestamps = (
+  events: readonly MessageStreamEvent[],
+  cache: TurnTimestampCache,
+): ReadonlyMap<string, TurnTimestamps> => {
+  if (events === cache.lastEvents) return cache.timestamps;
+
+  const scanned = cache.lastEvents;
+  const resumesScan =
+    scanned.length === 0 ||
+    events[scanned.length - 1] === scanned[scanned.length - 1];
+
+  let timestamps = cache.timestamps;
+  let draft: Map<string, TurnTimestamps> | undefined;
+  if (!resumesScan) {
+    draft = new Map();
+    timestamps = draft;
+  }
+  for (let i = resumesScan ? scanned.length : 0; i < events.length; i++) {
+    const event = events[i]!;
+    const role = ROLE_BY_EVENT_TYPE[event.type];
+    if (role === undefined) continue;
+    const data: unknown = (event as { readonly data?: unknown }).data;
+    if (typeof data !== "object" || data === null) continue;
+    const turnId = (data as { readonly turnId?: unknown }).turnId;
+    if (typeof turnId !== "string") continue;
+    const known = timestamps.get(turnId);
+    if (known?.[role] !== undefined) continue;
+    const at: unknown = (event as { readonly meta?: { readonly at?: unknown } })
+      .meta?.at;
+    if (typeof at !== "string") continue;
+    const date = new Date(at);
+    if (Number.isNaN(date.getTime())) continue;
+    draft ??= new Map(timestamps);
+    draft.set(turnId, { ...known, [role]: date });
+    timestamps = draft;
+  }
+
+  cache.lastEvents = events;
+  cache.timestamps = timestamps;
+  return timestamps;
+};

--- a/packages/eve/src/useEveAgentRuntime.eveResume.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.eveResume.test.tsx
@@ -57,7 +57,9 @@ const offlineSession = {
     throw new Error("the resume test must not reach the network");
   },
   stream: async function* () {
-    yield* resumedEvents;
+    yield* JSON.parse(
+      JSON.stringify(resumedEvents),
+    ) as readonly MessageStreamEvent[];
   },
 } as never;
 

--- a/packages/eve/src/useEveAgentRuntime.eveResume.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.eveResume.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+// Deliberately does not mock `eve/react`: the real `useEveAgent` resumes an
+// offline session so the durable `meta.at` values travel through eve's own
+// store and reducer before the adapter reads them. Supplying `session` keeps
+// the store from constructing a network client.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { MessageStreamEvent } from "eve/client";
+
+import { useEveAgentRuntime } from "./useEveAgentRuntime";
+
+const TURN = "turn_resumed";
+
+const USER_AT = "2026-01-02T10:00:01.000Z";
+const ASSISTANT_AT = "2026-01-02T10:02:00.000Z";
+
+const resumedEvents = [
+  {
+    type: "turn.started",
+    data: { sequence: 1, turnId: TURN },
+    meta: { at: "2026-01-02T10:00:00.000Z", id: "evt_001" },
+  },
+  {
+    type: "message.received",
+    data: { message: "hi", sequence: 2, turnId: TURN },
+    meta: { at: USER_AT, id: "evt_101" },
+  },
+  {
+    type: "step.started",
+    data: { modelId: "test-model", sequence: 3, stepIndex: 0, turnId: TURN },
+    meta: { at: ASSISTANT_AT, id: "evt_102" },
+  },
+  {
+    type: "message.completed",
+    data: {
+      finishReason: "stop",
+      message: "hello",
+      sequence: 5,
+      stepIndex: 0,
+      turnId: TURN,
+    },
+    meta: { at: "2026-01-02T10:02:06.000Z", id: "evt_003" },
+  },
+  {
+    type: "turn.completed",
+    data: { sequence: 6, turnId: TURN },
+    meta: { at: "2026-01-02T10:02:07.000Z", id: "evt_004" },
+  },
+] as const satisfies readonly MessageStreamEvent[];
+
+const offlineSession = {
+  state: { sessionId: "session_resumed", streamIndex: 0 },
+  cancel: async () => ({ status: "no_active_turn" }),
+  send: () => {
+    throw new Error("the resume test must not reach the network");
+  },
+  stream: async function* () {
+    yield* resumedEvents;
+  },
+} as never;
+
+describe("useEveAgentRuntime against a resumed eve session", () => {
+  it("renders resumed history at its durable event times, not the current time", async () => {
+    const { result } = renderHook(() =>
+      useEveAgentRuntime({ resume: true, session: offlineSession }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.thread.getState().messages).toHaveLength(2),
+    );
+
+    const messages = result.current.thread.getState().messages;
+    expect(messages[0]?.createdAt).toEqual(new Date(USER_AT));
+    expect(messages[1]?.createdAt).toEqual(new Date(ASSISTANT_AT));
+  });
+});

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -18,6 +18,7 @@ vi.mock("eve/react", async (importOriginal) => ({
   useEveAgent: mockUseEveAgent,
 }));
 
+import type { MessageStreamEvent } from "eve/client";
 import type { EveMessageData } from "eve/react";
 import { useEveAgentRuntime } from "./useEveAgentRuntime";
 import { eveExtras } from "./eveExtras";
@@ -2150,5 +2151,90 @@ describe("useEveAgentRuntime thread refetch", () => {
     await act(async () => {
       await result.current.threads.reloadMainThread();
     });
+  });
+});
+
+describe("useEveAgentRuntime createdAt derivation", () => {
+  const TURN = "turn_ts";
+  const USER_AT = "2026-01-02T10:00:01.000Z";
+  const ASSISTANT_AT = "2026-01-02T10:02:00.000Z";
+
+  const turnEvents = [
+    {
+      type: "turn.started",
+      data: { sequence: 1, turnId: TURN },
+      meta: { at: "2026-01-02T10:00:00.000Z", id: "evt_1" },
+    },
+    {
+      type: "message.received",
+      data: { message: "hi", sequence: 2, turnId: TURN },
+      meta: { at: USER_AT, id: "evt_2" },
+    },
+    {
+      type: "step.started",
+      data: { modelId: "m", sequence: 3, stepIndex: 0, turnId: TURN },
+      meta: { at: ASSISTANT_AT, id: "evt_3" },
+    },
+  ] satisfies readonly MessageStreamEvent[];
+
+  const turnData: EveMessageData = {
+    messages: [
+      {
+        id: `${TURN}:user`,
+        role: "user",
+        metadata: { turnId: TURN },
+        parts: [{ type: "text", text: "hi" }],
+      },
+      {
+        id: `${TURN}:assistant`,
+        role: "assistant",
+        metadata: { turnId: TURN },
+        parts: [{ type: "text", text: "hello" }],
+      },
+    ],
+  };
+
+  it("stamps a message with the wall clock when no event covers its turn, and keeps that stamp across renders", () => {
+    const before = Date.now();
+    const agent = createAgent({ data: turnData, events: [] });
+    mockUseEveAgent.mockReturnValue(agent as never);
+
+    const { result, rerender } = renderHook(() => useEveAgentRuntime());
+
+    const stamped = result.current.thread.getState().messages[0]?.createdAt;
+    expect(stamped?.getTime()).toBeGreaterThanOrEqual(before);
+
+    mockUseEveAgent.mockReturnValue({
+      ...agent,
+      data: { messages: [...turnData.messages] },
+    } as never);
+    rerender();
+
+    expect(result.current.thread.getState().messages[0]?.createdAt).toBe(
+      stamped,
+    );
+  });
+
+  it("keeps the message list identity when appended events stamp no message", () => {
+    const agent = createAgent({ data: turnData, events: turnEvents });
+    mockUseEveAgent.mockReturnValue(agent as never);
+
+    const { result, rerender } = renderHook(() => useEveAgentRuntime());
+    const first = result.current.thread.getState().messages;
+
+    mockUseEveAgent.mockReturnValue({
+      ...agent,
+      events: [
+        ...turnEvents,
+        {
+          type: "turn.started",
+          data: { sequence: 4, turnId: "turn_next" },
+          meta: { at: "2026-01-02T10:05:00.000Z", id: "evt_4" },
+        },
+      ],
+    } as never);
+    rerender();
+
+    expect(result.current.thread.getState().messages).toBe(first);
   });
 });

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -39,6 +39,10 @@ import {
   getEveMessageContent,
   toEveInputResponse,
 } from "./convertEveMessages";
+import {
+  collectTurnTimestamps,
+  createTurnTimestampCache,
+} from "./deriveCreatedAt";
 import { eveExtras } from "./eveExtras";
 
 const USER_STAGED_STATUS = {
@@ -211,6 +215,14 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     agent.status === "submitted" || agent.status === "streaming";
   const isRunning = providerIsRunning || hasExecutingTools;
 
+  // Kept apart from the message memo so events that teach no timestamp keep
+  // the map identity and skip rebuilding every ThreadMessage.
+  const turnTimestampCacheRef = useRef(createTurnTimestampCache());
+  const turnTimestamps = useMemo(
+    () => collectTurnTimestamps(agent.events, turnTimestampCacheRef.current),
+    [agent.events],
+  );
+
   const convertedMessages = useMemo(() => {
     const createdAtByMessageId = createdAtByMessageIdRef.current;
     const messageIds = new Set(
@@ -224,6 +236,13 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       isRunning,
       error: agent.error,
       getCreatedAt: (message) => {
+        const turnId = message.metadata?.turnId;
+        const durable =
+          turnId === undefined
+            ? undefined
+            : turnTimestamps.get(turnId)?.[message.role];
+        if (durable !== undefined) return durable;
+
         const existing = createdAtByMessageId.get(message.id);
         if (existing) return existing;
 
@@ -232,7 +251,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
         return createdAt;
       },
     });
-  }, [agent.data, agent.error, isRunning]);
+  }, [agent.data, agent.error, isRunning, turnTimestamps]);
 
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -35,8 +35,8 @@
   },
   "@assistant-ui/eve": {
     ".": {
-      "min": 11040,
-      "gzip": 4187
+      "min": 11897,
+      "gzip": 4523
     }
   },
   "@assistant-ui/react": {


### PR DESCRIPTION
Supersedes #5630, now closed so the fix has one canonical PR. Rebuilt from current `main`, with every review ask from that thread answered in the table below.

## Problem

Resume an eve session and the whole history reads as if it just arrived. Every message says "just now", yesterday's conversation included. Eve stamps `meta.at` on every stream event and replays those events on resume, but the adapter never reads them.

Reproduction: `packages/eve/src/useEveAgentRuntime.eveResume.test.tsx` drives the real `useEveAgent` (no `eve/react` mock) with `resume: true` against an offline session whose `stream()` yields a settled turn from 2026-01-02. On `main` both messages render at render time. With this change they render at `10:00:01` (user) and `10:02:00` (assistant). Affects every `@assistant-ui/eve` release.

## Root cause

`useEveAgentRuntime` stamps `createdAt` at first observation from the wall clock and never consults `agent.events`, where eve keeps the durable log with each event's `meta.at`.

## Change

Messages take `createdAt` from the stream event that creates them. Wall-clock stamping stays only where no such event exists (optimistic and failed sends carry no `turnId`); that code is untouched.

- `deriveCreatedAt.ts` scans `agent.events` into a map from turn id to `{user?, assistant?}`. The user message is stamped at `message.received`. The assistant message is stamped at the turn's first event that reaches eve's `updateAssistantMessage`, which is what creates `${turnId}:assistant`; on a normal turn that is `step.started`, and the table enumerates the whole set (fifteen cases across the peer range) so the stamp does not depend on eve's private emission order. First write wins, so the rest of the turn adds nothing. `turn.started` and the compaction events carry a turn id without creating a message and are deliberately absent, because stamping from one would date the assistant before the model ran. Every other event is skipped before any parsing.
- A confirmed message therefore carries eve's server `meta.at` rather than the client's first-observation clock, which is what makes its time survive a reload and agree across devices. Optimistic and failed sends have no durable event and keep the client wall clock, so the two clocks coexist and a skewed server clock shifts the confirmed times relative to the optimistic ones.
- The scan resumes with an O(1) check. Eve's store only appends to the log (`#u = [...this.#u, e]`) and replaces it only in `reset()`, which clears the messages in the same call. A snapshot that keeps the previous scan's last element by identity shares its whole prefix. Any other snapshot is re-derived into a fresh map, because turn ids are per-session sequence numbers (`turn_${sequence}`) that recur after `reset()`.
- The map is copy-on-write. A snapshot that stamps no message returns the same map identity, so the message memo skips the rebuild that reallocates every `ThreadMessage`. Lifecycle events such as `turn.started` leave both `agent.data` (reducer default branch) and the map untouched.
- The cache ref is written during render inside `useMemo`. Under the discarded-render invariant #6473 established this is safe: a returned map is never mutated, and a stale scan position only forces a re-derivation, never a wrong pair.
- Non-spec payloads (`data` not an object, `turnId` not a string, `meta.at` missing or unparseable) are skipped rather than thrown on. Events come off a bare `JSON.parse` of the wire, which is the case the defensive-converters rule covers.

## How each #5630 review ask is resolved

| Ask | Resolution |
| --- | --- |
| @Kinfe123 (changes requested): keep the original timestamp for messages still visible after the event list changes | Checked against eve 0.32.0 and 0.47.6: the only log replacement is `reset()`, which clears the messages with it. A visible message's creating event is always in the append-only log, so its stamp is re-derivable and stable. The per-message retention machinery from #5630 is gone with the scenario. |
| @Kinfe123: merge conflicts | Rebuilt on current `main`. |
| Full-prefix validation is O(N²) over a stream (rupic, cubic, claude-fork, twelve threads) | Replaced by the O(1) last-element identity check those reviewers proposed. Sound under the verified append-only store. |
| Neighbor-bounding pass "invents timestamps", drop it (claude-fork, rupic) | Dropped with its four tests. The fallback is `main`'s existing wall clock. |
| Clearing the map on rescan throws away correct mappings (claude-fork 08-05) | Rejected with evidence. Turn ids recur across sessions, so a retained entry would serve a previous session's time after `reset()`. Fresh map on any non-append snapshot, pinned by a unit test. |
| `"turnId" in event.data` throws on null `data` | Guarded. |
| Comments restate the algorithm | One docblock naming the two hidden invariants (append-only log, recurring turn ids). |
| Fixtures cast to `never` | Typed with `satisfies MessageStreamEvent`. The one remaining cast is the deliberately malformed-payload fixture. |
| Widened memo recompute per event (claude-fork 08-05) | Separate memo plus copy-on-write identity, pinned by the hook identity test across a new turn's `turn.started`. |
| Assistant stamped at the user's send on a live turn (claude-fork 08-11) | Per-role attribution, pinned by the resume test. |
| `agent.events` read unguarded against the peer floor | `events` is a required member of `EveAgentStoreSnapshot` in the published 0.32.0 tarball, as is `meta.at: string`. |
| Does eve's own `resume()` repopulate `agent.events` with `meta.at`? (claude-fork 08-28) | Yes. `EveAgentStore.resume()` replays the session stream through the same append path. The resume test drives that path instead of `initialEvents`. |
| Fixture places `step.started` minutes after receipt, unlike real eve (claude-fork 08-28) | The fixture gap is illustrative. In eve, `step.started` follows `message.received` after attachment staging, model resolution and any compaction, usually milliseconds, as on `main`. Compaction events in that window carry the turn id and are skipped; a unit test pins that. |
| Version drift in the body (rupic) | Floor facts verified in the published 0.32.0 tarball. The suite runs against the lockfile's 0.47.6. |
| `react-pi` generated-surface churn | The diff is `packages/eve` plus one changeset. |

## Verification

- `packages/eve/src/useEveAgentRuntime.eveResume.test.tsx`: unmocked `useEveAgent`, real `EveAgentStore.resume()`, offline session. Fails on `main` (both messages at render time), passes here. With only the `useEveAgentRuntime.ts` wiring reverted, this is the one test that fails.
- `packages/eve/src/deriveCreatedAt.test.ts`: per-role attribution with compaction events and a second step in the turn; incremental resume keeping map identity across a new turn's `turn.started` and then stamping the assistant; a turn cancelled before its first step; malformed payloads skipped without throwing; fresh derivation on a replaced log so a recurring turn id serves the new session.
- `packages/eve/src/useEveAgentRuntime.test.tsx`: wall-clock fallback kept and stable across renders for a turn with no events; message-list identity preserved when an appended `turn.started` stamps no message.
- Suite 170/170 across 6 files on node 24.11.1 with eve 0.47.6. `tsc --noEmit`, oxlint, oxfmt and `pnpm size:check` clean.
- Review before filing: two Codex rounds plus three fresh-context Claude rounds, each adjudicated against the installed eve dist. The last gate was a Claude round because the Codex quota is exhausted until Sep 6; a Codex pass will follow once it resets.

Size: 95 implementation lines (`deriveCreatedAt.ts` 75, runtime 20), 325 test lines, 7 changeset lines.

## Public surface

`@assistant-ui/eve` patch changeset. No new package exports; `deriveCreatedAt.ts` is internal. No docs or API-reference changes. The `@assistant-ui/eve` row in `size-budgets.json` moves from 4187 to 4523 gzip bytes (+8.0%), the derivation module itself. The widened event table adds 71 bytes on top of that, which `size:update` leaves unrecorded because it sits inside the row's tolerance.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wtEfJZBShFf4FZU-IrhUznkAcbHeUD2-sblmI7ICVjRtTsf1n8zzSR1xZqU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
