### PR TITLE
refactor(ui): drop the render-time ref read and dead zoom mount gate

### DIFF
--- a/packages/ui/src/components/react/assistant-ui/elements/image.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/image.tsx
@@ -253,15 +253,10 @@ type ImageZoomProps = PropsWithChildren<{
 }>;
 
 function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
-  const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   const handleOpen = useCallback(() => setIsOpen(true), []);
   const handleClose = useCallback(() => {
@@ -321,8 +316,7 @@ function ImageZoom({ src, alt = "Image preview", children }: ImageZoomProps) {
       >
         {children}
       </div>
-      {isMounted &&
-        isOpen &&
+      {isOpen &&
         createPortal(
           <div
             ref={overlayRef}

--- a/packages/ui/src/components/react/assistant-ui/elements/reasoning.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/reasoning.tsx
@@ -68,13 +68,13 @@ function ReasoningRoot({
   children,
   ...props
 }: ReasoningRootProps) {
-  const initialOpenRef = useRef(defaultOpen);
+  const [initialOpen] = useState(defaultOpen);
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
 
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled
     ? controlledOpen
-    : (userOpen ?? (streaming || initialOpenRef.current));
+    : (userOpen ?? (streaming || initialOpen));
   const isPreview = streaming === true && isOpen;
 
   const prevStreamingRef = useRef(streaming);
@@ -83,10 +83,10 @@ function ReasoningRoot({
     prevStreamingRef.current = streaming;
     // A streaming transition only animates the panel when the resting state
     // is collapsed; with `defaultOpen` the disclosure stays open across it.
-    if (!isControlled && userOpen === null && !initialOpenRef.current) {
+    if (!isControlled && userOpen === null && !initialOpen) {
       onAnimationStart?.();
     }
-  }, [streaming, isControlled, userOpen, onAnimationStart]);
+  }, [streaming, isControlled, userOpen, initialOpen, onAnimationStart]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {


### PR DESCRIPTION
## summary

- `ReasoningRoot` captures `defaultOpen` with `useState` instead of `useRef`, so nothing reads a ref during render. `initialOpen` is constant, so controlled, `defaultOpen`, and streaming behavior are unchanged.
- `ImageZoom` loses its `isMounted` state and the effect whose only job was setting it. `isOpen` starts false and only a client click flips it, so `createPortal` was already unreachable during SSR and hydration; the gate was dead code costing one extra render per mount.
- together these clear the `react-hooks/refs` half of #6362 and the `reasoning.tsx` plus `image.tsx` entries of #6311. the `file.tsx` `static-components` finding is deliberately untouched (see notes).

## test plan

### already verified

- [x] `npx oxlint -A all -D react/refs -D react/set-state-in-effect -D react/static-components <both files>` -> clean; the three diagnostics they carried before (reasoning.tsx:77 twice, image.tsx:263) are gone
- [x] `npx oxlint packages/ui/src` -> no new findings; the remaining warnings are the pre-existing #6311 set
- [x] `pnpm --filter @assistant-ui/ui test` -> 20 files, 724 passed, 16 skipped, including the existing `ImageZoom modal behavior` block and the reasoning `defaultOpen` and streaming cases
- [x] `pnpm sync-templates` -> in sync (neither minimal nor nuxt ships a reasoning or image copy)
- [x] `npx oxfmt --check` on both files -> pass
- [x] `npx tsc --noEmit -p packages/ui/tsconfig.json` -> 5 errors, byte-identical to the same run on a stashed clean tree; all pre-existing test-file typings

### reviewer should verify

- [ ] stream a reasoning part in a thread: the panel still animates open on stream start, and with `defaultOpen` set it stays open across the transition instead of animating
- [ ] click an image in a message to zoom, then dismiss with Escape and by clicking the backdrop; the overlay should mount on the first click with no flash or dropped frame

## notes

- no changeset: `@assistant-ui/ui` is private, and so are the templates.
- no new tests: both behaviors are already covered by the `ImageZoom modal behavior` block in `image.test.tsx` and by the reasoning suite, both green above.
- #6363 attempted these same two fixes alongside a `useSyncExternalStore` rewrite of `useFileSrc`, a name-indirection refactor of `file.tsx`, and a per-file rule allowlist in `.oxlintrc.json`. it predates the move to `components/react/assistant-ui/elements`, so every path in it is stale, and `useFileSrc` has since been extracted to `packages/ui/src/hooks/use-attachment-src.ts` with StrictMode and file-replacement coverage that already passes. this PR takes only the two hunks that fix a real mechanism.
- #6362 stays open for the `file.tsx` `static-components` finding. `getMimeTypeIcon` selects among six module-level icon components rather than creating one, so the rule is reporting a false positive there. if we want a consumer's ESLint to stay quiet, the narrow documented suppression the issue explicitly allows reads better than restructuring the helper to dodge the analyzer.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fICYwMExV1npcFht5x8uKV0gIpL-JJ8WvdUn3T0WSpa3mOofRts-Gg5sxz8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->