### PR TITLE
fix(cli): keep the selected directory when init delegates to create

### DIFF
--- a/.changeset/cli-init-forward-target-dir.md
+++ b/.changeset/cli-init-forward-target-dir.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: keep the directory selected with `--cwd` when init delegates to create

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -84,7 +84,7 @@ export const init = new Command()
       }
 
       const createArgs: string[] = [];
-      if (projectDirectory) createArgs.push(projectDirectory);
+      if (projectDirectory) createArgs.push(targetDir);
       if (presetUrl) createArgs.push("--preset", presetUrl);
       if (opts.useNpm) createArgs.push("--use-npm");
       if (opts.usePnpm) createArgs.push("--use-pnpm");

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   init,
@@ -66,11 +69,67 @@ describe("init command", () => {
       from: "node",
     });
 
-    expect(parseAsyncSpy).toHaveBeenCalledWith(["my-app", "--use-pnpm"], {
-      from: "user",
-    });
+    expect(parseAsyncSpy).toHaveBeenCalledWith(
+      [path.resolve("my-app"), "--use-pnpm"],
+      { from: "user" },
+    );
 
     parseAsyncSpy.mockRestore();
+  });
+
+  it("forwards the directory selected with --cwd to create", async () => {
+    const selected = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "aui-init-")),
+    );
+    const parseAsyncSpy = vi
+      .spyOn(create, "parseAsync")
+      .mockResolvedValue(create);
+
+    try {
+      await init.parseAsync(
+        ["node", "init", "my-app", "--cwd", selected, "--use-pnpm"],
+        { from: "node" },
+      );
+
+      expect(parseAsyncSpy).toHaveBeenCalledWith(
+        [path.join(selected, "my-app"), "--use-pnpm"],
+        { from: "user" },
+      );
+    } finally {
+      parseAsyncSpy.mockRestore();
+      fs.rmSync(selected, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a relative --cwd against the caller directory", async () => {
+    const root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "aui-init-")),
+    );
+    const caller = path.join(root, "caller");
+    const selected = path.join(root, "selected");
+    fs.mkdirSync(caller);
+    fs.mkdirSync(selected);
+    const previousCwd = process.cwd();
+    const parseAsyncSpy = vi
+      .spyOn(create, "parseAsync")
+      .mockResolvedValue(create);
+    process.chdir(caller);
+
+    try {
+      await init.parseAsync(
+        ["node", "init", "my-app", "--cwd", "../selected"],
+        { from: "node" },
+      );
+
+      expect(parseAsyncSpy).toHaveBeenCalledWith(
+        [path.join(selected, "my-app")],
+        { from: "user" },
+      );
+    } finally {
+      process.chdir(previousCwd);
+      parseAsyncSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("delegates to create.parseAsync with preset args", async () => {


### PR DESCRIPTION
## Problem

`assistant-ui init <name> --cwd <dir>` scaffolds into the caller directory instead of the selected one. from any directory other than `/tmp`, with no existing `my-app`:

```sh
assistant-ui init my-app --cwd /tmp --skip-install
```

the project lands in `./my-app` next to the caller, not in `/tmp/my-app`. reported against 0.0.114.

## Root cause

`init` resolves the target itself at `packages/cli/src/commands/init.ts:65` and uses it for the `components.json` and `package.json` existence checks, then hands `create` the bare positional it was given. `create` resolves that against `process.cwd()` (`packages/cli/src/commands/create.ts:544`), so `--cwd` is dropped at the handoff and only the checks honour it.

## Change

`init` forwards the resolved target instead of the raw name. `create` drives every filesystem operation off `path.resolve` of its positional already, including `pkg.name = path.basename(projectDir)` at `packages/cli/src/lib/create-project.ts:266`, so an absolute path yields the same project name and the same layout as the relative one did when the two directories happened to agree.

the no-project-name case is deliberately untouched: `createArgs` stays empty and `create` keeps prompting for a name and scaffolding a child of the caller directory. making `--cwd` mean "the project directory" there is a separate behaviour change with its own edge cases (a non-empty selected directory would start failing hard, and `init --cwd .` would diverge from a bare `init` in the same place), so it is not folded in here.

## Verification

`pnpm --dir packages/cli test`: 27 files, 317 tests passed.

the three `init.test.ts` cases that pin the forwarded args fail on the unpatched source and pass with it, confirmed by stashing the one-line change and rerunning:

```
× delegates to create.parseAsync with correct args when no package.json exists
× forwards the directory selected with --cwd to create
× resolves a relative --cwd against the caller directory
Tests  3 failed | 6 passed (9)
```

the two new cases cover an absolute `--cwd` and a relative one resolved against the caller, both asserting the exact positional handed to `create`.

`pnpm exec oxlint` and `pnpm exec oxfmt` clean on both touched files.

## Public surface

`assistant-ui` gets a patch changeset. no exports, options, help text, docs, or templates change.

---

split out of #6884 by @ephraimduncan, which carried this fix plus an unrelated rewrite of the `cd` guidance `create` prints. the guidance work follows separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.z3V7SQDSSQNPFZps9HRb_lxDIelww14fuBf4gib9WK7DXaVP_5ouveMrLBI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->