### PR TITLE
fix(assistant-stream): preserve positive exponent arguments

### DIFF
--- a/.changeset/stream-positive-exponent-fields.md
+++ b/.changeset/stream-positive-exponent-fields.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: Keep positive exponents incomplete until all argument digits arrive.

--- a/.changeset/stream-positive-exponent-fields.md
+++ b/.changeset/stream-positive-exponent-fields.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: Keep positive exponents incomplete until all argument digits arrive.
+fix: keep positive exponents incomplete until all argument digits arrive

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.test.ts
@@ -10,6 +10,17 @@ type Args = {
 const createReader = () => new ToolCallReaderImpl<Args, string>();
 
 describe("ToolCallArgsReader.get", () => {
+  it("waits for all digits of a positive exponent", async () => {
+    const reader = new ToolCallReaderImpl<{ amount: number }, string>();
+    const amount = reader.args.get("amount");
+
+    await reader.appendArgsTextDelta('{"amount":1e+2');
+    await reader.appendArgsTextDelta("3}");
+    await reader.finishArgsText();
+
+    expect(await amount).toBe(1e23);
+  });
+
   it("resolves with the value once the field is complete", async () => {
     const reader = createReader();
     const promise = reader.args.get("required");

--- a/packages/assistant-stream/src/utils/json/fix-json.ts
+++ b/packages/assistant-stream/src/utils/json/fix-json.ts
@@ -399,6 +399,7 @@ export function fixJson(input: string): [string, string[]] {
           case "e":
           case "E":
           case "-":
+          case "+":
           case ".": {
             break;
           }

--- a/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
+++ b/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
@@ -221,6 +221,17 @@ const tests: PartialJsonTest[] = [
     query: ["foo", 0, 0],
     result: "partial",
   },
+  // positive exponent whose digits have not arrived yet
+  {
+    input: `{"foo": 1e+`,
+    query: ["foo"],
+    result: "partial",
+  },
+  {
+    input: `{"foo": 1e+2`,
+    query: ["foo"],
+    result: "partial",
+  },
 ];
 
 describe("parsePartialJsonObject and getPartialJsonObjectFieldState", () => {


### PR DESCRIPTION
## Problem

In assistant-stream 0.3.41, a streamed `{"amount":1e+2` followed by `3}` resolves the awaited amount as `1`, not `1e23`.

## Root cause

The numeric scanner treats `+` as the end of a number and marks the field complete too early.

## Change

Keep `+` inside the number scan so the argument reader waits for the remaining digits.

## Verification

`ToolCallReader.test.ts` includes the reproduction, which failed before the correction and passed after it. `./node_modules/.bin/vitest run src/core/tool/ToolCallReader.test.ts src/utils/json/parse-partial-json-object.test.ts` passed all 53 tests from `packages/assistant-stream`.

## Public surface

`assistant-stream`, with a patch changeset. No export or documentation changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OYvoHXtTIfej2AmmKYlz5EK22mlFa5aCL3Zak-JucwCqvAqlf6U8tUo0uRE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->