### PR TITLE
fix(langgraph): keep supported continuation content blocks

### DIFF
--- a/.changeset/langgraph-continuation-content-blocks.md
+++ b/.changeset/langgraph-continuation-content-blocks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: keep supported content blocks from continuation chunks

--- a/.changeset/langgraph-continuation-content-blocks.md
+++ b/.changeset/langgraph-continuation-content-blocks.md
@@ -1,5 +1,8 @@
 ---
+"@assistant-ui/react-langchain": patch
 "@assistant-ui/react-langgraph": patch
 ---
 
 fix: keep supported content blocks from continuation chunks
+
+Keep earlier reasoning text when summaries arrive. Omit empty reasoning parts and retain provider signatures during chunk accumulation.

--- a/.changeset/langgraph-continuation-content-blocks.md
+++ b/.changeset/langgraph-continuation-content-blocks.md
@@ -5,4 +5,4 @@
 
 fix: keep supported content blocks from continuation chunks
 
-Keep earlier reasoning text when summaries arrive. Omit empty reasoning parts and retain provider signatures during chunk accumulation.
+Accumulate reasoning, thinking, files, audio and computer calls across AIMessageChunks by block index, the way `@langchain/core` merges chunk content, so provider signatures survive and a repeated indexed block updates its slot instead of appending a duplicate. Reasoning parts that carry only provider metadata no longer render as empty parts.

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -278,7 +278,7 @@ type AssistantCloudThreadsUpdateBody = {
 
 type AssistantMessageContent = string | AssistantMessageContentComplex[];
 
-type AssistantMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentToolUse | MessageContentFile | MessageContentReasoning | MessageContentThinking | MessageContentComputerCall;
+type AssistantMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentToolUse | MessageContentFile | MessageContentAudio | MessageContentReasoning | MessageContentThinking | MessageContentComputerCall;
 
 type AssistantRuntime = {
   readonly threads: ThreadListRuntime;
@@ -1262,11 +1262,13 @@ type MessageContentReasoning = {
   type: "reasoning";
   summary?: MessageContentReasoningSummaryText[];
   reasoning?: string;
+  index?: number;
 };
 
 type MessageContentReasoningSummaryText = {
   type: "summary_text";
   text?: string;
+  index?: number;
 };
 
 type MessageContentText = {
@@ -1277,6 +1279,7 @@ type MessageContentText = {
 type MessageContentThinking = {
   type: "thinking";
   thinking: string;
+  index?: number;
 };
 
 type MessageContentToolUse = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1262,6 +1262,7 @@ type MessageContentReasoning = {
   type: "reasoning";
   summary?: MessageContentReasoningSummaryText[];
   reasoning?: string;
+  signature?: string;
   index?: number;
 };
 
@@ -1279,6 +1280,7 @@ type MessageContentText = {
 type MessageContentThinking = {
   type: "thinking";
   thinking: string;
+  signature?: string;
   index?: number;
 };
 

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -768,21 +768,25 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "Answer." }]);
   });
 
-  it("preserves distinct reasoning and summary text with coincidentally matching letters", () => {
-    const result = convertLangChainBaseMessage(
-      aiMessage([
-        {
-          type: "reasoning",
-          reasoning: "Check net",
-          summary: [{ type: "summary_text", text: "temperature" }],
-        },
-      ]),
-      {},
-    );
+  it("renders the summary, falling back to the reasoning string when it is blank", () => {
+    const convert = (summary: string) =>
+      contentOf(
+        convertLangChainBaseMessage(
+          aiMessage([
+            {
+              type: "reasoning",
+              reasoning: "Check net",
+              summary: [{ type: "summary_text", text: summary }],
+            },
+          ]),
+          {},
+        ),
+      );
 
-    expect(contentOf(result)).toEqual([
-      { type: "reasoning", text: "Check net\n\n\ntemperature" },
+    expect(convert("temperature")).toEqual([
+      { type: "reasoning", text: "temperature" },
     ]);
+    expect(convert("  ")).toEqual([{ type: "reasoning", text: "Check net" }]);
   });
 
   it("tolerates null entries inside the summary array", () => {

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -755,13 +755,34 @@ describe("convertLangChainBaseMessage reasoning content parts", () => {
     ]);
   });
 
-  it("does not throw when a reasoning block omits both summary and reasoning", () => {
+  it("omits reasoning parts that contain only provider metadata", () => {
     const result = convertLangChainBaseMessage(
-      aiMessage([{ type: "reasoning" }]),
+      aiMessage([
+        { type: "reasoning", signature: "signed", index: 0 },
+        { type: "reasoning", summary: [{ type: "summary_text" }], index: 1 },
+        { type: "text", text: "Answer." },
+      ]),
       {},
     );
 
-    expect(contentOf(result)).toEqual([{ type: "reasoning", text: "" }]);
+    expect(contentOf(result)).toEqual([{ type: "text", text: "Answer." }]);
+  });
+
+  it("preserves distinct reasoning and summary text with coincidentally matching letters", () => {
+    const result = convertLangChainBaseMessage(
+      aiMessage([
+        {
+          type: "reasoning",
+          reasoning: "Check net",
+          summary: [{ type: "summary_text", text: "temperature" }],
+        },
+      ]),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      { type: "reasoning", text: "Check net\n\n\ntemperature" },
+    ]);
   });
 
   it("tolerates null entries inside the summary array", () => {

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -304,7 +304,7 @@ export const createLangChainStreamingTimingAccessors = <
           if (typeof part.text === "string") len += part.text.length;
           break;
         case "thinking":
-          if (typeof part.thinking === "string") len += part.thinking.length;
+          if (hasVisibleText(part.thinking)) len += part.thinking.length;
           break;
         case "reasoning":
           len += getReasoningText(part).length;

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -98,7 +98,9 @@ export const convertLangChainContentBlock = (
       };
     }
     case "thinking":
-      return { type: "reasoning" as const, text: part.thinking };
+      return hasVisibleText(part.thinking)
+        ? { type: "reasoning" as const, text: part.thinking }
+        : null;
     case "reasoning": {
       const text = getReasoningText(part);
       return text ? { type: "reasoning" as const, text } : null;
@@ -263,13 +265,9 @@ const getReasoningText = (part: {
   readonly reasoning?: string;
 }): string => {
   const summary = part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ?? "";
+  if (hasVisibleText(summary)) return summary;
   const reasoning = part.reasoning ?? "";
-  if (!hasVisibleText(summary))
-    return hasVisibleText(reasoning) ? reasoning : "";
-  if (!hasVisibleText(reasoning) || summary.includes(reasoning)) return summary;
-  if (reasoning.includes(summary)) return reasoning;
-
-  return `${reasoning}\n\n\n${summary}`;
+  return hasVisibleText(reasoning) ? reasoning : "";
 };
 
 export const createLangChainStreamingTimingAccessors = <

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -99,14 +99,10 @@ export const convertLangChainContentBlock = (
     }
     case "thinking":
       return { type: "reasoning" as const, text: part.thinking };
-    case "reasoning":
-      return {
-        type: "reasoning" as const,
-        text:
-          part.summary && part.summary.length > 0
-            ? part.summary.map((s) => s?.text ?? "").join("\n\n\n")
-            : (part.reasoning ?? ""),
-      };
+    case "reasoning": {
+      const text = getReasoningText(part);
+      return text ? { type: "reasoning" as const, text } : null;
+    }
     case "tool_use":
     case "input_json_delta":
       return null;
@@ -262,13 +258,18 @@ export const getMessageContent = (msg: AppendMessage) => {
   return content;
 };
 
-const reasoningTextLength = (part: {
+const getReasoningText = (part: {
   readonly summary?: ReadonlyArray<{ readonly text?: string }>;
   readonly reasoning?: string;
-}): number => {
-  if (part.summary && part.summary.length > 0)
-    return part.summary.map((s) => s?.text ?? "").join("\n\n\n").length;
-  return part.reasoning?.length ?? 0;
+}): string => {
+  const summary = part.summary?.map((s) => s?.text ?? "").join("\n\n\n") ?? "";
+  const reasoning = part.reasoning ?? "";
+  if (!hasVisibleText(summary))
+    return hasVisibleText(reasoning) ? reasoning : "";
+  if (!hasVisibleText(reasoning) || summary.includes(reasoning)) return summary;
+  if (reasoning.includes(summary)) return reasoning;
+
+  return `${reasoning}\n\n\n${summary}`;
 };
 
 export const createLangChainStreamingTimingAccessors = <
@@ -308,7 +309,7 @@ export const createLangChainStreamingTimingAccessors = <
           if (typeof part.thinking === "string") len += part.thinking.length;
           break;
         case "reasoning":
-          len += reasoningTextLength(part);
+          len += getReasoningText(part).length;
           break;
       }
     }

--- a/packages/react-langchain/src/streamingTiming.test.tsx
+++ b/packages/react-langchain/src/streamingTiming.test.tsx
@@ -35,6 +35,29 @@ describe("useLangChainStreamingTiming", () => {
     );
   });
 
+  it("counts a thinking block only when the converter renders it", () => {
+    const tokenCount = (thinking: string) => {
+      const messages: LangChainBaseMessage[] = [
+        {
+          id: "msg-1",
+          _getType: () => "ai",
+          content: [{ type: "thinking", thinking }],
+        },
+      ];
+      const { result, rerender } = renderHook(
+        ({ msgs, running }) => useLangChainStreamingTiming(msgs, running),
+        { initialProps: { msgs: messages, running: true } },
+      );
+      act(() => {
+        rerender({ msgs: messages, running: false });
+      });
+      return result.current["msg-1"]?.tokenCount;
+    };
+
+    expect(tokenCount("deduced")).toBe(Math.ceil("deduced".length / 4));
+    expect(tokenCount("   ")).toBeUndefined();
+  });
+
   it("counts the summary text the converter renders, not the reasoning it shadows", () => {
     const messages: LangChainBaseMessage[] = [
       {

--- a/packages/react-langchain/src/streamingTiming.test.tsx
+++ b/packages/react-langchain/src/streamingTiming.test.tsx
@@ -34,4 +34,31 @@ describe("useLangChainStreamingTiming", () => {
       Math.ceil("deduced".length / 4),
     );
   });
+
+  it("counts both preserved reasoning and summary text", () => {
+    const messages: LangChainBaseMessage[] = [
+      {
+        id: "msg-1",
+        _getType: () => "ai",
+        content: [
+          {
+            type: "reasoning",
+            reasoning: "partial thinking",
+            summary: [{ type: "summary_text", text: "first summary" }],
+          },
+        ],
+      },
+    ];
+    const { result, rerender } = renderHook(
+      ({ running }) => useLangChainStreamingTiming(messages, running),
+      { initialProps: { running: true } },
+    );
+    act(() => {
+      rerender({ running: false });
+    });
+
+    expect(result.current["msg-1"]?.tokenCount).toBe(
+      Math.ceil("partial thinking\n\n\nfirst summary".length / 4),
+    );
+  });
 });

--- a/packages/react-langchain/src/streamingTiming.test.tsx
+++ b/packages/react-langchain/src/streamingTiming.test.tsx
@@ -35,7 +35,7 @@ describe("useLangChainStreamingTiming", () => {
     );
   });
 
-  it("counts both preserved reasoning and summary text", () => {
+  it("counts the summary text the converter renders, not the reasoning it shadows", () => {
     const messages: LangChainBaseMessage[] = [
       {
         id: "msg-1",
@@ -58,7 +58,7 @@ describe("useLangChainStreamingTiming", () => {
     });
 
     expect(result.current["msg-1"]?.tokenCount).toBe(
-      Math.ceil("partial thinking\n\n\nfirst summary".length / 4),
+      Math.ceil("first summary".length / 4),
     );
   });
 });

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -205,20 +205,63 @@ describe("appendLangChainChunk continuation content", () => {
     ]);
   });
 
-  it("ignores signature-only chunks at the start and during thinking", () => {
-    const signature = JSON.parse(
-      '{"id":"ai-1","type":"AIMessageChunk","content":[{"type":"thinking","signature":"signed","index":0}]}',
-    );
-    const first = appendLangChainChunk(undefined, signature);
+  it("accumulates thinking signature fragments without rendering an empty part", () => {
+    const signatureChunk = (signature: string) =>
+      JSON.parse(
+        `{"id":"ai-1","type":"AIMessageChunk","content":[{"type":"thinking","signature":"${signature}","index":0}]}`,
+      );
+    const first = appendLangChainChunk(undefined, signatureChunk("sig-"));
     expect(convertLangChainMessages(first, {})).toHaveProperty("content", []);
     const thinking = appendLangChainChunk(first, {
       id: "ai-1",
       type: "AIMessageChunk",
       content: [{ type: "thinking", thinking: "Checking.", index: 0 }],
     });
-    const merged = appendLangChainChunk(thinking, signature);
+    const merged = appendLangChainChunk(thinking, signatureChunk("part2"));
+    expect(merged.content).toEqual([
+      expect.objectContaining({
+        index: 0,
+        thinking: "Checking.",
+        signature: "sig-part2",
+      }),
+    ]);
     expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
       { type: "reasoning", text: "Checking." },
+    ]);
+  });
+
+  it("merges a repeated indexed block instead of appending a duplicate", () => {
+    const call = (action: Record<string, unknown>) =>
+      ({
+        type: "computer_call",
+        id: "computer-1",
+        call_id: "call-1",
+        action,
+        pending_safety_checks: [],
+        index: 0,
+      }) satisfies Exclude<
+        LangChainMessageChunk["content"],
+        string | undefined
+      >[number];
+    const first = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [call({ type: "screenshot" })],
+    });
+    const merged = appendLangChainChunk(first, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [call({ type: "click", x: 1, y: 2 })],
+    });
+
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "computer_call",
+        args: { type: "click", x: 1, y: 2 },
+        argsText: '{"type":"click","x":1,"y":2}',
+      },
     ]);
   });
 
@@ -262,7 +305,7 @@ describe("appendLangChainChunk continuation content", () => {
   });
 
   it.each([{ index: 0 }, {}])(
-    "keeps earlier reasoning when summary chunks arrive with %j",
+    "falls back to the reasoning string until the summary carries text, with %j",
     (block) => {
       const first = appendLangChainChunk(undefined, {
         id: "ai-1",
@@ -271,7 +314,18 @@ describe("appendLangChainChunk continuation content", () => {
           { type: "reasoning", reasoning: "partial thinking", ...block },
         ],
       });
-      const summary = appendLangChainChunk(first, {
+      const blank = appendLangChainChunk(first, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          {
+            type: "reasoning",
+            ...block,
+            summary: [{ type: "summary_text", index: 0 }],
+          },
+        ],
+      });
+      const summary = appendLangChainChunk(blank, {
         id: "ai-1",
         type: "AIMessageChunk",
         content: [
@@ -300,52 +354,25 @@ describe("appendLangChainChunk continuation content", () => {
       expect(convertLangChainMessages(first, {})).toHaveProperty("content", [
         { type: "reasoning", text: "partial thinking" },
       ]);
+      expect(convertLangChainMessages(blank, {})).toHaveProperty("content", [
+        { type: "reasoning", text: "partial thinking" },
+      ]);
       expect(convertLangChainMessages(summary, {})).toHaveProperty("content", [
-        { type: "reasoning", text: "partial thinking\n\n\nfirst" },
+        { type: "reasoning", text: "first" },
       ]);
       expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
-        {
-          type: "reasoning",
-          text: "partial thinking\n\n\nfirst summary\n\n\nsecond summary",
-        },
+        { type: "reasoning", text: "first summary\n\n\nsecond summary" },
+      ]);
+      expect(merged.content).toEqual([
+        expect.objectContaining({ reasoning: "partial thinking" }),
       ]);
     },
   );
 
-  it("does not duplicate reasoning as an overlapping summary grows", () => {
-    let merged = appendLangChainChunk(undefined, {
-      id: "ai-1",
-      type: "AIMessageChunk",
-      content: [
-        { type: "reasoning", index: 0, reasoning: "We compare both plans." },
-      ],
-    });
-    for (const [text, expected] of [
-      ["We compare", "We compare both plans."],
-      [" both plans.", "We compare both plans."],
-      [" Then choose.", "We compare both plans. Then choose."],
-    ] as const) {
-      merged = appendLangChainChunk(merged, {
-        id: "ai-1",
-        type: "AIMessageChunk",
-        content: [
-          {
-            type: "reasoning",
-            index: 0,
-            summary: [{ type: "summary_text", index: 0, text }],
-          },
-        ],
-      });
-      expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
-        { type: "reasoning", text: expected },
-      ]);
-    }
-  });
-
   it("keeps reasoning signatures without empty parts or cross-index text", () => {
     const signature = {
       type: "reasoning" as const,
-      signature: "signed",
+      signature: "sig-",
       index: 0,
     };
     const first = appendLangChainChunk(undefined, {
@@ -379,7 +406,7 @@ describe("appendLangChainChunk continuation content", () => {
     expect(text.content).toEqual([
       expect.objectContaining({
         index: 0,
-        signature: "signed",
+        signature: "sig-",
         reasoning: "Checking.",
       }),
       expect.objectContaining({ index: 1, reasoning: "Separate." }),
@@ -388,12 +415,12 @@ describe("appendLangChainChunk continuation content", () => {
     const signed = appendLangChainChunk(text, {
       id: "ai-1",
       type: "AIMessageChunk",
-      content: [{ ...signature, signature: "completed" }],
+      content: [{ ...signature, signature: "part2" }],
     });
     expect(signed.content).toEqual([
       expect.objectContaining({
         index: 0,
-        signature: "completed",
+        signature: "sig-part2",
         reasoning: "Checking.",
       }),
       expect.objectContaining({ index: 1, reasoning: "Separate." }),

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -66,6 +66,76 @@ describe("appendLangChainChunk content-less chunks", () => {
   });
 });
 
+describe("appendLangChainChunk continuation content", () => {
+  it("keeps reasoning, files, computer calls, and text deltas for conversion", () => {
+    const first = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [],
+    });
+    const merged = appendLangChainChunk(first, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [
+        { type: "thinking", thinking: "Let me check." },
+        { type: "reasoning", reasoning: "The calculation is correct." },
+        {
+          type: "file",
+          source_type: "url",
+          url: "https://example.com/report.pdf",
+          mime_type: "application/pdf",
+        },
+        {
+          type: "computer_call",
+          id: "computer-1",
+          call_id: "call-1",
+          action: { type: "screenshot" },
+          pending_safety_checks: [],
+          index: 0,
+        },
+        { type: "tool_use" },
+        { type: "input_json_delta" },
+        { type: "text_delta", text: "Done." },
+      ],
+    });
+
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Let me check." },
+      { type: "reasoning", text: "The calculation is correct." },
+      {
+        type: "file",
+        filename: "file",
+        data: "https://example.com/report.pdf",
+        mimeType: "application/pdf",
+        sourceType: "url",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "computer_call",
+        args: { type: "screenshot" },
+        argsText: '{"type":"screenshot"}',
+      },
+      { type: "text", text: "Done." },
+    ]);
+    expect(merged.content).not.toContainEqual({ type: "tool_use" });
+    expect(merged.content).not.toContainEqual({ type: "input_json_delta" });
+  });
+
+  it("merges a text delta into the preceding text", () => {
+    const merged = appendLangChainChunk(
+      { id: "ai-1", type: "ai", content: "Hello" },
+      {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [{ type: "text_delta", text: " world" }],
+      },
+    );
+
+    expect(merged.content).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+});
+
 describe("appendLangChainChunk tool_call id merging", () => {
   it("merges chunk arriving with real id into entry that started with empty id", () => {
     let acc: AiMessage | undefined;

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -263,6 +263,21 @@ describe("appendLangChainChunk continuation content", () => {
         argsText: '{"type":"click","x":1,"y":2}',
       },
     ]);
+
+    const placeholders = appendLangChainChunk(
+      merged,
+      JSON.parse(
+        '{"id":"ai-1","type":"AIMessageChunk","content":[{"type":"computer_call","index":0,"call_id":"","id":null,"action":null,"status":"completed"}]}',
+      ),
+    );
+    expect(placeholders.content).toEqual([
+      expect.objectContaining({
+        call_id: "call-1",
+        id: "computer-1",
+        action: { type: "click", x: 1, y: 2 },
+        status: "completed",
+      }),
+    ]);
   });
 
   it("joins reasoning summary deltas by summary index", () => {

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -261,6 +261,150 @@ describe("appendLangChainChunk continuation content", () => {
     ]);
   });
 
+  it.each([{ index: 0 }, {}])(
+    "keeps earlier reasoning when summary chunks arrive with %j",
+    (block) => {
+      const first = appendLangChainChunk(undefined, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          { type: "reasoning", reasoning: "partial thinking", ...block },
+        ],
+      });
+      const summary = appendLangChainChunk(first, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          {
+            type: "reasoning",
+            ...block,
+            summary: [{ type: "summary_text", index: 0, text: "first" }],
+          },
+        ],
+      });
+      const merged = appendLangChainChunk(summary, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          {
+            type: "reasoning",
+            ...block,
+            summary: [
+              { type: "summary_text", index: 0, text: " summary" },
+              { type: "summary_text", index: 1, text: "second summary" },
+            ],
+          },
+        ],
+      });
+
+      expect(convertLangChainMessages(first, {})).toHaveProperty("content", [
+        { type: "reasoning", text: "partial thinking" },
+      ]);
+      expect(convertLangChainMessages(summary, {})).toHaveProperty("content", [
+        { type: "reasoning", text: "partial thinking\n\n\nfirst" },
+      ]);
+      expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+        {
+          type: "reasoning",
+          text: "partial thinking\n\n\nfirst summary\n\n\nsecond summary",
+        },
+      ]);
+    },
+  );
+
+  it("does not duplicate reasoning as an overlapping summary grows", () => {
+    let merged = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [
+        { type: "reasoning", index: 0, reasoning: "We compare both plans." },
+      ],
+    });
+    for (const [text, expected] of [
+      ["We compare", "We compare both plans."],
+      [" both plans.", "We compare both plans."],
+      [" Then choose.", "We compare both plans. Then choose."],
+    ] as const) {
+      merged = appendLangChainChunk(merged, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          {
+            type: "reasoning",
+            index: 0,
+            summary: [{ type: "summary_text", index: 0, text }],
+          },
+        ],
+      });
+      expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+        { type: "reasoning", text: expected },
+      ]);
+    }
+  });
+
+  it("keeps reasoning signatures without empty parts or cross-index text", () => {
+    const signature = {
+      type: "reasoning" as const,
+      signature: "signed",
+      index: 0,
+    };
+    const first = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [signature],
+    });
+    expect(convertLangChainMessages(first, {})).toHaveProperty("content", []);
+
+    const sibling = appendLangChainChunk(first, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [
+        { type: "reasoning", index: 1, reasoning: "Separate." },
+        {
+          type: "reasoning",
+          index: 0,
+          summary: [{ type: "summary_text", index: 0 }],
+        },
+      ],
+    });
+    expect(convertLangChainMessages(sibling, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Separate." },
+    ]);
+
+    const text = appendLangChainChunk(sibling, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [{ type: "reasoning", index: 0, reasoning: "Checking." }],
+    });
+    expect(text.content).toEqual([
+      expect.objectContaining({
+        index: 0,
+        signature: "signed",
+        reasoning: "Checking.",
+      }),
+      expect.objectContaining({ index: 1, reasoning: "Separate." }),
+    ]);
+
+    const signed = appendLangChainChunk(text, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [{ ...signature, signature: "completed" }],
+    });
+    expect(signed.content).toEqual([
+      expect.objectContaining({
+        index: 0,
+        signature: "completed",
+        reasoning: "Checking.",
+      }),
+      expect.objectContaining({ index: 1, reasoning: "Separate." }),
+    ]);
+    expect(convertLangChainMessages(signed, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Checking." },
+      { type: "reasoning", text: "Separate." },
+    ]);
+    expect(convertLangChainMessages(first, {})).toHaveProperty("content", []);
+  });
+
   it("joins unindexed reasoning deltas only while they are adjacent", () => {
     let merged = appendLangChainChunk(undefined, {
       id: "ai-1",

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -67,7 +67,7 @@ describe("appendLangChainChunk content-less chunks", () => {
 });
 
 describe("appendLangChainChunk continuation content", () => {
-  it("keeps reasoning, files, computer calls, and text deltas for conversion", () => {
+  it("keeps reasoning, files, audio, computer calls, and text deltas for conversion", () => {
     const first = appendLangChainChunk(undefined, {
       id: "ai-1",
       type: "AIMessageChunk",
@@ -84,6 +84,12 @@ describe("appendLangChainChunk continuation content", () => {
           source_type: "url",
           url: "https://example.com/report.pdf",
           mime_type: "application/pdf",
+        },
+        {
+          type: "audio",
+          data: "YXVkaW8=",
+          mime_type: "audio/wav",
+          source_type: "base64",
         },
         {
           type: "computer_call",
@@ -110,6 +116,12 @@ describe("appendLangChainChunk continuation content", () => {
         sourceType: "url",
       },
       {
+        type: "file",
+        filename: "audio.wav",
+        data: "YXVkaW8=",
+        mimeType: "audio/wav",
+      },
+      {
         type: "tool-call",
         toolCallId: "call-1",
         toolName: "computer_call",
@@ -133,6 +145,143 @@ describe("appendLangChainChunk continuation content", () => {
     );
 
     expect(merged.content).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("keeps text after intervening content and joins adjacent text deltas", () => {
+    const merged = appendLangChainChunk(
+      { id: "ai-1", type: "ai", content: [{ type: "text", text: "Hello" }] },
+      {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [
+          { type: "thinking", thinking: "Checking." },
+          { type: "text", text: "After thinking." },
+          {
+            type: "file",
+            source_type: "url",
+            url: "https://example.com/report.pdf",
+          },
+          { type: "text_delta", text: "Done" },
+          { type: "text_delta", text: "." },
+        ],
+      },
+    );
+
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "text", text: "Hello" },
+      { type: "reasoning", text: "Checking." },
+      { type: "text", text: "After thinking." },
+      {
+        type: "file",
+        filename: "file",
+        data: "https://example.com/report.pdf",
+        mimeType: "application/octet-stream",
+        sourceType: "url",
+      },
+      { type: "text", text: "Done." },
+    ]);
+  });
+
+  it("accumulates thinking by block index without changing earlier messages", () => {
+    const first = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [{ type: "thinking", thinking: "Let", index: 0 }],
+    });
+    const merged = appendLangChainChunk(first, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [
+        { type: "thinking", thinking: "Other.", index: 1 },
+        { type: "thinking", thinking: " me check.", index: 0 },
+      ],
+    });
+    expect(convertLangChainMessages(first, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Let" },
+    ]);
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Let me check." },
+      { type: "reasoning", text: "Other." },
+    ]);
+  });
+
+  it("ignores signature-only chunks at the start and during thinking", () => {
+    const signature = JSON.parse(
+      '{"id":"ai-1","type":"AIMessageChunk","content":[{"type":"thinking","signature":"signed","index":0}]}',
+    );
+    const first = appendLangChainChunk(undefined, signature);
+    expect(convertLangChainMessages(first, {})).toHaveProperty("content", []);
+    const thinking = appendLangChainChunk(first, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [{ type: "thinking", thinking: "Checking.", index: 0 }],
+    });
+    const merged = appendLangChainChunk(thinking, signature);
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "Checking." },
+    ]);
+  });
+
+  it("joins reasoning summary deltas by summary index", () => {
+    let merged: LangChainMessage = { id: "ai-1", type: "ai", content: [] };
+    const blocks = [
+      { type: "reasoning", index: 0, summary: [] },
+      {
+        type: "reasoning",
+        index: 0,
+        summary: [{ type: "summary_text", index: 0, text: "First" }],
+      },
+      {
+        type: "reasoning",
+        index: 0,
+        summary: [{ type: "summary_text", index: 1, text: "Second" }],
+      },
+      {
+        type: "reasoning",
+        index: 0,
+        summary: [{ type: "summary_text", index: 0, text: " step." }],
+      },
+      {
+        type: "reasoning",
+        index: 0,
+        summary: [{ type: "summary_text", index: 1, text: " step." }],
+      },
+      { type: "reasoning", index: 1, reasoning: "Separate." },
+    ] satisfies Exclude<LangChainMessageChunk["content"], string | undefined>;
+    for (const block of blocks) {
+      merged = appendLangChainChunk(merged, {
+        id: "ai-1",
+        type: "AIMessageChunk",
+        content: [block],
+      });
+    }
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "First step.\n\n\nSecond step." },
+      { type: "reasoning", text: "Separate." },
+    ]);
+  });
+
+  it("joins unindexed reasoning deltas only while they are adjacent", () => {
+    let merged = appendLangChainChunk(undefined, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [{ type: "reasoning", reasoning: "One" }],
+    });
+    merged = appendLangChainChunk(merged, {
+      id: "ai-1",
+      type: "AIMessageChunk",
+      content: [
+        { type: "reasoning", reasoning: " step." },
+        { type: "text_delta", text: "Answer." },
+        { type: "reasoning", reasoning: "Two" },
+        { type: "reasoning", reasoning: " steps." },
+      ],
+    });
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "reasoning", text: "One step." },
+      { type: "text", text: "Answer." },
+      { type: "reasoning", text: "Two steps." },
+    ]);
   });
 });
 

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -3,7 +3,6 @@ import type {
   LangChainMessageChunk,
   LangChainToolCall,
   LangChainToolCallChunk,
-  MessageContentText,
 } from "./types";
 import { parsePartialJsonObject } from "assistant-stream/utils";
 
@@ -80,14 +79,21 @@ export const appendLangChainChunk = (
   }
 
   if (!prev || prev.type !== "ai") {
-    const toolCalls = (curr.tool_call_chunks ?? []).map(chunkToToolCall);
-    return {
-      ...curr,
-      content: curr.content ?? [],
-      type: curr.type.replace("MessageChunk", "").toLowerCase(),
-      tool_call_chunks: undefined,
-      ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
-    } as LangChainMessage;
+    const { id, tool_call_chunks: _chunks, ...message } = curr;
+    prev = {
+      ...message,
+      ...(id !== undefined && { id }),
+      content: [],
+      type: "ai",
+    };
+    if (!Array.isArray(curr.content)) {
+      const toolCalls = (curr.tool_call_chunks ?? []).map(chunkToToolCall);
+      return {
+        ...prev,
+        content: curr.content ?? [],
+        ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+      };
+    }
   }
 
   const newContent =
@@ -97,33 +103,74 @@ export const appendLangChainChunk = (
 
   if (typeof curr?.content === "string") {
     const lastIndex = newContent.length - 1;
-    if (newContent[lastIndex]?.type === "text") {
-      (newContent[lastIndex] as MessageContentText).text =
-        (newContent[lastIndex] as MessageContentText).text + curr.content;
+    const last = newContent[lastIndex];
+    if (last?.type === "text") {
+      newContent[lastIndex] = { ...last, text: last.text + curr.content };
     } else {
       newContent.push({ type: "text", text: curr.content });
     }
   } else if (Array.isArray(curr.content)) {
-    const lastIndex = newContent.length - 1;
     for (const item of curr.content) {
       if (!("type" in item)) {
         continue;
       }
 
+      const lastIndex = newContent.length - 1;
+      const last = newContent[lastIndex];
       if (item.type === "text" || item.type === "text_delta") {
-        if (newContent[lastIndex]?.type === "text") {
-          (newContent[lastIndex] as MessageContentText).text =
-            (newContent[lastIndex] as MessageContentText).text + item.text;
+        if (last?.type === "text") {
+          newContent[lastIndex] = { ...last, text: last.text + item.text };
         } else {
           newContent.push({ type: "text", text: item.text });
         }
-      } else if (
-        item.type === "image_url" ||
-        item.type === "thinking" ||
-        item.type === "reasoning" ||
-        item.type === "file" ||
-        item.type === "computer_call"
-      ) {
+      } else if (item.type === "thinking" || item.type === "reasoning") {
+        const index =
+          item.index === undefined
+            ? lastIndex
+            : newContent.findIndex(
+                (part) =>
+                  part.type === item.type &&
+                  "index" in part &&
+                  part.index === item.index,
+              );
+        const existing = newContent[index];
+        if (item.type === "thinking") {
+          if (!item.thinking) continue;
+          if (existing?.type === "thinking") {
+            newContent[index] = {
+              ...existing,
+              thinking: (existing.thinking ?? "") + item.thinking,
+            };
+          } else {
+            newContent.push(item);
+          }
+        } else if (existing?.type === "reasoning") {
+          const summary = [...(existing.summary ?? [])];
+          for (const [position, part] of (item.summary ?? []).entries()) {
+            if (!part) continue;
+            const summaryIndex =
+              part.index === undefined
+                ? position
+                : summary.findIndex((s) => s?.index === part.index);
+            const previous = summary[summaryIndex];
+            if (previous) {
+              summary[summaryIndex] = {
+                ...previous,
+                text: (previous.text ?? "") + (part.text ?? ""),
+              };
+            } else {
+              summary.push(part);
+            }
+          }
+          newContent[index] = {
+            ...existing,
+            reasoning: (existing.reasoning ?? "") + (item.reasoning ?? ""),
+            ...(summary.length > 0 && { summary }),
+          };
+        } else {
+          newContent.push(item);
+        }
+      } else if (item.type !== "tool_use" && item.type !== "input_json_delta") {
         newContent.push(item);
       }
     }

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -24,6 +24,20 @@ const findByIndex = (
   );
 };
 
+// `_mergeDicts` skips a null incoming value and never lets an empty string
+// replace an accumulated one, so a continuation chunk that repeats a block's
+// keys as placeholders cannot erase what earlier chunks already carried.
+const mergeDefined = (
+  existing: AiContentBlock,
+  item: AiContentBlock,
+): AiContentBlock =>
+  ({
+    ...existing,
+    ...Object.fromEntries(
+      Object.entries(item).filter(([, value]) => value != null && value !== ""),
+    ),
+  }) as AiContentBlock;
+
 const chunkToToolCall = (chunk: LangChainToolCallChunk) => {
   const partialJson = chunk.args ?? chunk.args_json ?? "";
   return {
@@ -193,7 +207,7 @@ export const appendLangChainChunk = (
         const index = findByIndex(newContent, item);
         const existing = newContent[index];
         if (existing) {
-          newContent[index] = { ...existing, ...item };
+          newContent[index] = mergeDefined(existing, item);
         } else {
           newContent.push(item);
         }

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -7,6 +7,22 @@ import type {
 import { parsePartialJsonObject } from "assistant-stream/utils";
 
 type AiMessage = Extract<LangChainMessage, { type: "ai" }>;
+type AiContentBlock = Exclude<AiMessage["content"], string>[number];
+
+// Mirrors `_mergeLists` in @langchain/core: an indexed block names a slot in the
+// accumulated content, so a repeated chunk for that index updates the block
+// rather than appending a duplicate.
+const findByIndex = (
+  content: readonly AiContentBlock[],
+  item: AiContentBlock,
+): number => {
+  const index = "index" in item ? item.index : undefined;
+  if (index === undefined) return -1;
+  return content.findIndex(
+    (part) =>
+      part.type === item.type && "index" in part && part.index === index,
+  );
+};
 
 const chunkToToolCall = (chunk: LangChainToolCallChunk) => {
   const partialJson = chunk.args ?? chunk.args_json ?? "";
@@ -123,28 +139,29 @@ export const appendLangChainChunk = (
         } else {
           newContent.push({ type: "text", text: item.text });
         }
-      } else if (item.type === "thinking" || item.type === "reasoning") {
+      } else if (item.type === "thinking") {
         const index =
-          item.index === undefined
-            ? lastIndex
-            : newContent.findIndex(
-                (part) =>
-                  part.type === item.type &&
-                  "index" in part &&
-                  part.index === item.index,
-              );
+          item.index === undefined ? lastIndex : findByIndex(newContent, item);
         const existing = newContent[index];
-        if (item.type === "thinking") {
-          if (!item.thinking) continue;
-          if (existing?.type === "thinking") {
-            newContent[index] = {
-              ...existing,
-              thinking: (existing.thinking ?? "") + item.thinking,
-            };
-          } else {
-            newContent.push(item);
-          }
-        } else if (existing?.type === "reasoning") {
+        if (existing?.type !== "thinking") {
+          newContent.push({ ...item, thinking: item.thinking ?? "" });
+        } else {
+          const thinking = (existing.thinking ?? "") + (item.thinking ?? "");
+          const signature = (existing.signature ?? "") + (item.signature ?? "");
+          newContent[index] = {
+            ...existing,
+            ...item,
+            ...(thinking && { thinking }),
+            ...(signature && { signature }),
+          };
+        }
+      } else if (item.type === "reasoning") {
+        const index =
+          item.index === undefined ? lastIndex : findByIndex(newContent, item);
+        const existing = newContent[index];
+        if (existing?.type !== "reasoning") {
+          newContent.push(item);
+        } else {
           const summary = [...(existing.summary ?? [])];
           for (const [position, part] of (item.summary ?? []).entries()) {
             if (!part) continue;
@@ -162,17 +179,24 @@ export const appendLangChainChunk = (
               summary.push(part);
             }
           }
+          const reasoning = (existing.reasoning ?? "") + (item.reasoning ?? "");
+          const signature = (existing.signature ?? "") + (item.signature ?? "");
           newContent[index] = {
             ...existing,
             ...item,
-            reasoning: (existing.reasoning ?? "") + (item.reasoning ?? ""),
+            ...(reasoning && { reasoning }),
+            ...(signature && { signature }),
             ...(summary.length > 0 && { summary }),
           };
+        }
+      } else if (item.type !== "tool_use" && item.type !== "input_json_delta") {
+        const index = findByIndex(newContent, item);
+        const existing = newContent[index];
+        if (existing) {
+          newContent[index] = { ...existing, ...item };
         } else {
           newContent.push(item);
         }
-      } else if (item.type !== "tool_use" && item.type !== "input_json_delta") {
-        newContent.push(item);
       }
     }
   }

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -164,6 +164,7 @@ export const appendLangChainChunk = (
           }
           newContent[index] = {
             ...existing,
+            ...item,
             reasoning: (existing.reasoning ?? "") + (item.reasoning ?? ""),
             ...(summary.length > 0 && { summary }),
           };

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -110,14 +110,20 @@ export const appendLangChainChunk = (
         continue;
       }
 
-      if (item.type === "text") {
+      if (item.type === "text" || item.type === "text_delta") {
         if (newContent[lastIndex]?.type === "text") {
           (newContent[lastIndex] as MessageContentText).text =
             (newContent[lastIndex] as MessageContentText).text + item.text;
         } else {
           newContent.push({ type: "text", text: item.text });
         }
-      } else if (item.type === "image_url") {
+      } else if (
+        item.type === "image_url" ||
+        item.type === "thinking" ||
+        item.type === "reasoning" ||
+        item.type === "file" ||
+        item.type === "computer_call"
+      ) {
         newContent.push(item);
       }
     }

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -24,6 +24,11 @@ const findByIndex = (
   );
 };
 
+// The accumulated message stays faithful to the wire, so a block type the
+// converter does not render is still kept: only the tool-call representations
+// are excluded, because the structured tool_call_chunks own those values.
+// Unlike `_mergeDicts` this replaces rather than concatenates a repeated string
+// field, which no provider currently splits across chunks on such a block.
 // `_mergeDicts` skips a null incoming value and never lets an empty string
 // replace an accumulated one, so a continuation chunk that repeats a block's
 // keys as placeholders cannot erase what earlier chunks already carried.

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -962,16 +962,6 @@ describe("convertLangChainMessages reasoning content", () => {
       content: [{ type: "reasoning", text: "\n\n\nkept" }],
     });
   });
-
-  it("does not throw when a reasoning block omits summary and reasoning", () => {
-    expect(() =>
-      convertLangChainMessages({
-        type: "ai",
-        id: "ai-reasoning-empty",
-        content: [{ type: "reasoning" } as any],
-      }),
-    ).not.toThrow();
-  });
 });
 
 describe("convertLangChainMessages image content", () => {

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -46,6 +46,7 @@ export type MessageContentImageUrl = {
 export type MessageContentThinking = {
   type: "thinking";
   thinking: string;
+  signature?: string;
   index?: number;
 };
 
@@ -59,6 +60,7 @@ export type MessageContentReasoning = {
   type: "reasoning";
   summary?: MessageContentReasoningSummaryText[];
   reasoning?: string;
+  signature?: string;
   index?: number;
 };
 

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -46,17 +46,20 @@ export type MessageContentImageUrl = {
 export type MessageContentThinking = {
   type: "thinking";
   thinking: string;
+  index?: number;
 };
 
 export type MessageContentReasoningSummaryText = {
   type: "summary_text";
   text?: string;
+  index?: number;
 };
 
 export type MessageContentReasoning = {
   type: "reasoning";
   summary?: MessageContentReasoningSummaryText[];
   reasoning?: string;
+  index?: number;
 };
 
 type MessageContentToolUse = {
@@ -135,6 +138,7 @@ type AssistantMessageContentComplex =
   | MessageContentImageUrl
   | MessageContentToolUse
   | MessageContentFile
+  | MessageContentAudio
   | MessageContentReasoning
   | MessageContentThinking
   | MessageContentComputerCall;

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -141,8 +141,8 @@
   },
   "@assistant-ui/react-langgraph": {
     ".": {
-      "min": 26127,
-      "gzip": 9090
+      "min": 27176,
+      "gzip": 9366
     }
   },
   "@assistant-ui/react-lexical": {


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-langgraph` 0.14.26 an AI message loses every content block that is not text or an image once the first chunk has landed, so reasoning never renders. On `main`, a full Anthropic extended-thinking stream accumulates to the empty shell block that `content_block_start` opened:

```
[{"index":0,"type":"thinking","thinking":"","signature":""},{"type":"text","text":"Answer."}]
```

and an OpenAI Responses stream keeps only the empty summary array:

```
[{"index":0,"type":"reasoning","summary":[]},{"type":"text","text":"Done."}]
```

Minimal reproduction on 0.14.26:

```ts
import assert from "node:assert/strict";
import { appendLangChainChunk } from "@assistant-ui/react-langgraph";

const first = appendLangChainChunk(undefined, { id: "a", type: "AIMessageChunk", content: [] });
const thinking = { type: "thinking" as const, thinking: "Let me check the calculation." };
const result = appendLangChainChunk(first, { id: "a", type: "AIMessageChunk", content: [thinking] });
assert.deepEqual(result.content, [thinking]);
```

## Root cause

The first chunk was returned whole, but the continuation loop accepted only `text` and `image_url` and dropped everything else. It also computed the merge target once before the loop, so a chunk carrying several blocks merged them all against one stale position.

## Change

The loop now accumulates blocks by index, mirroring `_mergeLists` in `@langchain/core`: a block carrying an index names a slot in the accumulated content, so a repeated chunk for that index updates that block and an unindexed one is appended, and `text_delta` folds into the preceding text. `tool_use` and `input_json_delta` are the only exclusions, because the structured tool-call chunks own those values. A block type the converter does not render is still accumulated, so the accumulated message stays faithful to the wire rather than to a curated allowlist, which is the shape that produced this bug in the first place.

Three consequences worth naming:

- a `computer_call` split across two chunks used to render as two tool-call parts, the second with no `toolCallId` and no args. It now updates one part.
- `thinking` and `reasoning` retain and concatenate provider signatures. Anthropic emits `signature_delta` as a `thinking` block with no `thinking` field, so the signature only survives if metadata-only chunks merge instead of being skipped.
- `convertLangChainContentBlock` drops a reasoning or thinking part with no visible text instead of rendering an empty part, which is what keeps the `content_block_start` shell and the signature-only chunks off screen. This answers the question #6435 left open about a summary whose entries carry no text; it falls back to the `reasoning` string.

`getReasoningText` picks the summary when it has visible text and the `reasoning` string otherwise. It does not concatenate the two: no provider emits a reasoning block carrying both, because the standard block in `@langchain/core` (`dist/messages/content/index.d.ts`) has only `reasoning`, and the `summary` array is the raw OpenAI Responses shape that core's own openai translator joins into `reasoning`.

`MessageContentThinking` and `MessageContentReasoning` gain an optional `signature`, and `MessageContentAudio` joins the assistant content union, so the blocks that now survive accumulation are typed as what the wire actually carries.

## Verification

- `pnpm --filter @assistant-ui/react-langgraph test`: 13 files, 315 tests passed
- `pnpm --filter @assistant-ui/react-langchain test`: 8 files, 137 tests passed
- the reproduction above fails on `main` and passes here
- identical chunk sequences fed to `appendLangChainChunk` and to `AIMessageChunk.concat` from `@langchain/core` 1.2.9 now agree on the Anthropic thinking stream (including a signature split across two `signature_delta` events), the OpenAI Responses summary-delta stream, and a repeated indexed `computer_call`
- `tsc --noEmit` matches `main`'s baseline in both packages; `pnpm lint`, `pnpm api-surface:check` and `pnpm changesets:check` clean

## Public surface

`@assistant-ui/react-langgraph`: `MessageContentThinking.signature`, `MessageContentReasoning.signature`, and `MessageContentAudio` in the assistant content union; api-surface regenerated. `@assistant-ui/react-langchain`: `convertLangChainContentBlock` returns `null` for a reasoning or thinking block with no visible text. Both covered by one patch changeset. `appendLangChainChunk` also changes shape for a first chunk that carries array content: it now runs through the same accumulation loop instead of being returned whole, so `tool_use` and `input_json_delta` blocks are stripped, adjacent text blocks collapse, and `tool_calls` is always present (`[]` when there are none) where it was previously omitted. No converted message part changes, because the converter already discarded both tool-call block types. Documentation and templates unchanged.
