### PR TITLE
fix(cloud): resolve run telemetry model IDs from step metadata

### DIFF
--- a/.changeset/telemetry-step-model-id.md
+++ b/.changeset/telemetry-step-model-id.md
@@ -1,0 +1,7 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/core": patch
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: resolve run telemetry model IDs from per-step response metadata

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -567,6 +567,8 @@ declare function createSamplingCollector(): {
   reset: () => void;
 };
 
+declare function extractRunTelemetryModelId(metadata: Record<string, unknown> | undefined): string | undefined;
+
 declare function generateThreadTitle(cloud: AssistantCloud, options: {
   threadId: string;
   messages: readonly {
@@ -579,7 +581,7 @@ declare function generateThreadTitle(cloud: AssistantCloud, options: {
 }): Promise<string | null>;
 
 declare namespace entry_root_exports {
-  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, AssistantCloudThreadMessageFeedbackBody, AssistantCloudThreadMessageFeedbackResponse, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, generateThreadTitle, normalizeRunTelemetryUsage, readAnonymousRefreshToken, truncateRunTelemetryText, wrapSamplingHandler };
+  export { AssistantCloud, AssistantCloudRunReport, AssistantCloudRunReportToolCall, AssistantCloudTelemetryConfig, AssistantCloudThreadMessageFeedbackBody, AssistantCloudThreadMessageFeedbackResponse, CloudAPIError, CloudMessage, CloudMessagePersistence, CloudResponseError, McpSamplingHandler, MessageFormatAdapter, RunTelemetryToolCallInit, RunTelemetryUsage, RunTelemetryUsageInit, SamplingCallData, createFormattedPersistence, createRunTelemetryToolCall, createSamplingCollector, extractRunTelemetryModelId, generateThreadTitle, normalizeRunTelemetryUsage, readAnonymousRefreshToken, truncateRunTelemetryText, wrapSamplingHandler };
 }
 
 declare function normalizeRunTelemetryUsage(usage: RunTelemetryUsageInit): RunTelemetryUsage | undefined;

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.test.ts
@@ -187,6 +187,33 @@ describe("extractRunTelemetry", () => {
     expect(result.cachedInputTokens).toBe(2);
   });
 
+  it("resolves the model ID from the custom bag and from step metadata", () => {
+    expect(
+      extractRunTelemetry([
+        assistantMsg("m-1", [{ type: "text", text: "ok" }], {
+          custom: { modelId: "provider/from-custom" },
+        }),
+      ])!.modelId,
+    ).toBe("provider/from-custom");
+
+    expect(
+      extractRunTelemetry([
+        assistantMsg("m-2", [{ type: "text", text: "ok" }], {
+          steps: [{ response: { modelId: "provider/from-step" } }],
+        }),
+      ])!.modelId,
+    ).toBe("provider/from-step");
+
+    expect(
+      extractRunTelemetry([
+        assistantMsg("m-3", [{ type: "text", text: "ok" }], {
+          modelId: "provider/explicit",
+          steps: [{ response: { modelId: "provider/from-step" } }],
+        }),
+      ])!.modelId,
+    ).toBe("provider/explicit");
+  });
+
   it("attaches sampling calls from metadata to matching tool calls", () => {
     const result = extractRunTelemetry([
       assistantMsg(

--- a/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
+++ b/packages/cloud-ai-sdk/src/core/extractRunTelemetry.ts
@@ -3,6 +3,7 @@ import { getToolName, isStaticToolUIPart, isToolUIPart } from "ai";
 import {
   type AssistantCloudRunReportToolCall,
   createRunTelemetryToolCall,
+  extractRunTelemetryModelId,
   normalizeRunTelemetryUsage,
   type RunTelemetryUsageInit,
   type SamplingCallData,
@@ -74,8 +75,7 @@ export function extractRunTelemetry(
     : "incomplete";
 
   const metadata = assistant.metadata as Record<string, unknown> | undefined;
-  const modelId =
-    typeof metadata?.modelId === "string" ? metadata.modelId : undefined;
+  const modelId = extractRunTelemetryModelId(metadata);
   const usage = metadata?.usage as RunTelemetryUsageInit | undefined;
   const normalizedUsage = usage ? normalizeRunTelemetryUsage(usage) : undefined;
 

--- a/packages/cloud/src/index.ts
+++ b/packages/cloud/src/index.ts
@@ -10,6 +10,7 @@ export { generateThreadTitle } from "./generateThreadTitle";
 export type { AssistantCloudRunReport } from "./AssistantCloudRuns";
 export {
   createRunTelemetryToolCall,
+  extractRunTelemetryModelId,
   normalizeRunTelemetryUsage,
   truncateRunTelemetryText,
   type AssistantCloudRunReportToolCall,

--- a/packages/cloud/src/runTelemetry.test.ts
+++ b/packages/cloud/src/runTelemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createRunTelemetryToolCall,
+  extractRunTelemetryModelId,
   normalizeRunTelemetryUsage,
   truncateRunTelemetryText,
 } from "./runTelemetry";
@@ -165,6 +166,47 @@ describe("normalizeRunTelemetryUsage", () => {
       normalizeRunTelemetryUsage({
         inputTokenDetails: {},
         outputTokenDetails: {},
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("extractRunTelemetryModelId", () => {
+  it("prefers an explicit model ID over every fallback", () => {
+    expect(
+      extractRunTelemetryModelId({
+        modelId: "explicit",
+        custom: { modelId: "custom" },
+        steps: [{ response: { modelId: "step" } }],
+      }),
+    ).toBe("explicit");
+  });
+
+  it("falls back to the custom bag before the steps", () => {
+    expect(
+      extractRunTelemetryModelId({
+        custom: { modelId: "custom" },
+        steps: [{ response: { modelId: "step" } }],
+      }),
+    ).toBe("custom");
+  });
+
+  it("reads the first step that carries a response model ID", () => {
+    expect(
+      extractRunTelemetryModelId({
+        steps: [{ usage: { inputTokens: 1 } }, { response: { modelId: "b" } }],
+      }),
+    ).toBe("b");
+  });
+
+  it("returns undefined when no channel carries one", () => {
+    expect(extractRunTelemetryModelId(undefined)).toBeUndefined();
+    expect(extractRunTelemetryModelId({})).toBeUndefined();
+    expect(
+      extractRunTelemetryModelId({
+        modelId: 7,
+        custom: { modelId: null },
+        steps: [null, "step", { response: null }, { response: { modelId: 7 } }],
       }),
     ).toBeUndefined();
   });

--- a/packages/cloud/src/runTelemetry.ts
+++ b/packages/cloud/src/runTelemetry.ts
@@ -95,6 +95,33 @@ export function createRunTelemetryToolCall(
   return call;
 }
 
+/**
+ * Resolves the model ID a run reports, in the order an app can supply it: an
+ * explicit `modelId`, the `custom` bag, then the per-step `response.modelId`
+ * that a `messageMetadata` callback copies off the AI SDK's finish-step part.
+ * The AI SDK puts no model ID on a UI message part, so message metadata is the
+ * only channel one arrives on.
+ */
+export function extractRunTelemetryModelId(
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!metadata) return undefined;
+  if (typeof metadata.modelId === "string") return metadata.modelId;
+  const custom = metadata.custom as Record<string, unknown> | undefined;
+  if (typeof custom?.modelId === "string") return custom.modelId;
+
+  const steps: unknown = metadata.steps;
+  if (!Array.isArray(steps)) return undefined;
+  for (const step of steps as unknown[]) {
+    if (!step || typeof step !== "object") continue;
+    const response = (step as Record<string, unknown>).response;
+    if (!response || typeof response !== "object") continue;
+    const modelId = (response as Record<string, unknown>).modelId;
+    if (typeof modelId === "string") return modelId;
+  }
+  return undefined;
+}
+
 export type RunTelemetryUsage = {
   inputTokens?: number;
   outputTokens?: number;

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -415,6 +415,43 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
+  it("reports the model ID carried by aui/v0 step metadata", () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const formatted = result.current.withFormat({
+      format: "aui/v0",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message: { id: string }) => message.id,
+    });
+
+    formatted.reportTelemetry([
+      {
+        parentId: null,
+        message: {
+          id: "message-1",
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+          status: { type: "complete" },
+          metadata: {
+            steps: [{ response: { modelId: "provider/model-1" } }],
+          },
+        },
+      },
+    ]);
+
+    expect(cloud.runs.report).toHaveBeenCalledWith(
+      expect.objectContaining({ model_id: "provider/model-1" }),
+    );
+  });
+
   it("reports the model ID carried by ai-sdk/v6 step metadata", () => {
     mocks.aui = mocks.makeClient("thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -415,6 +415,42 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     );
   });
 
+  it("reports the model ID carried by ai-sdk/v6 step metadata", () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const formatted = result.current.withFormat({
+      format: "ai-sdk/v6",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message: { id: string }) => message.id,
+    });
+
+    formatted.reportTelemetry([
+      {
+        parentId: null,
+        message: {
+          id: "message-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }],
+          metadata: {
+            steps: [{ response: { modelId: "provider/model-1" } }],
+          },
+        },
+      },
+    ]);
+
+    expect(cloud.runs.report).toHaveBeenCalledWith(
+      expect.objectContaining({ model_id: "provider/model-1" }),
+    );
+  });
+
   it("initializes the pinned item instead of the new main thread", async () => {
     mocks.aui = mocks.makeClient(undefined, "new-thread", "thread-1");
     const cloud = makeCloud();

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -13,6 +13,7 @@ import {
   CloudMessagePersistence,
   createFormattedPersistence,
   createRunTelemetryToolCall,
+  extractRunTelemetryModelId,
   normalizeRunTelemetryUsage,
   type RunTelemetryUsageInit,
   truncateRunTelemetryText,
@@ -593,16 +594,6 @@ function collectAiSdkV6Parts(parts: readonly AiSdkV6Part[]): {
   return { textParts, toolCalls, stepsData };
 }
 
-function extractModelId(
-  metadata?: Record<string, unknown>,
-): string | undefined {
-  if (!metadata) return undefined;
-  if (typeof metadata.modelId === "string") return metadata.modelId;
-  const custom = metadata.custom as Record<string, unknown> | undefined;
-  if (typeof custom?.modelId === "string") return custom.modelId;
-  return undefined;
-}
-
 function buildAiSdkV6Result(
   textParts: string[],
   toolCalls: AssistantCloudRunReportToolCall[],
@@ -620,7 +611,7 @@ function buildAiSdkV6Result(
   const outputText = hasText
     ? truncateRunTelemetryText(textParts.join(""))
     : undefined;
-  const modelId = extractModelId(metadata);
+  const modelId = extractRunTelemetryModelId(metadata);
 
   const steps: TelemetryStepData[] | undefined =
     stepsData && stepsData.length > 1

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -476,11 +476,9 @@ export function extractAuiV0<T>(content: T): TelemetryData | null {
     (statusType && AUI_STATUS_MAP[statusType]) || "completed";
 
   const metadata = msg.metadata?.custom as Record<string, unknown> | undefined;
-  const modelId =
-    msg.metadata?.modelId ??
-    (typeof msg.metadata?.custom?.modelId === "string"
-      ? msg.metadata.custom.modelId
-      : undefined);
+  const modelId = extractRunTelemetryModelId(
+    msg.metadata as Record<string, unknown> | undefined,
+  );
 
   const telemetrySteps: TelemetryStepData[] | undefined =
     steps && steps.length > 1


### PR DESCRIPTION
refs #6950

## Problem

a run reported without `model_id` cannot be priced, and 5,378 of 37,981 runs in the last 30 days of production arrived without one. both cloud telemetry extractors only read `metadata.modelId`, and the core one also `metadata.custom.modelId`. an app that publishes the model per step, the way both cloud docs pages tell it to, still reported nothing.

## Root cause

`response.modelId` exists only on the server side of the AI SDK, on `TextStreamFinishStepPart`. the UI message stream's `finish-step` chunk carries no payload (`ai@7.0.85` `index.d.ts:2439`, `ai@6.0.272` alike), and no member of the `UIMessagePart` union has a `response` field (`:1866` in v7, `:1615` in v6), so a model ID reaches the client only when a `messageMetadata` callback copies it across. `apps/docs/content/docs/cloud/ai-sdk.mdx:407-411` documents exactly that.

apps that do it land the value under `metadata.steps[].response.modelId`. `steps` is already an established assistant-ui metadata key (`packages/ai-sdk/src/converters/convertMessage.ts:35-44`, and `usage.ts:148` reads it for token counts), but neither extractor looked past the top level, so the value sat in the payload unread.

## Change

`extractRunTelemetryModelId` moves the resolution into `packages/cloud/src/runTelemetry.ts`, next to the other shared run telemetry helpers both packages already import, and adds `metadata.steps[].response.modelId` as the last fallback after the explicit `modelId` and the `custom` bag.

three call sites had drifted: core's `ai-sdk/v6` extractor had a three-line function, its `aui/v0` extractor an inline `??` chain that trusted the declared `modelId?: string` without a runtime check, and the standalone hook a one-line expression with no `custom` fallback. all three now call the shared helper, so `useChatRuntime`, an external-store app on the `aui/v0` route, and `useCloudChat` resolve the same three channels in the same order.

parts are deliberately not scanned. the AI SDK puts no model ID on a UI message part, so a part-level fallback would be code that cannot execute against any real payload.

## Verification

- `pnpm --filter assistant-cloud test` -> 14 files, 127 tests green; `pnpm --filter @assistant-ui/core test` -> 164 files, 1744 tests green; `pnpm --filter @assistant-ui/cloud-ai-sdk test` -> 13 files, 109 tests on both the v7 and peer-v6 legs, plus the peer-v6 type check.
- both new consumer tests fail against the extractors they replace (checked out from main, 1 failed each) and pass with the shared helper.
- `pnpm lint`, `pnpm size:check`, `pnpm api-surface:check`, `pnpm changesets:check`, `pnpm changeset-semver:check` all clean. no size budget moved: `assistant-cloud` grows 131 B gzip, `cloud-ai-sdk` and `core ./react` shrink.

## Public surface

- `assistant-cloud` exports `extractRunTelemetryModelId`. additive, and shaped like the `truncateRunTelemetryText` / `normalizeRunTelemetryUsage` siblings already on that module. one `api-surface` snapshot changes; nothing is removed.
- changeset: `.changeset/telemetry-step-model-id.md`, patch for `assistant-cloud`, `@assistant-ui/core`, `@assistant-ui/cloud-ai-sdk`.

## Notes

- this does not close #6950. its second acceptance criterion asks for `model_id` on a plain `useChat` app *without the app setting metadata*, and that is not reachable from an extractor: the value never crosses the wire unless the route's `messageMetadata` puts it there. closing that gap needs a first-party server-side helper (or a documented default) so the wiring is not hand-written per app, which is a public API decision worth its own issue rather than a rider on this fix.
- supersedes the telemetry half of #6951.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mSOlux0V2NOqoAM51UNQxClJ5xnld-6DkG8s1V5RKoH1VSSXh9-qXwjLeCs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
