### PR TITLE
fix(react-ag-ui): preserve deferred replacement resumes

### DIFF
--- a/.changeset/fuzzy-agui-resumes.md
+++ b/.changeset/fuzzy-agui-resumes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: keep deferred continuations with the run that owns them

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -995,9 +995,12 @@ export class AgUiThreadRuntimeCore {
     }
     // MESSAGES_SNAPSHOT re-appends the active assistant, so a parked
     // continuation whose target survived the snapshot is still answerable.
+    // Membership is the head branch, not the repository: a soft merge leaves
+    // the messages it dropped behind as off-branch nodes.
+    const resumeTarget = this.pendingResume?.messageId;
     if (
-      this.pendingResume &&
-      !this.session.hasMessage(this.pendingResume.messageId)
+      resumeTarget !== undefined &&
+      !this.session.getMessages().some((message) => message.id === resumeTarget)
     ) {
       this.pendingResume = null;
     }

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -174,7 +174,9 @@ export class AgUiThreadRuntimeCore {
   private _loadPromise: Promise<void> | undefined;
   private _loadRequested = false;
   private pendingResumeMessageId: string | null = null;
+  private pendingResumeOwner: AbortController | null = null;
   private pendingA2uiResume = false;
+  private pendingA2uiResumeOwner: AbortController | null = null;
   private pendingA2uiAction: Record<string, unknown> | undefined;
 
   constructor(options: CoreOptions) {
@@ -880,6 +882,7 @@ export class AgUiThreadRuntimeCore {
 
     if (this.isRunningFlag) {
       this.pendingA2uiResume = true;
+      this.pendingA2uiResumeOwner = this.abortController;
       return;
     }
     this.startResumeRun(parentId);
@@ -895,6 +898,7 @@ export class AgUiThreadRuntimeCore {
       // A run is still draining (RUN_FINISHED arrived but the stream has not
       // closed). Defer until startRun's tail so we never start two runs.
       this.pendingResumeMessageId = messageId;
+      this.pendingResumeOwner = this.abortController;
       return;
     }
     this.startResumeRun(messageId);
@@ -945,6 +949,7 @@ export class AgUiThreadRuntimeCore {
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
     this.pendingA2uiResume = false;
+    this.pendingA2uiResumeOwner = null;
     this.pendingA2uiAction = undefined;
     this.assistantHistoryParents.clear();
 
@@ -1222,26 +1227,30 @@ export class AgUiThreadRuntimeCore {
     if (pendingError) {
       const err = pendingError;
       this.reportedErrors.add(err);
-      this.pendingResumeMessageId = null;
-      this.pendingA2uiResume = false;
-      this.pendingA2uiAction = undefined;
+      this.clearDeferredContinuations(abortController);
       throw err;
     }
 
     // A tool result that landed before the run settled deferred its
     // continuation here so a second run never overlaps the first.
-    if (this.pendingResumeMessageId !== null) {
+    if (
+      this.pendingResumeOwner === abortController &&
+      this.pendingResumeMessageId !== null
+    ) {
       const resumeMessageId = this.pendingResumeMessageId;
       this.pendingResumeMessageId = null;
+      this.pendingResumeOwner = null;
       if (!abortSignal.aborted) {
         this.startResumeRun(resumeMessageId);
-      } else {
-        this.pendingA2uiAction = undefined;
       }
     }
 
-    if (this.pendingA2uiResume) {
+    if (
+      this.pendingA2uiResumeOwner === abortController &&
+      this.pendingA2uiResume
+    ) {
       this.pendingA2uiResume = false;
+      this.pendingA2uiResumeOwner = null;
       if (!abortSignal.aborted && this.pendingA2uiAction !== undefined) {
         if (this.getPendingInterrupts()) {
           this.pendingA2uiAction = undefined;
@@ -1282,6 +1291,7 @@ export class AgUiThreadRuntimeCore {
   ): Promise<Error | undefined> {
     this.pendingA2uiAction = undefined;
     this.pendingA2uiResume = false;
+    this.pendingA2uiResumeOwner = null;
     const assistantId = ctx.ensureAssistant();
     const currentId = () => ctx.getAssistantMessageId() ?? assistantId;
     const options: ChatModelRunOptions = {
@@ -1357,7 +1367,21 @@ export class AgUiThreadRuntimeCore {
       ...(resume !== undefined ? { resume } : {}),
     };
     this.pendingA2uiAction = undefined;
+    this.pendingA2uiResume = false;
+    this.pendingA2uiResumeOwner = null;
     return input;
+  }
+
+  private clearDeferredContinuations(owner: AbortController): void {
+    if (this.pendingResumeOwner === owner) {
+      this.pendingResumeMessageId = null;
+      this.pendingResumeOwner = null;
+    }
+    if (this.pendingA2uiResumeOwner === owner) {
+      this.pendingA2uiResume = false;
+      this.pendingA2uiResumeOwner = null;
+      this.pendingA2uiAction = undefined;
+    }
   }
 
   private setRunning(running: boolean) {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -173,9 +173,8 @@ export class AgUiThreadRuntimeCore {
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
   private _loadRequested = false;
-  private pendingResumeMessageId: string | null = null;
-  private pendingResumeOwner: AbortController | null = null;
-  private pendingA2uiResume = false;
+  private pendingResume: { owner: AbortController; messageId: string } | null =
+    null;
   private pendingA2uiResumeOwner: AbortController | null = null;
   private pendingA2uiAction: Record<string, unknown> | undefined;
 
@@ -880,9 +879,9 @@ export class AgUiThreadRuntimeCore {
     }
     this.pendingA2uiAction = userAction;
 
-    if (this.isRunningFlag) {
-      this.pendingA2uiResume = true;
-      this.pendingA2uiResumeOwner = this.abortController;
+    const owner = this.abortController;
+    if (owner) {
+      this.pendingA2uiResumeOwner = owner;
       return;
     }
     this.startResumeRun(parentId);
@@ -894,11 +893,11 @@ export class AgUiThreadRuntimeCore {
   private maybeResumeAfterToolResults(messageId: string): void {
     if (!this.maybeCompleteAfterToolResults(messageId)) return;
 
-    if (this.isRunningFlag) {
+    const owner = this.abortController;
+    if (owner) {
       // A run is still draining (RUN_FINISHED arrived but the stream has not
       // closed). Defer until startRun's tail so we never start two runs.
-      this.pendingResumeMessageId = messageId;
-      this.pendingResumeOwner = this.abortController;
+      this.pendingResume = { owner, messageId };
       return;
     }
     this.startResumeRun(messageId);
@@ -948,7 +947,6 @@ export class AgUiThreadRuntimeCore {
   }
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
-    this.pendingA2uiResume = false;
     this.pendingA2uiResumeOwner = null;
     this.pendingA2uiAction = undefined;
     this.assistantHistoryParents.clear();
@@ -1233,23 +1231,15 @@ export class AgUiThreadRuntimeCore {
 
     // A tool result that landed before the run settled deferred its
     // continuation here so a second run never overlaps the first.
-    if (
-      this.pendingResumeOwner === abortController &&
-      this.pendingResumeMessageId !== null
-    ) {
-      const resumeMessageId = this.pendingResumeMessageId;
-      this.pendingResumeMessageId = null;
-      this.pendingResumeOwner = null;
+    if (this.pendingResume?.owner === abortController) {
+      const { messageId } = this.pendingResume;
+      this.pendingResume = null;
       if (!abortSignal.aborted) {
-        this.startResumeRun(resumeMessageId);
+        this.startResumeRun(messageId);
       }
     }
 
-    if (
-      this.pendingA2uiResumeOwner === abortController &&
-      this.pendingA2uiResume
-    ) {
-      this.pendingA2uiResume = false;
+    if (this.pendingA2uiResumeOwner === abortController) {
       this.pendingA2uiResumeOwner = null;
       if (!abortSignal.aborted && this.pendingA2uiAction !== undefined) {
         if (this.getPendingInterrupts()) {
@@ -1290,7 +1280,6 @@ export class AgUiThreadRuntimeCore {
     },
   ): Promise<Error | undefined> {
     this.pendingA2uiAction = undefined;
-    this.pendingA2uiResume = false;
     this.pendingA2uiResumeOwner = null;
     const assistantId = ctx.ensureAssistant();
     const currentId = () => ctx.getAssistantMessageId() ?? assistantId;
@@ -1367,18 +1356,14 @@ export class AgUiThreadRuntimeCore {
       ...(resume !== undefined ? { resume } : {}),
     };
     this.pendingA2uiAction = undefined;
-    this.pendingA2uiResume = false;
-    this.pendingA2uiResumeOwner = null;
     return input;
   }
 
   private clearDeferredContinuations(owner: AbortController): void {
-    if (this.pendingResumeOwner === owner) {
-      this.pendingResumeMessageId = null;
-      this.pendingResumeOwner = null;
+    if (this.pendingResume?.owner === owner) {
+      this.pendingResume = null;
     }
     if (this.pendingA2uiResumeOwner === owner) {
-      this.pendingA2uiResume = false;
       this.pendingA2uiResumeOwner = null;
       this.pendingA2uiAction = undefined;
     }

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -947,7 +947,6 @@ export class AgUiThreadRuntimeCore {
   }
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
-    this.pendingResume = null;
     this.pendingA2uiResumeOwner = null;
     this.pendingA2uiAction = undefined;
     this.assistantHistoryParents.clear();
@@ -993,6 +992,14 @@ export class AgUiThreadRuntimeCore {
     this.snapshotHistoryIds.clear();
     for (const { message } of this.getMessageRepository().messages) {
       this.snapshotHistoryIds.add(message.id);
+    }
+    // MESSAGES_SNAPSHOT re-appends the active assistant, so a parked
+    // continuation whose target survived the snapshot is still answerable.
+    if (
+      this.pendingResume &&
+      !this.session.hasMessage(this.pendingResume.messageId)
+    ) {
+      this.pendingResume = null;
     }
     this.notifyUpdate();
   }

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -947,6 +947,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
+    this.pendingResume = null;
     this.pendingA2uiResumeOwner = null;
     this.pendingA2uiAction = undefined;
     this.assistantHistoryParents.clear();

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1372,6 +1372,73 @@ describe("AGUIThreadRuntimeCore", () => {
     await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(2));
   });
 
+  it("drops a deferred resume a snapshot left off-branch", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    runs[0]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[0]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[0]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const [userMessage, assistant] = core.getMessages() as [
+      ThreadMessage,
+      ThreadAssistantMessage,
+    ];
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+    // The snapshot forks a sibling assistant, so the parked target stays in
+    // the repository while leaving the head branch.
+    core.applyExternalMessages([
+      userMessage,
+      {
+        ...assistant,
+        id: "rival-assistant",
+        content: [{ type: "text", text: "other branch" }],
+        status: { type: "complete", reason: "unknown" },
+      } as ThreadMessage,
+    ]);
+    expect(core.getMessages().map((message) => message.id)).toEqual([
+      userMessage.id,
+      "rival-assistant",
+    ]);
+
+    runs[0]?.resolve();
+    await firstRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(agent.runAgent).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1052,6 +1052,62 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("clears a cancelled run's deferred continuations", async () => {
+    const runInputs: any[] = [];
+    let firstSubscriber!: AgentSubscriber;
+    let resolveFirstRun!: () => void;
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runInputs.length > 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        firstSubscriber = subscriber;
+        return new Promise<void>((resolve) => {
+          resolveFirstRun = resolve;
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    firstSubscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    firstSubscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    firstSubscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    await core.cancel();
+    resolveFirstRun();
+    await firstRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(agent.runAgent).toHaveBeenCalledTimes(1);
+
+    await core.append(createAppendMessage());
+    expect(agent.runAgent).toHaveBeenCalledTimes(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -963,6 +963,95 @@ describe("AGUIThreadRuntimeCore", () => {
     await expect(replacementRun).rejects.toBe(replacementError);
   });
 
+  it("keeps a replacement run's deferred tool resume", async () => {
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((_input: unknown, subscriber: AgentSubscriber) => {
+        if (runs.length === 2) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    await core.cancel();
+
+    const replacementRun = core.append(createAppendMessage());
+    runs[1]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[1]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[1]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: "replacement" },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+
+    runs[0]?.resolve();
+    await firstRun;
+    runs[1]?.resolve();
+    await replacementRun;
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(3));
+  });
+
+  it("keeps a replacement run's deferred A2UI action", async () => {
+    const runInputs: unknown[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: unknown, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 2) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    await core.cancel();
+
+    const replacementRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    runs[0]?.resolve();
+    await firstRun;
+    runs[1]?.resolve();
+    await replacementRun;
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(3));
+
+    expect(runInputs[2]).toMatchObject({
+      forwardedProps: {
+        a2uiAction: { userAction: { name: "continue" } },
+      },
+    });
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1323,6 +1323,55 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(agent.runAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a deferred resume when a snapshot preserves its target", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    runs[0]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[0]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[0]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+    core.applyExternalMessages(core.getMessages());
+
+    runs[0]?.resolve();
+    await firstRun;
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(2));
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1273,6 +1273,56 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(agent.runAgent).toHaveBeenCalledTimes(2);
   });
 
+  it("drops a deferred resume when external messages replace the thread", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    runs[0]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[0]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[0]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+    core.applyExternalMessages([]);
+
+    runs[0]?.resolve();
+    await firstRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(agent.runAgent).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1108,6 +1108,171 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
   });
 
+  it("keeps a replacement run's A2UI action when a cancelled run owns the tool resume", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 2) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    const firstRun = core.append(createAppendMessage());
+    runs[0]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[0]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[0]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+
+    await core.cancel();
+    const replacementRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    runs[0]?.resolve();
+    await firstRun;
+    runs[1]?.resolve();
+    await replacementRun;
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(3));
+
+    expect(runInputs[2]).toMatchObject({
+      forwardedProps: {
+        a2uiAction: { userAction: { name: "continue" } },
+      },
+    });
+  });
+
+  it("keeps a replacement run's deferred resume when the cancelled run failed", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 2) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent, { onError: () => {} });
+    const firstError = new Error("first failed");
+    const firstRun = core.append(createAppendMessage());
+    runs[0]?.subscriber.onRunFailed?.({ error: firstError });
+
+    await core.cancel();
+    const replacementRun = core.append(createAppendMessage());
+    runs[1]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[1]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[1]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[1].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+
+    runs[0]?.resolve();
+    await expect(firstRun).rejects.toBe(firstError);
+    runs[1]?.resolve();
+    await replacementRun;
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledTimes(3));
+  });
+
+  it("never adopts a deferred resume another run parked", async () => {
+    const runInputs: any[] = [];
+    const runs: Array<{ subscriber: AgentSubscriber; resolve: () => void }> =
+      [];
+    const agent = {
+      runAgent: vi.fn((input: any, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runs.length === 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+          runs.push({ subscriber, resolve });
+        });
+      }),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    void core.append(createAppendMessage());
+    runs[0]?.subscriber.onToolCallStartEvent?.({
+      event: {
+        type: "TOOL_CALL_START",
+        toolCallId: "call-1",
+        toolCallName: "lookup",
+      },
+    });
+    runs[0]?.subscriber.onToolCallEndEvent?.({
+      event: { type: "TOOL_CALL_END", toolCallId: "call-1" },
+    });
+    runs[0]?.subscriber.onRunFinishedEvent?.({
+      event: { type: "RUN_FINISHED", runId: runInputs[0].runId },
+    });
+
+    const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
+    core.addToolResult({
+      messageId: assistant.id,
+      toolCallId: "call-1",
+      toolName: "lookup",
+      result: "done",
+      isError: false,
+    });
+
+    // The cancelled run never settles, so its parked resume outlives it.
+    await core.cancel();
+    await core.append(createAppendMessage());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(agent.runAgent).toHaveBeenCalledTimes(2);
+  });
+
   it("cancels an active run when the runtime detaches", async () => {
     let runSignal: AbortSignal | undefined;
     const agent = {


### PR DESCRIPTION
## Problem

A cancelled AG-UI run can settle after its replacement has already deferred a frontend-tool continuation or A2UI action. The cancelled run then clears that replacement state, so the continuation never reaches the agent.

Closes #6857.

## Root cause

Deferred tool resumes and A2UI actions were stored in instance-wide fields without recording which overlapping startRun invocation owned them. Every run tail could consume or clear the same fields.

## Change

Associate each deferred continuation with the abort controller of the run that parked it, and let a run consume or clear that state only when it owns it. The resume payload and its owner live in one record so the tail cannot read a message id against a stale owner, and the separate `pendingA2uiResume` flag is gone because a non-null owner already carries it. Starting a replacement still preserves the existing behavior where its input can consume a queued A2UI action; that path no longer touches another run's deferral.

The gate fixes three cases beyond the one in the issue:

- a cancelled run that owns the tool resume no longer wipes the replacement's queued A2UI action on its way past
- a cancelled run that also carries a run error no longer clears the replacement's deferred resume through the error path
- a later, unrelated run no longer adopts a resume parked by a cancelled predecessor that never settled, which produced a spurious extra run

It also carries one independent defect that predates the ownership keying, since it lives in the same state's lifecycle: `applyExternalMessages` discarded the queued A2UI action but left a parked tool resume behind, so the owning run's tail continued against a thread the external snapshot had replaced. The clear is gated on the resume target no longer being in the thread, because `applyExternalMessages` also serves the MESSAGES_SNAPSHOT handler, which deliberately re-appends the active assistant; clearing unconditionally would strand the tool result on that path. Both directions are pinned by tests.

## Verification

- Added regressions for replacement-owned frontend-tool resumes and A2UI actions, for the three cases above, and a combined cancellation regression proving one owner clears both continuation types without leaking the A2UI action into the next run.
- Confirmed all five behavioral regressions fail on current main (two agent calls where three are required, and three where two are) and pass with the fix. The clearing regression passes on both by design; it guards against over-preserving.
- pnpm -C packages/react-ag-ui exec vitest run (571 tests)
- pnpm -C packages/react-ag-ui exec tsc --noEmit
- pnpm lint
- pnpm changesets:check

## Public surface

Affected package: @assistant-ui/react-ag-ui, with a patch changeset. No exports, API-reference pages, docs, or templates change.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7DxIDg5UYb_NUgxC-2Uaq25JzjnIMr1_7RxnaXMB_OnxOWqsGS5OQiM2n6E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
