### PR TITLE
feat: submit message feedback from cloud-persisted threads

### DIFF
--- a/.changeset/cloud-message-feedback.md
+++ b/.changeset/cloud-message-feedback.md
@@ -1,0 +1,6 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/core": patch
+---
+
+feat: submit feedback for cloud-persisted thread messages

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -174,6 +174,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -192,6 +201,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -558,7 +568,7 @@ declare function generateThreadTitle(cloud: AssistantCloud, options: {
 }): Promise<string | null>;
 
 declare namespace entry_root_exports {
-  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, generateThreadTitle, normalizeRunTelemetryUsage, truncateRunTelemetryText, wrapSamplingHandler };
+  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, AssistantCloudThreadMessageFeedbackBody, AssistantCloudThreadMessageFeedbackResponse, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, generateThreadTitle, normalizeRunTelemetryUsage, truncateRunTelemetryText, wrapSamplingHandler };
 }
 
 declare function normalizeRunTelemetryUsage(usage: RunTelemetryUsageInit): RunTelemetryUsage | undefined;

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -180,7 +180,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -262,6 +262,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -280,6 +289,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -268,7 +268,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -178,6 +178,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -196,6 +205,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -184,7 +184,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -283,6 +283,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -301,6 +310,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -4007,6 +4017,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {
@@ -6326,7 +6337,9 @@ declare const useActionBarStopSpeaking: () => {
   disabled: boolean;
 };
 
-declare function useAssistantCloudThreadHistoryAdapter(cloudRef: RefObject<AssistantCloud>): ThreadHistoryAdapter;
+declare function useAssistantCloudThreadHistoryAdapter(cloudRef: RefObject<AssistantCloud>): ThreadHistoryAdapter & {
+  readonly feedback: FeedbackAdapter;
+};
 
 declare const useAssistantContext: (config: AssistantContextConfig) => void;
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -289,7 +289,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -262,6 +262,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -280,6 +289,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -268,7 +268,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -192,7 +192,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -186,6 +186,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -204,6 +213,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -561,7 +561,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -555,6 +555,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -573,6 +582,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -1804,6 +1814,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -264,7 +264,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -258,6 +258,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -276,6 +285,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -2956,6 +2966,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -202,7 +202,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -196,6 +196,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -214,6 +223,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -1513,6 +1523,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -204,7 +204,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -198,6 +198,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -216,6 +225,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -1674,6 +1684,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -262,7 +262,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -256,6 +256,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -274,6 +283,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -2622,6 +2632,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -425,7 +425,7 @@ type AssistantCloudThreadMessageFeedbackBody = {
 
 type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "negative" | "positive";
 };
 
 type AssistantCloudThreadMessageListQuery = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -419,6 +419,15 @@ type AssistantCloudThreadMessageCreateBody = {
   content: ReadonlyJSONObject;
 };
 
+type AssistantCloudThreadMessageFeedbackBody = {
+  type: "negative" | "positive";
+};
+
+type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
@@ -437,6 +446,7 @@ declare class AssistantCloudThreadMessages {
   list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
   create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
   update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  feedback(threadId: string, messageId: string, body: AssistantCloudThreadMessageFeedbackBody): Promise<AssistantCloudThreadMessageFeedbackResponse>;
 }
 
 declare class AssistantCloudThreads {
@@ -3843,6 +3853,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 type RuntimeCapabilities = {

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -61,6 +61,7 @@ type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 const useRuntimeAdapters: () => RuntimeAdapters | null;

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -25,6 +25,7 @@ The `useChatRuntime` hook from `@assistant-ui/ai-sdk` wraps AI SDK's `useChat` a
 2. Persists messages as they complete streaming
 3. Generates a conversation title after the assistant's first response
 4. Loads historical messages when switching threads via `<ThreadList />`
+5. Submits message feedback against the stored cloud message
 
 You provide the cloud configuration—everything else is handled. The default `AssistantChatTransport` automatically sends requests to `/api/chat`.
 
@@ -334,7 +335,7 @@ export function Chat() {
               name: "feedback",
               type: "FeedbackAdapter",
               description:
-                "Adapter for collecting user feedback on messages.",
+                "Adapter for collecting user feedback on messages. Defaults to the Assistant Cloud feedback adapter when `cloud` is set.",
             },
             {
               name: "history",

--- a/apps/docs/content/docs/cloud/index.mdx
+++ b/apps/docs/content/docs/cloud/index.mdx
@@ -10,6 +10,7 @@ Assistant Cloud is a hosted service that adds thread management, message persist
 - **Thread Persistence** — Messages automatically save as conversations progress. Users can resume chats at any time, even across sessions.
 - **Thread List** — Built-in UI components (or hooks) for browsing, switching, and managing conversations.
 - **Auto-Generated Titles** — Conversations get meaningful titles based on the initial messages.
+- **Message Feedback** — Positive and negative ratings persist against the stored message, so the feedback buttons work without a custom adapter.
 - **User Authorization** — Integrates with your auth provider to scope threads per user or workspace.
 
 ## Supported Backends

--- a/packages/cloud/src/AssistantCloudThreadMessages.test.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.test.ts
@@ -57,6 +57,15 @@ describe("AssistantCloudThreadMessages responses", () => {
     await expect(
       messages.feedback("thread-1", "message-1", body),
     ).rejects.toBeInstanceOf(CloudResponseError);
+
+    makeRequest.mockResolvedValueOnce({
+      feedback_id: "feedback-1",
+      type: "neutral",
+    });
+
+    await expect(
+      messages.feedback("thread-1", "message-1", body),
+    ).rejects.toThrow('expected one of "positive", "negative"');
   });
 
   it("decodes canonical message responses without changing content", async () => {

--- a/packages/cloud/src/AssistantCloudThreadMessages.test.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
 import { AssistantCloudThreadMessages } from "./AssistantCloudThreadMessages";
+import { CloudResponseError } from "./cloudResponse";
 
 const createCloudThreadMessages = () => {
   const makeRequest = vi.fn();
@@ -30,6 +31,32 @@ describe("AssistantCloudThreadMessages responses", () => {
     await expect(messages.create("thread-1", body)).rejects.toThrow(
       'Invalid Assistant Cloud response for "message_id": expected a string',
     );
+  });
+
+  it("submits and validates message feedback", async () => {
+    const { messages, makeRequest } = createCloudThreadMessages();
+    const body = { type: "positive" as const };
+    makeRequest.mockResolvedValueOnce({
+      feedback_id: "feedback-1",
+      type: "positive",
+    });
+
+    await expect(
+      messages.feedback("thread/1", "message/1", body),
+    ).resolves.toEqual({
+      feedback_id: "feedback-1",
+      type: "positive",
+    });
+    expect(makeRequest).toHaveBeenCalledWith(
+      "/threads/thread%2F1/messages/message%2F1/feedback",
+      { method: "POST", body },
+    );
+
+    makeRequest.mockResolvedValueOnce({ type: "positive" });
+
+    await expect(
+      messages.feedback("thread-1", "message-1", body),
+    ).rejects.toBeInstanceOf(CloudResponseError);
   });
 
   it("decodes canonical message responses without changing content", async () => {

--- a/packages/cloud/src/AssistantCloudThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.ts
@@ -42,6 +42,15 @@ type AssistantCloudThreadMessageUpdateBody = {
   content: ReadonlyJSONObject;
 };
 
+export type AssistantCloudThreadMessageFeedbackBody = {
+  type: "positive" | "negative";
+};
+
+export type AssistantCloudThreadMessageFeedbackResponse = {
+  feedback_id: string;
+  type: string;
+};
+
 export const decodeCloudMessage = (
   value: unknown,
   field: string,
@@ -111,5 +120,24 @@ export class AssistantCloudThreadMessages {
       `/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}`,
       { method: "PUT", body },
     );
+  }
+
+  public async feedback(
+    threadId: string,
+    messageId: string,
+    body: AssistantCloudThreadMessageFeedbackBody,
+  ): Promise<AssistantCloudThreadMessageFeedbackResponse> {
+    const response = readCloudRecord(
+      await this.cloud.makeRequest(
+        `/threads/${encodeURIComponent(threadId)}/messages/${encodeURIComponent(messageId)}/feedback`,
+        { method: "POST", body },
+      ),
+      "thread message feedback response",
+    );
+
+    return {
+      feedback_id: readCloudString(response.feedback_id, "feedback_id"),
+      type: readCloudString(response.type, "type"),
+    };
   }
 }

--- a/packages/cloud/src/AssistantCloudThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.ts
@@ -2,6 +2,7 @@ import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
 import {
   readCloudArray,
+  readCloudEnum,
   readCloudInteger,
   readCloudJSONObject,
   readCloudNullableString,
@@ -42,13 +43,15 @@ type AssistantCloudThreadMessageUpdateBody = {
   content: ReadonlyJSONObject;
 };
 
+const MESSAGE_FEEDBACK_TYPES = ["positive", "negative"] as const;
+
 export type AssistantCloudThreadMessageFeedbackBody = {
   type: "positive" | "negative";
 };
 
 export type AssistantCloudThreadMessageFeedbackResponse = {
   feedback_id: string;
-  type: string;
+  type: "positive" | "negative";
 };
 
 export const decodeCloudMessage = (
@@ -137,7 +140,7 @@ export class AssistantCloudThreadMessages {
 
     return {
       feedback_id: readCloudString(response.feedback_id, "feedback_id"),
-      type: readCloudString(response.type, "type"),
+      type: readCloudEnum(response.type, "type", MESSAGE_FEEDBACK_TYPES),
     };
   }
 }

--- a/packages/cloud/src/cloudResponse.ts
+++ b/packages/cloud/src/cloudResponse.ts
@@ -32,6 +32,21 @@ export const readCloudString = (value: unknown, field: string): string => {
   return value;
 };
 
+export const readCloudEnum = <const T extends readonly string[]>(
+  value: unknown,
+  field: string,
+  allowed: T,
+): T[number] => {
+  const text = readCloudString(value, field);
+  if (!allowed.includes(text)) {
+    throw invalidCloudResponse(
+      field,
+      `one of ${allowed.map((entry) => `"${entry}"`).join(", ")}`,
+    );
+  }
+  return text;
+};
+
 export const readCloudNullableString = (
   value: unknown,
   field: string,

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -1,4 +1,8 @@
-export type { CloudMessage } from "./AssistantCloudThreadMessages";
+export type {
+  CloudMessage,
+  AssistantCloudThreadMessageFeedbackBody,
+  AssistantCloudThreadMessageFeedbackResponse,
+} from "./AssistantCloudThreadMessages";
 export type { AssistantCloudTelemetryConfig } from "./AssistantCloudAPI";
 export { CloudAPIError } from "./AssistantCloudAPI";
 export { CloudResponseError } from "./cloudResponse";

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { AssistantCloud } from "assistant-cloud";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadAssistantMessage } from "../../../types/message";
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 
 const mocks = vi.hoisted(() => {
@@ -64,11 +65,34 @@ const makeCloud = () =>
         list: vi.fn().mockResolvedValue({ messages: [] }),
         create: vi.fn().mockResolvedValue({ message_id: "remote-message-1" }),
         update: vi.fn().mockResolvedValue(undefined),
+        feedback: vi.fn().mockResolvedValue({
+          feedback_id: "feedback-1",
+          type: "positive",
+        }),
       },
     },
     telemetry: { enabled: true },
     runs: { report: vi.fn().mockResolvedValue(undefined) },
   }) as unknown as AssistantCloud;
+
+const makeAssistantMessage = (id: string): ThreadAssistantMessage => ({
+  id,
+  role: "assistant",
+  content: [{ type: "text", text: "done" }],
+  status: { type: "complete", reason: "stop" },
+  createdAt: new Date(0),
+  metadata: {
+    unstable_state: null,
+    unstable_annotations: [],
+    unstable_data: [],
+    steps: [],
+    custom: {},
+  },
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useAssistantCloudThreadHistoryAdapter", () => {
   it("refreshes formatted persistence when the Cloud client changes", async () => {
@@ -159,6 +183,91 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await result.current.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
       format: "aui/v0",
+    });
+  });
+
+  it("submits feedback with the mapped cloud message ID", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    await result.current.append({ parentId: null, message });
+    result.current.feedback.submit({ message, type: "positive" });
+
+    await waitFor(() => {
+      expect(cloud.threads.messages.feedback).toHaveBeenCalledWith(
+        "thread-1",
+        "remote-message-1",
+        { type: "positive" },
+      );
+    });
+  });
+
+  it("warns and skips feedback before the thread has a remote ID", async () => {
+    mocks.aui = mocks.makeClient(undefined, "local-thread", "thread-1");
+    const cloud = makeCloud();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    result.current.feedback.submit({ message, type: "negative" });
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        "[assistant-ui] Skipping feedback for message local-message-1: the thread has no remote id.",
+      );
+    });
+    expect(cloud.threads.messages.feedback).not.toHaveBeenCalled();
+  });
+
+  it("warns and skips feedback before the message has a cloud ID", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    result.current.feedback.submit({ message, type: "negative" });
+
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        "[assistant-ui] Skipping feedback for message local-message-1: no cloud message id is mapped.",
+      );
+    });
+    expect(cloud.threads.messages.feedback).not.toHaveBeenCalled();
+  });
+
+  it("reports cloud feedback errors without throwing them into the UI", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const error = new Error("feedback unavailable");
+    vi.mocked(cloud.threads.messages.feedback).mockRejectedValue(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter({ current: cloud }),
+    );
+    const message = makeAssistantMessage("local-message-1");
+
+    await result.current.append({ parentId: null, message });
+    expect(() =>
+      result.current.feedback.submit({ message, type: "positive" }),
+    ).not.toThrow();
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Cloud feedback submission failed:",
+        error,
+      );
     });
   });
 

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -20,6 +20,7 @@ import {
 import { auiV0Decode, auiV0Encode } from "./auiV0";
 import { type AssistantClient, getClientId, useAui } from "@assistant-ui/store";
 import type { ThreadListItemMethods } from "../../../store/scopes/thread-list-item";
+import type { FeedbackAdapter } from "../../../adapters/feedback";
 
 type CloudThreadListItem = Pick<
   ThreadListItemMethods,
@@ -63,6 +64,42 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private get _persistence(): CloudMessagePersistence {
     return this.getPersistence();
   }
+
+  public readonly feedback: FeedbackAdapter = {
+    submit: ({ message, type }) => {
+      void (async () => {
+        const threadListItem = this.tryGetKeyedThreadListItem();
+        const remoteThreadId = threadListItem?.getState().remoteId;
+        if (!threadListItem || !remoteThreadId) {
+          console.warn(
+            `[assistant-ui] Skipping feedback for message ${message.id}: the thread has no remote id.`,
+          );
+          return;
+        }
+
+        const cloudMessageId = await this.getPersistence(
+          threadListItem,
+        ).getRemoteId(message.id);
+        if (!cloudMessageId) {
+          console.warn(
+            `[assistant-ui] Skipping feedback for message ${message.id}: no cloud message id is mapped.`,
+          );
+          return;
+        }
+
+        await this.cloudRef.current.threads.messages.feedback(
+          remoteThreadId,
+          cloudMessageId,
+          { type },
+        );
+      })().catch((error: unknown) => {
+        console.error(
+          "[assistant-ui] Cloud feedback submission failed:",
+          error,
+        );
+      });
+    },
+  };
 
   private tryGetKeyedThreadListItem(): CloudThreadListItem | undefined {
     const live = this.aui.threadListItem;
@@ -766,7 +803,7 @@ function aggregateAiSdkV6RunSteps<T>(stepMessages: T[]): TelemetryData | null {
 
 export function useAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
-): ThreadHistoryAdapter {
+): ThreadHistoryAdapter & { readonly feedback: FeedbackAdapter } {
   const aui = useAui();
   // Not useEffectEvent: history adapter methods run during render (SSR load).
   const auiRef = useRef(aui);

--- a/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/createCloudThreadListAdapter.ts
@@ -43,6 +43,7 @@ export const useCloudRuntimeAdapters = (
     () => ({
       history,
       attachments,
+      feedback: history.feedback,
     }),
     [history, attachments],
   );

--- a/packages/core/src/react/runtimes/useExternalStoreRuntime.lifecycle.test.tsx
+++ b/packages/core/src/react/runtimes/useExternalStoreRuntime.lifecycle.test.tsx
@@ -5,8 +5,46 @@ import { act, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import { RuntimeAdapterProvider } from "./RuntimeAdapterProvider";
 
 describe("useExternalStoreRuntime lifecycle", () => {
+  it("uses feedback supplied by the per-thread adapter context", () => {
+    const submit = vi.fn();
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+    const App = () => {
+      const runtime = useExternalStoreRuntime({
+        messages: [
+          {
+            id: "user-1",
+            role: "user" as const,
+            content: "hello",
+            createdAt: new Date(0),
+          },
+        ],
+        onNew: async () => {},
+      });
+      capture.runtime = runtime;
+      return null;
+    };
+
+    render(
+      <RuntimeAdapterProvider adapters={{ feedback: { submit } }}>
+        <App />
+      </RuntimeAdapterProvider>,
+    );
+
+    expect(capture.runtime!.thread.getState().capabilities.feedback).toBe(true);
+    act(() => {
+      capture
+        .runtime!.thread.getMessageById("user-1")
+        .submitFeedback({ type: "positive" });
+    });
+    expect(submit).toHaveBeenCalledWith({
+      message: expect.objectContaining({ id: "user-1" }),
+      type: "positive",
+    });
+  });
+
   it("keeps dispatching appends after StrictMode's simulated remount", async () => {
     const onNew = vi.fn(async () => {});
     const capture: { runtime: AssistantRuntime | null } = { runtime: null };

--- a/packages/core/src/react/runtimes/useExternalStoreRuntime.lifecycle.test.tsx
+++ b/packages/core/src/react/runtimes/useExternalStoreRuntime.lifecycle.test.tsx
@@ -5,7 +5,17 @@ import { act, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import type { ThreadMessage } from "../../types/message";
 import { RuntimeAdapterProvider } from "./RuntimeAdapterProvider";
+
+const userMessage: ThreadMessage = {
+  id: "user-1",
+  role: "user",
+  content: [{ type: "text", text: "hello" }],
+  attachments: [],
+  createdAt: new Date(0),
+  metadata: { custom: {} },
+};
 
 describe("useExternalStoreRuntime lifecycle", () => {
   it("uses feedback supplied by the per-thread adapter context", () => {
@@ -13,14 +23,7 @@ describe("useExternalStoreRuntime lifecycle", () => {
     const capture: { runtime: AssistantRuntime | null } = { runtime: null };
     const App = () => {
       const runtime = useExternalStoreRuntime({
-        messages: [
-          {
-            id: "user-1",
-            role: "user" as const,
-            content: "hello",
-            createdAt: new Date(0),
-          },
-        ],
+        messages: [userMessage],
         onNew: async () => {},
       });
       capture.runtime = runtime;

--- a/packages/core/src/react/runtimes/useExternalStoreRuntime.ts
+++ b/packages/core/src/react/runtimes/useExternalStoreRuntime.ts
@@ -11,7 +11,15 @@ import { useRuntimeAdapters } from "./RuntimeAdapterProvider";
 export const useExternalStoreRuntime = <T>(
   store: ExternalStoreAdapter<T>,
 ): AssistantRuntime => {
-  const [runtime] = useState(() => new ExternalStoreRuntimeCore(store));
+  const { modelContext, feedback } = useRuntimeAdapters() ?? {};
+  const adaptedStore = useMemo(() => {
+    if (!feedback || store.adapters?.feedback) return store;
+    return {
+      ...store,
+      adapters: { ...store.adapters, feedback },
+    };
+  }, [feedback, store]);
+  const [runtime] = useState(() => new ExternalStoreRuntimeCore(adaptedStore));
 
   useEffect(() => {
     return () => {
@@ -20,10 +28,8 @@ export const useExternalStoreRuntime = <T>(
   }, [runtime]);
 
   useEffect(() => {
-    runtime.setAdapter(store);
+    runtime.setAdapter(adaptedStore);
   });
-
-  const { modelContext } = useRuntimeAdapters() ?? {};
 
   useEffect(() => {
     if (!modelContext) return undefined;

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -32,6 +32,26 @@ afterEach(() => {
 });
 
 describe("useLocalRuntime", () => {
+  it("enables feedback for Cloud threads", async () => {
+    const cloud = makeCloud();
+    let runtime: ReturnType<typeof useLocalRuntime> | null = null;
+    const App = () => {
+      runtime = useLocalRuntime(chatModel, { cloud });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <div />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(cloud.threads.list).toHaveBeenCalledTimes(2);
+      expect(runtime!.thread.getState().capabilities.feedback).toBe(true);
+    });
+  });
+
   it("surfaces the live thread after mount without user input", async () => {
     const auiRef: { current: ReturnType<typeof useAui> | null } = {
       current: null,

--- a/packages/core/src/runtimes/remote-thread-list/types.ts
+++ b/packages/core/src/runtimes/remote-thread-list/types.ts
@@ -3,6 +3,7 @@ import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
 import type { AssistantStream } from "assistant-stream";
 import type { ThreadHistoryAdapter } from "../../adapters/thread-history";
 import type { AttachmentAdapter } from "../../adapters/attachment";
+import type { FeedbackAdapter } from "../../adapters/feedback";
 import type { ModelContextProvider } from "../../model-context/types";
 
 /* oxlint-disable typescript/no-explicit-any -- structural stand-in for ComponentType without depending on react types */
@@ -40,6 +41,7 @@ export type RuntimeAdapters = {
   modelContext?: ModelContextProvider | undefined;
   history?: ThreadHistoryAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
+  feedback?: FeedbackAdapter | undefined;
 };
 
 export type RemoteThreadListAdapter = {


### PR DESCRIPTION
## problem

assistant cloud stores threads and messages, but there was no way to record what a user thought of an answer. the `FeedbackAdapter` seam has existed for a while, so `<Thread />`'s thumbs-up and thumbs-down buttons render, but on the cloud path every host had to write and wire its own adapter to make them do anything, and there was no cloud endpoint on the client to write to.

## change

- `AssistantCloudThreadMessages.feedback(threadId, messageId, { type })` posts to `/threads/:threadId/messages/:messageId/feedback` and validates the response through the existing `readCloudRecord` / `readCloudString` helpers, so a shape the server did not promise fails as a `CloudResponseError` instead of surfacing as `undefined` later. the response `type` is decoded through a new `readCloudEnum` (package-internal, the next member of the `cloudResponse.ts` reader family) so it is typed and validated as the same `"positive" | "negative"` union the request body uses, rather than a bare string.
- `AssistantCloudThreadHistoryAdapter` grows a `feedback` adapter. it resolves the message's cloud id through the same `CloudMessagePersistence` id mapping the history writes use, so feedback lands on the stored message rather than on a local id. submission is fire-and-forget because `FeedbackAdapter.submit` returns void: a missing thread remote id or an unmapped message warns and skips, and a failed request is reported through `console.error` rather than thrown into the render path.
- `feedback` joins `RuntimeAdapters`, and `useCloudRuntimeAdapters` publishes the history adapter's instance, so every cloud-backed runtime picks it up from the shared adapter context with no per-host wiring.
- `useExternalStoreRuntime` now reads `feedback` off that context and injects it when the store does not carry its own. this is what gives the external-store runtimes parity: react-ag-ui, react-a2a, eve and the ai-sdk runtime all funnel through it, so none of them needed a change. an explicit `store.adapters.feedback` still wins.

## verification

- [x] `pnpm --filter assistant-cloud --filter @assistant-ui/core test` -> 112 and 1627 pass.
- [x] oxlint and oxfmt clean on every touched file.
- [x] new tests cover the cloud client three ways (valid response decoded, missing `feedback_id` rejected, unsupported `type` rejected with `expected one of "positive", "negative"`), the adapter's happy path against the mapped remote id, both skip warnings, the error path staying out of the UI, and the context injection in the external-store and local runtimes.
- [x] read the server handler on `assistant-cloud` main: the route is mounted at `POST /:messageId/feedback`, it returns `{ feedback_id, type }`, and `MESSAGE_FEEDBACK_TYPES` is `["positive", "negative"]`, matching the request body union and the response decoder exactly.
- [x] checked parity by running the ag-ui and a2a store shape (an `adapters` object whose `feedback` is `undefined`) through `useExternalStoreRuntime`: `capabilities.feedback` flips true and the context adapter receives the submission.
- [ ] note on types: a bare per-package `tsc --noEmit` is red in this repo on an unbuilt tree (27 core test files and 1 cloud test file, none of them touched here). the type error this PR did introduce, in `useExternalStoreRuntime.lifecycle.test.tsx`, is fixed. the authoritative signals are CI's Build Changed Packages and Test Changed Packages.

## public surface

- `assistant-cloud`: new `AssistantCloudThreadMessages.feedback` method, and two new exported types (`AssistantCloudThreadMessageFeedbackBody`, `AssistantCloudThreadMessageFeedbackResponse`). `readCloudEnum` is internal to the package and not exported from the entry. additive only.
- `@assistant-ui/core`: `RuntimeAdapters` gains an optional `feedback` field. additive only.
- docs: the cloud overview lists message feedback, and the ai-sdk cloud guide notes that the feedback adapter now defaults to the cloud one when `cloud` is set.
- api-surface and api-reference snapshots regenerated by autofix.ci.
- changeset: patch for both published packages. the docs app is private, so it is not named.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sEWNv9gyaX2_LxhG08aBQovjH6qeVqZrf27dTbRwa0Wp2CppygSq3yv7r2o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->