### PR TITLE
fix(react): keep empty mention categories empty

### DIFF
--- a/.changeset/empty-mention-categories.md
+++ b/.changeset/empty-mention-categories.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ignore flat mention items when categories is an empty list

--- a/packages/react/src/unstable/useMentionAdapter.test.tsx
+++ b/packages/react/src/unstable/useMentionAdapter.test.tsx
@@ -11,7 +11,10 @@ import type { Unstable_TriggerAdapter } from "@assistant-ui/core";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TriggerNavigationResource } from "../primitives/composer/trigger/triggerNavigationResource";
-import { unstable_useMentionAdapter } from "./useMentionAdapter";
+import {
+  unstable_useMentionAdapter,
+  type Unstable_UseMentionAdapterOptions,
+} from "./useMentionAdapter";
 
 const runtime = vi.hoisted(() => {
   const state = {
@@ -64,6 +67,49 @@ describe("unstable_useMentionAdapter", () => {
     runtime.state.tools = {};
     runtime.listeners.clear();
     runtime.events.length = 0;
+  });
+
+  it("ignores flat items when categories is explicitly empty", () => {
+    const { result } = renderHook(() =>
+      unstable_useMentionAdapter({
+        items: [{ id: "alice", type: "person", label: "Alice" }],
+        categories: [],
+      }),
+    );
+
+    expect(result.current.adapter.search?.("")).toEqual([]);
+  });
+
+  it("does not expose flat items when the last category is removed", () => {
+    const items = [{ id: "alice", type: "person", label: "Alice" }];
+    const { result, rerender } = renderHook(
+      (options: Unstable_UseMentionAdapterOptions) =>
+        unstable_useMentionAdapter(options),
+      {
+        initialProps: {
+          items,
+          categories: [
+            {
+              id: "people",
+              label: "People",
+              items: [{ id: "bob", type: "person", label: "Bob" }],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.current.adapter.search?.("")).toEqual([
+      { id: "bob", type: "person", label: "Bob" },
+    ]);
+
+    rerender({ items, categories: [] });
+    expect(result.current.adapter.search?.("")).toEqual([]);
+
+    rerender({ items });
+    expect(result.current.adapter.search?.("")).toEqual([
+      { id: "alice", type: "person", label: "Alice" },
+    ]);
   });
 
   it("keeps categorized model-context tools current", () => {

--- a/packages/react/src/unstable/useMentionAdapter.ts
+++ b/packages/react/src/unstable/useMentionAdapter.ts
@@ -152,7 +152,7 @@ export function unstable_useMentionAdapter(
   const formatter = options?.formatter;
   const onInserted = options?.onInserted;
   const isCategorized =
-    (categories !== undefined && categories.length > 0) ||
+    categories !== undefined ||
     (toolsConfig?.category !== undefined && items === undefined);
   const toolMentions = useModelContextSnapshot(
     aui,


### PR DESCRIPTION
## Problem

- An empty `categories` list exposes flat mention items instead of an empty result. The same error occurs after the last category disappears.
- Reproduced on base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a` (`@assistant-ui/react` 0.15.18). This component displays Alice before the correction and `[]` afterward:

```tsx
import { unstable_useMentionAdapter } from "@assistant-ui/react";

export function Repro() {
  const { adapter } = unstable_useMentionAdapter({
    items: [{ id: "alice", type: "person", label: "Alice" }],
    categories: [],
  });
  return <pre>{JSON.stringify(adapter.search?.(""))}</pre>;
}
```

## Root cause

- The hook selects categorized mode only when the category list contains entries. An empty list therefore activates the flat-item path.

## Change

- A supplied `categories` list takes precedence over `items`, including an empty list, as the existing options contract specifies.
- The existing categorized adapter handles the empty result. Tool-category selection and flat mode without categories remain unchanged.

## Verification

- `pnpm --filter @assistant-ui/react exec vitest run src/unstable/useMentionAdapter.test.tsx`: the two new regression cases failed before the correction. All nine tests passed afterward.
- An unmocked React DOM smoke check in JSDOM confirmed initial empty categories, populated categories, category removal, and omitted categories.
- Scoped Oxlint and formatting checks passed. `node scripts/check-changesets.mjs` passed.

## Public surface

- `@assistant-ui/react` receives a patch changeset. Public exports and signatures remain unchanged.
- Existing documentation already specifies category precedence. API-reference output and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1gcO5D4NUB3r88XImC9cBlMgBQjbvx7yGHAoVYRDEVm0oYSHDysQS559cd8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->