### PR TITLE
fix(cli): keep relative add directories anchored to the caller

### DIFF
--- a/.changeset/cli-add-relative-directory.md
+++ b/.changeset/cli-add-relative-directory.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: keep relative add directories anchored to the caller

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Command } from "commander";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
@@ -40,7 +41,7 @@ export function createAddComponentsPlan(params: {
   // This flag is for shadcn's own confirmation prompt.
   if (params.yes) args.push("--yes");
   if (params.overwrite) args.push("--overwrite");
-  if (params.cwd) args.push("--cwd", params.cwd);
+  if (params.cwd) args.push("--cwd", path.resolve(params.cwd));
   if (params.path) args.push("--path", params.path);
 
   return { command, args };

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { Command } from "commander";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
@@ -23,7 +22,6 @@ export function createAddComponentsPlan(params: {
   packageManager: PackageManagerName;
   yes?: boolean;
   overwrite?: boolean;
-  cwd?: string;
   path?: string;
   style?: string;
 }): AddComponentsPlan {
@@ -41,7 +39,6 @@ export function createAddComponentsPlan(params: {
   // This flag is for shadcn's own confirmation prompt.
   if (params.yes) args.push("--yes");
   if (params.overwrite) args.push("--overwrite");
-  if (params.cwd) args.push("--cwd", path.resolve(params.cwd));
   if (params.path) args.push("--path", params.path);
 
   return { command, args };
@@ -84,7 +81,6 @@ export const add = new Command()
       packageManager,
       yes: opts.yes,
       overwrite: opts.overwrite,
-      cwd: opts.cwd,
       path: opts.path,
       ...(style === undefined ? {} : { style }),
     });

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { add, createAddComponentsPlan } from "../../src/commands/add";
 
@@ -19,6 +20,18 @@ describe("add command", () => {
 });
 
 describe("createAddComponentsPlan", () => {
+  it("keeps a relative directory anchored outside the child process", () => {
+    const { args } = createAddComponentsPlan({
+      components: ["thread"],
+      packageManager: "npm",
+      cwd: "app",
+    });
+
+    expect(path.resolve("app", args[args.indexOf("--cwd") + 1]!)).toBe(
+      path.resolve("app"),
+    );
+  });
+
   it("uses npx --yes for npm", () => {
     expect(
       createAddComponentsPlan({

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -1,7 +1,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { add, createAddComponentsPlan } from "../../src/commands/add";
 
 describe("add command", () => {
@@ -100,6 +109,17 @@ describe("add directory selection", () => {
 
   let originalCwd: string;
   let originalPath: string | undefined;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
 
   beforeAll(() => {
     fs.mkdirSync(projectDir, { recursive: true });
@@ -130,10 +150,6 @@ describe("add directory selection", () => {
   });
 
   it("resolves a relative directory once, against the caller", async () => {
-    vi.spyOn(process, "exit").mockImplementation((code) => {
-      throw new Error(`process.exit(${String(code)})`);
-    });
-
     await add.parseAsync(["thread", "--cwd", "app", "--use-npm"], {
       from: "user",
     });

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -100,13 +100,10 @@ describe("createAddComponentsPlan", () => {
 });
 
 describe("add directory selection", () => {
-  const root = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), "aui-add-")),
-  );
-  const projectDir = path.join(root, "app");
-  const binDir = path.join(root, "bin");
-  const recordPath = path.join(root, "record.json");
-
+  let root: string;
+  let projectDir: string;
+  let binDir: string;
+  let recordPath: string;
   let originalCwd: string;
   let originalPath: string | undefined;
   let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -122,6 +119,11 @@ describe("add directory selection", () => {
   });
 
   beforeAll(() => {
+    root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "aui-add-")));
+    projectDir = path.join(root, "app");
+    binDir = path.join(root, "bin");
+    recordPath = path.join(root, "record.json");
+
     fs.mkdirSync(projectDir, { recursive: true });
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(path.join(projectDir, "package.json"), "{}");

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { add, createAddComponentsPlan } from "../../src/commands/add";
 
 describe("add command", () => {
@@ -20,25 +22,12 @@ describe("add command", () => {
 });
 
 describe("createAddComponentsPlan", () => {
-  it("keeps a relative directory anchored outside the child process", () => {
-    const { args } = createAddComponentsPlan({
-      components: ["thread"],
-      packageManager: "npm",
-      cwd: "app",
-    });
-
-    expect(path.resolve("app", args[args.indexOf("--cwd") + 1]!)).toBe(
-      path.resolve("app"),
-    );
-  });
-
   it("uses npx --yes for npm", () => {
     expect(
       createAddComponentsPlan({
         components: ["thread"],
         packageManager: "npm",
         yes: true,
-        cwd: "/repo",
       }),
     ).toEqual({
       command: "npx",
@@ -48,8 +37,6 @@ describe("createAddComponentsPlan", () => {
         "add",
         "https://r.assistant-ui.com/base/thread.json",
         "--yes",
-        "--cwd",
-        "/repo",
       ],
     });
   });
@@ -60,7 +47,6 @@ describe("createAddComponentsPlan", () => {
         components: ["thread", "markdown-text"],
         packageManager: "pnpm",
         overwrite: true,
-        cwd: "/repo",
         path: "components/assistant-ui",
       }),
     ).toEqual({
@@ -72,8 +58,6 @@ describe("createAddComponentsPlan", () => {
         "https://r.assistant-ui.com/base/thread.json",
         "https://r.assistant-ui.com/base/markdown-text.json",
         "--overwrite",
-        "--cwd",
-        "/repo",
         "--path",
         "components/assistant-ui",
       ],
@@ -103,5 +87,66 @@ describe("createAddComponentsPlan", () => {
         packageManager: "pnpm",
       }),
     ).toThrow("Invalid component name: ../thread");
+  });
+});
+
+describe("add directory selection", () => {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "aui-add-")),
+  );
+  const projectDir = path.join(root, "app");
+  const binDir = path.join(root, "bin");
+  const recordPath = path.join(root, "record.json");
+
+  let originalCwd: string;
+  let originalPath: string | undefined;
+
+  beforeAll(() => {
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "package.json"), "{}");
+    fs.writeFileSync(
+      path.join(projectDir, "components.json"),
+      JSON.stringify({ style: "new-york" }),
+    );
+
+    const shim = path.join(binDir, "npx");
+    fs.writeFileSync(
+      shim,
+      `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({ cwd: require("node:fs").realpathSync(process.cwd()), argv: process.argv.slice(2) }));\n`,
+    );
+    fs.chmodSync(shim, 0o755);
+
+    originalCwd = process.cwd();
+    originalPath = process.env["PATH"];
+    process.chdir(root);
+    process.env["PATH"] = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    process.env["PATH"] = originalPath ?? "";
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves a relative directory once, against the caller", async () => {
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    await add.parseAsync(["thread", "--cwd", "app", "--use-npm"], {
+      from: "user",
+    });
+
+    const record = JSON.parse(fs.readFileSync(recordPath, "utf8"));
+    // shadcn resolves its own `--cwd` against `process.cwd()`, defaulting to it,
+    // so this is the directory it operates on.
+    const flag = record.argv.indexOf("--cwd");
+    const target =
+      flag === -1
+        ? record.cwd
+        : path.resolve(record.cwd, record.argv[flag + 1] as string);
+
+    expect(target).toBe(projectDir);
   });
 });


### PR DESCRIPTION
## Problem

on `assistant-ui@0.0.114`, `assistant-ui add thread --cwd app` installs into `app/app` instead of `app`.

repro:

```sh
mkdir -p repro/app && cd repro
# app/ holds package.json + components.json
npx assistant-ui@0.0.114 add thread --cwd app
```

## Root cause

`add` selected the target directory twice. `runSpawn(command, args, opts.cwd)` starts the child in `app`, and the same relative value was also forwarded as `--cwd app`. shadcn resolves that flag against its own `process.cwd()` (`packages/shadcn/src/commands/add.ts`, `cwd: path.resolve(opts.cwd)`), so the second layer re-anchored a path the first had already applied.

## Change

drop the `--cwd` forwarding. shadcn defaults `--cwd` to `process.cwd()`, which `runSpawn` already sets to `opts.cwd`, so the flag was redundant with the child's working directory rather than additive to it. `init` has always worked this way (it spawns shadcn with `targetDir` and passes no `--cwd`), so this removes the double-resolution rather than compensating for it, and leaves both commands selecting the directory the same way.

the `cwd` parameter on `createAddComponentsPlan` goes with it, which keeps that function a pure plan builder instead of reading ambient `process.cwd()`.

## Verification

`packages/cli`: 27 files, 316 tests pass (`vitest run`).

`add.test.ts` gains a contract test for the seam that unit-testing the arg list cannot reach: it puts a shim `npx` on `PATH`, runs `add thread --cwd app --use-npm` from a temp root, and asserts the directory shadcn would operate on. against `main` it reports `<tmp>/app/app` and fails; with this change it reports `<tmp>/app` and passes.

## Public surface

`assistant-ui` (cli), patch changeset included. no exported API, docs, or api-reference output changes; `createAddComponentsPlan` is internal to the package, which publishes only a `bin`.
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ABy0DSxdVyQSAQaGP1A6aqALy4aRjmoAUQwFn1wbAaMkEKDgXkGYz558kMA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
