### PR TITLE
fix(opencode): count patch files by full path

### DIFF
--- a/examples/with-opencode/components/tools/tool-ui-apply-patch.tsx
+++ b/examples/with-opencode/components/tools/tool-ui-apply-patch.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { PatchDiff } from "@pierre/diffs/react";
 import {
   ToolStatusIcon,
+  formatPatchFiles,
   getPatchInfo,
   isCancelledToolStatus,
   str,
@@ -178,9 +179,7 @@ export const ApplyPatchDiff: ToolCallMessagePartComponent = memo(
               <span className="font-medium">{toolName}</span>
               {patchInfo.files.length > 0 && (
                 <span className="opacity-60">
-                  {patchInfo.files.length === 1
-                    ? patchInfo.files[0]
-                    : `${patchInfo.files.length} files`}
+                  {formatPatchFiles(patchInfo.files)}
                 </span>
               )}
               {(patchInfo.added > 0 || patchInfo.removed > 0) && !isRunning && (

--- a/examples/with-opencode/components/tools/tool-ui-inline.tsx
+++ b/examples/with-opencode/components/tools/tool-ui-inline.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import {
   ToolStatusIcon,
   basename,
+  formatPatchFiles,
   getPatchInfo,
   isCancelledToolStatus,
   str,
@@ -111,9 +112,7 @@ export const ApplyPatchInline: ToolCallMessagePartComponent = memo(
       <ToolCallShell toolName={toolName} status={status}>
         {patchInfo.files.length > 0 && (
           <span className="opacity-60">
-            {patchInfo.files.length === 1
-              ? patchInfo.files[0]
-              : `${patchInfo.files.length} files`}
+            {formatPatchFiles(patchInfo.files)}
           </span>
         )}
         {(patchInfo.added > 0 || patchInfo.removed > 0) && !isRunning && (

--- a/examples/with-opencode/components/tools/tool-ui-shared.tsx
+++ b/examples/with-opencode/components/tools/tool-ui-shared.tsx
@@ -36,7 +36,7 @@ export const getPatchInfo = (patchText: string) => {
     [...patchText.matchAll(/^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s+(.+)$/gm)]
       .map((match) => match[1]!.trim())
       .filter(Boolean),
-  ).map(basename);
+  );
 
   let added = 0;
   let removed = 0;
@@ -47,6 +47,9 @@ export const getPatchInfo = (patchText: string) => {
 
   return { files, added, removed };
 };
+
+export const formatPatchFiles = (files: readonly string[]): string =>
+  files.length === 1 ? basename(files[0]!) : `${files.length} files`;
 
 export const isCancelledToolStatus = (status?: ToolCallStatusLike) =>
   status?.type === "incomplete" && status.reason === "cancelled";

--- a/examples/with-opencode/components/tools/tool-ui-shared.tsx
+++ b/examples/with-opencode/components/tools/tool-ui-shared.tsx
@@ -34,9 +34,9 @@ export const getPatchInfo = (patchText: string) => {
 
   const files = unique(
     [...patchText.matchAll(/^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s+(.+)$/gm)]
-      .map((match) => basename(match[1]!.trim()))
+      .map((match) => match[1]!.trim())
       .filter(Boolean),
-  );
+  ).map(basename);
 
   let added = 0;
   let removed = 0;


### PR DESCRIPTION
## Problem

In the `with-opencode` example (version `0.0.0`), a patch for `src/index.ts` and `tests/index.ts` shows `index.ts` instead of `2 files`.

This input to `getPatchInfo` reproduces the incorrect count:

```ts
getPatchInfo(`*** Begin Patch
*** Update File: src/index.ts
-old
+new
*** Update File: tests/index.ts
-before
+after
*** End Patch`).files.length;
```

The result was `1` instead of `2`.

## Root cause

The parser removed directory names before it removed duplicate paths. Distinct files with the same name became one entry.

## Change

The parser removes duplicate full paths before it shortens display names. Repeated paths still count once, and the summary shows `2 files` for the reproduction.

## Verification

A Bun assertion against the real parser failed before the correction and passed after it. Focused assertions also passed for repeated trimmed paths, Add/Delete headers, empty input, and line counts.

Server renders of the actual `ApplyPatchDiff` and `ApplyPatchInline` components each contained `2 files`. This was not a live browser check. The example has no existing test suite, so the checks used temporary scripts without module mocks.

Changed-file `oxlint` and `oxfmt` completed successfully.

## Public surface

Only the private example changes. Published packages, exports, documentation, and templates remain unchanged. No changeset is necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CbQrrdkk3jmd9VF1IplmS6hqSvQfGT-3OXr0NNdd_3uabOeHyFNzVxqv4Ro?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->