### PR TITLE
fix(react-pi): keep the effective thinking level for subscribers

### DIFF
--- a/.changeset/pi-effective-thinking-level.md
+++ b/.changeset/pi-effective-thinking-level.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: keep the effective Pi thinking level for thread subscribers

--- a/packages/react-pi/src/node/ThreadSupervisor.test.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type * as PiSdk from "@earendil-works/pi-coding-agent";
 import type {
   AgentSession,
   SessionInfo,
@@ -20,7 +24,8 @@ const sdk = vi.hoisted(() => ({
   unlink: vi.fn(),
 }));
 
-vi.mock("@earendil-works/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => ({
+  ...(await importOriginal()),
   createAgentSession: sdk.createAgentSession,
   ModelRuntime: { create: sdk.modelRuntimeCreate },
   SessionManager: {
@@ -178,6 +183,67 @@ describe("PiThreadSupervisor", () => {
     expect(sdk.createAgentSession).toHaveBeenCalledTimes(1);
     expect(session.setThinkingLevel).toHaveBeenCalledTimes(2);
   });
+
+  it.each([
+    { provider: "anthropic", modelId: "claude-opus-4-5", levels: ["high"] },
+    { provider: "openai", modelId: "gpt-4o", levels: [] },
+  ])(
+    "keeps the effective thinking level for $modelId subscribers",
+    async ({ provider, modelId, levels }) => {
+      const actual = await vi.importActual<typeof PiSdk>(
+        "@earendil-works/pi-coding-agent",
+      );
+      const cwd = await mkdtemp(join(tmpdir(), "pi-thinking-"));
+      const supervisor = new PiThreadSupervisor({ workspacePath: cwd });
+      try {
+        const modelRuntime = await actual.ModelRuntime.create({
+          authPath: join(cwd, "auth.json"),
+          modelsPath: null,
+          refreshOnCreate: false,
+        });
+        const model = modelRuntime.getModel(provider, modelId);
+        if (!model) throw new Error(`Missing model: ${provider}/${modelId}`);
+        const settingsManager = actual.SettingsManager.inMemory();
+        sdk.create.mockReturnValue(actual.SessionManager.inMemory(cwd));
+        sdk.createAgentSession.mockImplementation(
+          (options: PiSdk.CreateAgentSessionOptions) =>
+            actual.createAgentSession({
+              ...options,
+              modelRuntime,
+              model,
+              thinkingLevel: "off",
+              settingsManager,
+              tools: [],
+              resourceLoader: new actual.DefaultResourceLoader({
+                cwd,
+                agentDir: cwd,
+                settingsManager,
+              }),
+            }),
+        );
+        const { metadata } = await supervisor.createThread();
+        const received: string[] = [];
+        supervisor.subscribe(
+          metadata.id,
+          (event) => {
+            if (event.type === "thinking_level_changed")
+              received.push(event.level);
+          },
+          { includeSnapshot: false },
+        );
+        await Promise.resolve();
+
+        await supervisor.setThinkingLevel(metadata.id, "xhigh");
+        expect(received).toEqual(levels);
+
+        await supervisor.setThinkingLevel(metadata.id, "xhigh");
+        expect(received).toEqual(levels);
+      } finally {
+        await supervisor.dispose();
+        await rm(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("discards a cold session that opens after its thread is deleted", async () => {
     const session = {

--- a/packages/react-pi/src/node/ThreadSupervisor.test.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.test.ts
@@ -249,6 +249,8 @@ describe("PiThreadSupervisor", () => {
 
         await supervisor.setThinkingLevel(metadata.id, "xhigh");
         expect(received).toEqual(levels);
+        const { metadata: after } = await supervisor.getThread(metadata.id);
+        expect(after.config?.thinkingLevel).toBe(levels[0] ?? "off");
       } finally {
         await supervisor.dispose();
         await rm(cwd, { recursive: true, force: true });

--- a/packages/react-pi/src/node/ThreadSupervisor.test.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.test.ts
@@ -185,11 +185,11 @@ describe("PiThreadSupervisor", () => {
   });
 
   it.each([
-    { provider: "anthropic", modelId: "claude-opus-4-5", levels: ["high"] },
-    { provider: "openai", modelId: "gpt-4o", levels: [] },
+    { supportsThinking: true, levels: ["high"] },
+    { supportsThinking: false, levels: [] },
   ])(
-    "keeps the effective thinking level for $modelId subscribers",
-    async ({ provider, modelId, levels }) => {
+    "keeps the effective thinking level when supportsThinking is $supportsThinking",
+    async ({ supportsThinking, levels }) => {
       const actual = await vi.importActual<typeof PiSdk>(
         "@earendil-works/pi-coding-agent",
       );
@@ -201,8 +201,19 @@ describe("PiThreadSupervisor", () => {
           modelsPath: null,
           refreshOnCreate: false,
         });
-        const model = modelRuntime.getModel(provider, modelId);
-        if (!model) throw new Error(`Missing model: ${provider}/${modelId}`);
+        const model = modelRuntime
+          .getModels()
+          .find(({ reasoning, thinkingLevelMap }) =>
+            supportsThinking
+              ? reasoning &&
+                thinkingLevelMap?.xhigh === null &&
+                thinkingLevelMap.max == null &&
+                thinkingLevelMap.high !== null &&
+                thinkingLevelMap.off !== null
+              : !reasoning,
+          );
+        if (!model)
+          throw new Error("Missing model with matching thinking support");
         const settingsManager = actual.SettingsManager.inMemory();
         sdk.create.mockReturnValue(actual.SessionManager.inMemory(cwd));
         sdk.createAgentSession.mockImplementation(

--- a/packages/react-pi/src/node/ThreadSupervisor.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.ts
@@ -233,9 +233,6 @@ export class PiThreadSupervisor {
   ): Promise<void> {
     const record = await this.ensureOpen(threadId);
     record.session.setThinkingLevel(level as never);
-    // No snapshot here: unlike `setModel`, this has a dedicated event the
-    // reducer applies, so a full-transcript broadcast would be redundant.
-    this.emit(record, { type: "thinking_level_changed", level });
   }
 
   async renameThread(threadId: string, title: string): Promise<void> {


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-pi@0.0.21`, thread subscribers can receive `xhigh` even when Pi uses `high` or `off` for the model.

The regression uses real SDK sessions with `@earendil-works/pi-coding-agent@0.84.4`. This reproduction compares the exact base source with the correction:

```sh
git clone --branch fix/pi-effective-thinking-level https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
pnpm install --frozen-lockfile
git restore --source=928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7 -- packages/react-pi/src/node/ThreadSupervisor.ts
cd packages/react-pi
node node_modules/vitest/vitest.mjs run src/node/ThreadSupervisor.test.ts -t 'keeps the effective thinking level'
git restore src/node/ThreadSupervisor.ts
node node_modules/vitest/vitest.mjs run src/node/ThreadSupervisor.test.ts -t 'keeps the effective thinking level'
```

The first run fails with an extra `xhigh` event. The second run passes. No model requests occur.

## Root cause

Pi sends the effective level, but the supervisor then sends the requested level and overwrites subscriber state.

## Change

The supervisor uses the existing SDK event relay. Subscribers retain the effective level, including when another request leaves that level unchanged.

## Verification

The same two regression cases failed before the correction and passed after it. These focused checks passed:

- From `packages/react-pi`: `node node_modules/vitest/vitest.mjs run src/node/ThreadSupervisor.test.ts src/node/mapping.test.ts src/runtime/threadState.test.ts` (49 tests).
- From the repository root: `node_modules/.bin/oxlint packages/react-pi/src/node/ThreadSupervisor.ts packages/react-pi/src/node/ThreadSupervisor.test.ts`.

## Public surface

The PR includes a patch changeset for `@assistant-ui/react-pi`. Exports and signatures do not change. The existing documentation already describes the effective level.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.g3_wwylpJ8n6Jw4SnI6tFuidFFosSMGcGESjAg8-LxRDUTcXUrwXw23CKMs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->