### PR TITLE
fix(store): expire falsy values in the last-valid cache

### DIFF
--- a/.changeset/last-valid-cache-falsy-values.md
+++ b/.changeset/last-valid-cache-falsy-values.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: expire falsy values in the last-valid cache and preserve cached null and undefined during the stale window.

--- a/packages/store/src/utils/last-valid-cache.test.ts
+++ b/packages/store/src/utils/last-valid-cache.test.ts
@@ -26,20 +26,27 @@ describe("createLastValidCache", () => {
     expect(cache.resolve(false, () => "fresh")).toBe("b");
   });
 
-  it("drops the cache and reports once the stale window settles", () => {
-    const scheduler = createScheduler();
-    const reportStale = vi.fn();
-    const cache = createLastValidCache<string>(reportStale, scheduler.schedule);
+  it.each([0, false, "", null, undefined, NaN, "a"])(
+    "drops cached %o and reports once the stale window settles",
+    (value) => {
+      const scheduler = createScheduler();
+      const reportStale = vi.fn();
+      const cache = createLastValidCache<unknown>(
+        reportStale,
+        scheduler.schedule,
+      );
 
-    cache.resolve(true, () => "a");
-    expect(cache.resolve(false, () => "fresh")).toBe("a");
-    scheduler.flush();
-    expect(reportStale).toHaveBeenCalledTimes(1);
+      expect(cache.resolve(true, () => value)).toBe(value);
+      expect(cache.resolve(false, () => "fresh")).toBe(value);
+      expect(cache.resolve(false, () => "fresh")).toBe(value);
+      scheduler.flush();
+      expect(reportStale).toHaveBeenCalledTimes(1);
 
-    const resolveItem = vi.fn(() => "fallthrough");
-    expect(cache.resolve(false, resolveItem)).toBe("fallthrough");
-    expect(resolveItem).toHaveBeenCalledTimes(1);
-  });
+      const resolveItem = vi.fn(() => "fallthrough");
+      expect(cache.resolve(false, resolveItem)).toBe("fallthrough");
+      expect(resolveItem).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("voids a pending expiry when a valid resolution lands first", () => {
     const scheduler = createScheduler();

--- a/packages/store/src/utils/last-valid-cache.ts
+++ b/packages/store/src/utils/last-valid-cache.ts
@@ -1,3 +1,5 @@
+const EMPTY = Symbol("last-valid-cache.empty");
+
 /**
  * Guards a positional or id-addressed scope resolution across a collection shrink. The scope
  * re-resolves inside the store notification, before the binding's queued
@@ -18,14 +20,14 @@ export const createLastValidCache = <T>(
   reportStale: (() => void) | null,
   scheduleExpiry: (callback: () => void) => void,
 ) => {
-  let last: T | undefined;
+  let last: T | typeof EMPTY = EMPTY;
   let generation = 0;
   const expire = () => {
     const scheduledAt = generation;
     scheduleExpiry(() => {
       if (generation !== scheduledAt) return;
-      if (last === undefined) return;
-      last = undefined;
+      if (last === EMPTY) return;
+      last = EMPTY;
       reportStale?.();
     });
   };
@@ -36,8 +38,8 @@ export const createLastValidCache = <T>(
         last = resolveItem();
         return last;
       }
-      if (last) expire();
-      return last ?? resolveItem();
+      if (last !== EMPTY) expire();
+      return last === EMPTY ? resolveItem() : last;
     },
   };
 };


### PR DESCRIPTION
## Problem

The last-valid cache retains `0`, `false`, `""`, and `NaN` after the stale window. Cached `null` and `undefined` bypass that window entirely.

The reproduction applies to base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`, where `@assistant-ui/store` is version `0.3.12`. From the repository root, `bun repro.mjs` runs this snippet:

```js
import assert from "node:assert/strict";
import { createLastValidCache } from "./packages/store/src/utils/last-valid-cache.ts";

const pending = [];
let reports = 0;
const cache = createLastValidCache(
  () => { reports++; },
  callback => pending.push(callback),
);
assert.equal(cache.resolve(true, () => 0), 0);
assert.equal(cache.resolve(false, () => 99), 0);
for (const callback of pending.splice(0)) callback();
assert.equal(reports, 1);
assert.equal(cache.resolve(false, () => 99), 99);
```

## Root cause

The expiry condition uses truthiness, but the return expression uses nullish fallback. Neither condition distinguishes an empty cache from all permitted values.

## Change

All cached values remain available during the stale window and expire afterward. A private symbol marks an empty cache without a wrapper object for each update. Generation-based expiry cancellation stays unchanged.

## Verification

- The reproduction fails before the correction because `reports` remains `0`, and passes afterward.
- `pnpm --filter @assistant-ui/store test src/utils/last-valid-cache.test.ts`: six regression cases fail before the correction, and all 12 tests pass afterward.
- `pnpm exec turbo build --filter=@assistant-ui/store --force`: the store and tap builds pass without cached build output.
- A Node smoke check through the rebuilt `@assistant-ui/store/client` entry passes for nine values with `queueMicrotask`, including expiry and subsequent resolver errors.
- Scoped Oxlint checks and `pnpm changesets:check` pass.

## Public surface

`@assistant-ui/store/client` retains its exports and public signatures. The PR includes a store patch changeset. Documentation, API-reference output, and templates remain unchanged because their contracts do not change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dubXz6RlXsok2O9w4eJZXYQambrfRQGZ9U4TJ4_TTF_JGIfz3kgLuWga70c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->