### PR TITLE
fix(assistant-stream): isolate replay byte buffers

### DIFF
--- a/.changeset/resumable-stream-owned-bytes.md
+++ b/.changeset/resumable-stream-owned-bytes.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: Keep stored replay bytes separate from producer and consumer buffers.

--- a/apps/docs/content/docs/guides/resumable-stream-stores.mdx
+++ b/apps/docs/content/docs/guides/resumable-stream-stores.mdx
@@ -36,9 +36,13 @@ export interface ResumableStreamStore {
 
 `append(streamId, chunk)` adds a `Uint8Array` to the log under a fresh, monotonically increasing cursor. Callers expect the chunk to be observable to `read` before the promise resolves. Implementations should refresh the TTL on each call so a stream that is still actively producing does not expire mid-flight, and should reject when the stream is missing or already finalized.
 
+After `append` resolves, changes to the input buffer must not change stored bytes.
+
 `finalize(streamId, status, error?)` flips the stream into a terminal state. Pending and future `read` iterables drain buffered entries and then either complete (`"done"`) or throw with `error` (`"error"`). Implementations must make `finalize` idempotent: a duplicate call with the same status is a no-op, and the producer task may retry on transient errors.
 
 `read(streamId, cursor, signal)` is the only streaming method. It yields every entry whose cursor sorts strictly after the supplied `cursor`, then waits for new appends, then completes when the stream finalizes. Aborting `signal` resolves the iterable cleanly without throwing. Networked stores typically combine a bounded fetch loop with pub/sub, long-poll, or notify wakeups; do not busy-loop.
+
+Changes to a yielded chunk must not affect other reads. In-memory stores must copy bytes on append and read, including Node.js `Buffer` inputs.
 
 `status(streamId)` returns one of `"streaming" | "done" | "error" | "missing"` synchronously with respect to the underlying store. It exists so the context can decide whether to start a new producer or attach a consumer without holding a `read` iterator open.
 
@@ -90,7 +94,10 @@ export function createMapResumableStreamStore(): ResumableStreamStore {
     async append(id, chunk) {
       const s = streams.get(id);
       if (!s || s.final) throw new Error(`Cannot append: ${id}`);
-      s.entries.push({ cursor: (++s.seq).toString(36), chunk });
+      s.entries.push({
+        cursor: (++s.seq).toString(36),
+        chunk: new Uint8Array(chunk),
+      });
       wake(s);
     },
     async finalize(id, status, error) {
@@ -104,7 +111,10 @@ export function createMapResumableStreamStore(): ResumableStreamStore {
       if (!s) throw new Error(`Stream not found: ${id}`);
       let i = cursor === "" ? 0 : Number.parseInt(cursor, 36);
       while (!signal.aborted) {
-        while (i < s.entries.length) yield s.entries[i++]!;
+        while (i < s.entries.length) {
+          const entry = s.entries[i++]!;
+          yield { ...entry, chunk: new Uint8Array(entry.chunk) };
+        }
         if (s.final) {
           if (s.final.status === "error") throw new Error(s.final.error);
           return;

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
@@ -15,6 +15,25 @@ async function drain(
 }
 
 describe("InMemoryResumableStreamStore", () => {
+  it("keeps replay bytes independent of producer and consumer buffers", async () => {
+    const store = createInMemoryResumableStreamStore();
+    const chunk = Buffer.from("a");
+    await store.acquire("a");
+    await store.append("a", chunk);
+    await store.finalize("a", "done");
+    chunk[0] = 98;
+
+    const signal = new AbortController().signal;
+    const seen: string[] = [];
+    for await (const entry of store.read("a", "", signal)) {
+      seen.push(decode(entry.chunk));
+      entry.chunk[0] = 99;
+    }
+
+    expect(seen).toEqual(["a"]);
+    expect(await drain(store.read("a", "", signal))).toEqual(["a"]);
+  });
+
   it("elects exactly one producer per stream id", async () => {
     const store = createInMemoryResumableStreamStore();
     const first = await store.acquire("a");

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
@@ -163,7 +163,10 @@ export function createInMemoryResumableStreamStore(
       }
       const seq = state.nextSeq;
       state.nextSeq += 1;
-      state.entries.push({ cursor: cursorOf(seq), chunk });
+      state.entries.push({
+        cursor: cursorOf(seq),
+        chunk: new Uint8Array(chunk),
+      });
       state.expiresAt = now() + state.ttlMs;
       notify(state);
     },
@@ -195,7 +198,8 @@ export function createInMemoryResumableStreamStore(
 
         while (idx < state.entries.length) {
           if (signal.aborted) return;
-          yield state.entries[idx]!;
+          const entry = state.entries[idx]!;
+          yield { ...entry, chunk: new Uint8Array(entry.chunk) };
           idx += 1;
         }
 

--- a/packages/assistant-stream/src/resumable/types.ts
+++ b/packages/assistant-stream/src/resumable/types.ts
@@ -22,7 +22,10 @@ export interface ResumableStreamStore {
     options?: ResumableStreamAcquireOptions,
   ): Promise<ResumableStreamRole>;
 
-  /** Implementations should refresh the TTL on each call. */
+  /**
+   * Implementations should refresh the TTL on each call.
+   * After the promise resolves, caller mutations must not change stored bytes.
+   */
   append(streamId: string, chunk: Uint8Array): Promise<void>;
 
   finalize(
@@ -35,6 +38,7 @@ export interface ResumableStreamStore {
    * Yields persisted entries strictly after `cursor` (`""` starts from the
    * beginning), then waits for new ones until the stream is finalized.
    * Aborting `signal` resolves the iterable without throwing.
+   * Caller mutations to yielded chunks must not affect other reads.
    */
   read(
     streamId: string,


### PR DESCRIPTION
## Problem

In assistant-stream 0.3.41, producer or consumer buffer mutations change the bytes returned by later stream replays.

## Root cause

The in-memory store retains the input array and returns that same array to each reader.

## Change

Copy bytes on append and read. `new Uint8Array` also copies Node.js Buffer inputs, whose `slice` method shares memory.

## Verification

The new mutation regression in `InMemoryResumableStreamStore.test.ts` failed before the correction and passed after it. From `packages/assistant-stream`, `./node_modules/.bin/vitest run src/resumable/stores/InMemoryResumableStreamStore.test.ts src/resumable/ResumableStreamContext.test.ts` passed 46 tests. A direct `requireResume` scenario returned the original bytes after producer and consumer mutations.

## Public surface

`assistant-stream/resumable`, with a patch changeset. No exports changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MrYpJRuQesh_g3cDvwPOF7-O48iZ5Ec7QuMi0BGS7UmJ6lud10583_zRgcg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->