### PR TITLE
fix(python): derive with_parent_id controllers without rebuilding a StateManager

### DIFF
--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -52,12 +52,20 @@ class RunController:
         self._cancelled_signal = ReadOnlyCancellationSignal(self._cancelled_event)
 
     def with_parent_id(self, parent_id: str) -> 'RunController':
-        """Create a new RunController instance with the specified parent_id."""
-        controller = RunController(self._queue, self._state_manager.state_data, parent_id)
+        """Create a new RunController instance with the specified parent_id.
+
+        The derived controller is a view over this one — every field but the
+        parent id is shared — so it is built without running ``__init__``,
+        which would construct (and immediately discard) a whole StateManager
+        and require a running event loop.
+        """
+        controller = RunController.__new__(RunController)
+        controller._queue = self._queue
         controller._loop = self._loop
         controller._dispose_callbacks = self._dispose_callbacks
         controller._stream_tasks = self._stream_tasks
         controller._state_manager = self._state_manager
+        controller._parent_id = parent_id
         controller._cancelled_event = self._cancelled_event
         controller._cancelled_signal = self._cancelled_signal
         return controller

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -54,10 +54,9 @@ class RunController:
     def with_parent_id(self, parent_id: str) -> 'RunController':
         """Create a new RunController instance with the specified parent_id.
 
-        The derived controller is a view over this one — every field but the
-        parent id is shared — so it is built without running ``__init__``,
-        which would construct (and immediately discard) a whole StateManager
-        and require a running event loop.
+        Every field but the parent id is shared with this controller, so the
+        derived one skips ``__init__``, which would build and discard a whole
+        StateManager and require a running event loop.
         """
         controller = RunController.__new__(RunController)
         controller._queue = self._queue

--- a/python/assistant-stream/tests/test_with_parent_id.py
+++ b/python/assistant-stream/tests/test_with_parent_id.py
@@ -40,20 +40,34 @@ async def test_with_parent_id_shares_everything_but_the_parent_id():
 
 
 @pytest.mark.anyio
-async def test_with_parent_id_works_outside_a_running_loop():
+async def test_with_parent_id_sets_every_field_init_sets():
     captured: dict[str, RunController] = {}
 
     async def run_callback(controller: RunController):
+        captured["derived"] = controller.with_parent_id("p1")
         captured["controller"] = controller
-        controller.append_text("hello")
 
     [chunk async for chunk in create_run(run_callback)]
 
-    def derive() -> RunController:
-        with pytest.raises(RuntimeError):
-            asyncio.get_running_loop()
-        return captured["controller"].with_parent_id("p2")
+    assert vars(captured["derived"]).keys() == vars(captured["controller"]).keys()
 
-    derived = await asyncio.to_thread(derive)
-    assert derived._parent_id == "p2"
-    assert derived._state_manager is captured["controller"]._state_manager
+
+@pytest.mark.anyio
+async def test_with_parent_id_works_outside_a_running_loop():
+    async def run_callback(controller: RunController):
+        def derive_and_use() -> RunController:
+            with pytest.raises(RuntimeError):
+                asyncio.get_running_loop()
+            derived = controller.with_parent_id("p2")
+            derived.append_text("from off loop")
+            return derived
+
+        derived = await asyncio.to_thread(derive_and_use)
+        assert derived._parent_id == "p2"
+        assert derived._state_manager is controller._state_manager
+
+    chunks = [chunk async for chunk in create_run(run_callback)]
+
+    assert [(chunk.type, chunk.parent_id) for chunk in chunks] == [
+        ("text-delta", "p2")
+    ]

--- a/python/assistant-stream/tests/test_with_parent_id.py
+++ b/python/assistant-stream/tests/test_with_parent_id.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+
+from assistant_stream import RunController, create_run
+
+
+@pytest.mark.anyio
+async def test_with_parent_id_shares_everything_but_the_parent_id():
+    observed: dict[str, object] = {}
+
+    async def run_callback(controller: RunController):
+        derived = controller.with_parent_id("p1")
+        observed["state_manager_shared"] = (
+            derived._state_manager is controller._state_manager
+        )
+        observed["queue_shared"] = derived._queue is controller._queue
+        observed["cancel_shared"] = (
+            derived._cancelled_event is controller._cancelled_event
+            and derived.cancelled_event is controller.cancelled_event
+        )
+        observed["dispose_shared"] = (
+            derived._dispose_callbacks is controller._dispose_callbacks
+        )
+        observed["tasks_shared"] = derived._stream_tasks is controller._stream_tasks
+        derived.append_text("nested")
+
+    chunks = [chunk async for chunk in create_run(run_callback)]
+
+    assert observed == {
+        "state_manager_shared": True,
+        "queue_shared": True,
+        "cancel_shared": True,
+        "dispose_shared": True,
+        "tasks_shared": True,
+    }
+    assert len(chunks) == 1
+    assert chunks[0].type == "text-delta"
+    assert chunks[0].parent_id == "p1"
+
+
+@pytest.mark.anyio
+async def test_with_parent_id_works_outside_a_running_loop():
+    captured: dict[str, RunController] = {}
+
+    async def run_callback(controller: RunController):
+        captured["controller"] = controller
+        controller.append_text("hello")
+
+    [chunk async for chunk in create_run(run_callback)]
+
+    def derive() -> RunController:
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        return captured["controller"].with_parent_id("p2")
+
+    derived = await asyncio.to_thread(derive)
+    assert derived._parent_id == "p2"
+    assert derived._state_manager is captured["controller"]._state_manager


### PR DESCRIPTION
Closes #6924.

## Problem

`RunController.with_parent_id` constructs a full `RunController` and then overwrites almost everything it just built. The constructor runs `StateManager(...)` — building an `AssistantState`, a `Flusher`, a `StateDraft` and a `StateProxy` — and calls `asyncio.get_running_loop()`; the next lines throw all of it away in favour of the parent's fields. Since #6923 detaches state on `AssistantState.__init__`, that discarded `StateManager` deep-copies the entire state on every call. It also means `with_parent_id` cannot be called outside a running loop, purely because of the constructor path it does not use.

## Change

The issue's suggested fix: the derived controller is built with `RunController.__new__` and explicit field assignments — every field `__init__` sets is either shared from the parent (queue, loop, dispose callbacks, stream tasks, state manager, cancellation event and signal) or is the new `parent_id`. No `StateManager` is constructed, no state is copied, and no running loop is required.

## Verification

- New `tests/test_with_parent_id.py`, three tests. The first pins that every shared field is identical between parent and derived controller and that a chunk emitted through the derived controller carries the parent id. The second pins `vars(derived).keys() == vars(controller).keys()`, so a future `__init__` field that `with_parent_id` forgets to carry over surfaces as a red test rather than a distant `AttributeError`. The third pins that `with_parent_id` works off-loop: it derives *and* appends from a worker thread (`asyncio.to_thread`, asserting no running loop first) and asserts the chunk arrives carrying the derived parent id. That third test fails on main with `RuntimeError: no running event loop` and passes with the fix.
- Full suite: 176 passed, 7 skipped (`tests/test_langgraph.py` fails collection on a clean checkout because `langchain_core` is not in the `dev` extra — pre-existing, untouched).

## Public surface

No API change; `with_parent_id`'s behavior for existing callers is identical. Python package, so no npm changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.PDBB5OI6oA5g6K_SD9YSWV1Ln0SijUTENhxlx6tJ_8KlrE8d_scj0SSJlTA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
