### PR TITLE
fix(langgraph): preserve streamed message snapshots

### DIFF
--- a/.changeset/quiet-text-snapshots.md
+++ b/.changeset/quiet-text-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: keep previous message text unchanged when new stream chunks arrive

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -351,3 +351,24 @@ describe("appendLangChainChunk updates-event partial_json", () => {
     expect(final).toBe(toolMessage);
   });
 });
+
+describe("appendLangChainChunk content snapshots", () => {
+  it.each(["B", [{ type: "text" as const, text: "B" }]])(
+    "keeps the previous text block unchanged for %j",
+    (content) => {
+      const before: AiMessage = {
+        id: "ai-1",
+        type: "ai",
+        content: [{ type: "text", text: "A" }],
+      };
+      const after = append(before, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content,
+      });
+
+      expect(after.content).toEqual([{ type: "text", text: "AB" }]);
+      expect(before.content).toEqual([{ type: "text", text: "A" }]);
+    },
+  );
+});

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -98,8 +98,10 @@ export const appendLangChainChunk = (
   if (typeof curr?.content === "string") {
     const lastIndex = newContent.length - 1;
     if (newContent[lastIndex]?.type === "text") {
-      (newContent[lastIndex] as MessageContentText).text =
-        (newContent[lastIndex] as MessageContentText).text + curr.content;
+      newContent[lastIndex] = {
+        ...newContent[lastIndex],
+        text: (newContent[lastIndex] as MessageContentText).text + curr.content,
+      };
     } else {
       newContent.push({ type: "text", text: curr.content });
     }
@@ -112,8 +114,11 @@ export const appendLangChainChunk = (
 
       if (item.type === "text") {
         if (newContent[lastIndex]?.type === "text") {
-          (newContent[lastIndex] as MessageContentText).text =
-            (newContent[lastIndex] as MessageContentText).text + item.text;
+          newContent[lastIndex] = {
+            ...newContent[lastIndex],
+            text:
+              (newContent[lastIndex] as MessageContentText).text + item.text,
+          };
         } else {
           newContent.push({ type: "text", text: item.text });
         }


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-langgraph` 0.14.26, a new text chunk changes text in a message that the runtime already emitted. Consumers cannot retain an unchanged snapshot.

## Root cause

The merger copies the content array but writes into the shared text block.

## Change

Each text append replaces the last block instead of changing the previous block.

## Verification

The regression in `appendLangChainChunk.test.ts` appends `B` to an array-backed `A` message through string and array chunks. The new message must contain `AB`, and the previous message must contain `A`.

The two cases failed before the correction. All 14 tests passed after it with `node node_modules/vitest/vitest.mjs run src/appendLangChainChunk.test.ts --config <local-source-config>`. The temporary configuration resolves copied package dependencies to this worktree's source because their built exports were stale. No live provider test was necessary for this pure merger.

## Public surface

The behavior changes in `@assistant-ui/react-langgraph`. Exports and signatures stay unchanged. A patch changeset is included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.B7f5dbK5wXRFBIsdJLNxYjIO264gCn2tGO_VSx4eIsbO9tl6zkX3aBGlh6s?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->