### PR TITLE
fix(react-ag-ui): preserve replacement run state

### DIFF
--- a/.changeset/calm-ag-ui-runs.md
+++ b/.changeset/calm-ag-ui-runs.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: keep replacement AG-UI runs marked as active

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1330,10 +1330,9 @@ export class AgUiThreadRuntimeCore {
   }
 
   private finishRun(controller: AbortController | null) {
-    if (this.abortController === controller) {
-      this.abortController = null;
-      this.activeRunAgent = null;
-    }
+    if (this.abortController !== controller) return;
+    this.abortController = null;
+    this.activeRunAgent = null;
     this.setRunning(false);
   }
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -905,6 +905,36 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(agent.abortRun).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a replacement run active when the cancelled run settles late", async () => {
+    const resolveRuns: Array<() => void> = [];
+    const agent = {
+      runAgent: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRuns.push(resolve);
+          }),
+      ),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    await core.cancel();
+
+    const replacementRun = core.append(createAppendMessage());
+    expect(resolveRuns).toHaveLength(2);
+    expect(core.isRunning()).toBe(true);
+
+    resolveRuns[0]?.();
+    await firstRun;
+
+    expect(core.isRunning()).toBe(true);
+
+    resolveRuns[1]?.();
+    await replacementRun;
+    expect(core.isRunning()).toBe(false);
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {


### PR DESCRIPTION
## Problem

Stopping an AG-UI run and immediately starting another can make the replacement look idle while it is still generating. If the cancelled run ignores its abort and settles later, its cleanup changes `isRunning` to `false`, which hides or disables loading and cancellation controls for the active replacement.

Reproduction on the base revision:

1. Start run A and leave its `runAgent()` promise pending.
2. Cancel A.
3. Start run B and leave it pending.
4. Settle A.
5. `isRunning()` becomes `false` even though B is still active.

The focused regression fails on the base revision with `expected false to be true`.

## Root cause

`finishRun()` conditionally cleared the abort controller by identity, but called `setRunning(false)` unconditionally. Cleanup from a stale run could therefore overwrite running state owned by a newer controller.

## Change

Return from `finishRun()` unless the settling run still owns the active abort controller. Only the owning run clears the controller, active agent, and running state.

Add a focused runtime regression covering a cancelled run settling after its replacement starts.

## Verification

- `pnpm -C packages/react-ag-ui exec vitest run test/ag-ui-thread-runtime-core.spec.ts` (149 passed)
- `pnpm exec turbo build --filter=@assistant-ui/react-ag-ui...`
- `pnpm exec oxfmt --check packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts .changeset/calm-ag-ui-runs.md`
- `pnpm exec oxlint packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts`
- `pnpm changesets:check`
- `pnpm changeset-semver:check`
- `pnpm workspace-ranges:check`

The package-wide suite currently reports 554 passing tests and one unrelated failure in `useAgUiRuntime.toolDeferral.test.tsx`; that same test fails after restoring the base implementation, so it is not introduced by this change.

## Public surface

- Affected package: `@assistant-ui/react-ag-ui`
- Exports and API signatures: unchanged
- Documentation and templates: unchanged
- Release: patch changeset included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-3wAHA4_dQsr9axMxgh_ov9bcyqDtxSTx-x5m2mG3PklEXh91ndk9kNF_NE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->