### PR TITLE
feat(docs): make open-source projects easier to navigate

### DIFF
--- a/apps/docs/app/(home)/oss/page.tsx
+++ b/apps/docs/app/(home)/oss/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import {
@@ -74,30 +75,7 @@ export default async function OssPage() {
                   {flagship.description}
                 </p>
                 <p className="mt-6 flex flex-wrap items-baseline gap-x-7 gap-y-2 font-mono text-[13px]">
-                  <Link
-                    href="/docs"
-                    className="text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    docs
-                  </Link>
-                  <a
-                    href={ossRepoUrl(flagship)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    github
-                  </a>
-                  {flagship.npm ? (
-                    <a
-                      href={ossNpmUrl(flagship.npm)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      npm
-                    </a>
-                  ) : null}
+                  <ProjectLinks project={flagship} />
                 </p>
               </div>
               {stars || weekly ? (
@@ -185,42 +163,93 @@ function ProjectRow({
   const license = project.license ?? "—";
   const href = ossPrimaryUrl(project);
   const external = href.startsWith("http");
-  const className =
-    "group hover:bg-foreground/[0.025] -mx-2 flex flex-col gap-1 px-2 py-2.5 transition-colors md:grid md:grid-cols-[minmax(0,16rem)_minmax(0,1fr)_3.5rem_5.5rem] md:items-baseline md:gap-6";
-  const content = (
+  const titleClassName =
+    "hover:text-foreground/70 inline-flex items-center text-sm font-medium transition-colors";
+  const title = (
     <>
-      <span className="text-sm font-medium">
-        {project.name}
-        <ArrowUpRight className="ms-1.5 mb-0.5 inline size-3.5 opacity-0 transition-opacity group-hover:opacity-50" />
-      </span>
-      <span className="text-muted-foreground text-sm leading-relaxed">
-        {project.description}
-      </span>
-      <span className="text-muted-foreground/70 hidden font-mono text-[11px] tracking-wide md:block">
-        {license}
-      </span>
-      <span className="text-muted-foreground/70 hidden text-right font-mono text-[11px] tracking-wide tabular-nums md:block">
-        {stat ?? "—"}
-      </span>
-      <span className="text-muted-foreground/60 mt-0.5 font-mono text-[10px] tracking-wide md:hidden">
-        {license}
-        {stat ? ` · ${stat}` : ""}
-      </span>
+      {project.name}
+      {external ? (
+        <ArrowUpRight className="ms-1.5 size-3.5 opacity-40" />
+      ) : null}
     </>
   );
 
-  return external ? (
+  return (
+    <div className="hover:bg-foreground/[0.025] -mx-2 flex flex-col gap-3 px-2 py-3 transition-colors md:grid md:grid-cols-[minmax(0,15rem)_minmax(0,1fr)_auto] md:items-start md:gap-6">
+      <div className="min-w-0">
+        {external ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={titleClassName}
+          >
+            {title}
+          </a>
+        ) : (
+          <Link href={href} className={titleClassName}>
+            {title}
+          </Link>
+        )}
+        <p className="text-muted-foreground/60 mt-1 font-mono text-[10px] tracking-wide">
+          {license}
+          {stat ? ` · ${stat}` : ""}
+        </p>
+      </div>
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        {project.description}
+      </p>
+      <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2 md:justify-end">
+        <ProjectLinks project={project} />
+      </div>
+    </div>
+  );
+}
+
+function ProjectLinks({ project }: { project: OssProject }) {
+  return (
+    <>
+      {project.docs ? (
+        <ProjectLink href={project.docs}>docs</ProjectLink>
+      ) : null}
+      {project.site ? (
+        <ProjectLink href={project.site}>website</ProjectLink>
+      ) : null}
+      <ProjectLink href={ossRepoUrl(project)}>github</ProjectLink>
+      {project.npm ? (
+        <ProjectLink href={ossNpmUrl(project.npm)}>npm</ProjectLink>
+      ) : null}
+      {project.pypi ? (
+        <ProjectLink href={`https://pypi.org/project/${project.pypi}/`}>
+          pypi
+        </ProjectLink>
+      ) : null}
+    </>
+  );
+}
+
+function ProjectLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  const className =
+    "text-muted-foreground hover:text-foreground text-xs transition-colors";
+
+  return href.startsWith("http") ? (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       className={className}
     >
-      {content}
+      {children}
     </a>
   ) : (
     <Link href={href} className={className}>
-      {content}
+      {children}
     </Link>
   );
 }

--- a/apps/docs/components/pages/docs/layout/docs-header.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-header.tsx
@@ -14,12 +14,15 @@ import { NavItems, NavItemsRoot } from "@/components/shared/nav-items";
 import { useDocsSidebar } from "@/components/pages/docs/contexts/sidebar";
 import { useAssistantPanel } from "@/components/pages/docs/assistant/context";
 import { ThemeToggle } from "@/components/shared/theme-toggle";
-import { HeaderBrandLink } from "@/components/shared/header-brand-link";
 import { headerBarClassName } from "@/components/shared/header-chrome";
 import { useScrolled } from "@/hooks/use-scrolled";
 import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { usePlatform } from "@/components/pages/docs/platform/context";
+import {
+  DocsProjectSwitcher,
+  type DocsProjectOption,
+} from "@/components/pages/docs/layout/docs-project-switcher";
 import {
   buildPlatformSections,
   findPathToNode,
@@ -28,6 +31,7 @@ import {
 interface DocsHeaderProps {
   section: string;
   sectionHref: string;
+  projects: DocsProjectOption[];
   mobileSectionTree?: PageTree.Root | undefined;
 }
 
@@ -128,6 +132,7 @@ function MobileSectionBreadcrumb({
 export function DocsHeader({
   section,
   sectionHref,
+  projects,
   mobileSectionTree,
 }: DocsHeaderProps) {
   const { setOpenSearch } = useSearchContext();
@@ -170,7 +175,7 @@ export function DocsHeader({
           )}
         >
           <div className="flex min-w-0 flex-1 items-center">
-            <HeaderBrandLink labelClassName="hidden sm:inline" />
+            <DocsProjectSwitcher projects={projects} />
             <span
               className={cn(
                 "text-muted-foreground/40 mx-3",

--- a/apps/docs/components/pages/docs/layout/docs-project-switcher.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-project-switcher.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ArrowUpRight, Check, ChevronDown, LayoutGrid } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+export type DocsProjectOption = {
+  id: string;
+  name: string;
+  href: string;
+  categoryLabel: string;
+};
+
+export function DocsProjectSwitcher({
+  projects,
+}: {
+  projects: DocsProjectOption[];
+}) {
+  const pathname = usePathname();
+  const activeProject = [...projects]
+    .filter(
+      (project) =>
+        !isExternal(project.href) &&
+        (pathname === project.href || pathname.startsWith(`${project.href}/`)),
+    )
+    .sort((a, b) => b.href.length - a.href.length)[0];
+  const currentProject = activeProject ?? projects[0];
+  const groups = projects.reduce((result, project) => {
+    const group = result.get(project.categoryLabel) ?? [];
+    group.push(project);
+    result.set(project.categoryLabel, group);
+    return result;
+  }, new Map<string, DocsProjectOption[]>());
+
+  if (!currentProject) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="hover:bg-foreground/[0.04] focus-visible:ring-ring group -ml-1.5 flex shrink-0 items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium tracking-tight transition-colors outline-none focus-visible:ring-2"
+        aria-label={`Switch open-source project, currently ${currentProject.name}`}
+      >
+        <Image
+          src="/favicon/icon.svg"
+          alt=""
+          width={18}
+          height={18}
+          className="size-[18px] dark:hue-rotate-180 dark:invert"
+        />
+        <span className="hidden sm:inline">{currentProject.name}</span>
+        <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[popup-open]:rotate-180" />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="start"
+        sideOffset={8}
+        className="max-h-[min(70vh,38rem)] w-72 overscroll-contain"
+      >
+        {[...groups].map(([category, options]) => (
+          <DropdownMenuGroup key={category}>
+            <DropdownMenuLabel>{category}</DropdownMenuLabel>
+            {options.map((project) => (
+              <ProjectItem
+                key={project.id}
+                project={project}
+                active={project.id === currentProject.id}
+              />
+            ))}
+          </DropdownMenuGroup>
+        ))}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem render={<Link href="/oss" />} className="py-2">
+          <LayoutGrid className="size-4" />
+          <span className="flex-1">All open-source projects</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ProjectItem({
+  project,
+  active,
+}: {
+  project: DocsProjectOption;
+  active: boolean;
+}) {
+  const content = (
+    <>
+      <span className="flex size-4 items-center justify-center">
+        <Check
+          className={cn(
+            "size-3.5 transition-opacity",
+            active ? "opacity-100" : "opacity-0",
+          )}
+        />
+      </span>
+      <span className="min-w-0 flex-1 truncate">{project.name}</span>
+      {isExternal(project.href) ? (
+        <ArrowUpRight className="text-muted-foreground size-3.5" />
+      ) : null}
+    </>
+  );
+
+  return (
+    <DropdownMenuItem
+      aria-current={active ? "page" : undefined}
+      className="py-2"
+      render={
+        isExternal(project.href) ? (
+          <a href={project.href} target="_blank" rel="noopener noreferrer" />
+        ) : (
+          <Link href={project.href} />
+        )
+      }
+    >
+      {content}
+    </DropdownMenuItem>
+  );
+}
+
+function isExternal(href: string) {
+  return href.startsWith("http");
+}

--- a/apps/docs/components/pages/docs/layout/docs-project-switcher.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-project-switcher.tsx
@@ -7,9 +7,7 @@ import { ArrowUpRight, Check, ChevronDown, LayoutGrid } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -19,7 +17,6 @@ export type DocsProjectOption = {
   id: string;
   name: string;
   href: string;
-  categoryLabel: string;
 };
 
 export function DocsProjectSwitcher({
@@ -36,12 +33,6 @@ export function DocsProjectSwitcher({
     )
     .sort((a, b) => b.href.length - a.href.length)[0];
   const currentProject = activeProject ?? projects[0];
-  const groups = projects.reduce((result, project) => {
-    const group = result.get(project.categoryLabel) ?? [];
-    group.push(project);
-    result.set(project.categoryLabel, group);
-    return result;
-  }, new Map<string, DocsProjectOption[]>());
 
   if (!currentProject) return null;
 
@@ -62,22 +53,13 @@ export function DocsProjectSwitcher({
         <ChevronDown className="text-muted-foreground size-3.5 transition-transform group-data-[popup-open]:rotate-180" />
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        align="start"
-        sideOffset={8}
-        className="max-h-[min(70vh,38rem)] w-72 overscroll-contain"
-      >
-        {[...groups].map(([category, options]) => (
-          <DropdownMenuGroup key={category}>
-            <DropdownMenuLabel>{category}</DropdownMenuLabel>
-            {options.map((project) => (
-              <ProjectItem
-                key={project.id}
-                project={project}
-                active={project.id === currentProject.id}
-              />
-            ))}
-          </DropdownMenuGroup>
+      <DropdownMenuContent align="start" sideOffset={8} className="w-64">
+        {projects.map((project) => (
+          <ProjectItem
+            key={project.id}
+            project={project}
+            active={project.id === currentProject.id}
+          />
         ))}
 
         <DropdownMenuSeparator />

--- a/apps/docs/components/pages/docs/layout/docs-root-layout.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-root-layout.tsx
@@ -13,6 +13,14 @@ import {
 import { DocsRuntimeProvider } from "@/runtimes/docs";
 import { CurrentPageProvider } from "@/components/pages/docs/contexts/current-page";
 import { PlatformProvider } from "@/components/pages/docs/platform/context";
+import { OSS_CATEGORIES, OSS_PROJECTS, ossPrimaryUrl } from "@/lib/oss";
+
+const DOCS_PROJECTS = OSS_PROJECTS.map((project) => ({
+  id: project.id,
+  name: project.name,
+  href: ossPrimaryUrl(project),
+  categoryLabel: OSS_CATEGORIES[project.category].label,
+}));
 
 type DocsRootLayoutProps = {
   tree: PageTree.Root;
@@ -41,6 +49,7 @@ export function DocsRootLayout({
               <DocsHeader
                 section={section}
                 sectionHref={sectionHref}
+                projects={DOCS_PROJECTS}
                 mobileSectionTree={
                   showMobileSectionBreadcrumb ? tree : undefined
                 }

--- a/apps/docs/components/pages/docs/layout/docs-root-layout.tsx
+++ b/apps/docs/components/pages/docs/layout/docs-root-layout.tsx
@@ -13,13 +13,14 @@ import {
 import { DocsRuntimeProvider } from "@/runtimes/docs";
 import { CurrentPageProvider } from "@/components/pages/docs/contexts/current-page";
 import { PlatformProvider } from "@/components/pages/docs/platform/context";
-import { OSS_CATEGORIES, OSS_PROJECTS, ossPrimaryUrl } from "@/lib/oss";
+import { OSS_PROJECTS, ossPrimaryUrl } from "@/lib/oss";
 
-const DOCS_PROJECTS = OSS_PROJECTS.map((project) => ({
+const DOCS_PROJECTS = OSS_PROJECTS.filter(
+  (project) => project.category === "sdk",
+).map((project) => ({
   id: project.id,
   name: project.name,
   href: ossPrimaryUrl(project),
-  categoryLabel: OSS_CATEGORIES[project.category].label,
 }));
 
 type DocsRootLayoutProps = {

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Menu, X, ArrowUpRight, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SearchDialog } from "./search-dialog";
@@ -57,10 +58,12 @@ function SearchButton({ onToggle }: { onToggle: () => void }) {
 }
 
 export function Header() {
+  const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const { toggle } = useAssistantPanel();
   const scrolled = useScrolled();
+  const isOssPage = pathname === "/oss";
 
   return (
     <header className="rounded-page sticky top-0 z-50 w-full">
@@ -71,7 +74,22 @@ export function Header() {
             "mx-auto flex h-12 w-full max-w-7xl items-center justify-between px-4 md:grid md:grid-cols-[1fr_auto_1fr]",
           )}
         >
-          <HeaderBrandLink className="justify-self-start" />
+          <div className="flex min-w-0 items-center justify-self-start">
+            <HeaderBrandLink
+              {...(isOssPage ? { labelClassName: "hidden sm:inline" } : {})}
+            />
+            {isOssPage ? (
+              <>
+                <span className="text-muted-foreground/40 mx-3">/</span>
+                <Link
+                  href="/oss"
+                  className="text-foreground hover:text-foreground/80 truncate text-sm font-medium transition-colors"
+                >
+                  Open source
+                </Link>
+              </>
+            ) : null}
+          </div>
 
           <NavItems
             items={NAV_ITEMS}


### PR DESCRIPTION
## Problem

The open-source directory did not identify itself in the global header, each project row behaved like one large ambiguous link, and the docs header had no product-level navigation. Visitors could not quickly tell where a project lived or reach the broader open-source catalog.

## Root cause

The shared home header only rendered the assistant-ui brand, the OSS rows collapsed each project's destinations into a single primary URL, and the docs shell treated the brand as a home link instead of a project context control.

## Change

- Show a static `assistant-ui / Open source` identity on `/oss`, without introducing a project switcher.
- Turn the project identity into an accessible dropdown inside docs only.
- Show released SDK products in that dropdown and keep one separated link to the complete `/oss` directory. Other libraries and primitives remain on the directory page.
- Keep unreleased projects out of the navigation and directory.
- Give each project explicit docs, website, GitHub, npm, and PyPI links when available.
- Rework project rows so their metadata, description, and destinations remain readable on desktop and mobile.

## Verification

- `pnpm exec oxfmt --check 'apps/docs/components/shared/header.tsx' 'apps/docs/app/(home)/oss/page.tsx'`
- `pnpm exec oxlint 'apps/docs/components/shared/header.tsx' 'apps/docs/app/(home)/oss/page.tsx'`
- `pnpm exec oxlint 'apps/docs/components/pages/docs/layout/docs-project-switcher.tsx' 'apps/docs/components/pages/docs/layout/docs-root-layout.tsx' 'apps/docs/components/pages/docs/layout/docs-header.tsx'`
- `pnpm --filter @assistant-ui/docs exec next typegen`
- `pnpm --filter @assistant-ui/docs exec tsc --noEmit`
- Browser-verified `/oss` at 1440x1000 and 390x844 with no error overlay; confirmed the linked `/docs` route loads.
- Browser-verified the compact docs dropdown at desktop and mobile widths, its two current destinations, and Escape/focus restoration.

## Public surface

Private docs application only. No package exports, generated API reference, templates, or changesets are affected.
