### PR TITLE
fix(react-a2a): ignore superseded thread loads

### DIFF
--- a/.changeset/tidy-apples-switch.md
+++ b/.changeset/tidy-apples-switch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: ignore thread loads superseded by a newer selection

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -94,6 +94,7 @@ const createThreadMessage = (id: string): ThreadMessage => ({
   id,
   role: "user",
   content: [{ type: "text", text: id }],
+  attachments: [],
   createdAt: new Date(0),
   metadata: { custom: {} },
 });
@@ -347,7 +348,7 @@ describe("useA2ARuntime", () => {
       resolveLoad = resolve;
     });
     const { result } = renderHook(() => {
-      const [threadId, setThreadId] = useState<string | undefined>("initial");
+      const [threadId, setThreadId] = useState("initial");
       return useA2ARuntime({
         client,
         adapters: {
@@ -358,7 +359,7 @@ describe("useA2ARuntime", () => {
               return load;
             },
             onSwitchToNewThread: async () => {
-              setThreadId(undefined);
+              setThreadId("thread-new");
             },
           },
         },

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -90,6 +90,14 @@ const createFetchMock = () =>
     );
   });
 
+const createThreadMessage = (id: string): ThreadMessage => ({
+  id,
+  role: "user",
+  content: [{ type: "text", text: id }],
+  createdAt: new Date(0),
+  metadata: { custom: {} },
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -294,14 +302,6 @@ describe("useA2ARuntime", () => {
     const second = new Promise<{ messages: ThreadMessage[] }>((resolve) => {
       resolveSecond = resolve;
     });
-    const message = (id: string): ThreadMessage => ({
-      id,
-      role: "user",
-      content: [{ type: "text", text: id }],
-      createdAt: new Date(0),
-      metadata: { custom: {} },
-    });
-
     const { result } = renderHook(() => {
       const [threadId, setThreadId] = useState("initial");
       return useA2ARuntime({
@@ -327,16 +327,56 @@ describe("useA2ARuntime", () => {
     expect(result.current.threads.getState().mainThreadId).toBe("thread-b");
 
     await act(async () => {
-      resolveSecond({ messages: [message("thread-b")] });
+      resolveSecond({ messages: [createThreadMessage("thread-b")] });
       await switchB;
     });
     await act(async () => {
-      resolveFirst({ messages: [message("thread-a")] });
+      resolveFirst({ messages: [createThreadMessage("thread-a")] });
       await switchA;
     });
 
     expect(result.current.thread.getState().messages.map((m) => m.id)).toEqual([
       "thread-b",
     ]);
+  });
+
+  it("ignores a thread load superseded by a new thread", async () => {
+    const { client } = createMockClient();
+    let resolveLoad!: (value: { messages: ThreadMessage[] }) => void;
+    const load = new Promise<{ messages: ThreadMessage[] }>((resolve) => {
+      resolveLoad = resolve;
+    });
+    const { result } = renderHook(() => {
+      const [threadId, setThreadId] = useState<string | undefined>("initial");
+      return useA2ARuntime({
+        client,
+        adapters: {
+          threadList: {
+            threadId,
+            onSwitchToThread: async (nextThreadId) => {
+              setThreadId(nextThreadId);
+              return load;
+            },
+            onSwitchToNewThread: async () => {
+              setThreadId(undefined);
+            },
+          },
+        },
+      });
+    });
+
+    let staleSwitch!: Promise<void>;
+    act(() => {
+      staleSwitch = result.current.threads.switchToThread("thread-a");
+    });
+    await act(async () => {
+      await result.current.threads.switchToNewThread();
+    });
+    await act(async () => {
+      resolveLoad({ messages: [createThreadMessage("thread-a")] });
+      await staleSwitch;
+    });
+
+    expect(result.current.thread.getState().messages).toEqual([]);
   });
 });

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -1,8 +1,14 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { startTransition, Suspense, type PropsWithChildren } from "react";
+import {
+  startTransition,
+  Suspense,
+  useState,
+  type PropsWithChildren,
+} from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadMessage } from "@assistant-ui/core";
 import type { A2AClient } from "./A2AClient";
 import type { A2AStreamEvent } from "./types";
 import { useA2ARuntime } from "./useA2ARuntime";
@@ -276,5 +282,61 @@ describe("useA2ARuntime", () => {
     expect(fetchMock.mock.calls[1]![1]?.headers).toMatchObject({
       Authorization: "Bearer workspace-a",
     });
+  });
+
+  it("ignores an older thread load after a newer selection", async () => {
+    const { client } = createMockClient();
+    let resolveFirst!: (value: { messages: ThreadMessage[] }) => void;
+    let resolveSecond!: (value: { messages: ThreadMessage[] }) => void;
+    const first = new Promise<{ messages: ThreadMessage[] }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<{ messages: ThreadMessage[] }>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const message = (id: string): ThreadMessage => ({
+      id,
+      role: "user",
+      content: [{ type: "text", text: id }],
+      createdAt: new Date(0),
+      metadata: { custom: {} },
+    });
+
+    const { result } = renderHook(() => {
+      const [threadId, setThreadId] = useState("initial");
+      return useA2ARuntime({
+        client,
+        adapters: {
+          threadList: {
+            threadId,
+            onSwitchToThread: async (nextThreadId) => {
+              setThreadId(nextThreadId);
+              return nextThreadId === "thread-a" ? first : second;
+            },
+          },
+        },
+      });
+    });
+
+    let switchA!: Promise<void>;
+    let switchB!: Promise<void>;
+    act(() => {
+      switchA = result.current.threads.switchToThread("thread-a");
+      switchB = result.current.threads.switchToThread("thread-b");
+    });
+    expect(result.current.threads.getState().mainThreadId).toBe("thread-b");
+
+    await act(async () => {
+      resolveSecond({ messages: [message("thread-b")] });
+      await switchB;
+    });
+    await act(async () => {
+      resolveFirst({ messages: [message("thread-a")] });
+      await switchA;
+    });
+
+    expect(result.current.thread.getState().messages.map((m) => m.id)).toEqual([
+      "thread-b",
+    ]);
   });
 });

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -110,6 +110,7 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   });
 
   // Thread list
+  const threadSwitchGenerationRef = useRef(0);
   const threadList = useMemo(() => {
     if (!threadListAdapter) return undefined;
 
@@ -119,7 +120,9 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
       threadId: threadListAdapter.threadId,
       onSwitchToNewThread: onSwitchToNewThread
         ? async () => {
+            const generation = ++threadSwitchGenerationRef.current;
             await onSwitchToNewThread();
+            if (generation !== threadSwitchGenerationRef.current) return;
             // Apply first so the abort inside resetContext finds an already
             // cleared repository and cannot persist the old thread's partial
             // assistant message.
@@ -129,7 +132,9 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
         : undefined,
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
+            const generation = ++threadSwitchGenerationRef.current;
             const result = await onSwitchToThread(threadId);
+            if (generation !== threadSwitchGenerationRef.current) return;
             core.applyExternalMessages(result.messages);
             core.resetContext();
           }


### PR DESCRIPTION
## Problem

Two rapid A2A thread switches can resolve out of order. When the newer thread loads first and the older request settles later, the older messages replace the selected thread's conversation.

On `main`, a focused reproduction selected `thread-b`, resolved B before A, and then observed `thread-a` messages under the still-selected B thread.

## Root cause

`onSwitchToThread` applies every completed adapter response without checking whether a newer thread selection has superseded it.

## Change

Assign each thread switch a monotonic generation and apply its result only while it remains current. New-thread switches use the same generation so they also invalidate pending loads for existing threads.

## Verification

- Confirmed the focused regression fails on `main` and passes with this change.
- `packages/react-a2a/node_modules/.bin/vitest run packages/react-a2a` (281 tests)
- Focused oxlint check for the changed TypeScript files
- `aui-build` for `@assistant-ui/react-a2a`

## Public surface

- `@assistant-ui/react-a2a`: behavior fix with a patch changeset
- Exports and APIs: unchanged
- Documentation and templates: unchanged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

