### PR TITLE
fix(core): preserve selected thread runtimes during slot collapse

### DIFF
--- a/.changeset/calm-slots-stay.md
+++ b/.changeset/calm-slots-stay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve selected remote thread runtimes when raced slots collapse

--- a/packages/core/src/react/client/RemoteThreadList.background.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.background.test.ts
@@ -88,15 +88,16 @@ const makeAdapter = (
   ...overrides,
 });
 
-const mountBackgroundList = (
+const mountThreadList = (
   adapter: RemoteThreadListAdapter,
   tracker: Tracker,
+  backgroundThreads = true,
 ) => {
   const handle = createAssistantClient(
     AuiConfig({
       threads: RemoteThreadList({
         adapter,
-        backgroundThreads: true,
+        backgroundThreads,
         thread: (id) =>
           withKey(id, TrackedThread({ threadId: id, tracker }) as never),
       }),
@@ -134,7 +135,7 @@ describe("RemoteThreadList backgroundThreads", () => {
       initialize: vi.fn(() => initialize.promise),
     });
     const tracker = createTracker();
-    const handle = mountBackgroundList(adapter, tracker);
+    const handle = mountThreadList(adapter, tracker);
     const aui = handle.getClient();
     const loadPromise = aui.threads.getLoadThreadsPromise();
     const localId = aui.threads.getState().mainThreadId;
@@ -167,9 +168,76 @@ describe("RemoteThreadList backgroundThreads", () => {
 
     expect(aui.threads.item({ id: "remote-1" }).getState().id).toBe(localId);
     expect(aui.threads.item("main").getState().id).toBe(localId);
+    expect(aui.threads.item("main").getState().externalId).toBe("remote-1");
     expect(aui.threads.item("main").getState().isRunning).toBe(true);
     expect(tracker.mounts.filter((id) => id === localId)).toHaveLength(
       localMountCount,
+    );
+    handle.destroy();
+  });
+
+  it("keeps the mounted listed body when an unmounted initialization completes", async () => {
+    const list = deferred<{
+      threads: [
+        {
+          status: "regular";
+          remoteId: string;
+          externalId: string;
+          title: string;
+        },
+      ];
+    }>();
+    const initialize = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => list.promise),
+      initialize: vi.fn(() => initialize.promise),
+    });
+    const tracker = createTracker();
+    const handle = mountThreadList(adapter, tracker, false);
+    const aui = handle.getClient();
+    const loadPromise = aui.threads.getLoadThreadsPromise();
+    const localId = aui.threads.getState().mainThreadId;
+    const initializePromise = aui.threads.item("main").initialize();
+
+    list.resolve({
+      threads: [
+        {
+          status: "regular",
+          remoteId: "remote-1",
+          externalId: "external-1",
+          title: "Listed thread",
+        },
+      ],
+    });
+    await loadPromise;
+    flushTapSync(() => aui.threads.switchToThread("remote-1"));
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).toBe("remote-1");
+      expect(tracker.alive.has(localId)).toBe(false);
+      expect(tracker.alive.has("remote-1")).toBe(true);
+    });
+    const listedMountCount = tracker.mounts.filter(
+      (id) => id === "remote-1",
+    ).length;
+
+    initialize.resolve({ remoteId: "remote-1", externalId: undefined });
+    await initializePromise;
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).toBe("remote-1");
+      expect(aui.threads.getState().threadIds).toEqual(["remote-1"]);
+      expect(tracker.alive.has("remote-1")).toBe(true);
+    });
+
+    expect(aui.threads.item("main").getState()).toMatchObject({
+      id: "remote-1",
+      externalId: "external-1",
+      title: "Listed thread",
+    });
+    expect(tracker.mounts.filter((id) => id === "remote-1")).toHaveLength(
+      listedMountCount,
     );
     handle.destroy();
   });
@@ -181,7 +249,7 @@ describe("RemoteThreadList backgroundThreads", () => {
       })),
     });
     const tracker = createTracker();
-    const handle = mountBackgroundList(adapter, tracker);
+    const handle = mountThreadList(adapter, tracker);
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     await vi.waitFor(() => {
@@ -225,7 +293,7 @@ describe("RemoteThreadList backgroundThreads", () => {
       })),
     });
     const tracker = createTracker();
-    const handle = mountBackgroundList(adapter, tracker);
+    const handle = mountThreadList(adapter, tracker);
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     await vi.waitFor(() => {
@@ -321,7 +389,7 @@ describe("RemoteThreadList backgroundThreads", () => {
     });
     const tracker = createTracker();
     tracker.messagesOf = () => [{ status: { type: "complete" } }];
-    const handle = mountBackgroundList(adapter, tracker);
+    const handle = mountThreadList(adapter, tracker);
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     await vi.waitFor(() => {
@@ -411,7 +479,7 @@ describe("RemoteThreadList backgroundThreads", () => {
       list: vi.fn(async () => ({ threads: listed })),
     });
     const tracker = createTracker();
-    const handle = mountBackgroundList(adapter, tracker);
+    const handle = mountThreadList(adapter, tracker);
     const aui = handle.getClient();
     await aui.threads.getLoadThreadsPromise();
     const localId = aui.threads.getState().mainThreadId;

--- a/packages/core/src/react/client/RemoteThreadList.background.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.background.test.ts
@@ -112,7 +112,65 @@ const createTracker = (): Tracker => ({
   running: new Set(),
 });
 
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
 describe("RemoteThreadList backgroundThreads", () => {
+  it("preserves a listed body selected while initialize was in flight", async () => {
+    const list = deferred<{
+      threads: [{ status: "regular"; remoteId: string; externalId: string }];
+    }>();
+    const initialize = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => list.promise),
+      initialize: vi.fn(() => initialize.promise),
+    });
+    const tracker = createTracker();
+    const handle = mountBackgroundList(adapter, tracker);
+    const aui = handle.getClient();
+    const loadPromise = aui.threads.getLoadThreadsPromise();
+    const localId = aui.threads.getState().mainThreadId;
+    const initializePromise = aui.threads.item("main").initialize();
+
+    list.resolve({
+      threads: [
+        { status: "regular", remoteId: "remote-1", externalId: "remote-1" },
+      ],
+    });
+    await loadPromise;
+    flushTapSync(() => aui.threads.switchToThread("remote-1"));
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().mainThreadId).toBe("remote-1");
+      expect(tracker.alive.has("remote-1")).toBe(true);
+    });
+    const remoteMountCount = tracker.mounts.filter(
+      (id) => id === "remote-1",
+    ).length;
+
+    initialize.resolve({ remoteId: "remote-1", externalId: undefined });
+    await initializePromise;
+    await vi.waitFor(() => {
+      expect(aui.threads.getState().threadIds).toEqual(["remote-1"]);
+      expect(tracker.alive.has("remote-1")).toBe(true);
+      expect(tracker.alive.has(localId)).toBe(false);
+    });
+
+    expect(aui.threads.item({ id: localId }).getState().id).toBe("remote-1");
+    expect(aui.threads.item("main").getState().id).toBe("remote-1");
+    expect(tracker.mounts.filter((id) => id === "remote-1")).toHaveLength(
+      remoteMountCount,
+    );
+    handle.destroy();
+  });
+
   it("keeps a switched-away thread mounted with live isRunning", async () => {
     const adapter = makeAdapter({
       list: vi.fn(async () => ({

--- a/packages/core/src/react/client/RemoteThreadList.background.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.background.test.ts
@@ -121,7 +121,7 @@ const deferred = <T>() => {
 };
 
 describe("RemoteThreadList backgroundThreads", () => {
-  it("preserves a listed body selected while initialize was in flight", async () => {
+  it("keeps the running initialized body when its listed duplicate is selected", async () => {
     const list = deferred<{
       threads: [{ status: "regular"; remoteId: string; externalId: string }];
     }>();
@@ -138,6 +138,7 @@ describe("RemoteThreadList backgroundThreads", () => {
     const aui = handle.getClient();
     const loadPromise = aui.threads.getLoadThreadsPromise();
     const localId = aui.threads.getState().mainThreadId;
+    tracker.running.add(localId);
     const initializePromise = aui.threads.item("main").initialize();
 
     list.resolve({
@@ -151,22 +152,24 @@ describe("RemoteThreadList backgroundThreads", () => {
       expect(aui.threads.getState().mainThreadId).toBe("remote-1");
       expect(tracker.alive.has("remote-1")).toBe(true);
     });
-    const remoteMountCount = tracker.mounts.filter(
-      (id) => id === "remote-1",
+    const localMountCount = tracker.mounts.filter(
+      (id) => id === localId,
     ).length;
 
     initialize.resolve({ remoteId: "remote-1", externalId: undefined });
     await initializePromise;
     await vi.waitFor(() => {
-      expect(aui.threads.getState().threadIds).toEqual(["remote-1"]);
-      expect(tracker.alive.has("remote-1")).toBe(true);
-      expect(tracker.alive.has(localId)).toBe(false);
+      expect(aui.threads.getState().mainThreadId).toBe(localId);
+      expect(aui.threads.getState().threadIds).toEqual([localId]);
+      expect(tracker.alive.has(localId)).toBe(true);
+      expect(tracker.alive.has("remote-1")).toBe(false);
     });
 
-    expect(aui.threads.item({ id: localId }).getState().id).toBe("remote-1");
-    expect(aui.threads.item("main").getState().id).toBe("remote-1");
-    expect(tracker.mounts.filter((id) => id === "remote-1")).toHaveLength(
-      remoteMountCount,
+    expect(aui.threads.item({ id: "remote-1" }).getState().id).toBe(localId);
+    expect(aui.threads.item("main").getState().id).toBe(localId);
+    expect(aui.threads.item("main").getState().isRunning).toBe(true);
+    expect(tracker.mounts.filter((id) => id === localId)).toHaveLength(
+      localMountCount,
     );
     handle.destroy();
   });

--- a/packages/core/src/react/client/RemoteThreadList.background.test.ts
+++ b/packages/core/src/react/client/RemoteThreadList.background.test.ts
@@ -124,7 +124,14 @@ const deferred = <T>() => {
 describe("RemoteThreadList backgroundThreads", () => {
   it("keeps the running initialized body when its listed duplicate is selected", async () => {
     const list = deferred<{
-      threads: [{ status: "regular"; remoteId: string; externalId: string }];
+      threads: [
+        {
+          status: "regular";
+          remoteId: string;
+          externalId: string;
+          title: string;
+        },
+      ];
     }>();
     const initialize = deferred<{
       remoteId: string;
@@ -144,7 +151,12 @@ describe("RemoteThreadList backgroundThreads", () => {
 
     list.resolve({
       threads: [
-        { status: "regular", remoteId: "remote-1", externalId: "remote-1" },
+        {
+          status: "regular",
+          remoteId: "remote-1",
+          externalId: "remote-1",
+          title: "Listed thread",
+        },
       ],
     });
     await loadPromise;
@@ -169,6 +181,7 @@ describe("RemoteThreadList backgroundThreads", () => {
     expect(aui.threads.item({ id: "remote-1" }).getState().id).toBe(localId);
     expect(aui.threads.item("main").getState().id).toBe(localId);
     expect(aui.threads.item("main").getState().externalId).toBe("remote-1");
+    expect(aui.threads.item("main").getState().title).toBe("Listed thread");
     expect(aui.threads.item("main").getState().isRunning).toBe(true);
     expect(tracker.mounts.filter((id) => id === localId)).toHaveLength(
       localMountCount,

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -40,7 +40,6 @@ import type {
 import { ThreadListAdapterChangedError } from "../../runtimes/remote-thread-list/adapter-changed";
 import type { ThreadMessage } from "../../types/message";
 import { handleThreadListAction } from "../../store/runtime-clients/handle-thread-list-action";
-import { nullProtoRecord } from "../../utils/record";
 import {
   inMemoryThreadListTransformScopes,
   type InMemoryThreadListProps,

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -958,7 +958,10 @@ const useRemoteThreadList = (
           prev.filter((startedId) => startedId !== removedMappingId),
         );
       }
-      if (replacementMainThreadId !== undefined) {
+      if (
+        replacementMainThreadId !== undefined &&
+        session.mainThreadId === removedMappingId
+      ) {
         assignMainThreadId(replacementMainThreadId);
       }
       if (threadId === session.mainThreadId) {

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -25,6 +25,7 @@ import {
   createThreadMappingId,
   getThreadData,
   normalizeCursor,
+  reconcileInitializedThread,
   updateStatusReducer,
   type RemoteThreadData,
   type RemoteThreadState,
@@ -908,6 +909,7 @@ const useRemoteThreadList = (
         requireAdapterGeneration(adapterGeneration);
         return result;
       }
+      let removedMappingId: string | undefined;
       const result = await store.optimisticUpdate({
         execute: () => {
           requireAdapterGeneration(adapterGeneration);
@@ -933,45 +935,23 @@ const useRemoteThreadList = (
           if (adapterGeneration !== session.adapterGeneration) return state;
           const data = getThreadData(state, threadId);
           if (!data) return state;
-          const mappingId = createThreadMappingId(threadId);
-          // A list() response that landed while this initialize was in flight
-          // could not know the remote id yet, so it may have minted its own
-          // slot for it; that slot collapses into this one.
-          const listedMappingId = Object.hasOwn(state.threadIdMap, remoteId)
-            ? state.threadIdMap[remoteId]
-            : undefined;
-          const orphan =
-            listedMappingId !== undefined &&
-            listedMappingId !== mappingId &&
-            Object.hasOwn(state.threadData, listedMappingId)
-              ? state.threadData[listedMappingId]
-              : undefined;
-
-          const threadData = nullProtoRecord(state.threadData);
-          if (orphan !== undefined) delete threadData[listedMappingId!];
-          threadData[mappingId] = {
-            ...data,
-            initializeTask: Promise.resolve({ remoteId, externalId }),
+          const reconciliation = reconcileInitializedThread(
+            state,
+            threadId,
             remoteId,
             externalId,
-          } as RemoteThreadData;
-
-          const rewire = (ids: readonly string[]) =>
-            orphan === undefined ? ids : ids.filter((id) => id !== orphan.id);
-
-          return {
-            ...state,
-            threadIds: rewire(state.threadIds),
-            archivedThreadIds: rewire(state.archivedThreadIds),
-            threadIdMap: {
-              ...state.threadIdMap,
-              [remoteId]: mappingId,
-            },
-            threadData,
-          };
+            session.mainThreadId,
+          );
+          removedMappingId = reconciliation.removedMappingId;
+          return reconciliation.state;
         },
       });
       requireAdapterGeneration(adapterGeneration);
+      if (removedMappingId !== undefined) {
+        setStartedIds((prev) =>
+          prev.filter((startedId) => startedId !== removedMappingId),
+        );
+      }
       if (threadId === session.mainThreadId) {
         notifyRemoteId(result.remoteId, true);
       }

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -909,6 +909,7 @@ const useRemoteThreadList = (
         return result;
       }
       let removedMappingId: string | undefined;
+      let replacementMainThreadId: string | undefined;
       const result = await store.optimisticUpdate({
         execute: () => {
           requireAdapterGeneration(adapterGeneration);
@@ -932,16 +933,17 @@ const useRemoteThreadList = (
         },
         then: (state, { remoteId, externalId }) => {
           if (adapterGeneration !== session.adapterGeneration) return state;
-          const data = getThreadData(state, threadId);
-          if (!data) return state;
           const reconciliation = reconcileInitializedThread(
             state,
             threadId,
             remoteId,
             externalId,
-            session.mainThreadId,
+            backgroundThreads ? threadId : session.mainThreadId,
           );
           removedMappingId = reconciliation.removedMappingId;
+          if (removedMappingId === session.mainThreadId) {
+            replacementMainThreadId = reconciliation.survivorMappingId;
+          }
           return reconciliation.state;
         },
       });
@@ -951,12 +953,22 @@ const useRemoteThreadList = (
           prev.filter((startedId) => startedId !== removedMappingId),
         );
       }
+      if (replacementMainThreadId !== undefined) {
+        assignMainThreadId(replacementMainThreadId);
+      }
       if (threadId === session.mainThreadId) {
         notifyRemoteId(result.remoteId, true);
       }
       return toInitializeResult(result);
     },
-    [notifyRemoteId, requireAdapterGeneration, session, store],
+    [
+      assignMainThreadId,
+      backgroundThreads,
+      notifyRemoteId,
+      requireAdapterGeneration,
+      session,
+      store,
+    ],
   );
 
   const rename = useCallback(

--- a/packages/core/src/react/client/RemoteThreadList.ts
+++ b/packages/core/src/react/client/RemoteThreadList.ts
@@ -933,12 +933,17 @@ const useRemoteThreadList = (
         },
         then: (state, { remoteId, externalId }) => {
           if (adapterGeneration !== session.adapterGeneration) return state;
+          // Background mode still owns the initializing body. Single-body mode
+          // has already replaced it, so retain the currently mounted body.
+          const retainedThreadId = backgroundThreads
+            ? threadId
+            : session.mainThreadId;
           const reconciliation = reconcileInitializedThread(
             state,
             threadId,
             remoteId,
             externalId,
-            backgroundThreads ? threadId : session.mainThreadId,
+            retainedThreadId,
           );
           removedMappingId = reconciliation.removedMappingId;
           if (removedMappingId === session.mainThreadId) {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -21,6 +21,7 @@ import {
   createThreadMappingId,
   getThreadData,
   normalizeCursor,
+  reconcileInitializedThread,
   updateStatusReducer,
   preserveMidLoadTransitions,
   seedNewThread,
@@ -810,6 +811,7 @@ export class RemoteThreadListThreadListRuntimeCore
       return { remoteId, externalId };
     }
 
+    let removedMappingId: string | undefined;
     const { remoteId, externalId } = await this._state.optimisticUpdate({
       execute: () => {
         this._requireAdapterGeneration(adapterGeneration);
@@ -838,45 +840,21 @@ export class RemoteThreadListThreadListRuntimeCore
         const data = getThreadData(state, threadId);
         if (!data) return state;
 
-        const mappingId = createThreadMappingId(threadId);
-        // A list() response that landed while this initialize was in flight
-        // could not know the remote id yet, so it may have minted its own slot
-        // for it; that slot collapses into this one.
-        const listedMappingId = Object.hasOwn(state.threadIdMap, remoteId)
-          ? state.threadIdMap[remoteId]
-          : undefined;
-        const orphan =
-          listedMappingId !== undefined &&
-          listedMappingId !== mappingId &&
-          Object.hasOwn(state.threadData, listedMappingId)
-            ? state.threadData[listedMappingId]
-            : undefined;
-
-        const threadData = nullProtoRecord(state.threadData);
-        if (orphan !== undefined) delete threadData[listedMappingId!];
-        threadData[mappingId] = {
-          ...data,
-          initializeTask: Promise.resolve({ remoteId, externalId }),
+        const reconciliation = reconcileInitializedThread(
+          state,
+          threadId,
           remoteId,
           externalId,
-        } as RemoteThreadData;
-
-        const rewire = (ids: readonly string[]) =>
-          orphan === undefined ? ids : ids.filter((id) => id !== orphan.id);
-
-        return {
-          ...state,
-          threadIds: rewire(state.threadIds),
-          archivedThreadIds: rewire(state.archivedThreadIds),
-          threadIdMap: {
-            ...state.threadIdMap,
-            [remoteId]: mappingId,
-          },
-          threadData,
-        };
+          this._mainThreadId,
+        );
+        removedMappingId = reconciliation.removedMappingId;
+        return reconciliation.state;
       },
     });
     this._requireAdapterGeneration(adapterGeneration);
+    if (removedMappingId !== undefined) {
+      this._hookManager.stopThreadRuntime(removedMappingId);
+    }
     return { remoteId, externalId };
   };
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -837,17 +837,17 @@ export class RemoteThreadListThreadListRuntimeCore
       },
       then: (state, { remoteId, externalId }) => {
         if (adapterGeneration !== this._adapterGeneration) return state;
-        const data = getThreadData(state, threadId);
-        if (!data) return state;
-
         const reconciliation = reconcileInitializedThread(
           state,
           threadId,
           remoteId,
           externalId,
-          this._mainThreadId,
+          threadId,
         );
         removedMappingId = reconciliation.removedMappingId;
+        if (removedMappingId === this._mainThreadId) {
+          this._mainThreadId = reconciliation.survivorMappingId;
+        }
         return reconciliation.state;
       },
     });

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.test.ts
@@ -3,6 +3,7 @@ import {
   classifyThreads,
   createEmptyRemoteThreadState,
   createThreadMappingId,
+  reconcileInitializedThread,
   seedNewThread,
   updateStatusReducer,
 } from "./remote-thread-state";
@@ -130,6 +131,43 @@ describe("remote thread state", () => {
 
     expect(listed.threadIds).toEqual(["a"]);
     expect(listed.threadData[createThreadMappingId("a")]?.title).toBe("second");
+  });
+
+  it("retains a listed external id when that slot survives reconciliation", async () => {
+    const seeded = seedNewThread(createEmptyRemoteThreadState());
+    const regular = updateStatusReducer(seeded.state, seeded.id, "regular");
+    const classified = classifyThreads(
+      [
+        {
+          status: "regular",
+          remoteId: "remote-1",
+          externalId: "external-1",
+        },
+      ],
+      {
+        threadIds: [...regular.threadIds],
+        archivedThreadIds: [...regular.archivedThreadIds],
+        threadIdMap: { ...regular.threadIdMap },
+        threadData: { ...regular.threadData },
+      },
+    );
+    const state = { ...regular, ...classified };
+
+    const reconciled = reconcileInitializedThread(
+      state,
+      seeded.id,
+      "remote-1",
+      undefined,
+      "remote-1",
+    );
+    const survivor = reconciled.state.threadData[reconciled.survivorMappingId]!;
+
+    expect(survivor.externalId).toBe("external-1");
+    if (survivor.status === "new") throw new Error("Expected initialized slot");
+    await expect(survivor.initializeTask).resolves.toEqual({
+      remoteId: "remote-1",
+      externalId: "external-1",
+    });
   });
 
   it.each(["__proto__", "constructor", "toString"])(

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -279,17 +279,23 @@ export const reconcileInitializedThread = (
   threadId: string,
   remoteId: string,
   externalId: string | undefined,
-  preferredThreadId?: string,
+  retainedThreadId?: string,
 ): {
   state: RemoteThreadState;
   removedMappingId: THREAD_MAPPING_ID | undefined;
+  survivorMappingId: THREAD_MAPPING_ID;
 } => {
   const mappingId = createThreadMappingId(threadId);
   const data = Object.hasOwn(state.threadData, mappingId)
     ? state.threadData[mappingId]
     : undefined;
-  if (!data) return { state, removedMappingId: undefined };
+  if (!data) {
+    return { state, removedMappingId: undefined, survivorMappingId: mappingId };
+  }
 
+  // A concurrent list cannot associate the remote ID with this initializing
+  // slot and may mint a duplicate. Retain the slot whose mounted runtime owns
+  // local state; initialized metadata remains authoritative over list metadata.
   const listedMappingId = Object.hasOwn(state.threadIdMap, remoteId)
     ? state.threadIdMap[remoteId]
     : undefined;
@@ -303,13 +309,13 @@ export const reconcileInitializedThread = (
     listedMappingId !== undefined && listedData !== undefined
       ? { mappingId: listedMappingId, data: listedData }
       : undefined;
-  const preferredMappingId =
-    preferredThreadId !== undefined &&
-    Object.hasOwn(state.threadIdMap, preferredThreadId)
-      ? state.threadIdMap[preferredThreadId]
+  const retainedMappingId =
+    retainedThreadId !== undefined &&
+    Object.hasOwn(state.threadIdMap, retainedThreadId)
+      ? state.threadIdMap[retainedThreadId]
       : undefined;
   const survivorMappingId =
-    listedSlot !== undefined && preferredMappingId === listedSlot.mappingId
+    listedSlot !== undefined && retainedMappingId === listedSlot.mappingId
       ? listedSlot.mappingId
       : mappingId;
   const removedMappingId =
@@ -367,6 +373,7 @@ export const reconcileInitializedThread = (
       threadData,
     },
     removedMappingId,
+    survivorMappingId,
   };
 };
 

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -324,14 +324,21 @@ export const reconcileInitializedThread = (
       : survivorMappingId === mappingId
         ? listedSlot.mappingId
         : mappingId;
+  const resolvedExternalId =
+    survivorMappingId === listedSlot?.mappingId
+      ? (externalId ?? listedSlot.data.externalId)
+      : externalId;
   const threadData = nullProtoRecord(state.threadData);
   if (removedMappingId !== undefined) delete threadData[removedMappingId];
   const initializedData = {
     ...data,
     id: survivorMappingId,
-    initializeTask: Promise.resolve({ remoteId, externalId }),
+    initializeTask: Promise.resolve({
+      remoteId,
+      externalId: resolvedExternalId,
+    }),
     remoteId,
-    externalId,
+    externalId: resolvedExternalId,
   } as RemoteThreadData;
   threadData[survivorMappingId] =
     survivorMappingId === mappingId

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -324,10 +324,7 @@ export const reconcileInitializedThread = (
       : survivorMappingId === mappingId
         ? listedSlot.mappingId
         : mappingId;
-  const resolvedExternalId =
-    survivorMappingId === listedSlot?.mappingId
-      ? (externalId ?? listedSlot.data.externalId)
-      : externalId;
+  const resolvedExternalId = externalId ?? listedSlot?.data.externalId;
   const threadData = nullProtoRecord(state.threadData);
   if (removedMappingId !== undefined) delete threadData[removedMappingId];
   const initializedData = {

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -293,11 +293,15 @@ export const reconcileInitializedThread = (
   const listedMappingId = Object.hasOwn(state.threadIdMap, remoteId)
     ? state.threadIdMap[remoteId]
     : undefined;
-  const orphan =
+  const listedData =
     listedMappingId !== undefined &&
     listedMappingId !== mappingId &&
     Object.hasOwn(state.threadData, listedMappingId)
       ? state.threadData[listedMappingId]
+      : undefined;
+  const listedSlot =
+    listedMappingId !== undefined && listedData !== undefined
+      ? { mappingId: listedMappingId, data: listedData }
       : undefined;
   const preferredMappingId =
     preferredThreadId !== undefined &&
@@ -305,14 +309,14 @@ export const reconcileInitializedThread = (
       ? state.threadIdMap[preferredThreadId]
       : undefined;
   const survivorMappingId =
-    orphan !== undefined && preferredMappingId === listedMappingId
-      ? listedMappingId
+    listedSlot !== undefined && preferredMappingId === listedSlot.mappingId
+      ? listedSlot.mappingId
       : mappingId;
   const removedMappingId =
-    orphan === undefined
+    listedSlot === undefined
       ? undefined
       : survivorMappingId === mappingId
-        ? listedMappingId
+        ? listedSlot.mappingId
         : mappingId;
   const threadData = nullProtoRecord(state.threadData);
   if (removedMappingId !== undefined) delete threadData[removedMappingId];
@@ -327,15 +331,15 @@ export const reconcileInitializedThread = (
     survivorMappingId === mappingId
       ? initializedData
       : ({
-          ...orphan,
+          ...listedSlot?.data,
           ...initializedData,
-          title: data.title ?? orphan?.title,
+          title: data.title ?? listedSlot?.data.title,
           lastMessageAt:
             ("lastMessageAt" in data ? data.lastMessageAt : undefined) ??
-            (orphan && "lastMessageAt" in orphan
-              ? orphan.lastMessageAt
+            (listedSlot && "lastMessageAt" in listedSlot.data
+              ? listedSlot.data.lastMessageAt
               : undefined),
-          custom: data.custom ?? orphan?.custom,
+          custom: data.custom ?? listedSlot?.data.custom,
         } as RemoteThreadData);
 
   const threadIdMap = nullProtoRecord(state.threadIdMap);
@@ -348,10 +352,10 @@ export const reconcileInitializedThread = (
   threadIdMap[remoteId] = survivorMappingId;
 
   const rewire = (ids: readonly string[]) =>
-    orphan === undefined
+    listedSlot === undefined
       ? ids
       : ids
-          .filter((id) => id !== orphan.id)
+          .filter((id) => id !== listedSlot.data.id)
           .map((id) => (id === data.id ? survivorMappingId : id));
 
   return {

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -337,20 +337,17 @@ export const reconcileInitializedThread = (
     remoteId,
     externalId: resolvedExternalId,
   } as RemoteThreadData;
-  threadData[survivorMappingId] =
-    survivorMappingId === mappingId
-      ? initializedData
-      : ({
-          ...listedSlot?.data,
-          ...initializedData,
-          title: data.title ?? listedSlot?.data.title,
-          lastMessageAt:
-            ("lastMessageAt" in data ? data.lastMessageAt : undefined) ??
-            (listedSlot && "lastMessageAt" in listedSlot.data
-              ? listedSlot.data.lastMessageAt
-              : undefined),
-          custom: data.custom ?? listedSlot?.data.custom,
-        } as RemoteThreadData);
+  threadData[survivorMappingId] = {
+    ...listedSlot?.data,
+    ...initializedData,
+    title: data.title ?? listedSlot?.data.title,
+    lastMessageAt:
+      ("lastMessageAt" in data ? data.lastMessageAt : undefined) ??
+      (listedSlot && "lastMessageAt" in listedSlot.data
+        ? listedSlot.data.lastMessageAt
+        : undefined),
+    custom: data.custom ?? listedSlot?.data.custom,
+  } as RemoteThreadData;
 
   const threadIdMap = nullProtoRecord(state.threadIdMap);
   if (removedMappingId !== undefined) {

--- a/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/remote-thread-state.ts
@@ -274,6 +274,98 @@ export const getThreadData = (
     : undefined;
 };
 
+export const reconcileInitializedThread = (
+  state: RemoteThreadState,
+  threadId: string,
+  remoteId: string,
+  externalId: string | undefined,
+  preferredThreadId?: string,
+): {
+  state: RemoteThreadState;
+  removedMappingId: THREAD_MAPPING_ID | undefined;
+} => {
+  const mappingId = createThreadMappingId(threadId);
+  const data = Object.hasOwn(state.threadData, mappingId)
+    ? state.threadData[mappingId]
+    : undefined;
+  if (!data) return { state, removedMappingId: undefined };
+
+  const listedMappingId = Object.hasOwn(state.threadIdMap, remoteId)
+    ? state.threadIdMap[remoteId]
+    : undefined;
+  const orphan =
+    listedMappingId !== undefined &&
+    listedMappingId !== mappingId &&
+    Object.hasOwn(state.threadData, listedMappingId)
+      ? state.threadData[listedMappingId]
+      : undefined;
+  const preferredMappingId =
+    preferredThreadId !== undefined &&
+    Object.hasOwn(state.threadIdMap, preferredThreadId)
+      ? state.threadIdMap[preferredThreadId]
+      : undefined;
+  const survivorMappingId =
+    orphan !== undefined && preferredMappingId === listedMappingId
+      ? listedMappingId
+      : mappingId;
+  const removedMappingId =
+    orphan === undefined
+      ? undefined
+      : survivorMappingId === mappingId
+        ? listedMappingId
+        : mappingId;
+  const threadData = nullProtoRecord(state.threadData);
+  if (removedMappingId !== undefined) delete threadData[removedMappingId];
+  const initializedData = {
+    ...data,
+    id: survivorMappingId,
+    initializeTask: Promise.resolve({ remoteId, externalId }),
+    remoteId,
+    externalId,
+  } as RemoteThreadData;
+  threadData[survivorMappingId] =
+    survivorMappingId === mappingId
+      ? initializedData
+      : ({
+          ...orphan,
+          ...initializedData,
+          title: data.title ?? orphan?.title,
+          lastMessageAt:
+            ("lastMessageAt" in data ? data.lastMessageAt : undefined) ??
+            (orphan && "lastMessageAt" in orphan
+              ? orphan.lastMessageAt
+              : undefined),
+          custom: data.custom ?? orphan?.custom,
+        } as RemoteThreadData);
+
+  const threadIdMap = nullProtoRecord(state.threadIdMap);
+  if (removedMappingId !== undefined) {
+    for (const [id, target] of Object.entries(threadIdMap)) {
+      if (target === removedMappingId) threadIdMap[id] = survivorMappingId;
+    }
+  }
+  threadIdMap[threadId] = survivorMappingId;
+  threadIdMap[remoteId] = survivorMappingId;
+
+  const rewire = (ids: readonly string[]) =>
+    orphan === undefined
+      ? ids
+      : ids
+          .filter((id) => id !== orphan.id)
+          .map((id) => (id === data.id ? survivorMappingId : id));
+
+  return {
+    state: {
+      ...state,
+      threadIds: rewire(state.threadIds),
+      archivedThreadIds: rewire(state.archivedThreadIds),
+      threadIdMap,
+      threadData,
+    },
+    removedMappingId,
+  };
+};
+
 export const updateStatusReducer = (
   state: RemoteThreadState,
   threadIdOrRemoteId: string,

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -154,6 +154,7 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.threadIds).toEqual([localId]);
     expect(Object.keys(core.threadItems)).toEqual([localId]);
     expect(core.getItemById("remote-1")?.id).toBe(localId);
+    expect(core.getItemById("remote-1")?.externalId).toBe("remote-1");
     expect(stopThreadRuntime).toHaveBeenCalledWith("remote-1");
     expect(stopThreadRuntime).not.toHaveBeenCalledWith(localId);
   });

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -113,6 +113,51 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.threadIds).toEqual([]);
   });
 
+  it("preserves a listed slot selected while initialize was in flight", async () => {
+    const listDeferred = deferred<ListResult>();
+    const initializeDeferred = deferred<{
+      remoteId: string;
+      externalId: undefined;
+    }>();
+    const adapter = makeAdapter({
+      list: vi.fn(() => listDeferred.promise),
+      initialize: vi.fn(() => initializeDeferred.promise),
+    });
+    const core = createCore(adapter);
+    const stopThreadRuntime = vi.fn();
+    (
+      core as unknown as {
+        _hookManager: { stopThreadRuntime: (threadId: string) => void };
+      }
+    )._hookManager.stopThreadRuntime = stopThreadRuntime;
+
+    const loadPromise = core.getLoadThreadsPromise();
+    await core.switchToNewThread();
+    const localId = core.newThreadId!;
+    const initializePromise = core.initialize(localId);
+
+    listDeferred.resolve({
+      threads: [
+        { status: "regular", remoteId: "remote-1", externalId: "remote-1" },
+      ],
+    });
+    await loadPromise;
+    await core.switchToThread("remote-1");
+
+    initializeDeferred.resolve({
+      remoteId: "remote-1",
+      externalId: undefined,
+    });
+    await initializePromise;
+
+    expect(core.mainThreadId).toBe("remote-1");
+    expect(core.threadIds).toEqual(["remote-1"]);
+    expect(Object.keys(core.threadItems)).toEqual(["remote-1"]);
+    expect(core.getItemById(localId)?.id).toBe("remote-1");
+    expect(stopThreadRuntime).toHaveBeenCalledWith(localId);
+    expect(stopThreadRuntime).not.toHaveBeenCalledWith("remote-1");
+  });
+
   it("does not leave the collapsed slot in both lists when the race reported it archived", async () => {
     const listDeferred = deferred<ListResult>();
     const initializeDeferred = deferred<{

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts
@@ -113,7 +113,7 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     expect(core.threadIds).toEqual([]);
   });
 
-  it("preserves a listed slot selected while initialize was in flight", async () => {
+  it("keeps the initialized runtime when its listed duplicate is selected", async () => {
     const listDeferred = deferred<ListResult>();
     const initializeDeferred = deferred<{
       remoteId: string;
@@ -124,12 +124,12 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
       initialize: vi.fn(() => initializeDeferred.promise),
     });
     const core = createCore(adapter);
-    const stopThreadRuntime = vi.fn();
-    (
+    const hookManager = (
       core as unknown as {
         _hookManager: { stopThreadRuntime: (threadId: string) => void };
       }
-    )._hookManager.stopThreadRuntime = stopThreadRuntime;
+    )._hookManager;
+    const stopThreadRuntime = vi.spyOn(hookManager, "stopThreadRuntime");
 
     const loadPromise = core.getLoadThreadsPromise();
     await core.switchToNewThread();
@@ -150,12 +150,12 @@ describe("RemoteThreadListThreadListRuntimeCore load race", () => {
     });
     await initializePromise;
 
-    expect(core.mainThreadId).toBe("remote-1");
-    expect(core.threadIds).toEqual(["remote-1"]);
-    expect(Object.keys(core.threadItems)).toEqual(["remote-1"]);
-    expect(core.getItemById(localId)?.id).toBe("remote-1");
-    expect(stopThreadRuntime).toHaveBeenCalledWith(localId);
-    expect(stopThreadRuntime).not.toHaveBeenCalledWith("remote-1");
+    expect(core.mainThreadId).toBe(localId);
+    expect(core.threadIds).toEqual([localId]);
+    expect(Object.keys(core.threadItems)).toEqual([localId]);
+    expect(core.getItemById("remote-1")?.id).toBe(localId);
+    expect(stopThreadRuntime).toHaveBeenCalledWith("remote-1");
+    expect(stopThreadRuntime).not.toHaveBeenCalledWith(localId);
   });
 
   it("does not leave the collapsed slot in both lists when the race reported it archived", async () => {

--- a/size-budgets.json
+++ b/size-budgets.json
@@ -25,8 +25,8 @@
       "gzip": 76397
     },
     "./store": {
-      "min": 93075,
-      "gzip": 30821
+      "min": 95034,
+      "gzip": 31499
     },
     "./store/internal": {
       "min": 21420,


### PR DESCRIPTION
## Problem

Closes #6673.

When a new thread is initialized while `list()` independently discovers the same remote thread, the two slots are collapsed. If the user switches to the listed remote slot before initialization finishes, current main removes that selected slot while leaving it as `mainThreadId`. The legacy core then stops the selected runtime, while the Tap client unmounts its selected body and can expose the local body under the remote ID.

A focused reproduction on current main leaves `mainThreadId` set to `remote-1` while `threadIds` contains only the local mapping. Both the legacy core and Tap regressions fail before this fix.

## Root cause

Slot reconciliation always kept the locally initialized slot. It did not account for runtime and body ownership after the independently listed slot became active.

## Change

Share slot reconciliation between the legacy core and Tap implementations and retain the slot whose mounted runtime or body owns local state. The legacy manager and Tap background mode keep the initialized local slot; single-body Tap keeps the currently mounted listed slot. Rewire local and remote aliases to the survivor, retarget main selection when necessary, and stop or unmount only the losing duplicate.

## Verification

- Confirmed both focused regressions fail on current main before the fix.
- `pnpm --dir packages/core exec vitest run src/runtimes/remote-thread-list/remote-thread-state.test.ts src/tests/RemoteThreadListThreadListRuntimeCore-load-race.test.ts src/react/client/RemoteThreadList.background.test.ts` (29 tests)
- `pnpm --dir packages/core exec vitest run --reporter=dot` (1,750 tests)
- `pnpm --dir packages/core build`
- `pnpm --dir examples/with-tap-runtime build`
- `pnpm lint`
- `pnpm changesets:check`

## Public surface

`@assistant-ui/core` behavior only. No exports, APIs, documentation, templates, or generated API-reference output change. Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8zcMJCKl4tDD7VzGAFxrc2DS10YDfaEj4Pa7AXi82tGjFRYuVBS5ZZ6gDQg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->