### PR TITLE
fix(ui): contain wide markdown tables in a scroll wrapper

### DIFF
--- a/apps/docs/components/pages/docs/samples/markdown.tsx
+++ b/apps/docs/components/pages/docs/samples/markdown.tsx
@@ -68,13 +68,15 @@ const components = {
     />
   ),
   table: ({ className, ...props }: React.HTMLAttributes<HTMLTableElement>) => (
-    <table
-      className={cn(
-        "aui-md-table my-5 w-full border-separate border-spacing-0 overflow-y-auto",
-        className,
-      )}
-      {...props}
-    />
+    <div className="aui-md-table-wrapper my-5 overflow-x-auto">
+      <table
+        className={cn(
+          "aui-md-table w-full border-separate border-spacing-0",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   ),
   th: ({
     className,

--- a/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/markdown-text.test.tsx
@@ -100,4 +100,22 @@ describe("MarkdownText component overrides", () => {
       mocks.messagePartText.text = "```tsx\nconst answer = 42;\n```";
     }
   });
+
+  it("gives a table its own horizontal scroll container", () => {
+    mocks.messagePartText.text =
+      "| ID |\n| --- |\n| aaaa0000bbbb1111cccc2222dddd3333 |";
+    try {
+      render(<MarkdownText />);
+
+      const table = screen.getByRole("table");
+      const wrapper = table.parentElement;
+
+      expect(wrapper?.classList.contains("aui-md-table-wrapper")).toBe(true);
+      expect(wrapper?.classList.contains("overflow-x-auto")).toBe(true);
+      expect(table.classList.contains("aui-md-table")).toBe(true);
+      expect(table.className).not.toContain("overflow");
+    } finally {
+      mocks.messagePartText.text = "```tsx\nconst answer = 42;\n```";
+    }
+  });
 });

--- a/packages/ui/src/components/react/assistant-ui/elements/markdown-text.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/markdown-text.tsx
@@ -190,13 +190,15 @@ const defaultComponents = memoizeMarkdownComponents({
     />
   ),
   table: ({ className, ...props }) => (
-    <table
-      className={cn(
-        "aui-md-table my-3 w-full border-separate border-spacing-0 overflow-y-auto",
-        className,
-      )}
-      {...props}
-    />
+    <div className="aui-md-table-wrapper my-3 overflow-x-auto">
+      <table
+        className={cn(
+          "aui-md-table w-full border-separate border-spacing-0",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   ),
   th: ({ className, ...props }) => (
     <th

--- a/templates/minimal/components/assistant-ui/elements/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/elements/markdown-text.tsx
@@ -183,13 +183,15 @@ const defaultComponents = memoizeMarkdownComponents({
     />
   ),
   table: ({ className, ...props }) => (
-    <table
-      className={cn(
-        "aui-md-table my-3 w-full border-separate border-spacing-0 overflow-y-auto",
-        className,
-      )}
-      {...props}
-    />
+    <div className="aui-md-table-wrapper my-3 overflow-x-auto">
+      <table
+        className={cn(
+          "aui-md-table w-full border-separate border-spacing-0",
+          className,
+        )}
+        {...props}
+      />
+    </div>
   ),
   th: ({ className, ...props }) => (
     <th


### PR DESCRIPTION
closes #6811

## Problem

a GFM table whose min-content width exceeds the message column overflows every ancestor instead of scrolling on its own. inside the registry thread this surfaces as a horizontal scrollbar on `aui_thread-viewport`; in narrower app layouts it reaches the page. code blocks do not have this problem because `pre` carries `overflow-x-auto` itself, so tables were the one block element shipping without a scroll container.

## Root cause

the table renderer put `overflow-y-auto` on the `<table>` element. overflow does not apply to table boxes, so the class was inert: computed `overflow-x` stays `visible`, the table is not a scroll container, and setting `scrollLeft` on it does nothing. the width therefore surfaced at the first ancestor able to show it, which for `thread.aui.tsx:162` is the `overflow-x-auto` viewport.

## Change

wrap the table in `aui-md-table-wrapper my-3 overflow-x-auto` and drop the inert `overflow-y-auto`. the table keeps `w-full`, its border-spacing classes, and any caller supplied `className`; the vertical margin moves to the wrapper so the scroll area starts at the table edge.

this is the shape the repo already uses. `packages/ui/src/components/react/ui/base/table.tsx` wraps its table the same way, and the docs markdown renderer got the same treatment in #6807. the wrapper carries no `w-full` because a block level div is already full width, which is why the docs wrapper does not carry one either.

three copies of this renderer exist and all three change: the canonical registry source in `packages/ui`, the `templates/minimal` scaffold copy, and the docs markdown sample. `apps/docs/components/assistant-ui/elements/markdown-text.tsx` is deliberately untouched because its table became a `figure` with its own `overflow-x-auto` in #6807. the Vue kit has no table renderer.

## Verification

`markdown-text.test.tsx` 5/5. the new case fails against the pre-change renderer (`expected false to be true`) and passes after, so it pins the mechanism rather than the markup.

browser, docs dev server at a 430px viewport, sample markdown carrying the issue's 48 character id:

- before: computed `overflow-x` on the table is `visible`, `scrollLeft` stays 0 when set, and the overflow propagates four levels up (`.aui-md` 392 to 648, demo card 424 to 664, `.not-prose` 426 to 665, demo surface 426 to 665, which is `overflow-x: hidden` and clips it, so the content is unreachable).
- after: only the wrapper overflows (392 to 648), it scrolls (`scrollLeft` reaches 256 of a 256 maximum), no ancestor overflows, and the document stays at 500/500.

`@assistant-ui/shadcn-registry` 77/77. `scripts/sync-templates.sh` reports every template component in sync. `oxlint` and `oxfmt --check` clean on all four files.

## Public surface

none. all three packages are private (`@assistant-ui/ui`, `@assistant-ui/docs`, `assistant-ui-starter-minimal`), so no changeset. the registry item `markdown-text` gains a wrapper div in its emitted markup; no export, prop, or signature changes.

supersedes #6812, which proposed the same wrapper but branched before #6807 landed, so its docs hunk would revert that table figure, and it misses the docs markdown sample copy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

