### PR TITLE
fix(react): apply live MCP tool allowlists

### DIFF
--- a/.changeset/mcp-live-tool-allowlist.md
+++ b/.changeset/mcp-live-tool-allowlist.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: apply tool allowlist changes to mounted MCP app frames

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -104,6 +104,8 @@ describe("McpAppFrame", () => {
   it.each([
     { initial: [], next: ["search"], allowed: true },
     { initial: ["search"], next: [], allowed: false },
+    { initial: undefined, next: ["other"], allowed: false },
+    { initial: [], next: undefined, allowed: true },
   ])(
     "applies replacement tool allowlists: $initial -> $next",
     async ({ initial, next, allowed }) => {
@@ -116,7 +118,7 @@ describe("McpAppFrame", () => {
         return null;
       });
       const callTool = vi.fn(() => ({ content: [] }));
-      const view = (allowedTools: readonly string[]) => (
+      const view = (allowedTools: readonly string[] | undefined) => (
         <McpAppFrame
           app={{ resourceUri: "ui://example/widget" }}
           resource={{
@@ -124,7 +126,11 @@ describe("McpAppFrame", () => {
             mimeType: MCP_APP_MIME_TYPE,
             html: "",
           }}
-          handlers={{ allowedTools, callTool }}
+          handlers={
+            allowedTools === undefined
+              ? { callTool }
+              : { allowedTools, callTool }
+          }
         />
       );
       const rendered = render(view(initial));

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -7,6 +7,7 @@ import type {
   SandboxHostProps,
 } from "../sandbox-host/SandboxHost";
 import type { CreateMcpAppBridgeOptions, McpAppBridge } from "./bridge";
+import type * as BridgeModule from "./bridge";
 import { MCP_APP_MIME_TYPE, type McpAppHostContext } from "./types";
 
 const { sandboxHostMock, createMcpAppBridgeMock } = vi.hoisted(() => ({
@@ -99,6 +100,70 @@ describe("McpAppFrame", () => {
 
     sandboxBridge.dispose();
   });
+
+  it.each([
+    { initial: [], next: ["search"], allowed: true },
+    { initial: ["search"], next: [], allowed: false },
+  ])(
+    "applies replacement tool allowlists: $initial -> $next",
+    async ({ initial, next, allowed }) => {
+      const { createMcpAppBridge } =
+        await vi.importActual<typeof BridgeModule>("./bridge");
+      createMcpAppBridgeMock.mockImplementationOnce(createMcpAppBridge);
+      const captured: { createBridge?: SandboxHostProps["createBridge"] } = {};
+      sandboxHostMock.mockImplementation((props: SandboxHostProps) => {
+        captured.createBridge ??= props.createBridge;
+        return null;
+      });
+      const callTool = vi.fn(() => ({ content: [] }));
+      const view = (allowedTools: readonly string[]) => (
+        <McpAppFrame
+          app={{ resourceUri: "ui://example/widget" }}
+          resource={{
+            uri: "ui://example/widget",
+            mimeType: MCP_APP_MIME_TYPE,
+            html: "",
+          }}
+          handlers={{ allowedTools, callTool }}
+        />
+      );
+      const rendered = render(view(initial));
+      if (!captured.createBridge) throw new Error("Frame did not mount");
+      const sendMessage = vi.fn();
+      const bridge = captured.createBridge(
+        {
+          iframe: document.createElement("iframe"),
+          origin: "https://widget.example",
+          sendMessage,
+        },
+        { setHeight: vi.fn() },
+      );
+      try {
+        rendered.rerender(view(next));
+        bridge.onMessage(
+          new MessageEvent("message", {
+            data: {
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: { name: "search" },
+            },
+          }),
+        );
+        await Promise.resolve();
+        expect(sendMessage).toHaveBeenCalledWith(
+          expect.objectContaining(
+            allowed
+              ? { id: 1, result: { content: [] } }
+              : { id: 1, error: expect.objectContaining({ code: -32602 }) },
+          ),
+        );
+        expect(callTool).toHaveBeenCalledTimes(allowed ? 1 : 0);
+      } finally {
+        bridge.dispose();
+      }
+    },
+  );
 
   it("only notifies the widget when host context actually changes", () => {
     let createBridge: SandboxHostProps["createBridge"] | null = null;

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -96,18 +96,32 @@ type LiveSnapshot = {
   output: unknown;
 };
 
+type FrameLifecycle = {
+  onInitialized: () => void;
+  onSizeChange: (params: { width?: number; height?: number }) => void;
+};
+
 // Proxy each per-call handler through liveRef so the bridge always dispatches
 // to the latest handler reference (e.g. inline callbacks closing over state).
 // Capability presence is snapshot at mount: a handler added later requires a
 // remount (keyed on resource URI) to expose the capability to the widget.
+// The frame's own lifecycle work arrives as a parameter rather than wrapping
+// the result, because spreading this object would evaluate the allowedTools
+// getter and freeze the allowlist at its mount-time value.
 function buildLiveHandlers(
   initial: McpAppBridgeHandlers | undefined,
   liveRef: { readonly current: LiveSnapshot },
+  lifecycle: FrameLifecycle,
 ): McpAppBridgeHandlers {
   const live = () => liveRef.current.handlers;
   const has = <K extends keyof McpAppBridgeHandlers>(key: K) =>
     initial?.[key] !== undefined;
   const out: McpAppBridgeHandlers = {};
+  Object.defineProperty(out, "allowedTools", {
+    get: () => live()?.allowedTools,
+    enumerable: true,
+    configurable: true,
+  });
   const liveCall = <K extends keyof McpAppBridgeHandlers>(
     key: K,
   ): NonNullable<McpAppBridgeHandlers[K]> =>
@@ -127,8 +141,14 @@ function buildLiveHandlers(
     out.updateModelContext = liveCall("updateModelContext");
   if (has("requestDisplayMode"))
     out.requestDisplayMode = liveCall("requestDisplayMode");
-  out.onSizeChange = (p) => live()?.onSizeChange?.(p);
-  out.onInitialized = () => live()?.onInitialized?.();
+  out.onSizeChange = (p) => {
+    lifecycle.onSizeChange(p);
+    live()?.onSizeChange?.(p);
+  };
+  out.onInitialized = () => {
+    lifecycle.onInitialized();
+    live()?.onInitialized?.();
+  };
   out.onRequestTeardown = (p) => live()?.onRequestTeardown?.(p);
   out.onLog = (p) => live()?.onLog?.(p);
   out.onError = (e) => live()?.onError?.(e);
@@ -208,26 +228,17 @@ export function McpAppFrame({
       }
     };
 
-    const liveHandlers = buildLiveHandlers(current.handlers, liveRef);
-    const liveOnInitialized = liveHandlers.onInitialized;
-    const wrappedHandlers: McpAppBridgeHandlers = {
-      ...liveHandlers,
+    const wrappedHandlers = buildLiveHandlers(current.handlers, liveRef, {
       onInitialized: () => {
         if (initTimeoutId !== null) {
           clearTimeout(initTimeoutId);
           initTimeoutId = null;
         }
         flushPending();
-        liveOnInitialized?.();
       },
       onSizeChange: (p) => {
         if (p.height != null) host.setHeight(p.height);
-        liveHandlers.onSizeChange?.(p);
       },
-    };
-    Object.defineProperty(wrappedHandlers, "allowedTools", {
-      get: () => liveRef.current.handlers?.allowedTools,
-      enumerable: true,
     });
 
     // Safety net: if the widget never sends notifications/initialized (broken

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -108,13 +108,6 @@ function buildLiveHandlers(
   const has = <K extends keyof McpAppBridgeHandlers>(key: K) =>
     initial?.[key] !== undefined;
   const out: McpAppBridgeHandlers = {};
-  if (has("allowedTools")) {
-    Object.defineProperty(out, "allowedTools", {
-      get: () => live()?.allowedTools,
-      enumerable: true,
-      configurable: true,
-    });
-  }
   const liveCall = <K extends keyof McpAppBridgeHandlers>(
     key: K,
   ): NonNullable<McpAppBridgeHandlers[K]> =>
@@ -233,7 +226,7 @@ export function McpAppFrame({
       },
     };
     Object.defineProperty(wrappedHandlers, "allowedTools", {
-      get: () => liveHandlers.allowedTools,
+      get: () => liveRef.current.handlers?.allowedTools,
       enumerable: true,
     });
 

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -232,6 +232,10 @@ export function McpAppFrame({
         liveHandlers.onSizeChange?.(p);
       },
     };
+    Object.defineProperty(wrappedHandlers, "allowedTools", {
+      get: () => liveHandlers.allowedTools,
+      enumerable: true,
+    });
 
     // Safety net: if the widget never sends notifications/initialized (broken
     // or non-spec-compliant), flush the queue anyway so the host doesn't

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -105,9 +105,10 @@ type FrameLifecycle = {
 // to the latest handler reference (e.g. inline callbacks closing over state).
 // Capability presence is snapshot at mount: a handler added later requires a
 // remount (keyed on resource URI) to expose the capability to the widget.
-// The frame's own lifecycle work arrives as a parameter rather than wrapping
-// the result, because spreading this object would evaluate the allowedTools
-// getter and freeze the allowlist at its mount-time value.
+// allowedTools is the exception: it is never advertised in the ui/initialize
+// response, so it stays a live getter, which means this object must reach the
+// bridge uncopied and the frame passes its lifecycle work in rather than
+// wrapping the result.
 function buildLiveHandlers(
   initial: McpAppBridgeHandlers | undefined,
   liveRef: { readonly current: LiveSnapshot },


### PR DESCRIPTION
## Problem

Mounted MCP apps keep the initial tool allowlist after the host replaces it. Newly permitted tools remain blocked, and removed tools remain callable.

The reproduction uses `@assistant-ui/react` 0.15.18 at base `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7`. It mounts a frame, replaces `allowedTools` between `[]` and `["search"]`, then sends `tools/call` through the same bridge.

```sh
git clone --branch fix/mcp-live-tool-allowlist https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
pnpm install --frozen-lockfile
git restore --source=928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7 -- packages/react/src/mcp-apps/app-frame.tsx
cd packages/react
./node_modules/.bin/vitest run src/mcp-apps/app-frame.test.tsx -t 'applies replacement tool allowlists'
git restore --source=HEAD -- src/mcp-apps/app-frame.tsx
./node_modules/.bin/vitest run src/mcp-apps/app-frame.test.tsx -t 'applies replacement tool allowlists'
```

## Root cause

Object spread evaluates the live `allowedTools` getter and copies its initial value into the lifecycle wrapper.

## Change

The wrapper retains a getter for the current allowlist. Lifecycle callbacks stay separate to prevent recursive calls.

## Verification

The two regression cases failed against the base source and passed after the correction. They use the real frame and RPC bridge, with the sandbox browser boundary mocked.

- `./node_modules/.bin/vitest run src/mcp-apps/app-frame.test.tsx src/mcp-apps/bridge.test.ts` from `packages/react`: 28 tests passed.
- Scoped Oxlint passed. The changed files have no TypeScript errors in the language server.

## Public surface

The correction affects `@assistant-ui/react` and includes a patch changeset. Public types, exports, documentation, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.H5HbXIhPu0MAlB879uVRf8s7nuXUm5lN5v_WEsmKTzysLSEUKkc0Xz5jDCs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->