### PR TITLE
fix(react-pi): clear settled snapshot activity flags

### DIFF
--- a/.changeset/pi-settled-snapshot-flags.md
+++ b/.changeset/pi-settled-snapshot-flags.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: clear retry and compaction flags when a snapshot reports a settled thread

--- a/packages/react-pi/src/runtime/threadState.test.ts
+++ b/packages/react-pi/src/runtime/threadState.test.ts
@@ -225,7 +225,7 @@ describe("threadState", () => {
   });
 
   it.each(["idle", "failed", "running"] as const)(
-    "recovers transient flags from a %s snapshot",
+    "reconciles compaction and retry flags with a %s snapshot",
     (status) => {
       const before = apply(
         createPiThreadState("t1"),

--- a/packages/react-pi/src/runtime/threadState.test.ts
+++ b/packages/react-pi/src/runtime/threadState.test.ts
@@ -224,6 +224,30 @@ describe("threadState", () => {
     expect(s.retry.active).toBe(false);
   });
 
+  it.each(["idle", "failed", "running"] as const)(
+    "recovers transient flags from a %s snapshot",
+    (status) => {
+      const before = apply(
+        createPiThreadState("t1"),
+        ev({ type: "compaction_start", reason: "threshold" }),
+        ev({ type: "auto_retry_start", attempt: 2, delayMs: 500 }),
+      );
+      const after = apply(
+        before,
+        ev({
+          type: "snapshot",
+          snapshot: { metadata: { id: "t1", status }, messages: [] },
+        }),
+      );
+      expect(after.compaction).toEqual(
+        status === "running" ? before.compaction : { active: false },
+      );
+      expect(after.retry).toEqual(
+        status === "running" ? before.retry : { active: false, attempt: 0 },
+      );
+    },
+  );
+
   it("agent_end with willRetry keeps running", () => {
     let s = apply(
       createPiThreadState("t1"),

--- a/packages/react-pi/src/runtime/threadState.ts
+++ b/packages/react-pi/src/runtime/threadState.ts
@@ -118,6 +118,9 @@ const applySnapshot = (
     streamingMessageIndex: undefined,
     toolExecutions: {},
     runStatus,
+    compaction: runStatus === "running" ? state.compaction : { active: false },
+    retry:
+      runStatus === "running" ? state.retry : { active: false, attempt: 0 },
     // A missing `queuedMessages` means an empty queue (snapshots omit the
     // field when there is nothing queued, and cold threads have no queue at
     // all) — keeping the prior queue here would let items drained while the

--- a/packages/react-pi/src/runtime/threadState.ts
+++ b/packages/react-pi/src/runtime/threadState.ts
@@ -118,6 +118,7 @@ const applySnapshot = (
     streamingMessageIndex: undefined,
     toolExecutions: {},
     runStatus,
+    // The supervisor reports "running" during compaction and retries.
     compaction: runStatus === "running" ? state.compaction : { active: false },
     retry:
       runStatus === "running" ? state.retry : { active: false, attempt: 0 },

--- a/packages/react-pi/src/runtime/threadState.ts
+++ b/packages/react-pi/src/runtime/threadState.ts
@@ -108,6 +108,9 @@ const applySnapshot = (
       : snapshot.metadata.status === "failed"
         ? "failed"
         : "idle";
+  // The supervisor reports "running" during compaction and retries, so only a
+  // settled snapshot proves neither is in flight.
+  const settled = runStatus !== "running";
 
   return {
     ...state,
@@ -118,10 +121,8 @@ const applySnapshot = (
     streamingMessageIndex: undefined,
     toolExecutions: {},
     runStatus,
-    // The supervisor reports "running" during compaction and retries.
-    compaction: runStatus === "running" ? state.compaction : { active: false },
-    retry:
-      runStatus === "running" ? state.retry : { active: false, attempt: 0 },
+    compaction: settled ? { active: false } : state.compaction,
+    retry: settled ? { active: false, attempt: 0 } : state.retry,
     // A missing `queuedMessages` means an empty queue (snapshots omit the
     // field when there is nothing queued, and cold threads have no queue at
     // all) — keeping the prior queue here would let items drained while the


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-pi` 0.0.21, a thread can remain active after reconnection if the client missed a retry or compaction end event.

## Root cause

The snapshot replaces the run status but retains the previous activity flags, which also determine `isRunning`.

## Change

Settled snapshots clear the retry and compaction flags. Active snapshots retain them because the snapshot cannot distinguish these operations from an ordinary run.

## Verification

The regression in `src/runtime/threadState.test.ts` applies start events, omits their end events, and then applies a snapshot. The idle and failed cases failed before the correction. All 21 tests passed afterward with `./node_modules/.bin/vitest run src/runtime/threadState.test.ts` from `packages/react-pi`.

## Public surface

A patch changeset covers `@assistant-ui/react-pi`. Exports and signatures do not change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GDERv07KlrDBgRd2ZKV0lcRkbwXv4RKyksBX-S09jRUrzbZQ5bQEIFhhDzQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->