### PR TITLE
fix(core): return metadata for the requested thread

### DIFF
--- a/.changeset/requested-thread-metadata.md
+++ b/.changeset/requested-thread-metadata.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: return the requested thread's metadata from getById when another thread is selected

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -263,7 +263,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
         getState: () => this._core.getThreadRuntimeCore(threadId),
         subscribe: (callback) => this._core.subscribe(callback),
       }),
-      this.mainItem,
+      this.getItemById(threadId),
     );
   }
 

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -15,6 +15,7 @@ import {
   type ThreadListItemRuntime,
   ThreadListItemRuntimeImpl,
   type ThreadListItemState,
+  type ThreadListItemStateBinding,
 } from "./thread-list-item-runtime";
 import {
   type ThreadListItemRuntimeBinding,
@@ -253,6 +254,21 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
     return this._mainThreadListItemRuntime;
   }
 
+  private _createItemStateBinding(
+    threadId: string,
+  ): ThreadListItemStateBinding {
+    return new ShallowMemoizeSubject({
+      path: {
+        ref: `threadItems[threadId=${threadId}]`,
+        threadSelector: { type: "threadId", threadId },
+      },
+      getState: () => {
+        return getThreadListItemState(this._core, threadId);
+      },
+      subscribe: (callback) => this._core.subscribe(callback),
+    });
+  }
+
   public getById(threadId: string) {
     return new this._runtimeFactory(
       new NestedSubscriptionSubject({
@@ -263,7 +279,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
         getState: () => this._core.getThreadRuntimeCore(threadId),
         subscribe: (callback) => this._core.subscribe(callback),
       }),
-      this.getItemById(threadId),
+      this._createItemStateBinding(threadId),
     );
   }
 
@@ -304,16 +320,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
 
   public getItemById(threadId: string) {
     return new ThreadListItemRuntimeImpl(
-      new ShallowMemoizeSubject({
-        path: {
-          ref: `threadItems[threadId=${threadId}]`,
-          threadSelector: { type: "threadId", threadId },
-        },
-        getState: () => {
-          return getThreadListItemState(this._core, threadId);
-        },
-        subscribe: (callback) => this._core.subscribe(callback),
-      }),
+      this._createItemStateBinding(threadId),
       this._core,
     );
   }

--- a/packages/core/src/tests/thread-switch-events.test.tsx
+++ b/packages/core/src/tests/thread-switch-events.test.tsx
@@ -352,6 +352,84 @@ const switchTo = async (runtime: AssistantRuntime, remoteId: string) => {
   });
 };
 
+describe("ThreadListRuntime.getById", () => {
+  it("keeps background messages and metadata bound to the requested thread", async () => {
+    const harness = renderRemoteList(listAdapter(), async () => ({
+      content: [],
+    }));
+    const runtime = harness.getRuntime();
+    await waitFor(() => {
+      expect(runtime.threads.mainItem.getState().remoteId).toBe("thread-a");
+    });
+    await act(async () => {
+      runtime.thread.reset([
+        {
+          id: "message-a",
+          role: "user",
+          content: [{ type: "text", text: "A" }],
+        },
+      ]);
+    });
+    await switchTo(runtime, "thread-b");
+    await act(async () => {
+      runtime.thread.reset([
+        {
+          id: "message-b",
+          role: "user",
+          content: [{ type: "text", text: "B" }],
+        },
+      ]);
+    });
+    const threadBId = runtime.threads.mainItem.getState().id;
+    await switchTo(runtime, "thread-a");
+
+    const threadB = runtime.threads.getById(threadBId);
+    expect(threadB.getState()).toMatchObject({
+      threadId: threadBId,
+      messages: [{ id: "message-b" }],
+      metadata: {
+        id: threadBId,
+        remoteId: "thread-b",
+        title: "B",
+        isMain: false,
+      },
+    });
+    expect(runtime.thread.getState()).toMatchObject({
+      messages: [{ id: "message-a" }],
+      metadata: { remoteId: "thread-a", isMain: true },
+    });
+
+    let observed = threadB.getState();
+    const unsubscribe = threadB.subscribe(() => {
+      observed = threadB.getState();
+    });
+    try {
+      await act(async () => {
+        await runtime.threads.getItemById(threadBId).rename("Renamed B");
+      });
+      expect(observed).toMatchObject({
+        threadId: threadBId,
+        messages: [{ id: "message-b" }],
+        metadata: { title: "Renamed B", isMain: false },
+      });
+
+      await switchTo(runtime, "thread-b");
+      expect(observed.metadata).toMatchObject({
+        title: "Renamed B",
+        isMain: true,
+      });
+      await switchTo(runtime, "thread-a");
+      expect(observed).toMatchObject({
+        threadId: threadBId,
+        messages: [{ id: "message-b" }],
+        metadata: { title: "Renamed B", isMain: false },
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+});
+
 describe("background thread run events", () => {
   it("delivers runEnd globally after the running thread is switched away", async () => {
     const runA = deferred<{ content: [] }>();


### PR DESCRIPTION
## Problem

`threads.getById()` returns a background thread's messages with the selected thread's ID and metadata. A caller can therefore read the wrong title or remote ID.

Affected source: `@assistant-ui/core` 0.3.17 at base `98010f17b4a8d4bc506a6084007ecdaf4a823503`.

Reproduction with a remote thread list that contains threads `A` and `B` and uses `useLocalRuntime`:

```ts
await runtime.threads.switchToThread("B");
runtime.thread.reset([
  { id: "message-B", role: "user", content: [{ type: "text", text: "B" }] },
]);
const threadBId = runtime.threads.mainItem.getState().id;
await runtime.threads.switchToThread("A");
const state = runtime.threads.getById(threadBId).getState();
console.log(state.messages[0]?.id, state.threadId, state.metadata.remoteId);
// Before: message-B A A
// After:  message-B B B
```

## Root cause

`getById()` selects the requested runtime core but takes metadata from `mainItem`, which follows the selected thread.

## Change

The returned runtime uses the existing ID-bound item for its metadata and subscription. The selected-thread runtime stays unchanged.

## Verification

- The regression and a standalone mounted runtime API reproduction failed before the correction and passed afterward.
- `pnpm --filter @assistant-ui/core test src/tests/thread-switch-events.test.tsx src/tests/thread-list-runtime-getLoadThreadsPromise.test.ts`: 17 tests passed, including background rename notifications and thread switches.
- Scoped Oxlint and `pnpm --filter @assistant-ui/core build` passed.

## Public surface

`@assistant-ui/core` patch changeset. Public exports and signatures stay unchanged. Documentation, generated API reference, and templates are unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/6982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6tlzXy42p_e46ADUYfA-dlufT054DIwaYHoaZT-TIiOAX8fm9ZcvgJPi2WY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->