### PR TITLE
fix(examples): release already-aborted pi event streams

### DIFF
--- a/examples/with-pi/app/api/pi/threads/[threadId]/events/route.ts
+++ b/examples/with-pi/app/api/pi/threads/[threadId]/events/route.ts
@@ -47,6 +47,7 @@ export async function GET(req: NextRequest, { params }: Context) {
     { includeSnapshot: req.nextUrl.searchParams.get("snapshot") !== "false" },
   );
   req.signal.addEventListener("abort", cleanup, { once: true });
+  if (req.signal.aborted) cleanup();
 
   return new Response(stream.readable, {
     headers: {


### PR DESCRIPTION
## Problem

A disconnected Pi events request could leave its subscription and heartbeat active if the request aborted before its route parameters resolved.

## Root cause

Abort signals do not replay an earlier abort event to a new listener.

## Change

The route checks the signal after listener registration and uses the existing cleanup. Disconnect still does not cancel the Pi run.

## Verification

A focused Bun check called the real route with deferred parameters, aborted the request, then resolved the parameters. Before the correction, one subscription and heartbeat remained. After the correction, neither remained. The Pi client boundary and timers were isolated. The commit hook passed Oxlint and Oxfmt.

Minimal reproduction sequence:

```ts
const controller = new AbortController();
const params = Promise.withResolvers<{ threadId: string }>();
const response = GET({
  signal: controller.signal,
  nextUrl: new URL("http://localhost/api/pi/threads/thread-1/events"),
} as NextRequest, { params: params.promise });
controller.abort();
params.resolve({ threadId: "thread-1" });
await (await response).body?.cancel();
```

## Public surface

Only the private Pi example changes. No published package or API changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-brBKsLYUr-uh86qYurf2B_J5kBsWW53P-b-BufQWz-CtbpEFWxdrKqgymc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->