### PR TITLE
fix(store): keep replacement listeners after stale unsubscribe

### DIFF
--- a/.changeset/stale-notification-unsubscribe.md
+++ b/.changeset/stale-notification-unsubscribe.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: keep replacement event listeners after a stale unsubscribe call.

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -250,6 +250,30 @@ describe("scope-filtered on", () => {
     await flushEvents();
     expect(cb).toHaveBeenCalledExactlyOnceWith({ value: "first" });
   });
+
+  it("a stale unsubscribe preserves a replacement listener", async () => {
+    const { getAui } = setup();
+    const aui = getAui();
+    const removed = vi.fn();
+    const unsub = aui.on("thread.pinged", removed);
+    unsub();
+
+    const replacement = vi.fn();
+    const unsubReplacement = aui.on("thread.pinged", replacement);
+    unsub();
+    aui.thread.ping("replacement");
+    await flushEvents();
+
+    expect(removed).not.toHaveBeenCalled();
+    expect(replacement).toHaveBeenCalledExactlyOnceWith({
+      value: "replacement",
+    });
+
+    unsubReplacement();
+    aui.thread.ping("removed");
+    await flushEvents();
+    expect(replacement).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("parent chaining", () => {

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -72,7 +72,8 @@ export const createNotificationManager = (): NotificationManager => {
 
       return () => {
         set!.delete(cb);
-        if (set!.size === 0) listeners.delete(event);
+        if (set!.size === 0 && listeners.get(event) === set)
+          listeners.delete(event);
       };
     },
 


### PR DESCRIPTION
## Problem

A second call to a stale unsubscribe function silently removes newer listeners for the same event. Replacement listeners must continue to receive events.

This reproduction uses `@assistant-ui/store` 0.3.12 at base `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7`. In a clone of this repository at that commit, install dependencies with `pnpm install --frozen-lockfile`, then run this command from the repository root:

```sh
bun -e '
import assert from "node:assert/strict";
import { createNotificationManager } from "./packages/store/src/utils/NotificationManager.ts";
const manager = createNotificationManager();
const oldUnsubscribe = manager.on("thread.pinged", () => {});
oldUnsubscribe();
let received = 0;
const unsubscribeNew = manager.on("thread.pinged", () => { received++; });
oldUnsubscribe();
manager.emit("thread.pinged", {}, []);
await new Promise(resolve => queueMicrotask(resolve));
unsubscribeNew();
assert.equal(received, 1);
'
```

The base produces `0 !== 1`. The corrected version passes.

## Root cause

The cleanup captures a listener set, but deletes the event entry whenever that captured set is empty, even after a replacement set exists.

## Change

The cleanup removes the map entry only when it still points to the captured empty set. Deferred event delivery stays unchanged.

## Verification

The reproduction and the public `aui.on` regression failed before the correction and pass after it. All 37 focused tests pass:

```sh
cd packages/store
node node_modules/vitest/vitest.mjs run src/utils/NotificationManager.test.ts src/__tests__/events.test.tsx
```

Scoped Oxlint and the commit lint and format hooks passed.

## Public surface

The change includes a patch changeset for `@assistant-ui/store`. Public exports, documentation, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.muZCVI1A4KyEvLtXAjz0zB1MQOg9aQ2xTEOJxD6KFg5LJ9SbhSh9LUud06c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->