### PR TITLE
fix(core): notify thread-list loading changes

### DIFF
--- a/.changeset/thread-list-loading-notifications.md
+++ b/.changeset/thread-list-loading-notifications.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: Notify thread-list subscribers when only the loading state changes.

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -110,6 +110,7 @@ export class ExternalStoreThreadListRuntimeCore
 
     if (
       !initialLoad &&
+      (previousAdapter.isLoading ?? false) === (adapter.isLoading ?? false) &&
       previousThreadId === newThreadId &&
       previousThreads === newThreads &&
       previousArchivedThreads === newArchivedThreads

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ExternalStoreThreadListRuntimeCore } from "../runtimes/external-store/external-store-thread-list-runtime-core";
 import type { ExternalStoreThreadRuntimeCore } from "../runtimes/external-store/external-store-thread-runtime-core";
 import { ExternalStoreThreadRuntimeCore as ExternalStoreThreadRuntimeCoreImpl } from "../runtimes/external-store/external-store-thread-runtime-core";
+import { ExternalStoreRuntimeCore } from "../runtimes/external-store/external-store-runtime-core";
 import type { ExternalStoreThreadListAdapter } from "../runtimes/external-store/external-store-adapter";
 import type { ExternalStoreAdapter } from "../runtimes/external-store/external-store-adapter";
 import type { ModelContextProvider } from "../model-context/types";
@@ -127,6 +128,38 @@ describe("ExternalStoreThreadListRuntimeCore - construction", () => {
 });
 
 describe("ExternalStoreThreadListRuntimeCore - __internal_setAdapter", () => {
+  it("updates subscribed loading state when thread ids and arrays stay unchanged", () => {
+    const threadList = makeAdapter({
+      threadId: "thread-alpha",
+      threads: [{ id: "thread-alpha", status: "regular" }],
+      archivedThreads: [],
+      isLoading: true,
+    });
+    const adapter: ExternalStoreAdapter = {
+      messages: [],
+      onNew: async () => {},
+      adapters: { threadList },
+    };
+    const core = new ExternalStoreRuntimeCore(adapter);
+    const runtime = new ThreadListRuntimeImpl(core.threads);
+    const seen: boolean[] = [];
+    const unsubscribe = runtime.subscribe(() => {
+      seen.push(runtime.getState().isLoading);
+    });
+    expect(runtime.getState().isLoading).toBe(true);
+
+    for (const isLoading of [false, true, undefined, false]) {
+      core.setAdapter({
+        ...adapter,
+        adapters: { threadList: { ...threadList, isLoading } },
+      });
+    }
+
+    expect(seen).toEqual([false, true, false]);
+    expect(runtime.getState().isLoading).toBe(false);
+    unsubscribe();
+  });
+
   it("updates mainThreadId when adapter.threadId changes", () => {
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha" }),


### PR DESCRIPTION
## Problem

Thread-list consumers can remain in the loading state after the host sets `isLoading` to `false`. This occurs when the thread ID and array references stay unchanged.

The reproduction uses `@assistant-ui/core` 0.3.17 at base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`.

<details>
<summary>Minimal reproduction</summary>

In a checkout of that base, install and build the dependencies:

```sh
pnpm install --frozen-lockfile
pnpm --filter @assistant-ui/tap --filter @assistant-ui/store --filter assistant-stream --filter @assistant-ui/x-generative-compiler --filter @assistant-ui/vite -r run build
```

Save this snippet as `repro.ts` in the repository root, then run `bun repro.ts`:

```ts
import assert from "node:assert/strict";
import { ExternalStoreRuntimeCore } from "./packages/core/src/runtimes/external-store/external-store-runtime-core";
import type { ExternalStoreAdapter } from "./packages/core/src/runtimes/external-store/external-store-adapter";
import { ThreadListRuntimeImpl } from "./packages/core/src/runtime/api/thread-list-runtime";

const threadList = { isLoading: true };
const adapter: ExternalStoreAdapter = {
  messages: [],
  onNew: async () => {},
  adapters: { threadList },
};
const core = new ExternalStoreRuntimeCore(adapter);
const runtime = new ThreadListRuntimeImpl(core.threads);
const seen: boolean[] = [];
const unsubscribe = runtime.subscribe(() => {
  seen.push(runtime.getState().isLoading);
});
assert.equal(runtime.getState().isLoading, true);
core.setAdapter({
  ...adapter,
  adapters: { threadList: { ...threadList, isLoading: false } },
});
assert.deepEqual(seen, [false]);
assert.equal(runtime.getState().isLoading, false);
unsubscribe();
```

The base produces no notification and retains `true` in the subscribed state. The corrected code sends `false` and updates the subscribed state.

</details>

## Root cause

The adapter equality check omits `isLoading`. Its early return prevents the notification that invalidates the public state cache.

## Change

The equality check includes the loading value, so subscribers receive loading-only changes. It treats an omitted value as `false`, consistent with the getter. Thread selection and array handling remain unchanged.

## Verification

- `pnpm --filter @assistant-ui/core test src/tests/external-store-thread-list-runtime-core.test.ts`: The new regression failed before the correction. All 33 tests passed afterward.
- The same API smoke failed before the correction and passed afterward.
- Scoped `oxlint` and `oxfmt --check` passed for the changed TypeScript files.
- `pnpm changesets:check` passed.

## Public surface

`@assistant-ui/core` has a patch changeset. Public exports and signatures remain unchanged. Documentation, API-reference output, and templates remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.I5_BbdkAea3LbN3KfpXqyNOhj4rifgTFI_N5ThbNIVb3DhYZ1oUJsv_wmig?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->