### PR TITLE
fix(docs): show five logos on the narrow logo wall, three over two

### DIFF
--- a/apps/docs/components/pages/home/trusted-by.tsx
+++ b/apps/docs/components/pages/home/trusted-by.tsx
@@ -145,7 +145,7 @@ const LOGOS: Logo[] = [
 
 const SLOTS = 9;
 export const ALL_SLOTS = Array.from({ length: SLOTS }, (_, index) => index);
-export const MOBILE_SLOTS = [0, 1, 2, 5, 6, 7];
+export const MOBILE_SLOTS = [0, 1, 2, 5, 6];
 const HOLD_MIN_MS = 1600;
 const HOLD_SPAN_MS = 900;
 const CROSSFADE_MS = 500;
@@ -398,7 +398,7 @@ export function TrustedBy() {
           />
         ))}
       </div>
-      <div className="mx-auto grid w-full grid-cols-3 sm:w-4/5 sm:grid-cols-4">
+      <div className="mx-auto grid w-full grid-cols-2 sm:w-4/5 sm:grid-cols-4">
         {shown.slice(5, SLOTS).map((logo, offset) => (
           <LogoSlot
             key={offset + 5}


### PR DESCRIPTION
## Problem

the home page logo wall shows six marks on a phone, in two rows of three. that is more than the width can carry, and the row width is what makes it read as crowded rather than the count alone: each cell is a third of the section, and a wide wordmark fills it to the `max-w-[9rem]` cap, 144px inside a 156px cell at 500px, six pixels of air on each side. narrower than about 430px the cap stops binding, the mark scales down to fit the cell instead, and it paints around 19px tall next to a compact mark at the full 24px, so the row also stops looking level.

## Change

`MOBILE_SLOTS` drops slot 7, leaving `[0, 1, 2, 5, 6]`: three marks over two.

the second row goes from `grid-cols-3` to `grid-cols-2` at the same breakpoint. this is not cosmetic sugar on the first change, it is required by it: hidden slots are `display: none` and leave the grid flow, so two marks in a three-column row would sit in columns one and two, left of centre under the row above. those two cells also widen from 156px to 234px at 500px.

the first row stays three across, so its cells stay a third of the section and a wide wordmark rotating into slots 0 to 2 is still the tight case. that is the arrangement itself, not an oversight: three over two is the layout asked for, and the only thing that would widen the top cells is showing fewer than three there. so what this ships is five marks instead of six, and room for the bottom two; the top row is unchanged by design.

rotation is untouched. `MOBILE_SLOTS` remains the single source of truth for both `hideOnMobile` and the rotation pool, so `takeSlot` still draws only from visible slots and `rotateSlot` still trades with a logo parked in a hidden slot rather than duplicating it. all nine stay distinct at either breakpoint, and the full catalogue still cycles through the five visible windows.

## Verification

`trusted-by.test.ts` 15/15. every assertion there derives from `MOBILE_SLOTS` and checks distinctness rather than a count, so it re-covers the new five-slot set with no edit; that test is the guard against a mis-set slot array. full `apps/docs` vitest 86 files, 722 tests pass. `oxfmt --check` clean.

browser pass on a dev server from this branch, following the duplicate-probe rule this component earned the hard way (enumerate every `<a>` layer in every painted slot, sample across the transition, not one layer per slot two seconds later):

- narrow (500px): three cells of 156px over two of 234px, five marks visible. LangChain measures 140px, so 47px of air per side in the new bottom cell against 8px in the old 156px one.
- wide (1100px): five over four, unchanged.
- 840 samples at 40ms across a 500 to 1100 to 500 round trip: zero duplicate layers, peak 10 layers (nine slots plus one mid crossfade), 10 distinct logos rotated through during the run, so the cycle keeps running across the breakpoint change.

## Public surface

none. `apps/docs` is private, so no changeset.

the narrow first paint changes from six marks to Anthropic, Google Cloud, AWS over Langchain, Builder.io; Paperclip is no longer in it.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GScBarmAnenSOdfz1SIlVjFgMU0x9CWcnMzuQjFpOEzzlCkE9iCJ9XLUBr0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->