### PR TITLE
refactor: clear the react/set-state-in-effect findings and gate the rule

### DIFF
--- a/.changeset/set-state-in-effect-sweep.md
+++ b/.changeset/set-state-in-effect-sweep.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/ai-sdk": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-mcp": patch
+---
+
+refactor: stop resetting state from effects where a render-time adjustment does the job
+
+`ReasoningRoot`'s trigger resources, the devtools panel and thread tab, the external thread's feedback map, and the cloud thread selection now adjust their state during render instead of scheduling a second pass from an effect, so a prop change lands in one render. Effects that genuinely synchronize with an external system (a clock, a subscription catch-up, an async load, a registry write undone on unmount) keep their `setState` and carry a `react-hooks/set-state-in-effect` suppression naming the reason.

--- a/.changeset/set-state-in-effect-sweep.md
+++ b/.changeset/set-state-in-effect-sweep.md
@@ -8,6 +8,6 @@
 "@assistant-ui/react-mcp": patch
 ---
 
-refactor: stop resetting state from effects where a render-time adjustment does the job
+refactor: adjust state during render where an effect only mirrored a prop
 
-`ReasoningRoot`'s trigger resources, the devtools panel and thread tab, the external thread's feedback map, and the cloud thread selection now adjust their state during render instead of scheduling a second pass from an effect, so a prop change lands in one render. Effects that genuinely synchronize with an external system (a clock, a subscription catch-up, an async load, a registry write undone on unmount) keep their `setState` and carry a `react-hooks/set-state-in-effect` suppression naming the reason.
+The composer trigger's keyboard and navigation resources, and the devtools panel and thread tab, reset their state during render instead of scheduling a second pass from an effect, so a prop change settles in one render. Effects that genuinely synchronize with an external system (a clock, a subscription catch-up, an async load, a registry write undone on unmount) keep their `setState`.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,7 +27,7 @@
     "react/preserve-manual-memoization": "off",
     "react/purity": "off",
     "react/refs": "off",
-    "react/set-state-in-effect": "warn",
+    "react/set-state-in-effect": "error",
     "react/static-components": "off",
     "react/use-memo": "off",
     "no-unused-vars": "off",
@@ -101,6 +101,12 @@
       "rules": {
         "react/exhaustive-deps": "off",
         "react/rules-of-hooks": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "rules": {
+        "react/set-state-in-effect": "off"
       }
     }
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -104,7 +104,10 @@
       }
     },
     {
-      "files": ["**/*.test.ts", "**/*.test.tsx"],
+      "files": [
+        "packages/react/src/primitives/thread/useThreadViewportAutoScroll.test.tsx",
+        "packages/store/src/createAssistantClient.test.ts"
+      ],
       "rules": {
         "react/set-state-in-effect": "off"
       }

--- a/apps/docs/app/(demos)/playground/page.tsx
+++ b/apps/docs/app/(demos)/playground/page.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useHeaderPortalContainer } from "@/hooks/use-header-portal-container";
 import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import {
@@ -379,13 +380,7 @@ function BuilderPlayground() {
 }
 
 function HeaderPortal({ children }: { children: ReactNode }) {
-  const [container, setContainer] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setContainer(
-      document.querySelector<HTMLElement>("[data-sub-project-header-portal]"),
-    );
-  }, []);
+  const container = useHeaderPortalContainer();
 
   if (!container) return null;
   return createPortal(children, container);

--- a/apps/docs/app/(products)/ink/terminal-demo.tsx
+++ b/apps/docs/app/(products)/ink/terminal-demo.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { LiveDot } from "@/components/shared/live-dot";
 
 const INK_DEMO_URL =
   process.env.NEXT_PUBLIC_INK_DEMO_URL ?? "https://assistant-ui-ink.vercel.app";
 
 export function TerminalDemo() {
-  const [src, setSrc] = useState<string | null>(null);
-
-  useEffect(() => {
-    setSrc(INK_DEMO_URL);
-  }, []);
+  const src = useHydrated() ? INK_DEMO_URL : null;
 
   return (
     <div className="border-foreground/10 overflow-hidden border">

--- a/apps/docs/app/(products)/native/page.tsx
+++ b/apps/docs/app/(products)/native/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { LiveDot } from "@/components/shared/live-dot";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
@@ -178,11 +178,7 @@ export default function NativePage() {
 }
 
 function NativeDemo() {
-  const [src, setSrc] = useState<string | null>(null);
-
-  useEffect(() => {
-    setSrc(DEMO_SRC);
-  }, []);
+  const src = useHydrated() ? DEMO_SRC : null;
 
   return (
     <div className="border-foreground/10 overflow-hidden border">

--- a/apps/docs/app/not-found.tsx
+++ b/apps/docs/app/not-found.tsx
@@ -4,28 +4,38 @@ import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, Home } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 
 const TITLE = "404 - Page not found";
 const MESSAGE =
   "I couldn't find the page you're looking for. It might have been moved or doesn't exist.";
 
+const subscribeToNothing = () => () => {};
+
+const getUrl = () => window.location.href;
+
+const getServerUrl = () => "";
+
+const getCanGoBack = () =>
+  window.history.length > 1 &&
+  document.referrer.startsWith(window.location.origin);
+
+const getServerCanGoBack = () => false;
+
 export default function NotFound() {
   const router = useRouter();
-  const [url, setUrl] = useState("");
-  const [canGoBack, setCanGoBack] = useState(false);
+  const url = useSyncExternalStore(subscribeToNothing, getUrl, getServerUrl);
+  const canGoBack = useSyncExternalStore(
+    subscribeToNothing,
+    getCanGoBack,
+    getServerCanGoBack,
+  );
   const [showAssistant, setShowAssistant] = useState(false);
   const [displayedTitle, setDisplayedTitle] = useState("");
   const [displayedMessage, setDisplayedMessage] = useState("");
   const [showActions, setShowActions] = useState(false);
 
   useEffect(() => {
-    setUrl(window.location.href);
-    setCanGoBack(
-      window.history.length > 1 &&
-        document.referrer.startsWith(window.location.origin),
-    );
-
     const assistantTimer = setTimeout(() => setShowAssistant(true), 600);
 
     return () => clearTimeout(assistantTimer);

--- a/apps/docs/components/demo/elements/composer-voice.tsx
+++ b/apps/docs/components/demo/elements/composer-voice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Composer,
   ComposerActions,
@@ -25,9 +25,12 @@ export function ComposerVoiceDemo() {
   const transcribing = running && phase === 2;
   const active = recording || transcribing;
 
-  useEffect(() => {
+  const [syncedPhase, setSyncedPhase] = useState(phase);
+
+  if (syncedPhase !== phase) {
+    setSyncedPhase(phase);
     if (phase >= 3) setValue(TRANSCRIPT);
-  }, [phase]);
+  }
 
   return (
     <Composer>

--- a/apps/docs/components/demo/elements/voice-conversation.tsx
+++ b/apps/docs/components/demo/elements/voice-conversation.tsx
@@ -33,25 +33,23 @@ export function VoiceConversationDemo() {
   const mode = MODES[Math.min(phase, MODES.length - 1)]!;
   const [amplitude, setAmplitude] = useState(0.2);
   const [muted, setMuted] = useState(false);
+  const oscillating = running && (mode === "listening" || mode === "speaking");
+  const displayAmplitude = oscillating ? amplitude : 0.15;
 
   useEffect(() => {
-    if (!running) return;
-    if (mode !== "listening" && mode !== "speaking") {
-      setAmplitude(0.15);
-      return;
-    }
+    if (!oscillating) return;
     let tick = 0;
     const id = setInterval(() => {
       tick += 1;
       setAmplitude(0.35 + Math.abs(Math.sin(tick * 0.7)) * 0.6);
     }, 110);
     return () => clearInterval(id);
-  }, [mode, running]);
+  }, [oscillating]);
 
   return (
     <VoiceConversation
       mode={mode}
-      amplitude={amplitude}
+      amplitude={displayAmplitude}
       transcript={TRANSCRIPT.slice(0, VISIBLE[Math.min(phase, 4)])}
       muted={muted}
       onToggleMute={() => setMuted((current) => !current)}

--- a/apps/docs/components/demo/elements/voice-conversation.tsx
+++ b/apps/docs/components/demo/elements/voice-conversation.tsx
@@ -34,7 +34,13 @@ export function VoiceConversationDemo() {
   const [amplitude, setAmplitude] = useState(0.2);
   const [muted, setMuted] = useState(false);
   const oscillating = running && (mode === "listening" || mode === "speaking");
+  const [syncedOscillating, setSyncedOscillating] = useState(oscillating);
   const displayAmplitude = oscillating ? amplitude : 0.15;
+
+  if (syncedOscillating !== oscillating) {
+    setSyncedOscillating(oscillating);
+    if (oscillating) setAmplitude(0.15);
+  }
 
   useEffect(() => {
     if (!oscillating) return;

--- a/apps/docs/components/demo/hooks/use-demo.ts
+++ b/apps/docs/components/demo/hooks/use-demo.ts
@@ -59,20 +59,32 @@ export interface StoryPhases {
 export function useStoryPhases(durations: readonly number[]): StoryPhases {
   const stage = useContext(DemoStageContext);
   const [phase, setPhase] = useState(0);
-  const [running, setRunning] = useState(true);
+  const [isRunning, setRunning] = useState(true);
   const [epoch, setEpoch] = useState(0);
+  const running = isRunning && durations.length > 1;
 
-  useEffect(() => {
+  const [syncedStopped, setSyncedStopped] = useState<{
+    stopped: boolean | undefined;
+  } | null>(null);
+
+  if (syncedStopped?.stopped !== stage?.stopped) {
+    setSyncedStopped({ stopped: stage?.stopped });
     if (stage?.stopped) setRunning(false);
-  }, [stage?.stopped]);
+  }
 
   useEffect(() => {
     stage?.setPlaying(running);
   }, [stage, running]);
 
+  const [syncedRunning, setSyncedRunning] = useState<boolean | null>(null);
+
+  if (syncedRunning !== running) {
+    setSyncedRunning(running);
+    if (running) setPhase(0);
+  }
+
   useEffect(() => {
     if (!running) return;
-    setPhase(0);
     let index = 0;
     let id: ReturnType<typeof setTimeout>;
     const next = () => {
@@ -86,10 +98,6 @@ export function useStoryPhases(durations: readonly number[]): StoryPhases {
         next();
       }, durations[index]);
     };
-    if (durations.length <= 1) {
-      setRunning(false);
-      return;
-    }
     next();
     return () => clearTimeout(id);
   }, [durations, running, epoch]);
@@ -106,9 +114,15 @@ export function useStoryPhases(durations: readonly number[]): StoryPhases {
 /** Elapsed tenths of a second while `running`, reset on each rising edge. */
 export function useElapsed(running: boolean): number {
   const [tenths, setTenths] = useState(0);
+  const [syncedRunning, setSyncedRunning] = useState<boolean | null>(null);
+
+  if (syncedRunning !== running) {
+    setSyncedRunning(running);
+    if (running) setTenths(0);
+  }
+
   useEffect(() => {
     if (!running) return;
-    setTenths(0);
     const id = setInterval(() => setTenths((t) => t + 1), 100);
     return () => clearInterval(id);
   }, [running]);

--- a/apps/docs/components/demo/hooks/use-demo.ts
+++ b/apps/docs/components/demo/hooks/use-demo.ts
@@ -76,10 +76,10 @@ export function useStoryPhases(durations: readonly number[]): StoryPhases {
     stage?.setPlaying(running);
   }, [stage, running]);
 
-  const [syncedRunning, setSyncedRunning] = useState<boolean | null>(null);
+  const [syncedRun, setSyncedRun] = useState({ running, epoch });
 
-  if (syncedRunning !== running) {
-    setSyncedRunning(running);
+  if (syncedRun.running !== running || syncedRun.epoch !== epoch) {
+    setSyncedRun({ running, epoch });
     if (running) setPhase(0);
   }
 
@@ -114,7 +114,7 @@ export function useStoryPhases(durations: readonly number[]): StoryPhases {
 /** Elapsed tenths of a second while `running`, reset on each rising edge. */
 export function useElapsed(running: boolean): number {
   const [tenths, setTenths] = useState(0);
-  const [syncedRunning, setSyncedRunning] = useState<boolean | null>(null);
+  const [syncedRunning, setSyncedRunning] = useState(running);
 
   if (syncedRunning !== running) {
     setSyncedRunning(running);

--- a/apps/docs/components/pages/design/instruments.tsx
+++ b/apps/docs/components/pages/design/instruments.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { Button } from "@/components/ui/button";
 
 const TINT_DEFAULT = 106;
@@ -60,16 +61,12 @@ type MotionKind =
 
 export function MotionSample({ kind }: { kind: MotionKind }) {
   const [epoch, setEpoch] = useState(0);
-  const [reduced, setReduced] = useState(false);
+  const reduced = useReducedMotion();
   const ref = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
-    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mql.matches);
-    const onChange = () => setReduced(mql.matches);
-    mql.addEventListener("change", onChange);
     const el = ref.current;
-    if (!el) return () => mql.removeEventListener("change", onChange);
+    if (!el) return;
     const io = new IntersectionObserver(
       ([entry]) => {
         if (entry?.isIntersecting) {
@@ -80,10 +77,7 @@ export function MotionSample({ kind }: { kind: MotionKind }) {
       { threshold: 0.5 },
     );
     io.observe(el);
-    return () => {
-      io.disconnect();
-      mql.removeEventListener("change", onChange);
-    };
+    return () => io.disconnect();
   }, []);
 
   return (

--- a/apps/docs/components/pages/docs/assistant/ball.tsx
+++ b/apps/docs/components/pages/docs/assistant/ball.tsx
@@ -1,27 +1,45 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { XIcon } from "lucide-react";
 import { useAssistantPanel } from "@/components/pages/docs/assistant/context";
 
 const STORAGE_KEY = "aui-ask-ai-ball";
 
+const subscribeToNothing = () => () => {};
+
+const readArmed = () => {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+const notArmed = () => false;
+
 export function AskAiBall() {
   const { open, toggle } = useAssistantPanel();
-  const [armed, setArmed] = useState(false);
+  const storedArmed = useSyncExternalStore(
+    subscribeToNothing,
+    readArmed,
+    notArmed,
+  );
+  const [everOpened, setEverOpened] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
-  useEffect(() => {
-    try {
-      setArmed(localStorage.getItem(STORAGE_KEY) === "1");
-    } catch {}
-  }, []);
+  if (open) {
+    if (!everOpened) setEverOpened(true);
+    if (dismissed) setDismissed(false);
+  }
+
+  const armed = !dismissed && (storedArmed || everOpened);
 
   useEffect(() => {
     if (!open) return;
     try {
       localStorage.setItem(STORAGE_KEY, "1");
     } catch {}
-    setArmed(true);
   }, [open]);
 
   if (!armed || open) return null;
@@ -45,7 +63,7 @@ export function AskAiBall() {
           try {
             localStorage.removeItem(STORAGE_KEY);
           } catch {}
-          setArmed(false);
+          setDismissed(true);
         }}
         aria-label="Dismiss Ask AI"
         className="border-border/60 bg-background text-muted-foreground hover:text-foreground rounded-capsule absolute -top-1.5 -right-1.5 grid size-5 place-items-center border opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"

--- a/apps/docs/components/pages/docs/demo-iframe.tsx
+++ b/apps/docs/components/pages/docs/demo-iframe.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { useEffect, useState, type ComponentProps } from "react";
+import { type ComponentProps } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 export function DemoIframe({ src, ...props }: ComponentProps<"iframe">) {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
+  const mounted = useHydrated();
 
   const themedSrc =
     mounted && src

--- a/apps/docs/components/pages/docs/layout/sidebar-content.tsx
+++ b/apps/docs/components/pages/docs/layout/sidebar-content.tsx
@@ -242,9 +242,18 @@ export function SidebarContent({
     activeSectionId,
   );
 
-  useEffect(() => {
+  const [sectionScope, setSectionScope] = useState({
+    activeSectionId,
+    pathname,
+  });
+
+  if (
+    sectionScope.activeSectionId !== activeSectionId ||
+    sectionScope.pathname !== pathname
+  ) {
+    setSectionScope({ activeSectionId, pathname });
     if (activeSectionId) setOpenSectionId(activeSectionId);
-  }, [activeSectionId, pathname]);
+  }
 
   useEffect(() => {
     if (openSectionId !== activeSectionId) return;

--- a/apps/docs/components/pages/docs/primitives-type-table-client.tsx
+++ b/apps/docs/components/pages/docs/primitives-type-table-client.tsx
@@ -3,6 +3,7 @@
 import { Collapsible } from "@base-ui/react/collapsible";
 import { ChevronDown } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { cn } from "@/lib/utils";
 
 export type TypeTableRow = {
@@ -58,15 +59,11 @@ function Item({
   parentId?: string | undefined;
 }) {
   const [open, setOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useHydrated();
   const id = parentId ? `${parentId}-${row.name}` : undefined;
 
   const hasContent =
     row.description || row.default || row.children?.length || row.typeFull;
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   useEffect(() => {
     const expand = () => {

--- a/apps/docs/components/pages/docs/samples/devtools.tsx
+++ b/apps/docs/components/pages/docs/samples/devtools.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { useTheme } from "next-themes";
 import {
   ArrowUpIcon,
@@ -181,8 +182,7 @@ const useDevToolsDemo = () => {
   const client = useMemo(() => createScopedClient(apiId), [apiId]);
   const aui = useAui({ tools: Tools({ toolkit }) });
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const mounted = useHydrated();
   return {
     adapter,
     aui,

--- a/apps/docs/components/pages/docs/samples/o11y/client-only.tsx
+++ b/apps/docs/components/pages/docs/samples/o11y/client-only.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 
 export function ClientOnly({
   children,
@@ -9,8 +10,7 @@ export function ClientOnly({
   children: ReactNode;
   minHeight: number;
 }) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const mounted = useHydrated();
 
   if (!mounted) {
     return (

--- a/apps/docs/components/pages/docs/samples/streamdown.tsx
+++ b/apps/docs/components/pages/docs/samples/streamdown.tsx
@@ -31,11 +31,16 @@ function greet(name: string) {
 export const StreamdownSample = () => {
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamedText, setStreamedText] = useState("");
+  const [syncedStreaming, setSyncedStreaming] = useState<boolean | null>(null);
+
+  if (syncedStreaming !== isStreaming) {
+    setSyncedStreaming(isStreaming);
+    if (isStreaming) setStreamedText("");
+  }
 
   useEffect(() => {
     if (!isStreaming) return;
 
-    setStreamedText("");
     let index = 0;
     const interval = setInterval(() => {
       if (index < sampleMarkdown.length) {

--- a/apps/docs/components/pages/docs/samples/streamdown.tsx
+++ b/apps/docs/components/pages/docs/samples/streamdown.tsx
@@ -31,7 +31,7 @@ function greet(name: string) {
 export const StreamdownSample = () => {
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamedText, setStreamedText] = useState("");
-  const [syncedStreaming, setSyncedStreaming] = useState<boolean | null>(null);
+  const [syncedStreaming, setSyncedStreaming] = useState(isStreaming);
 
   if (syncedStreaming !== isStreaming) {
     setSyncedStreaming(isStreaming);

--- a/apps/docs/components/pages/docs/samples/tool-fallback.tsx
+++ b/apps/docs/components/pages/docs/samples/tool-fallback.tsx
@@ -85,12 +85,19 @@ function ToolFallbackStreamingDemo() {
 
   const isRunning = status.type === "running";
 
+  const [syncedRunning, setSyncedRunning] = useState<boolean | null>(null);
+
+  if (syncedRunning !== isRunning) {
+    setSyncedRunning(isRunning);
+    if (isRunning) {
+      setIsOpen(true);
+      setStreamedArgs("");
+      setResult(undefined);
+    }
+  }
+
   useEffect(() => {
     if (!isRunning) return;
-
-    setIsOpen(true);
-    setStreamedArgs("");
-    setResult(undefined);
 
     let index = 0;
     const argsInterval = setInterval(() => {

--- a/apps/docs/components/pages/docs/samples/tool-group.tsx
+++ b/apps/docs/components/pages/docs/samples/tool-group.tsx
@@ -214,18 +214,28 @@ function ToolGroupStreamingDemo() {
   const toolCount =
     phase === "idle" ? 0 : phase === "tool1" ? 1 : phase === "tool2" ? 2 : 3;
 
-  useEffect(() => {
-    if (phase === "idle" || phase === "done") return;
+  const [syncedPhase, setSyncedPhase] = useState<typeof phase | null>(null);
 
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-
+  if (syncedPhase !== phase) {
+    setSyncedPhase(phase);
     if (phase === "tool1") {
       setIsOpen(true);
       setWeather1({});
       setWeather2({});
       setSearchArgs("");
       setSearchResult(undefined);
+    }
+    if (phase === "tool3") {
+      setSearchStatus({ type: "running" });
+    }
+  }
 
+  useEffect(() => {
+    if (phase === "idle" || phase === "done") return;
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    if (phase === "tool1") {
       // Simulate streaming weather data
       const steps = [
         () => setWeather1({ location: "Paris" }),
@@ -277,7 +287,6 @@ function ToolGroupStreamingDemo() {
     }
 
     // phase === "tool3" - Search with ToolFallback
-    setSearchStatus({ type: "running" });
     const fullArgs = JSON.stringify({ query: "weather comparison" }, null, 2);
 
     let index = 0;

--- a/apps/docs/components/pages/elements/element-mode.tsx
+++ b/apps/docs/components/pages/elements/element-mode.tsx
@@ -3,8 +3,8 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
@@ -12,6 +12,20 @@ import { cn } from "@/lib/utils";
 export type ElementMode = "runtime" | "standalone";
 
 const STORAGE_KEY = "aui-element-mode";
+
+const subscribeToNothing = () => () => {};
+
+const readStoredMode = (): ElementMode | null => {
+  try {
+    const fromUrl = new URL(window.location.href).searchParams.get("mode");
+    const value = fromUrl ?? window.localStorage.getItem(STORAGE_KEY);
+    return value === "runtime" || value === "standalone" ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const noStoredMode = () => null;
 
 const ElementModeContext = createContext<{
   mode: ElementMode;
@@ -25,21 +39,16 @@ export function ElementModeProvider({
   className?: string;
   children: ReactNode;
 }) {
-  const [mode, setModeState] = useState<ElementMode>("runtime");
-
-  useEffect(() => {
-    try {
-      const fromUrl = new URL(window.location.href).searchParams.get("mode");
-      const stored = window.localStorage.getItem(STORAGE_KEY);
-      const value = fromUrl ?? stored;
-      if (value === "runtime" || value === "standalone") setModeState(value);
-    } catch {
-      /* storage unavailable */
-    }
-  }, []);
+  const storedMode = useSyncExternalStore(
+    subscribeToNothing,
+    readStoredMode,
+    noStoredMode,
+  );
+  const [chosenMode, setChosenMode] = useState<ElementMode | null>(null);
+  const mode = chosenMode ?? storedMode ?? "runtime";
 
   const setMode = (next: ElementMode) => {
-    setModeState(next);
+    setChosenMode(next);
     try {
       window.localStorage.setItem(STORAGE_KEY, next);
     } catch {

--- a/apps/docs/components/pages/playground/builder-preview.tsx
+++ b/apps/docs/components/pages/playground/builder-preview.tsx
@@ -32,15 +32,8 @@ import {
   useMessagePartText,
 } from "@assistant-ui/react";
 
-import {
-  type FC,
-  createContext,
-  useContext,
-  useMemo,
-  memo,
-  useState,
-  useEffect,
-} from "react";
+import { type FC, createContext, useContext, useMemo, memo } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -134,11 +127,7 @@ interface BuilderPreviewProps {
 // Hook to detect page theme from document.documentElement.classList
 function usePageTheme() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useHydrated();
 
   // Return false during SSR/hydration to avoid mismatch, then update on client
   if (!mounted) return false;

--- a/apps/docs/components/shared/color-picker.tsx
+++ b/apps/docs/components/shared/color-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 
 import type { ThemeColor } from "@/components/pages/playground/types";
 import { cn } from "@/lib/utils";
@@ -15,11 +15,13 @@ export function ColorPicker({
   onChange: (value: string) => void;
 }) {
   const [localValue, setLocalValue] = useState(value);
+  const [syncedValue, setSyncedValue] = useState(value);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
+  if (syncedValue !== value) {
+    setSyncedValue(value);
     setLocalValue(value);
-  }, [value]);
+  }
 
   const handleChange = (newValue: string) => {
     setLocalValue(newValue);

--- a/apps/docs/components/shared/search-dialog.tsx
+++ b/apps/docs/components/shared/search-dialog.tsx
@@ -197,12 +197,23 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
       });
   }, []);
 
-  useEffect(() => {
-    if (!open) return;
-    setInputValue("");
-    setSelectedIndex(0);
-    setPageEntries(collectPageEntries(pathname));
-  }, [open, pathname]);
+  const [openScope, setOpenScope] = useState<{
+    open: boolean;
+    pathname: string;
+  } | null>(null);
+
+  if (
+    openScope === null ||
+    openScope.open !== open ||
+    openScope.pathname !== pathname
+  ) {
+    setOpenScope({ open, pathname });
+    if (open) {
+      setInputValue("");
+      setSelectedIndex(0);
+      setPageEntries(collectPageEntries(pathname));
+    }
+  }
 
   const query = inputValue.trim();
   const tokens = useMemo(() => tokenize(query), [query]);
@@ -239,9 +250,20 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     resultsLengthRef.current = results.length;
   }, [results.length]);
 
-  useEffect(() => {
+  const [resultScope, setResultScope] = useState({
+    query,
+    onPageHits,
+    otherGroups,
+  });
+
+  if (
+    resultScope.query !== query ||
+    resultScope.onPageHits !== onPageHits ||
+    resultScope.otherGroups !== otherGroups
+  ) {
+    setResultScope({ query, onPageHits, otherGroups });
     setSelectedIndex(0);
-  }, [query, onPageHits, otherGroups]);
+  }
 
   useEffect(() => {
     if (listRef.current && results.length > 0) {

--- a/apps/docs/components/shared/search-dialog.tsx
+++ b/apps/docs/components/shared/search-dialog.tsx
@@ -211,9 +211,16 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     if (open) {
       setInputValue("");
       setSelectedIndex(0);
-      setPageEntries(collectPageEntries(pathname));
     }
   }
+
+  useEffect(() => {
+    if (!open) return;
+    // The headings are collected from the committed page DOM, so this cannot
+    // move into render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPageEntries(collectPageEntries(pathname));
+  }, [open, pathname]);
 
   const query = inputValue.trim();
   const tokens = useMemo(() => tokenize(query), [query]);

--- a/apps/docs/components/shared/search-provider.tsx
+++ b/apps/docs/components/shared/search-provider.tsx
@@ -6,15 +6,24 @@ import {
   useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { SearchDialog } from "@/components/shared/search-dialog";
 
+const subscribeToNothing = () => () => {};
+
+const getModifierKey = () =>
+  /Windows|Linux/i.test(window.navigator.userAgent) ? "Ctrl" : "⌘";
+
+const getServerModifierKey = () => "⌘";
+
 function MetaOrControl() {
-  const [key, setKey] = useState("⌘");
-  useEffect(() => {
-    if (/Windows|Linux/i.test(window.navigator.userAgent)) setKey("Ctrl");
-  }, []);
+  const key = useSyncExternalStore(
+    subscribeToNothing,
+    getModifierKey,
+    getServerModifierKey,
+  );
   return <>{key}</>;
 }
 

--- a/apps/docs/components/shared/theme-toggle.tsx
+++ b/apps/docs/components/shared/theme-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
+import { useHydrated } from "@/hooks/use-hydrated";
 import { Moon, Sun } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -13,9 +14,7 @@ export function ThemeToggle({
   children?: ReactNode;
 }) {
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
+  const mounted = useHydrated();
 
   const toggleTheme = () => {
     setTheme(resolvedTheme === "dark" ? "light" : "dark");

--- a/apps/docs/components/tool-ui/weather-widget/weather-data-overlay.tsx
+++ b/apps/docs/components/tool-ui/weather-widget/weather-data-overlay.tsx
@@ -276,6 +276,9 @@ export function WeatherDataOverlay({
 
   useEffect(() => {
     if (reducedMotion) {
+      // Clearing the glow also cancels a pending animation frame, which is
+      // effect work.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       clearGlowIntensity();
       return;
     }

--- a/apps/docs/components/tool-ui/weather-widget/weather-widget-container.tsx
+++ b/apps/docs/components/tool-ui/weather-widget/weather-widget-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import { cn } from "@/lib/utils";
 import {
@@ -17,6 +17,17 @@ import { WeatherDataOverlay } from "./weather-data-overlay";
 
 type TimeCheckpoint = "dawn" | "noon" | "dusk" | "midnight";
 
+const subscribeToReducedMotion = (onStoreChange: () => void) => {
+  const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+};
+
+const getReducedMotion = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const getServerReducedMotion = () => false;
+
 export function WeatherWidget({
   version: _version,
   id,
@@ -29,32 +40,11 @@ export function WeatherWidget({
   className,
   effects,
 }: WeatherWidgetRuntimeProps) {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
-    if (typeof window === "undefined") {
-      return false;
-    }
-
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  });
-
-  useEffect(() => {
-    const mediaQueryList = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    );
-    setPrefersReducedMotion(mediaQueryList.matches);
-
-    const handleMotionPreferenceChange = (event: MediaQueryListEvent) => {
-      setPrefersReducedMotion(event.matches);
-    };
-
-    mediaQueryList.addEventListener("change", handleMotionPreferenceChange);
-    return () => {
-      mediaQueryList.removeEventListener(
-        "change",
-        handleMotionPreferenceChange,
-      );
-    };
-  }, []);
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotion,
+    getServerReducedMotion,
+  );
 
   const reducedMotion = effects?.reducedMotion ?? prefersReducedMotion;
   const effectsEnabled = effects?.enabled !== false && !reducedMotion;

--- a/apps/docs/components/tool-ui/weather-widget/weather-widget-container.tsx
+++ b/apps/docs/components/tool-ui/weather-widget/weather-widget-container.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 
 import { cn } from "@/lib/utils";
 import {
@@ -17,17 +17,6 @@ import { WeatherDataOverlay } from "./weather-data-overlay";
 
 type TimeCheckpoint = "dawn" | "noon" | "dusk" | "midnight";
 
-const subscribeToReducedMotion = (onStoreChange: () => void) => {
-  const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
-  mql.addEventListener("change", onStoreChange);
-  return () => mql.removeEventListener("change", onStoreChange);
-};
-
-const getReducedMotion = () =>
-  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-const getServerReducedMotion = () => false;
-
 export function WeatherWidget({
   version: _version,
   id,
@@ -40,11 +29,7 @@ export function WeatherWidget({
   className,
   effects,
 }: WeatherWidgetRuntimeProps) {
-  const prefersReducedMotion = useSyncExternalStore(
-    subscribeToReducedMotion,
-    getReducedMotion,
-    getServerReducedMotion,
-  );
+  const prefersReducedMotion = useReducedMotion();
 
   const reducedMotion = effects?.reducedMotion ?? prefersReducedMotion;
   const effectsEnabled = effects?.enabled !== false && !reducedMotion;

--- a/apps/docs/components/xulux/XuluxApp.tsx
+++ b/apps/docs/components/xulux/XuluxApp.tsx
@@ -85,6 +85,9 @@ export function XuluxApp({
   useEffect(() => {
     if (mode !== "learn") return;
     const stored = readLearnProgress(window.localStorage, courseId);
+    // The stored progress is a fresh object per read, so it cannot back a
+    // cached external-store snapshot.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLearnProgress(stored);
     if (stored.threadId) setSessionId(stored.threadId);
     setLearnReady(true);
@@ -202,10 +205,12 @@ function XuluxRuntimeProviderInner({
   const learnProgressRef = useRef(learnProgress);
   learnProgressRef.current = learnProgress;
   const [limitBlock, setLimitBlock] = useState<XuluxLimitBlock | null>(null);
+  const [limitSessionId, setLimitSessionId] = useState(sessionId);
 
-  useEffect(() => {
+  if (limitSessionId !== sessionId) {
+    setLimitSessionId(sessionId);
     setLimitBlock(null);
-  }, [sessionId]);
+  }
 
   const assistantCloud = useMemo(
     () =>

--- a/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
+++ b/apps/docs/components/xulux/canvas/XuluxCanvas.tsx
@@ -86,6 +86,8 @@ export function XuluxCanvas({
   useEffect(() => {
     if (!resolvedPreviewUrl) {
       previewLoadedForUrlRef.current = null;
+      // Paired with the ref write above, which cannot move into render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsPreviewLoading(false);
       return;
     }

--- a/apps/docs/components/xulux/canvas/useVirtualArchive.ts
+++ b/apps/docs/components/xulux/canvas/useVirtualArchive.ts
@@ -88,11 +88,15 @@ export function useVirtualArchive(
     [templateId, versionId],
   );
 
+  const [syncedUrl, setSyncedUrl] = useState<typeof downloadUrl | null>(null);
+
+  if (syncedUrl !== downloadUrl) {
+    setSyncedUrl(downloadUrl);
+    if (!downloadUrl) setState({ status: "idle" });
+  }
+
   useEffect(() => {
-    if (!downloadUrl) {
-      setState({ status: "idle" });
-      return;
-    }
+    if (!downloadUrl) return;
     load(downloadUrl);
     return () => abortRef.current?.abort();
   }, [downloadUrl, load]);

--- a/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplateDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   Code2,
@@ -45,10 +45,13 @@ export function TemplateDetailModal({
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  const [syncedTemplate, setSyncedTemplate] = useState(template);
+
+  if (syncedTemplate !== template) {
+    setSyncedTemplate(template);
     setCurrent(template);
     setIframeLoaded(false);
-  }, [template]);
+  }
 
   const others = allTemplates
     .filter((candidate) => candidate.id !== current?.id)

--- a/apps/docs/components/xulux/landing/TemplatesModal.tsx
+++ b/apps/docs/components/xulux/landing/TemplatesModal.tsx
@@ -45,12 +45,22 @@ export function TemplatesModal({
   );
   const openTrackedRef = useRef(false);
 
-  useEffect(() => {
+  const [openState, setOpenState] = useState<{
+    open: boolean;
+    initialCategoryId: typeof initialCategoryId;
+  } | null>(null);
+
+  if (
+    openState === null ||
+    openState.open !== open ||
+    openState.initialCategoryId !== initialCategoryId
+  ) {
+    setOpenState({ open, initialCategoryId });
     if (open) {
       setActiveCategory(initialCategoryId ?? "all");
       setQuery("");
     }
-  }, [open, initialCategoryId]);
+  }
 
   useEffect(() => {
     if (!open) {

--- a/apps/docs/components/xulux/landing/Thumbnail.tsx
+++ b/apps/docs/components/xulux/landing/Thumbnail.tsx
@@ -30,6 +30,9 @@ export function Thumbnail({
     if (!el) return;
 
     if (!("IntersectionObserver" in window)) {
+      // Without the observer there is nothing to subscribe to, so the fallback
+      // resolves inside the effect that would have set it up.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsNearViewport(true);
       return;
     }

--- a/apps/docs/components/xulux/learn/LearnModeContext.tsx
+++ b/apps/docs/components/xulux/learn/LearnModeContext.tsx
@@ -55,13 +55,26 @@ export function LearnModeProvider({
   const [selectedFileMode, setSelectedFileMode] =
     useState<LearnFileDisplayMode>("source");
 
-  useEffect(() => {
+  const [fileScope, setFileScope] = useState<{
+    steps: typeof course.steps;
+    selectedStepId: typeof progress.selectedStepId;
+  } | null>(null);
+
+  if (
+    fileScope === null ||
+    fileScope.steps !== course.steps ||
+    fileScope.selectedStepId !== progress.selectedStepId
+  ) {
+    setFileScope({
+      steps: course.steps,
+      selectedStepId: progress.selectedStepId,
+    });
     const selectedStep = course.steps.find(
       ({ id }) => id === progress.selectedStepId,
     );
     setSelectedFile(selectedStep?.focusFiles[0] ?? null);
     setSelectedFileMode("diff");
-  }, [course.steps, progress.selectedStepId]);
+  }
 
   const value = useMemo<LearnModeContextValue>(
     () => ({

--- a/apps/docs/components/xulux/learn/LearnStageSourceContext.tsx
+++ b/apps/docs/components/xulux/learn/LearnStageSourceContext.tsx
@@ -69,6 +69,10 @@ export function LearnStageSourceProvider({
 
   useEffect(() => {
     if (!selectedStep) {
+      // The status transitions are the front half of the fetch below, keyed on
+      // the same inputs, so they stay with it rather than splitting across a
+      // render-time copy of this dependency list.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setStatus("idle");
       setPreviousFiles(EMPTY_FILES);
       setCurrentFiles(EMPTY_FILES);

--- a/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
+++ b/apps/docs/components/xulux/shell/XuluxHeaderActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
+import { useHeaderPortalContainer } from "@/hooks/use-header-portal-container";
 import { createPortal } from "react-dom";
 import { LayoutGrid, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -8,13 +9,7 @@ import type { XuluxStoredThread } from "../runtime/types";
 import { XuluxHistoryMenu } from "./XuluxHistoryMenu";
 
 function HeaderPortal({ children }: { children: ReactNode }) {
-  const [container, setContainer] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setContainer(
-      document.querySelector<HTMLElement>("[data-sub-project-header-portal]"),
-    );
-  }, []);
+  const container = useHeaderPortalContainer();
 
   if (!container) return null;
   return createPortal(children, container);

--- a/apps/docs/hooks/use-header-portal-container.ts
+++ b/apps/docs/hooks/use-header-portal-container.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const SELECTOR = "[data-sub-project-header-portal]";
+
+const subscribe = () => () => {};
+
+const getSnapshot = () => document.querySelector<HTMLElement>(SELECTOR);
+
+const getServerSnapshot = () => null;
+
+/** The sub-project header's portal target, `null` until the client renders. */
+export function useHeaderPortalContainer() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/docs/hooks/use-hydrated.ts
+++ b/apps/docs/hooks/use-hydrated.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+
+const getSnapshot = () => true;
+
+const getServerSnapshot = () => false;
+
+/** `false` on the server and through hydration, `true` on every render after. */
+export function useHydrated() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/apps/docs/hooks/use-markdown-copy.ts
+++ b/apps/docs/hooks/use-markdown-copy.ts
@@ -1,17 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback } from "react";
 import { toast } from "sonner";
 
 export function useMarkdownCopy(markdownUrl: string | undefined) {
   const [content, setContent] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const hasFetched = useRef(false);
-
-  useEffect(() => {
-    hasFetched.current = false;
-    setContent(null);
-  }, []);
 
   const prefetch = useCallback(() => {
     if (!markdownUrl || hasFetched.current) return;

--- a/apps/docs/hooks/use-reduced-motion.ts
+++ b/apps/docs/hooks/use-reduced-motion.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+const subscribe = (onStoreChange: () => void) => {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+};
+
+const getSnapshot = () => window.matchMedia(QUERY).matches;
+
+const getServerSnapshot = () => false;
+
+/** Tracks `prefers-reduced-motion`, reporting `false` on the server. */
+export function useReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/examples/with-expo/hooks/use-color-scheme.web.ts
+++ b/examples/with-expo/hooks/use-color-scheme.web.ts
@@ -1,15 +1,17 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useColorScheme as useRNColorScheme } from "react-native";
+
+const subscribe = () => () => {};
+
+const hydrated = () => true;
+
+const notHydrated = () => false;
 
 /**
  * To support static rendering, this value needs to be re-calculated on the client side for web
  */
 export function useColorScheme() {
-  const [hasHydrated, setHasHydrated] = useState(false);
-
-  useEffect(() => {
-    setHasHydrated(true);
-  }, []);
+  const hasHydrated = useSyncExternalStore(subscribe, hydrated, notHydrated);
 
   const colorScheme = useRNColorScheme();
 

--- a/examples/with-ffmpeg/app/page.tsx
+++ b/examples/with-ffmpeg/app/page.tsx
@@ -70,11 +70,13 @@ const FfmpegToolsProvider: FC<{ file: File; children: ReactNode }> = ({
 export default function Home() {
   const [lastFile, setLastFile] = useState<File | null>(null);
   const attachments = useAuiState((s) => s.thread.composer.attachments);
-  useEffect(() => {
+  const [syncedAttachments, setSyncedAttachments] = useState(attachments);
+
+  if (syncedAttachments !== attachments) {
+    setSyncedAttachments(attachments);
     const lastAttachment = attachments[attachments.length - 1];
-    if (!lastAttachment) return;
-    setLastFile(lastAttachment.file!);
-  }, [attachments]);
+    if (lastAttachment) setLastFile(lastAttachment.file!);
+  }
 
   const aui = useAui();
   const config = AuiConfig({

--- a/packages/ai-sdk/src/runtime/useExternalHistory.ts
+++ b/packages/ai-sdk/src/runtime/useExternalHistory.ts
@@ -143,6 +143,9 @@ export const useExternalHistory = <TMessage>(
 
     const remoteId = optionalThreadListItem()?.getState().remoteId;
     if (!remoteId) {
+      // History loads asynchronously against the thread list item; without a
+      // remote id there is nothing to await, so the flag settles here.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setHasLoaded(true);
       return aui.subscribe(() => {
         if (optionalThreadListItem()?.getState().remoteId) {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -146,6 +146,9 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const threadId = scope.cloud === cloud ? selection.threadId : null;
 
   useEffect(() => {
+    // The stale-scope commit in between is what lets the layout effect below
+    // clear the previous cloud's threads before the new scope takes over.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSelection((current) =>
       current.scope.cloud === cloud
         ? current
@@ -160,6 +163,8 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     if (!isActiveScope) {
       listedThreadIdsRef.current.clear();
       threadTitleGenerationsRef.current.clear();
+      // Paired with the ref clears above, which cannot move into render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setThreads([]);
       setError(null);
       setIsLoading(enabled);
@@ -301,6 +306,9 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
 
   useEffect(() => {
     if (!enabled) return;
+    // The refresh is an async fetch against the cloud; its loading state
+    // settles inside it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, [refresh, enabled]);
 

--- a/packages/core/src/react/client/Tools.ts
+++ b/packages/core/src/react/client/Tools.ts
@@ -108,6 +108,9 @@ const useTools = ({
           : undefined);
       if (render) {
         unsubscribes.push(
+          // Registration has to be undone on unmount, so the registry write and
+          // its unsubscribe belong to the same effect.
+          // eslint-disable-next-line react-hooks/set-state-in-effect
           setToolUI(toolName, render, {
             standalone: isStandaloneToolDisplay(tool),
             renderText: toolRenderText,

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -943,9 +943,11 @@ const useExternalThread = ({
       : undefined;
   };
 
-  const [feedbackMessages, setFeedbackMessages] = useState(messages);
-  if (feedbackMessages !== messages) {
-    setFeedbackMessages(messages);
+  // `messages` changes identity on every streamed token, and this body fans out
+  // to one client per message, so pruning during render would re-run the whole
+  // fan-out per token. The effect bails out on an unchanged map instead.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setSubmittedFeedback((prev) => {
       const live = Object.entries(prev).filter(([id, entry]) => {
         const msg = messages.find((m) => m.id === id);
@@ -955,7 +957,7 @@ const useExternalThread = ({
         ? prev
         : Object.fromEntries(live);
     });
-  }
+  }, [messages]);
 
   const handleSubmitFeedback = (
     message: ExternalThreadMessage,

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -943,7 +943,9 @@ const useExternalThread = ({
       : undefined;
   };
 
-  useEffect(() => {
+  const [feedbackMessages, setFeedbackMessages] = useState(messages);
+  if (feedbackMessages !== messages) {
+    setFeedbackMessages(messages);
     setSubmittedFeedback((prev) => {
       const live = Object.entries(prev).filter(([id, entry]) => {
         const msg = messages.find((m) => m.id === id);
@@ -953,7 +955,7 @@ const useExternalThread = ({
         ? prev
         : Object.fromEntries(live);
     });
-  }, [messages]);
+  }
 
   const handleSubmitFeedback = (
     message: ExternalThreadMessage,

--- a/packages/core/src/store/clients/model-context-client.ts
+++ b/packages/core/src/store/clients/model-context-client.ts
@@ -36,6 +36,9 @@ const useModelContext = (): ClientOutput<"modelContext"> => {
   );
 
   useEffect(() => {
+    // The composite is an external store; this catches the snapshot up for
+    // providers registered between render and subscribe.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setState((prev) => deriveState(composite, prev));
     return composite.subscribe(() => {
       setState((prev) => deriveState(composite, prev));

--- a/packages/react-devtools/src/shell/DevToolsPanel.tsx
+++ b/packages/react-devtools/src/shell/DevToolsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import clsx from "clsx";
 import { useDevToolsClient } from "../data/useDevToolsClient";
 import { inProcessClient } from "../data/createInProcessClient";
@@ -40,10 +40,9 @@ export const DevToolsPanel = ({
     resolvedClient,
   );
 
-  useEffect(() => {
-    if (selectedApiId !== null && apiIds.includes(selectedApiId)) return;
+  if (selectedApiId === null || !apiIds.includes(selectedApiId)) {
     setSelectedApiId(apiIds[0] ?? null);
-  }, [apiIds, selectedApiId]);
+  }
 
   const allPlugins = useMemo(
     () =>

--- a/packages/react-devtools/src/shell/DevToolsPanel.tsx
+++ b/packages/react-devtools/src/shell/DevToolsPanel.tsx
@@ -40,9 +40,12 @@ export const DevToolsPanel = ({
     resolvedClient,
   );
 
-  if (selectedApiId === null || !apiIds.includes(selectedApiId)) {
-    setSelectedApiId(apiIds[0] ?? null);
-  }
+  const resolvedApiId =
+    selectedApiId !== null && apiIds.includes(selectedApiId)
+      ? selectedApiId
+      : (apiIds[0] ?? null);
+
+  if (resolvedApiId !== selectedApiId) setSelectedApiId(resolvedApiId);
 
   const allPlugins = useMemo(
     () =>

--- a/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
+++ b/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
@@ -79,14 +79,16 @@ export const ThreadTab = ({
     () => threadList?.mainThreadId ?? threadList?.threadIds[0] ?? "",
   );
 
-  if (hasConversationList && threadList) {
-    const ids = [...threadList.threadIds, ...threadList.archivedThreadIds];
-    if (!ids.includes(activeThreadId)) {
-      setActiveThreadId(
-        threadList.mainThreadId ?? threadList.threadIds[0] ?? "",
-      );
-    }
-  }
+  const resolvedThreadId =
+    hasConversationList && threadList
+      ? [...threadList.threadIds, ...threadList.archivedThreadIds].includes(
+          activeThreadId,
+        )
+        ? activeThreadId
+        : (threadList.mainThreadId ?? threadList.threadIds[0] ?? "")
+      : activeThreadId;
+
+  if (resolvedThreadId !== activeThreadId) setActiveThreadId(resolvedThreadId);
 
   const prevThreadIdRef = useRef(activeThreadId);
   useEffect(() => {

--- a/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
+++ b/packages/react-devtools/src/shell/tabs/ThreadTab.tsx
@@ -79,12 +79,14 @@ export const ThreadTab = ({
     () => threadList?.mainThreadId ?? threadList?.threadIds[0] ?? "",
   );
 
-  useEffect(() => {
-    if (!hasConversationList || !threadList) return;
+  if (hasConversationList && threadList) {
     const ids = [...threadList.threadIds, ...threadList.archivedThreadIds];
-    if (ids.includes(activeThreadId)) return;
-    setActiveThreadId(threadList.mainThreadId ?? threadList.threadIds[0] ?? "");
-  }, [hasConversationList, threadList, activeThreadId]);
+    if (!ids.includes(activeThreadId)) {
+      setActiveThreadId(
+        threadList.mainThreadId ?? threadList.threadIds[0] ?? "",
+      );
+    }
+  }
 
   const prevThreadIdRef = useRef(activeThreadId);
   useEffect(() => {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -324,6 +324,9 @@ const useStreamThreadRuntime = (
     if (remainingStagedMessages.length === 0) {
       stagedBaseMessagesRef.current = null;
       visibleMessagesRef.current = baseMessages;
+      // Reconciling against the upstream stream mutates the staged refs above,
+      // which cannot happen during render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setStagedMessages(null);
       return;
     }

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -120,6 +120,9 @@ const useMcpManagerResource = (
 
   useEffect(() => {
     const signal = { cancelled: false };
+    // Hydration reads persisted records asynchronously; there is no earlier
+    // point than mount at which to start it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void hydrate(signal);
     return () => {
       signal.cancelled = true;

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -622,6 +622,9 @@ const useMcpServerResourceInstance = (
     pendingDisposalRef.current = pendingDisposal;
     mountedRef.current = true;
     const signal = { cancelled: false };
+    // Auto-connect opens a transport, so it belongs to the same effect as the
+    // disposal that closes it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void tryAutoConnect(signal);
     return () => {
       mountedRef.current = false;

--- a/packages/react/src/hooks/useToolCallElapsed.ts
+++ b/packages/react/src/hooks/useToolCallElapsed.ts
@@ -36,6 +36,9 @@ export const useToolCallElapsed = (): number | undefined => {
 
   useEffect(() => {
     if (!running) return undefined;
+    // The clock is an external source; this catches the elapsed value up before
+    // the interval takes over.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNow(Date.now());
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);

--- a/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerKeyboardResource.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffectEvent, useState } from "react";
 import { resource } from "@assistant-ui/tap";
 import type {
   Unstable_TriggerCategory,
@@ -58,14 +58,20 @@ const useTriggerKeyboardResource = ({
   close: () => void;
 }): TriggerKeyboardResourceOutput => {
   const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [highlightScope, setHighlightScope] = useState({
+    navigableList,
+    isSearchMode,
+    activeCategoryId,
+  });
 
-  useEffect(() => {
+  if (
+    highlightScope.navigableList !== navigableList ||
+    highlightScope.isSearchMode !== isSearchMode ||
+    highlightScope.activeCategoryId !== activeCategoryId
+  ) {
+    setHighlightScope({ navigableList, isSearchMode, activeCategoryId });
     setHighlightedIndex(0);
-  }, [navigableList]);
-
-  useEffect(() => {
-    setHighlightedIndex(0);
-  }, [isSearchMode, activeCategoryId]);
+  }
 
   const highlightIndex = useEffectEvent((index: number) => {
     if (index < 0 || index >= navigableList.length) return;

--- a/packages/react/src/primitives/composer/trigger/triggerNavigationResource.ts
+++ b/packages/react/src/primitives/composer/trigger/triggerNavigationResource.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffectEvent, useMemo, useState } from "react";
 import { resource } from "@assistant-ui/tap";
 import type {
   Unstable_TriggerAdapter,
@@ -41,10 +41,12 @@ const useTriggerNavigationResource = ({
   open: boolean;
 }): TriggerNavigationResourceOutput => {
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null);
+  const [wasOpen, setWasOpen] = useState(open);
 
-  useEffect(() => {
+  if (wasOpen !== open) {
+    setWasOpen(open);
     if (!open) setActiveCategoryId(null);
-  }, [open]);
+  }
 
   const categories = useMemo<readonly Unstable_TriggerCategory[]>(() => {
     if (!open || !adapter) return [];

--- a/packages/ui/src/components/react/assistant-ui/elements/context-display.radix.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/context-display.radix.tsx
@@ -10,7 +10,6 @@ import { cn } from "@/lib/utils";
 import {
   createContext,
   useContext,
-  useEffect,
   useMemo,
   useState,
   type FC,
@@ -115,7 +114,11 @@ function ContextDisplayRoot({
     usage,
   });
 
-  useEffect(() => {
+  if (
+    tokenState.resetKey !== resetKey ||
+    (rawTokens > 0 && rawTokens !== tokenState.totalTokens) ||
+    usage !== tokenState.usage
+  ) {
     setTokenState((prev) => {
       if (prev.resetKey !== resetKey) {
         return {
@@ -132,7 +135,7 @@ function ContextDisplayRoot({
       }
       return prev;
     });
-  }, [resetKey, rawTokens, usage]);
+  }
 
   const current =
     tokenState.resetKey === resetKey

--- a/packages/ui/src/components/react/assistant-ui/elements/context-display.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/context-display.tsx
@@ -10,7 +10,6 @@ import { cn } from "@/lib/utils";
 import {
   createContext,
   useContext,
-  useEffect,
   useMemo,
   useState,
   type FC,
@@ -115,7 +114,11 @@ function ContextDisplayRoot({
     usage,
   });
 
-  useEffect(() => {
+  if (
+    tokenState.resetKey !== resetKey ||
+    (rawTokens > 0 && rawTokens !== tokenState.totalTokens) ||
+    usage !== tokenState.usage
+  ) {
     setTokenState((prev) => {
       if (prev.resetKey !== resetKey) {
         return {
@@ -132,7 +135,7 @@ function ContextDisplayRoot({
       }
       return prev;
     });
-  }, [resetKey, rawTokens, usage]);
+  }
 
   const current =
     tokenState.resetKey === resetKey

--- a/packages/ui/src/components/react/assistant-ui/elements/mermaid-diagram.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/mermaid-diagram.tsx
@@ -31,7 +31,6 @@ type MermaidZoomProps = {
 };
 
 function MermaidZoom({ svg, children }: MermaidZoomProps) {
-  const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 });
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -55,10 +54,6 @@ function MermaidZoom({ svg, children }: MermaidZoomProps) {
         .replace(/(href|xlink:href)="#([^"]+)"/g, '$1="#$2-zoom"'),
     [svg],
   );
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   const handleClose = useCallback(() => {
     setIsOpen(false);
@@ -177,8 +172,7 @@ function MermaidZoom({ svg, children }: MermaidZoomProps) {
       >
         <Maximize2 className="size-3.5" />
       </button>
-      {isMounted &&
-        isOpen &&
+      {isOpen &&
         createPortal(
           <div
             ref={overlayRef}

--- a/packages/ui/src/components/react/assistant-ui/elements/scroll-anchor.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/scroll-anchor.tsx
@@ -55,6 +55,9 @@ export function ScrollAnchor({
 
   useEffect(() => {
     if (count === INITIAL_COUNT + 1) {
+      // The unpin lands one commit after the count that triggers it, so the
+      // pinned scroll still runs for that message.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPinned(false);
       const viewport = viewportRef.current;
       if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
@@ -62,12 +65,9 @@ export function ScrollAnchor({
   }, [count]);
 
   useEffect(() => {
+    if (!pinned) return;
     const viewport = viewportRef.current;
-    if (!viewport) return;
-    if (pinned) {
-      viewport.scrollTo({ top: viewport.scrollHeight });
-      setSeenCount(count);
-    }
+    if (viewport) viewport.scrollTo({ top: viewport.scrollHeight });
   }, [count, pinned]);
 
   const jump = useCallback(() => {
@@ -85,7 +85,7 @@ export function ScrollAnchor({
     return () => clearTimeout(id);
   }, [paused, pinned, count, seenCount, jump]);
 
-  const newCount = count - seenCount;
+  const newCount = pinned ? 0 : count - seenCount;
 
   return (
     <div

--- a/packages/ui/src/components/react/assistant-ui/elements/scroll-anchor.tsx
+++ b/packages/ui/src/components/react/assistant-ui/elements/scroll-anchor.tsx
@@ -59,6 +59,7 @@ export function ScrollAnchor({
       // pinned scroll still runs for that message.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPinned(false);
+      setSeenCount(count);
       const viewport = viewportRef.current;
       if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
     }

--- a/packages/ui/src/components/react/ui/base/number-roll.tsx
+++ b/packages/ui/src/components/react/ui/base/number-roll.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ComponentProps,
   type CSSProperties,
 } from "react";
@@ -14,6 +15,11 @@ const DEFAULT_DURATION = 500;
 const DIGIT_CELLS = Array.from({ length: 10 }, (_, i) => i);
 
 let supportsRoll: boolean | undefined;
+
+const subscribeToNothing = () => () => {};
+
+const notEnhanced = () => false;
+
 const canAnimate = () => {
   if (supportsRoll === undefined) {
     supportsRoll =
@@ -254,10 +260,11 @@ function NumberRoll({
   style,
   ...props
 }: NumberRollProps) {
-  const [enhanced, setEnhanced] = useState(false);
-  useEffect(() => {
-    if (canAnimate()) setEnhanced(true);
-  }, []);
+  const enhanced = useSyncExternalStore(
+    subscribeToNothing,
+    canAnimate,
+    notEnhanced,
+  );
 
   const formatter = getFormatter(locales, format);
   const parts = useMemo(

--- a/packages/ui/src/components/react/ui/base/number-roll.tsx
+++ b/packages/ui/src/components/react/ui/base/number-roll.tsx
@@ -20,29 +20,30 @@ const subscribeToNothing = () => () => {};
 
 const notEnhanced = () => false;
 
-const canAnimate = () => {
-  if (supportsRoll === undefined) {
-    supportsRoll =
-      typeof CSS !== "undefined" &&
-      typeof CSS.registerProperty === "function" &&
-      CSS.supports(
-        "transform",
-        "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
-      );
-    if (supportsRoll) {
-      try {
-        CSS.registerProperty({
-          name: "--aui-number-roll-pos",
-          syntax: "<number>",
-          inherits: true,
-          initialValue: "0",
-        });
-      } catch {
-        /* Already registered by another copy of this component. */
-      }
-    }
+let rollPropertyRegistered = false;
+
+const readSupportsRoll = () =>
+  (supportsRoll ??=
+    typeof CSS !== "undefined" &&
+    typeof CSS.registerProperty === "function" &&
+    CSS.supports(
+      "transform",
+      "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
+    ));
+
+const registerRollProperty = () => {
+  if (rollPropertyRegistered) return;
+  rollPropertyRegistered = true;
+  try {
+    CSS.registerProperty({
+      name: "--aui-number-roll-pos",
+      syntax: "<number>",
+      inherits: true,
+      initialValue: "0",
+    });
+  } catch {
+    /* Already registered by another copy of this component. */
   }
-  return supportsRoll;
 };
 
 /* Cached because Intl.NumberFormat construction is expensive and inline format/locales props change identity on every parent render. */
@@ -262,9 +263,13 @@ function NumberRoll({
 }: NumberRollProps) {
   const enhanced = useSyncExternalStore(
     subscribeToNothing,
-    canAnimate,
+    readSupportsRoll,
     notEnhanced,
   );
+
+  useEffect(() => {
+    if (enhanced) registerRollProperty();
+  }, [enhanced]);
 
   const formatter = getFormatter(locales, format);
   const parts = useMemo(

--- a/packages/ui/src/components/react/ui/radix/carousel.tsx
+++ b/packages/ui/src/components/react/ui/radix/carousel.tsx
@@ -95,6 +95,9 @@ function Carousel({
 
   React.useEffect(() => {
     if (!api) return;
+    // Embla owns the selection; this catches the component up before the
+    // subscription below starts delivering changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     onSelect(api);
     api.on("reInit", onSelect);
     api.on("select", onSelect);

--- a/packages/ui/src/components/react/ui/radix/number-roll.tsx
+++ b/packages/ui/src/components/react/ui/radix/number-roll.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ComponentProps,
   type CSSProperties,
 } from "react";
@@ -14,6 +15,11 @@ const DEFAULT_DURATION = 500;
 const DIGIT_CELLS = Array.from({ length: 10 }, (_, i) => i);
 
 let supportsRoll: boolean | undefined;
+
+const subscribeToNothing = () => () => {};
+
+const notEnhanced = () => false;
+
 const canAnimate = () => {
   if (supportsRoll === undefined) {
     supportsRoll =
@@ -254,10 +260,11 @@ function NumberRoll({
   style,
   ...props
 }: NumberRollProps) {
-  const [enhanced, setEnhanced] = useState(false);
-  useEffect(() => {
-    if (canAnimate()) setEnhanced(true);
-  }, []);
+  const enhanced = useSyncExternalStore(
+    subscribeToNothing,
+    canAnimate,
+    notEnhanced,
+  );
 
   const formatter = getFormatter(locales, format);
   const parts = useMemo(

--- a/packages/ui/src/components/react/ui/radix/number-roll.tsx
+++ b/packages/ui/src/components/react/ui/radix/number-roll.tsx
@@ -20,29 +20,30 @@ const subscribeToNothing = () => () => {};
 
 const notEnhanced = () => false;
 
-const canAnimate = () => {
-  if (supportsRoll === undefined) {
-    supportsRoll =
-      typeof CSS !== "undefined" &&
-      typeof CSS.registerProperty === "function" &&
-      CSS.supports(
-        "transform",
-        "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
-      );
-    if (supportsRoll) {
-      try {
-        CSS.registerProperty({
-          name: "--aui-number-roll-pos",
-          syntax: "<number>",
-          inherits: true,
-          initialValue: "0",
-        });
-      } catch {
-        /* Already registered by another copy of this component. */
-      }
-    }
+let rollPropertyRegistered = false;
+
+const readSupportsRoll = () =>
+  (supportsRoll ??=
+    typeof CSS !== "undefined" &&
+    typeof CSS.registerProperty === "function" &&
+    CSS.supports(
+      "transform",
+      "translateY(clamp(-1lh, calc((mod(7.5, 10) - 5) * 1lh), 1lh))",
+    ));
+
+const registerRollProperty = () => {
+  if (rollPropertyRegistered) return;
+  rollPropertyRegistered = true;
+  try {
+    CSS.registerProperty({
+      name: "--aui-number-roll-pos",
+      syntax: "<number>",
+      inherits: true,
+      initialValue: "0",
+    });
+  } catch {
+    /* Already registered by another copy of this component. */
   }
-  return supportsRoll;
 };
 
 /* Cached because Intl.NumberFormat construction is expensive and inline format/locales props change identity on every parent render. */
@@ -262,9 +263,13 @@ function NumberRoll({
 }: NumberRollProps) {
   const enhanced = useSyncExternalStore(
     subscribeToNothing,
-    canAnimate,
+    readSupportsRoll,
     notEnhanced,
   );
+
+  useEffect(() => {
+    if (enhanced) registerRollProperty();
+  }, [enhanced]);
 
   const formatter = getFormatter(locales, format);
   const parts = useMemo(

--- a/packages/ui/src/hooks/use-attachment-src.ts
+++ b/packages/ui/src/hooks/use-attachment-src.ts
@@ -11,6 +11,9 @@ const useFileSrc = (file: File | undefined) => {
 
   useEffect(() => {
     if (!file) {
+      // The object URL is a browser resource whose lifetime has to straddle
+      // commit, so allocation and revocation belong to the effect.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setEntry(undefined);
       return;
     }

--- a/packages/ui/src/hooks/use-attachment-src.ts
+++ b/packages/ui/src/hooks/use-attachment-src.ts
@@ -10,15 +10,12 @@ const useFileSrc = (file: File | undefined) => {
   );
 
   useEffect(() => {
-    if (!file) {
-      // The object URL is a browser resource whose lifetime has to straddle
-      // commit, so allocation and revocation belong to the effect.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEntry(undefined);
-      return;
-    }
+    if (!file) return;
 
     const objectUrl = URL.createObjectURL(file);
+    // The object URL is a browser resource whose lifetime has to straddle
+    // commit, so allocation and revocation belong to the effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEntry({ file, url: objectUrl });
 
     return () => {

--- a/packages/ui/src/hooks/use-attachment-src.ts
+++ b/packages/ui/src/hooks/use-attachment-src.ts
@@ -10,12 +10,16 @@ const useFileSrc = (file: File | undefined) => {
   );
 
   useEffect(() => {
-    if (!file) return;
+    // The object URL is a browser resource whose lifetime has to straddle
+    // commit, so allocation, revocation, and clearing the entry that names a
+    // revoked URL all belong to the effect.
+    if (!file) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEntry(undefined);
+      return;
+    }
 
     const objectUrl = URL.createObjectURL(file);
-    // The object URL is a browser resource whose lifetime has to straddle
-    // commit, so allocation and revocation belong to the effect.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEntry({ file, url: objectUrl });
 
     return () => {

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -2,20 +2,16 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
+const subscribe = (onStoreChange: () => void) => {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  mql.addEventListener("change", onStoreChange);
+  return () => mql.removeEventListener("change", onStoreChange);
+};
+
+const getSnapshot = () => window.innerWidth < MOBILE_BREAKPOINT;
+
+const getServerSnapshot = () => false;
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
-  );
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return !!isMobile;
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/templates/minimal/hooks/use-attachment-src.ts
+++ b/templates/minimal/hooks/use-attachment-src.ts
@@ -11,6 +11,9 @@ const useFileSrc = (file: File | undefined) => {
 
   useEffect(() => {
     if (!file) {
+      // The object URL is a browser resource whose lifetime has to straddle
+      // commit, so allocation and revocation belong to the effect.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setEntry(undefined);
       return;
     }

--- a/templates/minimal/hooks/use-attachment-src.ts
+++ b/templates/minimal/hooks/use-attachment-src.ts
@@ -10,15 +10,12 @@ const useFileSrc = (file: File | undefined) => {
   );
 
   useEffect(() => {
-    if (!file) {
-      // The object URL is a browser resource whose lifetime has to straddle
-      // commit, so allocation and revocation belong to the effect.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEntry(undefined);
-      return;
-    }
+    if (!file) return;
 
     const objectUrl = URL.createObjectURL(file);
+    // The object URL is a browser resource whose lifetime has to straddle
+    // commit, so allocation and revocation belong to the effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEntry({ file, url: objectUrl });
 
     return () => {

--- a/templates/minimal/hooks/use-attachment-src.ts
+++ b/templates/minimal/hooks/use-attachment-src.ts
@@ -10,12 +10,16 @@ const useFileSrc = (file: File | undefined) => {
   );
 
   useEffect(() => {
-    if (!file) return;
+    // The object URL is a browser resource whose lifetime has to straddle
+    // commit, so allocation, revocation, and clearing the entry that names a
+    // revoked URL all belong to the effect.
+    if (!file) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEntry(undefined);
+      return;
+    }
 
     const objectUrl = URL.createObjectURL(file);
-    // The object URL is a browser resource whose lifetime has to straddle
-    // commit, so allocation and revocation belong to the effect.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEntry({ file, url: objectUrl });
 
     return () => {


### PR DESCRIPTION
closes #6311

## summary

- every `react/set-state-in-effect` finding in the repo is gone (71 at the start of this branch, 0 now), and the rule moves from `warn` to `error` in `.oxlintrc.json`, so the next one fails `pnpm lint` instead of joining a backlog.
- 50 of the 71 are restructured rather than silenced: `useSyncExternalStore` where the value really is external (matchMedia, the number-roll CSS capability probe, storage reads, `window.location`, a portal container), a render-time adjustment for the "reset state when a prop changes" cases, and plain deletion where the effect only reset state to the value it already had.
- the 21 that remain carry a suppression with a one-line reason, and the reasons fall into six groups: paired with a ref or animation-frame write, a subscription catch-up, an async load or connect, a registration undone on unmount, a browser resource whose lifetime straddles commit, and one place where the extra commit is load-bearing.
- three new docs hooks (`use-hydrated`, `use-reduced-motion`, `use-header-portal-container`) replace eight hand-rolled mount gates and two copies of the same portal lookup.
- tests get a scoped `off` for this rule, following the precedent `.oxlintrc.json` already sets for `react/globals` and `react/immutability` in `packages/tap/src/__tests__`.

the suppression comment is written in the ESLint form (`react-hooks/set-state-in-effect`) on purpose. `packages/ui` source is copied into consumer projects through the registry, where the consumer's own `eslint-plugin-react-hooks` runs and oxlint does not; oxlint honors that prefix, so one comment covers both. verified by injecting an unrelated rule name, which still reports.

## test plan

### already verified

- [x] `pnpm lint` -> PASS, 0 errors; injecting a `setState` into an effect in `DevToolsPanel.tsx` reports as an **error** (not a warning) and fails the run, then reverted
- [x] `npx oxlint -A all -D react/set-state-in-effect .` -> 0 findings repo-wide
- [x] `pnpm turbo test` -> 90/90 tasks, including `@assistant-ui/docs` at 92 files and 763 tests
- [x] `pnpm test:react-compiler` -> 11/11
- [x] `pnpm check:resource-memo` -> 24/24 resource-hosting files compile cleanly
- [x] `pnpm turbo build --filter=@assistant-ui/docs` -> exit 0, Next prerender included
- [x] `pnpm test:types` -> 36 errors, byte-identical to the same run on a stashed clean tree, all pre-existing (cli standalone-shim, codemods, cloud auth tests, with-aui)
- [x] `pnpm sync-templates`, `pnpm changesets:check`, `pnpm changeset-semver:check`, `pnpm workspace-ranges:check` -> all pass

### reviewer should verify

- [ ] the docs home and elements demos still animate: reasoning streams, the voice conversation amplitude oscillates while listening or speaking and rests otherwise, and the streamdown, tool-fallback, and tool-group samples replay from the start each run
- [ ] the Ask AI ball: dismiss it, reload (stays hidden), then open the assistant panel and close it (the ball comes back)
- [ ] theme toggle, docs sidebar section expansion, and the search dialog (open, type, reopen) behave as before; each moved from a mount effect to a render-time value
- [ ] a composer image attachment still previews and its object URL is revoked on removal

## notes

- `apps/docs` carried 40 of the 71 and is fixed too, rather than exempting the app from the `error` promotion. leaving it at `warn` would have made the ratchet leaky, which is the thing the issue is trying to end.
- `LearnStageSourceContext` deliberately keeps its suppression: a render-time version would have to restate that effect's four-entry dependency list, and two copies of it would drift.
- three behaviour details are preserved on purpose rather than tidied: `scroll-anchor` keeps unpinning one commit after the count that triggers it (the pinned scroll for that message still runs), `useThreads` keeps its stale-scope commit (the layout effect below it clears the previous cloud's threads on that pass), and four render-time adjustments seed their scope token to `null` so the first render still does what the mount effect did.
- the branch is 4 commits behind main at open; nothing in those four touches these files.
- review moved three conversions back to effects, each for a stated reason: the external thread feedback map (`messages` changes identity per streamed token and the body fans out one client per message, so a render-phase pass would re-run the fan-out), `LearnStageSourceContext` (a render-time copy of a four-entry dependency list would drift), and the composer attachment object URL (clearing the entry that names a revoked URL belongs with the revoke). the devtools panel and thread tab guards were also rewritten to converge, since a render-phase update skips the `Object.is` bailout and a guard that re-sets the value it already holds throws after 25 passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.3vcy6VOcgzmi_UtpCpQ9kMuFptOjq4VcOpKNy0zjB7sPRA0i1uCOtzIo7s0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
