### PR TITLE
fix(assistant-stream): serialize successful string tool inputs

### DIFF
--- a/.changeset/successful-string-tool-input.md
+++ b/.changeset/successful-string-tool-input.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: serialize successful string tool inputs as JSON strings
+fix: keep the JSON quotes on a successful tool input that is a plain string, so a tool with a string input schema executes instead of failing with a parameter parsing error

--- a/.changeset/successful-string-tool-input.md
+++ b/.changeset/successful-string-tool-input.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: serialize successful string tool inputs as JSON strings

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -896,6 +896,29 @@ describe("UIMessageStreamDecoder", () => {
       expect(result?.result).toEqual({ temp: 20 });
     });
 
+    it("serializes successful string input as a JSON string", async () => {
+      const events = [
+        JSON.stringify({
+          type: "tool-input-available",
+          toolCallId: "call_abc",
+          toolName: "weather",
+          input: "Berlin",
+        }),
+        "[DONE]",
+      ];
+
+      const chunks = await collectChunks(
+        createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+      );
+
+      const argsText = chunks
+        .filter((c) => c.type === "text-delta")
+        .map((c) => c.textDelta)
+        .join("");
+      expect(argsText).toBe('"Berlin"');
+      expect(JSON.parse(argsText)).toBe("Berlin");
+    });
+
     it("prefers tool-input-available.input over earlier deltas", async () => {
       const events = [
         JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
@@ -145,10 +145,11 @@ export const createChunkNormalizer = (): {
         }
         if (tool.emitted) return;
         if (chunk.input !== undefined) {
+          const isUnparsedInputText =
+            chunk.type === "tool-input-error" &&
+            typeof chunk.input === "string";
           tool.deltas = [
-            chunk.type === "tool-input-error" && typeof chunk.input === "string"
-              ? chunk.input
-              : JSON.stringify(chunk.input),
+            isUnparsedInputText ? chunk.input : JSON.stringify(chunk.input),
           ];
         }
         if (chunk.type === "tool-input-error") {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts
@@ -146,7 +146,7 @@ export const createChunkNormalizer = (): {
         if (tool.emitted) return;
         if (chunk.input !== undefined) {
           tool.deltas = [
-            typeof chunk.input === "string"
+            chunk.type === "tool-input-error" && typeof chunk.input === "string"
               ? chunk.input
               : JSON.stringify(chunk.input),
           ];


### PR DESCRIPTION
## Problem

Successful string inputs lose their JSON quotes. For input `"Berlin"`, the decoder emits raw `Berlin`, which is not valid JSON.

Reproduction base: `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a` (`assistant-stream@0.3.41`). After `pnpm install --frozen-lockfile`, run this script with Bun from the repository root:

```js
import assert from "node:assert/strict";
import { createChunkNormalizer } from "./packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-normalizer.ts";

const chunks = [];
createChunkNormalizer().normalize(
  { type: "tool-input-available", toolCallId: "call1", toolName: "lookup", input: "Berlin" },
  { enqueue(chunk) { chunks.push(chunk); } },
);
const args = chunks.filter(c => c.type === "tool-call-delta").map(c => c.argsText).join("");
assert.equal(args, '"Berlin"');
```

## Root cause

Successful input frames and input-error frames share a raw-string branch. Successful strings are input values, but error strings can contain unparsed input text.

## Change

Successful string inputs use the existing JSON serializer. Input-error strings keep their raw text. The correction stays in the shared chunk normalizer.

## Verification

- The reproduction and decoder regression failed before the correction and passed afterward.
- `pnpm --filter assistant-stream exec vitest run src/core/serialization/ui-message-stream/UIMessageStream.test.ts` passed all 38 tests, including the raw input-error case.
- Scoped `oxlint` and `oxfmt --check` passed for the two TypeScript files.

## Public surface

The change affects `assistant-stream` and includes a patch changeset. Exports, signatures, documentation, API-reference output, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IYIaPvlesVq4Gd5lYYoiayBLQZt54CaNzHnRmiRmAkqJDBdoIv7gBIbbD-s?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->