### PR TITLE
fix(react-streamdown): retain repairs across the full message

### DIFF
--- a/.changeset/streamdown-full-text-repair.md
+++ b/.changeset/streamdown-full-text-repair.md
@@ -2,8 +2,6 @@
 "@assistant-ui/react-streamdown": patch
 ---
 
-fix: apply Markdown repair to the full message so that custom handlers and built-in transforms retain changes to earlier paragraphs.
+fix: preserve text escapes and custom handler changes in earlier paragraphs without completing or deleting their unfinished Markdown.
 
-This removes the tail-only optimization from 0.3.4 because it can discard repairs in earlier paragraphs. Built-in transforms and custom handlers can change text across the full message.
-
-`tailBoundedRemend` repairs the full message on each call, so repair cost grows with message length. `findRemendWindowStart` remains available for compatibility, but its boundary is not a safe limit for Markdown repair.
+Incomplete Markdown repair stays in the final block. Earlier blocks receive numeric-range escapes, comparison-operator escapes, and custom handlers. Custom handlers receive the earlier text and final block as separate strings.

--- a/.changeset/streamdown-full-text-repair.md
+++ b/.changeset/streamdown-full-text-repair.md
@@ -3,3 +3,7 @@
 ---
 
 fix: apply Markdown repair to the full message so that custom handlers and built-in transforms retain changes to earlier paragraphs.
+
+This removes the tail-only optimization from 0.3.4 because it can discard repairs in earlier paragraphs. Built-in transforms and custom handlers can change text across the full message.
+
+`tailBoundedRemend` repairs the full message on each call, so repair cost grows with message length. `findRemendWindowStart` remains available for compatibility, but its boundary is not a safe limit for Markdown repair.

--- a/.changeset/streamdown-full-text-repair.md
+++ b/.changeset/streamdown-full-text-repair.md
@@ -5,3 +5,5 @@
 fix: preserve text escapes and custom handler changes in earlier paragraphs without completing or deleting their unfinished Markdown.
 
 Incomplete Markdown repair stays in the final block. Earlier blocks receive numeric-range escapes, comparison-operator escapes, and custom handlers. Custom handlers receive the earlier text and final block as separate strings.
+
+`RemendConfig` gains `singleTilde` and `comparisonOperators`, so the two escapes that now reach settled text can be turned off without disabling incomplete-Markdown repair.

--- a/.changeset/streamdown-full-text-repair.md
+++ b/.changeset/streamdown-full-text-repair.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: apply Markdown repair to the full message so that custom handlers and built-in transforms retain changes to earlier paragraphs.

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -917,6 +917,8 @@ type RemendConfig = {
   strikethrough?: boolean;
   katex?: boolean;
   setextHeadings?: boolean;
+  singleTilde?: boolean;
+  comparisonOperators?: boolean;
   handlers?: RemendHandler[];
 };
 

--- a/apps/docs/content/docs/guides/streamdown.mdx
+++ b/apps/docs/content/docs/guides/streamdown.mdx
@@ -237,6 +237,8 @@ Configure how incomplete markdown syntax is handled during streaming:
     strikethrough: true,   // Complete ~~text → ~~text~~
     katex: true,           // Complete $$equation → $$equation$$
     setextHeadings: true,  // Handle incomplete setext headings
+    singleTilde: true,     // Escape 20~25 → 20\~25 so it is not read as strikethrough
+    comparisonOperators: true, // Escape - > 25 → - \> 25 in list items
     handlers: [],          // Custom handlers for incomplete markdown completion
   }}
 />

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -41,6 +41,22 @@ Final paragraph with ~~strike~~ and unfinished [link text](https://exa
 const blocksOf = (text: string): string[] => parseMarkdownIntoBlocks(text);
 
 describe("tailBoundedRemend", () => {
+  it("applies custom handlers to earlier paragraphs", () => {
+    expect(
+      tailBoundedRemend("Draft\n\nTail", {
+        handlers: [
+          { name: "rename", handle: (text) => text.replace("Draft", "Final") },
+        ],
+      }),
+    ).toBe("Final\n\nTail");
+  });
+
+  it("keeps numeric ranges escaped after another paragraph starts", () => {
+    expect(tailBoundedRemend("20~25 and 30~35\n\nTail")).toBe(
+      "20\\~25 and 30\\~35\n\nTail",
+    );
+  });
+
   it("matches full remend block output at every streaming prefix", () => {
     for (let end = 1; end <= CORPUS.length; end++) {
       const prefix = CORPUS.slice(0, end);

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -1,7 +1,80 @@
+import remend from "remend";
+import { parseMarkdownIntoBlocks } from "streamdown";
 import { describe, expect, it } from "vitest";
 import { findRemendWindowStart, tailBoundedRemend } from "../remend";
 
+const CORPUS = `# Heading one
+
+Intro paragraph with **bold**, *italic*, \`inline code\`, and a [link](https://example.com).
+
+## Code
+
+\`\`\`python
+def main():
+    cost = "$5"
+    print(f"total: $\{cost}")
+\`\`\`
+
+Some text after the fence with $x^2 + y^2$ inline math.
+
+$$
+\\int_0^1 f(x) dx
+$$
+
+- list item one with **bold**
+- list item two
+
+| col a | col b |
+| ----- | ----- |
+| 1     | 2     |
+
+~~~js
+const s = \`template \${value}\`
+~~~
+
+Final paragraph with ~~strike~~ and unfinished [link text](https://exa
+`;
+
 describe("tailBoundedRemend", () => {
+  it("matches full remend block output at every streaming prefix", () => {
+    for (let end = 1; end <= CORPUS.length; end++) {
+      const prefix = CORPUS.slice(0, end);
+      expect(
+        parseMarkdownIntoBlocks(tailBoundedRemend(prefix)),
+        `prefix length ${end}`,
+      ).toEqual(parseMarkdownIntoBlocks(remend(prefix)));
+    }
+  });
+
+  it.each([
+    ["HTML", "Use the <select element for dropdowns."],
+    ["image", "See ![alt](htt for the image."],
+    ["link", "See [text](htt for the link."],
+    ["italic", "A *dangling in first para"],
+    ["code", "Check `code in first"],
+  ])(
+    "preserves earlier incomplete %s without changing later paragraphs",
+    (_, head) => {
+      const text = `${head}\n\nNext paragraph continues here.`;
+      expect(tailBoundedRemend(text)).toBe(text);
+      expect(tailBoundedRemend(`${text} **bold`)).toBe(`${text} **bold**`);
+    },
+  );
+
+  it("keeps comparison escapes after another paragraph starts", () => {
+    expect(tailBoundedRemend("- > 25\n\nTail")).toBe("- \\> 25\n\nTail");
+  });
+
+  it("respects disabled escapes in earlier paragraphs", () => {
+    const text = "20~25 and 30~35\n\n- > 25\n\nTail";
+    expect(
+      tailBoundedRemend(text, {
+        singleTilde: false,
+        comparisonOperators: false,
+      }),
+    ).toBe(text);
+  });
+
   it("applies custom handlers to earlier paragraphs", () => {
     expect(
       tailBoundedRemend("Draft\n\nTail", {

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -1,44 +1,5 @@
-import remend from "remend";
-import { parseMarkdownIntoBlocks } from "streamdown";
 import { describe, expect, it } from "vitest";
 import { findRemendWindowStart, tailBoundedRemend } from "../remend";
-
-const CORPUS = `# Heading one
-
-Intro paragraph with **bold**, *italic*, \`inline code\`, and a [link](https://example.com).
-
-## Code
-
-\`\`\`python
-def main():
-    cost = "$5"
-    print(f"total: $\{cost}")
-\`\`\`
-
-Some text after the fence with $x^2 + y^2$ inline math.
-
-$$
-\\int_0^1 f(x) dx
-$$
-
-- list item one with **bold**
-- list item two
-
-| col a | col b |
-| ----- | ----- |
-| 1     | 2     |
-
-~~~js
-const s = \`template \${value}\`
-~~~
-
-Final paragraph with ~~strike~~ and unfinished [link text](https://exa
-`;
-
-// Block-level equality is render equality: Streamdown renders each block
-// independently, so two repairs that produce the same blocks render identically
-// even if the raw strings differ.
-const blocksOf = (text: string): string[] => parseMarkdownIntoBlocks(text);
 
 describe("tailBoundedRemend", () => {
   it("applies custom handlers to earlier paragraphs", () => {
@@ -57,32 +18,19 @@ describe("tailBoundedRemend", () => {
     );
   });
 
-  it("matches full remend block output at every streaming prefix", () => {
-    for (let end = 1; end <= CORPUS.length; end++) {
-      const prefix = CORPUS.slice(0, end);
-      expect(
-        blocksOf(tailBoundedRemend(prefix)),
-        `prefix length ${end}: ${JSON.stringify(prefix.slice(-60))}`,
-      ).toEqual(blocksOf(remend(prefix)));
-    }
-  });
-
-  it("repairs an unclosed fence opened early in a long message", () => {
+  it("keeps an unclosed fence inside the window", () => {
     const text = `intro\n\n\`\`\`python\n${"x = 1\n".repeat(500)}print("$dollar")`;
-    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
     expect(findRemendWindowStart(text)).toBe(text.indexOf("```python"));
   });
 
   it("bounds the window to the tail paragraph when no fence is open", () => {
     const text = `para one\n\npara two\n\npara three with **bold`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("para three"));
-    expect(tailBoundedRemend(text)).toBe(remend(text));
   });
 
   it("widens the window across an open $$ math block", () => {
     const text = `before\n\n$$\n\\frac{a}{b}`;
     expect(findRemendWindowStart(text)).toBeLessThanOrEqual(text.indexOf("$$"));
-    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
   });
 
   it("leaves closed constructs untouched", () => {
@@ -90,25 +38,14 @@ describe("tailBoundedRemend", () => {
     expect(tailBoundedRemend(text)).toBe(text);
   });
 
-  it("forwards remend options", () => {
-    const text = "a [dangling";
-    expect(tailBoundedRemend(text, { links: false })).toBe(
-      remend(text, { links: false }),
-    );
+  it("keeps incomplete link text when link and image repair are disabled", () => {
+    expect(
+      tailBoundedRemend("a [dangling", { links: false, images: false }),
+    ).toBe("a [dangling");
   });
 
   it("treats CRLF blank lines as block boundaries", () => {
     const text = `para one\r\n\r\npara two with **bold`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("para two"));
-    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
-  });
-
-  it("matches full remend when $$ appears inside a math block", () => {
-    for (const text of [
-      "intro\n\n$$\nsome content with $$ inside\n\nmore content",
-      "p\n\n$$\nx\n$$\n\nafter $$ y $$ done\n\ntail **b",
-    ]) {
-      expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
-    }
   });
 });

--- a/packages/react-streamdown/src/__tests__/remend.test.ts
+++ b/packages/react-streamdown/src/__tests__/remend.test.ts
@@ -35,14 +35,21 @@ const s = \`template \${value}\`
 Final paragraph with ~~strike~~ and unfinished [link text](https://exa
 `;
 
+// Block-level equality is render equality: Streamdown renders each block
+// independently, so two repairs that produce the same blocks render identically
+// even if the raw strings differ. Full `remend` is a valid oracle only for text
+// whose earlier blocks hold no incomplete construct, since the tail-bounded
+// repair deliberately leaves those alone.
+const blocksOf = (text: string): string[] => parseMarkdownIntoBlocks(text);
+
 describe("tailBoundedRemend", () => {
   it("matches full remend block output at every streaming prefix", () => {
     for (let end = 1; end <= CORPUS.length; end++) {
       const prefix = CORPUS.slice(0, end);
       expect(
-        parseMarkdownIntoBlocks(tailBoundedRemend(prefix)),
+        blocksOf(tailBoundedRemend(prefix)),
         `prefix length ${end}`,
-      ).toEqual(parseMarkdownIntoBlocks(remend(prefix)));
+      ).toEqual(blocksOf(remend(prefix)));
     }
   });
 
@@ -94,16 +101,19 @@ describe("tailBoundedRemend", () => {
   it("keeps an unclosed fence inside the window", () => {
     const text = `intro\n\n\`\`\`python\n${"x = 1\n".repeat(500)}print("$dollar")`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("```python"));
+    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
   });
 
   it("bounds the window to the tail paragraph when no fence is open", () => {
     const text = `para one\n\npara two\n\npara three with **bold`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("para three"));
+    expect(tailBoundedRemend(text)).toBe(remend(text));
   });
 
   it("widens the window across an open $$ math block", () => {
     const text = `before\n\n$$\n\\frac{a}{b}`;
     expect(findRemendWindowStart(text)).toBeLessThanOrEqual(text.indexOf("$$"));
+    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
   });
 
   it("leaves closed constructs untouched", () => {
@@ -120,5 +130,15 @@ describe("tailBoundedRemend", () => {
   it("treats CRLF blank lines as block boundaries", () => {
     const text = `para one\r\n\r\npara two with **bold`;
     expect(findRemendWindowStart(text)).toBe(text.indexOf("para two"));
+    expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
+  });
+
+  it("matches full remend when $$ appears inside a math block", () => {
+    for (const text of [
+      "intro\n\n$$\nsome content with $$ inside\n\nmore content",
+      "p\n\n$$\nx\n$$\n\nafter $$ y $$ done\n\ntail **b",
+    ]) {
+      expect(blocksOf(tailBoundedRemend(text))).toEqual(blocksOf(remend(text)));
+    }
   });
 });

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -82,6 +82,32 @@ export function findRemendWindowStart(text: string): number {
 }
 
 /**
+ * Options remend applies to text anywhere in the message rather than to an
+ * incomplete construct at its end. Every other option completes a dangling
+ * opener, which mutates or deletes a block that has already settled, so the
+ * prefix pass disables all of them.
+ */
+type PrefixSafeOption =
+  | "singleTilde"
+  | "comparisonOperators"
+  | "handlers"
+  | "linkMode";
+
+const COMPLETION_OFF = {
+  bold: false,
+  boldItalic: false,
+  italic: false,
+  inlineCode: false,
+  strikethrough: false,
+  katex: false,
+  inlineKatex: false,
+  links: false,
+  images: false,
+  htmlTags: false,
+  setextHeadings: false,
+} satisfies Record<Exclude<keyof RemendOptions, PrefixSafeOption>, false>;
+
+/**
  * Repairs incomplete Markdown in the final block and applies text escapes to
  * earlier blocks. Custom handlers receive the prefix and final block separately.
  */
@@ -93,20 +119,7 @@ export function tailBoundedRemend(
   if (start <= 0) return remend(text, options);
 
   return (
-    remend(text.slice(0, start), {
-      ...options,
-      // This list must disable every remend completion handler. Only escapes and custom handlers can change the prefix.
-      bold: false,
-      boldItalic: false,
-      italic: false,
-      inlineCode: false,
-      strikethrough: false,
-      katex: false,
-      inlineKatex: false,
-      links: false,
-      images: false,
-      htmlTags: false,
-      setextHeadings: false,
-    }) + remend(text.slice(start), options)
+    remend(text.slice(0, start), { ...options, ...COMPLETION_OFF }) +
+    remend(text.slice(start), options)
   );
 }

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -17,11 +17,8 @@ function onlyWhitespace(text: string, from: number, to: number): boolean {
 }
 
 /**
- * Returns a blank-line boundary outside the tracked code fences and `$$` math
- * blocks. This boundary does not limit Markdown repair.
- *
- * @deprecated Use `tailBoundedRemend` with the full message. Transforms and
- * custom handlers can change text before this boundary.
+ * Returns the start of the last block outside open code fences and `$$` math.
+ * Completion can use this boundary, but escapes must also reach earlier text.
  */
 export function findRemendWindowStart(text: string): number {
   const n = text.length;
@@ -85,12 +82,30 @@ export function findRemendWindowStart(text: string): number {
 }
 
 /**
- * Repairs incomplete Markdown across the full message. Custom handlers and
- * built-in text transforms can change earlier blocks, not only the last block.
+ * Repairs incomplete Markdown in the final block and applies text escapes to
+ * earlier blocks. Custom handlers receive the prefix and final block separately.
  */
 export function tailBoundedRemend(
   text: string,
   options?: RemendOptions,
 ): string {
-  return remend(text, options);
+  const start = findRemendWindowStart(text);
+  if (start <= 0) return remend(text, options);
+
+  return (
+    remend(text.slice(0, start), {
+      ...options,
+      bold: false,
+      boldItalic: false,
+      italic: false,
+      inlineCode: false,
+      strikethrough: false,
+      katex: false,
+      inlineKatex: false,
+      links: false,
+      images: false,
+      htmlTags: false,
+      setextHeadings: false,
+    }) + remend(text.slice(start), options)
+  );
 }

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -86,7 +86,8 @@ export function findRemendWindowStart(text: string): number {
  * incomplete construct at its end, plus `linkMode`, which only configures the
  * disabled `links` handler. Every other option completes a dangling opener,
  * which mutates or deletes a block that has already settled, so the prefix pass
- * disables all of them.
+ * disables all of them. The two escapes skip backtick fences and inline spans
+ * but not `~~~` fences, indented code, or math (#6938).
  */
 type PrefixSafeOption =
   | "singleTilde"

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -84,20 +84,12 @@ export function findRemendWindowStart(text: string): number {
 }
 
 /**
- * Run incomplete-markdown repair (`remend`) on only the trailing block rather
- * than the whole message. Streamdown splits into blocks after repair and renders
- * each independently, and inline constructs cannot cross a blank line, so a
- * dangling opener can only be in the last block. Repairing just that block is
- * render-equivalent to repairing the full text, but bounds the heavier `remend`
- * repair to the tail instead of running it over the whole message every flush
- * (the cheap boundary scan still runs over the full text).
+ * Repairs incomplete Markdown across the full message. Custom handlers and
+ * built-in text transforms can change earlier blocks, not only the last block.
  */
 export function tailBoundedRemend(
   text: string,
   options?: RemendOptions,
 ): string {
-  const start = findRemendWindowStart(text);
-  return start <= 0
-    ? remend(text, options)
-    : text.slice(0, start) + remend(text.slice(start), options);
+  return remend(text, options);
 }

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -83,9 +83,10 @@ export function findRemendWindowStart(text: string): number {
 
 /**
  * Options remend applies to text anywhere in the message rather than to an
- * incomplete construct at its end. Every other option completes a dangling
- * opener, which mutates or deletes a block that has already settled, so the
- * prefix pass disables all of them.
+ * incomplete construct at its end, plus `linkMode`, which only configures the
+ * disabled `links` handler. Every other option completes a dangling opener,
+ * which mutates or deletes a block that has already settled, so the prefix pass
+ * disables all of them.
  */
 type PrefixSafeOption =
   | "singleTilde"

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -17,10 +17,11 @@ function onlyWhitespace(text: string, from: number, to: number): boolean {
 }
 
 /**
- * Index of the start of the last top-level block: the character after the most
- * recent blank line that sits outside any open code fence or `$$` math block.
- * Retained for compatibility. This boundary does not limit Markdown repair:
- * built-in transforms and custom handlers can change text before the boundary.
+ * Returns a blank-line boundary outside the tracked code fences and `$$` math
+ * blocks. This boundary does not limit Markdown repair.
+ *
+ * @deprecated Use `tailBoundedRemend` with the full message. Transforms and
+ * custom handlers can change text before this boundary.
  */
 export function findRemendWindowStart(text: string): number {
   const n = text.length;

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -19,8 +19,8 @@ function onlyWhitespace(text: string, from: number, to: number): boolean {
 /**
  * Index of the start of the last top-level block: the character after the most
  * recent blank line that sits outside any open code fence or `$$` math block.
- * An unclosed fence or math span always begins after such a blank, so it stays
- * wholly inside the returned window without separate tracking. One char pass.
+ * Retained for compatibility. This boundary does not limit Markdown repair:
+ * built-in transforms and custom handlers can change text before the boundary.
  */
 export function findRemendWindowStart(text: string): number {
   const n = text.length;

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -95,6 +95,7 @@ export function tailBoundedRemend(
   return (
     remend(text.slice(0, start), {
       ...options,
+      // This list must disable every remend completion handler. Only escapes and custom handlers can change the prefix.
       bold: false,
       boldItalic: false,
       italic: false,

--- a/packages/react-streamdown/src/remend.ts
+++ b/packages/react-streamdown/src/remend.ts
@@ -87,7 +87,7 @@ export function findRemendWindowStart(text: string): number {
  * disabled `links` handler. Every other option completes a dangling opener,
  * which mutates or deletes a block that has already settled, so the prefix pass
  * disables all of them. The two escapes skip backtick fences and inline spans
- * but not `~~~` fences, indented code, or math (#6938).
+ * but not `~~~` fences, indented code, or math.
  */
 type PrefixSafeOption =
   | "singleTilde"

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -93,6 +93,10 @@ export type RemendConfig = {
   katex?: boolean;
   /** Handle incomplete setext headings to prevent misinterpretation */
   setextHeadings?: boolean;
+  /** Escape single ~ between word characters to prevent false strikethrough (e.g., `20~25` → `20\~25`) */
+  singleTilde?: boolean;
+  /** Escape > as comparison operators in list items (e.g., `- > 25` → `- \> 25`) */
+  comparisonOperators?: boolean;
   /** Custom handlers for incomplete markdown completion */
   handlers?: RemendHandler[];
 };


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-streamdown` 0.3.13, a new paragraph can remove escapes from earlier text. For example, `20~25 and 30~35\n\nTail` can render as strikethrough. Custom handler changes can also disappear from earlier paragraphs.

## Root cause

Only the last block received repair. Applying every repair handler to the full message instead can delete later paragraphs after incomplete HTML, links, or images.

## Change

Keep incomplete-markup repair in the final block. Apply numeric-range escapes, comparison-operator escapes, and custom handlers to earlier text. Custom handlers receive the prefix and final block separately.

## Verification

- The five reported deletion and completion cases fail before the correction and pass after it.
- `node node_modules/vitest/vitest.mjs run src/__tests__/remend.test.ts src/__tests__/StreamdownText.test.tsx` passes all 38 tests from `packages/react-streamdown`.
- A browser consumer preserves all eight examples at 1440px and 390px in both themes, with deferred and smooth rendering enabled and disabled. Pointer and keyboard controls work.
- Focused lint, formatting, and TypeScript diagnostics pass.
- Repair-only timings against the pre-change implementation, not browser timings. On ordinary prose the split costs nothing measurable (1.0 to 1.1x at 5 to 82 KB). On tilde-dense text it costs 1.4 to 5.9x, bounded at 3.1 ms for an 82 KB message. Paragraph-dense corpora are dominated by `findRemendWindowStart` rather than by this change; that pre-existing quadratic scan is tracked in #6935.

- The disabled-completion list is enforced by `satisfies Record<Exclude<keyof RemendOptions, PrefixSafeOption>, false>`, so a new `remend` completion option under the `^1.3.1` range fails the build instead of silently reaching earlier blocks.

## Public surface

`@assistant-ui/react-streamdown`, with a patch changeset. Function signatures stay unchanged. `RemendConfig` gains two optional booleans, `singleTilde` and `comparisonOperators`, so the escapes that now reach settled text can be disabled without giving up incomplete-Markdown repair; the addition is append-only. `apps/docs/content/docs/guides/streamdown.mdx` gains the two matching rows in the config example that enumerates every key. No templates or API-reference declarations change.

Two upstream gaps found while verifying this and tracked separately: #6935 (`findRemendWindowStart` is quadratic on paragraph-dense messages) and #6938 (remend's escapes skip backtick code but not `~~~` fences, indented code, or math).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tvtffbbIvgxZNbMpfP-Ot9P5SkK7Gz9A_pnfHDaUc_GHRLR5NXVifkPFaUk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

