### PR TITLE
fix(langgraph): stop an anthropic citations_delta appending "undefined"

### DIFF
--- a/.changeset/olive-flowers-attack.md
+++ b/.changeset/olive-flowers-attack.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: merge anthropic citation deltas instead of appending "undefined"

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1275,6 +1275,8 @@ type MessageContentReasoningSummaryText = {
 type MessageContentText = {
   type: "text" | "text_delta";
   text: string;
+  index?: number;
+  citations?: readonly unknown[];
 };
 
 type MessageContentThinking = {

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -179,6 +179,43 @@ describe("appendLangChainChunk continuation content", () => {
     ]);
   });
 
+  it("accumulates one citation per delta across a cited answer", () => {
+    const first = { type: "char_location", cited_text: "Paris" };
+    const second = { type: "char_location", cited_text: "France" };
+    const chunk = (content: unknown) =>
+      ({
+        type: "AIMessageChunk",
+        id: "ai-1",
+        content,
+      }) as unknown as LangChainMessageChunk;
+
+    let merged = append(
+      undefined,
+      chunk([{ index: 0, type: "text_delta", text: "Paris" }]),
+    );
+    merged = append(
+      merged,
+      chunk([{ index: 0, type: "text", citations: [first] }]),
+    );
+    merged = append(
+      merged,
+      chunk([{ index: 0, type: "text_delta", text: " is in France" }]),
+    );
+    merged = append(
+      merged,
+      chunk([{ index: 0, type: "text", citations: [second] }]),
+    );
+
+    expect(merged.content).toEqual([
+      {
+        index: 0,
+        type: "text",
+        text: "Paris is in France",
+        citations: [first, second],
+      },
+    ]);
+  });
+
   it("merges a citation-only text_delta into the preceding text", () => {
     const first = append(undefined, {
       type: "AIMessageChunk",

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -147,6 +147,94 @@ describe("appendLangChainChunk continuation content", () => {
     expect(merged.content).toEqual([{ type: "text", text: "Hello world" }]);
   });
 
+  it("merges a citation-only delta into the preceding text", () => {
+    const first = append(undefined, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: [{ index: 0, type: "text", text: "Paris" }],
+    } as unknown as LangChainMessageChunk);
+
+    const merged = append(first, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: [
+        {
+          index: 0,
+          type: "text",
+          citations: [{ type: "char_location", cited_text: "Paris" }],
+        },
+      ],
+    } as unknown as LangChainMessageChunk);
+
+    expect(merged.content).toEqual([
+      {
+        index: 0,
+        type: "text",
+        text: "Paris",
+        citations: [{ type: "char_location", cited_text: "Paris" }],
+      },
+    ]);
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "text", text: "Paris" },
+    ]);
+  });
+
+  it("merges a citation-only text_delta into the preceding text", () => {
+    const first = append(undefined, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: [{ index: 0, type: "text_delta", text: "Paris" }],
+    } as unknown as LangChainMessageChunk);
+
+    const merged = append(first, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: [
+        {
+          index: 0,
+          type: "text_delta",
+          citations: [{ type: "char_location", cited_text: "Paris" }],
+        },
+      ],
+    } as unknown as LangChainMessageChunk);
+
+    expect(merged.content).toEqual([
+      {
+        index: 0,
+        type: "text",
+        text: "Paris",
+        citations: [{ type: "char_location", cited_text: "Paris" }],
+      },
+    ]);
+  });
+
+  it("opens a text block for a citation-only delta with no text to merge into", () => {
+    const merged = append(undefined, {
+      type: "AIMessageChunk",
+      id: "ai-1",
+      content: [
+        {
+          index: 0,
+          type: "text",
+          citations: [{ type: "char_location", cited_text: "Paris" }],
+        },
+        { index: 0, type: "text", text: "Paris" },
+      ],
+    } as unknown as LangChainMessageChunk);
+
+    expect(merged.content).toEqual([
+      {
+        index: 0,
+        type: "text",
+        text: "Paris",
+        citations: [{ type: "char_location", cited_text: "Paris" }],
+      },
+    ]);
+    expect(convertLangChainMessages(merged, {})).toHaveProperty("content", [
+      { type: "text", text: "Paris" },
+    ]);
+  });
+
   it("keeps text after intervening content and joins adjacent text deltas", () => {
     const merged = appendLangChainChunk(
       { id: "ai-1", type: "ai", content: [{ type: "text", text: "Hello" }] },

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -153,10 +153,17 @@ export const appendLangChainChunk = (
       const lastIndex = newContent.length - 1;
       const last = newContent[lastIndex];
       if (item.type === "text" || item.type === "text_delta") {
+        // `@langchain/anthropic` sends a citations_delta as a `text` block that
+        // carries only `citations`, so the declared `text` field can be absent.
+        const text = item.text ?? "";
         if (last?.type === "text") {
-          newContent[lastIndex] = { ...last, text: last.text + item.text };
+          newContent[lastIndex] = mergeDefined(last, {
+            ...item,
+            type: "text",
+            text: last.text + text,
+          });
         } else {
-          newContent.push({ type: "text", text: item.text });
+          newContent.push({ ...item, type: "text", text });
         }
       } else if (item.type === "thinking") {
         const index =

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -153,14 +153,21 @@ export const appendLangChainChunk = (
       const lastIndex = newContent.length - 1;
       const last = newContent[lastIndex];
       if (item.type === "text" || item.type === "text_delta") {
-        // `@langchain/anthropic` sends a citations_delta as a `text` block that
-        // carries only `citations`, so the declared `text` field can be absent.
+        // `@langchain/anthropic` sends each citation as its own citations_delta:
+        // a `text` block carrying only `citations` and no `text` field. Array
+        // fields reach `_mergeLists` upstream, which appends rather than
+        // replaces, so the citations of one answer accumulate across deltas.
         const text = item.text ?? "";
         if (last?.type === "text") {
+          const citations = [
+            ...(last.citations ?? []),
+            ...(item.citations ?? []),
+          ];
           newContent[lastIndex] = mergeDefined(last, {
             ...item,
             type: "text",
             text: last.text + text,
+            ...(citations.length > 0 && { citations }),
           });
         } else {
           newContent.push({ ...item, type: "text", text });

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -36,6 +36,8 @@ export type LangChainToolCall = {
 export type MessageContentText = {
   type: "text" | "text_delta";
   text: string;
+  index?: number;
+  citations?: readonly unknown[];
 };
 
 export type MessageContentImageUrl = {


### PR DESCRIPTION
## Problem

with citations enabled on an anthropic model, every cited sentence ends in a literal `undefined`:

```ts
import { appendLangChainChunk } from "@assistant-ui/react-langgraph";

let m = appendLangChainChunk(undefined, {
  id: "a", type: "AIMessageChunk",
  content: [{ index: 0, type: "text", text: "Paris" }],
});
m = appendLangChainChunk(m, {
  id: "a", type: "AIMessageChunk",
  content: [{ index: 0, type: "text", citations: [{ type: "char_location", cited_text: "Paris" }] }],
});
// m.content -> [{ type: "text", text: "Parisundefined" }]
```

reproduces on `4775f93` (current main), through both the `text` and the `text_delta` branch.

## Root cause

`@langchain/anthropic` turns a `citations_delta` into a content block typed `text` that carries `citations` and no `text` field (`dist/utils/message_outputs.js`, the `content_block_delta` branch that forces `type: "text"`). `MessageContentText` declares `text: string`, so the accumulation branch concatenated it unguarded and stringified the missing value into the answer.

## Change

the text branch now guards the concatenation and routes the block's remaining fields through `mergeDefined`, so a citation-only delta lands its metadata on the accumulated block instead of appending `undefined`. this is what `#6896` already does for every other block type.

anthropic sends one `citations_delta` per citation, so the citations of a single answer arrive as a sequence of one-element arrays. upstream routes an array field to `_mergeLists`, which appends, so they accumulate: `AIMessageChunk.concat` on `text("Paris")`, `citations([c1])`, `text(" is in France")`, `citations([c2])` yields `{ type: "text", text: "Paris is in France", citations: [c1, c2] }` on `@langchain/core@1.2.9`. this branch concatenates `citations` before `mergeDefined` so it produces the same block; `mergeDefined`'s own replace-not-append semantics stay as `#6896` set them for every other field. `MessageContentText` gains `index?` and `citations?` so the preserved metadata is on the type, matching `MessageContentThinking` and `MessageContentReasoning`.

dropping `citations` instead would contradict the contract `#6896` set one commit earlier: the accumulated message stays faithful to the wire, and only the tool-call representations are excluded. the converter still reads text blocks as `{ type, text }`, so nothing renders differently; the metadata is simply no longer discarded before anyone can build on it.

## Verification

- the repro above returns `Paris` (and the `text_delta` variant does too); on `4775f93` both return `Parisundefined`.
- the four-delta multi-citation sequence returns `citations: [c1, c2]`, byte-identical to `AIMessageChunk.concat` on the same input.
- four regression tests added; each fails on the unmodified source and passes with the fix.
- `pnpm --filter @assistant-ui/react-langgraph exec vitest run` — 319 tests passed across 13 files.
- `pnpm --filter @assistant-ui/react-langgraph build`, `oxlint`, `oxfmt --check`, `pnpm changesets:check` — passed.
- `tsc --noEmit` reports the same 6 pre-existing errors as `main`, all in test files this PR does not touch.

## Public surface

`MessageContentText` gains two optional fields (`index?`, `citations?`); it reaches the published surface transitively through `LangChainMessage`, so `api-surface/assistant-ui__react-langgraph.ts` is updated. purely additive: nothing removed or renamed. no other exports or signatures changed. changeset added for `@assistant-ui/react-langgraph`.

Fixes #6901
