### PR TITLE
fix(agent-launcher): keep selected skill with an empty prompt

### DIFF
--- a/.changeset/launcher-empty-prompt-skill.md
+++ b/.changeset/launcher-empty-prompt-skill.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/agent-launcher": patch
+---
+
+fix: keep the selected skill when the prompt is empty

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -27,6 +27,21 @@ describe("launch", () => {
     }
   });
 
+  it("invokes the selected skill when the prompt is empty", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    launch({
+      pluginDir: "/tmp/plugin",
+      skillName: "assistant-ui",
+      prompt: "",
+      dry: true,
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      "claude /assistant-ui --plugin-dir /tmp/plugin",
+    );
+  });
+
   it("falls back to a signal exit code if re-raising does not terminate", () => {
     mocks.sync.mockReturnValue({
       pid: 123,

--- a/packages/agent-launcher/src/launch.test.ts
+++ b/packages/agent-launcher/src/launch.test.ts
@@ -27,6 +27,21 @@ describe("launch", () => {
     }
   });
 
+  it("passes the prompt to the selected skill", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    launch({
+      pluginDir: "/tmp/plugin",
+      skillName: "assistant-ui",
+      prompt: "add a thread",
+      dry: true,
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      'claude "/assistant-ui add a thread" --plugin-dir /tmp/plugin',
+    );
+  });
+
   it("invokes the selected skill when the prompt is empty", () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
 

--- a/packages/agent-launcher/src/launch.ts
+++ b/packages/agent-launcher/src/launch.ts
@@ -20,8 +20,8 @@ export function launch(options: LaunchOptions): void {
 
   const claudeArgs: string[] = [];
 
-  if (skillName && prompt) {
-    claudeArgs.push(`/${skillName} ${prompt}`);
+  if (skillName) {
+    claudeArgs.push(prompt ? `/${skillName} ${prompt}` : `/${skillName}`);
   } else if (prompt) {
     claudeArgs.push(prompt);
   }


### PR DESCRIPTION
## Problem

A direct `launch` call with an empty prompt ignores the selected skill. Claude starts without the requested skill command.

Minimal reproduction at base `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7` (`@assistant-ui/agent-launcher` version `0.1.14`), run with Bun from the repository root:

```sh
bun --eval 'import { launch } from "./packages/agent-launcher/src/launch.ts"; launch({ pluginDir: "/tmp/plugin", skillName: "assistant-ui", prompt: "", dry: true });'
```

The output omits `/assistant-ui`. The corrected output is `claude /assistant-ui --plugin-dir /tmp/plugin`.

The shipped CLI reaches the same path. `agent` declares a required variadic `<prompt...>`, so `aui agent ""` parses as `[""]` and joins to an empty prompt before calling `launch`.

## Root cause

The skill condition requires a nonempty prompt, although the public API accepts an empty string.

## Change

The selected skill becomes the initial command even without prompt text. Nonempty prompts keep their existing behavior.

## Verification

The reproduction and regression failed before the correction and passed after it. A second regression pins the nonempty branch of the same condition, so both command forms the skill can produce are now asserted. All four tests passed with `./node_modules/.bin/vitest run src/launch.test.ts` from `packages/agent-launcher`.

A temporary local executable confirmed subprocess arguments for skill-only, skill-plus-prompt, prompt-only, and empty inputs. No model calls occurred. Scoped Oxlint and formatting completed successfully.

## Public surface

The PR includes a patch changeset for `@assistant-ui/agent-launcher`. Exports and types remain unchanged. Documentation and templates require no changes.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rh_ZKEPmeHAFh1cs56VovzrRbKdoDDaatP3rIodqIxRmci2FAMKMX7oca-k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


