### PR TITLE
fix(react): reject selections across excluded content

### DIFF
--- a/.changeset/reject-excluded-selection.md
+++ b/.changeset/reject-excluded-selection.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: reject quote selections that cross excluded content

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
@@ -34,6 +34,8 @@ Place this component inside `ThreadPrimitive.Root`:
 ```
 
 To prevent tool cards or other message UI from being quoted, wrap the message text in `data-aui-quote-selectable`. If a message contains that marker, the toolbar only appears for selections inside the same marked region. Set the attribute to `"false"` to exclude an element instead; on the message root it disables quoting for the whole message.
+
+If a selection crosses an excluded element, the toolbar does not appear. This includes a full paragraph selection that contains an excluded inline citation. The toolbar does not remove excluded text from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable.
 {/* api-manual:end */}
 
 {/* api-reference:start */}

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
@@ -35,7 +35,7 @@ Place this component inside `ThreadPrimitive.Root`:
 
 To prevent tool cards or other message UI from being quoted, wrap the message text in `data-aui-quote-selectable`. If a message contains that marker, the toolbar only appears for selections inside the same marked region. Set the attribute to `"false"` to exclude an element instead; on the message root it disables quoting for the whole message.
 
-If a selection crosses an excluded element, the toolbar does not appear. This includes a full paragraph selection that contains an excluded inline citation. The toolbar does not remove excluded text from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable.
+If a selection crosses an excluded element, the toolbar does not appear; excluded text is never stripped from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable. Because the whole selection is rejected, exclusions suit block-level UI such as tool cards and attachments; an exclusion placed inline in a paragraph makes any selection over that paragraph unquotable.
 {/* api-manual:end */}
 
 {/* api-reference:start */}

--- a/apps/docs/content/docs/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/primitives/selection-toolbar.mdx
@@ -78,6 +78,8 @@ By default, any selected text inside a message can be quoted. For rich messages 
 
 Set `data-aui-quote-selectable="false"` to exclude an element instead: on the message root it disables quoting for the entire message, and inside a quotable region it carves that subtree out. The nearest marker wins, and any value other than `"false"` (including empty) marks a quotable region.
 
+If a selection crosses an excluded element, the toolbar does not appear. This includes a full paragraph selection that contains an excluded inline citation. The toolbar does not remove excluded text from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable.
+
 Apps know the message role at render time, so a role gate is a conditional attribute:
 
 ```tsx

--- a/apps/docs/content/docs/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/primitives/selection-toolbar.mdx
@@ -78,7 +78,7 @@ By default, any selected text inside a message can be quoted. For rich messages 
 
 Set `data-aui-quote-selectable="false"` to exclude an element instead: on the message root it disables quoting for the entire message, and inside a quotable region it carves that subtree out. The nearest marker wins, and any value other than `"false"` (including empty) marks a quotable region.
 
-If a selection crosses an excluded element, the toolbar does not appear. This includes a full paragraph selection that contains an excluded inline citation. The toolbar does not remove excluded text from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable.
+If a selection crosses an excluded element, the toolbar does not appear; excluded text is never stripped from a quote. Selections that end immediately before or start immediately after the excluded element remain quotable. Because the whole selection is rejected, exclusions suit block-level UI such as tool cards and attachments; an exclusion placed inline in a paragraph makes any selection over that paragraph unquotable.
 
 Apps know the message role at render time, so a role gate is a conditional attribute:
 

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, assert, describe, expect, it } from "vitest";
 import { getSelectionMessageId } from "./getSelectionMessageId";
 
 const selectText = (start: Text, end = start) => {
@@ -137,6 +137,62 @@ describe("getSelectionMessageId", () => {
       ).toBeNull();
     },
   );
+
+  it("rejects a paragraph selection that spans an inline exclusion", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <p id="text" data-aui-quote-selectable>before <span data-aui-quote-selectable="false">[1]</span> after</p>
+      </div>
+    `;
+
+    const paragraph = document.querySelector("#text");
+    assert(paragraph);
+    const selection = selectText(textNode("#text"));
+    selection.getRangeAt(0).selectNodeContents(paragraph);
+
+    expect(getSelectionMessageId(selection)).toBeNull();
+  });
+
+  it("accepts selections that stop or start at an excluded node boundary", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1" data-aui-quote-selectable>
+        <span id="before">before</span><span id="chip" data-aui-quote-selectable="false">[1]</span><span id="after">after</span>
+      </div>
+    `;
+
+    const chip = document.querySelector("#chip");
+    assert(chip);
+    const before = selectText(textNode("#before"));
+    before.getRangeAt(0).setEndBefore(chip);
+    expect(getSelectionMessageId(before)).toBe("message-1");
+
+    const after = selectText(textNode("#after"));
+    after.getRangeAt(0).setStartAfter(chip);
+    expect(getSelectionMessageId(after)).toBe("message-1");
+  });
+
+  it("preserves a nested quote region inside an excluded subtree", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <div data-aui-quote-selectable="false">
+          <p data-aui-quote-selectable>
+            <span id="before">before</span>
+            <span data-aui-quote-selectable="false">[1]</span>
+            <span id="after">after</span>
+          </p>
+        </div>
+      </div>
+    `;
+
+    expect(getSelectionMessageId(selectText(textNode("#before")))).toBe(
+      "message-1",
+    );
+    expect(
+      getSelectionMessageId(
+        selectText(textNode("#before"), textNode("#after")),
+      ),
+    ).toBeNull();
+  });
 
   it("rejects selections outside quote-selectable regions when a message opts in", () => {
     document.body.innerHTML = `

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -222,6 +222,30 @@ describe("getSelectionMessageId", () => {
     expect(getSelectionMessageId(selection)).toBeNull();
   });
 
+  it("rejects another range over excluded content beside a nested quote region", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <div data-aui-quote-selectable="false">
+          <span id="sibling">excluded prose</span>
+          <p id="active" data-aui-quote-selectable>active text</p>
+        </div>
+      </div>
+    `;
+
+    const range = document.createRange();
+    range.selectNodeContents(textNode("#sibling"));
+    const selection = selectText(textNode("#active"));
+    const active = selection.getRangeAt(0);
+    vi.spyOn(selection, "rangeCount", "get").mockReturnValue(2);
+    vi.spyOn(selection, "getRangeAt").mockImplementation((index) => {
+      if (index === 0) return range;
+      if (index === 1) return active;
+      throw new DOMException("Range index out of bounds", "IndexSizeError");
+    });
+
+    expect(getSelectionMessageId(selection)).toBeNull();
+  });
+
   it("accepts disjoint ranges on either side of an excluded gap", () => {
     document.body.innerHTML = `
       <div data-message-id="message-1" data-aui-quote-selectable>

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -222,7 +222,7 @@ describe("getSelectionMessageId", () => {
     expect(getSelectionMessageId(selection)).toBeNull();
   });
 
-  it("rejects another range over excluded content beside a nested quote region", () => {
+  it("rejects another range inside the excluded ancestor of the active quote region", () => {
     document.body.innerHTML = `
       <div data-message-id="message-1">
         <div data-aui-quote-selectable="false">
@@ -234,6 +234,28 @@ describe("getSelectionMessageId", () => {
 
     const range = document.createRange();
     range.selectNodeContents(textNode("#sibling"));
+    const selection = selectText(textNode("#active"));
+    const active = selection.getRangeAt(0);
+    vi.spyOn(selection, "rangeCount", "get").mockReturnValue(2);
+    vi.spyOn(selection, "getRangeAt").mockImplementation((index) => {
+      if (index === 0) return range;
+      if (index === 1) return active;
+      throw new DOMException("Range index out of bounds", "IndexSizeError");
+    });
+
+    expect(getSelectionMessageId(selection)).toBeNull();
+  });
+
+  it("rejects another range in a different message", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1"><p id="active">active text</p></div>
+      <div data-message-id="message-2">
+        <p id="other" data-aui-quote-selectable="false">excluded prose</p>
+      </div>
+    `;
+
+    const range = document.createRange();
+    range.selectNodeContents(textNode("#other"));
     const selection = selectText(textNode("#active"));
     const active = selection.getRangeAt(0);
     vi.spyOn(selection, "rangeCount", "get").mockReturnValue(2);

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { afterEach, assert, describe, expect, it } from "vitest";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
 import { getSelectionMessageId } from "./getSelectionMessageId";
 
 const selectText = (start: Text, end = start) => {
@@ -24,6 +24,7 @@ const textNode = (selector: string) => {
 };
 
 afterEach(() => {
+  vi.restoreAllMocks();
   window.getSelection()?.removeAllRanges();
   document.body.replaceChildren();
 });
@@ -192,6 +193,56 @@ describe("getSelectionMessageId", () => {
         selectText(textNode("#before"), textNode("#after")),
       ),
     ).toBeNull();
+  });
+
+  it("checks another range outside the active quote region, including its excluded ancestor", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <p id="other">before <span id="chip" data-aui-quote-selectable="false">[1]</span> after</p>
+        <p id="active" data-aui-quote-selectable>active text</p>
+      </div>
+    `;
+
+    const other = document.querySelector("#other");
+    assert(other);
+    const range = document.createRange();
+    range.selectNodeContents(other);
+    const selection = selectText(textNode("#active"));
+    const active = selection.getRangeAt(0);
+    vi.spyOn(selection, "rangeCount", "get").mockReturnValue(2);
+    vi.spyOn(selection, "getRangeAt").mockImplementation((index) => {
+      if (index === 0) return range;
+      if (index === 1) return active;
+      throw new DOMException("Range index out of bounds", "IndexSizeError");
+    });
+
+    expect(getSelectionMessageId(selection)).toBeNull();
+
+    range.selectNodeContents(textNode("#chip"));
+    expect(getSelectionMessageId(selection)).toBeNull();
+  });
+
+  it("accepts disjoint ranges on either side of an excluded gap", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1" data-aui-quote-selectable>
+        <p id="before">before</p>
+        <p data-aui-quote-selectable="false">excluded</p>
+        <p id="after">after</p>
+      </div>
+    `;
+
+    const before = document.createRange();
+    before.selectNodeContents(textNode("#before"));
+    const selection = selectText(textNode("#after"));
+    const after = selection.getRangeAt(0);
+    vi.spyOn(selection, "rangeCount", "get").mockReturnValue(2);
+    vi.spyOn(selection, "getRangeAt").mockImplementation((index) => {
+      if (index === 0) return before;
+      if (index === 1) return after;
+      throw new DOMException("Range index out of bounds", "IndexSizeError");
+    });
+
+    expect(getSelectionMessageId(selection)).toBe("message-1");
   });
 
   it("rejects selections outside quote-selectable regions when a message opts in", () => {

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -116,6 +116,28 @@ describe("getSelectionMessageId", () => {
     ).toBeNull();
   });
 
+  it.each(["", "data-aui-quote-selectable"])(
+    "rejects selections spanning an excluded subtree with root %s",
+    (marker) => {
+      document.body.innerHTML = `
+        <div data-message-id="message-1" ${marker}>
+          <span id="before">before</span>
+          <span data-aui-quote-selectable="false">excluded</span>
+          <span id="after">after</span>
+        </div>
+      `;
+
+      expect(getSelectionMessageId(selectText(textNode("#before")))).toBe(
+        "message-1",
+      );
+      expect(
+        getSelectionMessageId(
+          selectText(textNode("#before"), textNode("#after")),
+        ),
+      ).toBeNull();
+    },
+  );
+
   it("rejects selections outside quote-selectable regions when a message opts in", () => {
     document.body.innerHTML = `
       <div data-message-id="message-1">

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -64,8 +64,9 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   if (focusMarker && isExcluded(focusMarker)) return null;
 
   for (const excluded of anchorMessageElement.querySelectorAll(
-    '[data-aui-quote-selectable="false"]',
+    QUOTE_SELECTABLE_SELECTOR,
   )) {
+    if (!isExcluded(excluded) || excluded.contains(anchorMarker)) continue;
     for (let i = 0; i < selection.rangeCount; i++) {
       if (selection.getRangeAt(i).intersectsNode(excluded)) return null;
     }

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -74,18 +74,16 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   if (anchorMarker && isExcluded(anchorMarker)) return null;
   if (focusMarker && isExcluded(focusMarker)) return null;
 
-  if (!hasQuoteSelectableRegion(anchorMessageElement)) {
-    return intersectsExcluded(anchorMessageElement, selection)
-      ? null
-      : messageId;
+  if (hasQuoteSelectableRegion(anchorMessageElement)) {
+    if (!anchorMarker || anchorMarker !== focusMarker) return null;
   }
 
-  if (!anchorMarker || anchorMarker !== focusMarker) return null;
+  const scope = anchorMarker ?? anchorMessageElement;
 
   for (let i = 0; i < selection.rangeCount; i++) {
     const { commonAncestorContainer } = selection.getRangeAt(i);
-    if (!anchorMarker.contains(commonAncestorContainer)) return null;
+    if (!scope.contains(commonAncestorContainer)) return null;
   }
 
-  return intersectsExcluded(anchorMarker, selection) ? null : messageId;
+  return intersectsExcluded(scope, selection) ? null : messageId;
 };

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -1,5 +1,4 @@
 const QUOTE_SELECTABLE_SELECTOR = "[data-aui-quote-selectable]";
-const QUOTE_EXCLUDED_SELECTOR = '[data-aui-quote-selectable="false"]';
 
 const getElement = (node: Node | null): HTMLElement | null => {
   return node instanceof HTMLElement ? node : (node?.parentElement ?? null);
@@ -44,6 +43,17 @@ const findQuoteMarker = (
   return marker;
 };
 
+const intersectsExcluded = (scope: Element, selection: Selection): boolean => {
+  const ranges = Array.from({ length: selection.rangeCount }, (_, i) =>
+    selection.getRangeAt(i),
+  );
+  for (const marker of scope.querySelectorAll(QUOTE_SELECTABLE_SELECTOR)) {
+    if (!isExcluded(marker)) continue;
+    if (ranges.some((range) => range.intersectsNode(marker))) return true;
+  }
+  return false;
+};
+
 export const getSelectionMessageId = (selection: Selection): string | null => {
   const { anchorNode, focusNode } = selection;
   if (!anchorNode || !focusNode) return null;
@@ -64,32 +74,18 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   if (anchorMarker && isExcluded(anchorMarker)) return null;
   if (focusMarker && isExcluded(focusMarker)) return null;
 
-  if (anchorMarker !== focusMarker) return null;
-  if (!anchorMarker && hasQuoteSelectableRegion(anchorMessageElement)) {
-    return null;
+  if (!hasQuoteSelectableRegion(anchorMessageElement)) {
+    return intersectsExcluded(anchorMessageElement, selection)
+      ? null
+      : messageId;
   }
+
+  if (!anchorMarker || anchorMarker !== focusMarker) return null;
 
   for (let i = 0; i < selection.rangeCount; i++) {
-    const range = selection.getRangeAt(i);
-    const ancestor = getElement(range.commonAncestorContainer);
-    const scope =
-      ancestor && anchorMessageElement.contains(ancestor)
-        ? ancestor
-        : anchorMessageElement;
-    const excludedAncestor = scope.closest(QUOTE_EXCLUDED_SELECTOR);
-    if (
-      excludedAncestor &&
-      anchorMessageElement.contains(excludedAncestor) &&
-      !excludedAncestor.contains(anchorMarker)
-    ) {
-      return null;
-    }
-
-    for (const excluded of scope.querySelectorAll(QUOTE_EXCLUDED_SELECTOR)) {
-      if (excluded.contains(anchorMarker)) continue;
-      if (range.intersectsNode(excluded)) return null;
-    }
+    const { commonAncestorContainer } = selection.getRangeAt(i);
+    if (!anchorMarker.contains(commonAncestorContainer)) return null;
   }
 
-  return messageId;
+  return intersectsExcluded(anchorMarker, selection) ? null : messageId;
 };

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -1,4 +1,5 @@
 const QUOTE_SELECTABLE_SELECTOR = "[data-aui-quote-selectable]";
+const QUOTE_EXCLUDED_SELECTOR = '[data-aui-quote-selectable="false"]';
 
 const getElement = (node: Node | null): HTMLElement | null => {
   return node instanceof HTMLElement ? node : (node?.parentElement ?? null);
@@ -63,18 +64,32 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   if (anchorMarker && isExcluded(anchorMarker)) return null;
   if (focusMarker && isExcluded(focusMarker)) return null;
 
-  for (const excluded of anchorMessageElement.querySelectorAll(
-    QUOTE_SELECTABLE_SELECTOR,
-  )) {
-    if (!isExcluded(excluded) || excluded.contains(anchorMarker)) continue;
-    for (let i = 0; i < selection.rangeCount; i++) {
-      if (selection.getRangeAt(i).intersectsNode(excluded)) return null;
-    }
+  if (anchorMarker !== focusMarker) return null;
+  if (!anchorMarker && hasQuoteSelectableRegion(anchorMessageElement)) {
+    return null;
   }
 
-  if (!hasQuoteSelectableRegion(anchorMessageElement)) return messageId;
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i);
+    const ancestor = getElement(range.commonAncestorContainer);
+    const scope =
+      ancestor && anchorMessageElement.contains(ancestor)
+        ? ancestor
+        : anchorMessageElement;
+    const excludedAncestor = scope.closest(QUOTE_EXCLUDED_SELECTOR);
+    if (
+      excludedAncestor &&
+      anchorMessageElement.contains(excludedAncestor) &&
+      !excludedAncestor.contains(anchorMarker)
+    ) {
+      return null;
+    }
 
-  if (!anchorMarker || anchorMarker !== focusMarker) return null;
+    for (const excluded of scope.querySelectorAll(QUOTE_EXCLUDED_SELECTOR)) {
+      if (excluded.contains(anchorMarker)) continue;
+      if (range.intersectsNode(excluded)) return null;
+    }
+  }
 
   return messageId;
 };

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -63,6 +63,14 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   if (anchorMarker && isExcluded(anchorMarker)) return null;
   if (focusMarker && isExcluded(focusMarker)) return null;
 
+  for (const excluded of anchorMessageElement.querySelectorAll(
+    '[data-aui-quote-selectable="false"]',
+  )) {
+    for (let i = 0; i < selection.rangeCount; i++) {
+      if (selection.getRangeAt(i).intersectsNode(excluded)) return null;
+    }
+  }
+
   if (!hasQuoteSelectableRegion(anchorMessageElement)) return messageId;
 
   if (!anchorMarker || anchorMarker !== focusMarker) return null;


### PR DESCRIPTION
## Problem

In `@assistant-ui/react` 0.15.18, a quote selection can include an excluded citation between two selected text spans.

## Root cause

The selection helper examines only the endpoints, so it accepts excluded content between them.

## Change

Selections that cross an excluded subtree return no message ID. Selections outside that subtree remain quotable.

## Verification

The regression in `getSelectionMessageId.test.ts` covers a message with and without an explicit quote region. The two new cases fail before the correction. All 12 tests pass after it.

Command: `cd packages/react && node node_modules/vitest/vitest.mjs run src/utils/getSelectionMessageId.test.ts --typecheck.enabled false`.

A Chromium check with the actual helper also rejects `BeforeExcludedAfter` across an excluded span.

## Public surface

`@assistant-ui/react` receives a patch changeset. No exports or documented options change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iKZnCLH8DT8v6MBbhHakCZTKDMbSHYLGVpOxWbb9mpmMStprpfSSCIsFq_s?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->