### PR TITLE
fix(core): remove pending attachments without contentType

### DIFF
--- a/.changeset/fix-pending-attachment-removal-file.md
+++ b/.changeset/fix-pending-attachment-removal-file.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: use the original file to select the adapter for attachment removal when contentType is absent

--- a/packages/core/src/adapters/attachment.test.ts
+++ b/packages/core/src/adapters/attachment.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getFileDataURL, SimpleImageAttachmentAdapter } from "./attachment";
+import {
+  type AttachmentAdapter,
+  CompositeAttachmentAdapter,
+  getFileDataURL,
+  SimpleImageAttachmentAdapter,
+} from "./attachment";
 
 const originalFileReader = globalThis.FileReader;
 const originalBuffer = globalThis.Buffer;
@@ -104,4 +109,48 @@ describe("SimpleImageAttachmentAdapter", () => {
       `data:image/png;base64,${originalBuffer.from("img").toString("base64")}`,
     );
   });
+});
+
+describe("CompositeAttachmentAdapter", () => {
+  it.each(["pending", "complete"])(
+    "removes a %s attachment through its matching adapter",
+    async (status) => {
+      const removed: string[] = [];
+      const imageAdapter = {
+        accept: "image/*",
+        async add({ file }) {
+          return {
+            id: "image-1",
+            type: "image",
+            name: file.name,
+            file,
+            status: { type: "requires-action", reason: "composer-send" },
+          };
+        },
+        async send(attachment) {
+          return {
+            id: attachment.id,
+            type: attachment.type,
+            name: attachment.name,
+            contentType: attachment.file.type,
+            status: { type: "complete" },
+            content: [],
+          };
+        },
+        async remove(attachment) {
+          removed.push(attachment.id);
+        },
+      } satisfies AttachmentAdapter;
+      const composite = new CompositeAttachmentAdapter([imageAdapter]);
+      const pending = await imageAdapter.add({
+        file: new File(["image bytes"], "photo.png", { type: "image/png" }),
+      });
+      const attachment =
+        status === "pending" ? pending : await composite.send(pending);
+
+      await composite.remove(attachment);
+
+      expect(removed).toEqual(["image-1"]);
+    },
+  );
 });

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -276,7 +276,7 @@ export class CompositeAttachmentAdapter implements AttachmentAdapter {
     for (const adapter of adapters) {
       if (
         fileMatchesAccept(
-          {
+          attachment.file ?? {
             name: attachment.name,
             type: attachment.contentType ?? "",
           },


### PR DESCRIPTION
## Problem

A pending image attachment can remain in the composer with an error when the custom adapter omits `contentType`. Removal must use the same adapter that accepted the file.

This occurs in `@assistant-ui/core` 0.3.17 at base `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7`.

<details>
<summary>Minimal reproduction</summary>

Clone the repository and install its dependencies:

```sh
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git checkout 928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7
pnpm install --frozen-lockfile
```

Save this as `repro.mjs` in the repository root. Run `bun repro.mjs`:

```js
import assert from 'node:assert/strict';
import { CompositeAttachmentAdapter } from './packages/core/src/adapters/attachment.ts';
let removed;
const imageAdapter = {
  accept: 'image/*',
  async add({ file }) {
    return {
      id: 'image-1', type: 'image', name: file.name, file,
      status: { type: 'requires-action', reason: 'composer-send' }
    };
  },
  async send(attachment) {
    return { ...attachment, status: { type: 'complete' }, content: [] };
  },
  async remove(attachment) { removed = attachment.id; }
};
const composite = new CompositeAttachmentAdapter([imageAdapter]);
const pending = await composite.add({
  file: new File(['image bytes'], 'photo.png', { type: 'image/png' })
});
await composite.remove(pending);
assert.equal(removed, 'image-1');
```

Before the correction, removal throws `No matching adapter found for attachment`. After the correction, the assertion passes.

</details>

## Root cause

Add and send select an adapter from the original `File`. Removal instead uses attachment metadata, where `contentType` is optional. An empty MIME type does not match `image/*`.

## Change

Removal uses the original `File` when present. Completed attachments without a `File` retain the name and content-type fallback.

## Verification

The reproduction and pending-removal regression failed before the correction and passed after it. The completed-attachment fallback also passes.

Focused checks passed:

```sh
pnpm --filter @assistant-ui/core test src/adapters/attachment.test.ts src/tests/attachment-adapters.test.ts
pnpm exec oxlint packages/core/src/adapters/attachment.ts packages/core/src/adapters/attachment.test.ts
pnpm exec oxfmt --check packages/core/src/adapters/attachment.ts packages/core/src/adapters/attachment.test.ts
```

All 15 tests passed. Verification covers the adapter at runtime, not a browser interface.

## Public surface

The PR includes a patch changeset for `@assistant-ui/core`. Exports, signatures, documentation, API-reference output, and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8T30wVR_aAOpkvvJIg6Mu9kqVeq4KzgJzJ5-1UZUkEYA1pHcgM7UlOVBWjA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->