### PR TITLE
fix(langgraph): keep mixed content blocks in order

### DIFF
--- a/.changeset/langgraph-mixed-content-order.md
+++ b/.changeset/langgraph-mixed-content-order.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: keep text and images in order when a streamed chunk contains multiple content blocks

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -351,3 +351,26 @@ describe("appendLangChainChunk updates-event partial_json", () => {
     expect(final).toBe(toolMessage);
   });
 });
+
+describe("appendLangChainChunk content order", () => {
+  it("keeps text after an image in the same chunk", () => {
+    const image = {
+      type: "image_url" as const,
+      image_url: "data:image/png;base64,AA==",
+    };
+    const result = append(
+      { id: "ai-1", type: "ai", content: "Before" },
+      {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [image, { type: "text", text: "After" }],
+      },
+    );
+
+    expect(result.content).toEqual([
+      { type: "text", text: "Before" },
+      image,
+      { type: "text", text: "After" },
+    ]);
+  });
+});

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -104,8 +104,8 @@ export const appendLangChainChunk = (
       newContent.push({ type: "text", text: curr.content });
     }
   } else if (Array.isArray(curr.content)) {
-    const lastIndex = newContent.length - 1;
     for (const item of curr.content) {
+      const lastIndex = newContent.length - 1;
       if (!("type" in item)) {
         continue;
       }


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-langgraph` 0.14.26, text after an image can move before that image when the two blocks arrive in one chunk. The corrected result keeps the text after the image.

Minimal reproduction:

```ts
import { appendLangChainChunk } from "@assistant-ui/react-langgraph";

const image = {
  type: "image_url" as const,
  image_url: "data:image/png;base64,AA==",
};
const result = appendLangChainChunk(
  { id: "a", type: "ai", content: "Before" },
  {
    id: "a",
    type: "AIMessageChunk",
    content: [image, { type: "text", text: "After" }],
  },
);
```

Before the correction, `result.content` contains text `BeforeAfter`, then the image. The expected result is text `Before`, the image, then text `After`.

## Root cause

The loop uses one tail index for the entire chunk. After it appends an image, that index still points to the text before the image.

## Change

The shared append function calculates the tail index for each block. No runtime API changes are necessary.

## Verification

The regression failed before the correction and passed after it. The append and accumulator suites passed all 43 tests with:

```sh
pnpm --filter @assistant-ui/react-langgraph test src/appendLangChainChunk.test.ts src/LangGraphMessageAccumulator.test.ts --config /tmp/langgraph-content-order.vitest.mjs
```

The temporary configuration used the package test settings and mapped `@assistant-ui/react-langchain/converter` to its workspace source because its local build was missing. It is not part of this PR.

A direct Bun call also passed assertions for image order and adjacent text merging. Changed-file `oxfmt --check` and `oxlint` checks passed.

## Public surface

The PR includes a patch changeset for `@assistant-ui/react-langgraph`. Exports, documentation, API reference, and templates are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZgfgpvVaYnWwYJCYm3vvCN8n9liXuLS6-BEEK4-ao-s6XIBm8oN5sTEE2Yc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->