### PR TITLE
fix(store): preserve numeric key insertion order

### DIFF
--- a/.changeset/fix-client-list-order.md
+++ b/.changeset/fix-client-list-order.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: preserve client list order for numeric string keys

--- a/packages/store/src/__tests__/useClientList.test.tsx
+++ b/packages/store/src/__tests__/useClientList.test.tsx
@@ -29,8 +29,8 @@ const ItemClient = resource(useItemClient);
 const useThreadClient = () => {
   const list = useClientList({
     initialValues: [
-      { id: "a", label: "A" },
-      { id: "b", label: "B" },
+      { id: "10", label: "A" },
+      { id: "2", label: "B" },
     ],
     getKey: (data: ItemData) => data.id,
     resource: ItemClient,
@@ -63,8 +63,8 @@ describe("useClientList", () => {
   it("exposes initial values as client states, in order", () => {
     const { hook } = setup();
     expect(hook.result.current).toEqual([
-      { id: "a", label: "A" },
-      { id: "b", label: "B" },
+      { id: "10", label: "A" },
+      { id: "2", label: "B" },
     ]);
   });
 
@@ -73,16 +73,16 @@ describe("useClientList", () => {
     const subscriber = vi.fn();
     getAui().subscribe(subscriber);
 
-    act(() => flushTapSync(() => getAui().thread.add({ id: "c", label: "C" })));
+    act(() => flushTapSync(() => getAui().thread.add({ id: "1", label: "C" })));
 
     expect(subscriber).toHaveBeenCalled();
     expect(hook.result.current).toEqual([
-      { id: "a", label: "A" },
-      { id: "b", label: "B" },
-      { id: "c", label: "C" },
+      { id: "10", label: "A" },
+      { id: "2", label: "B" },
+      { id: "1", label: "C" },
     ]);
-    expect(getAui().thread.item({ key: "c" }).getState()).toEqual({
-      id: "c",
+    expect(getAui().thread.item({ key: "1" }).getState()).toEqual({
+      id: "1",
       label: "C",
     });
   });
@@ -92,19 +92,19 @@ describe("useClientList", () => {
     const subscriber = vi.fn();
     getAui().subscribe(subscriber);
 
-    act(() => flushTapSync(() => getAui().thread.item({ key: "a" }).remove()));
+    act(() => flushTapSync(() => getAui().thread.item({ key: "10" }).remove()));
 
     expect(subscriber).toHaveBeenCalled();
-    expect(hook.result.current).toEqual([{ id: "b", label: "B" }]);
-    expect(() => getAui().thread.item({ key: "a" })).toThrow(
-      'key "a" not found',
+    expect(hook.result.current).toEqual([{ id: "2", label: "B" }]);
+    expect(() => getAui().thread.item({ key: "10" })).toThrow(
+      'key "10" not found',
     );
   });
 
   it("lookup works by index and by key", () => {
     const { getAui } = setup();
     expect(getAui().thread.item({ index: 1 }).getState()).toEqual({
-      id: "b",
+      id: "2",
       label: "B",
     });
     expect(() => getAui().thread.item({ index: 2 })).toThrow("out of bounds");
@@ -114,8 +114,8 @@ describe("useClientList", () => {
     const { getAui } = setup();
     expect(() =>
       act(() =>
-        flushTapSync(() => getAui().thread.add({ id: "a", label: "A2" })),
+        flushTapSync(() => getAui().thread.add({ id: "10", label: "A2" })),
       ),
-    ).toThrow("key a that already exists");
+    ).toThrow("key 10 that already exists");
   });
 });

--- a/packages/store/src/__tests__/useClientList.test.tsx
+++ b/packages/store/src/__tests__/useClientList.test.tsx
@@ -60,7 +60,7 @@ afterEach(() => {
 });
 
 describe("useClientList", () => {
-  it("exposes initial values as client states, in order", () => {
+  it("preserves insertion order for integer-like keys", () => {
     const { hook } = setup();
     expect(hook.result.current).toEqual([
       { id: "10", label: "A" },
@@ -68,7 +68,7 @@ describe("useClientList", () => {
     ]);
   });
 
-  it("add mounts a new client and notifies subscribers", () => {
+  it("appends integer-like keys and notifies subscribers", () => {
     const { getAui, hook } = setup();
     const subscriber = vi.fn();
     getAui().subscribe(subscriber);
@@ -87,18 +87,20 @@ describe("useClientList", () => {
     });
   });
 
-  it("remove unmounts the client and notifies subscribers", () => {
+  it("preserves integer-like key order after removal and notifies subscribers", () => {
     const { getAui, hook } = setup();
+    act(() => flushTapSync(() => getAui().thread.add({ id: "1", label: "C" })));
     const subscriber = vi.fn();
     getAui().subscribe(subscriber);
 
-    act(() => flushTapSync(() => getAui().thread.item({ key: "10" }).remove()));
+    act(() => flushTapSync(() => getAui().thread.item({ key: "2" }).remove()));
 
     expect(subscriber).toHaveBeenCalled();
-    expect(hook.result.current).toEqual([{ id: "2", label: "B" }]);
-    expect(() => getAui().thread.item({ key: "10" })).toThrow(
-      'key "10" not found',
-    );
+    expect(hook.result.current).toEqual([
+      { id: "10", label: "A" },
+      { id: "1", label: "C" },
+    ]);
+    expect(() => getAui().thread.item({ key: "2" })).toThrow(/not found/);
   });
 
   it("lookup works by index and by key", () => {

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -38,7 +38,7 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
 
   const initialDataHandles = useRef<DataHandle<TData>[]>([]).current;
 
-  const [items, setItems] = useState<Record<string, Props>>(() => {
+  const [items, setItems] = useState<Map<string, Props>>(() => {
     const entries: [string, Props][] = [];
     for (const data of initialValues) {
       const key = getKey(data);
@@ -47,20 +47,20 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
         key,
         createProps(key, handle, () => {
           setItems((items) => {
-            const newItems = { ...items };
-            delete newItems[key];
+            const newItems = new Map(items);
+            newItems.delete(key);
             return newItems;
           });
         }),
       ]);
       initialDataHandles.push(handle);
     }
-    return Object.fromEntries(entries);
+    return new Map(entries);
   });
 
   const lookup = useClientLookup<TMethods>(
     // `props` is stable per item (held in state), so reuse unchanged items.
-    Object.values(items).map((props) =>
+    [...items.values()].map((props) =>
       withKey(props.key, Resource(props), [props]),
     ),
   );
@@ -77,7 +77,7 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
   const add = (data: TData) => {
     const key = getKey(data);
     setItems((items) => {
-      if (key in items) {
+      if (items.has(key)) {
         throw new Error(
           `Tried to add item with a key ${key} that already exists`,
         );
@@ -86,16 +86,16 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
       const handle = { data, hasData: true };
       initialDataHandles.push(handle);
 
-      return {
-        ...items,
-        [key]: createProps(key, handle, () => {
+      return new Map(items).set(
+        key,
+        createProps(key, handle, () => {
           setItems((items) => {
-            const newItems = { ...items };
-            delete newItems[key];
+            const newItems = new Map(items);
+            newItems.delete(key);
             return newItems;
           });
         }),
-      };
+      );
     });
   };
 


### PR DESCRIPTION
## Problem

In `@assistant-ui/store` 0.3.12, a client list with keys `"10"` and `"2"` returned items in the wrong order. A later item with key `"1"` appeared first instead of last.

## Root cause

Object property enumeration sorts integer-like keys before other keys.

## Change

The list uses a Map to preserve initial and append order across additions and removals. Public types stay unchanged.

## Verification

The source reproduction returned `["2", "10"]` before the correction and `["10", "2"]` after it. The existing regression suite uses numeric keys for initial order, append, removal, and lookup. The inherited-key regression from main also passes.

`node node_modules/vitest/vitest.mjs run src/__tests__/useClientList.test.tsx src/__tests__/useClientList.replay.test.tsx` passed all 11 tests from `packages/store`.

## Public surface

`@assistant-ui/store`, with a patch changeset. No export, documentation, template, or API-reference changes.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5QOJ3Y2DdZtEzzjgeFFI9WtapK8AGyutthZqHllvTLhFhZYS5pMImOZXu6g?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->