### PR TITLE
test(core): pin title-state cleanup on successful thread deletion

### DIFF
--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -404,6 +404,41 @@ describe("RemoteThreadList", () => {
     handle.destroy();
   });
 
+  it("clears the deleted thread's title state so a reborn slot can auto-title", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+      })),
+    });
+    const { handle } = mountList(adapter);
+    const aui = handle.getClient();
+    await aui.threads.getLoadThreadsPromise();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual(["t1"]);
+    });
+
+    await aui.threads.item({ id: "t1" }).rename("Manual title");
+    await aui.threads.item({ id: "t1" }).delete();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual([]);
+    });
+
+    // The server still lists t1, so a reload rebirths the slot under the same
+    // remote id; a leaked manual-rename entry would suppress its auto-title.
+    await aui.threads.reload();
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual(["t1"]);
+    });
+    flushTapSync(() => aui.threads.switchToThread("t1"));
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).toBe("t1");
+    });
+
+    await aui.threads.item({ id: "t1" }).generateTitle({ automatic: true });
+    expect(adapter.generateTitle).toHaveBeenCalledOnce();
+    handle.destroy();
+  });
+
   it("keeps a manual rename made during automatic title generation", async () => {
     const generatedTitle = deferred<ReadableStream>();
     const adapter = makeAdapter({

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -407,27 +407,31 @@ describe("RemoteThreadList", () => {
   it("clears the deleted thread's title state so a reborn slot can auto-title", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({
-        threads: [{ status: "regular" as const, remoteId: "t1", title: "One" }],
+        threads: [
+          { status: "regular" as const, remoteId: "t1", title: "One" },
+          { status: "regular" as const, remoteId: "t2", title: "Two" },
+        ],
       })),
     });
     const { handle } = mountList(adapter);
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     await vi.waitFor(() => {
-      expect(aui.threads.getState().threadIds).toEqual(["t1"]);
+      expect(aui.threads.getState().threadIds).toEqual(["t1", "t2"]);
     });
 
     await aui.threads.item({ id: "t1" }).rename("Manual title");
+    await aui.threads.item({ id: "t2" }).rename("Kept manual title");
     await aui.threads.item({ id: "t1" }).delete();
     await vi.waitFor(() => {
-      expect(aui.threads.getState().threadIds).toEqual([]);
+      expect(aui.threads.getState().threadIds).toEqual(["t2"]);
     });
 
     // The server still lists t1, so a reload rebirths the slot under the same
     // remote id; a leaked manual-rename entry would suppress its auto-title.
     await aui.threads.reload();
     await vi.waitFor(() => {
-      expect(aui.threads.getState().threadIds).toEqual(["t1"]);
+      expect(aui.threads.getState().threadIds).toEqual(["t1", "t2"]);
     });
     flushTapSync(() => aui.threads.switchToThread("t1"));
     await vi.waitFor(() => {
@@ -435,6 +439,16 @@ describe("RemoteThreadList", () => {
     });
 
     await aui.threads.item({ id: "t1" }).generateTitle({ automatic: true });
+    expect(adapter.generateTitle).toHaveBeenCalledOnce();
+
+    // The undeleted t2 is the control: its manual rename survived the reload,
+    // so its auto-title stays suppressed. A reload that cleared every title
+    // state would generate here and fail, instead of hollowing out the pin.
+    flushTapSync(() => aui.threads.switchToThread("t2"));
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).toBe("t2");
+    });
+    await aui.threads.item({ id: "t2" }).generateTitle({ automatic: true });
     expect(adapter.generateTitle).toHaveBeenCalledOnce();
     handle.destroy();
   });

--- a/packages/core/src/react/client/RemoteThreadList.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.test.ts
@@ -441,9 +441,8 @@ describe("RemoteThreadList", () => {
     await aui.threads.item({ id: "t1" }).generateTitle({ automatic: true });
     expect(adapter.generateTitle).toHaveBeenCalledOnce();
 
-    // The undeleted t2 is the control: its manual rename survived the reload,
-    // so its auto-title stays suppressed. A reload that cleared every title
-    // state would generate here and fail, instead of hollowing out the pin.
+    // t2 is the control: a reload that cleared every title state would
+    // generate here as well.
     flushTapSync(() => aui.threads.switchToThread("t2"));
     await vi.waitFor(() => {
       expect(aui.threads.getState().mainThreadId).toBe("t2");

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts
@@ -158,6 +158,33 @@ describe("RemoteThreadListThreadListRuntimeCore switch/delete ordering", () => {
     expect(internals._titleStates.get(data.id)).toBe(titleState);
   });
 
+  it("clears the deleted thread's title state on successful deletion", async () => {
+    const adapter = makeAdapter({
+      list: vi.fn(async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "thread-b",
+            externalId: "thread-b",
+            title: "Thread B",
+          },
+        ],
+      })),
+    });
+    const core = createCore(adapter);
+    await core.getLoadThreadsPromise();
+    const data = core.getItemById("thread-b")!;
+    const internals = core as unknown as {
+      _titleStates: Map<string, unknown>;
+    };
+    internals._titleStates.set(data.id, {});
+
+    await core.delete(data.id);
+
+    expect(core.getItemById(data.id)).toBeUndefined();
+    expect(internals._titleStates.has(data.id)).toBe(false);
+  });
+
   it("stops the thread runtime when the adapter changes during a successful deletion", async () => {
     const removal = deferred<void>();
     const adapter = makeAdapter({


### PR DESCRIPTION
Closes #6929.

## Problem

`RemoteThreadListThreadListRuntimeCore.delete()` clears the deleted thread's title state on the success path, and nothing tests it — deleting the `clearThreadTitleState` line kept all 1688 core tests green. The issue also asked for the tap client's equivalent in `RemoteThreadList.ts` to be checked the same way; mutating that line kept the suite green too, so both cleanups were uncovered.

## Change

Two covering tests, one per client, both verified by mutation (each fails with its `clearThreadTitleState` call removed and passes with it restored):

- **Legacy runtime** (`RemoteThreadListThreadListRuntimeCore.switch-delete.test.ts`): exactly the sequence the issue specifies — seed a title state for a regular thread, delete against an adapter whose `delete()` resolves, assert the entry is gone, with no adapter swap anywhere (the earlier attempt in #6864 came out because `__internal_setOptions` clears `_titleStates` on adapter change, making the assertion vacuous). Mirrors the existing failure-path test ("preserves thread cleanup state when remote deletion fails") from the other side.
- **Tap client** (`RemoteThreadList.test.ts`): the tap client's session is not reachable from outside, so this one pins the observable consequence instead: rename a thread manually (recording the manual-title state), delete it, reload against a server that still lists the same remote id (the slot is reborn under the same id), and assert an `automatic: true` `generateTitle` on the reborn thread still reaches the adapter. With the cleanup removed, the leaked manual-rename entry suppresses the auto-title and the test fails.

## Verification

- Both target files green on this branch: 57 tests.
- Mutation check per test as above; the tap pin also fails when `reload()` clears every title state unconditionally, so the control cannot go vacuous.
- Full `@assistant-ui/core` suite green: 163 files, 1733 tests.

## Public surface

None; tests only, no changeset per repo precedent for test-only core PRs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MohokfHm3uNUK-iMVO7UZbp9GjUyFoAqjJN4KjYxa_hG9u3iIhxmQ-ojUqo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
