### PR TITLE
fix(core): keep nested branch selection through ancestors

### DIFF
--- a/.changeset/nested-branch-selection.md
+++ b/.changeset/nested-branch-selection.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep the selected nested branch when an ancestor is selected again

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -381,8 +381,14 @@ export class MessageRepository {
       );
 
     const previousHead = this.head;
-    const prevOrRoot = message.prev ?? this.root;
-    prevOrRoot.next = message;
+    for (
+      let current: RepositoryMessage | null = message;
+      current;
+      current = current.prev
+    ) {
+      const prevOrRoot = current.prev ?? this.root;
+      prevOrRoot.next = current;
+    }
 
     this.head = findHead(message);
 

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -240,6 +240,48 @@ describe("MessageRepository", () => {
       expect(messages2.map((m) => m.id)).toEqual(["parent-id", "branch2-id"]);
     });
 
+    it("keeps a nested branch selected when revisiting its ancestor", () => {
+      repository.addOrUpdateMessage(null, createTestMessage({ id: "r" }));
+      repository.addOrUpdateMessage("r", createTestMessage({ id: "a" }));
+      repository.addOrUpdateMessage("a", createTestMessage({ id: "x" }));
+      repository.addOrUpdateMessage("r", createTestMessage({ id: "b" }));
+      repository.addOrUpdateMessage("b", createTestMessage({ id: "y" }));
+
+      repository.switchToBranch("y");
+      expect(repository.getMessages().map((m) => m.id)).toEqual([
+        "r",
+        "b",
+        "y",
+      ]);
+
+      repository.switchToBranch("r");
+      expect(repository.getMessages().map((m) => m.id)).toEqual([
+        "r",
+        "b",
+        "y",
+      ]);
+
+      repository.switchToBranch("x");
+      repository.switchToBranch("r");
+      expect(repository.getMessages().map((m) => m.id)).toEqual([
+        "r",
+        "a",
+        "x",
+      ]);
+    });
+
+    it("keeps the selected root branch when deletion selects from the root", () => {
+      repository.addOrUpdateMessage(null, createTestMessage({ id: "a" }));
+      repository.addOrUpdateMessage("a", createTestMessage({ id: "x" }));
+      repository.addOrUpdateMessage(null, createTestMessage({ id: "b" }));
+      repository.addOrUpdateMessage("b", createTestMessage({ id: "y" }));
+
+      repository.switchToBranch("y");
+      repository.deleteMessage("y", null);
+
+      expect(repository.getMessages().map((m) => m.id)).toEqual(["b"]);
+    });
+
     it("should operate on a long message history without overflowing the stack", () => {
       const messageCount = 30_000;
       const messages = createLongBranchMessages(messageCount);


### PR DESCRIPTION
## Problem

A selected nested branch disappears when an ancestor is selected again. The thread returns to the previously selected sibling branch.

Reproduction on `@assistant-ui/core` 0.3.17 at base `98010f17b4a8d4bc506a6084007ecdaf4a823503`: this snippet runs with `bun repro.ts` from the repository root.

```ts
import assert from "node:assert/strict";
import {
  MessageRepository,
  ExportedMessageRepository,
} from "./packages/core/src/runtime/utils/message-repository.ts";

const repo = new MessageRepository();
const add = (parentId: string | null, id: string) => {
  for (const { message } of ExportedMessageRepository.fromArray([
    { id, role: "user", content: [{ type: "text", text: id }] },
  ]).messages) {
    repo.addOrUpdateMessage(parentId, message);
  }
};
add(null, "r");
add("r", "a");
add("a", "x");
add("r", "b");
add("b", "y");
repo.switchToBranch("y");
assert.deepEqual(repo.getMessages().map(m => m.id), ["r", "b", "y"]);
repo.switchToBranch("r");
assert.deepEqual(repo.getMessages().map(m => m.id), ["r", "b", "y"]);
```

The last assertion receives `["r", "a", "x"]` before the correction.

## Root cause

Branch selection updates only the immediate parent's `next` pointer. Ancestor selection follows unchanged pointers to a different branch.

## Change

Branch selection updates each ancestor pointer, including the root pointer. The selected branch stays visible after ancestor selection. Stored descendants and sibling branches remain available.

## Verification

- The same API reproduction fails before the correction and passes afterward.
- Two regression cases fail before the correction and pass afterward. They cover ancestor selection and root selection after message deletion.
- `pnpm --filter @assistant-ui/core test src/tests/MessageRepository.test.ts src/runtime/utils/message-repository-session.test.ts`: 52 tests pass.
- Scoped Oxlint and TypeScript diagnostics report no errors. `pnpm changesets:check` passes.

## Public surface

The correction affects `@assistant-ui/core` and includes a patch changeset. Public exports and signatures remain unchanged. No documentation, API-reference, or template changes are necessary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6Am-y1NSJh9N8YKHLJQXAgIwuAGskLsg8cSNjbSRpVJzciiW9khAlnGmWV8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->