### PR TITLE
fix(core): export parent messages before children

### DIFF
--- a/.changeset/message-export-parent-order.md
+++ b/.changeset/message-export-parent-order.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: export parent messages before their children so imports succeed after a parent change

--- a/.changeset/message-export-parent-order.md
+++ b/.changeset/message-export-parent-order.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: export parent messages before their children so imports succeed after a parent change
+fix: export parent messages before their children. a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported its messages in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded.

--- a/.changeset/message-export-parent-order.md
+++ b/.changeset/message-export-parent-order.md
@@ -4,4 +4,4 @@
 
 fix: export parent messages before their children
 
-a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded.
+a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded. the export now walks the tree in pre-order, which also emits siblings in branch order, so branch positions survive a round-trip.

--- a/.changeset/message-export-parent-order.md
+++ b/.changeset/message-export-parent-order.md
@@ -4,4 +4,4 @@
 
 fix: export parent messages before their children
 
-a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded. the export now walks the tree in pre-order, which also emits siblings in branch order, so branch positions survive a round-trip.
+a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and consumers that resolve each item's parent as they walk the exported array (`exportExternalState`, the external-store `messageRepository` prop) attached messages to the wrong parent. the export now walks the tree in pre-order, which also emits siblings in branch order, so branch positions survive a round-trip.

--- a/.changeset/message-export-parent-order.md
+++ b/.changeset/message-export-parent-order.md
@@ -2,4 +2,6 @@
 "@assistant-ui/core": patch
 ---
 
-fix: export parent messages before their children. a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported its messages in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded.
+fix: export parent messages before their children
+
+a thread whose message was reparented (`addOrUpdateMessage` with a new parent) exported in map insertion order, so a parent could be emitted after its own child. importing that export threw `Parent message not found`, and the persistence adapters that skip an item whose parent has not been seen yet silently dropped messages when the thread was reloaded.

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -456,7 +456,9 @@ export class MessageRepository {
     // Optimistic messages are ephemeral and never persisted. A persisted child
     // of an optimistic node is re-parented onto its nearest persisted ancestor
     // so the exported tree never references a skipped id.
-    for (const [, message] of this.messages) {
+    for (const message of [...this.messages.values()].sort(
+      (a, b) => a.level - b.level,
+    )) {
       if (message.current.metadata?.isOptimistic) continue;
       let prev = message.prev;
       while (prev && prev.current.metadata?.isOptimistic) {

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -456,11 +456,15 @@ export class MessageRepository {
     // Optimistic messages are ephemeral and never persisted. A persisted child
     // of an optimistic node is re-parented onto its nearest persisted ancestor
     // so the exported tree never references a skipped id.
-    // Import and external-state conversion require parents before children.
-    // Stable sorting also keeps siblings in their insertion order.
-    for (const message of [...this.messages.values()].sort(
-      (a, b) => a.level - b.level,
-    )) {
+    // Import and external-state conversion require parents before children, so
+    // the tree is walked in pre-order rather than iterated in insertion order.
+    const pending = [...this.root.children].reverse();
+    while (pending.length > 0) {
+      const message = this.messages.get(pending.pop()!);
+      if (!message) continue;
+      for (let i = message.children.length - 1; i >= 0; i--) {
+        pending.push(message.children[i]!);
+      }
       if (message.current.metadata?.isOptimistic) continue;
       let prev = message.prev;
       while (prev && prev.current.metadata?.isOptimistic) {

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -456,6 +456,8 @@ export class MessageRepository {
     // Optimistic messages are ephemeral and never persisted. A persisted child
     // of an optimistic node is re-parented onto its nearest persisted ancestor
     // so the exported tree never references a skipped id.
+    // Import and external-state conversion require parents before children.
+    // Stable sorting also keeps siblings in their insertion order.
     for (const message of [...this.messages.values()].sort(
       (a, b) => a.level - b.level,
     )) {

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -494,8 +494,16 @@ describe("MessageRepository", () => {
       repository.addOrUpdateMessage(null, createTestMessage({ id: "X" }));
       repository.addOrUpdateMessage("X", messageA);
 
+      const exported = repository.export();
+      expect(exported.messages.map((m) => m.message.id)).toEqual([
+        "X",
+        "A",
+        "B",
+        "C",
+      ]);
+
       const restored = new MessageRepository();
-      restored.import(repository.export());
+      restored.import(exported);
 
       expect(restored.headId).toBe("B");
       expect(restored.getMessages().map((m) => m.id)).toEqual(["X", "A", "B"]);

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -486,6 +486,23 @@ describe("MessageRepository", () => {
       ).toBe("parent-id");
     });
 
+    it("round-trips after reparenting under a later-added ancestor", () => {
+      const messageA = createTestMessage({ id: "A" });
+      repository.addOrUpdateMessage(null, messageA);
+      repository.addOrUpdateMessage("A", createTestMessage({ id: "B" }));
+      repository.addOrUpdateMessage("A", createTestMessage({ id: "C" }));
+      repository.addOrUpdateMessage(null, createTestMessage({ id: "X" }));
+      repository.addOrUpdateMessage("X", messageA);
+
+      const restored = new MessageRepository();
+      restored.import(repository.export());
+
+      expect(restored.headId).toBe("B");
+      expect(restored.getMessages().map((m) => m.id)).toEqual(["X", "A", "B"]);
+      restored.switchToBranch("C");
+      expect(restored.getMessages().map((m) => m.id)).toEqual(["X", "A", "C"]);
+    });
+
     it("should import repository state", () => {
       const parent = createTestMessage({ id: "parent-id" });
       const child = createTestMessage({ id: "child-id" });

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -645,19 +645,23 @@ describe("A2AThreadRuntimeCore", () => {
         parent.id,
         edited.id,
       ]);
-      expect(
-        core.getMessageRepository().messages.map(({ message, parentId }) => ({
+      const exportedMessages = core
+        .getMessageRepository()
+        .messages.map(({ message, parentId }) => ({
           id: message.id,
           parentId,
-        })),
-      ).toEqual([
-        { id: root.id, parentId: null },
-        { id: parent.id, parentId: root.id },
-        { id: source.id, parentId: parent.id },
-        { id: child.id, parentId: source.id },
-        { id: sibling.id, parentId: parent.id },
-        { id: edited.id, parentId: parent.id },
-      ]);
+        }));
+      expect(exportedMessages).toHaveLength(6);
+      expect(exportedMessages).toEqual(
+        expect.arrayContaining([
+          { id: root.id, parentId: null },
+          { id: parent.id, parentId: root.id },
+          { id: source.id, parentId: parent.id },
+          { id: child.id, parentId: source.id },
+          { id: sibling.id, parentId: parent.id },
+          { id: edited.id, parentId: parent.id },
+        ]),
+      );
 
       core.applyExternalMessages([root, parent, source, child]);
       expect(core.getMessages().map((message) => message.id)).toEqual([

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -662,6 +662,11 @@ describe("A2AThreadRuntimeCore", () => {
           { id: edited.id, parentId: parent.id },
         ]),
       );
+      const exportedIds = new Set<string>();
+      for (const { id, parentId } of exportedMessages) {
+        if (parentId !== null) expect(exportedIds.has(parentId)).toBe(true);
+        exportedIds.add(id);
+      }
 
       core.applyExternalMessages([root, parent, source, child]);
       expect(core.getMessages().map((message) => message.id)).toEqual([

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -645,28 +645,19 @@ describe("A2AThreadRuntimeCore", () => {
         parent.id,
         edited.id,
       ]);
-      const exportedMessages = core
-        .getMessageRepository()
-        .messages.map(({ message, parentId }) => ({
+      expect(
+        core.getMessageRepository().messages.map(({ message, parentId }) => ({
           id: message.id,
           parentId,
-        }));
-      expect(exportedMessages).toHaveLength(6);
-      expect(exportedMessages).toEqual(
-        expect.arrayContaining([
-          { id: root.id, parentId: null },
-          { id: parent.id, parentId: root.id },
-          { id: source.id, parentId: parent.id },
-          { id: child.id, parentId: source.id },
-          { id: sibling.id, parentId: parent.id },
-          { id: edited.id, parentId: parent.id },
-        ]),
-      );
-      const exportedIds = new Set<string>();
-      for (const { id, parentId } of exportedMessages) {
-        if (parentId !== null) expect(exportedIds.has(parentId)).toBe(true);
-        exportedIds.add(id);
-      }
+        })),
+      ).toEqual([
+        { id: root.id, parentId: null },
+        { id: parent.id, parentId: root.id },
+        { id: source.id, parentId: parent.id },
+        { id: child.id, parentId: source.id },
+        { id: sibling.id, parentId: parent.id },
+        { id: edited.id, parentId: parent.id },
+      ]);
 
       core.applyExternalMessages([root, parent, source, child]);
       expect(core.getMessages().map((message) => message.id)).toEqual([


### PR DESCRIPTION
## Problem

An exported thread cannot import after a message moves under a parent added later. The import throws `Parent message not found`.

Affected base: `98010f17b4a8d4bc506a6084007ecdaf4a823503` (`@assistant-ui/core` 0.3.17 in the checkout). This reproduction runs from the repository root with `bun repro.ts`:

```ts
import assert from "node:assert/strict";
import {
  MessageRepository,
  ExportedMessageRepository,
} from "./packages/core/src/runtime/utils/message-repository";

const message = (id: string) =>
  ExportedMessageRepository.fromArray([
    { id, role: "user", content: [{ type: "text", text: id }] },
  ]).messages[0]!.message;
const source = new MessageRepository();
source.addOrUpdateMessage(null, message("A"));
source.addOrUpdateMessage("A", message("B"));
source.addOrUpdateMessage(null, message("X"));
source.addOrUpdateMessage("X", message("A"));
const restored = new MessageRepository();
restored.import(source.export());
assert.deepEqual(restored.getMessages().map((m) => m.id), ["X", "A", "B"]);
```

## Root cause

A parent change updates tree levels but keeps map insertion order. Export emits `A, B, X`, but import requires each parent before its children.

## Change

Export sorts by existing tree levels, so the same import restores `X, A, B`. Optimistic-message filtering and parent selection stay unchanged.

## Verification

The reproduction and new regression produced the missing-parent error before the correction and passed afterward. The regression also confirms head and alternate-branch preservation.

Focused checks passed:

- `pnpm --filter @assistant-ui/core test src/tests/MessageRepository.test.ts src/runtime/utils/message-repository-session.test.ts src/tests/external-store-thread-runtime-core.test.ts src/tests/external-store-repository-instance.test.ts`: 132 tests.
- `pnpm exec oxlint packages/core/src/runtime/utils/message-repository.ts packages/core/src/tests/MessageRepository.test.ts`.
- `pnpm changesets:check`.

Local tap and store builds corrected an initial `shallowEqual is not a function` error in the external-store tests. Commit hooks passed lint and formatting checks.

## Public surface

`@assistant-ui/core` receives a patch changeset. Public signatures, exports, documentation, API-reference output, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QYO1_6aj5F7t6DiQ955Z03RdFryzpK6faW3iIb1wJwYMcqrpqEdiMrTGWXI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->