### PR TITLE
fix(markdown): preserve currency in tilde and unclosed code fences

### DIFF
--- a/.changeset/currency-tilde-code-fences.md
+++ b/.changeset/currency-tilde-code-fences.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-markdown": patch
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep currency text unchanged inside tilde code fences

--- a/.changeset/currency-tilde-code-fences.md
+++ b/.changeset/currency-tilde-code-fences.md
@@ -3,4 +3,4 @@
 "@assistant-ui/react-streamdown": patch
 ---
 
-fix: keep currency text unchanged inside tilde code fences
+fix: read tilde fences in the currency walker, and end an unclosed fence with its blockquote instead of the rest of the input

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -463,6 +463,19 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("preserves currency while a tilde fence is incomplete", () => {
+    const text = "~~~text\n$5\n~~~";
+    for (let end = 3; end <= text.length; end++) {
+      expect(escapeCurrencyDollars(text.slice(0, end))).toBe(
+        text.slice(0, end),
+      );
+    }
+  });
+
+  it("does not close an unclosed root fence on a quoted tilde run", () => {
+    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~")).toBe("~~~a\n$5\n> ~~~");
+  });
+
   it("accepts a longer closing run for a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
       "```\nconst price = $5;\n````",

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -231,6 +231,12 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
   });
 
+  it("ends an unclosed quoted fence with its blockquote", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n\nafter $x$");
+  });
+
   it("closes a blockquoted fence whose closer omits the marker space", () => {
     expect(
       rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n>~~~\n\nafter \\(x\\)"),
@@ -473,7 +479,21 @@ describe("escapeCurrencyDollars", () => {
   });
 
   it("does not close an unclosed root fence on a quoted tilde run", () => {
-    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~")).toBe("~~~a\n$5\n> ~~~");
+    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~\nafter $10")).toBe(
+      "~~~a\n$5\n> ~~~\nafter $10",
+    );
+  });
+
+  it("ends an unclosed quoted fence with its blockquote", () => {
+    expect(escapeCurrencyDollars("> ~~~\n> $5\n\nafter $10")).toBe(
+      "> ~~~\n> $5\n\nafter \\$10",
+    );
+  });
+
+  it("preserves currency while a backtick fence is incomplete", () => {
+    expect(escapeCurrencyDollars("```text\nconst price = $5;")).toBe(
+      "```text\nconst price = $5;",
+    );
   });
 
   it("accepts a longer closing run for a fenced block", () => {

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -457,6 +457,12 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("preserves tilde-fenced currency and escapes the following prose", () => {
+    expect(escapeCurrencyDollars("~~~text\n$5\n~~~\nafter $10")).toBe(
+      "~~~text\n$5\n~~~\nafter \\$10",
+    );
+  });
+
   it("accepts a longer closing run for a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
       "```\nconst price = $5;\n````",

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -464,6 +464,14 @@ function endOfVerbatimRun(text: string, index: number): number {
     const end = backtickEnd(text, index);
     return end === -1 ? index + runLength(text, index, "`") : end;
   }
+  if (
+    char === "~" &&
+    runLength(text, index, "~") >= 3 &&
+    atLineStart(text, index)
+  ) {
+    const end = fenceEnd(text, index, "~");
+    return end === -1 ? index + runLength(text, index, "~") : end;
+  }
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -138,7 +138,7 @@ function backtickEnd(text: string, start: number): number {
  * opens in. An unclosed span reads as literal text, while an unclosed fence is
  * one still streaming in and protects to the end of the input; that last case is
  * where this walker and `escapeCurrencyDollars` differ, since that one treats
- * the run as literal. Tilde runs only ever open a fence, read the same way.
+ * the run as literal. The two scanners protect unclosed tilde fences to the end.
  */
 function rewriteOutsideCode(
   text: string,
@@ -470,7 +470,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     atLineStart(text, index)
   ) {
     const end = fenceEnd(text, index, "~");
-    return end === -1 ? index + runLength(text, index, "~") : end;
+    return end === -1 ? text.length : end;
   }
   if (char !== "$") return index + 1;
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -34,18 +34,24 @@ const FENCE_CLOSE_QUOTED = {
 // prefix that fails cannot be re-split across two markers, and a list marker
 // still requires the space that separates it from its content.
 const FENCE_OPEN_PREFIX = /^[ \t]*(?:>[ \t]*|(?:[-*+]|\d{1,9}[.)])[ \t]+)*$/;
+// A fence body takes no lazy continuation, so a quoted fence left unclosed ends
+// on the first line that drops the marker. A blank line stays inside it, the way
+// a fence body carries one at the root.
+const QUOTE_CONTINUATION = /^(?:[ \t]*>|[ \t\r]*$)/;
 
 /**
  * End index (exclusive) of the fence opened by the `marker` run at `start`,
  * which the caller has verified opens one: the end of the first later line
- * carrying a closing run of at least the same length, or -1 when no line does.
+ * carrying a closing run of at least the same length, or the end of the
+ * container when no line does, since an unclosed fence is one still streaming
+ * in. A root fence's container is the whole input; a quoted one ends where its
+ * blockquote does.
  */
 function fenceEnd(text: string, start: number, marker: "`" | "~"): number {
   const fenceLength = runLength(text, start, marker);
   const openerLine = text.slice(text.lastIndexOf("\n", start - 1) + 1, start);
-  const closer = openerLine.includes(">")
-    ? FENCE_CLOSE_QUOTED[marker]
-    : FENCE_CLOSE_ROOT[marker];
+  const quoted = openerLine.includes(">");
+  const closer = quoted ? FENCE_CLOSE_QUOTED[marker] : FENCE_CLOSE_ROOT[marker];
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -58,10 +64,11 @@ function fenceEnd(text: string, start: number, marker: "`" | "~"): number {
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
+    if (quoted && !QUOTE_CONTINUATION.test(line)) return lineStart;
     lineStart = lineEnd;
   }
 
-  return -1;
+  return text.length;
 }
 
 /** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
@@ -113,7 +120,7 @@ function opensBacktickFence(text: string, start: number): boolean {
 /**
  * End index (exclusive) of the backtick construct opened at `start`: the fence
  * when {@link opensBacktickFence} accepts the run, the code span otherwise, or
- * -1 when that construct never closes.
+ * -1 when a span never closes.
  */
 function backtickEnd(text: string, start: number): number {
   return opensBacktickFence(text, start)
@@ -136,9 +143,8 @@ function backtickEnd(text: string, start: number): number {
  * anywhere else opens a code span, which closes on a run of exactly its own
  * length wherever on a line that run sits, and never past the paragraph it
  * opens in. An unclosed span reads as literal text, while an unclosed fence is
- * one still streaming in and protects to the end of the input; that last case is
- * where this walker and `escapeCurrencyDollars` differ, since that one treats
- * the run as literal. The two scanners protect unclosed tilde fences to the end.
+ * one still streaming in and protects to the end of its container. Tilde runs
+ * only ever open a fence, read the same way.
  */
 function rewriteOutsideCode(
   text: string,
@@ -180,15 +186,13 @@ function rewriteOutsideCode(
     } else if (char === "`") {
       const end = backtickEnd(text, index);
       if (end !== -1) copyVerbatim(end);
-      else if (opensBacktickFence(text, index)) copyVerbatim(text.length);
       else index += runLength(text, index, "`");
     } else if (
       char === "~" &&
       runLength(text, index, "~") >= 3 &&
       atLineStart(text, index)
     ) {
-      const end = fenceEnd(text, index, "~");
-      copyVerbatim(end === -1 ? text.length : end);
+      copyVerbatim(fenceEnd(text, index, "~"));
     } else {
       index += 1;
     }
@@ -454,8 +458,9 @@ function opensCurrencyAmount(text: string, index: number): boolean {
 
 /**
  * End index (exclusive) of the run at `index` that must be copied unchanged: a `\x`
- * escape, a code span, a `$$` display delimiter, an inline math span, or a plain
- * character. Returns `index` itself for a single `$`, which the caller has to decide.
+ * escape, a code span or fence, a `$$` display delimiter, an inline math span, or a
+ * plain character. Returns `index` itself for a single `$`, which the caller has to
+ * decide.
  */
 function endOfVerbatimRun(text: string, index: number): number {
   const char = text[index];
@@ -469,8 +474,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     runLength(text, index, "~") >= 3 &&
     atLineStart(text, index)
   ) {
-    const end = fenceEnd(text, index, "~");
-    return end === -1 ? text.length : end;
+    return fenceEnd(text, index, "~");
   }
   if (char !== "$") return index + 1;
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -118,6 +118,19 @@ function opensBacktickFence(text: string, start: number): boolean {
 }
 
 /**
+ * Whether the tilde run at `index` opens a fence. A tilde run only ever opens
+ * one, so unlike a backtick run it needs no info string rule, but it still has
+ * to start a line to be a flow construct.
+ */
+function opensTildeFence(text: string, index: number): boolean {
+  return (
+    text[index] === "~" &&
+    runLength(text, index, "~") >= 3 &&
+    atLineStart(text, index)
+  );
+}
+
+/**
  * End index (exclusive) of the backtick construct opened at `start`: the fence
  * when {@link opensBacktickFence} accepts the run, the code span otherwise, or
  * -1 when a span never closes.
@@ -187,11 +200,7 @@ function rewriteOutsideCode(
       const end = backtickEnd(text, index);
       if (end !== -1) copyVerbatim(end);
       else index += runLength(text, index, "`");
-    } else if (
-      char === "~" &&
-      runLength(text, index, "~") >= 3 &&
-      atLineStart(text, index)
-    ) {
+    } else if (opensTildeFence(text, index)) {
       copyVerbatim(fenceEnd(text, index, "~"));
     } else {
       index += 1;
@@ -469,13 +478,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     const end = backtickEnd(text, index);
     return end === -1 ? index + runLength(text, index, "`") : end;
   }
-  if (
-    char === "~" &&
-    runLength(text, index, "~") >= 3 &&
-    atLineStart(text, index)
-  ) {
-    return fenceEnd(text, index, "~");
-  }
+  if (opensTildeFence(text, index)) return fenceEnd(text, index, "~");
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -463,6 +463,19 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("preserves currency while a tilde fence is incomplete", () => {
+    const text = "~~~text\n$5\n~~~";
+    for (let end = 3; end <= text.length; end++) {
+      expect(escapeCurrencyDollars(text.slice(0, end))).toBe(
+        text.slice(0, end),
+      );
+    }
+  });
+
+  it("does not close an unclosed root fence on a quoted tilde run", () => {
+    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~")).toBe("~~~a\n$5\n> ~~~");
+  });
+
   it("accepts a longer closing run for a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
       "```\nconst price = $5;\n````",

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -231,6 +231,12 @@ describe("rewriteLatexBracketDelimiters", () => {
     ).toBe("> ~~~\n> \\[a\\]\n> ~~~\n\nafter $x$");
   });
 
+  it("ends an unclosed quoted fence with its blockquote", () => {
+    expect(
+      rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n\nafter \\(x\\)"),
+    ).toBe("> ~~~\n> \\[a\\]\n\nafter $x$");
+  });
+
   it("closes a blockquoted fence whose closer omits the marker space", () => {
     expect(
       rewriteLatexBracketDelimiters("> ~~~\n> \\[a\\]\n>~~~\n\nafter \\(x\\)"),
@@ -473,7 +479,21 @@ describe("escapeCurrencyDollars", () => {
   });
 
   it("does not close an unclosed root fence on a quoted tilde run", () => {
-    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~")).toBe("~~~a\n$5\n> ~~~");
+    expect(escapeCurrencyDollars("~~~a\n$5\n> ~~~\nafter $10")).toBe(
+      "~~~a\n$5\n> ~~~\nafter $10",
+    );
+  });
+
+  it("ends an unclosed quoted fence with its blockquote", () => {
+    expect(escapeCurrencyDollars("> ~~~\n> $5\n\nafter $10")).toBe(
+      "> ~~~\n> $5\n\nafter \\$10",
+    );
+  });
+
+  it("preserves currency while a backtick fence is incomplete", () => {
+    expect(escapeCurrencyDollars("```text\nconst price = $5;")).toBe(
+      "```text\nconst price = $5;",
+    );
   });
 
   it("accepts a longer closing run for a fenced block", () => {

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -457,6 +457,12 @@ describe("escapeCurrencyDollars", () => {
     );
   });
 
+  it("preserves tilde-fenced currency and escapes the following prose", () => {
+    expect(escapeCurrencyDollars("~~~text\n$5\n~~~\nafter $10")).toBe(
+      "~~~text\n$5\n~~~\nafter \\$10",
+    );
+  });
+
   it("accepts a longer closing run for a fenced block", () => {
     expect(escapeCurrencyDollars("```\nconst price = $5;\n````")).toBe(
       "```\nconst price = $5;\n````",

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -464,6 +464,14 @@ function endOfVerbatimRun(text: string, index: number): number {
     const end = backtickEnd(text, index);
     return end === -1 ? index + runLength(text, index, "`") : end;
   }
+  if (
+    char === "~" &&
+    runLength(text, index, "~") >= 3 &&
+    atLineStart(text, index)
+  ) {
+    const end = fenceEnd(text, index, "~");
+    return end === -1 ? index + runLength(text, index, "~") : end;
+  }
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -138,7 +138,7 @@ function backtickEnd(text: string, start: number): number {
  * opens in. An unclosed span reads as literal text, while an unclosed fence is
  * one still streaming in and protects to the end of the input; that last case is
  * where this walker and `escapeCurrencyDollars` differ, since that one treats
- * the run as literal. Tilde runs only ever open a fence, read the same way.
+ * the run as literal. The two scanners protect unclosed tilde fences to the end.
  */
 function rewriteOutsideCode(
   text: string,
@@ -470,7 +470,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     atLineStart(text, index)
   ) {
     const end = fenceEnd(text, index, "~");
-    return end === -1 ? index + runLength(text, index, "~") : end;
+    return end === -1 ? text.length : end;
   }
   if (char !== "$") return index + 1;
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -34,18 +34,24 @@ const FENCE_CLOSE_QUOTED = {
 // prefix that fails cannot be re-split across two markers, and a list marker
 // still requires the space that separates it from its content.
 const FENCE_OPEN_PREFIX = /^[ \t]*(?:>[ \t]*|(?:[-*+]|\d{1,9}[.)])[ \t]+)*$/;
+// A fence body takes no lazy continuation, so a quoted fence left unclosed ends
+// on the first line that drops the marker. A blank line stays inside it, the way
+// a fence body carries one at the root.
+const QUOTE_CONTINUATION = /^(?:[ \t]*>|[ \t\r]*$)/;
 
 /**
  * End index (exclusive) of the fence opened by the `marker` run at `start`,
  * which the caller has verified opens one: the end of the first later line
- * carrying a closing run of at least the same length, or -1 when no line does.
+ * carrying a closing run of at least the same length, or the end of the
+ * container when no line does, since an unclosed fence is one still streaming
+ * in. A root fence's container is the whole input; a quoted one ends where its
+ * blockquote does.
  */
 function fenceEnd(text: string, start: number, marker: "`" | "~"): number {
   const fenceLength = runLength(text, start, marker);
   const openerLine = text.slice(text.lastIndexOf("\n", start - 1) + 1, start);
-  const closer = openerLine.includes(">")
-    ? FENCE_CLOSE_QUOTED[marker]
-    : FENCE_CLOSE_ROOT[marker];
+  const quoted = openerLine.includes(">");
+  const closer = quoted ? FENCE_CLOSE_QUOTED[marker] : FENCE_CLOSE_ROOT[marker];
   let lineStart = text.indexOf("\n", start);
 
   while (lineStart !== -1) {
@@ -58,10 +64,11 @@ function fenceEnd(text: string, start: number, marker: "`" | "~"): number {
     if (close && close[1]!.length >= fenceLength) {
       return lineEnd === -1 ? text.length : lineEnd;
     }
+    if (quoted && !QUOTE_CONTINUATION.test(line)) return lineStart;
     lineStart = lineEnd;
   }
 
-  return -1;
+  return text.length;
 }
 
 /** Whether the character at `index` starts a line, allowing ≤3 spaces indent. */
@@ -113,7 +120,7 @@ function opensBacktickFence(text: string, start: number): boolean {
 /**
  * End index (exclusive) of the backtick construct opened at `start`: the fence
  * when {@link opensBacktickFence} accepts the run, the code span otherwise, or
- * -1 when that construct never closes.
+ * -1 when a span never closes.
  */
 function backtickEnd(text: string, start: number): number {
   return opensBacktickFence(text, start)
@@ -136,9 +143,8 @@ function backtickEnd(text: string, start: number): number {
  * anywhere else opens a code span, which closes on a run of exactly its own
  * length wherever on a line that run sits, and never past the paragraph it
  * opens in. An unclosed span reads as literal text, while an unclosed fence is
- * one still streaming in and protects to the end of the input; that last case is
- * where this walker and `escapeCurrencyDollars` differ, since that one treats
- * the run as literal. The two scanners protect unclosed tilde fences to the end.
+ * one still streaming in and protects to the end of its container. Tilde runs
+ * only ever open a fence, read the same way.
  */
 function rewriteOutsideCode(
   text: string,
@@ -180,15 +186,13 @@ function rewriteOutsideCode(
     } else if (char === "`") {
       const end = backtickEnd(text, index);
       if (end !== -1) copyVerbatim(end);
-      else if (opensBacktickFence(text, index)) copyVerbatim(text.length);
       else index += runLength(text, index, "`");
     } else if (
       char === "~" &&
       runLength(text, index, "~") >= 3 &&
       atLineStart(text, index)
     ) {
-      const end = fenceEnd(text, index, "~");
-      copyVerbatim(end === -1 ? text.length : end);
+      copyVerbatim(fenceEnd(text, index, "~"));
     } else {
       index += 1;
     }
@@ -454,8 +458,9 @@ function opensCurrencyAmount(text: string, index: number): boolean {
 
 /**
  * End index (exclusive) of the run at `index` that must be copied unchanged: a `\x`
- * escape, a code span, a `$$` display delimiter, an inline math span, or a plain
- * character. Returns `index` itself for a single `$`, which the caller has to decide.
+ * escape, a code span or fence, a `$$` display delimiter, an inline math span, or a
+ * plain character. Returns `index` itself for a single `$`, which the caller has to
+ * decide.
  */
 function endOfVerbatimRun(text: string, index: number): number {
   const char = text[index];
@@ -469,8 +474,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     runLength(text, index, "~") >= 3 &&
     atLineStart(text, index)
   ) {
-    const end = fenceEnd(text, index, "~");
-    return end === -1 ? text.length : end;
+    return fenceEnd(text, index, "~");
   }
   if (char !== "$") return index + 1;
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -118,6 +118,19 @@ function opensBacktickFence(text: string, start: number): boolean {
 }
 
 /**
+ * Whether the tilde run at `index` opens a fence. A tilde run only ever opens
+ * one, so unlike a backtick run it needs no info string rule, but it still has
+ * to start a line to be a flow construct.
+ */
+function opensTildeFence(text: string, index: number): boolean {
+  return (
+    text[index] === "~" &&
+    runLength(text, index, "~") >= 3 &&
+    atLineStart(text, index)
+  );
+}
+
+/**
  * End index (exclusive) of the backtick construct opened at `start`: the fence
  * when {@link opensBacktickFence} accepts the run, the code span otherwise, or
  * -1 when a span never closes.
@@ -187,11 +200,7 @@ function rewriteOutsideCode(
       const end = backtickEnd(text, index);
       if (end !== -1) copyVerbatim(end);
       else index += runLength(text, index, "`");
-    } else if (
-      char === "~" &&
-      runLength(text, index, "~") >= 3 &&
-      atLineStart(text, index)
-    ) {
+    } else if (opensTildeFence(text, index)) {
       copyVerbatim(fenceEnd(text, index, "~"));
     } else {
       index += 1;
@@ -469,13 +478,7 @@ function endOfVerbatimRun(text: string, index: number): number {
     const end = backtickEnd(text, index);
     return end === -1 ? index + runLength(text, index, "`") : end;
   }
-  if (
-    char === "~" &&
-    runLength(text, index, "~") >= 3 &&
-    atLineStart(text, index)
-  ) {
-    return fenceEnd(text, index, "~");
-  }
+  if (opensTildeFence(text, index)) return fenceEnd(text, index, "~");
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");


### PR DESCRIPTION
## Problem

currency preprocessing added a literal backslash before `$5` inside a closed tilde code fence. this affects react-markdown 0.14.14 and react-streamdown 0.3.13.

```ts
escapeCurrencyDollars("~~~text\n$5\n~~~");
// expected: "~~~text\n$5\n~~~"
```

closes #6860.

## Root cause

`endOfVerbatimRun` branched on `\`, on a backtick run and on `$`, with no branch for `~`, so a tilde fence was invisible to the currency walker while `rewriteOutsideCode` already read one.

two more gaps sat behind that one, both from `fenceEnd` returning -1 for a fence that never closes and leaving each caller to improvise a fallback. the currency walker read an unclosed backtick fence as a literal run, so a price still streaming inside one was escaped. and both walkers protected an unclosed quoted fence to the end of the input rather than to the end of its blockquote, so the prose after that blockquote kept its currency unescaped and its math delimiters unrewritten.

## Change

`endOfVerbatimRun` gains the tilde branch, reusing the existing fence parser.

`fenceEnd` becomes total: it returns the end of the fence's scope rather than -1, which is the whole input for a root fence and the blockquote for a quoted one. a blank line stays inside the body, so a fence quoted inside a list item still reads as one fence. both callers drop their -1 fallback, `rewriteOutsideCode` loses a branch that is now unreachable, and the two scanners read a fence the same way, which is what the walker docstring used to carry a caveat about.

opener detection is untouched. a tilde fence written on a list marker line or indented past a list item's content column still opens and never closes, as #6795 shipped it; #6810 widened those three cases for backticks only and that asymmetry stays for a separate change.

## Verification

micromark 4.0.2 as ground truth over fifteen fence shapes, comparing which `$` each walker judged code against which one micromark puts inside `<code>`: main disagrees on twelve of them, this branch on one. the remaining disagreement is a backtick fence opened inside a blockquote whose body carries a blank line, where micromark ends the blockquote at that line and the walker keeps the fence open. that is the deliberate reading `does not rewrite a fence quoted inside a list item` already pins, so it is left as is.

the six new or tightened assertions fail on `main` and pass here.

- `cd packages/react-markdown && node node_modules/vitest/vitest.mjs run src/preprocess.test.ts` (98 passed)
- `cd packages/react-streamdown && node node_modules/vitest/vitest.mjs run src/__tests__/preprocess.test.ts` (98 passed)
- `pnpm lint`
- `pnpm --filter @assistant-ui/react-markdown --filter @assistant-ui/react-streamdown build`

these exercise the preprocessing functions, not a mounted browser interface.

## Public surface

no export or signature changes. a patch changeset covers react-markdown and react-streamdown.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yXnABxAZAFCx1jE9LVgHmLwnrjIa3ttAkccOyLx4NmQj5QZGdH4zq66-Yxw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
