### PR TITLE
fix(docs): let the scrollbar overlay instead of reserving a gutter

### DIFF
--- a/apps/docs/app/(demos)/demos/[slug]/embed/page.tsx
+++ b/apps/docs/app/(demos)/demos/[slug]/embed/page.tsx
@@ -26,7 +26,7 @@ export default async function DemoEmbedPage({
 
   return (
     <div className="bg-background flex h-dvh flex-col overflow-hidden">
-      {/* The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the embed iframe that reserves a permanent 6px scrollbar strip along the right edge. */}
+      {/* The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the embed iframe that reserves a permanent scrollbar strip along the right edge wherever the platform draws classic scrollbars. */}
       <style>{`html { overflow: hidden; }`}</style>
       <main className="min-h-0 flex-1">
         <DocsRuntimeProvider>

--- a/apps/docs/app/(demos)/learn/preview/[stageId]/page.tsx
+++ b/apps/docs/app/(demos)/learn/preview/[stageId]/page.tsx
@@ -10,7 +10,7 @@ import { PublicAssistantSessionBoundary } from "@/components/xulux/learn/PublicA
 // Each preview needs its own server-side usage-budget session.
 export const dynamic = "force-dynamic";
 
-// The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the preview iframe that reserves a permanent 6px scrollbar strip along the right edge.
+// The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the preview iframe that reserves a permanent scrollbar strip along the right edge wherever the platform draws classic scrollbars.
 const PreviewShell = ({ children }: { children: React.ReactNode }) => (
   <div className="bg-background h-dvh overflow-hidden">
     <style>{`html { overflow: hidden; }`}</style>

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -291,9 +291,21 @@
     --removed-body-scroll-bar-size: 0px !important;
   }
 
-  @supports not selector(::-webkit-scrollbar) {
+  :focus-visible {
+    box-shadow: none;
+  }
+}
+
+/* Styling ::-webkit-scrollbar turns a scroller's overlay scrollbar into a classic
+   one that occupies layout width, so the scrollbar look is carried by the standard
+   properties instead. They sit a layer above `base` because tailwind-scrollbar
+   resets both of them on `*` at the end of that layer. */
+@layer components {
+  * {
+    scrollbar-width: thin;
+  }
+  @media (hover: hover) {
     * {
-      scrollbar-width: thin;
       scrollbar-color: transparent transparent;
     }
     *:hover {
@@ -304,38 +316,5 @@
         )
         transparent;
     }
-  }
-  *::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  *::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  *::-webkit-scrollbar-thumb {
-    background-color: transparent;
-    border-radius: 9999px;
-  }
-  *:hover::-webkit-scrollbar-thumb {
-    background-color: color-mix(
-      in srgb,
-      var(--muted-foreground) 30%,
-      transparent
-    );
-  }
-  *::-webkit-scrollbar-thumb:hover,
-  *::-webkit-scrollbar-thumb:active {
-    background-color: color-mix(
-      in srgb,
-      var(--muted-foreground) 50%,
-      transparent
-    );
-  }
-  *::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-
-  :focus-visible {
-    box-shadow: none;
   }
 }


### PR DESCRIPTION
## Problem

every page of the docs site is 6px narrower than the viewport, permanently, and every inner scroll box loses 6px the moment it becomes scrollable. on macOS, where the platform draws overlay scrollbars that cost no layout width, the site was still paying for a classic one. the cost is visible as a dead strip along the right edge, as content that reflows when a box starts scrolling (worst while a chat streams), and as a pile of local workarounds: two iframe routes inject `<style>html{overflow:hidden}</style>` to kill the strip, the docs sidebar hides its scrollbar outright, the home demo thread reserves `scrollbar-gutter: stable both-edges`, and 17 call sites reach for `scrollbar-none` / `scrollbar-thin`.

## Root cause

`*::-webkit-scrollbar { width: 6px; height: 6px }` in `globals.css`. defining any `::-webkit-scrollbar` rule switches that scroller from the platform overlay scrollbar to a custom, classic one that occupies layout width, and the selector was `*`, so it applied to the root scroller and to every scroll box on the site. `html { overflow-y: scroll }` then made the root strip permanent.

isolated in chrome on macOS: `html{overflow-y:scroll}` alone reserves 0px; adding `*::-webkit-scrollbar{width:6px}` reserves 6px. the standard properties do not have this effect, they reserve 0px and chrome still paints `scrollbar-color` onto the overlay thumb.

## Change

the whole `::-webkit-scrollbar` block is gone and the same look now comes from `scrollbar-width` / `scrollbar-color`, which the file already used, but only inside an `@supports not selector(::-webkit-scrollbar)` branch that made them Firefox only. that branch collapses, leaving one code path.

two placement details carry the change. the rules sit in `@layer components` rather than `base` because the `tailwind-scrollbar` plugin emits `* { scrollbar-color: initial; scrollbar-width: initial }` at the end of the base layer, which silently reset them; one layer up beats that reset while still losing to the `.scrollbar-none` utilities in the utilities layer, so those 17 call sites keep working. and the hover reveal is gated on `@media (hover: hover)` so a touch device gets a visible native scrollbar instead of a permanently transparent one.

`html { overflow-y: scroll }` stays. the measurement shows the webkit rule was the sole cause, and keeping the explicit root overflow avoids changing body to viewport overflow propagation, which the `body[data-scroll-locked]` block depends on. the two iframe comments lose their now stale reference to our own 6px.

## Verification

measured in chrome on macOS against a dev server from this branch, on `/`, `/docs` and `/docs/runtimes/langchain`:

- root gutter (`innerWidth - documentElement.clientWidth`) 6px to 0 on every page.
- every inner scroller (code blocks with `overflow-x-auto`, the sidebar) 6px to 0.
- the home demo thread's `[scrollbar-gutter:stable_both-edges]` 12px total to 0.
- horizontal overflow stays 0, and `.scrollbar-none` / `.sidebar-tree-content` still compute `scrollbar-width: none`, so the utilities layer still wins.
- a fresh element computes `scrollbar-width: thin` with a transparent-at-rest `scrollbar-color`, confirming the components layer beats the plugin reset.
- separately confirmed chrome on macOS paints `scrollbar-color` on an overlay scrollbar (red thumb rendered, gutter still 0), so the look survives the switch.

`pnpm exec oxlint apps/docs` clean apart from pre-existing `set-state-in-effect` warnings, `oxfmt --check` clean.

## Public surface

none. `apps/docs` is private, so no changeset. on platforms that always draw classic scrollbars (Windows, Linux, macOS set to always show) the thumb becomes the browser's `thin` scrollbar rather than a 6px rounded bar, and the thumb drag darkening from 30% to 50% is gone, because the standard properties cannot express thumb hover and active states.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.zupp0psfNSLJB6Or4N6QMqAP93IKO1_paZMt9HWUwWcXBUUUVSIXKNfMJo4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->