### PR TITLE
fix(core): keep discarded text out of dictation after reset

### DIFF
--- a/.changeset/clear-dictation-draft.md
+++ b/.changeset/clear-dictation-draft.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep discarded composer text out of dictation results after reset

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -159,6 +159,7 @@ export abstract class BaseComposerRuntimeCore
   private _emptyTextAndAttachments() {
     this._attachments = [];
     this._text = "";
+    this._rebaseDictation("");
     this._notifySubscribers();
   }
 

--- a/packages/core/src/tests/base-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core.test.ts
@@ -103,6 +103,45 @@ describe("BaseComposerRuntimeCore", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it("reset keeps discarded text out of later dictation results", async () => {
+    let emitSpeech!: (result: DictationAdapter.Result) => void;
+    composer.setDictationAdapter({
+      listen: () => ({
+        status: { type: "running" },
+        stop: async () => {},
+        cancel: () => {},
+        onSpeechStart: () => () => {},
+        onSpeechEnd: () => () => {},
+        onSpeech: (callback) => {
+          emitSpeech = callback;
+          return () => {};
+        },
+      }),
+    });
+
+    composer.setText("old");
+    composer.startDictation();
+    try {
+      await composer.reset();
+      expect(composer.text).toBe("");
+      emitSpeech({ transcript: "new", isFinal: true });
+      expect(composer.text).toBe("new");
+
+      emitSpeech({ transcript: "pending", isFinal: false });
+      expect(composer.text).toBe("new pending");
+      await composer.reset();
+      expect(composer.text).toBe("");
+      expect(composer.dictation?.transcript).toBeUndefined();
+
+      emitSpeech({ transcript: "next", isFinal: false });
+      expect(composer.text).toBe("next");
+      emitSpeech({ transcript: "next final", isFinal: true });
+      expect(composer.text).toBe("next final");
+    } finally {
+      composer.stopDictation();
+      await Promise.resolve();
+    }
+  });
   it("send includes quote in metadata and clears it", async () => {
     const quote = { text: "quoted", messageId: "m1" };
     composer.setText("reply");


### PR DESCRIPTION
## Problem

Dictation can restore discarded composer text after `reset()`. The next transcript must start from the empty draft, not the discarded draft.

Reproduction on base `98010f17b4a8d4bc506a6084007ecdaf4a823503` (`@assistant-ui/core` version `0.3.17`): after dependency installation and the core build, save this snippet as `repro.ts` at the repository root. Run `bun repro.ts`.

```ts
import assert from "node:assert/strict";
import { LocalRuntimeCore } from "./packages/core/src/runtimes/local/local-runtime-core.ts";

let emit;
const session = {
  status: { type: "running" },
  stop: async () => {},
  cancel: () => {},
  onSpeech: (callback) => { emit = callback; return () => {}; },
  onSpeechStart: () => () => {},
  onSpeechEnd: () => () => {},
};
const core = new LocalRuntimeCore({ adapters: {
  chatModel: { run: async () => ({ content: [] }) },
  dictation: { listen: () => session },
}}, undefined);
const composer = core.threads.getMainThreadRuntimeCore().composer;
try {
  composer.setText("old");
  composer.startDictation();
  await composer.reset();
  emit({ transcript: "new", isFinal: true });
  assert.equal(composer.text, "new");
} finally {
  composer.stopDictation();
  await Promise.resolve();
}
```

The base produces `"old new"`. The correction produces `"new"`. The adapter supplies speech results without a microphone.

## Root cause

Reset clears the composer text directly but retains the dictation baseline. The next speech result appends to that discarded baseline.

## Change

The reset helper uses the existing dictation rebase helper to clear the baseline and interim transcript. The dictation session stays active.

## Verification

- The runtime reproduction and regression failed before the correction and passed afterward.
- The regression also covers reset during an interim transcript, followed by interim and final speech results.
- `pnpm --filter @assistant-ui/core test src/tests/base-composer-runtime-core.test.ts src/tests/base-composer-runtime-core-send.test.ts src/tests/base-composer-runtime-core-addAttachment.test.ts src/tests/default-edit-composer-runtime-core.test.ts`: 93 tests passed.
- The core build and scoped oxlint check passed.
- Existing `QuoteInfo` type errors remain in the unchanged `retractDraft` test. This PR does not correct those errors.

## Public surface

`@assistant-ui/core` receives a patch changeset. Public exports and signatures, documentation, API-reference output, and templates stay unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sIIg9oXcCyEcexrQ68WUdWJnkbD5BodqhDdae1Y82CwUSPSJvjsJ7qG_VLY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->