### PR TITLE
fix(python): emit updates for new tool subgraphs

### DIFF
--- a/.changeset/python-subgraph-state-updates.md
+++ b/.changeset/python-subgraph-state-updates.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: emit Python LangGraph subgraph state updates after a new tool message reaches the stream.

--- a/.changeset/python-subgraph-state-updates.md
+++ b/.changeset/python-subgraph-state-updates.md
@@ -1,5 +1,0 @@
----
-"assistant-stream": patch
----
-
-fix: emit Python LangGraph subgraph state updates after a new tool message reaches the stream.

--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "assistant-stream"
-version = "0.0.36"
+version = "0.0.37"
 description = ""
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },

--- a/python/assistant-stream/src/assistant_stream/modules/langgraph.py
+++ b/python/assistant-stream/src/assistant_stream/modules/langgraph.py
@@ -257,7 +257,7 @@ def get_tool_call_subgraph_state(
                 ).model_dump()
 
                 messages.append(tool_message)
-                last_message = tool_message
+                last_message = messages[-1]
 
             # Check if last message is already a ToolMessage
             if last_message["type"] == "tool":

--- a/python/assistant-stream/tests/test_langgraph.py
+++ b/python/assistant-stream/tests/test_langgraph.py
@@ -284,3 +284,44 @@ async def test_existing_tool_artifact_survives_default_state(
     )
 
     assert state == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("artifact_field_name", "path"),
+    [
+        (None, ["messages", "1", "artifact", "answer"]),
+        ("subgraph_state", ["messages", "1", "artifact", "subgraph_state", "answer"]),
+    ],
+)
+async def test_new_tool_subgraph_emits_updates_after_initial_flush(
+    artifact_field_name, path
+) -> None:
+    queue = asyncio.Queue()
+    controller = RunController(
+        queue,
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"id": "c1", "name": "task_tool", "args": {}}],
+                ).model_dump()
+            ]
+        },
+    )
+    state = get_tool_call_subgraph_state(
+        controller,
+        ("tools:task1",),
+        "tools",
+        {},
+        artifact_field_name=artifact_field_name,
+    )
+    controller.flush()
+    await asyncio.sleep(0)
+    queue.get_nowait()
+
+    append_langgraph_event(state, (), "updates", {"worker": {"answer": "ready"}})
+    controller.flush()
+    await asyncio.sleep(0)
+
+    assert {"type": "set", "path": path, "value": "ready"} in queue.get_nowait().operations

--- a/python/assistant-stream/uv.lock
+++ b/python/assistant-stream/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "assistant-stream"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "." }
 dependencies = [
     { name = "starlette" },

--- a/python/state-test/uv.lock
+++ b/python/state-test/uv.lock
@@ -35,7 +35,7 @@ wheels = [
 
 [[package]]
 name = "assistant-stream"
-version = "0.0.36"
+version = "0.0.37"
 source = { editable = "../assistant-stream" }
 dependencies = [
     { name = "starlette" },


### PR DESCRIPTION
## Problem

The first Python LangGraph subgraph event after a tool call can be lost. Its updates reach neither controller state nor the client.

The reproduction applies to `assistant-stream` 0.0.36 at base `98010f17b4a8d4bc506a6084007ecdaf4a823503`. From `python/assistant-stream`, install the locked extras with `uv sync --frozen --extra dev --extra langgraph`. Save this snippet as `repro.py` and run `uv run --frozen --extra dev --extra langgraph python repro.py`:

```python
import asyncio
from langchain_core.messages import AIMessage
from assistant_stream.create_run import RunController
from assistant_stream.modules.langgraph import (
    get_tool_call_subgraph_state,
    append_langgraph_event,
)

async def main():
    queue = asyncio.Queue()
    controller = RunController(queue, {
        "messages": [AIMessage(content="", tool_calls=[
            {"id": "c1", "name": "task_tool", "args": {}}
        ]).model_dump()]
    })
    state = get_tool_call_subgraph_state(
        controller, ("tools:task1",), "tools", {},
        artifact_field_name="subgraph_state",
    )
    controller.flush()
    await asyncio.sleep(0)
    queue.get_nowait()
    append_langgraph_event(state, (), "updates", {"worker": {"answer": "ready"}})
    controller.flush()
    await asyncio.sleep(0)
    operations = []
    while not queue.empty():
        operations.extend(queue.get_nowait().operations)
    print("answer:", state["answer"], "subsequent operations:", operations)
    assert {
        "type": "set",
        "path": ["messages", "1", "artifact", "subgraph_state", "answer"],
        "value": "ready",
    } in operations

asyncio.run(main())
```

## Root cause

The helper retains the plain dictionary after it appends a tool message through the state proxy. Writes to the returned artifact bypass state operations.

## Change

The helper reads the appended message through the existing proxy. Subsequent writes emit state updates for direct artifacts and named artifact fields.

## Verification

- The real API reproduction reported `answer: ready subsequent operations: []` before the correction. The same command emitted the expected `set` operation afterward.
- `uv run --frozen --extra dev --extra langgraph pytest tests/test_langgraph.py -k new_tool_subgraph -q`: two regression failures before the correction, two passes afterward.
- `uv run --frozen --extra dev --extra langgraph pytest tests/test_langgraph.py tests/test_state.py tests/test_state_updates.py -q`: 63 passes.
- The reproduction uses the real SDK and controller without mocks. It does not call a live model or backend server.
- The two local lockfiles pass `uv lock --check`, and `uv build` produces version `0.0.37`. Installed-wheel runtime verification remains incomplete because the direct archive import could not load the module namespace.

## Public surface

The Python `assistant-stream` LangGraph integration changes. Public signatures and exports remain unchanged. This PR prepares Python version `0.0.37` and updates its local lockfiles. It does not change the npm package. Documentation, API-reference output, and templates remain unchanged because their contracts do not change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.X9V-DGX3-Dflrv2XHqIZT5LU0tPiz4ZtPNm62nGDnFQP-6akAs-jUsc7j6o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->