### PR TITLE
fix(stream): honor abort after the last buffered chunk

### DIFF
--- a/.changeset/resumable-abort-buffered-error.md
+++ b/.changeset/resumable-abort-buffered-error.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: complete aborted in-memory stream reads without throwing a stored error after the last buffered chunk.

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.test.ts
@@ -140,6 +140,22 @@ describe("InMemoryResumableStreamStore", () => {
     expect(collected).toEqual(["x"]);
   });
 
+  it("honors abort after the last buffered chunk before a stored error", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    await store.append("a", bytes("partial"));
+    await store.finalize("a", "error", "boom");
+    const ac = new AbortController();
+    const seen: string[] = [];
+
+    for await (const entry of store.read("a", "", ac.signal)) {
+      seen.push(decode(entry.chunk));
+      ac.abort();
+    }
+
+    expect(seen).toEqual(["partial"]);
+  });
+
   it("multiple consumers can read concurrently", async () => {
     const store = createInMemoryResumableStreamStore();
     await store.acquire("a");

--- a/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
+++ b/packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts
@@ -199,6 +199,8 @@ export function createInMemoryResumableStreamStore(
           idx += 1;
         }
 
+        if (signal.aborted) return;
+
         if (state.final) {
           if (state.final.kind === "error") {
             throw new Error(state.final.error);


### PR DESCRIPTION
## Problem

An aborted in-memory stream reader throws the stored producer error after its last buffered chunk. It must complete without throwing instead.

The reproduction uses the `assistant-stream` 0.3.41 source from this checkout. This snippet runs with Bun from the repository root:

```ts
import { createInMemoryResumableStreamStore } from "./packages/assistant-stream/src/resumable/stores/InMemoryResumableStreamStore.ts";

const store = createInMemoryResumableStreamStore();
await store.acquire("a");
await store.append("a", new Uint8Array([65]));
await store.finalize("a", "error", "boom");
const ac = new AbortController();
const reader = store.read("a", "", ac.signal)[Symbol.asyncIterator]();
await reader.next();
ac.abort();
console.log(await reader.next());
store.dispose();
```

Before the correction, the final `next()` rejects with `boom`. After the correction, it returns `done: true`.

## Root cause

After the final buffered yield, the generator reaches the stored-error branch before it examines the abort signal again.

## Change

The reader examines the abort signal before final-state handling. Active readers still receive the stored error after the buffered chunks.

## Verification

The new regression failed with `boom` before the source correction. All 46 tests passed after the correction with this command in `packages/assistant-stream`:

```sh
pnpm exec vitest run src/resumable/stores/InMemoryResumableStreamStore.test.ts src/resumable/ResumableStreamContext.test.ts
```

The direct Bun reproduction returned `done: true`. Changed-file oxlint and oxfmt also passed.

## Public surface

The `assistant-stream` patch changeset covers the correction. Exports, signatures, and the documented abort contract remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.juy9TP-2qUacRV_E4xfQzTTUvbfHroqdHnuqk8dTo1yCkRawLowwBvlLhaU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->