### PR TITLE
fix: harden the langchain converters against non-spec content blocks

### DIFF
--- a/.changeset/langchain-converter-hardening.md
+++ b/.changeset/langchain-converter-hardening.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: harden the shared content block converter against non-spec blocks

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -6,6 +6,7 @@ import {
   getMessageContent,
   getMessageType,
 } from "./convertMessages";
+import { createLangChainStreamingTimingAccessors } from "./converter";
 import type { LangChainBaseMessage, UIMessage } from "./types";
 
 const humanMessage = (content: unknown): LangChainBaseMessage => ({
@@ -1148,7 +1149,28 @@ describe("convertLangChainBaseMessage malformed messages", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
   });
 
-  it("skips a textless block when collecting system text", () => {
+  it("skips null entries when measuring streamed text length", () => {
+    const { getTextLength } = createLangChainStreamingTimingAccessors<{
+      id?: string | undefined;
+      content?: unknown;
+      _getType: () => string;
+    }>((message) => message._getType());
+
+    expect(
+      getTextLength(
+        [
+          {
+            _getType: () => "ai",
+            id: "ai-1",
+            content: [null, { type: "text", text: "abc" }, undefined],
+          },
+        ],
+        "ai-1",
+      ),
+    ).toBe(3);
+  });
+
+  it("renders a textless block as empty system text", () => {
     const result = convertLangChainBaseMessage(
       {
         _getType: () => "system",

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1139,6 +1139,28 @@ describe("convertLangChainBaseMessage malformed messages", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "kept" }]);
   });
 
+  it("coalesces a text block without a text field to empty text", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([{ type: "text" }]),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("skips a textless block when collecting system text", () => {
+    const result = convertLangChainBaseMessage(
+      {
+        _getType: () => "system",
+        id: "msg-7",
+        content: [{ type: "text" }, { type: "text", text: "kept" }],
+      },
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "kept" }]);
+  });
+
   it("skips null entries when collecting system text", () => {
     const result = convertLangChainBaseMessage(
       {

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -61,7 +61,10 @@ export const convertLangChainContentBlock = (
   switch (type) {
     case "text":
     case "text_delta":
-      return { type: "text" as const, text: part.text };
+      return {
+        type: "text" as const,
+        text: typeof part.text === "string" ? part.text : "",
+      };
     case "image_url": {
       const image =
         typeof part.image_url === "string"

--- a/packages/react-langchain/src/converter.ts
+++ b/packages/react-langchain/src/converter.ts
@@ -301,6 +301,7 @@ export const createLangChainStreamingTimingAccessors = <
     if (!Array.isArray(content)) return 0;
     let len = 0;
     for (const part of content as readonly LangChainContentBlock[]) {
+      if (typeof part !== "object" || part === null) continue;
       switch (part.type) {
         case "text":
         case "text_delta":

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -56,6 +56,17 @@ describe("convertLangChainMessages content-less messages", () => {
     expect(result.role).toBe("user");
     expect(result.content).toEqual([]);
   });
+
+  it("skips null entries inside a content array", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "h-2",
+      content: [null, { type: "text", text: "kept" }, undefined],
+    } as unknown as LangChainMessage);
+
+    expect(result.role).toBe("user");
+    expect(result.content).toEqual([{ type: "text", text: "kept" }]);
+  });
 });
 
 describe("convertLangChainMessages metadata", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -123,6 +123,7 @@ const contentToParts = (
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
   return content
+    .filter((part) => typeof part === "object" && part !== null)
     .map(
       (
         part,


### PR DESCRIPTION
Closes #6768.

## Problem

Two holes remained in the class #6753 closed, both reachable from the same non-spec provider payloads the "defensive converters" rule targets, and both reproducing on main:

1. A well-formed text block with no `text` field survives #6753's container guard (which only rejects non-objects) and `convertLangChainContentBlock` passes the missing field through, yielding `{ type: "text", text: undefined }` — a part violating its own `text: string` contract, inherited by both `react-langchain` and `react-langgraph` through the shared converter.
2. `react-langgraph`'s `contentToParts` maps a content array without a per-entry guard and reads `part.type` first, so a `null` entry throws `TypeError: Cannot read properties of null (reading 'type')` — the exact failure #6753 fixed on the langchain side, named there as a deliberate follow-up.

## Change

Per the issue's suggested shape:

- The shared `convertLangChainContentBlock` coalesces a missing or non-string `text` to `""`, so both packages inherit the guard. Coalescing (rather than dropping, as the `reasoning` case does) preserves the existing behavior for streaming `text_delta` frames that legitimately carry empty text.
- `react-langgraph`'s `contentToParts` filters non-object entries before mapping — #6753's `contentBlocks` filter lifted into the langgraph converter rather than exported, keeping `@assistant-ui/react-langchain`'s published surface unchanged. This also aligns the two converters on tolerating stray string entries, per the cross-runtime parity rule.

One extra test pins a neighboring seam that turned out to be accidentally safe: `getStringContent` maps a textless block to `undefined`, but `Array.prototype.join` renders that as an empty string, so system text was never corrupted — pinned so a future refactor away from `join` cannot regress it silently.

## Verification

- Both repros fail on main exactly as filed: the coalesce test sees `text: undefined`, the langgraph null-entry test throws the issue's `TypeError`. Both pass with the fix.
- Full suites: `react-langchain` 140 passed, `react-langgraph` 315 passed. (An initial 127-test failure storm in langgraph was ruled out as stale local dists: the identical failures reproduce on a clean main checkout and disappear after `turbo build` of the dependency graph, with zero source changes involved.)

## Public surface

No API changes; no new exports. Patch changesets for `@assistant-ui/react-langchain` and `@assistant-ui/react-langgraph`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.dWQiudeOhEqlQZR7Igd4KvYVKgnVIjeH9QD5ZSi1WHqmJOs0u73lDkkVRu0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->