### PR TITLE
fix(store): handle prototype-named lookup keys

### DIFF
--- a/.changeset/fix-client-lookup-keys.md
+++ b/.changeset/fix-client-lookup-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: retrieve client resources with prototype-named keys

--- a/.changeset/fix-client-lookup-keys.md
+++ b/.changeset/fix-client-lookup-keys.md
@@ -2,4 +2,4 @@
 "@assistant-ui/store": patch
 ---
 
-fix: retrieve client resources with prototype-named keys
+fix: add and retrieve client resources with prototype-named keys

--- a/packages/store/src/__tests__/proxy-invariants.test.tsx
+++ b/packages/store/src/__tests__/proxy-invariants.test.tsx
@@ -16,10 +16,10 @@ const useItem = ({ id }: { id: string }) => ({
 const Item = resource(useItem);
 
 const useThread = () => {
-  const items = useClientLookup([withKey("a", Item({ id: "a" }))]);
+  const items = useClientLookup([withKey("__proto__", Item({ id: "a" }))]);
   return {
     getState: () => ({ count: 1 }),
-    item: (lookup: { index: number }) => items.get(lookup),
+    item: (lookup: { index: number } | { key: string }) => items.get(lookup),
   };
 };
 const Thread = resource(useThread);
@@ -45,6 +45,16 @@ afterEach(() => {
 });
 
 describe("proxy invariants", () => {
+  it("retrieves prototype-named keys without inherited matches", () => {
+    render(<App />);
+    expect(probe.aui.thread().item({ key: "__proto__" }).getState()).toEqual({
+      id: "a",
+    });
+    expect(() => probe.aui.thread().item({ key: "constructor" })).toThrow(
+      /not found/,
+    );
+  });
+
   it("supports Object.keys and spread on a client", () => {
     render(<App />);
     const client = probe.aui.thread().item({ index: 0 });

--- a/packages/store/src/__tests__/proxy-invariants.test.tsx
+++ b/packages/store/src/__tests__/proxy-invariants.test.tsx
@@ -16,9 +16,12 @@ const useItem = ({ id }: { id: string }) => ({
 const Item = resource(useItem);
 
 const useThread = () => {
-  const items = useClientLookup([withKey("__proto__", Item({ id: "a" }))]);
+  const items = useClientLookup([
+    withKey("a", Item({ id: "a" })),
+    withKey("__proto__", Item({ id: "proto" })),
+  ]);
   return {
-    getState: () => ({ count: 1 }),
+    getState: () => ({ count: 2 }),
     item: (lookup: { index: number } | { key: string }) => items.get(lookup),
   };
 };
@@ -48,7 +51,7 @@ describe("proxy invariants", () => {
   it("retrieves prototype-named keys without inherited matches", () => {
     render(<App />);
     expect(probe.aui.thread().item({ key: "__proto__" }).getState()).toEqual({
-      id: "a",
+      id: "proto",
     });
     expect(() => probe.aui.thread().item({ key: "constructor" })).toThrow(
       /not found/,
@@ -83,7 +86,7 @@ describe("proxy invariants", () => {
 
     expect(Object.keys(probe.state)).toEqual(["thread", "optional"]);
     const spread = { ...probe.state };
-    expect(spread.thread).toEqual({ count: 1 });
+    expect(spread.thread).toEqual({ count: 2 });
     expect(
       Object.getOwnPropertyDescriptor(probe.state, "thread")?.configurable,
     ).toBe(true);
@@ -110,7 +113,7 @@ describe("proxy invariants", () => {
       "thread",
     ]);
     const spread = { ...probe.state };
-    expect(spread.thread).toEqual({ count: 1 });
+    expect(spread.thread).toEqual({ count: 2 });
     expect(spread.item).toEqual({ id: "x" });
   });
 });

--- a/packages/store/src/__tests__/useClientList.test.tsx
+++ b/packages/store/src/__tests__/useClientList.test.tsx
@@ -87,6 +87,41 @@ describe("useClientList", () => {
     });
   });
 
+  it("adds, removes, and re-adds an inherited key without losing plain keys", () => {
+    const { getAui, hook } = setup();
+    const data = { id: "constructor", label: "Added" };
+
+    act(() => flushTapSync(() => getAui().thread.add(data)));
+
+    expect(hook.result.current).toEqual([
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+      { id: "constructor", label: "Added" },
+    ]);
+    expect(getAui().thread.item({ key: "constructor" }).getState()).toEqual(
+      data,
+    );
+    expect(getAui().thread.item({ key: "a" }).getState()).toEqual({
+      id: "a",
+      label: "A",
+    });
+
+    act(() =>
+      flushTapSync(() => getAui().thread.item({ key: "constructor" }).remove()),
+    );
+    expect(() => getAui().thread.item({ key: "constructor" })).toThrow(
+      /not found/,
+    );
+
+    act(() => flushTapSync(() => getAui().thread.add(data)));
+    expect(getAui().thread.item({ key: "constructor" }).getState()).toEqual(
+      data,
+    );
+    expect(() =>
+      act(() => flushTapSync(() => getAui().thread.add(data))),
+    ).toThrow(/already exists/);
+  });
+
   it("remove unmounts the client and notifies subscribers", () => {
     const { getAui, hook } = setup();
     const subscriber = vi.fn();

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -77,7 +77,7 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
   const add = (data: TData) => {
     const key = getKey(data);
     setItems((items) => {
-      if (key in items) {
+      if (Object.hasOwn(items, key)) {
         throw new Error(
           `Tried to add item with a key ${key} that already exists`,
         );

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -29,7 +29,7 @@ export function useClientLookup<TMethods extends ClientMethods>(
         acc[getElementKey(element)] = index;
         return acc;
       },
-      {} as Record<string, number>,
+      Object.create(null) as Record<string, number>,
     );
   }, [elements]);
 


### PR DESCRIPTION
## Problem

A lookup for an existing `__proto__` item throws a `TypeError` instead of returning the item. This affects the `@assistant-ui/store` 0.3.12 source.

Minimal reproduction with Bun from `packages/store`:

```js
import assert from "node:assert/strict";
import { resource, withKey } from "@assistant-ui/tap";
import { createAssistantClient } from "./src/createAssistantClient.ts";
import { useClientLookup } from "./src/useClientLookup.ts";

const Item = resource(() => ({ getState: () => "present" }));
const List = resource(() => {
  const lookup = useClientLookup([withKey("__proto__", Item())]);
  return { getState: () => lookup.state, item: lookup.get };
});
const handle = createAssistantClient({ list: List() });
handle.subscribe(() => {});
try {
  assert.equal(handle.getClient().list.item({ key: "__proto__" }).getState(), "present");
} finally {
  handle.destroy();
}
```

## Root cause

The index dictionary inherits `Object.prototype`. An assignment to `__proto__` does not store the numeric index, and absent prototype names appear to be present.

## Change

The dictionary uses `Object.create(null)`, so prototype names are ordinary keys. Existing `__proto__` items return correctly, and absent `constructor` keys produce the normal lookup error.

## Verification

The regression failed with the original dictionary and passed with the correction. The standalone reproduction above also passed.

Focused checks passed:

- `pnpm --filter @assistant-ui/store test src/__tests__/proxy-invariants.test.tsx src/__tests__/renderBoundAui.test.tsx src/__tests__/AuiProvider-config.test.tsx` (41 tests).
- `pnpm exec oxfmt --check packages/store/src/useClientLookup.ts packages/store/src/__tests__/proxy-invariants.test.tsx .changeset/fix-client-lookup-keys.md`.
- `pnpm exec oxlint packages/store/src/useClientLookup.ts packages/store/src/__tests__/proxy-invariants.test.tsx`.

## Public surface

The PR includes a patch changeset for `@assistant-ui/store`. Public signatures and exports do not change. Documentation, API-reference output, and templates do not change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mBfTNgQu0G2uhh7xzOSsD_WkXWQQey1jD2L0ScSvX4iHJRZQ1K7c63XgUrw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->