### PR TITLE
feat(docs): raise the landing demo's daily conversation budget

### DIFF
--- a/apps/docs/lib/conversation-limit.ts
+++ b/apps/docs/lib/conversation-limit.ts
@@ -1,7 +1,7 @@
 import type { Redis } from "@upstash/redis";
 
-export const ANONYMOUS_CONVERSATIONS_PER_DAY = 3;
-export const SIGNED_IN_CONVERSATIONS_PER_DAY = 10;
+export const ANONYMOUS_CONVERSATIONS_PER_DAY = 10;
+export const SIGNED_IN_CONVERSATIONS_PER_DAY = 30;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## Problem

the landing demo's daily budget is 3 conversations anonymous and 10 signed in. three is not enough to form an impression of the product, and the jump to ten is a thin reason to sign in.

## Change

anonymous goes to 10 per day, signed in to 30. two constants in `lib/conversation-limit.ts`; the limit reaches the route and the UI through `conversationLimitFor`, and the user facing copy already interpolates `conversationsAllowedPerDay`, so no string carries a number.

nothing else moves. the request level limits on `/api/chat` sit far above this (500 per session per day, 2000 per IP per day, 20000 globally), so the conversation budget stays the binding constraint. the `limit: 3` values in the tests are each test's own fixture, not the constant, and `conversation-limit.test.ts` asserts against the exported constants, so it follows the change.

## Verification

`pnpm vitest run` in `apps/docs`: 86 files, 722 tests pass (full run, not a subset, since a previous subset run here missed `app/api/chat/route.test.ts`). `oxfmt --check` clean.

not exercised locally: the counter is Redis backed and `isDev` short circuits it, so the new ceilings first take effect on deploy.

## Public surface

none. `apps/docs` is private, so no changeset.

raising the per visitor budget raises the ceiling on daily spend proportionally. `AUI_PUBLIC_ASSISTANT_GLOBAL_REQUESTS_PER_DAY` is the env var to pull if that needs capping, no code change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4EubxjExEB8FhogJqXrBz1LP8VfRnQ_OvH0Pk6Sng8xO9r5q4rx7TTgtpoU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->