### PR TITLE
fix(cli): quote the project directory in create's cd instructions

### DIFF
--- a/.changeset/cli-create-cd-guidance.md
+++ b/.changeset/cli-create-cd-guidance.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: quote the project directory in the `cd` instructions create prints

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -388,6 +388,39 @@ export function resolveCreateProjectDirectory(params: {
   return undefined;
 }
 
+export function resolveProjectDirectoryGuidance(params: {
+  absoluteProjectDir: string;
+  cwd?: string;
+  platform?: NodeJS.Platform;
+}): { display: string; cdCommand: string } {
+  const {
+    absoluteProjectDir,
+    cwd = process.cwd(),
+    platform = process.platform,
+  } = params;
+  const isWindows = platform === "win32";
+  const pathApi = isWindows ? path.win32 : path.posix;
+
+  const relative = pathApi.relative(cwd, absoluteProjectDir);
+  const escapesCwd =
+    relative === ".." || relative.startsWith(`..${pathApi.sep}`);
+  const display =
+    relative && !escapesCwd && !pathApi.isAbsolute(relative)
+      ? relative
+      : absoluteProjectDir;
+
+  const target = display.startsWith("-")
+    ? `.${pathApi.sep}${display}`
+    : display;
+  const quoted = (isWindows ? /^[\w@.:/\\+-]+$/ : /^[\w@./+-]+$/).test(target)
+    ? target
+    : isWindows
+      ? `"${target}"`
+      : `'${target.replaceAll("'", "'\\''")}'`;
+
+  return { display, cdCommand: `cd ${quoted}` };
+}
+
 const PLAYGROUND_PRESET_BASE_URL =
   "https://www.assistant-ui.com/playground/init";
 
@@ -542,11 +575,13 @@ export const create = new Command()
 
     // Check directory
     const absoluteProjectDir = path.resolve(resolvedProjectDirectory);
+    const { display: displayProjectDir, cdCommand } =
+      resolveProjectDirectoryGuidance({ absoluteProjectDir });
     try {
       const files = fs.readdirSync(absoluteProjectDir);
       if (files.length > 0) {
         logger.error(
-          `Directory ${resolvedProjectDirectory} already exists and is not empty`,
+          `Directory ${displayProjectDir} already exists and is not empty`,
         );
         process.exit(1);
       }
@@ -557,12 +592,12 @@ export const create = new Command()
         // Directory doesn't exist — good, proceed
       } else if (code === "ENOTDIR") {
         logger.error(
-          `${resolvedProjectDirectory} already exists and is not a directory`,
+          `${displayProjectDir} already exists and is not a directory`,
         );
         process.exit(1);
       } else {
         const message = err instanceof Error ? err.message : String(err);
-        logger.error(`Cannot access ${resolvedProjectDirectory}: ${message}`);
+        logger.error(`Cannot access ${displayProjectDir}: ${message}`);
         process.exit(1);
       }
     }
@@ -700,7 +735,7 @@ export const create = new Command()
         logger.break();
         logger.error("Project created with missing components.");
         logger.info("Retry the component install with:");
-        logger.info(`  cd ${resolvedProjectDirectory}`);
+        logger.info(`  ${cdCommand}`);
         logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
         process.exit(1);
       }
@@ -758,7 +793,7 @@ export const create = new Command()
       }
 
       logger.info("Next steps:");
-      logger.info(`  cd ${resolvedProjectDirectory}`);
+      logger.info(`  ${cdCommand}`);
       if (opts.skipInstall) {
         logger.info(`  ${pm} install`);
       }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -412,6 +412,9 @@ export function resolveProjectDirectoryGuidance(params: {
   const target = display.startsWith("-")
     ? `.${pathApi.sep}${display}`
     : display;
+  // Neither Windows shell has a literal quoting form the other accepts: cmd
+  // reads single quotes as part of the name, and double quotes still expand
+  // %VAR% there and $var in PowerShell.
   const quoted = (isWindows ? /^[\w@.:/\\+-]+$/ : /^[\w@./+-]+$/).test(target)
     ? target
     : isWindows

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   create,
@@ -5,6 +9,7 @@ import {
   resolvePresetUrl,
   resolveProject,
   resolveScaffoldSelector,
+  resolveProjectDirectoryGuidance,
   PROJECT_METADATA,
 } from "../../src/commands/create";
 
@@ -342,6 +347,95 @@ describe("resolveCreateProjectDirectory", () => {
       }),
     ).toBe("custom-app");
   });
+});
+
+describe("resolveProjectDirectoryGuidance", () => {
+  it.each([
+    { abs: "/work/my-app", display: "my-app", cdCommand: "cd my-app" },
+    { abs: "/work/a/b", display: "a/b", cdCommand: "cd a/b" },
+    { abs: "/work/my app", display: "my app", cdCommand: "cd 'my app'" },
+    { abs: "/work/it's", display: "it's", cdCommand: "cd 'it'\\''s'" },
+    {
+      abs: "/work/$HOME & co",
+      display: "$HOME & co",
+      cdCommand: "cd '$HOME & co'",
+    },
+    { abs: "/work/-dash", display: "-dash", cdCommand: "cd ./-dash" },
+    {
+      abs: "/opt/apps/x",
+      display: "/opt/apps/x",
+      cdCommand: "cd /opt/apps/x",
+    },
+    {
+      abs: "/opt/apps/my app",
+      display: "/opt/apps/my app",
+      cdCommand: "cd '/opt/apps/my app'",
+    },
+  ])("describes $abs on posix", ({ abs, display, cdCommand }) => {
+    expect(
+      resolveProjectDirectoryGuidance({
+        absoluteProjectDir: abs,
+        cwd: "/work",
+        platform: "linux",
+      }),
+    ).toEqual({ display, cdCommand });
+  });
+
+  it.each([
+    {
+      abs: "C:\\Users\\me\\my-app",
+      display: "my-app",
+      cdCommand: "cd my-app",
+    },
+    { abs: "C:\\Users\\me\\a\\b", display: "a\\b", cdCommand: "cd a\\b" },
+    {
+      abs: "C:\\Users\\me\\my app",
+      display: "my app",
+      cdCommand: 'cd "my app"',
+    },
+    {
+      abs: "D:\\other\\app",
+      display: "D:\\other\\app",
+      cdCommand: "cd D:\\other\\app",
+    },
+  ])("describes $abs on windows", ({ abs, display, cdCommand }) => {
+    expect(
+      resolveProjectDirectoryGuidance({
+        absoluteProjectDir: abs,
+        cwd: "C:\\Users\\me",
+        platform: "win32",
+      }),
+    ).toEqual({ display, cdCommand });
+  });
+
+  it
+    .runIf(process.platform !== "win32")
+    .each(["my-app", "my app", "it's a $HOME & co", "-dash"])(
+    "emits a cd a posix shell can run for %s",
+    (name) => {
+      const cwd = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "aui-guidance-")),
+      );
+      const target = path.join(cwd, name);
+      fs.mkdirSync(target);
+
+      try {
+        const { cdCommand } = resolveProjectDirectoryGuidance({
+          absoluteProjectDir: target,
+          cwd,
+        });
+        const result = spawnSync("/bin/sh", ["-c", `${cdCommand} && pwd -P`], {
+          cwd,
+          encoding: "utf8",
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe(target);
+      } finally {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("resolvePresetUrl", () => {


### PR DESCRIPTION
## Problem

`create` builds the shell commands it prints by interpolating the project directory unquoted, so any directory whose name needs quoting produces a `cd` the user cannot paste back:

```sh
assistant-ui create "my app" --skip-install
# Next steps:
#   cd my app        <- enters $HOME
```

the same two lines carry the retry hint after a partial component install, and the three directory errors above them print the raw positional too.

this gets more reachable with #6899: `init` now forwards the resolved target to `create`, so `assistant-ui init my-app --cwd "/tmp/my dir"` prints an absolute path with a space in it, where before it printed the bare name.

## Root cause

both `cd` lines (`packages/cli/src/commands/create.ts:738` and `:796`) and the three directory messages interpolate `resolvedProjectDirectory`, the positional exactly as the user or `init` typed it. nothing quotes it, and nothing relates it back to where the user is standing.

## Change

one pure helper, `resolveProjectDirectoryGuidance`, returns the display path and the `cd` command, and the six call sites use it.

- relativize only when the target sits under the caller directory. `create /opt/apps/x` from `~` keeps printing `/opt/apps/x` rather than `../../opt/apps/x`.
- quote only when the path needs it, so the common `cd my-app` is byte for byte what it prints today. a leading `-` gets a `./` prefix instead of being read as an option.
- POSIX gets `'...'` with `'\''` escaping, which is literal for every byte a directory name can hold.
- Windows gets `"..."`. that covers the spaces that actually occur, in cmd.exe and PowerShell both, and it is deliberately not claimed as an escape: cmd expands `%VAR%` inside double quotes and PowerShell interpolates `$var` and backticks. no quoting form is literal in both dialects (PowerShell wants `'...'` with `''` doubling, cmd reads `'` as part of the name), so a directory named `%TEMP%app` or `my$app` stays exactly as unhandled as it is on `main`, which prints the bare path for it today. this is a narrowing of the broken cases, never a widening. the constraint is written on the branch so it does not get "fixed" into single quotes later.
- `cd -LiteralPath` would cover PowerShell alone and break cmd.exe and Git Bash, and `process.platform === "win32"` names the OS, not the shell, so there is no dialect to branch on. a cross-drive `cd D:\x` from `C:` likewise needs `cd /d` in cmd and rejects `/d` in PowerShell; that case prints the same string on `main` and is left alone here.

the helper takes `cwd` and `platform` as optional overrides for one reason: it lets the Windows output be asserted from a POSIX runner, which is the leg CI would otherwise never execute.

## Verification

`pnpm --dir packages/cli test`: 27 files, 331 tests passed.

16 new cases in `create.test.ts`, all of which run on this machine and on Linux CI:

- 8 POSIX shapes: plain name, nested relative, space, apostrophe, `$HOME & co`, leading dash, outside the caller directory, and outside with a space.
- 4 Windows shapes asserted through `platform: "win32"`: plain name stays bare, a backslash path stays bare, a space gets `"..."`, a different drive falls back to the absolute path.
- 4 that hand the emitted command to `/bin/sh` against a real directory and check `pwd -P` lands inside it, covering `my app`, `it's a $HOME & co` and `-dash`.

`pnpm exec tsc -p packages/cli/tsconfig.json --noEmit` reports the same 5 pre-existing errors as `main`, all in `src/codemods/v0-12/assistant-api-to-aui.ts`, none in the touched files. `oxlint` and `oxfmt` clean.

## Public surface

`assistant-ui` gets a patch changeset. `resolveProjectDirectoryGuidance` is a new export from `src/commands/create.ts`, which the CLI does not publish as a module entry; it sits with the other pure helpers there (`resolveCreateProjectDirectory`, `resolvePresetUrl`, `resolveScaffoldSelector`) that exist to be unit tested. no options, help text, docs, or templates change.

---

split out of #6884 by @ephraimduncan, whose version of this carried a `cd -LiteralPath` PowerShell branch. #6899 is the other half.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nlmVAHWlb3ZUFY6rCs9VOZkl2xtTEV4MSCuNrsVgX4ErRP1w3foZu03BUvY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->