### PR TITLE
fix: align docs with source and export SpanPrimitive.ChildByIndex

### DIFF
--- a/.changeset/react-o11y-child-by-index.md
+++ b/.changeset/react-o11y-child-by-index.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-o11y": patch
+---
+
+export `SpanPrimitive.ChildByIndex`, which the docs already describe, so a row can be scoped to one span index without wiring `SpanByIndexProvider` by hand

--- a/api-surface/assistant-ui__react-o11y.ts
+++ b/api-surface/assistant-ui__react-o11y.ts
@@ -104,6 +104,15 @@ type SpanMethods = {
   toggleCollapse: () => void;
 };
 
+declare namespace SpanPrimitiveChildByIndex {
+  type Props = {
+    index: number;
+    components: SpanChildrenComponentConfig;
+  };
+}
+
+declare const SpanPrimitiveChildByIndex: FC<SpanPrimitiveChildByIndex.Props>;
+
 declare namespace SpanPrimitiveChildren {
   type Props = {
     components: SpanChildrenComponentConfig;
@@ -242,7 +251,7 @@ declare namespace entry_root_exports {
 }
 
 declare namespace span_d_exports {
-  export { SpanPrimitiveChildren as Children, SpanPrimitiveCollapseToggle as CollapseToggle, SpanPrimitiveIndent as Indent, SpanPrimitiveName as Name, SpanPrimitiveRoot as Root, SpanTimelineRange, SpanPrimitiveStatusIndicator as StatusIndicator, SpanPrimitiveTimeline as Timeline, SpanPrimitiveTimelineBar as TimelineBar, SpanPrimitiveTypeBadge as TypeBadge };
+  export { SpanPrimitiveChildByIndex as ChildByIndex, SpanPrimitiveChildren as Children, SpanPrimitiveCollapseToggle as CollapseToggle, SpanPrimitiveIndent as Indent, SpanPrimitiveName as Name, SpanPrimitiveRoot as Root, SpanTimelineRange, SpanPrimitiveStatusIndicator as StatusIndicator, SpanPrimitiveTimeline as Timeline, SpanPrimitiveTimelineBar as TimelineBar, SpanPrimitiveTypeBadge as TypeBadge };
 }
 
 export { entry_root_exports as entry_root };

--- a/apps/docs/content/docs/(getting-started)/rtl.mdx
+++ b/apps/docs/content/docs/(getting-started)/rtl.mdx
@@ -4,7 +4,7 @@ description: Use assistant-ui with right-to-left languages like Arabic, Hebrew, 
 platforms: ["react"]
 ---
 
-Components shipped through `@assistant-ui/ui` (npm) and the shadcn registry (`npx shadcn@latest add @assistant-ui/<name>`) use logical Tailwind classes (`ms-*`, `pe-*`, `text-start`, `end-*`, `border-s`, ...). They flip automatically under `dir="rtl"` and render byte-identically under `dir="ltr"` (the default) — there is nothing to opt out of.
+Components shipped through the shadcn registry (`npx shadcn@latest add @assistant-ui/<name>`) use logical Tailwind classes (`ms-*`, `pe-*`, `text-start`, `end-*`, `border-s`, ...). They flip automatically under `dir="rtl"` and render byte-identically under `dir="ltr"` (the default) — there is nothing to opt out of.
 
 If you scaffolded from one of our templates (e.g. `npx assistant-ui@latest create -t default`), the generated `components/` folder still uses physical classes (`ml-*`, `text-left`, ...). Run shadcn's built-in migration **once** to convert both the shadcn primitives and assistant-ui's wrappers:
 
@@ -56,7 +56,7 @@ For apps that need to switch direction at runtime, drive `dir` from state and al
 
 ## How it works
 
-Every physical class (`ml-4`, `text-left`, `right-3`, `border-l`, ...) in `@assistant-ui/ui` is authored in logical form (`ms-4`, `text-start`, `end-3`, `border-s`, ...). Logical properties resolve to the matching physical side based on the ancestor with a `dir` attribute:
+Every physical class (`ml-4`, `text-left`, `right-3`, `border-l`, ...) in the registry components is authored in logical form (`ms-4`, `text-start`, `end-3`, `border-s`, ...). Logical properties resolve to the matching physical side based on the ancestor with a `dir` attribute:
 
 | Class | `dir="ltr"` | `dir="rtl"` |
 | ----- | ----------- | ----------- |

--- a/apps/docs/content/docs/(reference)/api-reference/generative-ui/tokens.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/generative-ui/tokens.mdx
@@ -36,6 +36,12 @@ const BUTTON_STYLES: readonly ["primary", "secondary", "outline", "ghost", "dang
 const COLORS: readonly ["emphasis", "secondary", "alpha-70", "white", "white-70", "white-50"];
 ```
 
+### ICON_NAMES
+
+```ts
+const ICON_NAMES: readonly ["sun", "moon", "cloud", "rain", "snow", "wind", "play", "pause", "check", "x", "star", "heart", "arrow-right", "arrow-up-right", "chevron-right", "calendar", "clock", "map-pin", "plane", "truck", "credit-card", "user", "search", "bell"];
+```
+
 ### IMAGE_SIZE_TOKENS
 
 ```ts

--- a/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/tools/component-tools.mdx
@@ -27,7 +27,7 @@ import { useAssistantTool } from "@/generated/typeDocs";
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use a toolkit with `Tools({ toolkit })` and register it via
-`useAui({ tools: Tools({ toolkit }) })` instead. See
+`AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
 https://assistant-ui.com/docs/migrations/toolkit-tools.
 </Callout>
 
@@ -51,7 +51,7 @@ const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: 
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use a toolkit with `Tools({ toolkit })` and register it via
-`useAui({ tools: Tools({ toolkit }) })` instead. See
+`AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
 https://assistant-ui.com/docs/migrations/toolkit-tools.
 </Callout>
 

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -19,7 +19,7 @@ This integration provides:
 
 ## How It Works
 
-The `useChatRuntime` hook from `@assistant-ui/ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` / `createAssistantClient` hosts. That host mounts only the visible thread, so a switch cancels an in-flight run. The runtime automatically:
+The `useChatRuntime` hook from `@assistant-ui/ai-sdk` wraps AI SDK's `useChat` and adds cloud persistence via the `cloud` parameter. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` / `createAssistantClient` hosts. With `cloud` bound it keeps every visited thread mounted, so a run continues after a switch and its exchange is still persisted. The runtime automatically:
 
 1. Creates a cloud thread on the first user message
 2. Persists messages as they complete streaming

--- a/apps/docs/content/docs/guides/image-generation.mdx
+++ b/apps/docs/content/docs/guides/image-generation.mdx
@@ -52,7 +52,7 @@ const part: ImageMessagePart = {
 
 ## Render with the `Image` component
 
-The `Image` component in `@assistant-ui/ui` handles the render states for you:
+The `image` element (`npx assistant-ui@latest add image`, installed at `components/assistant-ui/elements/image.tsx`) handles the render states for you:
 
 1. **Running** (`status.type === "running"`) renders a spinner.
 2. **Content filter** (`status.type === "incomplete"` with `reason: "content-filter"`) renders an error card with no `<img src>`.
@@ -61,7 +61,7 @@ The `Image` component in `@assistant-ui/ui` handles the render states for you:
 `Image.Actions` provides download and copy buttons, plus a regenerate button when you pass an `onRegenerate` callback. Wire it to the same generation flow you used above; debounce, rate limiting, and confirmation are your call.
 
 ```tsx
-import { Image } from "@assistant-ui/ui";
+import { Image } from "@/components/assistant-ui/elements/image";
 
 <>
   <Image {...imagePart} />

--- a/apps/docs/content/docs/guides/image-generation.mdx
+++ b/apps/docs/content/docs/guides/image-generation.mdx
@@ -3,7 +3,7 @@ title: Image Generation
 description: Generate images in your backend and render them inline in an assistant-ui thread.
 ---
 
-Image generation needs no dedicated primitive. Generate the image wherever you already run model calls (a route handler or a tool), store the result as an `ImageMessagePart`, and render it with the `@assistant-ui/ui` `Image` component.
+Image generation needs no dedicated primitive. Generate the image wherever you already run model calls (a route handler or a tool), store the result as an `ImageMessagePart`, and render it with the `image` element (`npx assistant-ui@latest add image`).
 
 <Callout type="info">
   This covers non-streaming generation, rendering, and actions. Streaming partial images and multi-image galleries are out of scope.

--- a/apps/docs/content/docs/ink/migration.mdx
+++ b/apps/docs/content/docs/ink/migration.mdx
@@ -20,7 +20,7 @@ If you already have an assistant-ui web app, most of your code transfers directl
 | `AssistantRuntimeProvider` | `AssistantRuntimeProvider` (same name, from `@assistant-ui/react-ink`) |
 | DOM primitives (`div`, `button`, `input`) | Ink primitives (`Box`, `Text`, `TextInput`) |
 | CSS / Tailwind styling | Ink's flexbox + ANSI colors |
-| `@assistant-ui/ui` (shadcn components) | Build your own terminal UI with primitives |
+| Styled registry elements (shadcn components) | Build your own terminal UI with primitives |
 | `@assistant-ui/react-markdown` | `@assistant-ui/react-ink-markdown` (ANSI-rendered markdown) |
 
 ## Step-by-step

--- a/apps/docs/content/docs/react-native/migration.mdx
+++ b/apps/docs/content/docs/react-native/migration.mdx
@@ -20,7 +20,7 @@ If you already have an assistant-ui web app, most of your code transfers directl
 | `AssistantRuntimeProvider` | `AssistantRuntimeProvider` (same name) |
 | DOM primitives (`div`, `button`, `input`) | Native primitives (`View`, `Pressable`, `TextInput`) |
 | CSS / Tailwind styling | React Native `StyleSheet` or inline styles |
-| `@assistant-ui/ui` (shadcn components) | Build your own native UI with primitives |
+| Styled registry elements (shadcn components) | Build your own native UI with primitives |
 
 ## Step-by-step
 
@@ -82,7 +82,7 @@ export default function App() {
 
 ### Rebuild the UI layer
 
-This is the main migration effort. Web components (`Thread`, `ThreadList` from `@assistant-ui/ui`) don't render in React Native. Replace them with native primitives:
+This is the main migration effort. Web components (the `thread` and `thread-list` elements) don't render in React Native. Replace them with native primitives:
 
 ```tsx
 // Web — DOM-based

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
@@ -327,10 +327,8 @@ On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMes
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import {
-  AssistantRuntimeProvider,
-  useAISDKRuntime,
-} from "@assistant-ui/react-ai-sdk";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { Thread } from "@/components/assistant-ui/elements/thread.aui";
 

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -338,10 +338,8 @@ On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMes
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import {
-  AssistantRuntimeProvider,
-  useAISDKRuntime,
-} from "@assistant-ui/ai-sdk";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useAISDKRuntime } from "@assistant-ui/ai-sdk";
 import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { Thread } from "@/components/assistant-ui/elements/thread.aui";
 

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -37,7 +37,7 @@ const cloud = new AssistantCloud({
 const runtime = useLocalRuntime(modelAdapter, { cloud });
 ```
 
-Framework adapters take `cloud` directly. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` hosts. It mounts only the visible thread, so a switch cancels an in-flight run and that exchange is not persisted.
+Framework adapters take `cloud` directly. `AISDKThreads({ cloud })` is the store-entry list for `AuiConfig` hosts. With `cloud` it is a `RemoteThreadList` with background threads: every visited thread stays mounted with its own history, a run keeps streaming after a switch and stops on delete, and a freshly created thread titles itself. Without `cloud`, only the visible thread is mounted, and a switched-away chat keeps streaming into its stored state until it settles.
 
 ```tsx
 const runtime = useChatRuntime({ cloud });

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -273,22 +273,27 @@ These two operations cover all complex state mutations: `set` for value updates 
 
 ### Wire format
 
-<Callout type="warn">
-The wire format will migrate to Server-Sent Events (SSE) in a future release.
-</Callout>
-
-Inspired by [AI SDK's data stream protocol](https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol).
+The response is a Server-Sent Events stream (`Content-Type: text/event-stream`). `AssistantTransportEncoder` writes one `data:` line per `AssistantStreamChunk`, JSON encoded, and a final `data: [DONE]` line when the stream completes. `AssistantTransportDecoder` stops at that marker and reports a stream that ends without it.
 
 **state update:**
 
 ```
-aui-state:[{"type":"set","path":["status"],"value":"completed"}]
+data: {"type":"update-state","path":[],"operations":[{"type":"set","path":["status"],"value":"completed"}]}
+
 ```
 
 **error:**
 
 ```
-3:"error message"
+data: {"type":"error","path":[],"error":"error message"}
+
+```
+
+**end of stream:**
+
+```
+data: [DONE]
+
 ```
 
 ## Building a frontend

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -293,12 +293,12 @@ aui-state:[{"type":"set","path":["status"],"value":"completed"}]
 3:"error message"
 ```
 
-Pass `protocol: "assistant-transport"` to consume the SSE encoding that `AssistantTransportEncoder` produces today: one `data:` line per JSON encoded `AssistantStreamChunk` and a final `data: [DONE]` line, which `AssistantTransportDecoder` requires. Message-level chunks such as `update-state` and `error` carry no `path`; the decoder fills in an empty one.
+Pass `protocol: "assistant-transport"` to consume the SSE encoding that `AssistantTransportEncoder` produces today: one `data:` line per JSON encoded `AssistantStreamChunk`, each carrying its `path` (`[]` for message-level chunks), and a final `data: [DONE]` line, which `AssistantTransportDecoder` requires. The decoder also accepts message-level chunks such as `update-state` and `error` without a `path`, which is what the Python `assistant_stream` package emits, and fills in the empty one.
 
 ```
-data: {"type":"update-state","operations":[{"type":"set","path":["status"],"value":"completed"}]}
+data: {"type":"update-state","path":[],"operations":[{"type":"set","path":["status"],"value":"completed"}]}
 
-data: {"type":"error","error":"error message"}
+data: {"type":"error","path":[],"error":"error message"}
 
 data: [DONE]
 ```

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -273,27 +273,34 @@ These two operations cover all complex state mutations: `set` for value updates 
 
 ### Wire format
 
-The response is a Server-Sent Events stream (`Content-Type: text/event-stream`). `AssistantTransportEncoder` writes one `data:` line per `AssistantStreamChunk`, JSON encoded, and a final `data: [DONE]` line when the stream completes. `AssistantTransportDecoder` stops at that marker and reports a stream that ends without it.
+`useAssistantTransportRuntime` speaks the data stream protocol by default (`protocol: "data-stream"`), which is what the reference backends above emit through `DataStreamResponse`.
+
+<Callout type="warn">
+The default wire format will migrate to Server-Sent Events (SSE) in a future release.
+</Callout>
+
+Inspired by [AI SDK's data stream protocol](https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol).
 
 **state update:**
 
 ```
-data: {"type":"update-state","path":[],"operations":[{"type":"set","path":["status"],"value":"completed"}]}
-
+aui-state:[{"type":"set","path":["status"],"value":"completed"}]
 ```
 
 **error:**
 
 ```
-data: {"type":"error","path":[],"error":"error message"}
-
+3:"error message"
 ```
 
-**end of stream:**
+Pass `protocol: "assistant-transport"` to consume the SSE encoding that `AssistantTransportEncoder` produces today: one `data:` line per JSON encoded `AssistantStreamChunk` and a final `data: [DONE]` line, which `AssistantTransportDecoder` requires. Message-level chunks such as `update-state` and `error` carry no `path`; the decoder fills in an empty one.
 
 ```
+data: {"type":"update-state","operations":[{"type":"set","path":["status"],"value":"completed"}]}
+
+data: {"type":"error","error":"error message"}
+
 data: [DONE]
-
 ```
 
 ## Building a frontend

--- a/apps/docs/content/docs/runtimes/langgraph/tutorial/part-2.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/tutorial/part-2.mdx
@@ -344,4 +344,4 @@ export default function Home() {
 }
 ```
 
-The `Thread` component from `@assistant-ui/ui` already includes a built-in `ToolFallback` and `MarkdownText`, so no additional configuration is needed.
+The `thread` element already includes a built-in `ToolFallback` and `MarkdownText`, so no additional configuration is needed.

--- a/apps/docs/content/docs/tools/generative-ui-primitive.mdx
+++ b/apps/docs/content/docs/tools/generative-ui-primitive.mdx
@@ -73,7 +73,7 @@ Live routes in [`examples/with-generative-ui`](https://github.com/assistant-ui/a
 
 ## Opt-in wiring
 
-The stock `@assistant-ui/ui` `Thread` switch returns `null` for unknown part types, including `generative-ui`. Add one of these patterns in **your** assistant message renderer.
+The stock `thread` element's part switch returns `null` for unknown part types, including `generative-ui`. Add one of these patterns in **your** assistant message renderer.
 
 ### Pattern 1 — `MessagePrimitive.Parts`
 

--- a/apps/docs/content/docs/tools/interactables.mdx
+++ b/apps/docs/content/docs/tools/interactables.mdx
@@ -652,10 +652,10 @@ State changes are automatically debounced (500ms) before saving. When the owning
 For custom persistence strategies, use `exportState` and `importState` directly:
 
 ```tsx
-const snapshot = aui.interactables.exportState();
+const snapshot = aui.unstable_interactables.exportState();
 // => { "note-1": { name: "note", state: { title: "Hello" } }, ... }
 
-aui.interactables.importState(snapshot);
+aui.unstable_interactables.importState(snapshot);
 // Imported state is picked up when components next register
 ```
 

--- a/apps/docs/content/docs/tools/multi-agent.mdx
+++ b/apps/docs/content/docs/tools/multi-agent.mdx
@@ -68,7 +68,7 @@ The sub-agent's conversation has to reach `ToolCallMessagePart.messages`. AI SDK
 tools: {
   invoke_researcher: tool({
     description: "Invoke the researcher sub-agent",
-    parameters: z.object({ query: z.string() }),
+    inputSchema: z.object({ query: z.string() }),
     execute: async ({ query }) => {
       const subAgentMessages = await runResearcherAgent(query);
       return {

--- a/apps/docs/content/elements/mcp-config.mdx
+++ b/apps/docs/content/elements/mcp-config.mdx
@@ -17,16 +17,24 @@ MCP config dialog lists every app-defined connector and user-added custom server
 `McpManagerResource` is the entry point: mount it once at the root of your app, with the connectors you want available to every user.
 
 ```tsx title="app/assistant.tsx"
-import { useAui } from "@assistant-ui/react";
+import { AuiConfig, AuiProvider, useAui } from "@assistant-ui/react";
 import { McpManagerResource } from "@assistant-ui/react-mcp";
 
-useAui({
-  mcp: McpManagerResource({
-    connectors: [
-      { id: "linear", name: "Linear", url: "https://mcp.linear.app/mcp", auth: { type: "oauth" } },
-    ],
-  }),
-});
+export function McpProviders({ children }: { children: React.ReactNode }) {
+  const aui = useAui();
+  const config = AuiConfig({
+    mcp: McpManagerResource({
+      connectors: [
+        { id: "linear", name: "Linear", url: "https://mcp.linear.app/mcp", auth: { type: "oauth" } },
+      ],
+    }),
+  });
+  return (
+    <AuiProvider extends={aui} config={config}>
+      {children}
+    </AuiProvider>
+  );
+}
 ```
 
   </Step>

--- a/apps/docs/content/elements/mcp-server-panel.mdx
+++ b/apps/docs/content/elements/mcp-server-panel.mdx
@@ -19,12 +19,23 @@ A compact list of MCP servers, each row collapsed to a name and a status dot unt
 ```tsx title="app/providers.tsx"
 "use client";
 
-import { useAui } from "@assistant-ui/store";
+import { AuiConfig, AuiProvider, useAui } from "@assistant-ui/store";
 import { McpManagerResource } from "@assistant-ui/react-mcp";
 
-function McpManagerMount({ connectors }: { connectors: MCPConnector[] }) {
-  useAui({ mcp: McpManagerResource({ connectors }) });
-  return null;
+function McpManagerMount({
+  connectors,
+  children,
+}: {
+  connectors: MCPConnector[];
+  children: React.ReactNode;
+}) {
+  const aui = useAui();
+  const config = AuiConfig({ mcp: McpManagerResource({ connectors }) });
+  return (
+    <AuiProvider extends={aui} config={config}>
+      {children}
+    </AuiProvider>
+  );
 }
 ```
 

--- a/apps/docs/scripts/generated-docs/classify.mts
+++ b/apps/docs/scripts/generated-docs/classify.mts
@@ -306,6 +306,7 @@ export const GENERATIVE_UI_PACKAGE_EXPORTS = new Map<
   ["JUSTIFIES", { page: "tokens", role: "primary" }],
   ["BUTTON_STYLES", { page: "tokens", role: "primary" }],
   ["ALERT_TONES", { page: "tokens", role: "primary" }],
+  ["ICON_NAMES", { page: "tokens", role: "primary" }],
   ["TextSize", { page: "tokens", role: "supporting-type" }],
   ["ImageSize", { page: "tokens", role: "supporting-type" }],
   ["Weight", { page: "tokens", role: "supporting-type" }],

--- a/packages/core/src/react/model-context/makeAssistantTool.ts
+++ b/packages/core/src/react/model-context/makeAssistantTool.ts
@@ -8,7 +8,7 @@ import { type AssistantToolProps, useAssistantTool } from "./useAssistantTool";
  * subtree.
  *
  * @deprecated Use a toolkit with `Tools({ toolkit })` and register it via
- * `useAui({ tools: Tools({ toolkit }) })` instead. See
+ * `AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
  * https://assistant-ui.com/docs/migrations/toolkit-tools.
  */
 export type AssistantTool = FC & {
@@ -25,7 +25,7 @@ export type AssistantTool = FC & {
  * @param tool - Tool definition and name to register.
  *
  * @deprecated Use a toolkit with `Tools({ toolkit })` and register it via
- * `useAui({ tools: Tools({ toolkit }) })` instead. See
+ * `AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
  * https://assistant-ui.com/docs/migrations/toolkit-tools.
  */
 export const makeAssistantTool = <

--- a/packages/core/src/react/model-context/useAssistantTool.ts
+++ b/packages/core/src/react/model-context/useAssistantTool.ts
@@ -12,7 +12,7 @@ import {
  * Props used to register a tool from React.
  *
  * @deprecated Use a toolkit with `Tools({ toolkit })` and register it via
- * `useAui({ tools: Tools({ toolkit }) })` instead. See
+ * `AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
  * https://assistant-ui.com/docs/migrations/toolkit-tools.
  */
 export type AssistantToolProps<
@@ -39,7 +39,7 @@ export type AssistantToolProps<
  * @param tool - Tool definition and name to register.
  *
  * @deprecated Use a toolkit with `Tools({ toolkit })` and register it via
- * `useAui({ tools: Tools({ toolkit }) })` instead. See
+ * `AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop instead. See
  * https://assistant-ui.com/docs/migrations/toolkit-tools.
  *
  * @example

--- a/packages/react-o11y/src/primitives/span.ts
+++ b/packages/react-o11y/src/primitives/span.ts
@@ -10,3 +10,4 @@ export {
   SpanPrimitiveTimelineBar as TimelineBar,
   type SpanTimelineRange,
 } from "./span/SpanTimeline";
+export { SpanPrimitiveChildByIndex as ChildByIndex } from "./span/SpanChildren";


### PR DESCRIPTION
## summary

- `@assistant-ui/react-o11y` now exports `SpanPrimitive.ChildByIndex`; the docs described it but the namespace never re-exported the existing implementation (patch changeset)
- the deprecation notices on `makeAssistantTool` and `useAssistantTool` pointed at the retired `useAui({ tools })` form; they now name `AuiConfig({ tools: Tools({ toolkit }) })` on the provider's `config` prop, and the generated `component-tools.mdx` follows
- the generative UI tokens reference gains `ICON_NAMES` (classified as a primary tokens export, page regenerated)
- docs pages corrected to match the source: `AISDKThreads({ cloud })` keeps visited threads mounted with background runs (threads and cloud pages said the opposite), the assistant transport wire format is documented as the SSE `data:` JSON lines plus `[DONE]` that the encoder emits instead of the numbered prefixes and the "will migrate to SSE" callout, the `mcp-config` and `mcp-server-panel` element recipes mount the manager through `AuiConfig` and `AuiProvider extends` instead of `useAui({ mcp })`, the image generation guide imports the `image` element instead of the nonexistent `@assistant-ui/ui` package, the multi-agent AI SDK sample uses `inputSchema`, the interactables export and import sample uses `aui.unstable_interactables`, and the v7 and v6 legacy pages import `AssistantRuntimeProvider` from `@assistant-ui/react`

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/docs generate:api-reference` -> only `tokens.mdx` and `component-tools.mdx` changed
- [x] `pnpm --filter @assistant-ui/docs test` -> 74 files, 615 tests green (after building `react-markdown` locally)
- [x] `pnpm --filter @assistant-ui/react-o11y exec tsc --noEmit` clean; oxlint and oxfmt clean on every changed file
- [x] every `import { ... } from "@assistant-ui/..."` in a docs code block checked against the built package exports; the only remaining unknown names are the intentionally old ones on the migration pages

### reviewer should verify

- [ ] open `/docs/runtimes/custom/assistant-transport` and confirm the wire format section matches a real `AssistantTransportEncoder` response

## notes

- found while refreshing the assistant-ui agent skills (assistant-ui/skills#16), which now verify their samples against the same export list

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wroxCAgrrZQhtTOfjwisdqFvOhH0N9JlSe2oQMcvVh0turmp71K7uPtHhA4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->