### PR TITLE
fix(core): match complete attachment extensions

### DIFF
--- a/.changeset/match-complete-attachment-extensions.md
+++ b/.changeset/match-complete-attachment-extensions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: match attachment extensions against the complete filename suffix, so `.tar.gz` accepts `backup.tar.gz` and `.png` rejects extensionless `png`.

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -142,11 +142,11 @@ export function fileMatchesAccept(
     .split(",")
     .map((type) => type.trim().toLowerCase());
 
-  const fileExtension = `.${file.name.split(".").pop()!.toLowerCase()}`;
+  const fileName = file.name.toLowerCase();
   const fileMimeType = file.type.split(";", 1)[0]!.trim().toLowerCase();
 
   for (const type of allowedTypes) {
-    if (type.startsWith(".") && type === fileExtension) {
+    if (type.startsWith(".") && fileName.endsWith(type)) {
       return true;
     }
 

--- a/packages/core/src/tests/attachment-adapters.test.ts
+++ b/packages/core/src/tests/attachment-adapters.test.ts
@@ -9,10 +9,17 @@ import {
 
 describe("fileMatchesAccept", () => {
   it.each([
-    ["BACKUP.TAR.GZ", ".tar.gz", true],
-    ["png", ".png", false],
-  ])("matches the full suffix of %s", (name, accept, expected) => {
-    expect(fileMatchesAccept({ name, type: "" }, accept)).toBe(expected);
+    ["BACKUP.TAR.GZ", ".tar.gz"],
+    [".env", ".env"],
+  ])("accepts %s for %s", (name, accept) => {
+    expect(fileMatchesAccept({ name, type: "" }, accept)).toBe(true);
+  });
+
+  it.each([
+    ["png", ".png"],
+    ["foo.mjs", ".js"],
+  ])("rejects %s for %s", (name, accept) => {
+    expect(fileMatchesAccept({ name, type: "" }, accept)).toBe(false);
   });
 
   it("matches MIME types with parameters", () => {

--- a/packages/core/src/tests/attachment-adapters.test.ts
+++ b/packages/core/src/tests/attachment-adapters.test.ts
@@ -8,6 +8,13 @@ import {
 } from "../adapters/attachment";
 
 describe("fileMatchesAccept", () => {
+  it.each([
+    ["BACKUP.TAR.GZ", ".tar.gz", true],
+    ["png", ".png", false],
+  ])("matches the full suffix of %s", (name, accept, expected) => {
+    expect(fileMatchesAccept({ name, type: "" }, accept)).toBe(expected);
+  });
+
   it("matches MIME types with parameters", () => {
     expect(
       fileMatchesAccept(


### PR DESCRIPTION
## Problem

Attachment adapters reject `backup.tar.gz` for `.tar.gz` and accept an extensionless file named `png` for `.png`. This affects `@assistant-ui/core` 0.3.17.

Minimal reproduction from the repository root with Bun:

```sh
bun --eval '
import assert from "node:assert/strict";
import { fileMatchesAccept } from "./packages/core/src/adapters/attachment.ts";
assert.equal(fileMatchesAccept({ name: "backup.tar.gz", type: "" }, ".tar.gz"), true);
assert.equal(fileMatchesAccept({ name: "png", type: "" }, ".png"), false);
'
```

## Root cause

The matcher keeps only the final dot-separated segment and adds a dot, even when the filename has no extension.

## Change

Extension rules compare against the complete filename suffix without case sensitivity. Composer acceptance and composite adapter selection use the same matcher. MIME rules remain unchanged.

## Verification

The two regression cases failed before the correction. All eight attachment tests pass after the correction:

```sh
cd packages/core
./node_modules/.bin/vitest run src/tests/attachment-adapters.test.ts
```

Bun assertions also passed for suffix boundaries, MIME rules, wildcards, and real composite adapter add/send/remove operations. Changed-file `oxlint` and `oxfmt` completed successfully.

## Public surface

The PR includes a patch changeset for `@assistant-ui/core`. Exports and signatures remain unchanged. No documentation, API-reference, or template changes are necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2CvGcEZusM4ZgKp1hc85zDR7QagAKA49gdaUyPIe4ZcSmChez9e76U0BDhQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->