### PR TITLE
fix(docs): answer an mcp sse stream open with 405 instead of 200

### DIFF
--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -51,7 +51,7 @@ import {
   type WebMcpModelContext,
 } from "@/lib/webmcp-tools";
 import { listTemplates } from "@/lib/xulux/template-service";
-import { POST } from "./route";
+import { GET, POST } from "./route";
 
 const ORIGIN = "https://www.assistant-ui.com";
 const encoder = new TextEncoder();
@@ -124,6 +124,47 @@ function inputSchemaShape(schema: Record<string, unknown>) {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+async function requestDescriptor(accept?: string) {
+  const request = new Request(`${ORIGIN}/api/mcp`, {
+    ...(accept ? { headers: { Accept: accept } } : {}),
+  });
+  return await GET(request as Parameters<typeof GET>[0]);
+}
+
+describe("GET /api/mcp", () => {
+  it("refuses the streamable HTTP server-to-client stream", async () => {
+    const response = await requestDescriptor("text/event-stream");
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST, OPTIONS");
+    expect(await response.json()).toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Method not allowed." },
+      id: null,
+    });
+  });
+
+  it("refuses a stream open listed among other media ranges", async () => {
+    const response = await requestDescriptor(
+      "application/json, text/event-stream;q=0.9",
+    );
+
+    expect(response.status).toBe(405);
+  });
+
+  it("serves the descriptor to discovery clients", async () => {
+    for (const accept of [undefined, "*/*", "application/json"]) {
+      const response = await requestDescriptor(accept);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        name: "assistant-ui-docs",
+        protocol: "mcp",
+      });
+    }
+  });
 });
 
 describe("POST /api/mcp", () => {

--- a/apps/docs/app/api/mcp/route.test.ts
+++ b/apps/docs/app/api/mcp/route.test.ts
@@ -146,9 +146,9 @@ describe("GET /api/mcp", () => {
     });
   });
 
-  it("refuses a stream open listed among other media ranges", async () => {
+  it("refuses a stream open whatever its casing or media range position", async () => {
     const response = await requestDescriptor(
-      "application/json, text/event-stream;q=0.9",
+      "application/json, Text/Event-Stream;q=0.9",
     );
 
     expect(response.status).toBe(405);

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -626,6 +626,7 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
 
 function acceptsEventStream(request: NextRequest) {
   return (request.headers.get("accept") ?? "")
+    .toLowerCase()
     .split(",")
     .some((range) => range.split(";")[0]?.trim() === "text/event-stream");
 }

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -624,7 +624,27 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
   });
 }
 
-export async function GET() {
+function acceptsEventStream(request: NextRequest) {
+  return (request.headers.get("accept") ?? "")
+    .split(",")
+    .some((range) => range.split(";")[0]?.trim() === "text/event-stream");
+}
+
+export async function GET(request: NextRequest) {
+  // `Accept: text/event-stream` opens the Streamable HTTP server-to-client
+  // stream, which this stateless endpoint does not offer; a 200 reads as a
+  // stream that opened and closed, and clients answer that by reconnecting.
+  if (acceptsEventStream(request)) {
+    return jsonResponse(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Method not allowed." },
+        id: null,
+      },
+      { status: 405, headers: { Allow: "POST, OPTIONS" } },
+    );
+  }
+
   return jsonResponse({
     name: "assistant-ui-docs",
     protocol: "mcp",


### PR DESCRIPTION
## Problem

`/api/mcp` took 64,662,045 requests on 2026-09-04, 99.5% of all traffic to the site. real MCP traffic that day was 75,523 POSTs. the rest were GETs, all answered `200`, all carrying `Accept: text/event-stream`, all from a single JA4 fingerprint under the `node` user agent. it started at 2026-09-03 14:00 UTC (58K GET/hour to 173K, then 524K, then 905K) and was still climbing at ~743 req/s a day and a half later.

## Root cause

a GET carrying `Accept: text/event-stream` is the streamable HTTP client opening the server-to-client stream. the endpoint is stateless and offers no such stream, and the spec gives exactly two conformant answers for that (2025-06-18 `basic/transports.mdx`, unchanged in 2025-11-25):

> The server **MUST** either return `Content-Type: text/event-stream` in response to this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server does not offer an SSE stream at this endpoint.

2026-07-28 removed the GET stream endpoint outright and says a server on that revision **SHOULD** answer GET with `405`.

the hand written `GET` export returned neither. it answered `200 application/json` with the discovery descriptor, which a client reads as a stream that opened and closed, so it reconnects immediately, forever. `@modelcontextprotocol/server`'s own stateless transport already answers GET with `405 Method not allowed.`; the route's `GET` export shadowed it.

`Cache-Control: no-store` on that response is the second amplifier: 64.69M function invocations against 65.13M edge requests, nothing served from the CDN.

## Change

`GET` now negotiates on `Accept`. a request that accepts an event stream gets `405` with `Allow: POST, OPTIONS` and the SDK's own error envelope (`-32000` / `Method not allowed.`); everything else still gets the descriptor, so `/mcp`, `/.well-known/mcp` and `/docs/mcp` keep working for discovery. `acceptsEventStream` splits on comma and strips media type parameters, so a stream open listed among other ranges is caught too.

conditioning on `Accept` rather than refusing every GET is deliberate: the spec requires a client opening a stream to send that header, so a GET without it is not a transport level stream open, and 100% of the observed loop carried it. `POST` is untouched.

`Allow` omits `GET` even though the resource still serves it, because the client that just got refused asked for GET and listing it invites the retry.

## Verification

- `pnpm -C apps/docs exec vitest run app/api/mcp` -> 3 files, 32 tests green, including three new cases: a bare `text/event-stream` open refused, a stream open listed among other media ranges refused, and the descriptor still served for no header, `*/*` and `application/json`
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both files -> clean
- `tsc --noEmit -p apps/docs/tsconfig.json` -> 6 errors, byte identical before and after the change (pre existing, in `packages/core` and one home component)
- reproduction against production before the fix: `curl -H 'Accept: text/event-stream' https://www.assistant-ui.com/api/mcp` -> `200`, `content-type: application/json`, `cache-control: no-store`, `x-vercel-cache: MISS`, 1942 bytes, repeatable

## Public surface

`@assistant-ui/docs` only, which is `private: true`, so no changeset. no published package changes. the descriptor payload and its three rewrite aliases are unchanged for every client that was not asking for an event stream.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.zrh7ODvCS0ZdS3G4614ATVbZ1mWxvN9r5DJuhdeuJ6RUbKjwvOpjpGWsbJg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->