### PR TITLE
fix(react-pi): recover snapshots after live stream disconnects

### DIFF
--- a/.changeset/pi-live-stream-recovery.md
+++ b/.changeset/pi-live-stream-recovery.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: recover missed messages and thread status from a snapshot after a live-only stream disconnects.

--- a/packages/react-pi/README.md
+++ b/packages/react-pi/README.md
@@ -212,9 +212,9 @@ degrade rather than crash.
 
 - The supervisor keeps the runtime alive across browser disconnects — only an
   explicit `cancelRun` or process exit stops a run. **A dropped SSE never aborts.**
-- Every (re)connect is **snapshot-first**: the server re-sends an authoritative
-  `snapshot` event, then live events apply on top. There is no event replay in the
-  MVP; the snapshot is authoritative.
+- HTTP reconnects receive an authoritative `snapshot` event, then live events.
+  `includeSnapshot: false` skips only the initial snapshot. Reconnect snapshots
+  recover missed messages and thread status without event replay.
 - Browser subscribers share the long-lived SSE connection. A subscriber joining
   late receives the current snapshot first; when the cached snapshot is behind,
   one short-lived snapshot request is shared by all subscribers waiting for it.

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -1100,48 +1100,54 @@ describe("openPiEventStream", () => {
     expect(event.type).toBe("snapshot");
   });
 
-  it("requests a snapshot after a malformed live-only event", async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        sseResponse([
-          rawSseFrame({ type: "message_end", threadId: "t1", seq: 1 }),
-        ]),
-      )
-      .mockResolvedValueOnce(
-        sseResponse([
-          sseFrame({
-            type: "snapshot",
-            threadId: "t1",
-            seq: 2,
-            snapshot: {
-              metadata: { id: "t1", status: "idle" },
-              messages: [],
-            },
-          }),
-        ]),
-      ) as unknown as typeof fetch;
+  it.each(["malformed", "closed", "error"])(
+    "requests a snapshot after a %s live-only stream",
+    async (failure) => {
+      const fetchImpl = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          if (failure === "error") throw new Error("network drop");
+          return sseResponse(
+            failure === "closed"
+              ? []
+              : [rawSseFrame({ type: "message_end", threadId: "t1", seq: 1 })],
+          );
+        })
+        .mockResolvedValueOnce(
+          sseResponse([
+            sseFrame({
+              type: "snapshot",
+              threadId: "t1",
+              seq: 2,
+              snapshot: {
+                metadata: { id: "t1", status: "idle" },
+                messages: [],
+              },
+            }),
+          ]),
+        ) as unknown as typeof fetch;
 
-    const event = await new Promise<PiAnyClientEvent>((resolve) => {
-      const close = openPiEventStream({
-        url: "/events?snapshot=false",
-        snapshotRecoveryUrl: "/events",
-        expectedThreadId: "t1",
-        fetchImpl,
-        reconnectDelay: () => Promise.resolve(),
-        onEvent: (value) => {
-          close();
-          resolve(value);
-        },
+      const event = await new Promise<PiAnyClientEvent>((resolve) => {
+        const close = openPiEventStream({
+          url: "/events?snapshot=false",
+          snapshotRecoveryUrl: "/events",
+          expectedThreadId: "t1",
+          fetchImpl,
+          reconnectDelay: () => Promise.resolve(),
+          onEvent: (value) => {
+            close();
+            resolve(value);
+          },
+        });
       });
-    });
 
-    expect(event.type).toBe("snapshot");
-    expect(fetchImpl.mock.calls.map(([requestUrl]) => requestUrl)).toEqual([
-      "/events?snapshot=false",
-      "/events",
-    ]);
-  });
+      expect(event.type).toBe("snapshot");
+      expect(fetchImpl.mock.calls.map(([requestUrl]) => requestUrl)).toEqual([
+        "/events?snapshot=false",
+        "/events",
+      ]);
+    },
+  );
 
   it("preserves forward-compatible values in known event types", async () => {
     const events: PiAnyClientEvent[] = [];

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -318,17 +318,10 @@ export const openPiEventStream = (
             parsed = parseEventStreamPayload(frame.data, expectedThreadId);
           } catch (error) {
             if (error instanceof InvalidKnownEventStreamPayloadError) {
-              needsSnapshotRecovery = true;
               throw error;
             }
             reportError(error);
             return;
-          }
-          if (
-            requestUrl === snapshotRecoveryUrl &&
-            parsed.type === "snapshot"
-          ) {
-            needsSnapshotRecovery = false;
           }
           if (!closed) emitEvent(parsed);
         };

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -72,7 +72,7 @@ export interface PiEventStreamOptions {
   headers?: Record<string, string>;
   /** Thread ID expected in every event envelope. */
   expectedThreadId?: string;
-  /** Snapshot-enabled URL used to recover after a malformed known event. */
+  /** Snapshot-enabled URL used to recover after a stream disconnect. */
   snapshotRecoveryUrl?: string;
   /** Reconnect backoff between a dropped stream and the next attempt. Rejections
    * are reported via `onError`, then followed by the default ~1s backoff. */
@@ -378,6 +378,7 @@ export const openPiEventStream = (
         reportError(error);
       }
       if (closed) break;
+      needsSnapshotRecovery = true;
       // Snapshot-first: the next connect replaces local state, so we lose
       // nothing by not replaying. Back off, then retry.
       try {

--- a/packages/react-pi/src/types.ts
+++ b/packages/react-pi/src/types.ts
@@ -611,8 +611,10 @@ export interface PiClient {
     response: PiHostUiResponse,
   ): Promise<void>;
 
-  /** Snapshot-first by default; callers that already loaded `getThread()` may
-   * opt out so live events layer on top without repeating snapshot work. */
+  /** Snapshot-first by default. Callers that already loaded `getThread()` can
+   * set `includeSnapshot: false` to skip the initial snapshot. The HTTP client
+   * still receives a snapshot after each stream disconnect to recover missed
+   * messages and thread status. */
   subscribe(
     threadId: string,
     listener: (event: PiClientEvent) => void,


### PR DESCRIPTION
## Problem

Pi live-only streams can miss messages and retain a running status after a disconnect. This affects the `@assistant-ui/react-pi` 0.0.21 source.

Minimal reproduction: a client subscribes with `{ includeSnapshot: false }`, the event response closes, and the agent finishes before reconnect. The next request still uses `?snapshot=false`, so the client never receives the missed state.

## Root cause

The reconnect loop selected the snapshot recovery URL only after a malformed known event. Normal stream completion and network errors reused the live-only URL.

## Change

Reconnects use the existing snapshot recovery path to restore messages and thread status. The first connection remains live-only, and callers without a recovery URL keep their current behavior.

## Verification

The focused checks passed:

- `pnpm --filter @assistant-ui/react-pi test src/client/eventSource.test.ts src/client/httpClient.test.ts`: 96 tests passed.
- The two disconnect regressions failed without the fix and passed with it. The existing malformed-event case still passed.
- A real local HTTP smoke check recovered a missed message and idle status after two disconnects through `createPiHttpClient`.
- Changed-file Oxlint and TypeScript-file formatting checks passed.

## Public surface

The PR includes a patch changeset for `@assistant-ui/react-pi` and an updated description of `snapshotRecoveryUrl`. Exports and signatures are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4AXwLjwU8clLcpLKwiEOo2gBoonn7xQPXT4PcToCaz0nMUpE-sIdN7aIrGA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->