### PR TITLE
fix: repair test:types drift across five packages

### DIFF
--- a/.changeset/test-types-drift.md
+++ b/.changeset/test-types-drift.md
@@ -1,0 +1,6 @@
+---
+"assistant-ui": patch
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix: repair the type drift tsc --noEmit catches in the codemod and proxy sources

--- a/packages/cli/src/codemods/v0-12/assistant-api-to-aui.ts
+++ b/packages/cli/src/codemods/v0-12/assistant-api-to-aui.ts
@@ -113,6 +113,7 @@ const migrateAssistantApiToAui = createTransformer(
         }
         if (j.VariableDeclaration.check(statement)) {
           for (const declarator of statement.declarations) {
+            if (!j.VariableDeclarator.check(declarator)) continue;
             if (
               j.Identifier.check(declarator.id) &&
               declarator.id.name === "api"
@@ -254,7 +255,7 @@ const migrateAssistantApiToAui = createTransformer(
             return;
           if (
             grandparent?.exportKind === "type" ||
-            parent.exportKind === "type"
+            (parent as { exportKind?: string }).exportKind === "type"
           )
             return;
           if (parent.exported === path.value && parent.local !== path.value)

--- a/packages/cli/src/codemods/v0-12/assistant-api-to-aui.ts
+++ b/packages/cli/src/codemods/v0-12/assistant-api-to-aui.ts
@@ -253,6 +253,8 @@ const migrateAssistantApiToAui = createTransformer(
             grandparent.source != null
           )
             return;
+          // Babel emits exportKind on ExportSpecifier for inline
+          // `export { type api }`; ast-types' typings omit it.
           if (
             grandparent?.exportKind === "type" ||
             (parent as { exportKind?: string }).exportKind === "type"

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AssistantCloudAnonymousAuthStrategy,
@@ -60,7 +61,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
   it("reads the stored anonymous refresh token", () => {
     const values = new Map([[refreshTokenKey, JSON.stringify(refreshToken)]]);
     installLocalStorage({
-      getItem: (key) => values.get(key) ?? null,
+      getItem: (key: string) => values.get(key) ?? null,
       setItem: (key, value) => {
         values.set(key, value);
       },
@@ -335,7 +336,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
                 { once: true },
               );
             }),
-        } as Response),
+        } as unknown as Response),
       )
       .mockResolvedValueOnce({
         ok: true,
@@ -664,7 +665,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     const removeItem = vi.fn(() => {
       throw new DOMException("blocked", "SecurityError");
     });
-    installLocalStorage({ getItem, setItem, removeItem } as Storage);
+    installLocalStorage({ getItem, setItem, removeItem } as unknown as Storage);
     mockAnonymousTokenFetch();
 
     await expect(

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -61,7 +61,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
   it("reads the stored anonymous refresh token", () => {
     const values = new Map([[refreshTokenKey, JSON.stringify(refreshToken)]]);
     installLocalStorage({
-      getItem: (key: string) => values.get(key) ?? null,
+      getItem: (key) => values.get(key) ?? null,
       setItem: (key, value) => {
         values.set(key, value);
       },
@@ -74,8 +74,10 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
   });
 
   it("reads the token stored for a base url given with a trailing slash", () => {
+    // The two-step cast below erases the contextual Storage typing the plain
+    // `as Storage` sites get, so this parameter needs its own annotation.
     installLocalStorage({
-      getItem: (key) =>
+      getItem: (key: string) =>
         key === refreshTokenKey ? JSON.stringify(refreshToken) : null,
       setItem: vi.fn(),
       removeItem: vi.fn(),

--- a/packages/mcp-docs-server/src/proxy.test.ts
+++ b/packages/mcp-docs-server/src/proxy.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import {
   createServer,
   type IncomingMessage,

--- a/packages/mcp-docs-server/src/proxy.ts
+++ b/packages/mcp-docs-server/src/proxy.ts
@@ -43,7 +43,7 @@ export async function runProxy({
   };
 
   stdio.onmessage = (message) => {
-    if (isInitializeRequest(message)) {
+    if (isJSONRPCRequest(message) && isInitializeRequest(message)) {
       initializeRequestId = message.id;
     }
 

--- a/packages/next/src/with-aui.test.ts
+++ b/packages/next/src/with-aui.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { withAui } from "./with-aui";
 
-type AuiNextConfig = Parameters<typeof withAui>[0];
+type AuiNextConfig = NonNullable<Parameters<typeof withAui>[0]>;
 
 const rulesFor = (config: AuiNextConfig) =>
   withAui(config).turbopack?.rules ?? {};

--- a/packages/next/src/with-aui.test.ts
+++ b/packages/next/src/with-aui.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { withAui } from "./with-aui";
 
-const rulesFor = (config: Parameters<typeof withAui>[0]) =>
+type AuiNextConfig = Parameters<typeof withAui>[0];
+
+const rulesFor = (config: AuiNextConfig) =>
   withAui(config).turbopack?.rules ?? {};
 
 const ourRule = (rule: unknown) =>
@@ -38,7 +40,8 @@ describe("withAui", () => {
   it("honors custom globs", () => {
     expect(
       Object.keys(
-        withAui({}, { rules: ["*.generative.tsx"] }).turbopack?.rules ?? {},
+        withAui<AuiNextConfig>({}, { rules: ["*.generative.tsx"] }).turbopack
+          ?.rules ?? {},
       ),
     ).toEqual(["*.generative.tsx"]);
   });
@@ -82,7 +85,7 @@ describe("withAui", () => {
   });
 
   it("reads options from the `aui` config key and strips it", () => {
-    const result = withAui({
+    const result = withAui<AuiNextConfig>({
       aui: { rules: ["*.generative.tsx"], backendless: true },
     });
 
@@ -98,7 +101,7 @@ describe("withAui", () => {
     const userWebpack = vi.fn((config) => config);
     const config = { module: { rules: [] as unknown[] } };
 
-    withAui({ webpack: userWebpack }).webpack!(config, {});
+    withAui<AuiNextConfig>({ webpack: userWebpack }).webpack!(config, {});
 
     expect(userWebpack).toHaveBeenCalledWith(config, {});
     expect(config.module.rules).toHaveLength(1);

--- a/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.graph.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/tap/src/standalone-shim/standalone-shim.parity.test.ts
+++ b/packages/tap/src/standalone-shim/standalone-shim.parity.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
Addresses #6801's five reported packages (the CI-lane half — whether a job should run `test:types` — is a maintainer scope decision and stays out, same split as #6690).

## Problem

`pnpm test:types` fails in the five packages the issue names on a clean checkout: `@assistant-ui/mcp-docs-server`, `@assistant-ui/tap`, `assistant-ui` (the CLI), `@assistant-ui/next`, and `@assistant-ui/cloud`. Nothing gates the script, so it drifted — two distinct causes, per the issue.

## Change

**Test files outside their tsconfig's type environment** (no behavior change):

- `mcp-docs-server/proxy.test.ts` used bare `describe`/`it`/`expect`/`vi`; they are now imported from vitest explicitly, the repo's convention everywhere else.
- `tap`'s two standalone-shim tests and `cloud`'s auth-strategy test use node builtins (`node:fs`, `__dirname`, `Buffer`) but both packages extend the browser-neutral `ts/base`, which deliberately omits node globals. Each file now carries `/// <reference types="node" />`, pulling node types for that file alone via the shared typeRoots without changing the packages' neutral typing.
- `cloud`'s test also had one implicitly-any parameter and two casts `@tsconfig/strictest` rejects (`as Response`, `as Storage` on partial mocks), now explicit (`(key: string)`, `as unknown as`).
- `next/with-aui.test.ts` called `withAui` with literal configs, so the generic inferred types without `turbopack`/`webpack`; the calls now pass `Parameters<typeof withAui>[0]` explicitly (a pattern the file's own `rulesFor` helper already used).

**Genuine drift in source** (both behavior-neutral, changeset attached):

- `mcp-docs-server/proxy.ts`: `isInitializeRequest` narrows to a shape without `id`; the read is now guarded by the already-imported `isJSONRPCRequest` too, which carries `id` in its narrowing — an initialize request is always a JSON-RPC request, so the runtime path is identical.
- `cli` codemod: `VariableDeclaration.declarations` is typed `(VariableDeclarator | IdentifierKind)[]`, so declarators are now guarded with `j.VariableDeclarator.check` before `.id` access, and the `exportKind` read on `ExportSpecifier` (a runtime-real Babel property missing from ast-types' typings) goes through a narrow structural type.

## Newer drift, out of scope

While verifying, `@assistant-ui/store` now also fails `tsc --noEmit` (10 errors in 4 test files) on clean main — that landed after this issue was filed and sits in the actively-developed custom-scope test area (#6511's territory), so it is deliberately not bundled here; noting it on the issue.

## Verification

- Before: `pnpm test:types` fails in the five named packages with the issue's exact errors. After: all five pass `tsc --noEmit`.
- All five packages' vitest suites pass unchanged: tap 581, cli 339, cloud 119, next 9, mcp-docs-server 1.

## Public surface

No API changes. Patch changesets for the two source-touched published packages (`assistant-ui`, `@assistant-ui/mcp-docs-server`); the rest are test-only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VHrseGLncdKVGhy4LNxAOIKRGEHr-y0TN4OzDGzfYSbAKtx7Ob1tjevWuQI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->