### PR TITLE
fix(mcp-docs-server): exit the proxy when stdin closes

### DIFF
--- a/.changeset/docs-proxy-stdin-eof.md
+++ b/.changeset/docs-proxy-stdin-eof.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/mcp-docs-server": patch
+---
+
+fix: close the docs proxy and its HTTP transport once stdin can no longer deliver messages, whether it reaches EOF or is destroyed

--- a/packages/mcp-docs-server/src/proxy.test.ts
+++ b/packages/mcp-docs-server/src/proxy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { once } from "node:events";
 import {
   createServer,
   type IncomingMessage,
@@ -148,6 +149,62 @@ const createRpcClient = (stdin: PassThrough, stdout: PassThrough) => {
 };
 
 describe("runProxy", () => {
+  it.each([
+    {
+      scenario: "stdin reached EOF before startup",
+      createStdin: async () => {
+        const stdin = new PassThrough();
+        const ended = once(stdin, "end");
+        stdin.resume();
+        stdin.end();
+        await ended;
+        return stdin;
+      },
+      stopInput: (stdin: PassThrough) => stdin.end(),
+    },
+    {
+      scenario: "stdin reaches EOF after startup",
+      createStdin: async () => new PassThrough(),
+      stopInput: (stdin: PassThrough) => stdin.end(),
+    },
+    {
+      scenario: "stdin ends without emitting close",
+      createStdin: async () => new PassThrough({ autoDestroy: false }),
+      stopInput: (stdin: PassThrough) => stdin.end(),
+    },
+    {
+      scenario: "stdin is destroyed without EOF",
+      createStdin: async () => new PassThrough(),
+      stopInput: (stdin: PassThrough) => stdin.destroy(),
+    },
+  ])("closes when $scenario", async ({ createStdin, stopInput }) => {
+    const stdin = await createStdin();
+    const stdout = new PassThrough();
+    const stderr = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const proxy = runProxy({
+      url: new URL("https://example.invalid/mcp"),
+      stdin,
+      stdout,
+    });
+    let closed = false;
+
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      stopInput(stdin);
+      await expect(
+        withTimeout(proxy, "proxy shutdown after stdin closed"),
+      ).resolves.toBeUndefined();
+      closed = true;
+    } finally {
+      stdout.destroy(closed ? undefined : new Error("Proxy test cleanup"));
+      await proxy;
+      stdin.destroy();
+      stderr.mockRestore();
+    }
+  });
+
   it("proxies MCP requests and returns transport failures", async () => {
     const inputSchema = fromJsonSchema<{ text: string }>({
       type: "object",

--- a/packages/mcp-docs-server/src/proxy.ts
+++ b/packages/mcp-docs-server/src/proxy.ts
@@ -5,7 +5,7 @@ import {
   isJSONRPCResultResponse,
 } from "@modelcontextprotocol/client";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import type { Readable, Writable } from "node:stream";
+import { type Readable, type Writable, finished } from "node:stream";
 
 const DEFAULT_URL = "https://www.assistant-ui.com/mcp";
 
@@ -22,7 +22,8 @@ export async function runProxy({
   stdin?: NodeJS.ReadableStream;
   stdout?: NodeJS.WritableStream;
 } = {}) {
-  const stdio = new StdioServerTransport(stdin as Readable, stdout as Writable);
+  const input = stdin as Readable;
+  const stdio = new StdioServerTransport(input, stdout as Writable);
   const http = new StreamableHTTPClientTransport(url);
   let initializeRequestId: string | number | undefined;
   let closing = false;
@@ -97,15 +98,23 @@ export async function runProxy({
     closeCounterpart(stdio);
   };
 
+  let releaseInput: (() => void) | undefined;
+
   try {
     await http.start();
     await stdio.start();
+    releaseInput = finished(input, { writable: false }, () => {
+      void stdio.close().catch((error: unknown) => {
+        logError("failed to close transport", error);
+      });
+    });
+    await closed;
   } catch (error) {
     closing = true;
     await Promise.allSettled([http.close(), stdio.close()]);
     resolveClosed();
     throw error;
+  } finally {
+    releaseInput?.();
   }
-
-  await closed;
 }


### PR DESCRIPTION
## Problem

the docs proxy stays alive after its client goes away. `runProxy` settles only when one of its two transports reports a close, and stdin reaching EOF is not one of those events, so the process keeps running behind an open HTTP event stream.

affected base: `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a` (`@assistant-ui/mcp-docs-server` 0.3.0).

at the process level, against a local MCP server so no network is involved: start `src/stdio.ts` with `ASSISTANT_UI_MCP_URL` pointing at it, complete the initialize handshake, then close the child's stdin. on `main` the child is still alive 15 seconds later; with this change it exits with code 0.

the same thing reproduces in-process without a server, because `runProxy` itself never settles. after `pnpm install --frozen-lockfile`, from `packages/mcp-docs-server`:

```sh
node --import tsx --input-type=module <<'JS'
import { PassThrough } from 'node:stream';
import { runProxy } from './src/proxy.ts';
const stdin = new PassThrough();
const proxy = runProxy({
  url: new URL('https://example.invalid/mcp'),
  stdin,
  stdout: new PassThrough(),
});
const timeout = setTimeout(() => {
  throw new Error('Proxy did not close after EOF');
}, 2000);
stdin.end();
await proxy;
clearTimeout(timeout);
console.log('Proxy closed after EOF');
JS
```

## Root cause

`StdioServerTransport.start()` subscribes to `data` and `error` on stdin and nothing else, and its `onclose` fires only from an explicit `close()`. nothing turns "stdin is finished" into a transport close, so `runProxy` waits on `closed` forever.

## Change

`runProxy` hands stdin to `stream.finished(input, { writable: false })` and closes the stdio transport from that callback, through the existing shutdown path that closes the HTTP transport with it. reaching for the platform primitive instead of a hand-rolled `end` listener is what makes this cover every way stdin can stop rather than one of them: a clean EOF, an EOF on a stream that never emits `close`, a stream destroyed without EOF, and a stream that had already finished before the proxy started. the cleanup function `finished` returns runs in `finally`, so the proxy leaves no listeners behind on a `process.stdin` that outlives it.

## Verification

- `pnpm --filter @assistant-ui/mcp-docs-server test`: 5 passed. each of the four new cases times out against `main`'s `proxy.ts` and passes with the change.
- process level: with a local MCP server and a completed handshake, the CLI is still alive 15 seconds after stdin EOF on `main`, and exits with code 0 with this change.
- `tsc --noEmit` is clean, scoped oxlint and oxfmt pass, and `pnpm changesets:check` and `pnpm changeset-semver:check` pass.

known and left out of this PR: closing the HTTP transport aborts its in-flight request, so a clean shutdown now prints one `HTTP transport error [AbortError]` line on stderr. that is shutdown log policy rather than the hang, and pinning it needs a streaming SSE test harness this file does not have yet, so it is tracked in #6968.

## Public surface

`@assistant-ui/mcp-docs-server` gets a patch changeset. exports and signatures are unchanged. docs, api-reference output, and templates are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BTGAn59_WiNtrbw39SL6y_fN98E9CQJ-CHroox2xxWxI09b7vVnIxUA7hNg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
