### PR TITLE
fix(react): honor the message text render prop

### DIFF
--- a/.changeset/quiet-text-render.md
+++ b/.changeset/quiet-text-render.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: render message part text inside the supplied render element.

--- a/packages/react/src/primitives/messagePart/MessagePartText.test.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartText.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TextMessagePartProvider } from "../../context/providers/TextMessagePartProvider";
+import { MessagePartPrimitiveText } from "./MessagePartText";
+
+describe("MessagePartPrimitive.Text", () => {
+  it("renders text in the supplied element and composes its props and refs", () => {
+    const ref = createRef<HTMLSpanElement>();
+    const targetRef = createRef<HTMLElement>();
+    const { rerender } = render(
+      <TextMessagePartProvider text="Hello">
+        <MessagePartPrimitiveText
+          smooth={false}
+          render={<mark ref={targetRef} className="target" />}
+          className="text"
+          ref={ref}
+        />
+      </TextMessagePartProvider>,
+    );
+
+    const text = screen.getByText("Hello");
+    expect(text.tagName).toBe("MARK");
+    expect(text.classList.contains("target")).toBe(true);
+    expect(text.classList.contains("text")).toBe(true);
+    expect(text.getAttribute("data-status")).toBe("complete");
+    expect(text.hasAttribute("render")).toBe(false);
+    expect(ref.current).toBe(text);
+    expect(targetRef.current).toBe(text);
+
+    rerender(
+      <TextMessagePartProvider text="Hello again" isRunning>
+        <MessagePartPrimitiveText smooth={false} render={<mark />} />
+      </TextMessagePartProvider>,
+    );
+
+    const updated = screen.getByText("Hello again");
+    expect(updated.tagName).toBe("MARK");
+    expect(updated.getAttribute("data-status")).toBe("running");
+  });
+
+  it("keeps the default span and explicit component behavior", () => {
+    render(
+      <TextMessagePartProvider text="Hello">
+        <MessagePartPrimitiveText />
+        <MessagePartPrimitiveText component="p" />
+      </TextMessagePartProvider>,
+    );
+
+    expect(screen.getAllByText("Hello").map((text) => text.tagName)).toEqual([
+      "SPAN",
+      "P",
+    ]);
+  });
+});

--- a/packages/react/src/primitives/messagePart/MessagePartText.tsx
+++ b/packages/react/src/primitives/messagePart/MessagePartText.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Primitive } from "../../utils/Primitive";
+import { Primitive } from "../../utils/Primitive";
 import {
   type ComponentRef,
   forwardRef,
@@ -51,14 +51,19 @@ export namespace MessagePartPrimitiveText {
 export const MessagePartPrimitiveText = forwardRef<
   MessagePartPrimitiveText.Element,
   MessagePartPrimitiveText.Props
->(({ smooth = true, component: Component = "span", ...rest }, forwardedRef) => {
-  const { text, status } = useSmooth(useMessagePartText(), smooth);
+>(
+  (
+    { smooth = true, component: Component = Primitive.span, ...rest },
+    forwardedRef,
+  ) => {
+    const { text, status } = useSmooth(useMessagePartText(), smooth);
 
-  return (
-    <Component data-status={status.type} {...rest} ref={forwardedRef}>
-      {text}
-    </Component>
-  );
-});
+    return (
+      <Component data-status={status.type} {...rest} ref={forwardedRef}>
+        {text}
+      </Component>
+    );
+  },
+);
 
 MessagePartPrimitiveText.displayName = "MessagePartPrimitive.Text";


### PR DESCRIPTION
## Problem

`MessagePartPrimitive.Text` ignores the accepted `render` prop. Text stays in a span instead of the supplied element, so `<mark />` does not highlight it.

This reproduction affects `@assistant-ui/react` 0.15.18 at base `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`:

```tsx
import {
  MessagePartPrimitive,
  TextMessagePartProvider,
} from "@assistant-ui/react";

export function Example() {
  return (
    <TextMessagePartProvider text="Hello">
      <MessagePartPrimitive.Text
        smooth={false}
        render={<mark data-render-target="yes" />}
      />
    </TextMessagePartProvider>
  );
}
```

## Root cause

The literal span bypasses the shared render adapter and sends the `render` object to the DOM as an attribute.

## Change

The default uses `Primitive.span`, so the supplied element receives the text, props, and refs. Explicit `component` values keep their existing behavior.

## Verification

The regression expected `MARK` but received `SPAN` before the correction. The same check passes after the correction.

All 77 tests pass with:

```sh
pnpm --filter @assistant-ui/react test src/primitives/messagePart/MessagePartText.test.tsx src/utils/Primitive.test.tsx src/tests/messagePartTypeMismatch.test.tsx src/tests/MessageParts.loading.test.tsx src/utils/smooth/useSmooth.test.tsx
```

The browser confirms the supplied element during text updates, plus the default span and explicit paragraph. The React package build, scoped oxlint, and `pnpm changesets:check` pass.

## Public surface

This corrects existing behavior in `@assistant-ui/react` and includes a patch changeset. Public signatures, exports, documentation, API-reference output, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.S9BTuRZy9QU5-P2GxIDiptYKrZd9oqvfq4LHUQgB3QWZP9Xi1qccKUWbsRc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->