### PR TITLE
fix(cloud): page thread messages so long threads reload in full

### DIFF
--- a/.changeset/cloud-message-pagination.md
+++ b/.changeset/cloud-message-pagination.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: page the cloud thread message list so threads longer than 200 messages reload in full

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -185,6 +185,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__ai-sdk.ts
+++ b/api-surface/assistant-ui__ai-sdk.ts
@@ -273,6 +273,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -189,6 +189,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -294,6 +294,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -273,6 +273,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -197,6 +197,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -566,6 +566,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -269,6 +269,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -207,6 +207,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -209,6 +209,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -267,6 +267,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -430,6 +430,8 @@ type AssistantCloudThreadMessageFeedbackResponse = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/packages/cloud/src/AssistantCloudThreadMessages.test.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.test.ts
@@ -94,4 +94,19 @@ describe("AssistantCloudThreadMessages responses", () => {
       created_at: "leave-this-string-untouched",
     });
   });
+
+  it("forwards the pagination query to the list endpoint", async () => {
+    const { messages, makeRequest } = createCloudThreadMessages();
+    makeRequest.mockResolvedValueOnce({ messages: [] });
+
+    await messages.list("thread/1", {
+      format: "aui/v0",
+      limit: 200,
+      after: "message-200",
+    });
+
+    expect(makeRequest).toHaveBeenCalledWith("/threads/thread%2F1/messages", {
+      query: { format: "aui/v0", limit: 200, after: "message-200" },
+    });
+  });
 });

--- a/packages/cloud/src/AssistantCloudThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.ts
@@ -23,6 +23,8 @@ export type CloudMessage = {
 
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
+  limit?: number;
+  after?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -127,6 +127,7 @@ export class CloudMessagePersistence {
   async load(threadId: string, format?: string) {
     const cloud = this.getCloud();
     const messages: CloudMessage[] = [];
+    const seen = new Set<string>();
     let after: string | undefined;
 
     while (true) {
@@ -136,11 +137,15 @@ export class CloudMessagePersistence {
         ...(after ? { after } : undefined),
       });
       const last = page.messages.at(-1);
-      // A cursor the server cannot resolve drops the keyset filter and returns
-      // the first page again, so a page that does not advance ends the walk.
-      if (!last || last.id === after) break;
+      if (!last) break;
 
-      messages.push(...page.messages);
+      // A cursor the server cannot resolve drops the keyset filter and replays
+      // an earlier page, so already-seen rows end the walk instead of repeating.
+      const fresh = page.messages.filter((m) => !seen.has(m.id));
+      if (fresh.length === 0) break;
+      for (const m of fresh) seen.add(m.id);
+
+      messages.push(...fresh);
       if (page.messages.length < CLOUD_MESSAGE_PAGE_SIZE) break;
       after = last.id;
     }

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -1,5 +1,8 @@
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type { AssistantCloud } from "./AssistantCloud";
+import type { CloudMessage } from "./AssistantCloudThreadMessages";
+
+const CLOUD_MESSAGE_PAGE_SIZE = 200;
 
 /**
  * Shared persistence logic for cloud message storage.
@@ -111,6 +114,9 @@ export class CloudMessagePersistence {
   /**
    * Load messages from the cloud and populate the ID mapping.
    *
+   * The list endpoint caps a response at 200 rows, so pages are followed by
+   * message ID cursor until a short page and concatenated in server order.
+   *
    * The ID mapping is populated so that `isPersisted()` returns true for
    * loaded messages, preventing re-persistence of already-stored messages.
    *
@@ -120,10 +126,25 @@ export class CloudMessagePersistence {
    */
   async load(threadId: string, format?: string) {
     const cloud = this.getCloud();
-    const { messages } = await cloud.threads.messages.list(
-      threadId,
-      format ? { format } : undefined,
-    );
+    const messages: CloudMessage[] = [];
+    let after: string | undefined;
+
+    while (true) {
+      const page = await cloud.threads.messages.list(threadId, {
+        ...(format ? { format } : undefined),
+        limit: CLOUD_MESSAGE_PAGE_SIZE,
+        ...(after ? { after } : undefined),
+      });
+      const last = page.messages.at(-1);
+      // A cursor the server cannot resolve drops the keyset filter and returns
+      // the first page again, so a page that does not advance ends the walk.
+      if (!last || last.id === after) break;
+
+      messages.push(...page.messages);
+      if (page.messages.length < CLOUD_MESSAGE_PAGE_SIZE) break;
+      after = last.id;
+    }
+
     // Populate ID mapping so isPersisted() recognizes loaded messages
     for (const m of messages) {
       this.idMapping[m.id] = m.id;

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -14,6 +14,18 @@ function createMockCloud() {
   } as unknown as AssistantCloud;
 }
 
+function createCloudMessages(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `message-${index + 1}`,
+    parent_id: null,
+    height: index,
+    created_at: "2025-01-01T00:00:00Z" as unknown as Date,
+    updated_at: "2025-01-01T00:00:00Z" as unknown as Date,
+    format: "aui/v0",
+    content: {},
+  }));
+}
+
 describe("CloudMessagePersistence", () => {
   let cloud: AssistantCloud;
   let persistence: CloudMessagePersistence;
@@ -219,6 +231,45 @@ describe("CloudMessagePersistence", () => {
     await persistence.load("thread-1");
 
     expect(persistence.isPersisted("msg-1")).toBe(true);
+  });
+
+  it("follows the message cursor across pages in server order", async () => {
+    const rows = createCloudMessages(450);
+    vi.mocked(cloud.threads.messages.list).mockImplementation(
+      async (_threadId, query) => {
+        const start = query?.after
+          ? rows.findIndex((row) => row.id === query.after) + 1
+          : 0;
+        return { messages: rows.slice(start, start + 200) };
+      },
+    );
+
+    const messages = await persistence.load("thread-1", "aui/v0");
+
+    expect(messages.map((message) => message.id)).toEqual(
+      rows.map((row) => row.id),
+    );
+    expect(cloud.threads.messages.list).toHaveBeenCalledTimes(3);
+    expect(cloud.threads.messages.list).toHaveBeenNthCalledWith(1, "thread-1", {
+      format: "aui/v0",
+      limit: 200,
+    });
+    expect(cloud.threads.messages.list).toHaveBeenNthCalledWith(3, "thread-1", {
+      format: "aui/v0",
+      limit: 200,
+      after: "message-400",
+    });
+  });
+
+  it("stops when a page does not advance the cursor", async () => {
+    vi.mocked(cloud.threads.messages.list).mockResolvedValue({
+      messages: createCloudMessages(200),
+    });
+
+    const messages = await persistence.load("thread-1", "aui/v0");
+
+    expect(messages).toHaveLength(200);
+    expect(cloud.threads.messages.list).toHaveBeenCalledTimes(2);
   });
 
   it("updates an already-persisted message", async () => {

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -261,6 +261,28 @@ describe("CloudMessagePersistence", () => {
     });
   });
 
+  it("stops without duplicates when a later cursor stops resolving", async () => {
+    const rows = createCloudMessages(450);
+    vi.mocked(cloud.threads.messages.list).mockImplementation(
+      async (_threadId, query) => {
+        // The third request replays page one, the way the endpoint answers a
+        // cursor whose message no longer resolves.
+        const start =
+          query?.after && query.after !== "message-400"
+            ? rows.findIndex((row) => row.id === query.after) + 1
+            : 0;
+        return { messages: rows.slice(start, start + 200) };
+      },
+    );
+
+    const messages = await persistence.load("thread-1", "aui/v0");
+
+    expect(messages.map((message) => message.id)).toEqual(
+      rows.slice(0, 400).map((row) => row.id),
+    );
+    expect(cloud.threads.messages.list).toHaveBeenCalledTimes(3);
+  });
+
   it("stops when a page does not advance the cursor", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: createCloudMessages(200),

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -128,6 +128,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(secondCloud.threads.messages.list).toHaveBeenCalledOnce();
     expect(secondCloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
       format: "test",
+      limit: 200,
     });
   });
 
@@ -154,6 +155,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await formatted.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
       format: "test",
+      limit: 200,
     });
 
     mocks.aui = mocks.makeClient("thread-2");
@@ -161,6 +163,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await formatted.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
       format: "test",
+      limit: 200,
     });
   });
 
@@ -175,6 +178,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await result.current.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
       format: "aui/v0",
+      limit: 200,
     });
 
     mocks.aui = mocks.makeClient("thread-2");
@@ -183,6 +187,7 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await result.current.load();
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
       format: "aui/v0",
+      limit: 200,
     });
   });
 

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -261,8 +261,8 @@
   },
   "assistant-cloud": {
     ".": {
-      "min": 15447,
-      "gzip": 5095
+      "min": 16268,
+      "gzip": 5352
     }
   },
   "assistant-stream": {


### PR DESCRIPTION
refs #6950

## Problem

`GET /threads/:threadId/messages` caps a response at 200 rows. `CloudMessagePersistence.load` made one request, so reloading a thread with more than 200 messages silently dropped the oldest ones. both cloud history paths go through this loader: `AssistantCloudThreadHistoryAdapter.load` (the assistant-ui runtime) and `MessagePersistence.loadMessages` (the standalone `useCloudChat` hook).

## Root cause

`load` never passed a query beyond `format`, so it always read the first page and returned it as if it were the whole thread. the endpoint has accepted `limit` and `after` since assistant-cloud#53, but `AssistantCloudThreadMessageListQuery` did not model them, so no caller could ask for the rest.

## Change

`AssistantCloudThreadMessageListQuery` gains the additive optional `limit` and `after` fields, and `load` walks the cursor until a short page, concatenating in server order so the existing `.reverse()` in the history adapter still yields chronological order. page size is 200 because that is the endpoint's own maximum (`limit` validates as 1 to 200).

the walk follows the keyset precedent `useThreads` already uses for the thread list (`packages/cloud-ai-sdk/src/threads/useThreads.ts:101-121`), plus a dedupe set. the set is not defensive padding: when the cursor subquery cannot resolve `after` (the message was deleted, or ownership changed mid-walk) the endpoint drops the keyset predicate and replays an earlier page. comparing only the cursor catches that on the first hop and nowhere deeper, so a cursor invalidated at page three would append 200 rows twice; skipping already-seen ids ends the walk wherever the replay lands.

core's adapter test pins the query the loader now sends.

## Verification

- `pnpm --filter assistant-cloud test` -> 14 files, 123 tests green; `pnpm --filter @assistant-ui/core test` -> 164 files, 1743 tests green.
- each new test fails against the code it replaces and passes with it: the two pagination tests against the single-request loader (2 failed, 11 passed), and the dedupe test against the cursor-only guard (1 failed, 13 passed, 1.7s spent on the repeated requests).
- `pnpm lint`, `pnpm api-surface:check`, `pnpm changesets:check`, `pnpm changeset-semver:check`, `pnpm size:check` all clean.
- `pnpm --filter assistant-cloud exec tsc --noEmit` reports the same 5 pre-existing errors as main, all in `src/tests/AssistantCloudAuthStrategy.test.ts`; this change adds none.
- ordering and cursor semantics checked against the deployed route, which orders `desc(height), desc(created_at), desc(id)` with `after` as a strict less-than keyset, so following the last row id walks toward older messages.
- [ ] reviewer: a cloud thread with more than 200 messages reloads with every message, in order, in both `useChatRuntime` and `useCloudChat`.

## Public surface

- `assistant-cloud`: `AssistantCloudThreadMessageListQuery` gains optional `limit` and `after`. additive, nothing removed.
- generated files in the diff: 12 `api-surface/*.ts` snapshots and one `size-budgets.json` entry (`assistant-cloud .`, 5095 to 5352 gzip, the cursor walk). the reviewable logic is in `packages/cloud/src/`.
- changeset: `.changeset/cloud-message-pagination.md`, patch for `assistant-cloud`.

## Notes

- supersedes the pagination half of #6951. the other half of that PR (filling `model_id` from AI SDK response metadata) is not included here and lands separately.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kI6ohXe76nwLdPkmLEhALP7sj8uD8xdFrZFofRjMAH5a9_HO9Ko_bBE90cM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->