### PR TITLE
fix(core): keep tool calls without IDs separate

### DIFF
--- a/.changeset/keep-tool-calls-without-ids.md
+++ b/.changeset/keep-tool-calls-without-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep separate tool calls when their IDs are absent

--- a/packages/core/src/runtime/api/message-runtime.test.ts
+++ b/packages/core/src/runtime/api/message-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   type MessageStateBinding,
 } from "./message-runtime";
 import { toMessagePartStatus } from "../../utils/normalizePartStatus";
+import { convertExternalMessageChunk } from "../utils/external-message-conversion";
 
 const messagePath = {
   ref: "threads.main.messages[0]",
@@ -256,6 +257,80 @@ describe("toMessagePartStatus", () => {
 });
 
 describe("MessageRuntimeImpl paths", () => {
+  it.each([undefined, ""])(
+    "looks up separate tool calls with ID %s without breaking provider result matching",
+    (toolCallId) => {
+      const id = toolCallId === undefined ? {} : { toolCallId };
+      const converted = convertExternalMessageChunk(
+        {
+          inputs: [{}],
+          outputs: [
+            {
+              role: "assistant",
+              content: [
+                { type: "tool-call", ...id, toolName: "weather", args: {} },
+                { type: "tool-call", ...id, toolName: "search", args: {} },
+                {
+                  type: "tool-call",
+                  toolCallId: "provider-call",
+                  toolName: "calendar",
+                  args: { day: "Monday" },
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool-call",
+                  toolCallId: "provider-call",
+                  toolName: "calendar",
+                  args: { day: "Tuesday" },
+                },
+              ],
+            },
+            {
+              role: "tool",
+              toolCallId: "provider-call",
+              toolName: "calendar",
+              result: "Meeting at noon",
+            },
+          ],
+        },
+        0,
+        1,
+        false,
+        undefined,
+      );
+      const runtime = new MessageRuntimeImpl(
+        {
+          ...messageBinding,
+          getState: () => ({ ...message, ...converted }),
+        },
+        threadBinding,
+      );
+      const calls = converted.content.filter(
+        (part) => part.type === "tool-call",
+      );
+
+      expect(
+        calls.map((call) =>
+          runtime.getMessagePartByToolCallId(call.toolCallId).getState(),
+        ),
+      ).toMatchObject([
+        { type: "tool-call", toolName: "weather" },
+        { type: "tool-call", toolName: "search" },
+        {
+          type: "tool-call",
+          toolCallId: "provider-call",
+          toolName: "calendar",
+          args: { day: "Tuesday" },
+          result: "Meeting at noon",
+        },
+      ]);
+    },
+  );
+
   it("appends nested selectors to the message path", () => {
     const runtime = new MessageRuntimeImpl(messageBinding, threadBinding);
 

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -83,6 +83,34 @@ describe("chunkExternalMessages", () => {
 });
 
 describe("convertExternalMessageChunk", () => {
+  it("keeps separate tool calls without IDs", () => {
+    const result = convertExternalMessageChunk(
+      {
+        inputs: [{}],
+        outputs: [
+          {
+            role: "assistant",
+            content: [
+              { type: "tool-call", toolName: "weather", args: {} },
+              { type: "tool-call", toolName: "search", args: {} },
+            ],
+          },
+        ],
+      },
+      0,
+      1,
+      false,
+      undefined,
+    );
+
+    expect(result.content).toMatchObject([
+      { type: "tool-call", toolName: "weather" },
+      { type: "tool-call", toolName: "search" },
+    ]);
+    const calls = result.content.filter((part) => part.type === "tool-call");
+    expect(calls[0]!.toolCallId).not.toBe(calls[1]!.toolCallId);
+  });
+
   it("reuses a cached message when the error status is unchanged", () => {
     const input = {};
     const chunk = {

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -109,6 +109,7 @@ describe("convertExternalMessageChunk", () => {
     ]);
     const calls = result.content.filter((part) => part.type === "tool-call");
     expect(calls[0]!.toolCallId).not.toBe(calls[1]!.toolCallId);
+    expect(calls.map((call) => call.toolCallId)).not.toContain("");
   });
 
   it("keeps separate tool calls with empty IDs", () => {
@@ -145,6 +146,9 @@ describe("convertExternalMessageChunk", () => {
       { type: "tool-call", toolName: "weather" },
       { type: "tool-call", toolName: "search" },
     ]);
+    const calls = result.content.filter((part) => part.type === "tool-call");
+    expect(calls[0]?.toolCallId).not.toBe(calls[1]?.toolCallId);
+    expect(calls.map((call) => call.toolCallId)).not.toContain("");
   });
 
   it("reuses a cached message when the error status is unchanged", () => {

--- a/packages/core/src/runtime/utils/external-message-conversion.test.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.test.ts
@@ -111,6 +111,42 @@ describe("convertExternalMessageChunk", () => {
     expect(calls[0]!.toolCallId).not.toBe(calls[1]!.toolCallId);
   });
 
+  it("keeps separate tool calls with empty IDs", () => {
+    const result = convertExternalMessageChunk(
+      {
+        inputs: [{}],
+        outputs: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "",
+                toolName: "weather",
+                args: {},
+              },
+              {
+                type: "tool-call",
+                toolCallId: "",
+                toolName: "search",
+                args: {},
+              },
+            ],
+          },
+        ],
+      },
+      0,
+      1,
+      false,
+      undefined,
+    );
+
+    expect(result.content).toMatchObject([
+      { type: "tool-call", toolName: "weather" },
+      { type: "tool-call", toolName: "search" },
+    ]);
+  });
+
   it("reuses a cached message when the error status is unchanged", () => {
     const input = {};
     const chunk = {

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -252,7 +252,7 @@ export const joinExternalMessages = (
 
           // Add content parts, merging reasoning parts with same parentId
           for (const part of content) {
-            if (part.type === "tool-call" && part.toolCallId !== undefined) {
+            if (part.type === "tool-call" && part.toolCallId) {
               const existingIdx = assistantMessage.content.findIndex(
                 (c) =>
                   c.type === "tool-call" && c.toolCallId === part.toolCallId,

--- a/packages/core/src/runtime/utils/external-message-conversion.ts
+++ b/packages/core/src/runtime/utils/external-message-conversion.ts
@@ -252,7 +252,7 @@ export const joinExternalMessages = (
 
           // Add content parts, merging reasoning parts with same parentId
           for (const part of content) {
-            if (part.type === "tool-call") {
+            if (part.type === "tool-call" && part.toolCallId !== undefined) {
               const existingIdx = assistantMessage.content.findIndex(
                 (c) =>
                   c.type === "tool-call" && c.toolCallId === part.toolCallId,

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -179,7 +179,7 @@ export const fromThreadMessageLike = (
                 const { parentId, messages, ...basePart } = part;
                 const commonProps = {
                   ...basePart,
-                  toolCallId: part.toolCallId ?? `tool-${generateId()}`,
+                  toolCallId: part.toolCallId || `tool-${generateId()}`,
                   ...(parentId !== undefined && { parentId }),
                   ...(messages !== undefined && { messages }),
                 };


### PR DESCRIPTION
## Problem

In core 0.3.17, two tool calls without IDs become one call after conversion. For example, `weather` disappears when `search` follows it.

## Root cause

The converter treats two absent IDs as equal before it generates IDs.

## Change

Tool calls merge only when the incoming call supplies an ID.

## Verification

The regression `keeps separate tool calls without IDs` in `external-message-conversion.test.ts` failed before the correction and passes after it.

`cd packages/core && node node_modules/vitest/vitest.mjs run src/runtime/utils/external-message-conversion.test.ts` passes all eight tests.

## Public surface

The correction includes a patch changeset for `@assistant-ui/core`. Exports and API signatures are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5yWwCHODCFhTcw_sp3VIjkqD0V3mHP9fZ7gYoJBqK5V_AGjchfDCe-UUogA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->