### PR TITLE
fix(assistant-stream): keep the first sse event after a bom

### DIFF
--- a/.changeset/sse-leading-bom.md
+++ b/.changeset/sse-leading-bom.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: keep the first SSE event when a text stream starts with a byte-order mark

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -7,6 +7,47 @@ describe("SSEEventDecoder", () => {
     expect(decoder.push("data: x\n\n")).toEqual([{ data: "x" }]);
   });
 
+  it("ignores one initial BOM across chunk boundaries and empty pushes", () => {
+    const text = "\uFEFFdata: hello\n\n";
+    for (let split = 0; split <= text.length; split++) {
+      const decoder = new SSEEventDecoder();
+      const events = [
+        ...decoder.push(""),
+        ...decoder.push(text.slice(0, split)),
+        ...decoder.push(""),
+        ...decoder.push(text.slice(split)),
+      ];
+      expect(events).toEqual([{ data: "hello" }]);
+    }
+  });
+
+  it("preserves a later BOM at the start of a data chunk", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: ")).toEqual([]);
+    expect(decoder.push("\uFEFFhello\n\n")).toEqual([{ data: "\uFEFFhello" }]);
+  });
+
+  it("does not strip a second BOM or leading whitespace from field names", () => {
+    for (const prefix of ["\uFEFF\uFEFF", " ", "\n\uFEFF"]) {
+      const decoder = new SSEEventDecoder();
+      expect(decoder.push(`${prefix}data: ignored\ndata: kept\n\n`)).toEqual([
+        { data: "kept" },
+      ]);
+    }
+  });
+
+  it("does not strip a BOM from later frames or after flush", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("\uFEFFdata: first\n\n")).toEqual([{ data: "first" }]);
+    expect(decoder.push("\uFEFFdata: ignored\ndata: second\n\n")).toEqual([
+      { data: "second" },
+    ]);
+    expect(decoder.flush()).toBeNull();
+    expect(decoder.push("\uFEFFdata: ignored\ndata: third\n\n")).toEqual([
+      { data: "third" },
+    ]);
+  });
+
   it("decodes CRLF terminated events", () => {
     const decoder = new SSEEventDecoder();
     expect(decoder.push("data: x\r\n\r\n")).toEqual([{ data: "x" }]);

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -12,6 +12,7 @@ export class SSEEventDecoder {
   private lastEventId: string | undefined;
   private retry: number | undefined;
   private pendingLF = false;
+  private started = false;
   private readonly trailing: "drop" | "dispatch";
 
   constructor(options?: { trailing?: "drop" | "dispatch" }) {
@@ -21,6 +22,11 @@ export class SSEEventDecoder {
   push(text: string): SSEEvent[] {
     const events: SSEEvent[] = [];
     if (text === "") return events;
+
+    if (!this.started) {
+      this.started = true;
+      if (text.startsWith("\uFEFF")) text = text.slice(1);
+    }
 
     // Lines end with LF, CRLF, or CR. A chunk-trailing "\r" terminates its
     // line immediately; pendingLF then swallows the leading "\n" of the next


### PR DESCRIPTION
## Problem

The public text decoder silently loses the first SSE event when the stream starts with a byte-order mark (BOM).

This reproduction uses Bun from the repository root at `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a` (`assistant-stream` version `0.3.41`):

```sh
bun -e '
import assert from "node:assert/strict";
import { SSEEventDecoder } from "./packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts";
const events = new SSEEventDecoder().push("\uFEFFdata: hello\n\n");
assert.deepEqual(events, [{ data: "hello" }]);
'
```

The decoder returns `[]` before the correction and `[{ data: "hello" }]` after it.

## Root cause

The parser includes the initial BOM in the field name, so `\uFEFFdata` does not match `data`. Byte-based callers already use `TextDecoder` or `TextDecoderStream`, which remove the initial UTF-8 BOM.

## Change

The shared text decoder removes exactly one BOM from the first nonempty input. Empty pushes do not consume that position. Later BOM characters and leading whitespace remain unchanged.

## Verification

The reproduction and two regression tests failed before the correction. The same reproduction passes after it. The focused checks pass:

- `pnpm --filter assistant-stream exec vitest run src/core/utils/stream/SSEEventDecoder.test.ts src/core/utils/stream/SSEEventDecoderStream.test.ts src/core/utils/stream/SSEJson.test.ts src/core/utils/stream/SSE.test.ts` (40 tests).
- `pnpm --filter assistant-stream build` and a Node smoke check through the rebuilt `assistant-stream/utils` export.
- `pnpm exec oxlint packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts`.
- `pnpm changesets:check`.

## Public surface

The change affects `SSEEventDecoder` from `assistant-stream/utils`. Public signatures and exports remain unchanged. The PR includes an `assistant-stream` patch changeset. Documentation, API-reference output, and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2nudj0xSH4sEDhJQ64nPvya0aYbXRbN4UyhikTo33-Cj_RN27bWk-LPOO4k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->