### PR TITLE
test(react): cover MCP app size forwarding

### DIFF
--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -171,6 +171,67 @@ describe("McpAppFrame", () => {
     },
   );
 
+  it("forwards size changes to the sandbox host and live handler", () => {
+    let createBridge: SandboxHostProps["createBridge"] | null = null;
+    sandboxHostMock.mockImplementation((props: SandboxHostProps) => {
+      createBridge ??= props.createBridge;
+      return null;
+    });
+    const bridge: McpAppBridge = {
+      onMessage: vi.fn(),
+      dispose: vi.fn(),
+      notifyToolInput: vi.fn(),
+      notifyToolResult: vi.fn(),
+      notifyHostContextChanged: vi.fn(),
+    };
+    createMcpAppBridgeMock.mockReturnValue(bridge);
+    const initialOnSizeChange = vi.fn();
+    const replacementOnSizeChange = vi.fn();
+    const view = (onSizeChange: typeof initialOnSizeChange) => (
+      <McpAppFrame
+        app={{ resourceUri: "ui://example/widget" }}
+        resource={{
+          uri: "ui://example/widget",
+          mimeType: MCP_APP_MIME_TYPE,
+          html: "",
+        }}
+        handlers={{ onSizeChange }}
+      />
+    );
+    const rendered = render(view(initialOnSizeChange));
+
+    const setHeight = vi.fn();
+    const sandboxBridge = createBridge!(
+      {
+        iframe: document.createElement("iframe"),
+        origin: "https://widget.example",
+        sendMessage: vi.fn(),
+      },
+      { setHeight },
+    );
+    const options = createMcpAppBridgeMock.mock
+      .calls[0]![0] as CreateMcpAppBridgeOptions;
+
+    try {
+      const initialSize = { width: 640, height: 360 };
+      options.handlers?.onSizeChange?.(initialSize);
+      expect(setHeight).toHaveBeenCalledWith(360);
+      expect(initialOnSizeChange).toHaveBeenCalledWith(initialSize);
+
+      rendered.rerender(view(replacementOnSizeChange));
+      const replacementSize = { width: 800, height: 480 };
+      options.handlers?.onSizeChange?.(replacementSize);
+      expect(setHeight).toHaveBeenNthCalledWith(2, 480);
+      expect(initialOnSizeChange).toHaveBeenCalledOnce();
+      expect(replacementOnSizeChange).toHaveBeenCalledOnce();
+      expect(replacementOnSizeChange).toHaveBeenCalledWith(replacementSize);
+    } finally {
+      sandboxBridge.dispose();
+    }
+
+    expect(bridge.dispose).toHaveBeenCalledOnce();
+  });
+
   it("only notifies the widget when host context actually changes", () => {
     let createBridge: SandboxHostProps["createBridge"] | null = null;
     sandboxHostMock.mockImplementation((props: SandboxHostProps) => {

--- a/packages/react/src/mcp-apps/app-frame.test.tsx
+++ b/packages/react/src/mcp-apps/app-frame.test.tsx
@@ -225,9 +225,50 @@ describe("McpAppFrame", () => {
       expect(initialOnSizeChange).toHaveBeenCalledOnce();
       expect(replacementOnSizeChange).toHaveBeenCalledOnce();
       expect(replacementOnSizeChange).toHaveBeenCalledWith(replacementSize);
+
+      const widthOnlySize = { width: 720 };
+      options.handlers?.onSizeChange?.(widthOnlySize);
+      expect(setHeight).toHaveBeenCalledTimes(2);
+      expect(replacementOnSizeChange).toHaveBeenCalledWith(widthOnlySize);
     } finally {
       sandboxBridge.dispose();
     }
+  });
+
+  it("disposes the underlying bridge with the sandbox bridge", () => {
+    let createBridge: SandboxHostProps["createBridge"] | null = null;
+    sandboxHostMock.mockImplementation((props: SandboxHostProps) => {
+      createBridge ??= props.createBridge;
+      return null;
+    });
+    const bridge: McpAppBridge = {
+      onMessage: vi.fn(),
+      dispose: vi.fn(),
+      notifyToolInput: vi.fn(),
+      notifyToolResult: vi.fn(),
+      notifyHostContextChanged: vi.fn(),
+    };
+    createMcpAppBridgeMock.mockReturnValue(bridge);
+    render(
+      <McpAppFrame
+        app={{ resourceUri: "ui://example/widget" }}
+        resource={{
+          uri: "ui://example/widget",
+          mimeType: MCP_APP_MIME_TYPE,
+          html: "",
+        }}
+      />,
+    );
+
+    const sandboxBridge = createBridge!(
+      {
+        iframe: document.createElement("iframe"),
+        origin: "https://widget.example",
+        sendMessage: vi.fn(),
+      },
+      { setHeight: vi.fn() },
+    );
+    sandboxBridge.dispose();
 
     expect(bridge.dispose).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## Problem

`McpAppFrame` already forwards widget size changes to both the sandbox host and the host callback, but the existing tests only supplied `setHeight` as a signature placeholder. Either forwarding path could regress without a test failure.

Closes #6907.

## Root cause

The app-frame suite did not drive the `onSizeChange` handler created by `McpAppFrame`, and it did not exercise handler replacement through the live ref.

## Change

Add a focused regression test that:

- verifies a size event calls `SandboxHostApi.setHeight` with the reported height;
- verifies the complete size event reaches the host `onSizeChange` handler;
- rerenders with a replacement handler and confirms the existing bridge dispatches to the new callback;
- disposes the sandbox bridge and confirms the underlying MCP app bridge is disposed.

## Verification

- `packages/react/node_modules/.bin/vitest.cmd run src/mcp-apps/app-frame.test.tsx` — 11 tests passed; no type errors
- scoped `oxfmt --check`
- scoped `oxlint`
- `node scripts/check-changesets.mjs`
- repository `lint-staged` tasks for the changed file
- `git diff --check`

## Public surface

None. This changes test coverage only; runtime code, exports, documentation, templates, and release metadata are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yHQ2UWU0f4HUzRh8mfydF7ufrQJtmpx7BYS5NFYrRPZm0uOHgVRfxSAFtH0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->