### PR TITLE
fix(react-ag-ui): cancel the superseded run through the agent

### DIFF
--- a/.changeset/ag-ui-supersede-abort-run.md
+++ b/.changeset/ag-ui-supersede-abort-run.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: cancel the superseded run through the agent when a new run starts

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -343,16 +343,23 @@ export class AgUiThreadRuntimeCore {
   }
 
   async cancel(): Promise<void> {
-    if (!this.abortController) return;
-    // Before the local abort, whose listener runs onCancel synchronously: a
-    // callback that starts another run replaces the agent's controller, and
-    // aborting afterwards would kill that replacement and leave this run live.
-    // The local abort is unconditional because abortRun is a user subclass's
-    // code, and a throw there would otherwise strand the thread as running.
+    this.abortActiveRun();
+  }
+
+  // abortRun is what stops an upstream agent: AbstractAgent.runAgent declares
+  // two parameters and HttpAgent binds its request to a controller of its own,
+  // so the run options object reaches only subclasses that read it. The local
+  // abort comes last and is unconditional: its listener runs onCancel
+  // synchronously, so a callback that starts another run must keep the
+  // controller it installed, and a throw from a subclass's abortRun would
+  // otherwise strand the thread as running.
+  private abortActiveRun(): void {
+    const controller = this.abortController;
+    if (!controller) return;
     try {
       (this.activeRunAgent ?? this.agent).abortRun();
     } finally {
-      this.abortController.abort();
+      controller.abort();
     }
   }
 
@@ -987,6 +994,13 @@ export class AgUiThreadRuntimeCore {
     resume?: AgUiResumeEntry[],
     resumeStream?: ResumeStream,
   ): Promise<void> {
+    // A default AG-UI run supersedes the active run; the hook's opt-in message
+    // queue serializes sends instead. Cancelling before this run reads the
+    // thread lets it build on the superseded run's settled messages, and a
+    // replacement installed by a synchronous onCancel keeps the thread.
+    this.abortActiveRun();
+    if (this.abortController !== null) return;
+
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
     const parent =

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -381,7 +381,11 @@ export class AgUiThreadRuntimeCore {
     } catch (error) {
       this.logger.error?.("[agui] agent abortRun failed", error);
     }
-    return this.abortController === null;
+    if (this.abortController === null) return true;
+    this.logger.debug?.(
+      "[agui] onCancel started a replacement run; dropping the superseding send",
+    );
+    return false;
   }
 
   async resume(config: ResumeRunConfig): Promise<void> {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -295,12 +295,17 @@ export class AgUiThreadRuntimeCore {
 
   async append(message: AppendMessage): Promise<void> {
     const startRun = message.startRun ?? message.role === "user";
+    let ownsThread = true;
     if (startRun) {
       this.assertNoPendingInterrupts();
       this.maybeAutoCancelPendingToolCalls();
+      // Before the message is linked: callers parent it on the in-flight
+      // assistant, and settling that assistant reassigns its optimistic id,
+      // which would evict it and reparent this message onto a branch.
+      ownsThread = this.supersedeActiveRun();
     }
     const threadMessageId = this.appendEntry(message);
-    if (!startRun) return;
+    if (!startRun || !ownsThread) return;
     await this.startRun(threadMessageId, message.runConfig);
   }
 
@@ -361,6 +366,22 @@ export class AgUiThreadRuntimeCore {
     } finally {
       controller.abort();
     }
+  }
+
+  // Starting a run supersedes the active one, and reports whether the caller
+  // still owns the thread afterwards: the local abort runs onCancel
+  // synchronously, so a callback that starts its own run keeps it. abortRun is a
+  // subclass's code, and a throw there must not abandon the run being started,
+  // unlike cancel(), where the failed operation is the caller's own. Calling
+  // this twice for one run is harmless, because the second call finds no active
+  // run to supersede.
+  private supersedeActiveRun(): boolean {
+    try {
+      this.abortActiveRun();
+    } catch (error) {
+      this.logger.error?.("[agui] agent abortRun failed", error);
+    }
+    return this.abortController === null;
   }
 
   async resume(config: ResumeRunConfig): Promise<void> {
@@ -995,11 +1016,9 @@ export class AgUiThreadRuntimeCore {
     resumeStream?: ResumeStream,
   ): Promise<void> {
     // A default AG-UI run supersedes the active run; the hook's opt-in message
-    // queue serializes sends instead. Cancelling before this run reads the
-    // thread lets it build on the superseded run's settled messages, and a
-    // replacement installed by a synchronous onCancel keeps the thread.
-    this.abortActiveRun();
-    if (this.abortController !== null) return;
+    // queue serializes sends instead. append supersedes earlier, before it links
+    // its message; this covers the entry points that start a run without one.
+    if (!this.supersedeActiveRun()) return;
 
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1208,6 +1208,76 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("aborts the superseded HttpAgent request when a later append starts", async () => {
+    const requestSignals: AbortSignal[] = [];
+    let resolveFirstRequest!: () => void;
+    const firstRequestStarted = new Promise<void>((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const agent = new HttpAgent({
+      url: "https://example.invalid",
+      fetch: async (_url, requestInit) => {
+        const signal = requestInit.signal;
+        if (!signal) throw new Error("missing request signal");
+        requestSignals.push(signal);
+        if (requestSignals.length === 1) resolveFirstRequest();
+        return await new Promise<Response>((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+
+    const core = createCore(agent);
+    const superseded = core.append(createAppendMessage());
+    await firstRequestStarted;
+
+    void core.append(createAppendMessage());
+    await superseded;
+    await vi.waitFor(() => expect(requestSignals).toHaveLength(2));
+
+    expect(requestSignals[0]?.aborted).toBe(true);
+    expect(requestSignals[1]?.aborted).toBe(false);
+  });
+
+  it("keeps a run started by onCancel when an append supersedes", async () => {
+    const resolveRuns: Array<() => void> = [];
+    let core!: AgUiThreadRuntimeCore;
+    const onCancel = vi.fn(() => {
+      void core.append(createAppendMessage());
+    });
+    const agent = {
+      runAgent: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRuns.push(resolve);
+          }),
+      ),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    core = createCore(agent, { onCancel });
+    const superseded = core.append(createAppendMessage());
+    void core.append(createAppendMessage());
+
+    // the superseding append cancelled the first run, and onCancel started its
+    // own; that replacement owns the thread, so the append must not run again
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(resolveRuns).toHaveLength(2);
+    expect(core.isRunning()).toBe(true);
+
+    resolveRuns[0]?.();
+    await superseded;
+    expect(core.isRunning()).toBe(true);
+  });
+
   it("surfaces errors and rejects append", async () => {
     const agent = {
       runAgent: vi.fn(async () => {
@@ -6268,6 +6338,7 @@ describe("AGUIThreadRuntimeCore", () => {
         }
         subscriber.onRunFinalized?.();
       }),
+      abortRun: vi.fn(),
     } as unknown as HttpAgent;
     const core = createCore(agent);
 
@@ -6294,6 +6365,7 @@ describe("AGUIThreadRuntimeCore", () => {
         if (runInputs.length === 1) await activeRun;
         subscriber.onRunFinalized?.();
       }),
+      abortRun: vi.fn(),
     } as unknown as HttpAgent;
     const core = createCore(agent);
 
@@ -6363,6 +6435,7 @@ describe("AGUIThreadRuntimeCore", () => {
         if (runInputs.length === 1) await activeRun;
         subscriber.onRunFinalized?.();
       }),
+      abortRun: vi.fn(),
     } as unknown as HttpAgent;
     const core = createCore(agent);
 

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1247,6 +1247,71 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(requestSignals[1]?.aborted).toBe(false);
   });
 
+  it("keeps the thread linear when an append supersedes a run", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn(
+        (_input: any, subscriber: AgentSubscriber, { signal }: any) => {
+          runInputs.push(_input);
+          if (runInputs.length > 1) {
+            subscriber.onRunFinalized?.();
+            return Promise.resolve();
+          }
+          subscriber.onTextMessageContentEvent?.({
+            event: { type: "TEXT_MESSAGE_CONTENT", delta: "partial" },
+          } as never);
+          return new Promise<void>((resolve) => {
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+      ),
+      abortRun: vi.fn(),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    void core.append(createAppendMessage());
+    await vi.waitFor(() => expect(runInputs).toHaveLength(1));
+
+    // callers parent the next message on the in-flight assistant
+    const inFlightAssistantId = core.getMessages().at(-1)!.id;
+    await core.append(createAppendMessage({ parentId: inFlightAssistantId }));
+
+    const parents = core
+      .getMessageRepository()
+      .messages.map(({ parentId }) => parentId);
+    expect(new Set(parents).size).toBe(parents.length);
+    expect(runInputs[1].messages.map((m: { role: string }) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+  });
+
+  it("starts the superseding run when a subclass abortRun throws", async () => {
+    const runInputs: unknown[] = [];
+    const agent = {
+      runAgent: vi.fn((input: unknown, subscriber: AgentSubscriber) => {
+        runInputs.push(input);
+        if (runInputs.length > 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise<void>(() => {});
+      }),
+      abortRun: vi.fn(() => {
+        throw new Error("subclass abortRun blew up");
+      }),
+    } as unknown as HttpAgent;
+    const logger = { ...noopLogger, error: vi.fn() };
+
+    const core = createCore(agent, { logger });
+    void core.append(createAppendMessage());
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(2);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a run started by onCancel when an append supersedes", async () => {
     const resolveRuns: Array<() => void> = [];
     let core!: AgUiThreadRuntimeCore;


### PR DESCRIPTION
## Problem

A default AG-UI append supersedes the active run, but nothing cancelled the run it displaced. The previous agent run stayed live: still streaming server side, holding its connection and burning tokens, with its output discarded at the client and its `append()` promise never settling.

Reproduction on `@assistant-ui/react-ag-ui@0.2.13` with the default `HttpAgent`: send a message, and before the first run finishes send another. The first request's `AbortSignal` is never aborted and its fetch stays open.

Closes #6946. Supersedes #6948, which aborts only the local controller; upstream never sees that controller, so the request the user is paying for keeps running.

## Root cause

`startRun` assigned `this.abortController` over the previous run's controller without cancelling it.

Aborting that controller is not what stops an AG-UI run. `AbstractAgent.runAgent(parameters, subscriber)` declares two parameters and `HttpAgent.runAgent` rebinds `this.abortController` from `parameters.abortController`, which `requestInit` uses as the request signal; the third `{ signal }` argument this runtime passes reaches only subclasses that read it, and `AbstractAgent.abortRun` is an empty base method. `agent.abortRun()` is the cancellation hook, which is why `cancel()` calls it before the local abort and why the type comment above `RunAgentWithRunOptions` says so.

So `cancel()` held the only complete definition of cancelling a run, and `startRun` had none.

## Change

Extract that sequence as `abortActiveRun()` and call it from both `cancel()` and the supersede path, so supersession and explicit cancellation cannot drift apart again. The ordering `cancel()` documented is preserved: `abortRun()` on the agent that started the run, then the local abort last, whose listener runs `onCancel` synchronously.

Supersession happens in `append`, before `appendEntry` links the new message. Callers parent that message on the in-flight optimistic assistant, so cancelling afterwards let the settling assistant reassign its optimistic id, evict itself off-branch, and reparent the new message onto a sibling branch: a phantom branch picker on the user's second message, and a run input that dropped the superseded assistant. `startRun` still supersedes for the entry points that start a run without appending one (`reload`, `resume`, `resumeInFlightRun`).

`supersedeActiveRun()` reports whether the caller still owns the thread, so a replacement started by a synchronous `onCancel` keeps it wherever the supersede happened, and a second call for the same run is a no-op. It also contains a throwing subclass `abortRun` rather than letting it reject the send; `cancel()` keeps surfacing that throw, because there the failed operation is the caller's own.

AG-UI keeps its existing semantics: the default path supersedes like Google ADK, and `unstable_enableMessageQueue` serializes like React LangGraph. Three test doubles that supersede an in-flight run gained the `abortRun` every `AbstractAgent` has.

## Verification

- `pnpm -C packages/react-ag-ui test` (560 tests, 17 files)
- Each of the four regressions fails without the change it pins: the `HttpAgent` one times out because the superseded `append()` never settles; the layout one leaves `user1` with two children and hands the second `runAgent` `[user, user]`; the `onCancel` one starts a third run; the throwing-`abortRun` one never starts the superseding run.
- The `HttpAgent` regression drives a real `HttpAgent` through a fake `fetch`, so it asserts the request signal itself, not a hand-rolled double.
- `tsc --noEmit -p packages/react-ag-ui/tsconfig.json`
- `oxlint` and `oxfmt --check` on the changed files
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `node scripts/check-changeset-semver.mjs`

## Public surface

`@assistant-ui/react-ag-ui` with a patch changeset. No exports, signatures, or wire formats changed; `abortActiveRun` and `supersedeActiveRun` are private.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FMvyt_DeeEDrTmFVncUI8bEVwqouNOOcmkbf1toIu33o3S9rBhlmPmcqtBc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->