### PR TITLE
fix: preserve highlighted code and copy headers in both renderers

### DIFF
--- a/.changeset/streamdown-nested-code-text.md
+++ b/.changeset/streamdown-nested-code-text.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/react-streamdown": patch
+"@assistant-ui/react-markdown": patch
 ---
 
-fix: keep code text from nested React children in code headers and syntax highlighters.
+fix: preserve rehype plugin markup in code blocks and pass the complete code text to code headers in both Markdown renderers.

--- a/.changeset/streamdown-nested-code-text.md
+++ b/.changeset/streamdown-nested-code-text.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: keep code text from nested React children in code headers and syntax highlighters.

--- a/apps/docs/content/docs/guides/streamdown.mdx
+++ b/apps/docs/content/docs/guides/streamdown.mdx
@@ -109,6 +109,8 @@ const StreamdownText = () => (
 );
 ```
 
+Both renderers preserve code markup from rehype plugins, such as `rehype-highlight` or `rehype-pretty-code`. In this case, `CodeHeader` receives the complete code text, but `SyntaxHighlighter` is skipped to preserve the plugin's markup. Plain string children still use `SyntaxHighlighter`.
+
 ## Props
 
 | Prop | Type | Default | Description |

--- a/packages/react-markdown/src/overrides/CodeOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.test.tsx
@@ -90,6 +90,39 @@ describe("CodeOverride language extraction", () => {
     const html = render("", undefined, CodeHeader);
     expect(html).toContain(`data-testid="header" data-language=""`);
   });
+
+  it("keeps the highlighter as an empty fence receives code", () => {
+    for (const [markdown, code] of [
+      ["```js\n```", ""],
+      ["```js\n", ""],
+      ["```js\nx", "x\n"],
+    ]) {
+      const html = renderToStaticMarkup(
+        <ReactMarkdown
+          components={{
+            pre: (props) => <PreOverride {...props} fallbackPre={Pre} />,
+            code: (props) => (
+              <CodeOverride
+                {...props}
+                components={{
+                  Pre,
+                  Code,
+                  CodeHeader: () => null,
+                  SyntaxHighlighter: FallbackHighlighter,
+                }}
+              />
+            ),
+          }}
+        >
+          {markdown}
+        </ReactMarkdown>,
+      );
+
+      expect(html).toContain(
+        `data-testid="fallback" data-language="js" data-code="${code}"`,
+      );
+    }
+  });
 });
 
 describe("CodeOverride rehype markup", () => {

--- a/packages/react-markdown/src/overrides/CodeOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { FC } from "react";
+import type { Root } from "hast";
+import ReactMarkdown from "react-markdown";
 import { CodeOverride, compareComponentsByLanguage } from "./CodeOverride";
-import { PreContext } from "./PreOverride";
+import { PreContext, PreOverride } from "./PreOverride";
 import type {
   CodeComponent,
   CodeHeaderProps,
@@ -87,6 +89,65 @@ describe("CodeOverride language extraction", () => {
     );
     const html = render("", undefined, CodeHeader);
     expect(html).toContain(`data-testid="header" data-language=""`);
+  });
+});
+
+describe("CodeOverride rehype markup", () => {
+  it("keeps decorated code and its language-specific header", () => {
+    const rehypeLines = () => (tree: Root) => {
+      for (const pre of tree.children) {
+        if (pre.type !== "element" || pre.tagName !== "pre") continue;
+        for (const code of pre.children) {
+          if (code.type !== "element" || code.tagName !== "code") continue;
+          code.children = code.children.flatMap<(typeof code.children)[number]>(
+            (child) =>
+              child.type === "text"
+                ? child.value.split(/(?<=\n)/).map((value) => ({
+                    type: "element" as const,
+                    tagName: "span",
+                    properties: { className: ["line"] },
+                    children: [{ type: "text" as const, value }],
+                  }))
+                : [child],
+          );
+        }
+      }
+    };
+    const code = "const x = 1;\nconst y = 2;\n";
+    const html = renderToStaticMarkup(
+      <ReactMarkdown
+        rehypePlugins={[rehypeLines]}
+        components={{
+          pre: (props) => <PreOverride {...props} fallbackPre={Pre} />,
+          code: (props) => (
+            <CodeOverride
+              {...props}
+              components={{
+                Pre,
+                Code,
+                CodeHeader: () => <header>fallback</header>,
+                SyntaxHighlighter: FallbackHighlighter,
+              }}
+              componentsByLanguage={{
+                js: {
+                  CodeHeader: ({ code, language }) => (
+                    <header data-language={language}>{code}</header>
+                  ),
+                  SyntaxHighlighter: FallbackHighlighter,
+                },
+              }}
+            />
+          ),
+        }}
+      >
+        {"```js\n" + code + "```"}
+      </ReactMarkdown>,
+    );
+
+    expect(html).toContain(`<header data-language="js">${code}</header>`);
+    expect(html).toContain('<span class="line">const x = 1;\n</span>');
+    expect(html).toContain('<span class="line">const y = 2;\n</span>');
+    expect(html).not.toContain('data-testid="fallback"');
   });
 });
 

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -2,6 +2,7 @@ import {
   type ComponentPropsWithoutRef,
   type ComponentType,
   type FC,
+  isValidElement,
   memo,
   useContext,
 } from "react";
@@ -18,6 +19,20 @@ import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { withDefaultProps } from "./withDefaults";
 import { DefaultCodeBlockContent } from "./defaultComponents";
 import { memoCompareNodes } from "../memoization";
+
+function extractCode(children: unknown): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) {
+    let code = "";
+    for (const child of children) code += extractCode(child);
+    return code;
+  }
+  if (isValidElement<{ children?: unknown }>(children)) {
+    return extractCode(children.props.children);
+  }
+  return "";
+}
 
 const CodeBlockOverride: FC<CodeOverrideProps> = ({
   node,
@@ -44,23 +59,29 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
 
   const language = parseLanguageClass(codeProps.className);
 
-  // if the code content is not string (due to rehype plugins), return a default code block
-  if (typeof children !== "string") {
-    return (
-      <DefaultCodeBlockContent
-        node={node}
-        components={{ Pre: WrappedPre, Code: WrappedCode }}
-        code={children}
-      />
-    );
-  }
-
   const SyntaxHighlighter: ComponentType<SyntaxHighlighterProps> =
     componentsByLanguage[language]?.SyntaxHighlighter ??
     FallbackSyntaxHighlighter;
 
   const CodeHeader: ComponentType<CodeHeaderProps> =
     componentsByLanguage[language]?.CodeHeader ?? FallbackCodeHeader;
+
+  if (typeof children !== "string") {
+    return (
+      <>
+        <CodeHeader
+          node={node}
+          language={language}
+          code={extractCode(children)}
+        />
+        <DefaultCodeBlockContent
+          node={node}
+          components={{ Pre: WrappedPre, Code: WrappedCode }}
+          code={children}
+        />
+      </>
+    );
+  }
 
   return (
     <DefaultCodeBlock

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -22,7 +22,6 @@ import { memoCompareNodes } from "../memoization";
 
 function extractCode(children: unknown): string {
   if (typeof children === "string") return children;
-  if (typeof children === "number") return String(children);
   if (Array.isArray(children)) {
     let code = "";
     for (const child of children) code += extractCode(child);

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -66,7 +66,7 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
   const CodeHeader: ComponentType<CodeHeaderProps> =
     componentsByLanguage[language]?.CodeHeader ?? FallbackCodeHeader;
 
-  if (typeof children !== "string") {
+  if (children != null && typeof children !== "string") {
     return (
       <>
         <CodeHeader
@@ -93,7 +93,7 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
         CodeHeader,
       }}
       language={language}
-      code={children}
+      code={children ?? ""}
     />
   );
 };

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -259,6 +259,7 @@ describe("createCodeAdapter integration", () => {
 
     it("keeps the highlighter as an empty fence receives code", () => {
       const AdaptedCode = createCodeAdapter({
+        CodeHeader: ({ code }) => <header data-testid="header">{code}</header>,
         SyntaxHighlighter: ({ code }) => <pre data-testid="syntax">{code}</pre>,
       });
       const components = { code: AdaptedCode, pre: PreOverride };
@@ -267,10 +268,13 @@ describe("createCodeAdapter integration", () => {
       );
 
       expect(screen.getByTestId("syntax").textContent).toBe("");
+      expect(screen.getByTestId("header").textContent).toBe("");
       rerender(<Streamdown components={components}>{"```js\n"}</Streamdown>);
       expect(screen.getByTestId("syntax").textContent).toBe("");
+      expect(screen.getByTestId("header").textContent).toBe("");
       rerender(<Streamdown components={components}>{"```js\nx"}</Streamdown>);
       expect(screen.getByTestId("syntax").textContent).toBe("x\n");
+      expect(screen.getByTestId("header").textContent).toBe("x\n");
     });
 
     it("omits null and boolean children from the code header", () => {

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -257,21 +257,34 @@ describe("createCodeAdapter integration", () => {
       expect(container.querySelector("[data-rehighlighted]")).toBeNull();
     });
 
-    it("handles empty children", () => {
-      const MockSyntax = vi.fn(({ code }) => (
-        <div data-testid="syntax-empty">{code || "empty"}</div>
-      ));
+    it("keeps the highlighter as an empty fence receives code", () => {
       const AdaptedCode = createCodeAdapter({
-        SyntaxHighlighter: MockSyntax,
+        SyntaxHighlighter: ({ code }) => <pre data-testid="syntax">{code}</pre>,
       });
+      const components = { code: AdaptedCode, pre: PreOverride };
+      const { rerender } = render(
+        <Streamdown components={components}>{"```js\n```"}</Streamdown>,
+      );
 
-      render(
-        <AdaptedCode className="language-js" data-block="true">
-          {""}
+      expect(screen.getByTestId("syntax").textContent).toBe("");
+      rerender(<Streamdown components={components}>{"```js\n"}</Streamdown>);
+      expect(screen.getByTestId("syntax").textContent).toBe("");
+      rerender(<Streamdown components={components}>{"```js\nx"}</Streamdown>);
+      expect(screen.getByTestId("syntax").textContent).toBe("x\n");
+    });
+
+    it("omits null and boolean children from the code header", () => {
+      const AdaptedCode = createCodeAdapter({
+        CodeHeader: ({ code }) => <header>{code}</header>,
+      });
+      const { container } = render(
+        <AdaptedCode data-block="true">
+          {[null, false, undefined, true, ";\n"]}
         </AdaptedCode>,
       );
 
-      expect(screen.getByTestId("syntax-empty").textContent).toBe("empty");
+      expect(container.querySelector("header")?.textContent).toBe(";\n");
+      expect(container.querySelector("pre > code")?.textContent).toBe(";\n");
     });
   });
 

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -209,23 +209,31 @@ describe("createCodeAdapter integration", () => {
       expect(screen.getByTestId("syntax").textContent).toBe("const x = 1;");
     });
 
-    it("extracts code from React element children", () => {
-      const MockSyntax = vi.fn(({ code }) => (
-        <div data-testid="syntax">{code}</div>
-      ));
+    it("preserves split and nested code text in the header and highlighter", () => {
       const AdaptedCode = createCodeAdapter({
-        SyntaxHighlighter: MockSyntax,
+        CodeHeader: ({ code }) => <header>{code}</header>,
+        SyntaxHighlighter: ({ code }) => <pre>{code}</pre>,
       });
 
-      const nestedElement = <span>nested code</span>;
-
-      render(
+      const { container } = render(
         <AdaptedCode className="language-js" data-block="true">
-          {nestedElement}
+          <span>const</span>
+          {" x = "}
+          <>
+            <span>
+              <span>{0}</span>
+            </span>
+            {[null, false, undefined, true, ";\n"]}
+          </>
         </AdaptedCode>,
       );
 
-      expect(MockSyntax).toHaveBeenCalled();
+      expect(container.querySelector("header")?.textContent).toBe(
+        "const x = 0;\n",
+      );
+      expect(container.querySelector("pre")?.textContent).toBe(
+        "const x = 0;\n",
+      );
     });
 
     it("handles empty children", () => {

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { createCodeAdapter } from "../adapters/code-adapter";
 import { PreOverride } from "../adapters/PreOverride";
+import type { Root } from "hast";
+import { Streamdown } from "streamdown";
 
 afterEach(cleanup);
 
@@ -209,31 +211,50 @@ describe("createCodeAdapter integration", () => {
       expect(screen.getByTestId("syntax").textContent).toBe("const x = 1;");
     });
 
-    it("preserves split and nested code text in the header and highlighter", () => {
+    it("keeps rehype markup and passes its text to the code header", () => {
+      const rehypeLines = () => (tree: Root) => {
+        for (const pre of tree.children) {
+          if (pre.type !== "element" || pre.tagName !== "pre") continue;
+          for (const code of pre.children) {
+            if (code.type !== "element" || code.tagName !== "code") continue;
+            code.children = code.children.flatMap<
+              (typeof code.children)[number]
+            >((child) =>
+              child.type === "text"
+                ? child.value.split(/(?<=\n)/).map((value) => ({
+                    type: "element" as const,
+                    tagName: "span",
+                    properties: { className: ["line"] },
+                    children: [{ type: "text" as const, value }],
+                  }))
+                : [child],
+            );
+          }
+        }
+      };
       const AdaptedCode = createCodeAdapter({
         CodeHeader: ({ code }) => <header>{code}</header>,
-        SyntaxHighlighter: ({ code }) => <pre>{code}</pre>,
+        SyntaxHighlighter: ({ code }) => <pre data-rehighlighted>{code}</pre>,
       });
-
+      const code = "const x = 1;\nconst y = 2;\n";
       const { container } = render(
-        <AdaptedCode className="language-js" data-block="true">
-          <span>const</span>
-          {" x = "}
-          <>
-            <span>
-              <span>{0}</span>
-            </span>
-            {[null, false, undefined, true, ";\n"]}
-          </>
-        </AdaptedCode>,
+        <Streamdown
+          components={{ code: AdaptedCode, pre: PreOverride }}
+          rehypePlugins={[rehypeLines]}
+        >
+          {"```js\n" + code + "```"}
+        </Streamdown>,
       );
 
-      expect(container.querySelector("header")?.textContent).toBe(
-        "const x = 0;\n",
-      );
-      expect(container.querySelector("pre")?.textContent).toBe(
-        "const x = 0;\n",
-      );
+      expect(container.querySelector("header")?.textContent).toBe(code);
+      expect(container.querySelector("pre > code")?.textContent).toBe(code);
+      expect(
+        Array.from(
+          container.querySelectorAll("pre > code > span.line"),
+          (line) => line.textContent,
+        ),
+      ).toEqual(["const x = 1;\n", "const y = 2;\n"]);
+      expect(container.querySelector("[data-rehighlighted]")).toBeNull();
     });
 
     it("handles empty children", () => {

--- a/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
+++ b/packages/react-streamdown/src/__tests__/code-adapter.integration.test.tsx
@@ -215,6 +215,11 @@ describe("createCodeAdapter integration", () => {
       const rehypeLines = () => (tree: Root) => {
         for (const pre of tree.children) {
           if (pre.type !== "element" || pre.tagName !== "pre") continue;
+          pre.properties = {
+            ...pre.properties,
+            className: ["shiki"],
+            "data-theme": "github-dark",
+          };
           for (const code of pre.children) {
             if (code.type !== "element" || code.tagName !== "code") continue;
             code.children = code.children.flatMap<
@@ -248,6 +253,9 @@ describe("createCodeAdapter integration", () => {
 
       expect(container.querySelector("header")?.textContent).toBe(code);
       expect(container.querySelector("pre > code")?.textContent).toBe(code);
+      const pre = container.querySelector("pre");
+      expect(pre?.className).toBe("shiki");
+      expect(pre?.getAttribute("data-theme")).toBe("github-dark");
       expect(
         Array.from(
           container.querySelectorAll("pre > code > span.line"),

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -29,16 +29,16 @@ interface CodeAdapterOptions {
   componentsByLanguage?: ComponentsByLanguage | undefined;
 }
 
-/**
- * Extracts code string from children.
- */
 function extractCode(children: unknown): string {
   if (typeof children === "string") return children;
-  if (!isValidElement(children)) return "";
-
-  const props = children.props as Record<string, unknown> | null;
-  if (props && typeof props.children === "string") {
-    return props.children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) {
+    let code = "";
+    for (const child of children) code += extractCode(child);
+    return code;
+  }
+  if (isValidElement<{ children?: unknown }>(children)) {
+    return extractCode(children.props.children);
   }
   return "";
 }

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -84,11 +84,8 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
       );
     }
 
-    // Block code - extract language and code content
     const language = parseLanguageClass(className);
-    const code = extractCode(children);
 
-    // Get language-specific or fallback components
     const SyntaxHighlighter =
       componentsByLanguage[language]?.SyntaxHighlighter ??
       UserSyntaxHighlighter;
@@ -97,10 +94,14 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
       componentsByLanguage[language]?.CodeHeader ?? UserCodeHeader;
 
     const headerElement = CodeHeader ? (
-      <CodeHeader node={node} language={language} code={code} />
+      <CodeHeader
+        node={node}
+        language={language}
+        code={extractCode(children)}
+      />
     ) : null;
 
-    if (SyntaxHighlighter) {
+    if (SyntaxHighlighter && typeof children === "string") {
       return (
         <>
           {headerElement}
@@ -108,7 +109,7 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
             node={node}
             components={{ Pre: DefaultPre, Code: DefaultCode }}
             language={language}
-            code={code}
+            code={children}
           />
         </>
       );

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -101,7 +101,10 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
       />
     ) : null;
 
-    if (SyntaxHighlighter && typeof children === "string") {
+    if (
+      SyntaxHighlighter &&
+      (children == null || typeof children === "string")
+    ) {
       return (
         <>
           {headerElement}
@@ -109,7 +112,7 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
             node={node}
             components={{ Pre: DefaultPre, Code: DefaultCode }}
             language={language}
-            code={children}
+            code={children ?? ""}
           />
         </>
       );

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -14,6 +14,7 @@ import type {
   ComponentsByLanguage,
   SyntaxHighlighterProps,
 } from "../types";
+import { useStreamdownPreProps } from "./PreOverride";
 
 type CodeProps = ComponentPropsWithoutRef<"code"> & {
   node?: Element | undefined;
@@ -72,6 +73,8 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     "data-block": dataBlock,
     ...props
   }: CodeProps & { "data-block"?: string }) {
+    const preProps = useStreamdownPreProps();
+
     if (!dataBlock) {
       return (
         <code
@@ -120,7 +123,7 @@ export function createCodeAdapter(options: CodeAdapterOptions) {
     return (
       <>
         {headerElement}
-        <DefaultPre node={node}>
+        <DefaultPre {...preProps} node={node}>
           <code className={className} {...props}>
             {children}
           </code>

--- a/packages/react-streamdown/src/adapters/code-adapter.tsx
+++ b/packages/react-streamdown/src/adapters/code-adapter.tsx
@@ -31,7 +31,6 @@ interface CodeAdapterOptions {
 
 function extractCode(children: unknown): string {
   if (typeof children === "string") return children;
-  if (typeof children === "number") return String(children);
   if (Array.isArray(children)) {
     let code = "";
     for (const child of children) code += extractCode(child);

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -153,8 +153,8 @@
   },
   "@assistant-ui/react-markdown": {
     ".": {
-      "min": 7397,
-      "gzip": 3056
+      "min": 8341,
+      "gzip": 3357
     },
     "./code-fence": {
       "min": 84,


### PR DESCRIPTION
## Problem

In `@assistant-ui/react-streamdown` 0.3.13, code blocks can appear empty when a rehype plugin wraps code text in elements. The initial fix restores text but discards the plugin markup. `@assistant-ui/react-markdown` 0.14.14 preserves that markup but loses the code header and copy control.

The regression tests reproduce this with a fenced JavaScript block and a rehype plugin that wraps each line in a span. Each renderer receives a code header and a custom highlighter.

## Root cause

The two renderers treated plugin-produced elements differently. One passed extracted text to a second highlighter; the other skipped the header along with that highlighter.

## Change

Both renderers preserve plugin markup and send the complete text to the code header. Plain strings still use the custom highlighter. Language-specific overrides follow the same rule.

## Verification

The new regressions fail before the correction and pass after it. Run these focused checks from each package directory:

```sh
# packages/react-streamdown
node node_modules/vitest/vitest.mjs run src/__tests__/code-adapter.integration.test.tsx src/__tests__/code-adapter.test.tsx src/__tests__/components-adapter.test.tsx src/__tests__/StreamdownText.test.tsx

# packages/react-markdown
node node_modules/vitest/vitest.mjs run src/overrides/CodeOverride.test.tsx src/overrides/PreOverride.test.tsx src/primitives/MarkdownText.test.tsx
```

All 84 tests pass. The package builds and scoped lint and formatting checks pass.

A production browser consumer exercises all eight variants at 1440px and 390px, in both themes, during streaming and after completion. Complete code text and plugin markup remain visible. Native keyboard checks confirm visible focus without clipping. A pointer copy check confirms the complete clipboard text.

## Public surface

A patch changeset covers `@assistant-ui/react-streamdown` and `@assistant-ui/react-markdown`. The Streamdown guide describes the shared behavior. Export signatures, documentation snippets, templates, and API-reference declarations stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7V5rPho1kejry3TAV6hhsSS5xn2UFuE30cu2E6-Hw99IfioIsboyJL5vXcI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->