### PR TITLE
fix(python): serialize draft proxies in stream payloads

### DIFF
--- a/python/assistant-stream/src/assistant_stream/state_proxy.py
+++ b/python/assistant-stream/src/assistant_stream/state_proxy.py
@@ -19,6 +19,6 @@ class StateProxyJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that can handle StateProxy objects."""
 
     def default(self, obj: Any) -> Any:
-        if isinstance(obj, StateProxy):
+        if isinstance(obj, BaseStateProxy):
             return obj._get_value()
         return super().default(obj)

--- a/python/assistant-stream/src/assistant_stream/state_proxy.py
+++ b/python/assistant-stream/src/assistant_stream/state_proxy.py
@@ -1,24 +1,13 @@
 import json
 from typing import Any
 
-from assistant_stream.state import StateProxy as BaseStateProxy
-
-
-class StateProxy(BaseStateProxy):
-    """Proxy object for state access and updates using dictionary-style access.
-
-    Example:
-        state_proxy["user"]["name"] = "John"
-        name = state_proxy["user"]["name"]
-        state_proxy["messages"] += "Hello"
-        state_proxy["items"].append("item")
-    """
+from assistant_stream.state import StateProxy
 
 
 class StateProxyJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that can handle StateProxy objects."""
 
     def default(self, obj: Any) -> Any:
-        if isinstance(obj, BaseStateProxy):
+        if isinstance(obj, StateProxy):
             return obj._get_value()
         return super().default(obj)

--- a/python/assistant-stream/tests/test_data_stream.py
+++ b/python/assistant-stream/tests/test_data_stream.py
@@ -6,6 +6,7 @@ from assistant_stream import create_run, RunController
 
 from assistant_stream.assistant_stream_chunk import (
     AnnotationsChunk,
+    DataChunk,
     ErrorChunk,
     FileChunk,
     StepFinishChunk,
@@ -21,6 +22,17 @@ from assistant_stream.assistant_stream_chunk import (
 )
 from assistant_stream.modules.tool_call import create_tool_call
 from assistant_stream.serialization.data_stream import DataStreamEncoder
+from assistant_stream.state import AssistantState
+
+
+def test_data_stream_encoder_serializes_draft_proxies() -> None:
+    draft = AssistantState({"items": [1]}).draft(lambda _ops: None)
+
+    encoded = DataStreamEncoder().encode_chunk(
+        DataChunk(data={"root": draft, "items": draft["items"]})
+    )
+
+    assert json.loads(encoded[2:]) == [{"root": {"items": [1]}, "items": [1]}]
 
 
 def test_data_stream_encoder_update_state_shape() -> None:


### PR DESCRIPTION
## Problem

`StateProxyJSONEncoder` cannot serialize proxies produced by `AssistantState.draft`, raising `TypeError` instead of JSON. It is reachable today only by constructing a draft directly against `assistant_stream.state`; the shipped path (`create_run` → `StateManager`) hands out the subclass the guard already matched, so no released API hits it.

```python
from assistant_stream.assistant_stream_chunk import DataChunk
from assistant_stream.serialization.data_stream import DataStreamEncoder
from assistant_stream.state import AssistantState

draft = AssistantState({"items": [1]}).draft(lambda _ops: None)
DataStreamEncoder().encode_chunk(
    DataChunk(data={"root": draft, "items": draft["items"]})
)
```

## Root cause

There were two names for one class. `state_proxy.StateProxy` was a docstring-only subclass of `state.StateProxy`, left behind when #5062 moved the real proxy into `state.py`. `AssistantState.draft` constructs the base class while the encoder guarded the subclass, and nested proxies inherit whichever class the root was (`type(self)`), so an entire subtree fell outside the guard.

## Change

Delete the empty subclass, so `assistant_stream.state_proxy.StateProxy` is `assistant_stream.state.StateProxy`. The encoder's existing `isinstance` guard is then correct for every proxy by construction, rather than widened to a base class that a redundant subclass keeps shadowing. `state_proxy` is left holding only the encoder, and the `assistant_stream.state_proxy.StateProxy` import path keeps working for `state_manager` and any external caller.

## Verification

```sh
cd python/assistant-stream
uv sync --extra dev --extra langgraph
.venv/bin/python -m pytest tests/ -q
```

176 passed, 7 skipped. The added regression test fails on `main` with `TypeError: Object of type StateProxy is not JSON serializable` and passes with the change.

## Public surface

Python `assistant-stream` only. No exports removed: `state_proxy.StateProxy` still resolves, now to the base class, so `isinstance` checks against it widen rather than narrow. No documentation or api-reference claims change. Python releases ship through PyPI, outside the Changesets workspace, so no changeset (matching #6869).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EBa8h4x9ZQPEpAd4eP4kRu-G-2fbJyYoRw7zMqnk-vL60owjXTHZjk3Ze5A?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
