### PR TITLE
fix(examples): accept resumable frontend tool schemas

### DIFF
--- a/examples/with-resumable-stream/app/api/chat/route.ts
+++ b/examples/with-resumable-stream/app/api/chat/route.ts
@@ -9,6 +9,7 @@ import {
   tool,
   stepCountIs,
   zodSchema,
+  jsonSchema,
 } from "ai";
 import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
 import { z } from "zod";
@@ -59,7 +60,7 @@ function convertFrontendTools(
       name,
       tool({
         ...(t.description ? { description: t.description } : {}),
-        inputSchema: t.parameters as never,
+        inputSchema: jsonSchema(t.parameters),
       }),
     ]),
   );

--- a/examples/with-resumable-stream/app/api/chat/route.ts
+++ b/examples/with-resumable-stream/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { frontendTools } from "@assistant-ui/ai-sdk";
 import {
   type JSONSchema7,
   streamText,
@@ -9,7 +10,6 @@ import {
   tool,
   stepCountIs,
   zodSchema,
-  jsonSchema,
 } from "ai";
 import { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
 import { z } from "zod";
@@ -52,20 +52,6 @@ export async function POST(req: Request) {
   });
 }
 
-function convertFrontendTools(
-  tools: Record<string, { description?: string; parameters: JSONSchema7 }>,
-): Record<string, ReturnType<typeof tool>> {
-  return Object.fromEntries(
-    Object.entries(tools).map(([name, t]) => [
-      name,
-      tool({
-        ...(t.description ? { description: t.description } : {}),
-        inputSchema: jsonSchema(t.parameters),
-      }),
-    ]),
-  );
-}
-
 async function buildOpenAIBody({
   messages,
   system,
@@ -87,7 +73,7 @@ async function buildOpenAIBody({
     ...(system ? { system } : {}),
     stopWhen: stepCountIs(10),
     tools: {
-      ...convertFrontendTools(tools ?? {}),
+      ...frontendTools(tools ?? {}),
       get_current_weather: tool({
         description: "Get the current weather",
         inputSchema: zodSchema(z.object({ city: z.string() })),


### PR DESCRIPTION
## Problem

Requests with frontend tools in the resumable example stop before the model request with `TypeError: schema is not a function`.
The affected base is `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7`, with `ai@7.0.85`.

## Root cause

The route supplies raw JSON Schema as `inputSchema`. The SDK expects a schema wrapper, and the `as never` cast hides the mismatch.

## Change

The route uses the SDK's `jsonSchema` wrapper so frontend tool definitions reach the provider without changes to their parameters.

## Verification

The same offline route check failed before the correction and passed afterward. It uses the real SDK and in-memory resumable store.
Only `fetch` is replaced, so no network request occurs. The local HTTP 400 response stops the request after capture.
Scoped Oxlint passed. TypeScript diagnostics contained no errors and one existing deprecation hint.

<details>
<summary>Minimal reproduction</summary>

With repository dependencies installed, build `assistant-stream` through `pnpm --filter assistant-stream build` if its `dist` directory is absent.
Save this snippet as `examples/with-resumable-stream/schema-repro.mjs`.
From that example directory, run `bun schema-repro.mjs` (Bun 1.4.0).
The base stops with a schema error and zero provider requests. This branch passes the assertions after the expected local HTTP 400 error.

```js
import assert from "node:assert/strict";
import { POST } from "./app/api/chat/route.ts";

process.env.OPENAI_API_KEY = "offline-test-value";
process.env.OPENAI_BASE_URL = "https://offline.invalid/v1";
delete process.env.REDIS_URL;
const requests = [];
globalThis.fetch = async (_url, init) => {
  requests.push(JSON.parse(init.body));
  return new Response("Offline boundary reached", { status: 400 });
};
const response = await POST(new Request("https://offline.invalid/api/chat", {
  method: "POST",
  headers: { "Content-Type": "application/json" },
  body: JSON.stringify({
    messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "Look up cats" }] }],
    tools: {
      lookup: {
        description: "Look up a query",
        parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
      }
    },
  }),
}));
await response.text();
assert.equal(requests.length, 1, "The route must reach the provider request boundary");
assert.deepEqual(requests[0].tools.find((tool) => tool.name === "lookup"), {
  type: "function",
  name: "lookup",
  description: "Look up a query",
  parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
});
console.log("PASS: frontend JSON schema reaches the provider unchanged; no network request was sent");
```

</details>

## Public surface

Only the private example changes. No published exports or documentation contracts change, so no changeset is necessary.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dSTvDj2GRUSI8OTug5u84NQhNwhHRrk2I2bxznbMbAeWyi3FAJCBEvdLCxw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->