### PR TITLE
fix(cli): preserve operator precedence in v0-12 AuiIf conditions

### DIFF
--- a/.changeset/khaki-pugs-shave.md
+++ b/.changeset/khaki-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: preserve operator precedence when the v0-12 codemod builds AuiIf conditions

--- a/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
+++ b/packages/cli/src/codemods/v0-12/__tests__/primitive-if-to-aui-if.test.ts
@@ -346,7 +346,7 @@ import { MessagePrimitive, AuiIf } from "@assistant-ui/react";
 
 function MyComponent() {
   return (
-    <AuiIf condition={(s) => !s.message.speech != null}>
+    <AuiIf condition={(s) => !(s.message.speech != null)}>
       <SpeakIcon />
     </AuiIf>
   );
@@ -935,5 +935,52 @@ function MyComponent() {
     expect(output).toContain(
       "(s.message.metadata.submittedFeedback?.type ?? null) === null",
     );
+  });
+});
+
+describe("condition precedence", () => {
+  const compileCondition = (jsx: string) => {
+    const output = applyTransform(`
+import { MessagePrimitive, ComposerPrimitive } from "@assistant-ui/react";
+
+const view = ${jsx};
+`);
+    const arrow = j(output!).find(j.ArrowFunctionExpression).nodes()[0]!;
+    return new Function("s", `return ${j(arrow.body).toSource()};`) as (
+      s: unknown,
+    ) => boolean;
+  };
+
+  it.each([
+    {
+      jsx: "<MessagePrimitive.If speaking={false} />",
+      hidden: { message: { speech: { status: "running" } } },
+      visible: { message: { speech: null } },
+    },
+    {
+      jsx: "<ComposerPrimitive.If dictation={false} />",
+      hidden: { composer: { dictation: { status: "running" } } },
+      visible: { composer: { dictation: null } },
+    },
+    {
+      jsx: "<MessagePrimitive.If hasContent={false} />",
+      hidden: { message: { parts: [{}] } },
+      visible: { message: { parts: [] } },
+    },
+    {
+      jsx: "<MessagePrimitive.If lastOrHover copied />",
+      hidden: { message: { isHovering: true, isLast: false, isCopied: false } },
+      visible: { message: { isHovering: true, isLast: false, isCopied: true } },
+    },
+    {
+      jsx: "<MessagePrimitive.If hasAttachments={false} copied />",
+      hidden: { message: { role: "assistant", isCopied: false } },
+      visible: { message: { role: "assistant", isCopied: true } },
+    },
+  ])("keeps every filter in $jsx", ({ jsx, hidden, visible }) => {
+    const condition = compileCondition(jsx);
+
+    expect(condition(hidden)).toBe(false);
+    expect(condition(visible)).toBe(true);
   });
 });

--- a/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
+++ b/packages/cli/src/codemods/v0-12/primitive-if-to-aui-if.ts
@@ -161,12 +161,23 @@ const getAttrValue = (j: any, attr: any): unknown => {
   return UNSUPPORTED_VALUE;
 };
 
-const buildConditionString = (fragments: ConditionFragment[]): string => {
-  const parts = fragments.map((f) =>
-    f.negated ? `!${f.expression}` : f.expression,
-  );
-  if (parts.length === 1) return parts[0]!;
-  return parts.join(" && ");
+// Composed as a syntax tree so the printer parenthesizes by precedence;
+// concatenated text lets `!` and `&&` reassociate a fragment's own operators.
+const buildConditionString = (
+  j: any,
+  fragments: ConditionFragment[],
+): string => {
+  const parseExpression = (source: string) =>
+    j(`${source};`).find(j.ExpressionStatement).nodes()[0]!.expression;
+
+  const condition = fragments
+    .map((f) => {
+      const expression = parseExpression(f.expression);
+      return f.negated ? j.unaryExpression("!", expression) : expression;
+    })
+    .reduce((left: any, right: any) => j.logicalExpression("&&", left, right));
+
+  return j(condition).toSource();
 };
 
 const migratePrimitiveIfToAuiIf = createTransformer(
@@ -290,7 +301,7 @@ const migratePrimitiveIfToAuiIf = createTransformer(
       // If we couldn't map all props, skip this element
       if (hasUnknownProp || fragments.length === 0) return;
 
-      convertElementToAuiIf(path, buildConditionString(fragments));
+      convertElementToAuiIf(path, buildConditionString(j, fragments));
     });
 
     // Add AuiIf import if needed


### PR DESCRIPTION
## Problem

the v0-12 `primitive-if-to-aui-if` codemod silently changes what a migrated filter means. reported in #6898, reproduced on `01fdd4b` (current main) from `packages/cli`:

```sh
cat > fixture.tsx <<'EOF'
import { MessagePrimitive } from "@assistant-ui/react";
export const a = <MessagePrimitive.If speaking={false} />;
export const b = <MessagePrimitive.If lastOrHover copied />;
EOF
./node_modules/.bin/jscodeshift -t src/codemods/v0-12/primitive-if-to-aui-if.ts fixture.tsx --parser tsx --run-in-band
```

emits

```tsx
export const a = <AuiIf condition={(s) => !s.message.speech != null} />;
export const b = <AuiIf condition={(s) => s.message.isHovering || s.message.isLast && s.message.isCopied} />;
```

`!s.message.speech != null` parses as `(!s.message.speech) != null`, which is `true` whether or not speech is active, so `speaking={false}` content stays on screen during playback. in the second, `&&` binds tighter than `||`, so `copied` no longer constrains the `isHovering` branch and the button shows uncopied.

the affected shapes are `speaking={false}`, `dictation={false}`, and either of `lastOrHover` / `hasAttachments={false}` combined with a second filter.

## Root cause

`buildConditionString` assembled the condition out of source text: `` `!${expression}` `` for a negated fragment, `parts.join(" && ")` to combine them. a fragment is not an atom, so the `!` and `&&` added around it reassociate against the operators already inside it.

the fixture test for `speaking={false}` asserted `!s.message.speech != null` as its expected output, so the suite pinned the defect instead of catching it.

## Change

`buildConditionString` composes the fragments as a syntax tree (`j.unaryExpression`, `j.logicalExpression`) and prints that, so recast inserts exactly the parentheses precedence requires and nothing else. no operator-specific rules, and no blanket grouping of every fragment: atomic fragments print unchanged, and only `!(s.message.speech != null)` and `(s.message.isHovering || s.message.isLast) && s.message.isCopied` gain parens. the emitted text of a codemod is the deliverable, so leaving it minimal matters as much as the semantics.

because the output is otherwise byte-identical, all 27 exact-string fixtures stay exact-string comparisons; the single expectation that encoded the bug is corrected to `!(s.message.speech != null)`.

## Verification

`pnpm -C packages/cli test` passes, 338 tests over 27 files.

five new cases in `condition precedence` compile the generated arrow body and evaluate it against a hidden state and a visible state. four of them (`speaking={false}`, `dictation={false}`, `lastOrHover copied`, `hasAttachments={false} copied`) fail against main's transform and pass with this change; `hasContent={false}` is included because the emitted text changes, though `!x.length > 0` happened to coerce to the right answer.

the CLI reproduction above returns `!(s.message.speech != null)` and `(s.message.isHovering || s.message.isLast) && s.message.isCopied` with the change applied.

oxlint and `tsc --noEmit -p packages/cli/tsconfig.json` report no new diagnostics (the 9 pre-existing errors in `assistant-api-to-aui.ts` are unchanged).

## Public surface

`assistant-ui` (the CLI) with a patch changeset. no exports, runtime APIs, docs, api-reference, or templates change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.iMcYhLznDbyR82KvmlT5XvBW2DXGXJz1JdAN9GLajiN5_s7xsr4QMzfGoa0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
