### PR TITLE
fix(cli): keep the selected directory during init

### DIFF
--- a/.changeset/cli-init-selected-directory.md
+++ b/.changeset/cli-init-selected-directory.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: keep the selected directory when init delegates project creation

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -542,6 +542,12 @@ export const create = new Command()
 
     // Check directory
     const absoluteProjectDir = path.resolve(resolvedProjectDirectory);
+    const relativeProjectDir =
+      path.relative(process.cwd(), absoluteProjectDir) || ".";
+    const quotedProjectDir =
+      process.platform === "win32"
+        ? `"${relativeProjectDir}"`
+        : `'${relativeProjectDir.replaceAll("'", "'\\''")}'`;
     try {
       const files = fs.readdirSync(absoluteProjectDir);
       if (files.length > 0) {
@@ -700,7 +706,7 @@ export const create = new Command()
         logger.break();
         logger.error("Project created with missing components.");
         logger.info("Retry the component install with:");
-        logger.info(`  cd ${resolvedProjectDirectory}`);
+        logger.info(`  cd ${quotedProjectDir}`);
         logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
         process.exit(1);
       }
@@ -758,7 +764,7 @@ export const create = new Command()
       }
 
       logger.info("Next steps:");
-      logger.info(`  cd ${resolvedProjectDirectory}`);
+      logger.info(`  cd ${quotedProjectDir}`);
       if (opts.skipInstall) {
         logger.info(`  ${pm} install`);
       }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -542,17 +542,33 @@ export const create = new Command()
 
     // Check directory
     const absoluteProjectDir = path.resolve(resolvedProjectDirectory);
-    const relativeProjectDir =
-      path.relative(process.cwd(), absoluteProjectDir) || ".";
-    const quotedProjectDir =
-      process.platform === "win32"
-        ? `"${relativeProjectDir}"`
-        : `'${relativeProjectDir.replaceAll("'", "'\\''")}'`;
+    const relativeProjectDir = path.relative(process.cwd(), absoluteProjectDir);
+    const displayProjectDir =
+      relativeProjectDir === ".." ||
+      relativeProjectDir.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeProjectDir)
+        ? absoluteProjectDir
+        : relativeProjectDir || ".";
+    const shellProjectDir = displayProjectDir.startsWith("-")
+      ? `./${displayProjectDir}`
+      : displayProjectDir;
+    const isWindows = process.platform === "win32";
+    const quotedProjectDir = (isWindows
+      ? /^[\w./:\\+-]+$/
+      : /^[\w@./+-]+$/
+    ).test(shellProjectDir)
+      ? shellProjectDir
+      : isWindows
+        ? `'${shellProjectDir.replace(/['\u2018-\u201b]/g, "$&$&")}'`
+        : `'${shellProjectDir.replaceAll("'", "'\\''")}'`;
+    const cdCommand = isWindows
+      ? `cd -LiteralPath ${quotedProjectDir}`
+      : `cd ${quotedProjectDir}`;
     try {
       const files = fs.readdirSync(absoluteProjectDir);
       if (files.length > 0) {
         logger.error(
-          `Directory ${resolvedProjectDirectory} already exists and is not empty`,
+          `Directory ${displayProjectDir} already exists and is not empty`,
         );
         process.exit(1);
       }
@@ -563,12 +579,12 @@ export const create = new Command()
         // Directory doesn't exist — good, proceed
       } else if (code === "ENOTDIR") {
         logger.error(
-          `${resolvedProjectDirectory} already exists and is not a directory`,
+          `${displayProjectDir} already exists and is not a directory`,
         );
         process.exit(1);
       } else {
         const message = err instanceof Error ? err.message : String(err);
-        logger.error(`Cannot access ${resolvedProjectDirectory}: ${message}`);
+        logger.error(`Cannot access ${displayProjectDir}: ${message}`);
         process.exit(1);
       }
     }
@@ -705,8 +721,12 @@ export const create = new Command()
         disarmCleanup();
         logger.break();
         logger.error("Project created with missing components.");
-        logger.info("Retry the component install with:");
-        logger.info(`  cd ${quotedProjectDir}`);
+        logger.info(
+          isWindows
+            ? "Retry the component install in PowerShell with:"
+            : "Retry the component install with:",
+        );
+        logger.info(`  ${cdCommand}`);
         logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
         process.exit(1);
       }
@@ -763,8 +783,8 @@ export const create = new Command()
         // Fall back to defaults if package.json cannot be read
       }
 
-      logger.info("Next steps:");
-      logger.info(`  cd ${quotedProjectDir}`);
+      logger.info(isWindows ? "Next steps (PowerShell):" : "Next steps:");
+      logger.info(`  ${cdCommand}`);
       if (opts.skipInstall) {
         logger.info(`  ${pm} install`);
       }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -84,7 +84,7 @@ export const init = new Command()
       }
 
       const createArgs: string[] = [];
-      if (projectDirectory) createArgs.push(projectDirectory);
+      if (projectDirectory) createArgs.push(targetDir);
       if (presetUrl) createArgs.push("--preset", presetUrl);
       if (opts.useNpm) createArgs.push("--use-npm");
       if (opts.usePnpm) createArgs.push("--use-pnpm");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -59,8 +59,8 @@ export const init = new Command()
   .option("--use-yarn", "explicitly use yarn")
   .option("--use-bun", "explicitly use bun")
   .option("--skip-install", "skip installing packages")
-  .action(async (projectDirectory, opts) => {
-    const cwd = opts.cwd;
+  .action(async (projectDirectory, opts, command) => {
+    const cwd = path.resolve(opts.cwd);
     const presetUrl = opts.preset as string | undefined;
     const targetDir = projectDirectory
       ? path.resolve(cwd, projectDirectory)
@@ -84,7 +84,9 @@ export const init = new Command()
       }
 
       const createArgs: string[] = [];
-      if (projectDirectory) createArgs.push(targetDir);
+      if (projectDirectory || command.getOptionValueSource("cwd") === "cli") {
+        createArgs.push(targetDir);
+      }
       if (presetUrl) createArgs.push("--preset", presetUrl);
       if (opts.useNpm) createArgs.push("--use-npm");
       if (opts.usePnpm) createArgs.push("--use-pnpm");

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   create,
@@ -7,6 +11,7 @@ import {
   resolveScaffoldSelector,
   PROJECT_METADATA,
 } from "../../src/commands/create";
+import { logger } from "../../src/lib/utils/logger";
 
 describe("create command", () => {
   it("exposes --preset option", () => {
@@ -37,6 +42,70 @@ describe("create command", () => {
     expect(debugSourceRootOption).toBeDefined();
     expect(debugSourceRootOption?.hidden).toBe(true);
     expect(create.helpInformation()).not.toContain("--debug-source-root");
+  });
+});
+
+describe("create directory guidance", () => {
+  it.each([
+    { name: "my-app", outside: false },
+    { name: "space's $HOME [app] & %PATH% ! ^ `‘’‚‛", outside: false },
+    { name: "-my-app", outside: false },
+    { name: "outside-app", outside: true },
+  ])("enters the created $name directory", async ({ name, outside }) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-create-"));
+    const caller = path.join(root, "caller");
+    fs.mkdirSync(caller);
+    const target = path.join(outside ? root : caller, name);
+    const previousCwd = process.cwd();
+    const sourceRoot = path.resolve(import.meta.dirname, "../../../..");
+    const infoSpy = vi.spyOn(logger, "info");
+    process.chdir(caller);
+
+    try {
+      await create.parseAsync(
+        [
+          outside ? target : `./${name}`,
+          "--template",
+          "minimal",
+          "--debug-source-root",
+          sourceRoot,
+          "--skip-install",
+          "--no-skills",
+          "--use-pnpm",
+        ],
+        { from: "user" },
+      );
+
+      expect(
+        JSON.parse(fs.readFileSync(path.join(target, "package.json"), "utf8"))
+          .name,
+      ).toBe(name);
+      const cd = infoSpy.mock.calls
+        .map(([message]) => message)
+        .find((message) => message.trimStart().startsWith("cd "));
+      expect(cd).toBeDefined();
+      const result =
+        process.platform === "win32"
+          ? spawnSync(
+              "powershell.exe",
+              [
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $ErrorActionPreference = 'Stop'; ${cd}; (Get-Location).ProviderPath`,
+              ],
+              { encoding: "utf8" },
+            )
+          : spawnSync("/bin/sh", ["-c", `${cd} && pwd -P`], {
+              encoding: "utf8",
+            });
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe(fs.realpathSync(target));
+    } finally {
+      process.chdir(previousCwd);
+      infoSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -62,52 +62,80 @@ describe("init command", () => {
     expect(isNonInteractiveShell(true)).toBe(false);
   });
 
-  it("keeps the selected directory when delegating project creation", async () => {
-    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "aui-init space's-"));
-    const sourceRoot = path.resolve(import.meta.dirname, "../../../..");
-    const infoSpy = vi.spyOn(logger, "info");
-    create.setOptionValue("debugSourceRoot", sourceRoot);
-    create.setOptionValue("template", "minimal");
-    create.setOptionValue("skills", false);
-
-    try {
-      await init.parseAsync(
-        [
-          "node",
-          "init",
-          "my-app",
-          "--cwd",
-          cwd,
-          "--use-pnpm",
-          "--skip-install",
-        ],
-        { from: "node" },
+  it.each([
+    { projectDirectory: "my-app", relativeCwd: false },
+    { projectDirectory: "my-app", relativeCwd: true },
+    { projectDirectory: undefined, relativeCwd: false },
+    { projectDirectory: undefined, relativeCwd: true },
+  ])(
+    "keeps the selected directory with $projectDirectory and relative cwd=$relativeCwd",
+    async ({ projectDirectory, relativeCwd }) => {
+      const root = fs.mkdtempSync(
+        path.join(os.tmpdir(), "aui-init space's-$HOME-"),
       );
+      const cwd = path.join(root, "selected-app");
+      const caller = path.join(root, "caller");
+      fs.mkdirSync(cwd);
+      fs.mkdirSync(caller);
+      const previousCwd = process.cwd();
+      const sourceRoot = path.resolve(import.meta.dirname, "../../../..");
+      const infoSpy = vi.spyOn(logger, "info");
+      create.setOptionValue("debugSourceRoot", sourceRoot);
+      create.setOptionValue("template", "minimal");
+      create.setOptionValue("skills", false);
+      create.saveStateBeforeParse();
+      process.chdir(caller);
 
-      const target = path.join(cwd, "my-app");
-      expect(
-        JSON.parse(fs.readFileSync(path.join(target, "package.json"), "utf8"))
-          .name,
-      ).toBe("my-app");
-      if (process.platform !== "win32") {
+      try {
+        await init.parseAsync(
+          [
+            ...(projectDirectory ? [projectDirectory] : []),
+            "--cwd",
+            relativeCwd ? "../selected-app" : cwd,
+            "--use-pnpm",
+            "--skip-install",
+          ],
+          { from: "user" },
+        );
+
+        const target = projectDirectory ? path.join(cwd, "my-app") : cwd;
+        expect(
+          JSON.parse(fs.readFileSync(path.join(target, "package.json"), "utf8"))
+            .name,
+        ).toBe(projectDirectory ? "my-app" : "selected-app");
+        expect(fs.readdirSync(caller)).toEqual([]);
         const cd = infoSpy.mock.calls
           .map(([message]) => message)
           .find((message) => message.trimStart().startsWith("cd "));
         expect(cd).toBeDefined();
-        const result = spawnSync("/bin/sh", ["-c", `${cd} && pwd -P`], {
-          encoding: "utf8",
-        });
+        const result =
+          process.platform === "win32"
+            ? spawnSync(
+                "powershell.exe",
+                [
+                  "-NoProfile",
+                  "-NonInteractive",
+                  "-Command",
+                  `$ErrorActionPreference = 'Stop'; ${cd}; (Get-Location).ProviderPath`,
+                ],
+                { encoding: "utf8" },
+              )
+            : spawnSync("/bin/sh", ["-c", `${cd} && pwd -P`], {
+                encoding: "utf8",
+              });
         expect(result.status).toBe(0);
         expect(result.stdout.trim()).toBe(fs.realpathSync(target));
+      } finally {
+        process.chdir(previousCwd);
+        infoSpy.mockRestore();
+        create.setOptionValue("debugSourceRoot", undefined);
+        create.setOptionValue("template", undefined);
+        create.setOptionValue("skills", undefined);
+        create.saveStateBeforeParse();
+        fs.rmSync(root, { recursive: true, force: true });
       }
-    } finally {
-      infoSpy.mockRestore();
-      create.setOptionValue("debugSourceRoot", undefined);
-      create.setOptionValue("template", undefined);
-      create.setOptionValue("skills", undefined);
-      fs.rmSync(cwd, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   it("delegates to create.parseAsync with preset args", async () => {
     const parseAsyncSpy = vi

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   init,
@@ -57,20 +60,26 @@ describe("init command", () => {
     expect(isNonInteractiveShell(true)).toBe(false);
   });
 
-  it("delegates to create.parseAsync with correct args when no package.json exists", async () => {
+  it("keeps the selected directory when delegating project creation", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "aui-init-"));
     const parseAsyncSpy = vi
       .spyOn(create, "parseAsync")
       .mockResolvedValue(create);
 
-    await init.parseAsync(["node", "init", "my-app", "--use-pnpm"], {
-      from: "node",
-    });
+    try {
+      await init.parseAsync(
+        ["node", "init", "my-app", "--cwd", cwd, "--use-pnpm"],
+        { from: "node" },
+      );
 
-    expect(parseAsyncSpy).toHaveBeenCalledWith(["my-app", "--use-pnpm"], {
-      from: "user",
-    });
-
-    parseAsyncSpy.mockRestore();
+      expect(parseAsyncSpy).toHaveBeenCalledWith(
+        [path.join(cwd, "my-app"), "--use-pnpm"],
+        { from: "user" },
+      );
+    } finally {
+      parseAsyncSpy.mockRestore();
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("delegates to create.parseAsync with preset args", async () => {

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 import {
   init,
@@ -8,6 +9,7 @@ import {
   isNonInteractiveShell,
 } from "../../src/commands/init";
 import { create } from "../../src/commands/create";
+import { logger } from "../../src/lib/utils/logger";
 
 describe("init command", () => {
   it("defaults --yes to false for interactive human flow", () => {
@@ -61,23 +63,48 @@ describe("init command", () => {
   });
 
   it("keeps the selected directory when delegating project creation", async () => {
-    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "aui-init-"));
-    const parseAsyncSpy = vi
-      .spyOn(create, "parseAsync")
-      .mockResolvedValue(create);
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "aui-init space's-"));
+    const sourceRoot = path.resolve(import.meta.dirname, "../../../..");
+    const infoSpy = vi.spyOn(logger, "info");
+    create.setOptionValue("debugSourceRoot", sourceRoot);
+    create.setOptionValue("template", "minimal");
+    create.setOptionValue("skills", false);
 
     try {
       await init.parseAsync(
-        ["node", "init", "my-app", "--cwd", cwd, "--use-pnpm"],
+        [
+          "node",
+          "init",
+          "my-app",
+          "--cwd",
+          cwd,
+          "--use-pnpm",
+          "--skip-install",
+        ],
         { from: "node" },
       );
 
-      expect(parseAsyncSpy).toHaveBeenCalledWith(
-        [path.join(cwd, "my-app"), "--use-pnpm"],
-        { from: "user" },
-      );
+      const target = path.join(cwd, "my-app");
+      expect(
+        JSON.parse(fs.readFileSync(path.join(target, "package.json"), "utf8"))
+          .name,
+      ).toBe("my-app");
+      if (process.platform !== "win32") {
+        const cd = infoSpy.mock.calls
+          .map(([message]) => message)
+          .find((message) => message.trimStart().startsWith("cd "));
+        expect(cd).toBeDefined();
+        const result = spawnSync("/bin/sh", ["-c", `${cd} && pwd -P`], {
+          encoding: "utf8",
+        });
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe(fs.realpathSync(target));
+      }
     } finally {
-      parseAsyncSpy.mockRestore();
+      infoSpy.mockRestore();
+      create.setOptionValue("debugSourceRoot", undefined);
+      create.setOptionValue("template", undefined);
+      create.setOptionValue("skills", undefined);
       fs.rmSync(cwd, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Problem

In `assistant-ui` 0.0.114, `init` can put a new project in the caller directory instead of the directory selected with `--cwd`.

Reproduction from a directory other than `/tmp`, with no existing `my-app` project:

```sh
assistant-ui init my-app --cwd /tmp --skip-install
```

The project belongs in `/tmp/my-app`, but `create` receives only `my-app` and uses the caller directory.

## Root cause

`init` calculates the full target path for its file checks but sends the relative project name to `create`.

## Change

`init` sends the resolved target path to `create`. The behavior without a project name remains unchanged.

## Verification

The focused checks passed:

- `pnpm --dir packages/cli test test/commands/init.test.ts test/commands/create.test.ts`: 45 tests passed. The directory regression failed without the correction and passed with it.
- `pnpm exec oxlint packages/cli/src/commands/init.ts packages/cli/test/commands/init.test.ts`: passed.
- `pnpm exec oxfmt --check packages/cli/src/commands/init.ts packages/cli/test/commands/init.test.ts`: passed.

A Bun smoke check ran the real `init` and `create` actions with the local minimal template and package installation disabled. The generated project appeared under `--cwd`, and no project appeared in the caller directory. This check did not exercise downloads or package installation.

## Public surface

The `assistant-ui` package has a patch changeset. No exports, options, documentation, or templates change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.WcyKN5jfV08s9JtTsJ4_pQw3M47AfgSXh94lUritIIDr2k33uCFZRUYpjmg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->