### PR TITLE
fix(react): open controlled modals when a run starts

### DIFF
--- a/.changeset/controlled-modal-run-start.md
+++ b/.changeset/controlled-modal-run-start.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: notify controlled modal owners when a run starts so the modal can open

--- a/.changeset/controlled-modal-run-start.md
+++ b/.changeset/controlled-modal-run-start.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: notify controlled modal owners when a run starts so the modal can open
+fix: notify controlled and uncontrolled modal owners when a run opens a closed modal

--- a/packages/react/src/primitives/assistantModal/AssistantModalRoot.test.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalRoot.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AssistantRuntimeProvider } from "../../context";
+import { useLocalRuntime } from "../../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import { AssistantModalPrimitiveContent } from "./AssistantModalContent";
+import { AssistantModalPrimitiveRoot } from "./AssistantModalRoot";
+import { AssistantModalPrimitiveTrigger } from "./AssistantModalTrigger";
+
+const adapter = {
+  async *run() {
+    yield { content: [{ type: "text" as const, text: "Hello" }] };
+  },
+};
+
+const Modal = ({
+  controlled = true,
+  ...props
+}: AssistantModalPrimitiveRoot.Props & { controlled?: boolean }) => {
+  const runtime = useLocalRuntime(adapter);
+  const [open, setOpen] = useState(false);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <button onClick={() => runtime.thread.append("Hello")}>Start run</button>
+      <AssistantModalPrimitiveRoot
+        {...(controlled ? { open } : {})}
+        onOpenChange={setOpen}
+        {...props}
+      >
+        <AssistantModalPrimitiveTrigger>
+          Toggle chat
+        </AssistantModalPrimitiveTrigger>
+        <AssistantModalPrimitiveContent aria-label="Chat">
+          Response
+        </AssistantModalPrimitiveContent>
+      </AssistantModalPrimitiveRoot>
+    </AssistantRuntimeProvider>
+  );
+};
+
+afterEach(cleanup);
+
+describe("AssistantModalPrimitiveRoot run start", () => {
+  it.each([true, false])(
+    "opens on run start and closes through the trigger (controlled: %s)",
+    async (controlled) => {
+      render(<Modal controlled={controlled} />);
+      expect(screen.queryByRole("dialog")).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+      });
+      expect(await screen.findByRole("dialog", { name: "Chat" })).toBeDefined();
+
+      fireEvent.click(screen.getByRole("button", { name: "Toggle chat" }));
+      expect(screen.queryByRole("dialog")).toBeNull();
+    },
+  );
+
+  it("notifies the current owner without overriding its controlled value", async () => {
+    const previous = vi.fn();
+    const current = vi.fn();
+    const view = render(<Modal open={false} onOpenChange={previous} />);
+    view.rerender(<Modal open={false} onOpenChange={current} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+    });
+
+    expect(current).toHaveBeenCalledExactlyOnceWith(true);
+    expect(previous).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("does not request opening when auto-open is disabled", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Modal unstable_openOnRunStart={false} onOpenChange={onOpenChange} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/packages/react/src/primitives/assistantModal/AssistantModalRoot.test.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalRoot.test.tsx
@@ -23,6 +23,7 @@ const adapter = {
 
 const Modal = ({
   controlled = true,
+  onOpenChange,
   ...props
 }: AssistantModalPrimitiveRoot.Props & { controlled?: boolean }) => {
   const runtime = useLocalRuntime(adapter);
@@ -32,7 +33,10 @@ const Modal = ({
       <button onClick={() => runtime.thread.append("Hello")}>Start run</button>
       <AssistantModalPrimitiveRoot
         {...(controlled ? { open } : {})}
-        onOpenChange={setOpen}
+        onOpenChange={(value) => {
+          setOpen(value);
+          onOpenChange?.(value);
+        }}
         {...props}
       >
         <AssistantModalPrimitiveTrigger>
@@ -52,16 +56,39 @@ describe("AssistantModalPrimitiveRoot run start", () => {
   it.each([true, false])(
     "opens on run start and closes through the trigger (controlled: %s)",
     async (controlled) => {
-      render(<Modal controlled={controlled} />);
+      const onOpenChange = vi.fn();
+      render(<Modal controlled={controlled} onOpenChange={onOpenChange} />);
       expect(screen.queryByRole("dialog")).toBeNull();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Start run" }));
       });
       expect(await screen.findByRole("dialog", { name: "Chat" })).toBeDefined();
+      expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+      });
+      expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(true);
 
       fireEvent.click(screen.getByRole("button", { name: "Toggle chat" }));
       expect(screen.queryByRole("dialog")).toBeNull();
+    },
+  );
+
+  it.each([{ open: true }, { controlled: false, defaultOpen: true }])(
+    "does not request opening when already open (%o)",
+    async (props) => {
+      const onOpenChange = vi.fn();
+      render(<Modal {...props} onOpenChange={onOpenChange} />);
+      expect(screen.getByRole("dialog", { name: "Chat" })).toBeDefined();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+      });
+
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(screen.getByRole("dialog", { name: "Chat" })).toBeDefined();
     },
   );
 

--- a/packages/react/src/primitives/assistantModal/AssistantModalRoot.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalRoot.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { type FC, useEffect, useState } from "react";
+import { type FC, useState } from "react";
 import { Popover as PopoverPrimitive } from "radix-ui";
 import { type ScopedProps, usePopoverScope } from "./scope";
-import { useAui } from "@assistant-ui/store";
+import { useAuiEvent } from "@assistant-ui/store";
 
 export namespace AssistantModalPrimitiveRoot {
   export type Props = PopoverPrimitive.PopoverProps & {
@@ -11,58 +11,34 @@ export namespace AssistantModalPrimitiveRoot {
   };
 }
 
-const useAssistantModalOpenState = ({
-  defaultOpen = false,
-  unstable_openOnRunStart = true,
-  onOpenChange,
-}: {
-  defaultOpen?: boolean | undefined;
-  unstable_openOnRunStart?: boolean | undefined;
-  onOpenChange?: PopoverPrimitive.PopoverProps["onOpenChange"];
-}) => {
-  const state = useState(defaultOpen);
-
-  const [, setOpen] = state;
-  const aui = useAui();
-  useEffect(() => {
-    if (!unstable_openOnRunStart) return undefined;
-
-    return aui.on("thread.runStart", () => {
-      onOpenChange?.(true);
-      setOpen(true);
-    });
-  }, [unstable_openOnRunStart, aui, setOpen, onOpenChange]);
-
-  return state;
-};
-
 export const AssistantModalPrimitiveRoot: FC<
   AssistantModalPrimitiveRoot.Props
 > = ({
   __scopeAssistantModal,
-  defaultOpen,
-  unstable_openOnRunStart,
+  defaultOpen = false,
+  unstable_openOnRunStart = true,
   open,
   onOpenChange,
   ...rest
 }: ScopedProps<AssistantModalPrimitiveRoot.Props>) => {
   const scope = usePopoverScope(__scopeAssistantModal);
 
-  const [modalOpen, setOpen] = useAssistantModalOpenState({
-    defaultOpen,
-    unstable_openOnRunStart,
-    onOpenChange,
-  });
+  const [modalOpen, setOpen] = useState(defaultOpen);
+  const isOpen = open ?? modalOpen;
 
   const openChangeHandler = (open: boolean) => {
     onOpenChange?.(open);
     setOpen(open);
   };
 
+  useAuiEvent("thread.runStart", () => {
+    if (unstable_openOnRunStart && !isOpen) openChangeHandler(true);
+  });
+
   return (
     <PopoverPrimitive.Root
       {...scope}
-      open={open === undefined ? modalOpen : open}
+      open={isOpen}
       onOpenChange={openChangeHandler}
       {...rest}
     />

--- a/packages/react/src/primitives/assistantModal/AssistantModalRoot.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalRoot.tsx
@@ -14,9 +14,11 @@ export namespace AssistantModalPrimitiveRoot {
 const useAssistantModalOpenState = ({
   defaultOpen = false,
   unstable_openOnRunStart = true,
+  onOpenChange,
 }: {
   defaultOpen?: boolean | undefined;
   unstable_openOnRunStart?: boolean | undefined;
+  onOpenChange?: PopoverPrimitive.PopoverProps["onOpenChange"];
 }) => {
   const state = useState(defaultOpen);
 
@@ -26,9 +28,10 @@ const useAssistantModalOpenState = ({
     if (!unstable_openOnRunStart) return undefined;
 
     return aui.on("thread.runStart", () => {
+      onOpenChange?.(true);
       setOpen(true);
     });
-  }, [unstable_openOnRunStart, aui, setOpen]);
+  }, [unstable_openOnRunStart, aui, setOpen, onOpenChange]);
 
   return state;
 };
@@ -48,6 +51,7 @@ export const AssistantModalPrimitiveRoot: FC<
   const [modalOpen, setOpen] = useAssistantModalOpenState({
     defaultOpen,
     unstable_openOnRunStart,
+    onOpenChange,
   });
 
   const openChangeHandler = (open: boolean) => {

--- a/packages/react/src/primitives/assistantModal/AssistantModalTrigger.test.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalTrigger.test.tsx
@@ -1,7 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantModalPrimitiveAnchor } from "./AssistantModalAnchor";
-import { AssistantModalPrimitiveContent } from "./AssistantModalContent";
 import { AssistantModalPrimitiveRoot } from "./AssistantModalRoot";
 import { AssistantModalPrimitiveTrigger } from "./AssistantModalTrigger";
 
@@ -9,9 +8,7 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@assistant-ui/store")>();
   return {
     ...actual,
-    useAui: () => ({
-      on: () => () => {},
-    }),
+    useAuiEvent: () => {},
   };
 });
 
@@ -64,17 +61,5 @@ describe("AssistantModalPrimitive render props", () => {
     expect(renderHtml).toBe(asChildHtml);
     expect(renderHtml).toContain('class="anchor"');
     expect(renderHtml).toContain("Anchor");
-  });
-
-  it("accepts render on Trigger, Anchor, and Content", () => {
-    const tree = (
-      <AssistantModalPrimitiveRoot open>
-        <AssistantModalPrimitiveTrigger render={<button type="button" />} />
-        <AssistantModalPrimitiveAnchor render={<div />} />
-        <AssistantModalPrimitiveContent render={<div />} />
-      </AssistantModalPrimitiveRoot>
-    );
-
-    expect(tree).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Problem

Controlled assistant modals stay closed when a run starts, even with auto-open active. The owner never receives `onOpenChange(true)`.

The reproduction uses `@assistant-ui/react` 0.15.18 source at main commit `7fd03e375b41101f9ff57874d11e4f8eb0e80c4a`. Click **Start run** with the modal closed:

```tsx
import { useState } from "react";
import {
  AssistantModalPrimitive,
  AssistantRuntimeProvider,
  useLocalRuntime,
  type ChatModelAdapter,
} from "@assistant-ui/react";

const adapter: ChatModelAdapter = {
  async *run() {
    yield { content: [{ type: "text", text: "Hello" }] };
  },
};

export function Repro() {
  const runtime = useLocalRuntime(adapter);
  const [open, setOpen] = useState(false);
  return (
    <AssistantRuntimeProvider runtime={runtime}>
      <button onClick={() => runtime.thread.append("Hello")}>Start run</button>
      <AssistantModalPrimitive.Root
        open={open}
        onOpenChange={setOpen}
        unstable_openOnRunStart
      >
        <AssistantModalPrimitive.Trigger>Toggle chat</AssistantModalPrimitive.Trigger>
        <AssistantModalPrimitive.Content aria-label="Chat">
          Response
        </AssistantModalPrimitive.Content>
      </AssistantModalPrimitive.Root>
    </AssistantRuntimeProvider>
  );
}
```

## Root cause

The run-start handler updates only private state. The controlled `open` prop takes precedence, so that update cannot open the modal.

## Change

Closed modals notify their owner when a run requests opening. Already-open modals do not send duplicate requests. This applies to controlled and uncontrolled use.

`useAuiEvent` keeps the current callback without replacing the subscription. Owners can reject requests, and `unstable_openOnRunStart={false}` still disables automatic opening.

## Verification

- `pnpm --filter @assistant-ui/react test`: 564 tests across 62 files pass.
- Four repeated-run and initially-open regressions failed before the correction. All eight modal tests pass afterward.
- `pnpm --filter @assistant-ui/x-performance exec vitest run contracts/thread-length.test.tsx`: two tests pass. The earlier CI failure was a timeout in this unchanged test.
- Production Chromium checks pass at 1440px and 390px in light and dark themes. The actual documentation sample, Radix kit, and controlled modal pass pointer, keyboard, focus, loading, error, and long-content checks.
- The controlled modal stays closed on the main-branch version and opens on the corrected version. Current callbacks, repeated runs, owner rejection, and auto-open opt-out pass.
- The React build, modal TypeScript diagnostics, scoped Oxlint and Oxfmt, and `pnpm changesets:check` pass.
- The full React `tsc --noEmit` check still reports 12 errors in unchanged tests outside the modal.

## Public surface

`@assistant-ui/react` receives a patch changeset. Public exports and signatures stay unchanged. Existing documentation already describes automatic opening, so documentation, generated API output, and templates stay unchanged.

## Screenshots

The production verification page uses the real components and runtime with a local response adapter. The temporary page is not part of this PR.

### Controlled modal before and after

| Viewport and theme | Before | After |
| --- | --- | --- |
| 1440px, light | ![Closed modal before correction, 1440px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-before-1440-light.png) | ![Open modal after correction, 1440px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-after-1440-light.png) |
| 1440px, dark | ![Closed modal before correction, 1440px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-before-1440-dark.png) | ![Open modal after correction, 1440px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-after-1440-dark.png) |
| 390px, light | ![Closed modal before correction, 390px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-before-390-light.png) | ![Open modal after correction, 390px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-after-390-light.png) |
| 390px, dark | ![Closed modal before correction, 390px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-before-390-dark.png) | ![Open modal after correction, 390px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-controlled-after-390-dark.png) |

<details>
<summary>Documentation sample and Radix kit</summary>

| Viewport and theme | Documentation sample | Radix kit |
| --- | --- | --- |
| 1440px, light | ![Documentation sample, 1440px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-sample-1440-light.png) | ![Radix kit, 1440px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-kit-1440-light.png) |
| 1440px, dark | ![Documentation sample, 1440px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-sample-1440-dark.png) | ![Radix kit, 1440px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-kit-1440-dark.png) |
| 390px, light | ![Documentation sample, 390px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-sample-390-light.png) | ![Radix kit, 390px light](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-kit-390-light.png) |
| 390px, dark | ![Documentation sample, 390px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-sample-390-dark.png) | ![Radix kit, 390px dark](https://artifacts.duncan.land/assistant-modal-opening-a3d967a3-kit-390-dark.png) |

</details>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.c9gTuNPyU1PZXhBtf5WClQNo--EX6QgYIXjZD3JeaiBKVY53dXUUD9Qv6Q0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->