### PR TITLE
fix(react-mcp): keep static oauth clients out of the dynamic cache

### DIFF
--- a/.changeset/oauth-static-client-cache.md
+++ b/.changeset/oauth-static-client-cache.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: keep static OAuth client updates out of the dynamic registration cache

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -68,6 +68,41 @@ const createProvider = (storage: MCPStorage) =>
     onAuthorizationUrl: () => {},
   });
 
+const createStaticProvider = (storage: MCPStorage, clientSecret?: string) =>
+  createOAuthProvider({
+    serverId: "docs",
+    serverUrl,
+    config: {
+      type: "oauth",
+      clientId: "client-a",
+      ...(clientSecret ? { clientSecret } : {}),
+    },
+    storage,
+    redirectUri: "http://localhost/callback",
+    onAuthorizationUrl: () => {},
+  });
+
+const discoveryStateFor = (issuer: string): OAuthDiscoveryState => ({
+  ...discoveryState,
+  authorizationServerUrl: issuer,
+  authorizationServerMetadata: {
+    issuer,
+    authorization_endpoint: `${issuer}/authorize`,
+    token_endpoint: `${issuer}/token`,
+    registration_endpoint: `${issuer}/register`,
+    response_types_supported: ["code"],
+    code_challenge_methods_supported: ["S256"],
+  },
+  resourceMetadata: {
+    resource: "https://mcp.example.com",
+    authorization_servers: [issuer],
+  },
+});
+
+const rejectFetch = async () => {
+  throw new Error("Unexpected OAuth request");
+};
+
 describe("createOAuthProvider callback state", () => {
   it("persists the generated state with the PKCE verifier", async () => {
     const { storage, getState } = createStorage();
@@ -587,13 +622,7 @@ describe("createOAuthProvider persistence across provider instances", () => {
     async (clientId) => {
       const { storage, getState } = createStorage({
         serverUrl,
-        discoveryState: {
-          ...discoveryState,
-          authorizationServerMetadata: {
-            ...discoveryState.authorizationServerMetadata,
-            code_challenge_methods_supported: ["S256"],
-          },
-        },
+        discoveryState: discoveryStateFor("https://auth.example.com"),
       });
       const dynamicProvider = createProvider(storage);
       if (clientId) {
@@ -602,22 +631,10 @@ describe("createOAuthProvider persistence across provider instances", () => {
           redirect_uris: ["http://localhost/callback"],
         });
       }
-      const staticProvider = createOAuthProvider({
-        serverId: "docs",
-        serverUrl,
-        config: { type: "oauth", clientId: "client-a" },
-        storage,
-        redirectUri: "http://localhost/callback",
-        onAuthorizationUrl: () => {},
-      });
+      const staticProvider = createStaticProvider(storage);
 
       await expect(
-        auth(staticProvider, {
-          serverUrl,
-          fetchFn: async () => {
-            throw new Error("Unexpected OAuth request");
-          },
-        }),
+        auth(staticProvider, { serverUrl, fetchFn: rejectFetch }),
       ).resolves.toBe("REDIRECT");
 
       expect(await dynamicProvider.clientInformation()).toEqual(
@@ -636,6 +653,64 @@ describe("createOAuthProvider persistence across provider instances", () => {
       expect(await staticProvider.clientInformation()).toMatchObject({
         client_id: "client-a",
         issuer: "https://auth.example.com",
+      });
+    },
+  );
+
+  it("drops the configured secret when the SDK re-registers at a new issuer", async () => {
+    const { storage, getState } = createStorage({
+      serverUrl,
+      discoveryState: discoveryStateFor("https://auth.example.com"),
+    });
+    const provider = createStaticProvider(storage, "client-secret");
+
+    await expect(
+      auth(provider, { serverUrl, fetchFn: rejectFetch }),
+    ).resolves.toBe("REDIRECT");
+    await provider.saveDiscoveryState?.(
+      discoveryStateFor("https://moved.example.com"),
+    );
+
+    await expect(
+      auth(provider, {
+        serverUrl,
+        fetchFn: async () =>
+          new Response(
+            JSON.stringify({
+              client_id: "registered-client",
+              redirect_uris: ["http://localhost/callback"],
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      }),
+    ).resolves.toBe("REDIRECT");
+
+    expect(await provider.clientInformation()).toEqual({
+      client_id: "registered-client",
+      redirect_uris: ["http://localhost/callback"],
+      issuer: "https://moved.example.com",
+    });
+    expect(getState()?.clientInformation).toBeUndefined();
+  });
+
+  it.each(["client", "all"] as const)(
+    "restores the configured client through the %s invalidation scope",
+    async (scope) => {
+      const { storage } = createStorage({
+        serverUrl,
+        discoveryState: discoveryStateFor("https://auth.example.com"),
+      });
+      const provider = createStaticProvider(storage, "client-secret");
+
+      await expect(
+        auth(provider, { serverUrl, fetchFn: rejectFetch }),
+      ).resolves.toBe("REDIRECT");
+      await provider.invalidateCredentials?.(scope);
+
+      expect(await provider.clientInformation()).toEqual({
+        client_id: "client-a",
+        client_secret: "client-secret",
+        redirect_uris: ["http://localhost/callback"],
       });
     },
   );

--- a/packages/react-mcp/src/auth/createOAuthProvider.test.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.test.ts
@@ -1,4 +1,4 @@
-import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
+import { auth, type OAuthDiscoveryState } from "@modelcontextprotocol/client";
 import { describe, expect, it, vi } from "vitest";
 import type { MCPStorage } from "../resources/storage/types";
 import type { MCPPersistedAuthState } from "./types";
@@ -582,24 +582,63 @@ describe("createOAuthProvider persistence across provider instances", () => {
     });
   });
 
-  it("does not leak static client information to a dynamic provider", async () => {
-    const { storage } = createStorage();
-    const staticProvider = createOAuthProvider({
-      serverId: "docs",
-      serverUrl,
-      config: { type: "oauth", clientId: "client-a" },
-      storage,
-      redirectUri: "http://localhost/callback",
-      onAuthorizationUrl: () => {},
-    });
-    await expect(staticProvider.clientInformation()).resolves.toEqual({
-      client_id: "client-a",
-      redirect_uris: ["http://localhost/callback"],
-    });
+  it.each([undefined, "registered-client"])(
+    "keeps static SDK writeback separate from dynamic client %s",
+    async (clientId) => {
+      const { storage, getState } = createStorage({
+        serverUrl,
+        discoveryState: {
+          ...discoveryState,
+          authorizationServerMetadata: {
+            ...discoveryState.authorizationServerMetadata,
+            code_challenge_methods_supported: ["S256"],
+          },
+        },
+      });
+      const dynamicProvider = createProvider(storage);
+      if (clientId) {
+        await dynamicProvider.saveClientInformation?.({
+          client_id: clientId,
+          redirect_uris: ["http://localhost/callback"],
+        });
+      }
+      const staticProvider = createOAuthProvider({
+        serverId: "docs",
+        serverUrl,
+        config: { type: "oauth", clientId: "client-a" },
+        storage,
+        redirectUri: "http://localhost/callback",
+        onAuthorizationUrl: () => {},
+      });
 
-    const dynamicProvider = createProvider(storage);
-    await expect(dynamicProvider.clientInformation()).resolves.toBeUndefined();
-  });
+      await expect(
+        auth(staticProvider, {
+          serverUrl,
+          fetchFn: async () => {
+            throw new Error("Unexpected OAuth request");
+          },
+        }),
+      ).resolves.toBe("REDIRECT");
+
+      expect(await dynamicProvider.clientInformation()).toEqual(
+        clientId
+          ? {
+              client_id: "registered-client",
+              redirect_uris: ["http://localhost/callback"],
+            }
+          : undefined,
+      );
+      expect(
+        await createProvider(
+          createStorage(getState()).storage,
+        ).clientInformation(),
+      ).toEqual(await dynamicProvider.clientInformation());
+      expect(await staticProvider.clientInformation()).toMatchObject({
+        client_id: "client-a",
+        issuer: "https://auth.example.com",
+      });
+    },
+  );
 
   it("keeps a provider built while the clear is in flight usable", async () => {
     const { storage, getState } = createStorage();

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -216,7 +216,8 @@ export function createOAuthProvider(
   // and server URL, so a statically configured client stays a read-time overlay
   // owned by this provider. Writing it into the cache would leak this provider's
   // registration to a replacement built for a different, or absent, clientId.
-  const staticClientInformation = (():
+  // The SDK's write-backs, its issuer stamp included, replace the overlay.
+  const configuredClientInformation = ():
     | OAuthClientInformationFull
     | undefined => {
     if (!config.clientId) return undefined;
@@ -226,7 +227,8 @@ export function createOAuthProvider(
     };
     if (config.clientSecret) ci.client_secret = config.clientSecret;
     return ci;
-  })();
+  };
+  let clientInformationOverlay = configuredClientInformation();
 
   const loadCache = (): Promise<OAuthProviderCache> => {
     if (endpoint.invalidated) return Promise.resolve({});
@@ -306,11 +308,11 @@ export function createOAuthProvider(
     },
     async clientInformation() {
       const c = await loadCache();
-      return staticClientInformation ?? c.clientInformation;
+      return clientInformationOverlay ?? c.clientInformation;
     },
     async saveClientInformation(info) {
-      if (staticClientInformation) {
-        Object.assign(staticClientInformation, info);
+      if (clientInformationOverlay) {
+        clientInformationOverlay = info as OAuthClientInformationFull;
         return;
       }
       const c = await loadCache();
@@ -358,7 +360,10 @@ export function createOAuthProvider(
     async invalidateCredentials(scope) {
       const c = await loadCache();
       if (scope === "all" || scope === "tokens") delete c.tokens;
-      if (scope === "all" || scope === "client") delete c.clientInformation;
+      if (scope === "all" || scope === "client") {
+        delete c.clientInformation;
+        clientInformationOverlay = configuredClientInformation();
+      }
       if (scope === "all" || scope === "verifier") {
         delete c.codeVerifier;
         delete c.state;

--- a/packages/react-mcp/src/auth/createOAuthProvider.ts
+++ b/packages/react-mcp/src/auth/createOAuthProvider.ts
@@ -309,6 +309,10 @@ export function createOAuthProvider(
       return staticClientInformation ?? c.clientInformation;
     },
     async saveClientInformation(info) {
+      if (staticClientInformation) {
+        Object.assign(staticClientInformation, info);
+        return;
+      }
       const c = await loadCache();
       c.clientInformation = info as OAuthClientInformationFull;
       await persist();


### PR DESCRIPTION
## Problem

After an app removes `clientId`, a dynamic OAuth provider can return the former static client instead of an independent registration.

The reproduction applies to `@assistant-ui/react-mcp` 0.1.16 at base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`. Save this as `repro.ts` in the repository root and run `bun repro.ts`:

```ts
import assert from "node:assert/strict";
import { createOAuthProvider } from "./packages/react-mcp/src/auth/createOAuthProvider";

let saved = null;
const storage = {
  loadCustomServers: async () => [],
  saveCustomServers: async () => {},
  loadAuthState: async () => saved,
  saveAuthState: async (_id, state) => { saved = structuredClone(state); },
  clearAuthState: async () => { saved = null; },
};
const options = {
  serverId: "docs",
  serverUrl: "https://example.invalid/mcp",
  storage,
  redirectUri: "https://app.invalid/callback",
  onAuthorizationUrl: () => {},
};
const configured = createOAuthProvider({
  ...options, config: { type: "oauth", clientId: "configured-client" },
});
const info = await configured.clientInformation();
assert.ok(info);
await configured.saveClientInformation({
  ...info, issuer: "https://issuer.invalid",
}, { issuer: "https://issuer.invalid" });
const dynamic = createOAuthProvider({ ...options, config: { type: "oauth" } });
assert.equal(await dynamic.clientInformation(), undefined);
```

## Root cause

The SDK adds an issuer to static client information and calls `saveClientInformation`. That method wrote the static client into the shared dynamic cache and storage.

## Change

The statically configured client becomes a provider-owned overlay that the SDK's write-backs replace wholesale, so the issuer stamp lands locally and dynamic registrations stay in the shared record. `invalidateCredentials("client")` and `("all")` reset the overlay to the configured client, keeping its lifecycle in step with the cache it shadows.

Replacing rather than merging matters when a changed issuer makes the SDK discard the static client and register a new one: a merge would leave the configured `client_secret` on the freshly issued `client_id`, and `selectClientAuthMethod` would then send that secret to the new authorization server.

This prevents new cache pollution without a migration of saved records.

## Verification

- The API reproduction failed before the correction and passed afterward.
- The regressions call real SDK `auth` with cached discovery data. All five cases failed before the correction and passed afterward: the two write-back isolation cases, the re-registration at a new issuer, and the two invalidation scopes.
- `pnpm --filter @assistant-ui/react-mcp test`: 192 tests passed.
- `pnpm exec turbo run build --filter=@assistant-ui/react-mcp --force`: the package and its dependencies built successfully.
- Scoped `oxlint` and `pnpm changesets:check` passed.

The checks used local storage data and did not contact a live OAuth server.

## Public surface

`@assistant-ui/react-mcp` has a patch changeset. Exports, signatures, documentation, API-reference output, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sKbOgqMb65s41EYx6TqJO5CO-V0noJjPaJunfzN8SWj8gVI5x33G1F5vGgo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
