### PR TITLE
fix(core): preserve remote threads after deletion failures

### DIFF
--- a/.changeset/tidy-threads-wait.md
+++ b/.changeset/tidy-threads-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: defer remote thread deletion cleanup until persistence succeeds

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -117,6 +117,7 @@ const mountList = (
   threadId?: string,
   refetch?: () => Promise<void>,
   onSwitchToThread?: (id: string) => void,
+  onDelete?: (id: string) => void,
 ) => {
   const onThreadIdChange = vi.fn();
   const handle = createAssistantClient(
@@ -127,6 +128,7 @@ const mountList = (
         threadId,
         onThreadIdChange,
         onSwitchToThread,
+        onDelete,
       }),
     }),
   );
@@ -683,10 +685,17 @@ describe("RemoteThreadList", () => {
   });
 
   it("keeps one slot per remote id across reload and clears it on delete", async () => {
+    const onDelete = vi.fn();
     const adapter = makeAdapter({
       list: vi.fn(async () => ({ threads: [] })),
     });
-    const { handle } = mountList(adapter);
+    const { handle } = mountList(
+      adapter,
+      undefined,
+      undefined,
+      undefined,
+      onDelete,
+    );
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     const localId = aui.threads.getState().mainThreadId;
@@ -706,6 +715,39 @@ describe("RemoteThreadList", () => {
     });
     expect(() => aui.threads.item({ id: localId }).getState()).toThrow();
     expect(() => aui.threads.item({ id: remoteId }).getState()).toThrow();
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith(localId);
+    handle.destroy();
+  });
+
+  it("does not invoke deletion cleanup when the remote deletion fails", async () => {
+    const error = new Error("delete failed");
+    const onDelete = vi.fn();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+      })),
+      delete: vi.fn(async () => {
+        throw error;
+      }),
+    });
+    const { handle } = mountList(
+      adapter,
+      undefined,
+      undefined,
+      undefined,
+      onDelete,
+    );
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toContain("t1");
+    });
+
+    await expect(aui.threads.item({ id: "t1" }).delete()).rejects.toBe(error);
+
+    expect(aui.threads.getState().threadIds).toContain("t1");
+    expect(onDelete).not.toHaveBeenCalled();
     handle.destroy();
   });
 

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -751,6 +751,87 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  const deleteDuringAdapterSwap = async (
+    replacementThreads: readonly {
+      status: "regular";
+      remoteId: string;
+      title: string;
+    }[],
+  ) => {
+    const removal = deferred<void>();
+    const onDelete = vi.fn();
+    const adapterA = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+      })),
+      delete: vi.fn(() => removal.promise),
+    });
+    const adapterB = makeAdapter({
+      list: vi.fn(async () => ({ threads: replacementThreads })),
+    });
+    let adapter: RemoteThreadListAdapter = adapterA;
+    const listeners = new Set<() => void>();
+    const source: AssistantConfigSource = {
+      getConfig: () =>
+        AuiConfig({
+          threads: RemoteThreadList({
+            adapter,
+            thread: (id) => StubThread({ threadId: id }) as never,
+            onDelete,
+          }),
+        }),
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+    const handle = createAssistantClient(source);
+    handle.subscribe(() => {});
+    await handle.getClient().threads.getLoadThreadsPromise();
+    await vi.waitFor(() => {
+      expect(handle.getClient().threads.getState().threadIds).toContain("t1");
+    });
+
+    const deletion = handle.getClient().threads.item({ id: "t1" }).delete();
+    await vi.waitFor(() => {
+      expect(adapterA.delete).toHaveBeenCalledWith("t1");
+    });
+
+    adapter = adapterB;
+    for (const listener of listeners) listener();
+    await vi.waitFor(async () => {
+      flushTapSync(() => {});
+      await handle.getClient().threads.reload();
+      expect(adapterB.list).toHaveBeenCalled();
+      expect(handle.getClient().threads.getState().threadIds).toEqual(
+        replacementThreads.map((thread) => thread.remoteId),
+      );
+    });
+
+    removal.resolve();
+    await deletion;
+    return { handle, onDelete };
+  };
+
+  it("invokes deletion cleanup when the adapter changes during a successful deletion", async () => {
+    const { handle, onDelete } = await deleteDuringAdapterSwap([]);
+
+    expect(onDelete).toHaveBeenCalledWith("t1");
+    handle.destroy();
+  });
+
+  it("skips deletion cleanup when the replacement adapter re-lists the deleted id", async () => {
+    const { handle, onDelete } = await deleteDuringAdapterSwap([
+      { status: "regular" as const, remoteId: "t1", title: "One" },
+    ]);
+
+    expect(handle.getClient().threads.getState().threadIds).toContain("t1");
+    expect(onDelete).not.toHaveBeenCalled();
+    handle.destroy();
+  });
+
   const mountRacedInitialize = async (status: "regular" | "archived") => {
     const initialize = deferred<{ remoteId: string; externalId: undefined }>();
     const adapter = makeAdapter({

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -1145,9 +1145,7 @@ const useRemoteThreadList = (
       }
       await ensureNotMain(data.id);
       requireAdapterGeneration(adapterGeneration);
-      onDelete?.(data.id);
-      clearThreadTitleState(session.titleStates, data.id);
-      return store.optimisticUpdate({
+      const result = await store.optimisticUpdate({
         execute: async () => {
           const { remoteId } = await data.initializeTask;
           requireAdapterGeneration(adapterGeneration);
@@ -1155,6 +1153,10 @@ const useRemoteThreadList = (
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "deleted"),
       });
+      requireAdapterGeneration(adapterGeneration);
+      clearThreadTitleState(session.titleStates, data.id);
+      onDelete?.(data.id);
+      return result;
     },
     [ensureNotMain, onDelete, requireAdapterGeneration, session, store],
   );

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -76,6 +76,7 @@ export type RemoteThreadListProps = {
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   onSwitchToThread?: ((threadId: string) => void) | undefined;
   onSwitchToNewThread?: (() => void) | undefined;
+  /** Called after the backing adapter successfully deletes the thread. */
   onDelete?: ((threadId: string) => void) | undefined;
   /**
    * Keeps every thread the session switched to mounted, so a run continues
@@ -1153,7 +1154,7 @@ const useRemoteThreadList = (
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "deleted"),
       });
-      requireAdapterGeneration(adapterGeneration);
+      if (adapterGeneration !== session.adapterGeneration) return result;
       clearThreadTitleState(session.titleStates, data.id);
       onDelete?.(data.id);
       return result;

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -1154,7 +1154,10 @@ const useRemoteThreadList = (
         },
         optimistic: (state) => updateStatusReducer(state, data.id, "deleted"),
       });
-      if (adapterGeneration !== session.adapterGeneration) return result;
+      // An adapter swap resets the optimistic layer, and a listed thread's slot
+      // id is its remote id, so a replacement adapter can re-list this slot
+      // while the deletion is in flight.
+      if (getThreadData(store.value, data.id) !== undefined) return result;
       clearThreadTitleState(session.titleStates, data.id);
       onDelete?.(data.id);
       return result;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -120,6 +120,44 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     expect(core.getItemById(core.mainThreadId!)).toBeDefined();
   });
 
+  it("preserves thread cleanup state when remote deletion fails", async () => {
+    const error = new Error("delete failed");
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+      delete: vi.fn(async () => {
+        throw error;
+      }),
+    });
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    const data = core.getItemById("thread-b")!;
+    const internals = core as unknown as {
+      _hookManager: { stopThreadRuntime: (id: string) => void };
+      _titleStates: Map<string, unknown>;
+    };
+    const stopThreadRuntime = vi.spyOn(
+      internals._hookManager,
+      "stopThreadRuntime",
+    );
+    const titleState = {};
+    internals._titleStates.set(data.id, titleState);
+
+    await expect(core.delete(data.id)).rejects.toBe(error);
+
+    expect(core.getItemById(data.id)).toBeDefined();
+    expect(stopThreadRuntime).not.toHaveBeenCalled();
+    expect(internals._titleStates.get(data.id)).toBe(titleState);
+  });
+
   it("does not unarchive again when the target became regular during initialization", async () => {
     const initialization = deferred<{
       remoteId: string;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -158,6 +158,49 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     expect(internals._titleStates.get(data.id)).toBe(titleState);
   });
 
+  it("stops the thread runtime when the adapter changes during a successful deletion", async () => {
+    const removal = deferred<void>();
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+      delete: vi.fn(() => removal.promise),
+    });
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    const internals = core as unknown as {
+      _hookManager: { stopThreadRuntime: (id: string) => void };
+      _titleStates: Map<string, unknown>;
+    };
+    const stopThreadRuntime = vi.spyOn(
+      internals._hookManager,
+      "stopThreadRuntime",
+    );
+    internals._titleStates.set("thread-b", {});
+
+    const deletion = core.delete("thread-b");
+    await vi.waitFor(() => {
+      expect(adapter.delete).toHaveBeenCalledWith("thread-b");
+    });
+    core.__internal_setOptions({
+      adapter: makeAdapter(),
+      runtimeHook: () => ({}) as never,
+    });
+    removal.resolve();
+    await deletion;
+
+    expect(core.getItemById("thread-b")).toBeUndefined();
+    expect(stopThreadRuntime).toHaveBeenCalledWith("thread-b");
+    expect(internals._titleStates.has("thread-b")).toBe(false);
+  });
+
   it("does not unarchive again when the target became regular during initialization", async () => {
     const initialization = deferred<{
       remoteId: string;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -177,13 +177,11 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     await core.getLoadThreadsPromise();
     const internals = core as unknown as {
       _hookManager: { stopThreadRuntime: (id: string) => void };
-      _titleStates: Map<string, unknown>;
     };
     const stopThreadRuntime = vi.spyOn(
       internals._hookManager,
       "stopThreadRuntime",
     );
-    internals._titleStates.set("thread-b", {});
 
     const deletion = core.delete("thread-b");
     await vi.waitFor(() => {
@@ -198,7 +196,6 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
 
     expect(core.getItemById("thread-b")).toBeUndefined();
     expect(stopThreadRuntime).toHaveBeenCalledWith("thread-b");
-    expect(internals._titleStates.has("thread-b")).toBe(false);
   });
 
   it("does not unarchive again when the target became regular during initialization", async () => {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1107,10 +1107,7 @@ export class RemoteThreadListThreadListRuntimeCore
 
     await this._ensureThreadIsNotMain(data.id);
     this._requireAdapterGeneration(adapterGeneration);
-    this._hookManager.stopThreadRuntime(data.id);
-    clearThreadTitleState(this._titleStates, data.id);
-
-    return this._state.optimisticUpdate({
+    const result = await this._state.optimisticUpdate({
       execute: async () => {
         const { remoteId } = await data.initializeTask;
         this._requireAdapterGeneration(adapterGeneration);
@@ -1120,6 +1117,10 @@ export class RemoteThreadListThreadListRuntimeCore
         return updateStatusReducer(state, data.id, "deleted");
       },
     });
+    if (adapterGeneration !== this._adapterGeneration) return result;
+    this._hookManager.stopThreadRuntime(data.id);
+    clearThreadTitleState(this._titleStates, data.id);
+    return result;
   }
 
   public __internal_dispose() {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -1117,7 +1117,9 @@ export class RemoteThreadListThreadListRuntimeCore
         return updateStatusReducer(state, data.id, "deleted");
       },
     });
-    if (adapterGeneration !== this._adapterGeneration) return result;
+    // The optimistic layer survives an adapter swap, so a resolved deletion has
+    // dropped the slot from `threadData`, where `_replaceWithThreads` would
+    // otherwise have found it to stop.
     this._hookManager.stopThreadRuntime(data.id);
     clearThreadTitleState(this._titleStates, data.id);
     return result;


### PR DESCRIPTION
## Problem

Remote thread deletion is optimistic. When `RemoteThreadListAdapter.delete()` rejects, the thread is restored in the list, but deletion cleanup has already run: the tap client calls `onDelete` and clears title state, while the legacy runtime stops the thread runtime and clears title state.

Reproduction on current main: load `t1`, configure `delete()` to reject, then call the item delete method. The list restores `t1`, while the corresponding cleanup still runs.

## Root cause

Both remote thread-list implementations ran irreversible cleanup before awaiting the optimistic operation's remote `delete()` task.

## Change

Await the optimistic deletion before running callback, runtime, or title-state cleanup in both implementations. Failed remote deletions now roll back without those cleanup steps. If the adapter changes while a successful deletion is in flight, the operation preserves its successful result and skips cleanup against the replacement adapter scope.

`RemoteThreadListProps.onDelete` now documents that it runs after the backing adapter successfully deletes the thread.

## Verification

- `pnpm -C packages/core test -- RemoteThreadList.test.ts RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts` (161 files, 1,685 tests)
- `pnpm -C packages/core exec vitest run src/react/client/RemoteThreadList.test.ts src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts` (52 tests)
- `pnpm lint`
- `pnpm changesets:check`
- `pnpm --filter @assistant-ui/core... build`
- Initial `pnpm build` reached 92 successful tasks before unrelated Next.js example cache writes exhausted local disk space (`ENOSPC`); the required changed-package and changed-app CI builds subsequently passed

The regressions fail on main because cleanup runs after the adapter rejects, and pass with this change.

## Public surface

- `@assistant-ui/core`: deletion callback timing is documented; no API or export shape changes
- Added a patch changeset
- Documentation, templates, and API reference: unchanged

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TaQy-l_0X6gjzwBukMwbaB9nu82adS2ukWM3qtv1nPVYdS9XWDnaW4q3828?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->