### PR TITLE
fix(core): report thread list load failures and retry after reconnect

### DIFF
--- a/.changeset/thread-list-load-error.md
+++ b/.changeset/thread-list-load-error.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix(core): keep the thread list and report the error when a load fails. failed loads previously looked like an empty thread list; thread list state now exposes `loadError` and clears it when a later load starts.
+fix(core): keep the thread list and report the error when a load fails. failed loads previously looked like an empty thread list; thread list state now exposes `loadError`, clears it when a later load starts, and in browsers retries a failed load once when the window comes back online or the document becomes visible again. React Native has neither event, so it keeps recovering through `reload()`.

--- a/.changeset/thread-list-load-error.md
+++ b/.changeset/thread-list-load-error.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): keep the thread list and report the error when a load fails. failed loads previously looked like an empty thread list; thread list state now exposes `loadError` and clears it when a later load starts.

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -1756,6 +1756,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1833,6 +1833,7 @@ type ExternalStoreThreadListAdapter = {
 declare class ExternalStoreThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
   #private;
   get isLoading(): boolean;
+  get loadError(): undefined;
   get newThreadId(): undefined;
   get threadIds(): readonly string[];
   get archivedThreadIds(): readonly string[];
@@ -2418,6 +2419,7 @@ declare class LocalThreadListRuntimeCore extends BaseSubscribable implements Thr
   #private;
   constructor(_threadFactory: LocalThreadFactory);
   get isLoading(): boolean;
+  get loadError(): undefined;
   getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
   get newThreadId(): string | undefined;
   get threadIds(): readonly string[];
@@ -3808,6 +3810,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   reloadMainThread(): Promise<void>;
   reload(): Promise<void>;
   get isLoading(): boolean;
+  get loadError(): unknown;
   get isLoadingMore(): boolean;
   get hasMore(): boolean;
   get threadIds(): readonly string[];
@@ -3957,6 +3960,7 @@ type RemoteThreadMetadata = {
 
 type RemoteThreadState = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly cursor: string | undefined;
   readonly newThreadId: string | undefined;
@@ -4749,6 +4753,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;
@@ -4821,6 +4826,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
@@ -5328,6 +5334,7 @@ type ThreadsState = {
   readonly mainThreadId: string;
   readonly newThreadId: string | null;
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadIds: readonly string[];

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1833,7 +1833,6 @@ type ExternalStoreThreadListAdapter = {
 declare class ExternalStoreThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
   #private;
   get isLoading(): boolean;
-  get loadError(): undefined;
   get newThreadId(): undefined;
   get threadIds(): readonly string[];
   get archivedThreadIds(): readonly string[];
@@ -2419,7 +2418,6 @@ declare class LocalThreadListRuntimeCore extends BaseSubscribable implements Thr
   #private;
   constructor(_threadFactory: LocalThreadFactory);
   get isLoading(): boolean;
-  get loadError(): undefined;
   getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
   get newThreadId(): string | undefined;
   get threadIds(): readonly string[];
@@ -4753,7 +4751,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
-  readonly loadError: unknown;
+  readonly loadError?: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1167,6 +1167,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1494,6 +1494,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1280,6 +1280,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1756,6 +1756,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1498,6 +1498,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2072,6 +2072,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3598,7 +3598,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
-  readonly loadError: unknown;
+  readonly loadError?: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3598,6 +3598,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;
@@ -3670,6 +3671,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
@@ -4114,6 +4116,7 @@ type ThreadsState = {
   readonly mainThreadId: string;
   readonly newThreadId: string | null;
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadIds: readonly string[];

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1787,6 +1787,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1944,6 +1944,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3172,6 +3172,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;
@@ -3244,6 +3245,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
@@ -3675,6 +3677,7 @@ type ThreadsState = {
   readonly mainThreadId: string;
   readonly newThreadId: string | null;
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadIds: readonly string[];

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3172,7 +3172,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
-  readonly loadError: unknown;
+  readonly loadError?: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1578,6 +1578,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1990,6 +1990,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4618,7 +4618,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
-  readonly loadError: unknown;
+  readonly loadError?: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4618,6 +4618,7 @@ type ThreadListRuntime = {
 
 type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;
@@ -4690,6 +4691,7 @@ type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;

--- a/apps/docs/components/pages/home/demo/sidebar.tsx
+++ b/apps/docs/components/pages/home/demo/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThreadListPrimitive, useAuiState } from "@assistant-ui/react";
+import { ThreadListPrimitive, useAui, useAuiState } from "@assistant-ui/react";
 import { ChevronDownIcon, PlusIcon } from "lucide-react";
 import { Fragment, useMemo, useState, type ReactNode } from "react";
 import {
@@ -67,12 +67,17 @@ export function Sidebar({
 }
 
 function ThreadList({ search }: { search: string }): ReactNode {
+  const aui = useAui();
   const isLoading = useAuiState((s) => s.threads.isLoading);
+  const hasLoadError = useAuiState((s) => s.threads.loadError !== undefined);
   const hasThreads = useAuiState((s) => s.threads.threadIds.length > 0);
   const hasArchived = useAuiState(
     (s) => s.threads.archivedThreadIds.length > 0,
   );
-  if (!isLoading && !hasThreads && !hasArchived) return null;
+  if (!isLoading && !hasLoadError && !hasThreads && !hasArchived) return null;
+
+  const showLoadError =
+    !isLoading && hasLoadError && !hasThreads && !hasArchived;
 
   return (
     <>
@@ -87,6 +92,19 @@ function ThreadList({ search }: { search: string }): ReactNode {
               <Skeleton className={cn("h-3.5", width)} />
             </div>
           ))}
+        </div>
+      ) : showLoadError ? (
+        <div className="mt-1 flex h-8 shrink-0 items-center justify-between px-2 text-[13px]">
+          <span className="text-muted-foreground">
+            Threads could not be loaded
+          </span>
+          <button
+            type="button"
+            onClick={() => void aui.threads.reload()}
+            className="text-muted-foreground hover:text-foreground rounded-control -me-2 h-8 px-2 transition-colors"
+          >
+            Retry
+          </button>
         </div>
       ) : (
         <ThreadGroups search={search} />

--- a/apps/docs/components/pages/home/demo/sidebar.tsx
+++ b/apps/docs/components/pages/home/demo/sidebar.tsx
@@ -94,7 +94,10 @@ function ThreadList({ search }: { search: string }): ReactNode {
           ))}
         </div>
       ) : showLoadError ? (
-        <div className="mt-1 flex h-8 shrink-0 items-center justify-between px-2 text-[13px]">
+        <div
+          role="alert"
+          className="mt-1 flex h-8 shrink-0 items-center justify-between px-2 text-[13px]"
+        >
           <span className="text-muted-foreground">
             Threads could not be loaded
           </span>

--- a/packages/core/src/react/client/InMemoryThreadList.ts
+++ b/packages/core/src/react/client/InMemoryThreadList.ts
@@ -209,6 +209,7 @@ const useInMemoryThreadList = (
       mainThreadId,
       newThreadId: null,
       isLoading: false,
+      loadError: undefined,
       isLoadingMore: false,
       hasMore: false,
       threadIds: regularThreads.map((t) => t.id),

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -933,6 +933,7 @@ describe("RemoteThreadList", () => {
   });
 
   it("does not reset again when retrying a failed replacement load", async () => {
+    const error = new Error("network");
     const methodsA = makeAdapter({
       list: vi.fn(async () => ({
         threads: [
@@ -943,8 +944,8 @@ describe("RemoteThreadList", () => {
     const methodsB = makeAdapter({
       list: vi
         .fn()
-        .mockRejectedValueOnce(new Error("network"))
-        .mockResolvedValueOnce({
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue({
           threads: [
             { status: "regular" as const, remoteId: "thread-b", title: "B" },
           ],
@@ -993,6 +994,7 @@ describe("RemoteThreadList", () => {
       const mainAfterFailure = handle
         .getClient()
         .threads.getState().mainThreadId;
+      expect(handle.getClient().threads.getState().loadError).toBe(error);
       await handle.getClient().threads.reload();
       await vi.waitFor(() => {
         expect(handle.getClient().threads.getState().threadIds).toEqual([
@@ -1002,6 +1004,7 @@ describe("RemoteThreadList", () => {
       expect(handle.getClient().threads.getState().mainThreadId).toBe(
         mainAfterFailure,
       );
+      expect(handle.getClient().threads.getState().loadError).toBeUndefined();
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1049,6 +1049,49 @@ describe("RemoteThreadList", () => {
     }
   });
 
+  it("retries once when the document becomes visible after a failed load", async () => {
+    vi.stubGlobal("window", new EventTarget());
+    const document = Object.assign(new EventTarget(), {
+      visibilityState: "hidden",
+    });
+    vi.stubGlobal("document", document);
+    const error = new Error("offline");
+    const firstLoad = deferred<{ threads: [] }>();
+    const list = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockResolvedValueOnce({ threads: [] });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { handle } = mountList(makeAdapter({ list }));
+
+    try {
+      await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+      firstLoad.reject(error);
+      await vi.waitFor(() =>
+        expect(handle.getClient().threads.getState().loadError).toBe(error),
+      );
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(list).toHaveBeenCalledTimes(1);
+
+      document.visibilityState = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() =>
+        expect(handle.getClient().threads.getState().loadError).toBeUndefined(),
+      );
+      expect(list).toHaveBeenCalledTimes(2);
+    } finally {
+      handle.destroy();
+      consoleError.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("does not send a superseded rename through the replacement adapter", async () => {
     const initializeRequest = deferred<{
       remoteId: string;

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -1011,6 +1011,44 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("reloads once when the browser comes online after a failed load", async () => {
+    vi.stubGlobal("window", new EventTarget());
+    vi.stubGlobal(
+      "document",
+      Object.assign(new EventTarget(), { visibilityState: "visible" }),
+    );
+    const error = new Error("offline");
+    const firstLoad = deferred<{ threads: [] }>();
+    const list = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockResolvedValueOnce({ threads: [] });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { handle } = mountList(makeAdapter({ list }));
+
+    try {
+      await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+      firstLoad.reject(error);
+      await vi.waitFor(() =>
+        expect(handle.getClient().threads.getState().loadError).toBe(error),
+      );
+
+      window.dispatchEvent(new Event("online"));
+
+      await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() =>
+        expect(handle.getClient().threads.getState().loadError).toBeUndefined(),
+      );
+      expect(list).toHaveBeenCalledTimes(2);
+    } finally {
+      handle.destroy();
+      consoleError.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("does not send a superseded rename through the replacement adapter", async () => {
     const initializeRequest = deferred<{
       remoteId: string;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -633,6 +633,26 @@ const useRemoteThreadList = (
   ]);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const reloadAfterError = () => {
+      if (store.value.loadError !== undefined) void reload();
+    };
+    const reloadAfterVisible = () => {
+      if (document.visibilityState === "visible") reloadAfterError();
+    };
+
+    window.addEventListener("online", reloadAfterError);
+    document.addEventListener("visibilitychange", reloadAfterVisible);
+    return () => {
+      window.removeEventListener("online", reloadAfterError);
+      document.removeEventListener("visibilitychange", reloadAfterVisible);
+    };
+  }, [reload, store]);
+
+  useEffect(() => {
     void getLoadThreadsPromise();
   }, [getLoadThreadsPromise]);
 

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -562,7 +562,7 @@ const useRemoteThreadList = (
         execute: () => adapter.list(),
         loading: (state) => {
           if (generation !== session.loadGeneration) return state;
-          return { ...state, isLoading: true };
+          return { ...state, isLoading: true, loadError: undefined };
         },
         then: (state, page) => {
           if (generation !== session.loadGeneration) return state;
@@ -576,6 +576,7 @@ const useRemoteThreadList = (
           const merged = {
             ...state,
             isLoading: false,
+            loadError: undefined,
             cursor: normalizeCursor(page.nextCursor),
             threadIds: fresh.threadIds,
             archivedThreadIds: fresh.archivedThreadIds,
@@ -592,6 +593,7 @@ const useRemoteThreadList = (
         store.update({
           ...store.baseValue,
           isLoading: false,
+          loadError: error,
         });
       })
       .then(() => {});
@@ -1264,6 +1266,7 @@ const useRemoteThreadList = (
       mainThreadId,
       newThreadId: listState.newThreadId ?? null,
       isLoading: listState.isLoading,
+      loadError: listState.loadError,
       isLoadingMore: listState.isLoadingMore,
       hasMore: listState.cursor !== undefined,
       threadIds: listState.threadIds,
@@ -1275,6 +1278,7 @@ const useRemoteThreadList = (
       listState.archivedThreadIds,
       listState.cursor,
       listState.isLoading,
+      listState.loadError,
       listState.isLoadingMore,
       listState.newThreadId,
       listState.threadIds,

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -637,20 +637,20 @@ const useRemoteThreadList = (
       return;
     }
 
-    const reloadAfterError = () => {
-      if (store.value.loadError !== undefined) void reload();
+    const retryAfterError = () => {
+      if (store.value.loadError !== undefined) void getLoadThreadsPromise();
     };
-    const reloadAfterVisible = () => {
-      if (document.visibilityState === "visible") reloadAfterError();
+    const retryAfterVisible = () => {
+      if (document.visibilityState === "visible") retryAfterError();
     };
 
-    window.addEventListener("online", reloadAfterError);
-    document.addEventListener("visibilitychange", reloadAfterVisible);
+    window.addEventListener("online", retryAfterError);
+    document.addEventListener("visibilitychange", retryAfterVisible);
     return () => {
-      window.removeEventListener("online", reloadAfterError);
-      document.removeEventListener("visibilitychange", reloadAfterVisible);
+      window.removeEventListener("online", retryAfterError);
+      document.removeEventListener("visibilitychange", retryAfterVisible);
     };
-  }, [reload, store]);
+  }, [getLoadThreadsPromise, store]);
 
   useEffect(() => {
     void getLoadThreadsPromise();

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
@@ -62,6 +62,34 @@ describe("RemoteThreadListThreadListRuntimeCore load errors", () => {
     expect(core.loadError).toBe(error);
   });
 
+  it("clears the previous adapter's error before loading its replacement", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("network error");
+    const core = createCore(
+      makeAdapter({
+        list: vi.fn(async () => {
+          throw error;
+        }),
+      }),
+    );
+    await core.getLoadThreadsPromise();
+    expect(core.loadError).toBe(error);
+
+    const replacementLoad = deferred<RemoteThreadListResponse>();
+    const replacementList = vi.fn(() => replacementLoad.promise);
+    core.__internal_setOptions({
+      adapter: makeAdapter({ list: replacementList }),
+      runtimeHook: () => ({}) as never,
+    });
+
+    expect(replacementList).not.toHaveBeenCalled();
+    expect(core.loadError).toBeUndefined();
+
+    const loadPromise = core.getLoadThreadsPromise();
+    replacementLoad.resolve({ threads: [] });
+    await loadPromise;
+  });
+
   it("clears the error when a reload resolves", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const error = new Error("network error");

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.load-error.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemoteThreadListResponse } from "../../runtimes/remote-thread-list/types";
+import {
+  createCore,
+  deferred,
+  makeAdapter,
+} from "../../tests/remote-thread-list-test-helpers";
+
+const loadedThread = {
+  status: "regular" as const,
+  remoteId: "thread-1",
+  externalId: "thread-1",
+  title: "Thread 1",
+};
+
+describe("RemoteThreadListThreadListRuntimeCore load errors", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps loaded threads and reports a later load failure", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("network error");
+    const list = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockResolvedValueOnce({ threads: [loadedThread] })
+      .mockRejectedValueOnce(error);
+    const core = createCore(makeAdapter({ list }));
+
+    await core.getLoadThreadsPromise();
+    await core.reload();
+
+    expect(core.threadIds).toEqual(["thread-1"]);
+    expect(core.loadError).toBe(error);
+    expect(core.isLoading).toBe(false);
+  });
+
+  it("removes the previous adapter's threads when its replacement load fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("replacement failed");
+    const core = createCore(
+      makeAdapter({
+        list: vi.fn(async () => ({ threads: [loadedThread] })),
+      }),
+    );
+    await core.getLoadThreadsPromise();
+
+    const replacement = makeAdapter({
+      list: vi.fn(async () => {
+        throw error;
+      }),
+    });
+    core.__internal_setOptions({
+      adapter: replacement,
+      runtimeHook: () => ({}) as never,
+    });
+    await core.getLoadThreadsPromise();
+
+    expect(core.threadIds).toEqual([]);
+    expect(core.archivedThreadIds).toEqual([]);
+    expect(core.getItemById("thread-1")).toBeUndefined();
+    expect(core.loadError).toBe(error);
+  });
+
+  it("clears the error when a reload resolves", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("network error");
+    const list = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ threads: [loadedThread] });
+    const core = createCore(makeAdapter({ list }));
+
+    await core.getLoadThreadsPromise();
+    expect(core.loadError).toBe(error);
+
+    await core.reload();
+
+    expect(core.loadError).toBeUndefined();
+    expect(core.threadIds).toEqual(["thread-1"]);
+  });
+
+  it("clears the error while a later load is in progress", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("network error");
+    const retry = deferred<RemoteThreadListResponse>();
+    const list = vi
+      .fn<() => Promise<RemoteThreadListResponse>>()
+      .mockRejectedValueOnce(error)
+      .mockReturnValueOnce(retry.promise);
+    const core = createCore(makeAdapter({ list }));
+
+    await core.getLoadThreadsPromise();
+    expect(core.loadError).toBe(error);
+
+    const retryPromise = core.reload();
+
+    expect(core.isLoading).toBe(true);
+    expect(core.loadError).toBeUndefined();
+
+    retry.resolve({ threads: [] });
+    await retryPromise;
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -147,6 +147,7 @@ export class RemoteThreadListThreadListRuntimeCore
             return {
               ...state,
               isLoading: true,
+              loadError: undefined,
             };
           },
           then: (state, l) => {
@@ -156,7 +157,7 @@ export class RemoteThreadListThreadListRuntimeCore
               this._replaceListOnNextLoad = false;
               replacedList = true;
               return this._replaceWithThreads(
-                state,
+                { ...state, loadError: undefined },
                 l.threads,
                 normalizeCursor(l.nextCursor),
               );
@@ -171,6 +172,7 @@ export class RemoteThreadListThreadListRuntimeCore
             const merged = {
               ...state,
               isLoading: false,
+              loadError: undefined,
               cursor: normalizeCursor(l.nextCursor),
               threadIds: fresh.threadIds,
               archivedThreadIds: fresh.archivedThreadIds,
@@ -188,13 +190,18 @@ export class RemoteThreadListThreadListRuntimeCore
             this._state.update({
               ...this._state.baseValue,
               isLoading: false,
+              loadError: error,
             });
             return;
           }
           this._replaceListOnNextLoad = false;
           replacedList = true;
           this._state.update(
-            this._replaceWithThreads(this._state.baseValue, [], undefined),
+            this._replaceWithThreads(
+              { ...this._state.baseValue, loadError: error },
+              [],
+              undefined,
+            ),
           );
         })
         .then(() => {
@@ -510,6 +517,10 @@ export class RemoteThreadListThreadListRuntimeCore
 
   public get isLoading() {
     return this._state.value.isLoading;
+  }
+
+  public get loadError() {
+    return this._state.value.loadError;
   }
 
   public get isLoadingMore() {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -337,6 +337,7 @@ export class RemoteThreadListThreadListRuntimeCore
       this._state.update({
         ...this._state.baseValue,
         cursor: undefined,
+        loadError: undefined,
       });
       this._titleStates.clear();
     }

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.load-error.test.tsx
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.load-error.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import { makeAdapter } from "../../tests/remote-thread-list-test-helpers";
+import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useExternalStoreRuntime } from "./useExternalStoreRuntime";
+import { useRemoteThreadListRuntime } from "./useRemoteThreadListRuntime";
+
+const EMPTY_MESSAGES: readonly never[] = [];
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useRemoteThreadListRuntime load recovery", () => {
+  it("reloads once when the browser comes online after a failed load", async () => {
+    const error = new Error("offline");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ threads: [] });
+    const adapter = makeAdapter({ list });
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    const useThreadRuntime = () =>
+      useExternalStoreRuntime({
+        messages: EMPTY_MESSAGES,
+        onNew: async () => {},
+      } as never);
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: useThreadRuntime,
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(runtimeRef.current!.threads.getState().loadError).toBe(error),
+    );
+
+    act(() => window.dispatchEvent(new Event("online")));
+
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+    await act(async () => {});
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(runtimeRef.current!.threads.getState().loadError).toBeUndefined();
+  });
+});

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.load-error.test.tsx
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.load-error.test.tsx
@@ -57,4 +57,52 @@ describe("useRemoteThreadListRuntime load recovery", () => {
     expect(list).toHaveBeenCalledTimes(2);
     expect(runtimeRef.current!.threads.getState().loadError).toBeUndefined();
   });
+
+  it("reloads once when the page becomes visible after a failed load", async () => {
+    const error = new Error("offline");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ threads: [] });
+    const adapter = makeAdapter({ list });
+    const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+    const useThreadRuntime = () =>
+      useExternalStoreRuntime({
+        messages: EMPTY_MESSAGES,
+        onNew: async () => {},
+      } as never);
+
+    const App = () => {
+      const runtime = useRemoteThreadListRuntime({
+        adapter,
+        runtimeHook: useThreadRuntime,
+      });
+      runtimeRef.current = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          {null}
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    render(<App />);
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(runtimeRef.current!.threads.getState().loadError).toBe(error),
+    );
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(runtimeRef.current!.threads.getState().loadError).toBeUndefined(),
+    );
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await act(async () => {});
+
+    expect(list).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
+++ b/packages/core/src/react/runtimes/useRemoteThreadListRuntime.ts
@@ -44,6 +44,28 @@ const useRemoteThreadListRuntimeImpl = (
     runtime.threads.__internal_load();
   }, [runtime, options]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const reloadAfterError = () => {
+      if (runtime.threads.loadError !== undefined) {
+        void runtime.threads.reload();
+      }
+    };
+    const reloadAfterVisible = () => {
+      if (document.visibilityState === "visible") reloadAfterError();
+    };
+
+    window.addEventListener("online", reloadAfterError);
+    document.addEventListener("visibilitychange", reloadAfterVisible);
+    return () => {
+      window.removeEventListener("online", reloadAfterError);
+      document.removeEventListener("visibilitychange", reloadAfterVisible);
+    };
+  }, [runtime]);
+
   return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime]);
 };
 

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -32,6 +32,8 @@ export type ThreadListState = {
   readonly threadIds: readonly string[];
   readonly archivedThreadIds: readonly string[];
   readonly isLoading: boolean;
+  /** The error thrown by the most recent thread list load that failed, cleared when a later load starts. */
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<
@@ -97,6 +99,7 @@ const getThreadListState = (
     threadIds: threadList.threadIds,
     archivedThreadIds: threadList.archivedThreadIds,
     isLoading: threadList.isLoading,
+    loadError: threadList.loadError,
     isLoadingMore: threadList.isLoadingMore ?? false,
     hasMore: threadList.hasMore ?? false,
     threadItems: threadList.threadItems,

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -26,6 +26,7 @@ export type ThreadListRuntimeEvent = {
 
 export type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -26,7 +26,7 @@ export type ThreadListRuntimeEvent = {
 
 export type ThreadListRuntimeCore = {
   readonly isLoading: boolean;
-  readonly loadError: unknown;
+  readonly loadError?: unknown;
   readonly isLoadingMore?: boolean;
   readonly hasMore?: boolean;
   mainThreadId: string;

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -38,10 +38,6 @@ export class ExternalStoreThreadListRuntimeCore
     return this.adapter.isLoading ?? false;
   }
 
-  public get loadError() {
-    return undefined;
-  }
-
   public get newThreadId() {
     return undefined;
   }

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -38,6 +38,10 @@ export class ExternalStoreThreadListRuntimeCore
     return this.adapter.isLoading ?? false;
   }
 
+  public get loadError() {
+    return undefined;
+  }
+
   public get newThreadId() {
     return undefined;
   }

--- a/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
@@ -30,10 +30,6 @@ export class LocalThreadListRuntimeCore
     return false;
   }
 
-  public get loadError() {
-    return undefined;
-  }
-
   public getMainThreadRuntimeCore() {
     return this._mainThread;
   }

--- a/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-list-runtime-core.ts
@@ -30,6 +30,10 @@ export class LocalThreadListRuntimeCore
     return false;
   }
 
+  public get loadError() {
+    return undefined;
+  }
+
   public getMainThreadRuntimeCore() {
     return this._mainThread;
   }

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
@@ -54,6 +54,7 @@ describe("remote thread state", () => {
   it("creates an empty state", () => {
     expect(createEmptyRemoteThreadState()).toEqual({
       isLoading: true,
+      loadError: undefined,
       isLoadingMore: false,
       cursor: undefined,
       newThreadId: undefined,

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -130,6 +130,7 @@ export const classifyThreads = (
 
 export type RemoteThreadState = {
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly cursor: string | undefined;
   readonly newThreadId: string | undefined;
@@ -141,6 +142,7 @@ export type RemoteThreadState = {
 
 export const createEmptyRemoteThreadState = (): RemoteThreadState => ({
   isLoading: true,
+  loadError: undefined,
   isLoadingMore: false,
   cursor: undefined,
   newThreadId: undefined,

--- a/packages/core/src/store/clients/single-thread-list.ts
+++ b/packages/core/src/store/clients/single-thread-list.ts
@@ -59,6 +59,7 @@ const useSingleThreadList = ({
       mainThreadId: THREAD_ID,
       newThreadId: null,
       isLoading: false,
+      loadError: undefined,
       isLoadingMore: false,
       hasMore: false,
       threadIds: [THREAD_ID],

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -82,6 +82,7 @@ const useThreadListClient = ({
       mainThreadId: runtimeState.mainThreadId,
       newThreadId: runtimeState.newThreadId ?? null,
       isLoading: runtimeState.isLoading,
+      loadError: runtimeState.loadError,
       isLoadingMore: runtimeState.isLoadingMore,
       hasMore: runtimeState.hasMore,
       threadIds: runtimeState.threadIds,

--- a/packages/core/src/store/scopes/threads.ts
+++ b/packages/core/src/store/scopes/threads.ts
@@ -9,6 +9,7 @@ export type ThreadsState = {
   readonly mainThreadId: string;
   readonly newThreadId: string | null;
   readonly isLoading: boolean;
+  readonly loadError: unknown;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadIds: readonly string[];

--- a/packages/core/src/tests/OptimisticState-list-race.test.ts
+++ b/packages/core/src/tests/OptimisticState-list-race.test.ts
@@ -22,6 +22,7 @@ import { deferred } from "./remote-thread-list-test-helpers";
 
 const EMPTY_STATE: RemoteThreadState = {
   isLoading: false,
+  loadError: undefined,
   isLoadingMore: false,
   cursor: undefined,
   newThreadId: undefined,

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -160,6 +160,7 @@ describe("preserveMidLoadTransitions", () => {
     lists: { threadIds?: string[]; archivedThreadIds?: string[] } = {},
   ): RemoteThreadState => ({
     isLoading: false,
+    loadError: undefined,
     isLoadingMore: false,
     cursor: undefined,
     newThreadId: undefined,

--- a/packages/core/src/tests/remote-thread-list-isLoading.test.ts
+++ b/packages/core/src/tests/remote-thread-list-isLoading.test.ts
@@ -26,6 +26,7 @@ type ListResult = {
 
 const INITIAL_STATE: RemoteThreadState = {
   isLoading: true,
+  loadError: undefined,
   isLoadingMore: false,
   cursor: undefined,
   newThreadId: undefined,

--- a/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
+++ b/packages/core/src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts
@@ -9,6 +9,7 @@ const createMockCore = (
   loadPromise: Promise<void> = Promise.resolve(),
 ): ThreadListRuntimeCore => ({
   isLoading: false,
+  loadError: undefined,
   mainThreadId: MAIN_THREAD_ID,
   newThreadId: undefined,
   threadIds: [MAIN_THREAD_ID],


### PR DESCRIPTION
## Problem

when the remote thread list's first load fails (a network failure, an auth token that could not be minted, a backend error), the sidebar renders exactly like an empty list: no skeleton, no message, no way to retry. the docs landing demo showed this on 2026-09-04 during a cloud API failure window and again on a single failed page load, and it reads as "my history is gone".

## Root cause

`RemoteThreadListThreadListRuntimeCore.getLoadThreadsPromise` catches the failure, logs it, and sets `isLoading` false with no threads and no error state. nothing distinguishes a failed load from an empty workspace, and nothing retries until a full page reload.

## Change

`ThreadListState` gains `loadError`, the error of the most recent failed load, cleared when a later load starts. on failure the core keeps the threads it already had; after an adapter swap it still replaces the list with nothing, because that list belonged to the previous adapter, and sets the error. `useRemoteThreadListRuntime` reloads once on the window `online` event and when the document becomes visible while an error is set. the aui store exposes the same field as `s.threads.loadError`. the demo sidebar renders a "Threads could not be loaded" row with a Retry button in the Load more grammar instead of nothing.

## Verification

- `packages/core` vitest: 161 files, 1678 tests pass, including the new `RemoteThreadListThreadListRuntimeCore.load-error.test.ts` (kept list on failure, replacement failure clears the list, reload clears the error, loading clears the error) and `useRemoteThreadListRuntime.load-error.test.tsx` (one reload on `online`).
- `apps/docs` demo tests: 7 pass. tsc on `packages/core` reports the same 102 pre-existing diagnostics as main and none in touched files.

- browser pass on a dev server from this branch: with `/v1/threads` requests made to reject at the network level, the sidebar rendered the "Threads could not be loaded" row with Retry and the console carried the load failure; dispatching `online` after restoring the network re-fetched both lists (200) and cleared the row without a click; on a fresh failed load, clicking Retry cleared the row and reloaded the list.

## Public surface

`@assistant-ui/core`: `ThreadListState.loadError` (append only), mirrored on `ThreadListRuntimeCore` and the aui store `threads` scope; changeset patch. docs sidebar change is private to `apps/docs`. api-surface and api-reference regeneration land in this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TVKJXi473-5N344ESYkQiJqBNRHXszguZrqrNIbqjINPp5q02XnvDgN5tj4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
