### PR TITLE
fix(ui): stretch the context display popover to its own width

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/context-display.radix.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/context-display.radix.tsx
@@ -225,7 +225,7 @@ function ContextDisplayContent({
       sideOffset={8}
       data-slot="context-display-popover"
       className={cn(
-        "bg-popover text-popover-foreground w-56 border p-3 text-left [&_[data-slot=tooltip-arrow]]:hidden",
+        "bg-popover text-popover-foreground block w-56 border p-3 text-left [&_[data-slot=tooltip-arrow]]:hidden",
         className,
       )}
     >

--- a/packages/ui/src/components/react/assistant-ui/elements/context-display.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/context-display.tsx
@@ -227,7 +227,7 @@ function ContextDisplayContent({
       sideOffset={8}
       data-slot="context-display-popover"
       className={cn(
-        "bg-popover text-popover-foreground w-56 border p-3 text-left [&_[data-slot=tooltip-arrow]]:hidden",
+        "bg-popover text-popover-foreground block w-56 border p-3 text-left [&_[data-slot=tooltip-arrow]]:hidden",
         className,
       )}
     >


### PR DESCRIPTION
## Problem

the context display popover leaves a wide empty column on its right. the header row's `1% full` / `11k / 1.1M` pair, every segment row's value, and the usage bar all stop well short of the card's right padding edge, so a layout written as `justify-between` inside a fixed width card reads as left aligned with a dead margin.

## Root cause

`TooltipContent`'s popup carries `inline-flex w-fit ... items-center gap-1.5` in both flavors, which is right for the single line icon plus label plus kbd tooltip it was designed for. the context display passes `w-56 border p-3`, and `cn` resolves that against `w-fit` and the padding but leaves the display alone. so the popup is a 224px flex container and its single block child is a flex item at `flex: 0 1 auto`, sized to max-content rather than stretched.

measured with the real merged class strings: the content block is 134px inside a 198px content box, and the values sit 66px inside the right padding edge. that matches the gap in the report.

## Change

`block` in the popup className of both flavors. `cn` (a tailwind-merge parity implementation) drops the conflicting `inline-flex`, the child becomes an ordinary block and fills the content box, and the leftover `items-center` / `gap-1.5` go inert.

the tooltip primitives are untouched: their inline-flex default is correct for every other tooltip in the kit, and a panel shaped popup overriding display at the call site is the existing idiom, `assistant-modal.aui.tsx` does exactly this.

## Verification

`cn` output for both flavors: display resolves to `block`, width to `w-56`, `inline-flex` and `w-fit` dropped.

rendered in chrome with those merged strings, before and after:

- content block 134px to 198px (224px minus 24px padding minus the border), so it now fills the card.
- usage bar track 134px to 198px.
- right hand values 65px inside the padding edge to 1px, ie. flush.

`vitest` context-display 10/10, `oxlint` and `oxfmt --check` clean on both files.

## Public surface

none. `@assistant-ui/ui` is private, so no changeset. rendering only, no API or prop change.

two adjacent oddities in the same popover are deliberately left alone: the usage bar renders as a 4px dot at low percentages (`min-w-1` on a `h-1 rounded-full` fill), and the segment rows do not sum to the total because cached input is a subset of input for some providers and a sibling for others, which the code comment already rules on.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qKZzmsgSwyytjYA1nQmrUfXIp2bW84tdDL3gltTocJENSjKY_eMzrqHEVeY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->