### PR TITLE
feat(ui): add failed todo state and reason

### DIFF
--- a/apps/docs/components/pages/elements/element-docs.ts
+++ b/apps/docs/components/pages/elements/element-docs.ts
@@ -1919,16 +1919,10 @@ const matches = useMentionMatches(value, people);
           },
           {
             name: "status",
-            type: '"pending" | "active" | "done" | "failed"',
+            type: '"pending" | "active" | "done"',
             required: true,
             description:
-              "Per-item state. More than one item may be active if the agent works in parallel. Only done counts toward the progress numerator.",
-          },
-          {
-            name: "reason",
-            type: "string",
-            description:
-              "Why a failed item did not complete, rendered under its text.",
+              "Per-item state. More than one item may be active if the agent works in parallel.",
           },
         ],
       },

--- a/apps/docs/components/pages/elements/element-docs.ts
+++ b/apps/docs/components/pages/elements/element-docs.ts
@@ -1919,10 +1919,16 @@ const matches = useMentionMatches(value, people);
           },
           {
             name: "status",
-            type: '"pending" | "active" | "done"',
+            type: '"pending" | "active" | "done" | "failed"',
             required: true,
             description:
-              "Per-item state. More than one item may be active if the agent works in parallel.",
+              "Per-item state. More than one item may be active if the agent works in parallel. Only done counts toward the progress numerator.",
+          },
+          {
+            name: "reason",
+            type: "string",
+            description:
+              "Why a failed item did not complete, rendered under its text.",
           },
         ],
       },

--- a/apps/docs/content/elements/todo-list.mdx
+++ b/apps/docs/content/elements/todo-list.mdx
@@ -137,7 +137,8 @@ function advance(id: string) {
   </div>
   <ul>
     <li>
-      <span>{/* status icon: check, spinner, failure marker, or empty box */}</span>
+      <span>{/* status icon: check, spinner, cross, or empty box */}</span>
+      <span>{/* the status as visually hidden text */}</span>
       <div>
         <span>{/* item text */}</span>
         <p>{/* optional failure reason */}</p>

--- a/apps/docs/content/elements/todo-list.mdx
+++ b/apps/docs/content/elements/todo-list.mdx
@@ -3,7 +3,7 @@ title: "Todo list"
 description: "The agent's own working list, rewritten mid-run as it discovers what else is needed."
 ---
 
-A todo list shows the plan an agent is working through right now: what is done, what is active, and what is still pending. With a runtime the list comes from a tool call the model keeps rewriting as it works; standalone you pass the items in yourself.
+A todo list shows the plan an agent is working through right now: what is done, what is active, what failed, and what is still pending. With a runtime the list comes from a tool call the model keeps rewriting as it works; standalone you pass the items in yourself.
 
 ## Getting started
 
@@ -93,7 +93,8 @@ import { TodoList, type TodoItem } from "@/components/assistant-ui/elements/todo
 const initialItems: TodoItem[] = [
   { id: "1", text: "Read the failing test", status: "done" },
   { id: "2", text: "Reproduce locally", status: "active" },
-  { id: "3", text: "Write the fix", status: "failed", reason: "Tests timed out" },
+  { id: "3", text: "Write the fix", status: "pending" },
+  { id: "4", text: "Re-run the suite", status: "failed", reason: "Tests timed out" },
 ];
 
 export function Plan() {
@@ -147,9 +148,9 @@ function advance(id: string) {
 </div>
 ```
 
-Each row shows one of four status icons: a checked box for `done`, a spinning loader for `active`, an accessible failure marker for `failed`, and an empty outlined box for `pending`. Failed rows may include a reason below the item text. Text dims and gets struck through when done, reads at full opacity when active, sits at reduced opacity while pending, and uses error styling when failed. Rows key off `item.id`; passing a new array with the same ids only restyles the existing rows, while a genuinely new id mounts a row that fades and slides in.
+Each row shows one of four status icons: a checked box for `done`, a spinning loader for `active`, a red cross for `failed`, and an empty outlined box for `pending`. The icon is decorative; every row carries its status as visually hidden text so a screen reader announces it alongside the item. Failed rows may include a reason below the item text. Text dims and gets struck through when done, reads at full opacity when active, sits at reduced opacity while pending, and uses error styling when failed. Rows key off `item.id`; passing a new array with the same ids only restyles the existing rows, while a genuinely new id mounts a row that fades and slides in.
 
-The counter treats both `done` and `failed` items as settled. With zero items the header still renders `0/0` and the list is simply empty; there is no placeholder message. `revision` is decorative and does not affect the count or the render; it only appends `· rev {revision}` next to the ratio when you pass a number.
+A failed item is terminal but it is not a success, so it counts toward the denominator and never toward the numerator: three items that have all settled with one of them failed read `2/3`, not `3/3`. With zero items the header still renders `0/0` and the list is simply empty; there is no placeholder message. `revision` is decorative and does not affect the count or the render; it only appends `· rev {revision}` next to the ratio when you pass a number.
 
 ## Examples
 
@@ -251,7 +252,7 @@ Both lanes take `className` on the root, and the revision counter uses the share
 |-------|------|-------------|
 | `id` | `string` | Row key; stable ids keep entrance animation from replaying on every render. |
 | `text` | `string` | The step's label. |
-| `status` | `"pending" \| "active" \| "done" \| "failed"` | Drives the icon and text styling. `done` and `failed` count as settled. |
+| `status` | `"pending" \| "active" \| "done" \| "failed"` | Drives the icon and text styling. Only `done` counts toward the progress numerator. |
 | `reason` | `string` | Optional detail rendered below a failed item. |
 
 All other `div` props are forwarded to the root.

--- a/apps/docs/content/elements/todo-list.mdx
+++ b/apps/docs/content/elements/todo-list.mdx
@@ -32,7 +32,8 @@ export const toolkit = defineToolkit({
         z.object({
           id: z.string(),
           text: z.string(),
-          status: z.enum(["pending", "active", "done"]),
+          status: z.enum(["pending", "active", "done", "failed"]),
+          reason: z.string().optional(),
         }),
       ),
     }),
@@ -92,7 +93,7 @@ import { TodoList, type TodoItem } from "@/components/assistant-ui/elements/todo
 const initialItems: TodoItem[] = [
   { id: "1", text: "Read the failing test", status: "done" },
   { id: "2", text: "Reproduce locally", status: "active" },
-  { id: "3", text: "Write the fix", status: "pending" },
+  { id: "3", text: "Write the fix", status: "failed", reason: "Tests timed out" },
 ];
 
 export function Plan() {
@@ -135,23 +136,26 @@ function advance(id: string) {
   </div>
   <ul>
     <li>
-      <span>{/* status icon: check, spinner, or empty box */}</span>
-      <span>{/* item text */}</span>
+      <span>{/* status icon: check, spinner, failure marker, or empty box */}</span>
+      <div>
+        <span>{/* item text */}</span>
+        <p>{/* optional failure reason */}</p>
+      </div>
     </li>
     {/* one row per item */}
   </ul>
 </div>
 ```
 
-Each row shows one of three status icons: a checked box for `done`, a spinning loader for `active`, and an empty outlined box for `pending`. Text dims and gets struck through when done, reads at full opacity when active, and sits at reduced opacity while pending. Rows key off `item.id`; passing a new array with the same ids only restyles the existing rows, while a genuinely new id mounts a row that fades and slides in.
+Each row shows one of four status icons: a checked box for `done`, a spinning loader for `active`, an accessible failure marker for `failed`, and an empty outlined box for `pending`. Failed rows may include a reason below the item text. Text dims and gets struck through when done, reads at full opacity when active, sits at reduced opacity while pending, and uses error styling when failed. Rows key off `item.id`; passing a new array with the same ids only restyles the existing rows, while a genuinely new id mounts a row that fades and slides in.
 
-With zero items the header still renders `0/0` and the list is simply empty; there is no placeholder message. `revision` is decorative and does not affect the count or the render; it only appends `· rev {revision}` next to the ratio when you pass a number.
+The counter treats both `done` and `failed` items as settled. With zero items the header still renders `0/0` and the list is simply empty; there is no placeholder message. `revision` is decorative and does not affect the count or the render; it only appends `· rev {revision}` next to the ratio when you pass a number.
 
 ## Examples
 
 ### Item states
 
-The three states rendered together, independent of how the list is produced:
+The four states rendered together, independent of how the list is produced:
 
 ```tsx
 <TodoList
@@ -159,6 +163,7 @@ The three states rendered together, independent of how the list is produced:
     { id: "1", text: "Read the failing test", status: "done" },
     { id: "2", text: "Reproduce locally", status: "active" },
     { id: "3", text: "Write the fix", status: "pending" },
+    { id: "4", text: "Run deployment", status: "failed", reason: "Timed out" },
   ]}
 />
 ```
@@ -246,7 +251,8 @@ Both lanes take `className` on the root, and the revision counter uses the share
 |-------|------|-------------|
 | `id` | `string` | Row key; stable ids keep entrance animation from replaying on every render. |
 | `text` | `string` | The step's label. |
-| `status` | `"pending" \| "active" \| "done"` | Drives the icon and text styling. |
+| `status` | `"pending" \| "active" \| "done" \| "failed"` | Drives the icon and text styling. `done` and `failed` count as settled. |
+| `reason` | `string` | Optional detail rendered below a failed item. |
 
 All other `div` props are forwarded to the root.
 

--- a/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
@@ -7,13 +7,12 @@ import { mono } from "./surfaces";
 
 export type TodoStatus = "pending" | "active" | "done" | "failed";
 
-export type TodoItem = {
+export interface TodoItem {
   id: string;
   text: string;
-} & (
-  | { status: Exclude<TodoStatus, "failed">; reason?: never }
-  | { status: "failed"; reason?: string }
-);
+  status: TodoStatus;
+  reason?: string;
+}
 
 export function TodoList({
   items,
@@ -24,23 +23,20 @@ export function TodoList({
   items: readonly TodoItem[];
   revision?: number;
 }) {
-  const settled = items.filter(
-    (item) => item.status === "done" || item.status === "failed",
-  ).length;
+  const done = items.filter((item) => item.status === "done").length;
 
   return (
     <div
       data-slot="todo-list"
       className={cn("flex w-full max-w-sm flex-col gap-3", className)}
-
       {...props}
     >
       <div className="flex items-baseline justify-between">
         <span className="text-[13.5px] font-medium">Todos</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>
           {revision === undefined
-            ? `${settled}/${items.length}`
-            : `${settled}/${items.length} · rev ${revision}`}
+            ? `${done}/${items.length}`
+            : `${done}/${items.length} · rev ${revision}`}
         </span>
       </div>
       <ul className="flex flex-col gap-1">
@@ -49,35 +45,28 @@ export function TodoList({
             key={item.id}
             className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex items-start gap-2.5 py-0.5 text-[13.5px] duration-300"
           >
-            <span className="flex size-4 h-5 shrink-0 items-center justify-center">
+            <span
+              aria-hidden
+              className="flex size-4 h-5 shrink-0 items-center justify-center"
+            >
               {item.status === "done" ? (
                 <span className="border-foreground/20 bg-foreground/[0.06] flex size-3.5 items-center justify-center rounded-[5px] border">
                   <CheckIcon className="text-foreground/45 size-2.5" />
                 </span>
               ) : item.status === "failed" ? (
-                <span
-                  aria-label="Failed"
-                  role="status"
-                  className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-600/25 bg-red-600/[0.08] dark:border-red-400/25 dark:bg-red-400/[0.08]"
-                >
-                  <XIcon
-                    aria-hidden
-                    className="size-2.5 text-red-600 dark:text-red-400"
-                  />
+                <span className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-600/25 bg-red-600/[0.08] dark:border-red-400/25 dark:bg-red-400/[0.08]">
+                  <XIcon className="size-2.5 text-red-600 dark:text-red-400" />
                 </span>
               ) : item.status === "active" ? (
                 <Loader2Icon className="size-3.5 animate-spin text-blue-500 motion-reduce:animate-none dark:text-blue-400" />
               ) : (
-                <span
-                  aria-hidden
-                  className="border-foreground/15 size-3.5 rounded-[5px] border"
-                />
+                <span className="border-foreground/15 size-3.5 rounded-[5px] border" />
               )}
             </span>
-            <div className="min-w-0 flex-1 break-words">
+            <span className="sr-only">{item.status}</span>
+            <div className="min-w-0 flex-1 leading-5 break-words">
               <span
                 className={cn(
-                  "leading-5 break-words",
                   item.status === "done" &&
                     "text-foreground/35 line-through decoration-[1.5px]",
                   item.status === "active" && "text-foreground/90",

--- a/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { CheckIcon, Loader2Icon } from "lucide-react";
+import { CheckIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mono } from "./surfaces";
 
-export type TodoStatus = "pending" | "active" | "done";
+export type TodoStatus = "pending" | "active" | "done" | "failed";
 
 export interface TodoItem {
   id: string;
   text: string;
   status: TodoStatus;
+  reason?: string;
 }
 
 export function TodoList({
@@ -22,7 +23,9 @@ export function TodoList({
   items: readonly TodoItem[];
   revision?: number;
 }) {
-  const done = items.filter((item) => item.status === "done").length;
+  const complete = items.filter(
+    (item) => item.status === "done" || item.status === "failed",
+  ).length;
 
   return (
     <div
@@ -35,8 +38,8 @@ export function TodoList({
         <span className="text-[13.5px] font-medium">Todos</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>
           {revision === undefined
-            ? `${done}/${items.length}`
-            : `${done}/${items.length} · rev ${revision}`}
+            ? `${complete}/${items.length}`
+            : `${complete}/${items.length} · rev ${revision}`}
         </span>
       </div>
       <ul className="flex flex-col gap-1">
@@ -50,6 +53,10 @@ export function TodoList({
                 <span className="border-foreground/20 bg-foreground/[0.06] flex size-3.5 items-center justify-center rounded-[5px] border">
                   <CheckIcon className="text-foreground/45 size-2.5" />
                 </span>
+              ) : item.status === "failed" ? (
+                <span className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-500/25 bg-red-500/[0.08]">
+                  <XIcon className="size-2.5 text-red-500/70 dark:text-red-400/70" />
+                </span>
               ) : item.status === "active" ? (
                 <Loader2Icon className="size-3.5 animate-spin text-blue-500 motion-reduce:animate-none dark:text-blue-400" />
               ) : (
@@ -59,17 +66,26 @@ export function TodoList({
                 />
               )}
             </span>
-            <span
-              className={cn(
-                "min-w-0 flex-1 leading-5 break-words",
-                item.status === "done" &&
-                  "text-foreground/35 line-through decoration-[1.5px]",
-                item.status === "active" && "text-foreground/90",
-                item.status === "pending" && "text-foreground/50",
-              )}
-            >
-              {item.text}
-            </span>
+            <div className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  "leading-5 break-words",
+                  item.status === "done" &&
+                    "text-foreground/35 line-through decoration-[1.5px]",
+                  item.status === "active" && "text-foreground/90",
+                  item.status === "pending" && "text-foreground/50",
+                  item.status === "failed" &&
+                    "text-red-500/70 dark:text-red-400/70",
+                )}
+              >
+                {item.text}
+              </span>
+              {item.status === "failed" && item.reason ? (
+                <p className="text-foreground/45 text-xs leading-4 break-words">
+                  {item.reason}
+                </p>
+              ) : null}
+            </div>
           </li>
         ))}
       </ul>

--- a/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
@@ -7,12 +7,13 @@ import { mono } from "./surfaces";
 
 export type TodoStatus = "pending" | "active" | "done" | "failed";
 
-export interface TodoItem {
+export type TodoItem = {
   id: string;
   text: string;
-  status: TodoStatus;
-  reason?: string;
-}
+} & (
+  | { status: Exclude<TodoStatus, "failed">; reason?: never }
+  | { status: "failed"; reason?: string }
+);
 
 export function TodoList({
   items,
@@ -23,9 +24,7 @@ export function TodoList({
   items: readonly TodoItem[];
   revision?: number;
 }) {
-  const complete = items.filter(
-    (item) => item.status === "done" || item.status === "failed",
-  ).length;
+  const complete = items.filter((item) => item.status === "done").length;
 
   return (
     <div
@@ -54,8 +53,14 @@ export function TodoList({
                   <CheckIcon className="text-foreground/45 size-2.5" />
                 </span>
               ) : item.status === "failed" ? (
-                <span className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-500/25 bg-red-500/[0.08]">
-                  <XIcon className="size-2.5 text-red-500/70 dark:text-red-400/70" />
+                <span
+                  aria-label="Failed"
+                  className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-600/25 bg-red-600/[0.08] dark:border-red-400/25 dark:bg-red-400/[0.08]"
+                >
+                  <XIcon
+                    aria-hidden
+                    className="size-2.5 text-red-600 dark:text-red-400"
+                  />
                 </span>
               ) : item.status === "active" ? (
                 <Loader2Icon className="size-3.5 animate-spin text-blue-500 motion-reduce:animate-none dark:text-blue-400" />
@@ -74,8 +79,7 @@ export function TodoList({
                     "text-foreground/35 line-through decoration-[1.5px]",
                   item.status === "active" && "text-foreground/90",
                   item.status === "pending" && "text-foreground/50",
-                  item.status === "failed" &&
-                    "text-red-500/70 dark:text-red-400/70",
+                  item.status === "failed" && "text-red-600 dark:text-red-400",
                 )}
               >
                 {item.text}

--- a/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/todo-list.tsx
@@ -24,7 +24,9 @@ export function TodoList({
   items: readonly TodoItem[];
   revision?: number;
 }) {
-  const complete = items.filter((item) => item.status === "done").length;
+  const settled = items.filter(
+    (item) => item.status === "done" || item.status === "failed",
+  ).length;
 
   return (
     <div
@@ -37,8 +39,8 @@ export function TodoList({
         <span className="text-[13.5px] font-medium">Todos</span>
         <span className={cn(mono, "text-foreground/35 tabular-nums")}>
           {revision === undefined
-            ? `${complete}/${items.length}`
-            : `${complete}/${items.length} · rev ${revision}`}
+            ? `${settled}/${items.length}`
+            : `${settled}/${items.length} · rev ${revision}`}
         </span>
       </div>
       <ul className="flex flex-col gap-1">
@@ -55,6 +57,7 @@ export function TodoList({
               ) : item.status === "failed" ? (
                 <span
                   aria-label="Failed"
+                  role="status"
                   className="flex size-3.5 items-center justify-center rounded-[5px] border border-red-600/25 bg-red-600/[0.08] dark:border-red-400/25 dark:bg-red-400/[0.08]"
                 >
                   <XIcon
@@ -71,7 +74,7 @@ export function TodoList({
                 />
               )}
             </span>
-            <div className="min-w-0 flex-1">
+            <div className="min-w-0 flex-1 break-words">
               <span
                 className={cn(
                   "leading-5 break-words",

--- a/packages/ui/src/components/react/assistant-ui/tests/elements.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/tests/elements.test.tsx
@@ -561,8 +561,8 @@ beforeAll(() => {
 afterEach(cleanup);
 
 describe("todo-list", () => {
-  it("renders failed items and counts done and failed items as settled", () => {
-    const { container, getByText } = render(
+  it("renders a failed item with its reason and keeps it out of the numerator", () => {
+    const { getByText } = render(
       <TodoList
         items={[
           { id: "done", text: "Done item", status: "done" },
@@ -577,12 +577,41 @@ describe("todo-list", () => {
       />,
     );
 
-    expect(getByText("2/3")).toBeTruthy();
+    expect(getByText("1/3")).toBeTruthy();
     expect(getByText("Failed item")).toBeTruthy();
     expect(getByText("Timed out")).toBeTruthy();
+  });
+
+  it("keeps a fully settled list with a failure below its total", () => {
+    const { getByText } = render(
+      <TodoList
+        items={[
+          { id: "a", text: "First", status: "done" },
+          { id: "b", text: "Second", status: "done" },
+          { id: "c", text: "Third", status: "failed" },
+        ]}
+      />,
+    );
+
+    expect(getByText("2/3")).toBeTruthy();
+  });
+
+  it("announces every status as hidden text beside a decorative icon", () => {
+    const { container } = render(
+      <TodoList
+        items={[
+          { id: "pending", text: "Pending item", status: "pending" },
+          { id: "active", text: "Active item", status: "active" },
+          { id: "done", text: "Done item", status: "done" },
+          { id: "failed", text: "Failed item", status: "failed" },
+        ]}
+      />,
+    );
+
     expect(
-      container.querySelector('[role="status"]')?.getAttribute("aria-label"),
-    ).toBe("Failed");
+      [...container.querySelectorAll("li .sr-only")].map((n) => n.textContent),
+    ).toEqual(["pending", "active", "done", "failed"]);
+    expect(container.querySelectorAll("li > [aria-hidden]")).toHaveLength(4);
   });
 
   it("does not render a failure reason when none is provided", () => {
@@ -592,7 +621,7 @@ describe("todo-list", () => {
       />,
     );
 
-    expect(container.textContent).toContain("1/1");
+    expect(container.textContent).toContain("0/1");
     expect(container.querySelector("p")).toBeNull();
   });
 });

--- a/packages/ui/src/components/react/assistant-ui/tests/elements.test.tsx
+++ b/packages/ui/src/components/react/assistant-ui/tests/elements.test.tsx
@@ -40,6 +40,7 @@ import { TerminalBlock } from "../elements/terminal-block";
 import { ThreadList } from "../elements/thread-list";
 import { Timeline } from "../elements/timeline";
 import { ThinkingIndicator } from "../elements/thinking-indicator";
+import { TodoList } from "../elements/todo-list";
 import { ToolCall } from "../elements/tool-call";
 import { ToolTimeline } from "../elements/tool-timeline";
 import { TraceWaterfall } from "../elements/trace-waterfall";
@@ -558,6 +559,43 @@ beforeAll(() => {
 });
 
 afterEach(cleanup);
+
+describe("todo-list", () => {
+  it("renders failed items and counts done and failed items as settled", () => {
+    const { container, getByText } = render(
+      <TodoList
+        items={[
+          { id: "done", text: "Done item", status: "done" },
+          {
+            id: "failed",
+            text: "Failed item",
+            status: "failed",
+            reason: "Timed out",
+          },
+          { id: "active", text: "Active item", status: "active" },
+        ]}
+      />,
+    );
+
+    expect(getByText("2/3")).toBeTruthy();
+    expect(getByText("Failed item")).toBeTruthy();
+    expect(getByText("Timed out")).toBeTruthy();
+    expect(
+      container.querySelector('[role="status"]')?.getAttribute("aria-label"),
+    ).toBe("Failed");
+  });
+
+  it("does not render a failure reason when none is provided", () => {
+    const { container } = render(
+      <TodoList
+        items={[{ id: "failed", text: "Failed item", status: "failed" }]}
+      />,
+    );
+
+    expect(container.textContent).toContain("1/1");
+    expect(container.querySelector("p")).toBeNull();
+  });
+});
 
 describe.each(Object.entries(CASES))("%s", (name, make) => {
   it.each(HOSTILE)("survives a %s numeric prop", (_label, n, items) => {


### PR DESCRIPTION
## Problem

`elements-todo-list` shipped three statuses and no way to record that a task ended without completing. an agent that hits a failed tool or an ask it cannot serve has to either leave the item `active`, which renders a spinner indefinitely, or mark it `done`, which is false. the progress counter has the same gap: a list where everything has settled but one item failed reads `2/3` forever, and every consumer adding a failure state would decide independently whether it counts.

Closes #6468

## Change

adds `"failed"` to `TodoStatus` and an optional `reason?: string` on `TodoItem`, rendered under the item text when the status is `failed`.

the counter keeps `done` as its numerator. a failed item is terminal but it is not a success, and an all-failed list reading `3/3` would be indistinguishable from three successes, so failed items count toward the denominator and never toward it. the docs now state that rule instead of leaving each consumer to guess.

`TodoItem` stays a plain interface. an earlier revision modelled `reason` with a `reason?: never` discriminated union, which rejects the exact shape the documented zod schema produces, so neither the `render` example nor the `advance` snippet on the same docs page compiled against it.

every row carries its status as `sr-only` text beside an `aria-hidden` icon, following `mcp-server-panel.tsx` and `agent-status.tsx`. before this only `failed` had an accessible name, and it got one through `role="status"`, which makes each failed row a polite live region inside a component that is rewritten on every tool call.

## Verification

- `vitest run src/components/react/assistant-ui/tests/elements.test.tsx` in `packages/ui`: 557 passed, 16 skipped
- `tsc --noEmit -p packages/ui/tsconfig.json`: no errors in `todo-list.tsx`; the remaining ones are pre-existing in `image.test.tsx`, `thread-list.aui.test.tsx`, and the vue tests
- both documented paths typecheck against the shipped type: the zod-derived `{ status: TodoStatus; reason?: string }[]` handed to `<TodoList items={...} />`, and the `advance()` map snippet
- `oxlint` and `oxfmt --check` clean on the changed files

## Public surface

- `@assistant-ui/ui` (private, so no changeset): `TodoStatus` gains `"failed"`, `TodoItem` gains `reason?: string`
- docs: `apps/docs/content/elements/todo-list.mdx` (schema, prose, anatomy, examples, props table)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2a-BfpY3eb3D2GOXjk9KcYCcgEDWY_165YaB9Tng8LaIIwdHNgZoenZtylw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
