### PR TITLE
fix(python): keep setdefault containers attached to state

### DIFF
--- a/python/assistant-stream/src/assistant_stream/state.py
+++ b/python/assistant-stream/src/assistant_stream/state.py
@@ -486,7 +486,7 @@ class StateProxy:
             return self[key]
 
         self[key] = default
-        return default
+        return self[key]
 
     # Unsupported operations that would be inefficient
     def insert(self, index: int, item: Any) -> None:

--- a/python/assistant-stream/tests/test_state.py
+++ b/python/assistant-stream/tests/test_state.py
@@ -155,6 +155,19 @@ def test_draft_list_append_emits_index_set() -> None:
     assert state.state["items"] == ["a", "b"]
 
 
+def test_draft_setdefault_container_emits_later_writes() -> None:
+    ops: list[dict[str, Any]] = []
+    state = AssistantState({})
+    draft = state.draft(ops.extend)
+    items = draft.setdefault("items", [])
+    ops.clear()
+
+    items.append("x")
+
+    assert ops == [{"type": "set", "path": ["items", "0"], "value": "x"}]
+    assert state.state == {"items": ["x"]}
+
+
 def test_draft_mutating_list_methods_raise() -> None:
     state = AssistantState({"items": ["a", "b"]})
     draft = state.draft(lambda _ops: None)


### PR DESCRIPTION
## Problem

In Python assistant-stream 0.0.36, writes through a new `draft.setdefault("items", [])` result change server state without stream updates.

## Root cause

The missing-key branch returns the plain default container instead of a state proxy.

## Change

The result uses the same live lookup as the existing-key branch, so later writes reach the client.

## Verification

`uv run --frozen --extra dev --extra langgraph pytest tests/test_state.py -q` passes 29 tests from `python/assistant-stream`.

The new `test_draft_setdefault_container_emits_later_writes` regression fails before the correction and passes after it. It inserts an empty list, clears the initial operations, and appends through the returned value.

## Public surface

Python `assistant-stream` state proxies. No export or documentation contract changes. The Python package is outside the npm changeset release system.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.znSdh2YIijFxmqzmajBhtxpKqn3XlTLtrfXjd1KxkdMXE62iz-e_rDoEhpY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->