### PR TITLE
fix(react-ag-ui): ignore superseded thread loads

### DIFF
--- a/.changeset/agui-superseded-thread-loads.md
+++ b/.changeset/agui-superseded-thread-loads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+Ignore superseded thread switches so late history loads cannot overwrite the active thread's messages or state, resume a stale run, or clear a newer selection.

--- a/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/runtime-options.mdx
@@ -121,14 +121,19 @@ const runtime = useAgUiRuntime({
         setCurrentThreadId(await createThread());
       },
       onSwitchToThread: async (id) => {
-        const { messages, state } = await loadThread(id);
         setCurrentThreadId(id);
+        const { messages, state } = await loadThread(id);
         return { messages, state };
       },
     },
   },
 });
 ```
+
+Set the selected thread ID before awaiting its history. The runtime ignores messages,
+state, and resume requests returned by a superseded thread switch, but it cannot
+undo state updates inside your adapter. If creating a thread is asynchronous, also
+guard your adapter's thread ID update against a newer selection.
 
 ## Interrupts (experimental)
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.thread-switch.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.thread-switch.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { HttpAgent } from "@ag-ui/client";
+import type { ThreadMessage } from "@assistant-ui/core";
+import { AgUiThreadRuntimeCore } from "./runtime/AgUiThreadRuntimeCore";
+import type { UseAgUiThreadListAdapter } from "./runtime/types";
+import { useAgUiRuntime } from "./useAgUiRuntime";
+
+type ThreadLoad = Awaited<
+  ReturnType<NonNullable<UseAgUiThreadListAdapter["onSwitchToThread"]>>
+>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function message(id: string): ThreadMessage {
+  return {
+    id,
+    role: "user",
+    content: [{ type: "text", text: id }],
+    attachments: [],
+    createdAt: new Date(0),
+    metadata: { custom: {} },
+  };
+}
+
+function renderRuntime(
+  load: (id: string) => Promise<ThreadLoad>,
+  create: () => Promise<void> = async () => {},
+) {
+  const agent = {
+    runAgent: vi.fn(),
+    abortRun: vi.fn(),
+  } as unknown as HttpAgent;
+  return renderHook(() => {
+    const [threadId, setThreadId] = useState("initial");
+    return useAgUiRuntime({
+      agent,
+      adapters: {
+        threadList: {
+          threadId,
+          onSwitchToThread: (id) => {
+            setThreadId(id);
+            return load(id);
+          },
+          onSwitchToNewThread: () => {
+            setThreadId("thread-new");
+            return create();
+          },
+        },
+      },
+    });
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useAgUiRuntime thread switching", () => {
+  it.each([undefined, { owner: "thread-a" }])(
+    "ignores an older load and its resume request with state %j",
+    async (state) => {
+      const resume = vi
+        .spyOn(AgUiThreadRuntimeCore.prototype, "resumeInFlightRun")
+        .mockResolvedValue();
+      const first = deferred<ThreadLoad>();
+      const second = deferred<ThreadLoad>();
+      const { result } = renderRuntime((id) =>
+        id === "thread-a" ? first.promise : second.promise,
+      );
+
+      let switchA!: Promise<void>;
+      let switchB!: Promise<void>;
+      act(() => {
+        switchA = result.current.threads.switchToThread("thread-a");
+        switchB = result.current.threads.switchToThread("thread-b");
+      });
+      await act(async () => {
+        second.resolve({
+          messages: [message("thread-b")],
+          state: { owner: "thread-b" },
+        });
+        await switchB;
+      });
+      await act(async () => {
+        first.resolve({
+          messages: [message("thread-a")],
+          ...(state !== undefined && { state }),
+          unstable_resume: true,
+        });
+        await switchA;
+      });
+
+      expect(result.current.threads.getState().mainThreadId).toBe("thread-b");
+      expect(
+        result.current.thread.getState().messages.map((m) => m.id),
+      ).toEqual(["thread-b"]);
+      expect(result.current.thread.getState().state).toEqual({
+        owner: "thread-b",
+      });
+      expect(resume).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores a load superseded by creating a new thread", async () => {
+    const resume = vi
+      .spyOn(AgUiThreadRuntimeCore.prototype, "resumeInFlightRun")
+      .mockResolvedValue();
+    const load = deferred<ThreadLoad>();
+    const { result } = renderRuntime(() => load.promise);
+
+    let switchA!: Promise<void>;
+    act(() => {
+      switchA = result.current.threads.switchToThread("thread-a");
+    });
+    await act(async () => {
+      await result.current.threads.switchToNewThread();
+    });
+    const newThreadState = result.current.thread.getState().state;
+    await act(async () => {
+      load.resolve({
+        messages: [message("thread-a")],
+        state: { owner: "thread-a" },
+        unstable_resume: true,
+      });
+      await switchA;
+    });
+
+    expect(result.current.threads.getState().mainThreadId).toBe("thread-new");
+    expect(result.current.thread.getState().messages).toEqual([]);
+    expect(result.current.thread.getState().state).toEqual(newThreadState);
+    expect(resume).not.toHaveBeenCalled();
+  });
+
+  it("does not clear a newer thread when an older creation finishes", async () => {
+    const creation = deferred<void>();
+    const { result } = renderRuntime(
+      async () => ({
+        messages: [message("thread-b")],
+        state: { owner: "thread-b" },
+      }),
+      () => creation.promise,
+    );
+
+    let switchNew!: Promise<void>;
+    act(() => {
+      switchNew = result.current.threads.switchToNewThread();
+    });
+    await act(async () => {
+      await result.current.threads.switchToThread("thread-b");
+    });
+    await act(async () => {
+      creation.resolve();
+      await switchNew;
+    });
+
+    expect(result.current.threads.getState().mainThreadId).toBe("thread-b");
+    expect(result.current.thread.getState().messages.map((m) => m.id)).toEqual([
+      "thread-b",
+    ]);
+    expect(result.current.thread.getState().state).toEqual({
+      owner: "thread-b",
+    });
+  });
+
+  it("applies the current load and resumes it", async () => {
+    const resume = vi
+      .spyOn(AgUiThreadRuntimeCore.prototype, "resumeInFlightRun")
+      .mockResolvedValue();
+    const messages = [message("thread-a")];
+    const { result } = renderRuntime(async () => ({
+      messages,
+      state: { owner: "thread-a" },
+      unstable_resume: true,
+    }));
+
+    await act(async () => {
+      await result.current.threads.switchToThread("thread-a");
+    });
+
+    expect(result.current.thread.getState().messages.map((m) => m.id)).toEqual([
+      "thread-a",
+    ]);
+    expect(result.current.thread.getState().state).toEqual({
+      owner: "thread-a",
+    });
+    expect(resume).toHaveBeenCalledExactlyOnceWith(messages);
+  });
+});

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -62,6 +62,7 @@ export function useAgUiRuntime(
   const [_version, setVersion] = useState(0);
   const notifyUpdate = useCallback(() => setVersion((v) => v + 1), []);
   const coreRef = useRef<AgUiThreadRuntimeCore | null>(null);
+  const threadSwitchGenerationRef = useRef(0);
   const runtimeAdapters = useRuntimeAdapters();
 
   const historyAdapter = options.adapters?.history ?? runtimeAdapters?.history;
@@ -182,17 +183,21 @@ export function useAgUiRuntime(
       ...rest,
       onSwitchToNewThread: onSwitchToNewThread
         ? async () => {
+            const generation = ++threadSwitchGenerationRef.current;
             await onSwitchToNewThread();
+            if (generation !== threadSwitchGenerationRef.current) return;
             core.applyExternalMessages([]);
             core.resetState();
           }
         : undefined,
       onSwitchToThread: onSwitchToThread
         ? async (threadId: string) => {
+            const generation = ++threadSwitchGenerationRef.current;
             // Clear before the thread id flips, or the old messages leak
             // into the new thread as a sibling branch.
             core.applyExternalMessages([]);
             const result = await onSwitchToThread(threadId);
+            if (generation !== threadSwitchGenerationRef.current) return;
             core.applyExternalMessages(result.messages);
             if (result.state !== undefined) {
               core.loadExternalState(result.state);


### PR DESCRIPTION
## Problem

Rapid AG-UI thread switches can resolve out of order. Select A and then B, let B finish loading first, and finally resolve A: the UI still selects B but displays A's messages. The late result also replaces or resets state and can resume the wrong run. Creating a new thread has the same race in either direction.

Reproduced on main at `96f011a916de97ea73e25c307d9b2cb2f4758a85` (`@assistant-ui/react-ag-ui` 0.0.58). The included deferred-promise tests are a minimal offline reproduction.

Fixes #6855.

## Root cause

Both adapter wrappers apply their post-await effects without checking whether a newer switch has superseded them.

## Change

Use one monotonically increasing generation shared by existing-thread and new-thread switches, following the A2A runtime's existing approach. Only the current generation applies messages, state, or resume requests. Preserve the existing clear-before-ID-change ordering.

The runtime-options example now selects the thread before fetching history and explains that adapter-owned state updates need their own ordering guard.

## Verification

- On the unmodified source, the focused regression suite has 4 failures and 1 passing control; with the fix all 5 pass.
- `pnpm --filter @assistant-ui/react-ag-ui test`: 561 tests pass across 18 files.
- `pnpm exec turbo build --filter=@assistant-ui/react-ag-ui... --concurrency=4`: 11 successful tasks.
- `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit`: passes.
- `pnpm lint`: passes, with existing hook warnings.
- `pnpm changesets:check`: passes.
- `git diff --check`: passes.

## Public surface

`@assistant-ui/react-ag-ui` behavior fix with a patch changeset and runtime-options documentation update. No exports, signatures, templates, or generated API-reference pages change.

Implementation and validation were completed with AI assistance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AJvpCd56_VWur7KraNbmoz61ypbq9Rnwtv_rMILO_72j-51GIYioavvZwPY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->