### PR TITLE
fix(ai-sdk): leave a cancelled assistant message when a run is stopped before the first chunk

### DIFF
--- a/.changeset/ai-sdk-pre-chunk-cancel.md
+++ b/.changeset/ai-sdk-pre-chunk-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/ai-sdk": patch
+---
+
+fix: leave a cancelled assistant message when a run is stopped before the first chunk

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.test.ts
@@ -352,6 +352,104 @@ describe("useAISDKRuntime", () => {
     });
   });
 
+  it("synthesizes a cancelled assistant message when stopped before the first chunk", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ]);
+    chat.status = "submitted";
+    chat.stop = vi.fn(async () => {});
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    await act(async () => {
+      result.current.thread.cancelRun();
+    });
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
+
+    await waitFor(() => {
+      const tail = result.current.thread.getState().messages.at(-1);
+      expect(tail?.role).toBe("assistant");
+      expect(tail?.content).toEqual([]);
+      expect(tail?.status).toMatchObject({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+    });
+    expect(chat.messages).toHaveLength(2);
+  });
+
+  it("marks the assistant message that raced the abort instead of synthesizing one", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ]);
+    chat.status = "submitted";
+    let resolveStop!: () => void;
+    chat.stop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        }),
+    );
+
+    const { result, rerender } = renderHook(() => useAISDKRuntime(chat));
+
+    await act(async () => {
+      result.current.thread.cancelRun();
+      chat.setMessages([
+        ...chat.messages,
+        {
+          id: "assistant-raced",
+          role: "assistant",
+          parts: [{ type: "text", text: "par" }],
+        },
+      ]);
+      resolveStop();
+      await Promise.resolve();
+    });
+    act(() => {
+      chat.status = "ready";
+      rerender();
+    });
+
+    await waitFor(() => {
+      const tail = result.current.thread.getState().messages.at(-1);
+      expect(tail?.id).toBe("assistant-raced");
+      expect(tail?.status).toMatchObject({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+    });
+    expect(chat.messages).toHaveLength(2);
+  });
+
+  it("does not synthesize a message when stop rejects with a real error", async () => {
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    ]);
+    chat.status = "submitted";
+    chat.stop = vi.fn(async () => {
+      throw new TypeError("network down");
+    });
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const { result } = renderHook(() => useAISDKRuntime(chat));
+
+      await act(async () => {
+        result.current.thread.cancelRun();
+      });
+
+      expect(chat.messages).toHaveLength(1);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("does not mark completed output cancelled when already idle", async () => {
     const chat = createChatHelpers([
       {

--- a/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
+++ b/packages/ai-sdk/src/runtime/useAISDKRuntime.ts
@@ -494,10 +494,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
       runtimeRef.current.thread.import(exportedRepo);
     },
     onCancel: async () => {
-      const message = chatHelpers.messages.at(-1);
-      const cancelledId =
-        isRunning && message?.role === "assistant" ? message.id : undefined;
-      if (cancelledId) {
+      const markCancelled = (cancelledId: string) => {
         const liveIds = new Set(chatHelpers.messages.map((m) => m.id));
         setCancelledMessages((prev) => {
           const kept =
@@ -509,7 +506,14 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
             ids: new Set([...kept, cancelledId]),
           };
         });
-      }
+      };
+
+      const message = chatHelpers.messages.at(-1);
+      const cancelledId =
+        isRunning && message?.role === "assistant" ? message.id : undefined;
+      if (cancelledId) markCancelled(cancelledId);
+      const stoppedBeforeFirstChunk =
+        !cancelledId && chatHelpers.status === "submitted";
       try {
         await chatHelpers.stop();
       } catch (error) {
@@ -518,6 +522,29 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
           throw error;
         }
       }
+      if (!stoppedBeforeFirstChunk) return;
+
+      // The AI SDK creates the assistant message with the stream's first part,
+      // so a run stopped during `submitted` has nothing to carry the cancelled
+      // status; LocalRuntime appends its assistant message at run start and
+      // keeps it. Synthesize that message after the stop settles — unless a
+      // first chunk raced the abort and created the real one, which then takes
+      // the mark instead.
+      const tail = chatHelpers.messages.at(-1);
+      if (tail?.role === "assistant") {
+        markCancelled(tail.id);
+        return;
+      }
+      const syntheticId = generateId();
+      markCancelled(syntheticId);
+      chatHelpers.setMessages((current) => [
+        ...current,
+        {
+          id: syntheticId,
+          role: "assistant",
+          parts: [],
+        } as UIMessage as UI_MESSAGE,
+      ]);
     },
     onNew: async (message) => {
       const createMessage = (


### PR DESCRIPTION
Closes #6772.

## Problem

On `useAISDKRuntime`, pressing stop while `chatHelpers.status` is still `submitted` — the request is out, no chunk has arrived — leaves the thread ending on the user message with no indication a run was started and stopped. #6761 reports a stopped run as `incomplete`/`cancelled`, but only for an assistant message that already exists; the AI SDK creates the assistant `UIMessage` with the stream's first part, so during `submitted` there is nothing to mark. LocalRuntime appends its assistant message at run start, so the same action there leaves `{ type: "incomplete", reason: "cancelled" }` with an empty body — this is the remaining half of the #6745 parity gap.

## Change

Takes the issue's proposal: `onCancel` synthesizes the assistant message LocalRuntime would have appended. When the cancel began during `submitted` and no assistant tail existed, then after `chatHelpers.stop()` settles it appends an empty assistant `UIMessage` via `setMessages` and marks its id cancelled, so the shared conversion renders it as `incomplete`/`cancelled` — same shape as LocalRuntime.

Ordering safeguards:

- The synthesis happens **after** the stop settles, so a first chunk racing the abort cannot leave two assistant messages: if the tail is an assistant message by then, that raced-in message takes the mark instead and nothing is appended.
- A non-`AbortError` rejection from `stop()` rethrows before any synthesis, so a failed stop appends nothing (the existing retraction path for pre-marked ids is unchanged).
- A later provider run that resumes into the synthesized tail retracts its cancellation through the existing `resumedMessageId` effect, unchanged.

The pre-existing mark path for an existing assistant tail is untouched; its marking block is extracted as a local `markCancelled` shared by both paths.

## Verification

- The issue's repro (single user message, `status: "submitted"`, `thread.cancelRun()`, flip to `ready`) fails on main — the thread still ends `user:undefined` — and with this change ends on an empty assistant message with `{ type: "incomplete", reason: "cancelled" }`. The new test pins it and fails without the fix.
- Two more tests pin the safeguards: the raced-first-chunk case marks the real message and appends nothing, and a `TypeError` from `stop()` synthesizes nothing.
- Full `@assistant-ui/ai-sdk` suite: 268 tests pass.

## Public surface

No API changes. Changeset: patch for `@assistant-ui/ai-sdk`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UdXkFnEjyaplNbtjqbDzT2xOhQ3iEU4iC2AlhvB96geUScxu4lu6dzDmkF4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->