### PR TITLE
fix(core): keep explicit null parents in thread append

### DIFF
--- a/.changeset/append-explicit-root-parent.md
+++ b/.changeset/append-explicit-root-parent.md
@@ -7,4 +7,6 @@ fix: keep an explicit null parent when a thread appends a message
 
 An explicit `parentId: null` selects a root branch instead of the current tail. This also applies to AG-UI steering and the tap `ExternalThread` client.
 
+For AG-UI, this includes a normalized `AppendMessage` with `parentId: null` passed to `steerAway` or `useAgUiSteerAway`. Such a message starts a root branch. To continue the current branch, omit `parentId` or pass `undefined`.
+
 On a nonempty `useExternalStoreRuntime` thread, an explicit null parent calls `onEdit` instead of `onNew`. Without `onEdit`, the runtime reports that it cannot edit messages. To append at the current tail, omit `parentId` or pass `undefined`.

--- a/.changeset/append-explicit-root-parent.md
+++ b/.changeset/append-explicit-root-parent.md
@@ -1,5 +1,10 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react-ag-ui": patch
 ---
 
 fix: keep an explicit null parent when a thread appends a message
+
+An explicit `parentId: null` selects a root branch instead of the current tail. This also applies to AG-UI steering and the tap `ExternalThread` client.
+
+On a nonempty `useExternalStoreRuntime` thread, an explicit null parent calls `onEdit` instead of `onNew`. Without `onEdit`, the runtime reports that it cannot edit messages. To append at the current tail, omit `parentId` or pass `undefined`.

--- a/.changeset/append-explicit-root-parent.md
+++ b/.changeset/append-explicit-root-parent.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep an explicit null parent when a thread appends a message

--- a/.changeset/append-explicit-root-parent.md
+++ b/.changeset/append-explicit-root-parent.md
@@ -10,3 +10,5 @@ An explicit `parentId: null` selects a root branch instead of the current tail. 
 For AG-UI, this includes a normalized `AppendMessage` with `parentId: null` passed to `steerAway` or `useAgUiSteerAway`. Such a message starts a root branch. To continue the current branch, omit `parentId` or pass `undefined`.
 
 On a nonempty `useExternalStoreRuntime` thread, an explicit null parent calls `onEdit` instead of `onNew`. Without `onEdit`, the runtime reports that it cannot edit messages. To append at the current tail, omit `parentId` or pass `undefined`.
+
+The tap `ExternalThread` client instead passes the null parent straight to `onNew`. Its `thread.append` has no `onEdit` route, so the host owns what a root append means there.

--- a/packages/core/src/runtime/api/thread-runtime.test.ts
+++ b/packages/core/src/runtime/api/thread-runtime.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
+import { ExternalStoreRuntimeCore } from "../../runtimes/external-store/external-store-runtime-core";
 import { AssistantRuntimeImpl } from "./assistant-runtime";
 
 describe("ThreadRuntime.append", () => {
@@ -39,4 +40,39 @@ describe("ThreadRuntime.append", () => {
       expect(thread.export().messages.at(-1)?.parentId).toBe(expectedParent);
     },
   );
+});
+
+describe("ThreadRuntime.append with an external store", () => {
+  it("routes an explicit root parent to onEdit instead of onNew", async () => {
+    const onNew = vi.fn(async () => {});
+    const onEdit = vi.fn(async () => {});
+    const core = new ExternalStoreRuntimeCore({
+      messages: [
+        {
+          id: "old",
+          role: "user",
+          content: [{ type: "text", text: "old" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        },
+      ],
+      onNew,
+      onEdit,
+    });
+    const thread = new AssistantRuntimeImpl(core).thread;
+
+    thread.append({
+      parentId: null,
+      content: [{ type: "text", text: "new root" }],
+      startRun: false,
+    });
+
+    await vi.waitFor(() =>
+      expect(onEdit).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ parentId: null }),
+      ),
+    );
+    expect(onNew).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/runtime/api/thread-runtime.test.ts
+++ b/packages/core/src/runtime/api/thread-runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { LocalRuntimeCore } from "../../runtimes/local/local-runtime-core";
+import { AssistantRuntimeImpl } from "./assistant-runtime";
+
+describe("ThreadRuntime.append", () => {
+  it.each([
+    { parent: { parentId: null }, expectedParent: null, visible: ["new"] },
+    {
+      parent: {},
+      expectedParent: "tail",
+      visible: ["root", "tail", "new"],
+    },
+    {
+      parent: { parentId: "root" },
+      expectedParent: "root",
+      visible: ["root", "new"],
+    },
+  ])(
+    "selects the branch under $expectedParent",
+    ({ parent, expectedParent, visible }) => {
+      const core = new LocalRuntimeCore(
+        { adapters: { chatModel: { run: async () => ({ content: [] }) } } },
+        [
+          { id: "root", role: "user", content: "root" },
+          { id: "tail", role: "assistant", content: "tail" },
+        ],
+      );
+      const thread = new AssistantRuntimeImpl(core).thread;
+
+      thread.append({
+        ...parent,
+        content: [{ type: "text", text: "new" }],
+        startRun: false,
+      });
+
+      expect(
+        thread.getState().messages.map((message) => message.content),
+      ).toEqual(visible.map((text) => [{ type: "text", text }]));
+      expect(thread.export().messages.at(-1)?.parentId).toBe(expectedParent);
+    },
+  );
+});

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -77,6 +77,10 @@ const toStartRunConfig = (message: CreateStartRunConfig): StartRunConfig => {
 export type CreateAppendMessage =
   | string
   | {
+      /**
+       * An omitted value or `undefined` selects the current tail.
+       * `null` selects a root branch.
+       */
       parentId?: string | null | undefined;
       sourceId?: string | null | undefined;
       role?: AppendMessage["role"] | undefined;

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -107,7 +107,10 @@ const toAppendMessage = (
 
   return {
     createdAt: message.createdAt ?? new Date(),
-    parentId: message.parentId ?? messages.at(-1)?.id ?? null,
+    parentId:
+      message.parentId === undefined
+        ? (messages.at(-1)?.id ?? null)
+        : message.parentId,
     sourceId: message.sourceId ?? null,
     role: message.role ?? "user",
     content: message.content,

--- a/packages/core/src/store/clients/external-thread.ts
+++ b/packages/core/src/store/clients/external-thread.ts
@@ -1155,7 +1155,10 @@ const useExternalThread = ({
             }
           : {
               createdAt: message.createdAt ?? new Date(),
-              parentId: message.parentId ?? messages.at(-1)?.id ?? null,
+              parentId:
+                message.parentId === undefined
+                  ? (messages.at(-1)?.id ?? null)
+                  : message.parentId,
               sourceId: message.sourceId ?? null,
               role: message.role ?? "user",
               content: message.content,

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -160,26 +160,35 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(onNew).not.toHaveBeenCalled();
     });
 
-    it("throws when adapter has no onEdit and parentId differs from head", async () => {
-      const messages = [createUserMessage("u1"), createAssistantMessage("a1")];
-      const adapter = createBaseAdapter({ messages });
-      const core = new ExternalStoreThreadRuntimeCore(contextProvider, adapter);
+    it.each(["u1", null])(
+      "rejects parent %s without onEdit",
+      async (parentId) => {
+        const messages = [
+          createUserMessage("u1"),
+          createAssistantMessage("a1"),
+        ];
+        const adapter = createBaseAdapter({ messages });
+        const core = new ExternalStoreThreadRuntimeCore(
+          contextProvider,
+          adapter,
+        );
 
-      const appendMessage: AppendMessage = {
-        role: "user",
-        content: [{ type: "text", text: "Edit" }],
-        attachments: [],
-        createdAt: new Date(),
-        parentId: "u1",
-        sourceId: null,
-        runConfig: undefined,
-        metadata: { custom: {} },
-      } as AppendMessage;
+        const appendMessage: AppendMessage = {
+          role: "user",
+          content: [{ type: "text", text: "Edit" }],
+          attachments: [],
+          createdAt: new Date(),
+          parentId,
+          sourceId: null,
+          runConfig: undefined,
+          metadata: { custom: {} },
+        } as AppendMessage;
 
-      await expect(core.append(appendMessage)).rejects.toThrow(
-        "Runtime does not support editing messages.",
-      );
-    });
+        await expect(core.append(appendMessage)).rejects.toThrow(
+          "Runtime does not support editing messages.",
+        );
+      },
+    );
   });
 
   describe("startRun", () => {

--- a/packages/core/src/tests/external-thread-parity.test.tsx
+++ b/packages/core/src/tests/external-thread-parity.test.tsx
@@ -229,6 +229,29 @@ describe("ExternalThread unset optional callbacks", () => {
   });
 });
 
+describe("ExternalThread append parent selection", () => {
+  it("passes an explicit null parent to the host", () => {
+    const onNew = vi.fn();
+    const { aui } = renderThread({
+      messages: [assistantMessage({ type: "complete", reason: "stop" })],
+      onNew,
+    });
+
+    aui().thread.append({
+      parentId: null,
+      content: [{ type: "text", text: "new root" }],
+      startRun: false,
+    });
+
+    expect(onNew).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        parentId: null,
+        content: [{ type: "text", text: "new root" }],
+      }),
+    );
+  });
+});
+
 describe("ExternalThread composer", () => {
   it("dispatches a synchronous setText + send sequence", async () => {
     const onNew = vi.fn();

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.test.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.test.ts
@@ -103,3 +103,21 @@ describe("AgUiThreadRuntimeCore late history loading", () => {
     expect(replacement.load).not.toHaveBeenCalled();
   });
 });
+
+describe("AgUiThreadRuntimeCore steerAway parent selection", () => {
+  it("starts a root branch for an explicit null parent", async () => {
+    const { core } = createCore();
+    await core.append(userMessage("old"));
+
+    await core.steerAway({
+      parentId: null,
+      content: [{ type: "text", text: "new root" }],
+      startRun: false,
+    });
+
+    expect(core.getMessages().map((message) => message.content)).toEqual([
+      [{ type: "text", text: "new root" }],
+    ]);
+    expect(core.getMessageRepository().messages.at(-1)?.parentId).toBeNull();
+  });
+});

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -750,7 +750,8 @@ export class AgUiThreadRuntimeCore {
     }
     return {
       createdAt: message.createdAt ?? new Date(),
-      parentId: message.parentId ?? this.session.headId,
+      parentId:
+        message.parentId === undefined ? this.session.headId : message.parentId,
       sourceId: message.sourceId ?? null,
       role: message.role ?? "user",
       content: message.content,

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -3483,7 +3483,7 @@ describe("AGUIThreadRuntimeCore", () => {
     await core.append(createAppendMessage());
     expect(core.getPendingInterrupts()).toBeNull();
 
-    await core.steerAway(createAppendMessage());
+    await core.steerAway({ content: [{ type: "text", text: "hi" }] });
 
     expect(runCount).toBe(2);
     expect(runInputs[1].resume).toBeUndefined();


### PR DESCRIPTION
## Problem

On a nonempty local thread, `thread.append({ parentId: null, ... })` adds the message after the current tail instead of as a separate root.

The reproduction uses base `98010f17b4a8d4bc506a6084007ecdaf4a823503` (`@assistant-ui/core` 0.3.17). From the repository root, install dependencies with `pnpm install --frozen-lockfile` and build dependencies with `pnpm exec turbo run build --filter='@assistant-ui/core^...'`. Save this as `repro.ts` and run `bun repro.ts`:

```ts
import assert from "node:assert/strict";
import { LocalRuntimeCore } from "./packages/core/src/runtimes/local/local-runtime-core";
import { AssistantRuntimeImpl } from "./packages/core/src/runtime/api/assistant-runtime";

const core = new LocalRuntimeCore(
  { adapters: { chatModel: { run: async () => ({ content: [] }) } } },
  [{ id: "old", role: "user", content: "old" }],
);
const thread = new AssistantRuntimeImpl(core).thread;
thread.append({
  parentId: null,
  content: [{ type: "text", text: "new root" }],
  startRun: false,
});
const added = thread.export().messages.find(({ message }) => message.id !== "old");
assert.equal(added?.parentId, null);
assert.deepEqual(thread.getState().messages.map(({ content }) => content), [
  [{ type: "text", text: "new root" }],
]);
```

## Root cause

The append conversions used `??`, which replaced an explicit `null` with the current tail ID.

## Change

Only `undefined` selects the default parent. Explicit null parents remain intact in the shared runtime, AG-UI steering, and the tap `ExternalThread` client.

On nonempty external-store threads, a null parent calls `onEdit`. Without `onEdit`, the runtime reports an error. The host owns message updates. To append at the tail, omit `parentId` or pass `undefined`.

## Verification

The original API reproduction and the AG-UI and tap regressions failed before their corrections and pass afterward. The 76 focused core tests and all 575 AG-UI package tests pass. Scoped lint and the changeset check pass.

Existing test type errors outside the changed lines prevent a clean package-wide typecheck claim.

## Public surface

The patch changeset covers `@assistant-ui/core` and `@assistant-ui/react-ag-ui`. Parent-selection JSDoc documents the existing input type. API-reference generation completes without generated changes. Public signatures and exports stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.h03jA51ZVrunIBxm1YAb1UhyL5FJmh87PHelK9QvXvVCyCYH0gfmQyNy2uU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->