### PR TITLE
fix(python): use default subgraph state for null tool artifacts

### DIFF
--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -267,7 +267,7 @@ def get_tool_call_subgraph_state(
                 artifact = last_message["artifact"]
 
                 if artifact_field_name:
-                    if artifact_field_name not in artifact:
+                    if artifact.get(artifact_field_name) is None:
                         artifact[artifact_field_name] = default_state
                     return artifact[artifact_field_name]
                 else:

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -262,7 +262,7 @@ def get_tool_call_subgraph_state(
             # Check if last message is already a ToolMessage
             if last_message["type"] == "tool":
                 # Last message is already a ToolMessage, extract and return artifact field
-                if "artifact" not in last_message:
+                if last_message.get("artifact") is None:
                     last_message["artifact"] = {} if artifact_field_name else default_state
                 artifact = last_message["artifact"]
 

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -256,3 +256,31 @@ async def test_null_tool_artifact_uses_default_subgraph_state(
     if artifact_field_name:
         artifact = artifact[artifact_field_name]
     assert artifact["answer"] == "42"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("artifact", "artifact_field_name", "expected"),
+    [
+        ({"answer": "kept"}, None, {"answer": "kept"}),
+        ({"subgraph_state": {"answer": "kept"}}, "subgraph_state", {"answer": "kept"}),
+        ({"subgraph_state": {}}, "subgraph_state", {}),
+    ],
+)
+async def test_existing_tool_artifact_survives_default_state(
+    artifact, artifact_field_name, expected
+) -> None:
+    controller = RunController(
+        asyncio.Queue(),
+        {"messages": [ToolMessage(content="", tool_call_id="c1", artifact=artifact).model_dump()]},
+    )
+
+    state = get_tool_call_subgraph_state(
+        controller,
+        ("tools:task1",),
+        "tools",
+        {"answer": "default"},
+        artifact_field_name=artifact_field_name,
+    )
+
+    assert state == expected

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -8,12 +8,17 @@ first argument is the state proxy, the event type is langgraph's stream mode nam
 tuple carrying a single message or message chunk.
 """
 
+import asyncio
 from typing import Any
 
 import pytest
-from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 
-from assistant_stream.modules.langgraph import append_langgraph_event
+from assistant_stream.create_run import RunController
+from assistant_stream.modules.langgraph import (
+    append_langgraph_event,
+    get_tool_call_subgraph_state,
+)
 from assistant_stream.state_manager import StateManager
 
 
@@ -221,3 +226,28 @@ async def test_unknown_event_type_is_ignored() -> None:
     append_langgraph_event(manager.state, (), "custom", "anything")
 
     assert manager.state_data == {"existing": "value"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("artifact_field_name", [None, "subgraph_state"])
+async def test_null_tool_artifact_uses_default_subgraph_state(artifact_field_name) -> None:
+    controller = RunController(
+        asyncio.Queue(),
+        {"messages": [ToolMessage(content="", tool_call_id="c1", artifact=None).model_dump()]},
+    )
+
+    state = get_tool_call_subgraph_state(
+        controller,
+        ("tools:task1",),
+        "tools",
+        {"answer": "pending"},
+        artifact_field_name=artifact_field_name,
+    )
+
+    assert state["answer"] == "pending"
+    append_langgraph_event(state, (), "updates", {"agent": {"answer": "42"}})
+
+    artifact = controller.state["messages"][0]["artifact"]
+    if artifact_field_name:
+        artifact = artifact[artifact_field_name]
+    assert artifact["answer"] == "42"

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -229,11 +229,16 @@ async def test_unknown_event_type_is_ignored() -> None:
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("artifact_field_name", [None, "subgraph_state"])
-async def test_null_tool_artifact_uses_default_subgraph_state(artifact_field_name) -> None:
+@pytest.mark.parametrize(
+    ("artifact", "artifact_field_name"),
+    [(None, None), (None, "subgraph_state"), ({"subgraph_state": None}, "subgraph_state")],
+)
+async def test_null_tool_artifact_uses_default_subgraph_state(
+    artifact, artifact_field_name
+) -> None:
     controller = RunController(
         asyncio.Queue(),
-        {"messages": [ToolMessage(content="", tool_call_id="c1", artifact=None).model_dump()]},
+        {"messages": [ToolMessage(content="", tool_call_id="c1", artifact=artifact).model_dump()]},
     )
 
     state = get_tool_call_subgraph_state(


### PR DESCRIPTION
## Problem

A tool message with `artifact=None` stops subgraph processing with `TypeError` when the caller requests `subgraph_state`. Without a field name, the helper returns `None` instead of the supplied default.

Reproduction on `assistant-stream 0.0.36`:

```sh
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git checkout 928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7
cd python/assistant-stream
uv sync --all-extras --frozen
uv run --frozen python - <<'PY'
from types import SimpleNamespace
from langchain_core.messages import ToolMessage
from assistant_stream import get_tool_call_subgraph_state

controller = SimpleNamespace(state={"messages": [
    ToolMessage(content="", tool_call_id="c1", artifact=None).model_dump()
]})
state = get_tool_call_subgraph_state(
    controller, ("tools:task1",), "tools", {},
    artifact_field_name="subgraph_state",
)
assert state == {}
PY
```

## Root cause

The helper initializes an absent artifact key but leaves a null value unchanged.

## Change

Null artifacts use the existing default-state assignment. Non-null artifacts retain their behavior.

## Verification

The regression uses real `ToolMessage` and `RunController` objects. The two field-selection cases raise `TypeError` before the fix and pass after it. The tests also confirm that subsequent events update the stored artifact.

From `python/assistant-stream`:

```sh
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen pytest -p anyio.pytest_plugin tests/test_langgraph.py -k null_tool_artifact -q -o faulthandler_timeout=15
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen pytest -p anyio.pytest_plugin tests/test_langgraph.py -q
```

The focused regression passes twice, and all 12 module tests pass. The direct public-export call returns `{}` after the fix. The default pytest invocation timed out, so these runs load only the AnyIO plugin.

## Public surface

Only the Python `assistant-stream` behavior changes. Exports, signatures, and documentation remain unchanged. No JavaScript package or changeset is affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1ZYGmUStbLTC-7QWT9XglXFapGu_eNg-wYCIeFMhnJiA6LMRqch4X2R7AUk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->