### PR TITLE
feat(eve): ship a standalone tool UI for eve's ask_question tool

### DIFF
--- a/apps/docs/content/docs/runtimes/eve/overview.mdx
+++ b/apps/docs/content/docs/runtimes/eve/overview.mdx
@@ -100,6 +100,49 @@ export const AuthorizationUI = makeAssistantDataUI<EveAuthorizationData>({
 Mount `<AuthorizationUI />` inside the `AssistantRuntimeProvider` tree. The
 standard thread intentionally leaves unmatched data parts unrendered.
 
+## Questions
+
+Eve's built-in `ask_question` tool pauses the turn until the user answers. The
+runtime projects it onto an assistant-ui tool approval that carries the
+`prompt`, the `options`, and whether a free-form answer is accepted, and the
+answer goes back through `respondToApproval`. Eve records a question the user
+never answers as `ignored` when the next message arrives, so a reply typed into
+the composer does not answer it.
+
+Without a renderer for `ask_question`, the question is drawn by the default
+`ToolFallback` inside the collapsed tool group, which reads as a step in the
+agent's trace rather than as the agent talking to the user. The Eve template
+ships a renderer as `components/eve-ask-question.tsx` that presents the question
+on its own with the answer controls, and `eve add @assistant-ui/eve-chat`
+installs it. Add it to an existing app from the registry:
+
+```sh
+eve add @assistant-ui/eve-ask-question
+```
+
+or
+
+```sh
+npx shadcn@latest add https://r.assistant-ui.com/eve-ask-question.json
+```
+
+Then register the toolkit it exports on the runtime provider:
+
+```tsx title="app/page.tsx"
+import { eveAskQuestionToolkit } from "@/components/eve-ask-question";
+import { AssistantRuntimeProvider, AuiConfig, Tools } from "@assistant-ui/react";
+
+const config = AuiConfig({ tools: Tools({ toolkit: eveAskQuestionToolkit }) });
+
+<AssistantRuntimeProvider runtime={runtime} config={config}>
+  <Thread />
+</AssistantRuntimeProvider>;
+```
+
+The renderer builds on `ToolFallback.Approval`, so it inherits the option
+buttons, the free-form answer field, and the confirmation step, and it shows
+the recorded answer once the question is resolved.
+
 ## Requirements
 
 - Node.js 24 or higher.

--- a/apps/docs/content/docs/runtimes/eve/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/eve/quickstart.mdx
@@ -54,7 +54,7 @@ eve registry add @assistant-ui=https://r.assistant-ui.com/{name}.json
 eve add @assistant-ui/eve-chat --overwrite
 ```
 
-`eve registry add` records the namespace in your `package.json`. `eve add` then installs `@assistant-ui/react` and `@assistant-ui/eve`, writes `app/page.tsx`, and writes the thread component together with everything it imports into `components/assistant-ui` and `components/ui`. It expects an Eve app that carries the Next.js Web Chat scaffold, because the installed files import `@/lib/utils` through the `@/*` alias that `eve init --channel-web-nextjs` sets up.
+`eve registry add` records the namespace in your `package.json`. `eve add` then installs `@assistant-ui/react` and `@assistant-ui/eve`, writes `app/page.tsx`, writes the thread component together with everything it imports into `components/assistant-ui` and `components/ui`, and writes `components/eve-ask-question.tsx`, the renderer for Eve's built-in `ask_question` tool. It expects an Eve app that carries the Next.js Web Chat scaffold, because the installed files import `@/lib/utils` through the `@/*` alias that `eve init --channel-web-nextjs` sets up.
 
 `--overwrite` is global rather than per file. It is what lets the item replace the scaffold's own `app/page.tsx`, and it also replaces any `components/assistant-ui` or `components/ui` file already in the project, including `avatar`, `button`, `collapsible`, `dialog`, and `tooltip`, so install on a clean tree and read the diff before keeping it. A plain `eve add` skips every pre-existing file instead, which leaves `app/page.tsx` untouched. Inspect an item before installing it with `eve registry view @assistant-ui/eve-chat`, and browse the rest of the registry with `eve registry list --registry @assistant-ui`.
 
@@ -157,6 +157,32 @@ export default function Home() {
   );
 }
 ```
+
+</Step>
+<Step>
+
+### Render questions
+
+Eve's built-in `ask_question` tool needs a renderer, or the question lands inside the collapsed tool group. Install it from the registry:
+
+```sh
+npx shadcn@latest add https://r.assistant-ui.com/eve-ask-question.json
+```
+
+Then register its toolkit on the provider:
+
+```tsx title="app/page.tsx"
+import { eveAskQuestionToolkit } from "@/components/eve-ask-question";
+import { AuiConfig, Tools } from "@assistant-ui/react";
+
+const config = AuiConfig({ tools: Tools({ toolkit: eveAskQuestionToolkit }) });
+
+<AssistantRuntimeProvider runtime={runtime} config={config}>
+  <Thread />
+</AssistantRuntimeProvider>;
+```
+
+See [Questions](/docs/runtimes/eve/overview#questions) for how the answer flows back to Eve.
 
 </Step>
 </Steps>

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1017,13 +1017,32 @@ export const registry: RegistryItem[] = [
       },
     ],
     dependencies: ["@assistant-ui/eve"],
-    bundledRegistryDependencies: ["https://r.assistant-ui.com/thread.json"],
+    bundledRegistryDependencies: [
+      "https://r.assistant-ui.com/thread.json",
+      "https://r.assistant-ui.com/eve-ask-question.json",
+    ],
     docs: "Eve installs registry files without touching CSS, so add the reasoning and collapsible styles to app/globals.css, and replace the default auth policy in agent/channels/eve.ts before deploying: https://www.assistant-ui.com/docs/runtimes/eve/quickstart",
     meta: {
       eve: {
         requires: ">=0.27.6",
       },
     },
+  },
+  {
+    name: "eve-ask-question",
+    type: "registry:component",
+    title: "Eve Ask Question",
+    description:
+      "Renders Eve's built-in ask_question tool as a standalone question with answer controls, outside the collapsed tool group.",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/eve-ask-question.tsx",
+        sourcePath: "templates/eve/components/eve-ask-question.tsx",
+      },
+    ],
+    dependencies: ["@assistant-ui/react"],
+    registryDependencies: ["https://r.assistant-ui.com/tool-fallback.json"],
   },
   {
     name: "thread",

--- a/apps/registry/templates/eve/app/page.tsx
+++ b/apps/registry/templates/eve/app/page.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { Thread } from "@/components/assistant-ui/elements/thread.aui";
-import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { eveAskQuestionToolkit } from "@/components/eve-ask-question";
 import { useEveAgentRuntime } from "@assistant-ui/eve";
+import {
+  AssistantRuntimeProvider,
+  AuiConfig,
+  Tools,
+} from "@assistant-ui/react";
 
 export default function Home() {
   const runtime = useEveAgentRuntime();
+  const config = AuiConfig({
+    tools: Tools({ toolkit: eveAskQuestionToolkit }),
+  });
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
+    <AssistantRuntimeProvider runtime={runtime} config={config}>
       <div className="h-dvh">
         <Thread />
       </div>

--- a/apps/registry/templates/eve/components/eve-ask-question.tsx
+++ b/apps/registry/templates/eve/components/eve-ask-question.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  defineToolkit,
+  type ToolCallMessagePartComponent,
+} from "@assistant-ui/react";
+import { ToolFallbackApproval } from "@/components/assistant-ui/elements/tool-fallback.aui";
+
+type AskQuestionArgs = {
+  prompt?: string;
+  options?: { id: string; label: string }[];
+  allowFreeform?: boolean;
+};
+
+type AskQuestionResult = {
+  status: "answered" | "ignored";
+  optionId?: string;
+  text?: string;
+};
+
+const EveAskQuestion: ToolCallMessagePartComponent<
+  AskQuestionArgs,
+  AskQuestionResult
+> = ({ args, approval, result, status, respondToApproval }) => {
+  const prompt = approval?.prompt ?? args.prompt;
+  const isPending =
+    approval !== undefined &&
+    approval.approved === undefined &&
+    approval.resolution === undefined;
+
+  if (isPending) {
+    return (
+      <div className="aui-eve-ask-question my-2 flex flex-col gap-2">
+        <ToolFallbackApproval
+          approval={approval}
+          respondToApproval={respondToApproval}
+          status={status}
+        />
+      </div>
+    );
+  }
+
+  const optionId = approval?.optionId ?? result?.optionId;
+  const answer =
+    approval?.text ??
+    result?.text ??
+    approval?.options?.find((option) => option.id === optionId)?.label ??
+    optionId;
+  const skipped =
+    approval?.resolution !== undefined || result?.status === "ignored";
+
+  return (
+    <div className="aui-eve-ask-question my-2 flex flex-col gap-1">
+      {prompt && <p className="text-foreground">{prompt}</p>}
+      {answer ? (
+        <p className="text-muted-foreground text-sm">{answer}</p>
+      ) : skipped ? (
+        <p className="text-muted-foreground text-sm">Skipped</p>
+      ) : null}
+    </div>
+  );
+};
+
+export const eveAskQuestionToolkit = defineToolkit({
+  ask_question: {
+    type: "backend",
+    display: "standalone",
+    render: EveAskQuestion,
+  },
+});

--- a/examples/with-eve/app/page.tsx
+++ b/examples/with-eve/app/page.tsx
@@ -1,17 +1,20 @@
 "use client";
 
 import { Thread } from "@/components/assistant-ui/elements/thread.aui";
+import { eveAskQuestionToolkit } from "@/components/eve-ask-question";
 import { EveAuthorization } from "@/components/eve-authorization";
 import {
   AssistantRuntimeProvider,
   AuiConfig,
   Suggestions,
+  Tools,
 } from "@assistant-ui/react";
 import { useEveAgentRuntime } from "@assistant-ui/eve";
 
 export default function Home() {
   const runtime = useEveAgentRuntime();
   const config = AuiConfig({
+    tools: Tools({ toolkit: eveAskQuestionToolkit }),
     suggestions: Suggestions([
       {
         title: "Explain Eve",

--- a/examples/with-eve/components/eve-ask-question.tsx
+++ b/examples/with-eve/components/eve-ask-question.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  defineToolkit,
+  type ToolCallMessagePartComponent,
+} from "@assistant-ui/react";
+import { ToolFallbackApproval } from "@/components/assistant-ui/elements/tool-fallback.aui";
+
+type AskQuestionArgs = {
+  prompt?: string;
+  options?: { id: string; label: string }[];
+  allowFreeform?: boolean;
+};
+
+type AskQuestionResult = {
+  status: "answered" | "ignored";
+  optionId?: string;
+  text?: string;
+};
+
+const EveAskQuestion: ToolCallMessagePartComponent<
+  AskQuestionArgs,
+  AskQuestionResult
+> = ({ args, approval, result, status, respondToApproval }) => {
+  const prompt = approval?.prompt ?? args.prompt;
+  const isPending =
+    approval !== undefined &&
+    approval.approved === undefined &&
+    approval.resolution === undefined;
+
+  if (isPending) {
+    return (
+      <div className="aui-eve-ask-question my-2 flex flex-col gap-2">
+        <ToolFallbackApproval
+          approval={approval}
+          respondToApproval={respondToApproval}
+          status={status}
+        />
+      </div>
+    );
+  }
+
+  const optionId = approval?.optionId ?? result?.optionId;
+  const answer =
+    approval?.text ??
+    result?.text ??
+    approval?.options?.find((option) => option.id === optionId)?.label ??
+    optionId;
+  const skipped =
+    approval?.resolution !== undefined || result?.status === "ignored";
+
+  return (
+    <div className="aui-eve-ask-question my-2 flex flex-col gap-1">
+      {prompt && <p className="text-foreground">{prompt}</p>}
+      {answer ? (
+        <p className="text-muted-foreground text-sm">{answer}</p>
+      ) : skipped ? (
+        <p className="text-muted-foreground text-sm">Skipped</p>
+      ) : null}
+    </div>
+  );
+};
+
+export const eveAskQuestionToolkit = defineToolkit({
+  ask_question: {
+    type: "backend",
+    display: "standalone",
+    render: EveAskQuestion,
+  },
+});

--- a/templates/eve/app/page.tsx
+++ b/templates/eve/app/page.tsx
@@ -1,17 +1,20 @@
 "use client";
 
 import { Thread } from "@/components/assistant-ui/elements/thread.aui";
+import { eveAskQuestionToolkit } from "@/components/eve-ask-question";
 import { EveAuthorization } from "@/components/eve-authorization";
 import {
   AssistantRuntimeProvider,
   AuiConfig,
   Suggestions,
+  Tools,
 } from "@assistant-ui/react";
 import { useEveAgentRuntime } from "@assistant-ui/eve";
 
 export default function Home() {
   const runtime = useEveAgentRuntime();
   const config = AuiConfig({
+    tools: Tools({ toolkit: eveAskQuestionToolkit }),
     suggestions: Suggestions([
       {
         title: "Explain Eve",

--- a/templates/eve/components/eve-ask-question.tsx
+++ b/templates/eve/components/eve-ask-question.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  defineToolkit,
+  type ToolCallMessagePartComponent,
+} from "@assistant-ui/react";
+import { ToolFallbackApproval } from "@/components/assistant-ui/elements/tool-fallback.aui";
+
+type AskQuestionArgs = {
+  prompt?: string;
+  options?: { id: string; label: string }[];
+  allowFreeform?: boolean;
+};
+
+type AskQuestionResult = {
+  status: "answered" | "ignored";
+  optionId?: string;
+  text?: string;
+};
+
+const EveAskQuestion: ToolCallMessagePartComponent<
+  AskQuestionArgs,
+  AskQuestionResult
+> = ({ args, approval, result, status, respondToApproval }) => {
+  const prompt = approval?.prompt ?? args.prompt;
+  const isPending =
+    approval !== undefined &&
+    approval.approved === undefined &&
+    approval.resolution === undefined;
+
+  if (isPending) {
+    return (
+      <div className="aui-eve-ask-question my-2 flex flex-col gap-2">
+        <ToolFallbackApproval
+          approval={approval}
+          respondToApproval={respondToApproval}
+          status={status}
+        />
+      </div>
+    );
+  }
+
+  const optionId = approval?.optionId ?? result?.optionId;
+  const answer =
+    approval?.text ??
+    result?.text ??
+    approval?.options?.find((option) => option.id === optionId)?.label ??
+    optionId;
+  const skipped =
+    approval?.resolution !== undefined || result?.status === "ignored";
+
+  return (
+    <div className="aui-eve-ask-question my-2 flex flex-col gap-1">
+      {prompt && <p className="text-foreground">{prompt}</p>}
+      {answer ? (
+        <p className="text-muted-foreground text-sm">{answer}</p>
+      ) : skipped ? (
+        <p className="text-muted-foreground text-sm">Skipped</p>
+      ) : null}
+    </div>
+  );
+};
+
+export const eveAskQuestionToolkit = defineToolkit({
+  ask_question: {
+    type: "backend",
+    display: "standalone",
+    render: EveAskQuestion,
+  },
+});


### PR DESCRIPTION
## Problem

Eve's built-in `ask_question` tool pauses the turn until the user answers. With no renderer registered for it, the default `ToolFallback` draws the prompt and the answer field inside the collapsed chain-of-thought tool group, so the question reads as a step in the agent's trace rather than the agent talking to the user. Reported by an `@assistant-ui/eve` user integrating a fresh Eve agent: "as-is it rendered the question as part of the chain-of-thought tool-call".

## Root cause

`useEveAgentRuntime` already projects `ask_question` onto an assistant-ui tool approval carrying `prompt`, `options`, `display`, and `allowFreeform`, so the data is right. But the tool call is an ordinary `tool-call` part with no tool UI, and `groupPartByType` only lifts a call out of the group when a registered UI opts into standalone display. Nothing in the eve integration registered one.

## Change

- `templates/eve/components/eve-ask-question.tsx` exports `eveAskQuestionToolkit`, a `defineToolkit` entry for `ask_question` with `display: "standalone"`. While the question is pending it renders `ToolFallback.Approval`, so it reuses the kit's option buttons, free-form answer field, confirmation step, and error handling; once resolved it shows the prompt and the recorded answer, or "Skipped" when Eve recorded the question as ignored.
- The eve template and the `with-eve` example register the toolkit through `AuiConfig({ tools: Tools({ toolkit }) })`, following the same pattern the template already uses for `Suggestions`.
- The registry gains an `eve-ask-question` item (depending on `tool-fallback`), and `eve-chat` bundles it so `eve add @assistant-ui/eve-chat` installs it. The registry's own copy of the eve page registers the toolkit.
- The eve overview gains a "Questions" section explaining the mechanism and the install command, and the quickstart gains a "Render questions" step and mentions the file in the `eve add` path.

This follows the precedent of `eve-authorization`, the other template-local renderer for an eve-specific part.

## Verification

- `tsc --noEmit` in `templates/eve` and `examples/with-eve` after rebuilding `@assistant-ui/react` (the remaining `use-attachment-src.ts` errors are pre-existing and unrelated).
- `pnpm -C apps/registry build` and `pnpm -C apps/registry test`: 77 passing from a clean `dist`. Two tests fail on `main` and on this branch only when a stale `dist/mcp-manager.json` is present from an older build.
- `oxlint` and `oxfmt --check` on every touched file.

## Public surface

No published package changes, so no changeset. Touched: `templates/eve`, `examples/with-eve`, `apps/registry` (new `eve-ask-question` item, `eve-chat` bundle), and the eve overview and quickstart docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M61YBT4XEXyCR2xp33Yf5L


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

