### PR TITLE
fix(store): detect changes in sparse array positions

### DIFF
--- a/.changeset/shallow-sparse-array-positions.md
+++ b/.changeset/shallow-sparse-array-positions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: detect values that replace empty positions in sparse arrays during shallow comparison

--- a/packages/store/src/utils/shallow-equal.test.ts
+++ b/packages/store/src/utils/shallow-equal.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { shallowEqual } from "./shallow-equal";
+
+describe("shallowEqual", () => {
+  it("detects a value in a previously empty array position", () => {
+    const sparse = new Array<number>(1);
+    const filled = [42];
+
+    expect(shallowEqual(sparse, filled)).toBe(false);
+    expect(shallowEqual(filled, sparse)).toBe(false);
+  });
+
+  it("compares sparse values at their array positions", () => {
+    const left = new Array<number>(2);
+    left[0] = 42;
+    const right = new Array<number>(2);
+    right[1] = 42;
+
+    expect(shallowEqual(left, right)).toBe(false);
+    expect(shallowEqual(right, left)).toBe(false);
+  });
+
+  it("treats empty array positions as undefined", () => {
+    const sparse = new Array<undefined>(1);
+
+    expect(shallowEqual(sparse, new Array<undefined>(1))).toBe(true);
+    expect(shallowEqual(sparse, [undefined])).toBe(true);
+    expect(shallowEqual([undefined], sparse)).toBe(true);
+    expect(shallowEqual(sparse, [])).toBe(false);
+    expect(shallowEqual([], sparse)).toBe(false);
+  });
+
+  it("preserves Object.is comparisons for array values", () => {
+    expect(shallowEqual([NaN], [NaN])).toBe(true);
+    expect(shallowEqual([0], [-0])).toBe(false);
+  });
+});

--- a/packages/store/src/utils/shallow-equal.ts
+++ b/packages/store/src/utils/shallow-equal.ts
@@ -1,9 +1,11 @@
 export const shallowEqual = (a: object, b: object): boolean => {
   if (Array.isArray(a) !== Array.isArray(b)) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
-    return (
-      a.length === b.length && a.every((value, i) => Object.is(value, b[i]))
-    );
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!Object.is(a[i], b[i])) return false;
+    }
+    return true;
   }
   const aKeys = Object.keys(a);
   return (


### PR DESCRIPTION
## Problem

Shallow selectors can keep an empty array position after a new value replaces it. The result also depends on the argument order.

The reproduction uses `@assistant-ui/store` 0.3.12 source at base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`. This command runs from the repository root with Bun:

```sh
bun -e '
import assert from "node:assert/strict";
import { shallowEqual } from "./packages/store/src/utils/shallow-equal.ts";
const before = new Array(1);
const after = [42];
assert.equal(shallowEqual(before, after), false);
assert.equal(shallowEqual(after, before), false);
'
```

## Root cause

`Array.prototype.every` skips empty positions in the first array. Thus, `new Array(1)` compares equal to `[42]`, but the reverse comparison returns `false`.

## Change

The shared comparator visits each array index. Shallow selectors accept values that replace empty positions. Empty positions still compare as `undefined`. Length checks and `Object.is` comparisons stay unchanged.

## Verification

The reproduction and the regression test returned `true` instead of `false` before the correction. The same checks pass after the correction.

- `pnpm --filter @assistant-ui/store test src/utils/shallow-equal.test.ts` passes all four tests.
- `pnpm --filter @assistant-ui/tap build && pnpm --filter @assistant-ui/store build` completes.
- Scoped `oxlint` and `oxfmt --check` pass for the changed TypeScript files.
- Direct API checks pass for the freshly built client export. Real hook checks cover filled positions, cleared positions, and equal-value reference reuse.

## Public surface

`@assistant-ui/store` receives a patch changeset. Public exports and signatures stay unchanged. Documentation, API-reference output, and templates need no changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Yg-CIUC7_VtpeCJZSOaF3BRR2QHujDZSvPbTE-ar585g9WN6a_duBiDNkWM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->