### PR TITLE
fix(ui): show the source icon fallback when a favicon fails before hydration

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/sources.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/sources.aui.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SourceIcon } from "./sources.aui";
 
@@ -69,5 +69,17 @@ describe("SourceIcon", () => {
     fireEvent.error(image);
 
     expect(screen.getByText("E")).toBeTruthy();
+  });
+
+  it("detects the failure even when the caller passes a ref", () => {
+    stubImage(true, 0);
+    const callerRef = vi.fn();
+
+    render(<SourceIcon url="https://example.com/reference" ref={callerRef} />);
+
+    expect(screen.getByText("E")).toBeTruthy();
+    expect(callerRef).toHaveBeenCalledWith(
+      screen.getByText("E") as HTMLSpanElement,
+    );
   });
 });

--- a/packages/ui/src/components/react/assistant-ui/elements/sources.aui.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/sources.aui.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SourceIcon } from "./sources.aui";
+
+const imageDescriptors = {
+  complete: Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    "complete",
+  )!,
+  naturalWidth: Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    "naturalWidth",
+  )!,
+};
+
+const stubImage = (complete: boolean, naturalWidth: number) => {
+  Object.defineProperties(HTMLImageElement.prototype, {
+    complete: { configurable: true, get: () => complete },
+    naturalWidth: { configurable: true, get: () => naturalWidth },
+  });
+};
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperties(HTMLImageElement.prototype, imageDescriptors);
+});
+
+const renderIcon = () =>
+  render(<SourceIcon url="https://example.com/reference" />);
+
+describe("SourceIcon", () => {
+  it("falls back to the domain initial when the image failed before mount", () => {
+    stubImage(true, 0);
+
+    const { container } = renderIcon();
+
+    expect(screen.getByText("E")).toBeTruthy();
+    expect(container.querySelector('[data-slot="source-icon"]')).toBeNull();
+  });
+
+  it("keeps the image while it is still loading", () => {
+    stubImage(false, 0);
+
+    const { container } = renderIcon();
+
+    expect(container.querySelector('[data-slot="source-icon"]')).toBeTruthy();
+    expect(
+      container.querySelector('[data-slot="source-icon-fallback"]'),
+    ).toBeNull();
+  });
+
+  it("keeps an image that loaded", () => {
+    stubImage(true, 16);
+
+    const { container } = renderIcon();
+
+    expect(container.querySelector('[data-slot="source-icon"]')).toBeTruthy();
+    expect(
+      container.querySelector('[data-slot="source-icon-fallback"]'),
+    ).toBeNull();
+  });
+
+  it("falls back when a loading image errors after mount", () => {
+    stubImage(false, 0);
+
+    const { container } = renderIcon();
+    const image = container.querySelector('[data-slot="source-icon"]')!;
+    fireEvent.error(image);
+
+    expect(screen.getByText("E")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/react/assistant-ui/elements/sources.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/sources.aui.tsx
@@ -87,12 +87,12 @@ function SourceIcon({
       src={src}
       alt=""
       className={cn("size-3 shrink-0 rounded-sm", className)}
+      onError={() => setErrorSrc(src)}
+      {...(props as ComponentProps<"img">)}
       // A server-rendered image that fails before hydration never fires onError.
       ref={(el) => {
         if (el?.complete && el.naturalWidth === 0) setErrorSrc(src);
       }}
-      onError={() => setErrorSrc(src)}
-      {...(props as ComponentProps<"img">)}
     />
   );
 }

--- a/packages/ui/src/components/react/assistant-ui/elements/sources.aui.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/sources.aui.tsx
@@ -87,6 +87,10 @@ function SourceIcon({
       src={src}
       alt=""
       className={cn("size-3 shrink-0 rounded-sm", className)}
+      // A server-rendered image that fails before hydration never fires onError.
+      ref={(el) => {
+        if (el?.complete && el.naturalWidth === 0) setErrorSrc(src);
+      }}
       onError={() => setErrorSrc(src)}
       {...(props as ComponentProps<"img">)}
     />


### PR DESCRIPTION
## Problem

`SourceIcon` promises a fallback: when a favicon fails to load, it renders the domain's first letter in place of the image. Server-rendered, it does not. A source whose favicon 404s keeps a broken image icon forever.

Reproduced on the docs elements page with a favicon path that does not resolve: the server-rendered HTML ships the `<img>` with no fallback, and on the client that image reports `complete: true, naturalWidth: 0`, meaning it finished and failed, while the fallback never renders.

## Root cause

The component learns about failure only through `onError`. React attaches that handler during hydration, and it does not replay a media error that already fired before then, so `errorSrc` never updates and `hasError` stays false. The same hole swallows an image already cached as failed when a client navigation mounts the icon.

## Change

A ref callback on the `<img>` checks the state the missed event would have reported: an image that is `complete` with `naturalWidth === 0` has failed, so the fallback renders on mount. `onError` still covers the ordinary case where the image is still loading when it mounts.

The ref sits after the prop spread so a caller-supplied ref cannot replace it and silently disable the fallback. Composing the two would mean designing ref forwarding for a component that renders an `img` while loading and a `span` once it falls back, from one props type that describes only the span; the fallback `span` still spreads props untouched, so a caller ref lands where that type actually fits.

## Verification

- `packages/ui`: `vitest run` is green (20 files, 713 passed, 16 skipped), including a new colocated `sources.aui.test.tsx` covering the failed-before-mount case, the still-loading case, the loaded case, the post-mount error, and a caller-supplied ref. Removing the ref check fails the first of those and passes the other three, so the test measures the fix rather than the component.
- `oxlint` and `oxfmt --check` clean on both files; `tsc --noEmit` adds no error in either (`packages/ui` carries five pre-existing errors in `image.test.tsx`, `thread-list.aui.test.tsx`, and the two Vue tests, unchanged by this diff).
- In a browser: with a 404 favicon the fallback now renders after SSR where it previously did not, and on the elements page all nine working favicons still render as images with zero spurious fallbacks.

## Public surface

`@assistant-ui/ui` is private, so no changeset. The file is registry-distributed, so the behavior reaches user projects through `shadcn add` rather than through an npm version.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1j1Sz8vtO7-gbxEYOONUiWh1DVe836Ke7R2BeTPvB3c1DSycPMkEaLKByfY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->