### PR TITLE
fix(react): preserve nested viewport scroll behavior

### DIFF
--- a/.changeset/nested-viewport-scroll-behavior.md
+++ b/.changeset/nested-viewport-scroll-behavior.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: preserve the requested scroll behavior across nested viewport providers

--- a/packages/react/src/context/providers/ThreadViewportProvider.tsx
+++ b/packages/react/src/context/providers/ThreadViewportProvider.tsx
@@ -25,8 +25,8 @@ const useThreadViewportStoreValue = (options: ThreadViewportStoreOptions) => {
 
   // Forward scrollToBottom from outer viewport to inner viewport
   useEffect(() => {
-    return outerViewport?.getState().onScrollToBottom(() => {
-      store.getState().scrollToBottom();
+    return outerViewport?.getState().onScrollToBottom((config) => {
+      store.getState().scrollToBottom(config);
     });
   }, [outerViewport, store]);
 

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import {
   afterAll,
   afterEach,
@@ -18,6 +25,7 @@ import * as MessagePrimitive from "../message";
 import { ThreadPrimitiveMessages } from "./ThreadMessages";
 import { ThreadPrimitiveRoot } from "./ThreadRoot";
 import { ThreadPrimitiveViewport } from "./ThreadViewport";
+import { ThreadPrimitiveScrollToBottom } from "./ThreadScrollToBottom";
 import {
   ExportedMessageRepository,
   useLocalRuntime,
@@ -242,6 +250,36 @@ const DelayedThread = ({
 };
 
 describe("useThreadViewportAutoScroll", () => {
+  it("preserves smooth scrolling from a control outside the viewport", async () => {
+    render(
+      <SyncRuntimeProvider>
+        <Thread autoScroll={false} scrollToBottomOnInitialize={false} />
+        <ThreadPrimitiveScrollToBottom behavior="smooth">
+          Scroll to bottom
+        </ThreadPrimitiveScrollToBottom>
+      </SyncRuntimeProvider>,
+    );
+
+    const viewport = getViewport();
+    act(() => {
+      viewport.dispatchEvent(new Event("scroll"));
+    });
+    const button = screen.getByRole("button", { name: "Scroll to bottom" });
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBe(false));
+
+    const scrollToSpy = vi.spyOn(viewport, "scrollTo");
+    try {
+      fireEvent.click(button);
+      expect(scrollToSpy).toHaveBeenCalledWith({
+        top: viewport.scrollHeight,
+        behavior: "smooth",
+      });
+      expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
+    } finally {
+      scrollToSpy.mockRestore();
+    }
+  });
+
   it("scrolls sync initialMessages to the bottom when the viewport mounts after initialization", async () => {
     render(
       <SyncRuntimeProvider>

--- a/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
+++ b/packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx
@@ -24,8 +24,8 @@ import { useThreadViewport } from "../../context/react/ThreadViewportContext";
 import * as MessagePrimitive from "../message";
 import { ThreadPrimitiveMessages } from "./ThreadMessages";
 import { ThreadPrimitiveRoot } from "./ThreadRoot";
-import { ThreadPrimitiveViewport } from "./ThreadViewport";
 import { ThreadPrimitiveScrollToBottom } from "./ThreadScrollToBottom";
+import { ThreadPrimitiveViewport } from "./ThreadViewport";
 import {
   ExportedMessageRepository,
   useLocalRuntime,
@@ -274,7 +274,6 @@ describe("useThreadViewportAutoScroll", () => {
         top: viewport.scrollHeight,
         behavior: "smooth",
       });
-      expect(viewport.scrollTop).toBe(getMaxScrollTop(viewport));
     } finally {
       scrollToSpy.mockRestore();
     }


### PR DESCRIPTION
## Problem

a scroll control rendered outside `ThreadPrimitive.Viewport` jumps to the bottom instantly even when it asks for smooth scrolling. reproduced on `@assistant-ui/react` 0.15.18:

```tsx
<AssistantRuntimeProvider runtime={runtime}>
  <ThreadPrimitive.Viewport
    autoScroll={false}
    scrollToBottomOnInitialize={false}
    style={{ height: 240, overflowY: "auto" }}
  >
    <div style={{ height: 1800 }}>Thread content</div>
  </ThreadPrimitive.Viewport>
  <ThreadPrimitive.ScrollToBottom behavior="smooth">
    Scroll to bottom
  </ThreadPrimitive.ScrollToBottom>
</AssistantRuntimeProvider>
```

## Root cause

`AssistantRuntimeProvider` mounts a viewport store, and `ThreadPrimitive.Viewport` mounts a second one nested inside it. a control outside the viewport therefore reaches the outer store, which forwards the request down to the inner store in `ThreadViewportProvider`. that forwarding callback dropped its config argument, so the inner `scrollToBottom` fell back to its `"auto"` default. the forwarding has been there since #1551.

## Change

forward the config through. outer and inner both default `behavior` to `"auto"`, so a call that passes no behavior is unchanged and only an explicit behavior is newly preserved. a control inside the viewport already talked to the inner store directly, so nothing about that path moves. subscription cleanup and public APIs are untouched.

## Verification

```sh
pnpm --filter @assistant-ui/react exec vitest run src/primitives/thread/useThreadViewportAutoScroll.test.tsx
```

10 passed. the new regression asserts the viewport's `scrollTo` receives `behavior: "smooth"`; reverting the one-line change makes exactly that test fail with `"auto"` and leaves the other 9 green.

## Public surface

`@assistant-ui/react` gets a patch changeset. no exports, API signatures, documentation claims, or templates change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9Abn3qpv5RAMXAsrJ8wllGTcVNBwBAE9QXivbMD_bhwAZgdiFah2MIP2wxI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
