### PR TITLE
fix(cli): preserve condition precedence in primitive migrations

### DIFF
--- a/.changeset/fix-codemod-condition-precedence.md
+++ b/.changeset/fix-codemod-condition-precedence.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: preserve condition precedence when the codemod migrates primitive filters to AuiIf

--- a/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
+++ b/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
@@ -20,6 +20,15 @@ function applyTransform(source: string): string | null {
   return transform(fileInfo, api, {});
 }
 
+function expectTransform(input: string, expected: string) {
+  const output = applyTransform(input);
+  if (output === null)
+    throw new Error("The codemod did not transform the input");
+  expect(
+    j.types.astNodesAreEquivalent(j(output).nodes(), j(expected).nodes()),
+  ).toBe(true);
+}
+
 describe("primitive-if-to-aui-if", () => {
   // ── ThreadPrimitive.If ─────────────────────────────────────────────
 
@@ -49,7 +58,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ThreadPrimitive.If empty={false}>", () => {
@@ -77,7 +86,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ThreadPrimitive.If running>", () => {
@@ -105,7 +114,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ThreadPrimitive.If running={false}>", () => {
@@ -133,7 +142,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ThreadPrimitive.If disabled>", () => {
@@ -161,7 +170,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should handle self-closing ThreadPrimitive.If", () => {
@@ -181,7 +190,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
   });
 
@@ -213,7 +222,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If assistant>", () => {
@@ -241,7 +250,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If copied>", () => {
@@ -269,7 +278,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If copied={false}>", () => {
@@ -297,7 +306,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If speaking>", () => {
@@ -325,35 +334,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
-    });
-
-    it("should migrate <MessagePrimitive.If speaking={false}>", () => {
-      const input = `
-import { MessagePrimitive } from "@assistant-ui/react";
-
-function MyComponent() {
-  return (
-    <MessagePrimitive.If speaking={false}>
-      <SpeakIcon />
-    </MessagePrimitive.If>
-  );
-}
-`;
-
-      const expected = `
-import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
-
-function MyComponent() {
-  return (
-    <AuiIf condition={(s) => !s.message.speech != null}>
-      <SpeakIcon />
-    </AuiIf>
-  );
-}
-`;
-
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If last>", () => {
@@ -381,7 +362,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If hasBranches>", () => {
@@ -409,7 +390,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If hasAttachments>", () => {
@@ -437,7 +418,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If hasContent>", () => {
@@ -465,7 +446,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <MessagePrimitive.If lastOrHover>", () => {
@@ -493,7 +474,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
   });
 
@@ -525,7 +506,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ComposerPrimitive.If editing={false}>", () => {
@@ -553,7 +534,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should migrate <ComposerPrimitive.If dictation>", () => {
@@ -581,7 +562,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
   });
 
@@ -613,7 +594,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should handle self-closing <ThreadPrimitive.Empty />", () => {
@@ -633,7 +614,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should handle ThreadPrimitive.Empty alongside ThreadPrimitive.If", () => {
@@ -671,7 +652,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
   });
 
@@ -703,7 +684,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should handle multiple Primitive.If in the same file", () => {
@@ -741,7 +722,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should not transform if no @assistant-ui import", () => {
@@ -799,7 +780,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
 
     it("should preserve other JSX elements alongside migrated ones", () => {
@@ -833,7 +814,7 @@ function MyComponent() {
 }
 `;
 
-      expect(applyTransform(input)?.trim()).toBe(expected.trim());
+      expectTransform(input, expected);
     });
   });
 });
@@ -935,5 +916,59 @@ function MyComponent() {
     expect(output).toContain(
       "(s.message.metadata.submittedFeedback?.type ?? null) === null",
     );
+  });
+});
+
+describe("condition precedence", () => {
+  it.each([
+    {
+      jsx: "<MessagePrimitive.If speaking={false} />",
+      hidden: { message: { speech: { status: "running" } } },
+      visible: { message: { speech: null } },
+    },
+    {
+      jsx: "<ComposerPrimitive.If dictation={false} />",
+      hidden: { composer: { dictation: { status: "running" } } },
+      visible: { composer: { dictation: null } },
+    },
+    {
+      jsx: "<MessagePrimitive.If lastOrHover copied />",
+      hidden: {
+        message: { isHovering: true, isLast: false, isCopied: false },
+      },
+      visible: {
+        message: { isHovering: true, isLast: false, isCopied: true },
+      },
+    },
+    {
+      jsx: "<MessagePrimitive.If copied lastOrHover />",
+      hidden: {
+        message: { isHovering: false, isLast: true, isCopied: false },
+      },
+      visible: {
+        message: { isHovering: false, isLast: true, isCopied: true },
+      },
+    },
+    {
+      jsx: "<MessagePrimitive.If hasAttachments={false} copied />",
+      hidden: { message: { role: "assistant", isCopied: false } },
+      visible: { message: { role: "assistant", isCopied: true } },
+    },
+  ])("preserves the filters in $jsx", ({ jsx, hidden, visible }) => {
+    const output = applyTransform(`
+import { MessagePrimitive, ComposerPrimitive } from "@assistant-ui/react";
+const view = ${jsx};
+`);
+    if (output === null)
+      throw new Error("The codemod did not transform the input");
+    const arrow = j(output).find(j.ArrowFunctionExpression).nodes()[0];
+    if (!arrow) throw new Error("The codemod did not produce a condition");
+    const condition = new Function(
+      "s",
+      `return (${j(arrow.body).toSource()});`,
+    );
+
+    expect(condition(hidden)).toBe(false);
+    expect(condition(visible)).toBe(true);
   });
 });

--- a/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
+++ b/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
@@ -162,8 +162,8 @@ const getAttrValue = (j: any, attr: any): unknown => {
 };
 
 const buildConditionString = (fragments: ConditionFragment[]): string => {
-  const parts = fragments.map((f) =>
-    f.negated ? `!${f.expression}` : f.expression,
+  const parts = fragments.map(
+    (f) => `${f.negated ? "!" : ""}(${f.expression})`,
   );
   if (parts.length === 1) return parts[0]!;
   return parts.join(" && ");


### PR DESCRIPTION
## Problem

After migration, `speaking={false}` shows content during active speech. Combined filters can also ignore `copied` when an OR condition is true.

Minimal reproduction at base `928c580f4132496ee6ae9dc5a64fe44ca4bfd1b7` (`assistant-ui` version `0.0.114`):

```tsx
import { MessagePrimitive } from "@assistant-ui/react";
const view = <MessagePrimitive.If speaking={false} />;
```

With this input in `fixture.tsx`, the command from `packages/cli` is:

```sh
./node_modules/.bin/jscodeshift -t src/codemods/v0-12/primitive-if-to-aui-if.ts fixture.tsx --parser tsx --run-in-band
```

The generated predicate is `!s.message.speech != null`, which returns `true` even when speech is active.

## Root cause

The condition builder applies `!` and joins fragments with `&&` without parentheses. Operator precedence changes the original filters.

## Change

Each fragment has parentheses before negation or combination. Speech and dictation filters retain their meaning, and OR conditions cannot bypass adjacent filters. Existing fixture tests compare syntax trees instead of optional parentheses.

## Verification

The actual codemod CLI reproduction returned the incorrect value before the correction and the expected value after it. Five behavioral regressions failed before the correction and pass after it.

From `packages/cli`, `./node_modules/.bin/vitest run src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts` passed all 41 tests. Changed-file Oxlint and TypeScript diagnostics passed.

## Public surface

The `assistant-ui` CLI has a patch changeset. Exports, runtime APIs, documentation, and templates are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kugkvSqh_mQT62kjv-BGeXaL4uDnhIx_QYsJ1f1Rd9uAgb4BF9tus969NL0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->